### PR TITLE
Expose compiled site artifact report

### DIFF
--- a/php-transformer/docs/contracts/result-envelope.md
+++ b/php-transformer/docs/contracts/result-envelope.md
@@ -34,6 +34,8 @@ Required top-level keys for successful transformations:
 
 `status` is one of `success`, `success_with_warnings`, or `failed`. Artifact compiler callers should use `source_reports.artifact` for normalized input metadata such as entry path, accepted/rejected file counts, MIME/kind/role counts, and source HTML metrics.
 
+Artifact compiler callers that need a compiled site view should read `source_reports.compiled_site`. It exposes a generic `blocks-engine/php-transformer/compiled-site/v1` report with normalized `pages`, `assets`, and `theme` buckets for stylesheets, scripts, fonts, images, and generated block types. Product adapters should map from this report plus the top-level `documents` and `assets` arrays instead of depending on product-specific artifact semantics.
+
 `components` contains inspectable component candidates discovered before materialization. `block_types` contains generated block type artifacts promoted from `block.json` roots. `legacy_mapping` is transitional metadata for consumer-owned migration mappers and is not a long-term package feature commitment.
 
 `blocks` is always a list-shaped array of parsed WordPress block arrays when exposed through `TransformerResult` or `FormatBridge::toBlocks()`. `fallbacks` entries should include stable generic metadata such as `type`, `reason`, `diagnostic_code`, `source_format`, and the preserved source fragment needed by callers to inspect or replay unsupported content.

--- a/php-transformer/docs/html-transform-coverage.md
+++ b/php-transformer/docs/html-transform-coverage.md
@@ -18,6 +18,7 @@ Run the coverage fixtures with `composer parity` or as part of `composer test`.
 | Shortcodes | `html-core-media-actions.json` | `core/shortcode` for standalone shortcode text |
 | Unsupported fallback | `unsupported-fallback.json`, `html-unsupported-context-required.json` | Unsupported elements are reported in `fallbacks` and do not fail supported siblings |
 | Website artifact bundle | `website-artifact-bundle.json` | HTML, CSS, and JS artifact inputs compile into the shared result envelope |
