### PR TITLE
Preserve SVG image primitive parity

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -135,7 +135,7 @@ final class ArtifactCompiler
             );
         }
 
-        $result = ( new HtmlTransformer() )->transform($html, array(
+        $result = ( new HtmlTransformer() )->transform($this->safeEntryImageHtml($html, $entryPath, $files), array(
             'source'       => $entryPath,
             'source_scope' => 'artifact-entry',
         ))->toArray();
@@ -165,6 +165,23 @@ final class ArtifactCompiler
         }
 
         return false;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     */
+    private function safeEntryImageHtml(string $html, string $entryPath, array $files): string
+    {
+        $html = preg_replace_callback('/<img\s+[^>]*src\s*=\s*(["\'])([^"\']+)\1[^>]*>/i', function (array $matches) use ($entryPath, $files): string {
+            $asset = $this->findAssetByHtmlReference((string) $matches[2], $entryPath, $files);
+            if ( is_array($asset) && 'image/svg+xml' === ($asset['mime_type'] ?? '') && ! $this->isSafeImageAsset($asset) ) {
+                return '';
+            }
+
+            return (string) $matches[0];
+        }, $html) ?? $html;
+
+        return preg_replace('/<figure\b[^>]*>\s*<\/figure>/i', '', $html) ?? $html;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -141,19 +141,39 @@ final class BlockFactory
      */
     private function imageHtml(array $attrs): string
     {
+        $figureAttrs = $attrs;
+        if ( ! empty($attrs['sizeSlug']) ) {
+            $figureAttrs['className'] = $this->mergeClassNames((string) ($figureAttrs['className'] ?? ''), 'size-' . (string) $attrs['sizeSlug']);
+        }
+
         $imageAttrs = array(
             'src'    => $attrs['url'] ?? '',
             'alt'    => $attrs['alt'] ?? '',
             'title'  => $attrs['title'] ?? '',
             'srcset' => $attrs['srcset'] ?? '',
             'sizes'  => $attrs['sizes'] ?? '',
-            'width'  => $attrs['width'] ?? '',
-            'height' => $attrs['height'] ?? '',
+            'width'  => (string) ($attrs['width'] ?? ''),
+            'height' => (string) ($attrs['height'] ?? ''),
+            'class'  => ! empty($attrs['id']) ? 'wp-image-' . (string) $attrs['id'] : '',
         );
 
         $img = '<img' . $this->htmlAttrs($imageAttrs, array( 'alt' )) . '/>';
         $caption = ! empty($attrs['caption']) ? '<figcaption class="wp-element-caption">' . $attrs['caption'] . '</figcaption>' : '';
-        return '<figure' . $this->blockSupportAttrs($attrs, 'wp-block-image') . '>' . $img . $caption . '</figure>';
+        return '<figure' . $this->blockSupportAttrs($figureAttrs, 'wp-block-image') . '>' . $img . $caption . '</figure>';
+    }
+
+    private function mergeClassNames(string ...$classNames): string
+    {
+        $classes = array();
+        foreach ( $classNames as $className ) {
+            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
+                if ( '' !== $class && ! in_array($class, $classes, true) ) {
+                    $classes[] = $class;
+                }
+            }
+        }
+
+        return implode(' ', $classes);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -628,17 +628,31 @@ final class HtmlTransformer
         return trim(preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '');
     }
 
-    private function convertImageElement(DOMElement $image, ?DOMElement $figure = null): array
+    private function convertImageElement(DOMElement $image, ?DOMElement $figure = null): ?array
     {
-        $attrs = array_filter(array_merge($this->presentationAttributes($figure ?? $image), array(
-            'url'    => $this->attr($image, 'src'),
+        $url = $this->safeImageUrl($this->attr($image, 'src'));
+        if ( '' === $url ) {
+            return null;
+        }
+
+        $attrs = $this->imagePresentationAttributes($image, $figure);
+        $width = $this->attr($image, 'width');
+        $height = $this->attr($image, 'height');
+        if ( '' !== $width || '' !== $height ) {
+            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), 'is-resized');
+        }
+
+        $attrs = array_filter(array_merge($attrs, array(
+            'url'    => $url,
             'alt'    => $this->attr($image, 'alt'),
             'title'  => $this->attr($image, 'title'),
             'srcset' => $this->attr($image, 'srcset'),
             'sizes'  => $this->attr($image, 'sizes'),
-            'width'  => $this->attr($image, 'width'),
-            'height' => $this->attr($image, 'height'),
+            'width'  => $width,
+            'height' => $height,
         )), static fn ($value): bool => '' !== $value);
+
+        $attrs = array_filter(array_merge($attrs, $this->imageIdentityAttributes($image)), static fn ($value): bool => '' !== $value);
 
         if ( $figure instanceof DOMElement ) {
             $caption = $this->firstChildElement($figure, 'figcaption');
@@ -648,6 +662,84 @@ final class HtmlTransformer
         }
 
         return $this->createBlock('core/image', $attrs);
+    }
+
+    private function safeImageUrl(string $url): string
+    {
+        if ( ! preg_match('#^data:image/svg\+xml(?:[;,][^,]*)?,#i', $url) ) {
+            return $url;
+        }
+
+        $parts = explode(',', $url, 2);
+        if ( 2 !== count($parts) ) {
+            return '';
+        }
+
+        $metadata = strtolower($parts[0]);
+        $svg = str_contains($metadata, ';base64') ? base64_decode($parts[1], true) : rawurldecode($parts[1]);
+        if ( false === $svg || ! $this->isSafeSvgContent($svg) ) {
+            return '';
+        }
+
+        return $url;
+    }
+
+    private function isSafeSvgContent(string $content): bool
+    {
+        return '' !== trim($content) && preg_match('/<svg(?:\s|>)/i', $content) && ! preg_match('/<\s*script\b|\son[a-z]+\s*=|javascript\s*:/i', $content);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function imagePresentationAttributes(DOMElement $image, ?DOMElement $figure): array
+    {
+        $attrs = $this->presentationAttributes($figure ?? $image);
+        if ( $figure instanceof DOMElement ) {
+            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->nonCoreImageClassName($image));
+        }
+
+        return array_filter($attrs, static fn (string $value): bool => '' !== trim($value));
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    private function imageIdentityAttributes(DOMElement $image): array
+    {
+        $attrs = array();
+        $className = $this->attr($image, 'class');
+        if ( preg_match('/(?:^|\s)wp-image-(\d+)(?:\s|$)/', $className, $matches) ) {
+            $attrs['id'] = (int) $matches[1];
+        }
+        if ( preg_match('/(?:^|\s)size-([a-z0-9_-]+)(?:\s|$)/i', $className, $matches) ) {
+            $attrs['sizeSlug'] = strtolower($matches[1]);
+        }
+
+        return $attrs;
+    }
+
+    private function nonCoreImageClassName(DOMElement $image): string
+    {
+        $classes = array_filter(preg_split('/\s+/', trim($this->attr($image, 'class'))) ?: array(), static function (string $className): bool {
+            return ! preg_match('/^(?:wp-image-\d+|size-[a-z0-9_-]+)$/i', $className);
+        });
+
+        return implode(' ', $classes);
+    }
+
+    private function mergeClassNames(string ...$classNames): string
+    {
+        $classes = array();
+        foreach ( $classNames as $className ) {
+            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
+                if ( '' !== $class && ! in_array($class, $classes, true) ) {
+                    $classes[] = $class;
+                }
+            }
+        }
+
+        return implode(' ', $classes);
     }
 
     private function buttonBlockFromAnchor(DOMElement $anchor): array

--- a/php-transformer/tests/fixtures/parity/artifact-image-assets.json
+++ b/php-transformer/tests/fixtures/parity/artifact-image-assets.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "artifact-image-assets",
-  "description": "Compiles artifact entry HTML with safe referenced image assets into core image blocks while preserving asset metadata.",
+  "description": "Compiles artifact entry HTML with safe referenced image assets into core image blocks while preserving image class/dimension metadata and excluding unsafe SVG image markup.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/artifact-image-assets.json",
-    "notes": "Covers artifact-local image reference resolution and safe SVG payload preservation."
+    "notes": "Covers artifact-local image reference resolution, safe SVG payload preservation, unsafe SVG image serialization guards, and generic image primitive fidelity."
   },
   "legacy_comparison": {
     "skip": true,
@@ -18,7 +18,7 @@
       "files": [
         {
           "path": "pages/home.html",
-          "content": "<main><figure><img src=\"../assets/logo.svg\" alt=\"Logo\" width=\"120\" height=\"80\"><figcaption>Brand</figcaption></figure></main>",
+          "content": "<main><figure class=\"hero-logo\"><img class=\"wp-image-42 size-medium rounded\" src=\"../assets/logo.svg\" alt=\"Logo\" width=\"120\" height=\"80\"><figcaption>Brand</figcaption></figure><figure><img src=\"../assets/bad.svg\" alt=\"Bad\"></figure></main>",
           "mime_type": "text/html",
           "role": "entry"
         },
@@ -26,25 +26,41 @@
           "path": "assets/logo.svg",
           "content": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 80\"><rect width=\"120\" height=\"80\"/></svg>",
           "mime_type": "image/svg+xml"
+        },
+        {
+          "path": "assets/bad.svg",
+          "content": "<svg xmlns=\"http://www.w3.org/2000/svg\" onload=\"alert(1)\"><rect width=\"1\" height=\"1\"/></svg>",
+          "mime_type": "image/svg+xml"
         }
       ]
     }
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/image", "attrs": { "url": "../assets/logo.svg", "alt": "Logo", "width": "120", "height": "80", "caption": "Brand" } }
+    { "path": "blocks.0", "name": "core/image", "attrs": { "url": "../assets/logo.svg", "alt": "Logo", "width": "120", "height": "80", "caption": "Brand", "className": "hero-logo rounded is-resized", "id": 42, "sizeSlug": "medium" } }
   ],
   "expected_fallbacks": [],
   "expect": [
-    { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "source_reports.artifact.files_by_mime.image/svg+xml", "assert": "equals", "value": 1 },
+    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
+    { "path": "source_reports.artifact.files_by_mime.image/svg+xml", "assert": "equals", "value": 2 },
     { "path": "source_reports.artifact.image_references.0.source_path", "assert": "equals", "value": "pages/home.html" },
     { "path": "source_reports.artifact.image_references.0.selector", "assert": "equals", "value": "img:nth-of-type(1)" },
     { "path": "source_reports.artifact.image_references.0.resolved_path", "assert": "equals", "value": "assets/logo.svg" },
     { "path": "source_reports.artifact.image_references.0.asset_path", "assert": "equals", "value": "assets/logo.svg" },
     { "path": "source_reports.artifact.image_references.0.safe", "assert": "equals", "value": true },
+    { "path": "source_reports.artifact.image_references.1.asset_path", "assert": "equals", "value": "assets/bad.svg" },
+    { "path": "source_reports.artifact.image_references.1.safe", "assert": "equals", "value": false },
     { "path": "assets.0.path", "assert": "equals", "value": "assets/logo.svg" },
     { "path": "assets.0.content", "assert": "contains", "value": "<svg" },
+    { "path": "assets.1.path", "assert": "equals", "value": "assets/bad.svg" },
+    { "path": "assets.1.content", "assert": "equals", "value": null },
+    { "path": "diagnostics.0.code", "assert": "equals", "value": "unsafe_svg_asset" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"id\":42" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"sizeSlug\":\"medium\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-image-42\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-image hero-logo rounded is-resized size-medium" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "bad.svg" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "onload" },
     { "path": "metrics.block_count", "assert": "equals", "value": 1 }
   ]
 }


### PR DESCRIPTION
## Summary

Improves generic SVG/image handling in `php-transformer`.

Changes include:

- Filter unsafe local SVG image references before artifact entry HTML is transformed.
- Preserve safe SVG asset content while keeping unsafe SVG content out of exposed asset payloads.
- Improve image fidelity by deriving `id`, `sizeSlug`, `is-resized`, figure/image class preservation, width, and height.
- Extend artifact image parity coverage for safe SVG, unsafe SVG exclusion, image classes, dimensions, `wp-image-*`, and `size-*` serialization.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the SVG/image primitive parity slice, fixture coverage, and PR text. Chris remains responsible for review and final submission.
