### PR TITLE
Add HTML chrome primitive transforms

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -84,6 +84,13 @@ final class BlockFactory
             return $this->tableHtml($attrs);
         }
 
+        if ( 'core/details' === $name ) {
+            return array(
+                'opening' => '<details' . $this->blockSupportAttrs($attrs, 'wp-block-details') . '><summary>' . ($attrs['summary'] ?? '') . '</summary>',
+                'closing' => '</details>',
+            );
+        }
+
         if ( 'core/image' === $name ) {
             return $this->imageHtml($attrs);
         }
@@ -95,6 +102,15 @@ final class BlockFactory
         if ( 'core/button' === $name ) {
             $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
             return '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"' . $href . '>' . ($attrs['text'] ?? '') . '</a></div>';
+        }
+
+        if ( 'core/navigation' === $name ) {
+            return array( 'opening' => '<nav' . $this->blockSupportAttrs($attrs, 'wp-block-navigation') . '>', 'closing' => '</nav>' );
+        }
+
+        if ( 'core/navigation-link' === $name ) {
+            $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
+            return '<a class="wp-block-navigation-item__content"' . $href . '>' . ($attrs['label'] ?? '') . '</a>';
         }
 
         if ( 'core/shortcode' === $name ) {

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -88,7 +88,7 @@ final class HtmlTransformer
         $diagnostics = array(
             array(
                 'code'    => 'html_to_blocks_core_slice',
-                'message' => 'Converted supported core text, media, table, button, shortcode, definition-list, and wrapper elements; unsupported elements are reported as fallbacks.',
+                'message' => 'Converted supported core text, media, table, button, shortcode, definition-list, details, navigation, and wrapper elements; unsupported elements are reported as fallbacks.',
                 'source'  => self::class,
             ),
         );
@@ -115,7 +115,7 @@ final class HtmlTransformer
             provenance: $provenance,
             coverage: array(
                 array(
-                    'supported_blocks' => array( 'core/button', 'core/buttons', 'core/code', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/shortcode', 'core/table' ),
+                    'supported_blocks' => array( 'core/button', 'core/buttons', 'core/code', 'core/details', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/shortcode', 'core/table' ),
                     'block_count'      => count($blocks),
                     'fallback_count'   => count($fallbacks),
                 ),
@@ -319,6 +319,18 @@ final class HtmlTransformer
             return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), $this->tableAttributes($element)));
         }
 
+        if ( 'details' === $tagName ) {
+            $summary = $this->firstChildElement($element, 'summary');
+            $children = $this->convertChildrenWithoutTags($element, $fallbacks, array( 'summary' ));
+            if ( null === $summary && array() === $children ) {
+                return null;
+            }
+
+            return $this->createBlock('core/details', array_filter(array_merge($this->presentationAttributes($element), array(
+                'summary' => $summary instanceof DOMElement ? $this->innerHtml($summary) : '',
+            )), static fn ($value): bool => '' !== $value), $children);
+        }
+
         if ( 'img' === $tagName ) {
             return $this->convertImageElement($element);
         }
@@ -348,7 +360,14 @@ final class HtmlTransformer
             return null;
         }
 
