### PR TITLE
Preserve HTML fallback provenance

### DIFF
--- a/php-transformer/docs/html-transform-coverage.md
+++ b/php-transformer/docs/html-transform-coverage.md
@@ -16,6 +16,7 @@ Run the coverage fixtures with `composer parity` or as part of `composer test`.
 | Images | `html-core-media-actions.json` | `core/image` with URL, alt, dimensions, caption attrs |
 | Buttons | `html-core-media-actions.json` | `core/buttons` containing `core/button` children |
 | Shortcodes | `html-core-media-actions.json` | `core/shortcode` for standalone shortcode text |
+| Wrapper provenance and safety | `html-provenance-wrapper-safety.json` | Presentational semantic wrappers are preserved as `core/group`; unsupported fallback records include selector/source metadata and sanitized fallback HTML |
 | Unsupported fallback | `unsupported-fallback.json`, `html-unsupported-context-required.json` | Unsupported elements are reported in `fallbacks` and do not fail supported siblings |
 | Website artifact bundle | `website-artifact-bundle.json` | HTML, CSS, and JS artifact inputs compile into the shared result envelope |
 | Generated store artifacts | `generated-store-inferred-html.json`, `generated-store-manifest-valid-artifact.json`, `generated-store-manifest-invalid-artifact.json` | Product-shaped generated artifacts preserve files, manifests, components, and diagnostics without owning product validation |
@@ -26,5 +27,5 @@ Run the coverage fixtures with `composer parity` or as part of `composer test`.
 | Category | Status | Notes |
 | --- | --- | --- |
 | Supported | Heading, paragraph, unordered/ordered list, quote, pullquote, code, preformatted, table, image, buttons/button, shortcode | Fixtures assert the block names and representative attrs currently emitted by `HtmlTransformer`. |
-| Unsupported fallback | Unknown/custom elements, form controls, other unsupported top-level HTML | Fallbacks use `type: unsupported_element`, include the source tag, and increment `coverage.0.fallback_count`. |
+| Unsupported fallback | Unknown/custom elements, SVG markup, form controls, other unsupported top-level HTML | Fallbacks use `type: unsupported_element`, include the source tag, selector, caller source/scope when provided, sanitized HTML, and increment `coverage.0.fallback_count`. |
 | Context-required | Interactive/form behavior, embeds, advanced layout semantics, raw-handler hooks | These require WordPress/Gutenberg runtime context or richer product converter behavior and remain outside the PHP transformer's supported slice. |

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -14,6 +14,11 @@ final class HtmlTransformer
 {
     private readonly BlockFactory $blockFactory;
 
+    /**
+     * @var array<string, string>
+     */
+    private array $fallbackProvenance = array();
+
     public function __construct(private readonly Runtime $runtime = new Runtime())
     {
         $this->blockFactory = new BlockFactory();
@@ -24,15 +29,15 @@ final class HtmlTransformer
      */
     public function transform(string $html, array $options = array()): TransformerResult
     {
-        $context    = TransformationOptions::context($options);
-        $context    = TransformationOptions::context($options);
-        $startedAt  = hrtime(true);
-        $provenance = array(
+        $context                  = TransformationOptions::context($options);
+        $startedAt                = hrtime(true);
+        $this->fallbackProvenance = TransformationOptions::provenance($options);
+        $provenance               = array(
             array_merge(array(
                 'source_format' => 'html',
                 'input_bytes'   => strlen($html),
                 'transformer'   => self::class,
-            ), TransformationOptions::provenance($options)),
+            ), $this->fallbackProvenance),
         );
 
         $document = new DOMDocument();
@@ -50,13 +55,13 @@ final class HtmlTransformer
                 ),
             );
             $fallbacks = array(
-                array(
+                array_merge(array(
                     'type'            => 'html',
                     'reason'          => 'parse_failed',
                     'diagnostic_code' => 'html_parse_failed',
                     'source_format'   => 'html',
                     'html'            => $html,
-                ),
+                ), $this->fallbackProvenance),
             );
 
             return new TransformerResult(
@@ -327,7 +332,7 @@ final class HtmlTransformer
         }
 
         if ( 'form' === $tagName ) {
-            $fallbacks[] = array(
+            $fallbacks[] = array_merge(array(
                 'type'            => 'html',
                 'reason'          => 'form_requires_runtime',
                 'diagnostic_code' => 'html_form_fallback',
@@ -339,7 +344,7 @@ final class HtmlTransformer
                 'text_length'     => strlen(trim($element->textContent ?? '')),
                 'child_count'     => $this->childElementCount($element),
                 'html'            => $this->safeFallbackHtml($element),
-            );
+            ), $this->fallbackProvenance);
             return null;
         }
 