+| Compiled site contract | `compiled-site-contract.json` | Generic site artifacts expose normalized pages, assets, and theme buckets in `source_reports.compiled_site` |
 | Generated store artifacts | `generated-store-inferred-html.json`, `generated-store-manifest-valid-artifact.json`, `generated-store-manifest-invalid-artifact.json` | Product-shaped generated artifacts preserve files, manifests, components, and diagnostics without owning product validation |
 | Mixed source markdown | `mixed-source-markdown.json` | Markdown documents compile into transformer document output |
 

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -8,7 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 
 final class ArtifactCompiler
 {
-    private const INPUT_SCHEMA = 'block-artifact-compiler/website-artifact/v1';
+    private const INPUT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
 
     /**
      * @param array<string, mixed> $artifact
@@ -67,6 +67,7 @@ final class ArtifactCompiler
                 'image_references' => $this->imageReferenceReport($html, $entryPath, $normalized['files']),
             ),
         );
+        $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
 
         return new TransformerResult(
             status: $this->statusFromDiagnostics($diagnostics),
@@ -189,6 +190,150 @@ final class ArtifactCompiler
         }
 
         return $references;
+    }
+
+    /**
+     * @param array{files: array<int, array<string, mixed>>, bytes: int, hash_payload: string} $artifact
+     * @param array<int, array<string, mixed>> $documents
+     * @param array<int, array<string, mixed>> $assets
+     * @param array<int, array<string, mixed>> $blockTypes
+     * @return array<string, mixed>
+     */
+    private function compiledSiteReport(array $artifact, string $entryPath, array $documents, array $assets, array $blockTypes, string $serializedBlocks): array
+    {
+        $pages = array();
+        foreach ( $artifact['files'] as $file ) {
+            if ( 'html' !== ($file['kind'] ?? '') ) {
+                continue;
+            }
+
+            $path = (string) ($file['path'] ?? '');
+            $pages[] = array_filter(
+                array(
+                    'source_path'    => $path,
+                    'kind'           => 'html',
+                    'role'           => $file['role'] ?? 'document',
+                    'entrypoint'     => $path === $entryPath || ! empty($file['entrypoint']),
+                    'slug'           => $this->slugFromPath($path),
+                    'title'          => $this->titleFromHtml((string) ($file['content'] ?? ''), $path),
+                    'body_format'    => 'html',
+                    'block_markup'   => $path === $entryPath ? $serializedBlocks : '',
+                    'bytes'          => $file['bytes'] ?? 0,
+                    'mime_type'      => $file['mime_type'] ?? 'text/html',
+                    'asset_references' => $path === $entryPath ? $this->assetReferencePaths($assets) : array(),
+                    'provenance'     => $file['provenance'] ?? array(),
+                ),
+                static fn (mixed $value): bool => array() !== $value
+            );
+        }
+
+        foreach ( $documents as $document ) {
+            $pages[] = array_filter(
+                array(
+                    'source_path'  => $document['source_path'] ?? '',
+                    'kind'         => $document['kind'] ?? 'document',
+                    'role'         => 'document',
+                    'entrypoint'   => false,
+                    'slug'         => $document['slug'] ?? '',
+                    'title'        => $document['title'] ?? '',
+                    'body_format'  => $document['body_format'] ?? '',
+                    'block_markup' => $document['block_markup'] ?? '',
+                    'provenance'   => $document['provenance'] ?? array(),
+                ),
+                static fn (mixed $value): bool => array() !== $value
+            );
+        }
+
+        return array(
+            'schema'      => 'blocks-engine/php-transformer/compiled-site/v1',
+            'source_hash' => hash('sha256', $artifact['hash_payload']),
+            'entry_path'  => $entryPath,
+            'pages'       => $pages,
+            'assets'      => $this->compiledSiteAssets($assets),
+            'theme'       => array(
+                'stylesheets' => $this->assetPathsByIntentOrRole($assets, 'style', 'stylesheet'),
+                'scripts'     => $this->assetPathsByIntentOrRole($assets, 'behavior', 'script'),
+                'fonts'       => $this->assetPathsByRole($assets, 'font'),
+                'images'      => $this->assetPathsByRole($assets, 'image'),
+                'block_types' => array_values(array_map(
+                    static fn (array $blockType): string => (string) ($blockType['name'] ?? ''),
+                    $blockTypes
+                )),
+            ),
+            'totals'      => array(
+                'pages'       => count($pages),
+                'assets'      => count($assets),
+                'input_bytes' => $artifact['bytes'],
+            ),
+        );
+    }
+
+    private function titleFromHtml(string $html, string $path): string
+    {
+        if ( preg_match('/<h1\b[^>]*>(.*?)<\/h1>/is', $html, $match) || preg_match('/<title\b[^>]*>(.*?)<\/title>/is', $html, $match) ) {
+            $title = trim(html_entity_decode(strip_tags($match[1]), ENT_QUOTES | ENT_HTML5));
+            if ( '' !== $title ) {
+                return $title;
+            }
+        }
+
+        return $this->titleFromPath($path);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     * @return array<int, array<string, mixed>>
+     */
+    private function compiledSiteAssets(array $assets): array
+    {
+        return array_values(array_map(
+            static fn (array $asset): array => array_filter(
+                array(
+                    'path'      => $asset['path'] ?? '',
+                    'kind'      => $asset['kind'] ?? '',
+                    'role'      => $asset['role'] ?? '',
+                    'intent'    => $asset['intent'] ?? '',
+                    'mime_type' => $asset['mime_type'] ?? '',
+                    'bytes'     => $asset['bytes'] ?? 0,
+                    'binary'    => $asset['binary'] ?? false,
+                ),
+                static fn (mixed $value): bool => '' !== $value
+            ),
+            $assets
+        ));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     * @return array<int, string>
+     */
+    private function assetReferencePaths(array $assets): array
+    {
+        return array_values(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $assets));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     * @return array<int, string>
+     */
+    private function assetPathsByIntentOrRole(array $assets, string $intent, string $role): array
+    {
+        return array_values(array_map(
+            static fn (array $asset): string => (string) ($asset['path'] ?? ''),
+            array_filter($assets, static fn (array $asset): bool => $intent === ($asset['intent'] ?? '') || $role === ($asset['role'] ?? ''))
+        ));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     * @return array<int, string>
+     */
+    private function assetPathsByRole(array $assets, string $role): array
+    {
+        return array_values(array_map(
+            static fn (array $asset): string => (string) ($asset['path'] ?? ''),
+            array_filter($assets, static fn (array $asset): bool => $role === ($asset['role'] ?? ''))
+        ));
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/compiled-site-contract.json
+++ b/php-transformer/tests/fixtures/parity/compiled-site-contract.json
@@ -1,0 +1,67 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "compiled-site-contract",
+  "description": "Compiles a generic site artifact into normalized pages, assets, and theme-ish output reports.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/compiled-site-contract.json",
+    "notes": "Covers the upstream compiled-site contract without product adapter semantics."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Compiled-site reporting is an upstream transformer contract with no legacy package equivalent."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "public/index.html",
+      "files": [
+        {
+          "path": "public/index.html",
+          "content": "<main><h1>Compiled Site</h1><p>Generic upstream contract.</p><img src=\"assets/hero.svg\" alt=\"Hero\"></main>"
+        },
+        {
+          "path": "public/about.html",
+          "content": "<main><h1>About The Site</h1><p>Secondary page.</p></main>"
+        },
+        {
+          "path": "public/assets/site.css",
+          "content": "main{max-width:60rem;margin:auto}",
+          "kind": "css"
+        },
+        {
+          "path": "public/assets/site.js",
+          "content": "document.documentElement.dataset.compiledSite='1';",
+          "kind": "js"
+        },
+        {
+          "path": "public/assets/hero.svg",
+          "content": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\"><rect width=\"10\" height=\"10\"/></svg>",
+          "mime_type": "image/svg+xml"
+        },
+        {
+          "path": "content/guide.md",
+          "content": "---\ntitle: Guide Page\nslug: guide\n---\n\n# Guide Page\n\nMarkdown source page."
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
+    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
+    { "path": "source_reports.artifact.schema", "assert": "equals", "value": "blocks-engine/php-transformer/site-artifact/v1" },
+    { "path": "source_reports.compiled_site.schema", "assert": "equals", "value": "blocks-engine/php-transformer/compiled-site/v1" },
+    { "path": "source_reports.compiled_site.entry_path", "assert": "equals", "value": "public/index.html" },
+    { "path": "source_reports.compiled_site.pages", "assert": "count", "count": 3 },
+    { "path": "source_reports.compiled_site.pages.0.title", "assert": "equals", "value": "Compiled Site" },
+    { "path": "source_reports.compiled_site.pages.0.entrypoint", "assert": "equals", "value": true },
+    { "path": "source_reports.compiled_site.pages.1.slug", "assert": "equals", "value": "about" },
+    { "path": "source_reports.compiled_site.pages.2.slug", "assert": "equals", "value": "guide" },
+    { "path": "source_reports.compiled_site.assets", "assert": "count", "count": 5 },
+    { "path": "source_reports.compiled_site.theme.stylesheets.0", "assert": "equals", "value": "public/assets/site.css" },
+    { "path": "source_reports.compiled_site.theme.scripts.0", "assert": "equals", "value": "public/assets/site.js" },
+    { "path": "source_reports.compiled_site.theme.images.0", "assert": "equals", "value": "public/assets/hero.svg" },
+    { "path": "documents.0.slug", "assert": "equals", "value": "guide" },
+    { "path": "assets.3.path", "assert": "equals", "value": "public/assets/hero.svg" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a generic compiled-site report to `ArtifactCompiler` output.

The new `source_reports.compiled_site` report exposes normalized pages, assets, and theme buckets for product adapters without importing product-specific importer semantics into `php-transformer`.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed. Canonical parity covered 18 fixtures.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the compiled-site report contract, fixture/docs updates, and PR text. Chris remains responsible for review and final submission.