-        if ( in_array($tagName, array( 'article', 'body', 'div', 'main', 'section' ), true) ) {
+        if ( 'nav' === $tagName ) {
+            $navigationLinks = $this->navigationLinks($element);
+            if ( array() !== $navigationLinks ) {
+                return $this->createBlock('core/navigation', $this->presentationAttributes($element), $navigationLinks);
+            }
+        }
+
+        if ( in_array($tagName, array( 'article', 'body', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
             $buttonChildren = $this->buttonChildren($element);
             if ( array() !== $buttonChildren ) {
                 return $this->createBlock('core/buttons', $this->presentationAttributes($element), $buttonChildren);
@@ -443,7 +462,7 @@ final class HtmlTransformer
 
     private function shouldPreserveWrapper(DOMElement $element): bool
     {
-        return in_array(strtolower($element->tagName), array( 'article', 'div', 'main', 'section' ), true) && array() !== $this->presentationAttributes($element);
+        return in_array(strtolower($element->tagName), array( 'article', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) && array() !== $this->presentationAttributes($element);
     }
 
     private function isInlineContentElement(string $tagName): bool
@@ -529,6 +548,38 @@ final class HtmlTransformer
             $html .= $element->ownerDocument->saveHTML($child);
         }
         return trim($html);
+    }
+
+    /**
+     * @param array<int, string> $excludedTags
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<int, array<string, mixed>>
+     */
+    private function convertChildrenWithoutTags(DOMElement $element, array &$fallbacks, array $excludedTags): array
+    {
+        $blocks = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), $excludedTags, true) ) {
+                continue;
+            }
+
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                $text = trim($child->textContent ?? '');
+                if ( '' !== $text ) {
+                    $blocks = array_merge($blocks, $this->convertText($text));
+                }
+                continue;
+            }
+
+            if ( $child instanceof DOMElement ) {
+                $block = $this->convertElement($child, $fallbacks, true);
+                if ( null !== $block ) {
+                    $blocks[] = $block;
+                }
+            }
+        }
+
+        return $blocks;
     }
 
     /**
@@ -656,6 +707,65 @@ final class HtmlTransformer
             'text' => $this->innerHtml($anchor),
             'url'  => $this->attr($anchor, 'href'),
         )), static fn ($value): bool => '' !== $value));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function navigationLinks(DOMElement $element): array
+    {
+        $links = array();
+        foreach ( $this->directNavigationAnchors($element) as $anchor ) {
+            $links[] = $this->createBlock('core/navigation-link', array_filter(array(
+                'label' => $this->innerHtml($anchor),
+                'url'   => $this->attr($anchor, 'href'),
+                'kind'  => 'custom',
+            ), static fn ($value): bool => '' !== $value));
+        }
+
+        return $links;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function directNavigationAnchors(DOMElement $element): array
+    {
+        $anchors = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') ) {
+                $anchors[] = $child;
+                continue;
+            }
+
+            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'ul', 'ol' ), true) ) {
+                foreach ( $child->childNodes as $item ) {
+                    if ( XML_TEXT_NODE === $item->nodeType && '' === trim($item->textContent ?? '') ) {
+                        continue;
+                    }
+
+                    if ( ! $item instanceof DOMElement || 'li' !== strtolower($item->tagName) ) {
+                        return array();
+                    }
+
+                    $anchor = $this->firstChildElement($item, 'a');
+                    if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') || 1 !== $this->childElementCount($item) ) {
+                        return array();
+                    }
+
+                    $anchors[] = $anchor;
+                }
+                continue;
+            }
+
+            return array();
+        }
+
+        return $anchors;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-interactive-chrome-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-interactive-chrome-primitives.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-interactive-chrome-primitives",
+  "description": "Converts generic details, safe navigation links, and static header/footer chrome into core block primitives without fallback metadata.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-interactive-chrome-primitives.json",
+    "notes": "Product-neutral fixture for upstream HTML primitive migration gaps."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"site-header\"><h1>Brand</h1><nav class=\"primary-nav\"><ul><li><a href=\"/docs\">Docs</a></li><li><a href=\"/pricing\">Pricing</a></li></ul></nav></header><main><details class=\"faq\" open><summary>What ships?</summary><p>Native primitives.</p></details></main><footer class=\"site-footer\"><p><a href=\"/contact\">Contact</a></p></footer>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Brand", "level": 1 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Docs", "url": "/docs", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Pricing", "url": "/pricing", "kind": "custom" } },
+    { "path": "blocks.1", "name": "core/details", "attrs": { "summary": "What ships?", "className": "faq" } },
+    { "path": "blocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Native primitives." } },
+    { "path": "blocks.2", "name": "core/group", "attrs": { "className": "site-footer" } },
+    { "path": "blocks.2.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "<a href=\"/contact\">Contact</a>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.1.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:details" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a focused set of generic HTML chrome/interactive primitives to `php-transformer`.

Changes include:

- `details` to `core/details` with summary and converted inner blocks.
- Safe `nav` link lists/direct anchors to `core/navigation` and `core/navigation-link`.
- `header`, `footer`, and fallback `nav` static chrome handled as `core/group`.
- New parity fixture for header/nav/details/footer chrome primitives.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the HTML chrome primitive slice, fixture coverage, and PR text. Chris remains responsible for review and final submission.
