### PR TITLE
Accept block markup artifact entries

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -116,6 +116,15 @@ final class ArtifactCompiler
      */
     private function compileEntryBlocks(string $html, string $entryPath, array $files): array
     {
+        if ( $this->containsBlockMarkup($html) ) {
+            return array(
+                'blocks'            => array(),
+                'serialized_blocks' => $html,
+                'diagnostics'       => array(),
+                'fallbacks'         => array(),
+            );
+        }
+
         if ( '' === trim($html) || ! $this->entryHtmlReferencesImageAsset($html, $entryPath, $files) ) {
             return array(
                 'blocks'            => array(),
@@ -290,25 +299,42 @@ final class ArtifactCompiler
     {
         foreach ( $entrypoints as $entrypoint ) {
             foreach ( $files as $file ) {
-                if ( $entrypoint === $file['path'] && 'html' === $file['kind'] && empty($file['binary']) ) {
+                if ( $entrypoint === $file['path'] && $this->isEntryFile($file) ) {
                     return $file;
                 }
             }
         }
         foreach ( array('index.html', 'index.htm', 'static-site/index.html', 'public/index.html') as $preferred ) {
             foreach ( $files as $file ) {
-                if ( $preferred === strtolower((string) $file['path']) && empty($file['binary']) ) {
+                if ( $preferred === strtolower((string) $file['path']) && $this->isEntryFile($file) ) {
                     return $file;
                 }
             }
         }
         foreach ( $files as $file ) {
-            if ( 'html' === $file['kind'] && empty($file['binary']) ) {
+            if ( $this->isEntryFile($file) ) {
                 return $file;
             }
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, mixed> $file
+     */
+    private function isEntryFile(array $file): bool
+    {
+        if ( ! empty($file['binary']) ) {
+            return false;
+        }
+
+        return 'html' === ($file['kind'] ?? '') || 'blocks' === ($file['kind'] ?? '') || $this->containsBlockMarkup((string) ($file['content'] ?? ''));
+    }
+
+    private function containsBlockMarkup(string $content): bool
+    {
+        return str_contains($content, '<!-- wp:');
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -90,7 +90,7 @@ final class ArtifactNormalizer
             $kind = $this->kind((string) ($file['kind'] ?? $file['type'] ?? ''), $path, $payload['content'], $mimeType);
             $role = $this->role((string) ($file['role'] ?? ''), $kind, $mimeType, $path);
             $intent = $this->intent((string) ($file['intent'] ?? ''), $kind, $role);
-            $binary = $payload['binary'] || $this->isBinaryMimeType($mimeType);
+            $binary = $payload['binary'] || ( ! $this->isTextKind($kind) && $this->isBinaryMimeType($mimeType) );
             $contentBase64 = $payload['content_base64'];
             if ( $binary && '' === $contentBase64 ) {
                 $contentBase64 = base64_encode($payload['content']);
@@ -315,6 +315,11 @@ final class ArtifactNormalizer
     private function isBinaryMimeType(string $mimeType): bool
     {
         return ! str_starts_with($mimeType, 'text/') && ! in_array($mimeType, array('application/json', 'application/javascript', 'image/svg+xml'), true);
+    }
+
+    private function isTextKind(string $kind): bool
+    {
+        return in_array($kind, array('html', 'css', 'js', 'jsx', 'tsx', 'json', 'markdown', 'mdx', 'blocks'), true);
     }
 
     private function role(string $role, string $kind, string $mimeType, string $path): string

--- a/php-transformer/tests/fixtures/parity/artifact-blocks-entry.json
+++ b/php-transformer/tests/fixtures/parity/artifact-blocks-entry.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-blocks-entry",
+  "description": "Accepts an explicit serialized WordPress block markup artifact entry.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-blocks-entry.json",
+    "notes": "Covers the artifact compiler entry contract for kind blocks."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Serialized block artifact entries are covered by the PHP transformer contract."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "content.blocks",
+      "files": [
+        {
+          "path": "content.blocks",
+          "kind": "blocks",
+          "content": "<!-- wp:heading {\"level\":2} --><h2>Block artifact heading</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Block artifact body.</p><!-- /wp:paragraph -->"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.artifact.entry_path", "assert": "equals", "value": "content.blocks" },
+    { "path": "source_reports.artifact.files_by_kind.blocks", "assert": "equals", "value": 1 },
+    { "path": "diagnostics", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "equals", "value": "<!-- wp:heading {\"level\":2} --><h2>Block artifact heading</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Block artifact body.</p><!-- /wp:paragraph -->" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/artifact-inferred-blocks-entry.json
+++ b/php-transformer/tests/fixtures/parity/artifact-inferred-blocks-entry.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-inferred-blocks-entry",
+  "description": "Accepts serialized WordPress block markup as an artifact entry when kind is inferred from content.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-inferred-blocks-entry.json",
+    "notes": "Covers block comment detection for non-HTML artifact files."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Serialized block artifact entries are covered by the PHP transformer contract."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "files": [
+        {
+          "path": "page.fragment",
+          "content": "<!-- wp:paragraph --><p>Inferred block entry.</p><!-- /wp:paragraph -->"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.artifact.entry_path", "assert": "equals", "value": "page.fragment" },
+    { "path": "source_reports.artifact.files_by_kind.blocks", "assert": "equals", "value": 1 },
+    { "path": "diagnostics", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "equals", "value": "<!-- wp:paragraph --><p>Inferred block entry.</p><!-- /wp:paragraph -->" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds support for serialized WordPress block markup artifacts as valid `ArtifactCompiler` entries.

This lets artifact bundles whose entry is already block markup avoid the `missing_entry_html` diagnostic and preserves the block markup directly as `serialized_blocks`.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed. Canonical parity covered 19 fixtures.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the focused artifact entry support, fixture coverage, and PR text. Chris remains responsible for review and final submission.