@@ -351,7 +356,7 @@ final class HtmlTransformer
 
             $children = $this->convertChildren($element, $fallbacks, true);
             if ( 1 === count($children) ) {
-                if ( $this->shouldPreserveWrapper($element) ) {
+                if ( $this->shouldPreserveWrapper($element) && 'core/group' !== ($children[0]['blockName'] ?? '') ) {
                     return $this->createBlock('core/group', $this->presentationAttributes($element), $children);
                 }
                 return $children[0];
@@ -363,7 +368,7 @@ final class HtmlTransformer
         }
 
         if ( $captureUnsupported ) {
-            $fallbacks[] = array(
+            $fallbacks[] = array_merge(array(
                 'type'            => 'unsupported_element',
                 'reason'          => 'unsupported_element',
                 'diagnostic_code' => 'html_unsupported_element',
@@ -373,8 +378,8 @@ final class HtmlTransformer
                 'attributes'      => $this->htmlAttributes($element),
                 'text_length'     => strlen(trim($element->textContent ?? '')),
                 'child_count'     => $this->childElementCount($element),
-                'html'            => $this->outerHtml($element),
-            );
+                'html'            => $this->safeFallbackHtml($element),
+            ), $this->fallbackProvenance);
         }
 
         return null;
@@ -438,7 +443,7 @@ final class HtmlTransformer
 
     private function shouldPreserveWrapper(DOMElement $element): bool
     {
-        return 'div' === strtolower($element->tagName) && array() !== $this->presentationAttributes($element);
+        return in_array(strtolower($element->tagName), array( 'article', 'div', 'main', 'section' ), true) && array() !== $this->presentationAttributes($element);
     }
 
     private function isInlineContentElement(string $tagName): bool

--- a/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
+++ b/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-provenance-wrapper-safety",
+  "description": "Preserves presentational semantic wrappers and carries source provenance plus safe fallback HTML for unsupported elements.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-provenance-wrapper-safety.json",
+    "notes": "Product-neutral fixture for HTML selector/source provenance and fallback safety."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"hero-shell\"><h2>Only child</h2></section><svg class=\"badge\"><script>alert(1)</script><circle cx=\"1\" cy=\"1\" r=\"1\"></circle></svg>",
+    "options": {
+      "source": "fixture:html-provenance-wrapper-safety",
+      "source_scope": "parity"
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-shell" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Only child", "level": 2 } }
+  ],
+  "expected_fallbacks": [
+    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "svg", "diagnostic_code": "html_unsupported_element", "selector": "svg:nth-of-type(1)", "source": "fixture:html-provenance-wrapper-safety", "scope": "parity" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.html", "assert": "contains", "value": "<svg class=\"badge\">" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script>" },
+    { "path": "provenance.0.source", "assert": "equals", "value": "fixture:html-provenance-wrapper-safety" },
+    { "path": "provenance.0.scope", "assert": "equals", "value": "parity" },
+    { "path": "diagnostics.1.selector", "assert": "equals", "value": "svg:nth-of-type(1)" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+  ]
+}

--- a/php-transformer/tests/parity/run.php
+++ b/php-transformer/tests/parity/run.php
@@ -199,7 +199,12 @@ function runFixture(array $fixture): array
     $input = $fixture['input'];
 
     if ( 'html_transformer.transform' === $fixture['operation'] ) {
-        return ( new HtmlTransformer() )->transform((string) ($input['content'] ?? ''))->toArray();
+        $options = $input['options'] ?? array();
+        if ( ! is_array($options) ) {
+            fail("Fixture {$fixture['name']} HTML transform options must be an object.");
+        }
+
+        return ( new HtmlTransformer() )->transform((string) ($input['content'] ?? ''), $options)->toArray();
     }
 
     if ( 'artifact_compiler.compile' === $fixture['operation'] ) {
@@ -567,6 +572,14 @@ function assertExpectation(array $output, array $expectation, string $fixtureNam
         $expected = (string) ($expectation['value'] ?? '');
         if ( ! is_string($actual) || ! str_contains($actual, $expected) ) {
             failExpectation($fixtureName, $path, $expected, $actual);
+        }
+        return;
+    }
+
+    if ( 'not_contains' === $assertion ) {
+        $expected = (string) ($expectation['value'] ?? '');
+        if ( is_string($actual) && str_contains($actual, $expected) ) {
+            failExpectation($fixtureName, $path, 'not containing ' . $expected, $actual);
         }
         return;
     }


### PR DESCRIPTION
## Summary

Improves generic HTML transform fallback metadata and wrapper preservation.

Changes include:

- HTML fallbacks carry caller source/scope provenance when provided.
- Unsupported fallback HTML uses the safe sanitizer path.
- Presentational `article`, `main`, and `section` single-child wrappers can be preserved as `core/group`.
- Parity coverage for provenance, selectors, sanitized SVG fallback, and wrapper preservation.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed. Canonical parity covered 18 fixtures.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the fallback provenance/wrapper preservation slice, fixture/docs updates, and PR text. Chris remains responsible for review and final submission.
