### PR TITLE
Preserve HTML presentation provenance

### DIFF
--- a/docs/contracts/php-transformer-parity-fixtures.md
+++ b/docs/contracts/php-transformer-parity-fixtures.md
@@ -41,5 +41,6 @@ Product-shaped fixtures are compact contract slices inspired by representative p
 - HTML-to-block conversion for representative hero/action and product-card structures.
 - Markdown conversion for nested mixed-source documents.
 - Artifact compilation for website artifact bundles and manifest files as preserved data assets.
+- Generic HTML wrapper presentation provenance for useful class, style, and layout signals. Supported blocks keep these signals in block attributes, while `source_reports.html.presentation_signals` records the source selector, tag, captured signals, and source attributes that produced them.
 
 The consuming product remains responsible for source discovery, route/link rewrites, import reports, product manifest validation, generated theme files, navigation entities, and visual/semantic parity gates.

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -19,6 +19,11 @@ final class HtmlTransformer
      */
     private array $fallbackProvenance = array();
 
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $presentationProvenance = array();
+
     public function __construct(private readonly Runtime $runtime = new Runtime())
     {
         $this->blockFactory = new BlockFactory();
@@ -32,6 +37,7 @@ final class HtmlTransformer
         $context                  = TransformationOptions::context($options);
         $startedAt                = hrtime(true);
         $this->fallbackProvenance = TransformationOptions::provenance($options);
+        $this->presentationProvenance = array();
         $provenance               = array(
             array_merge(array(
                 'source_format' => 'html',
@@ -113,6 +119,11 @@ final class HtmlTransformer
             diagnostics: $diagnostics,
             fallbacks: $fallbacks,
             provenance: $provenance,
+            sourceReports: array(
+                'html' => array(
+                    'presentation_signals' => $this->presentationProvenance,
+                ),
+            ),
             coverage: array(
                 array(
                     'supported_blocks' => array( 'core/button', 'core/buttons', 'core/code', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/shortcode', 'core/table' ),
@@ -220,7 +231,7 @@ final class HtmlTransformer
             return $this->createBlock('core/heading', array_merge($this->presentationAttributes($element), array(
                 'content' => $content,
                 'level'   => (int) $matches[1],
-            )));
+            )), array(), $element);
         }
 
         if ( 'p' === $tagName ) {
@@ -230,7 +241,7 @@ final class HtmlTransformer
                 return $textBlocks[0] ?? null;
             }
 
-            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )));
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
         }
 
         if ( $this->isInlineContentElement($tagName) ) {
@@ -246,7 +257,7 @@ final class HtmlTransformer
             $items = array();
             foreach ( $element->childNodes as $child ) {
                 if ( $child instanceof DOMElement && 'li' === strtolower($child->tagName) ) {
-                    $items[] = $this->createBlock('core/list-item', array_merge($this->presentationAttributes($child), array( 'content' => $this->innerHtml($child) )));
+                    $items[] = $this->createBlock('core/list-item', array_merge($this->presentationAttributes($child), array( 'content' => $this->innerHtml($child) )), array(), $child);
                 }
             }
 
@@ -254,7 +265,7 @@ final class HtmlTransformer
                 return null;
             }
 
-            return $this->createBlock('core/list', array_merge($this->presentationAttributes($element), 'ol' === $tagName ? array( 'ordered' => true ) : array()), $items);
+            return $this->createBlock('core/list', array_merge($this->presentationAttributes($element), 'ol' === $tagName ? array( 'ordered' => true ) : array()), $items, $element);
         }
 
         if ( 'dl' === $tagName ) {
@@ -263,7 +274,7 @@ final class HtmlTransformer
                 return null;
             }
 
-            return $this->createBlock('core/list', $this->presentationAttributes($element), $items);
+            return $this->createBlock('core/list', $this->presentationAttributes($element), $items, $element);
         }
 
         if ( 'blockquote' === $tagName ) {
@@ -283,7 +294,7 @@ final class HtmlTransformer
                 return $this->createBlock('core/pullquote', array_filter(array_merge($this->presentationAttributes($element), array(
                     'value'    => $value,
                     'citation' => $citation,
-                )), static fn ($value): bool => '' !== $value));
+                )), static fn ($value): bool => '' !== $value), array(), $element);
             }
 
             $innerBlocks = $this->convertChildren($element, $fallbacks);
@@ -291,7 +302,7 @@ final class HtmlTransformer
                 $innerBlocks[] = $this->createBlock('core/paragraph', array( 'content' => $value ));
             }
 
-            return $this->createBlock('core/quote', array_filter(array_merge($this->presentationAttributes($element), array( 'citation' => $citation )), static fn ($value): bool => '' !== $value), $innerBlocks);
+            return $this->createBlock('core/quote', array_filter(array_merge($this->presentationAttributes($element), array( 'citation' => $citation )), static fn ($value): bool => '' !== $value), $innerBlocks, $element);
         }
 
         if ( 'figure' === $tagName ) {
@@ -309,14 +320,14 @@ final class HtmlTransformer
         if ( 'pre' === $tagName ) {
             $code = $this->firstChildElement($element, 'code');
             if ( $code instanceof DOMElement ) {
-                return $this->createBlock('core/code', array_merge($this->presentationAttributes($element), array( 'content' => $code->textContent ?? '' )));
+                return $this->createBlock('core/code', array_merge($this->presentationAttributes($element), array( 'content' => $code->textContent ?? '' )), array(), $element);
             }
 
-            return $this->createBlock('core/preformatted', array_merge($this->presentationAttributes($element), array( 'content' => $this->innerHtml($element) )));
+            return $this->createBlock('core/preformatted', array_merge($this->presentationAttributes($element), array( 'content' => $this->innerHtml($element) )), array(), $element);
         }
 
         if ( 'table' === $tagName ) {
-            return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), $this->tableAttributes($element)));
+            return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), $this->tableAttributes($element)), array(), $element);
         }
 
         if ( 'img' === $tagName ) {
@@ -324,11 +335,11 @@ final class HtmlTransformer
         }
 
         if ( 'a' === $tagName && '' !== trim($element->textContent ?? '') ) {
-            return $this->createBlock('core/buttons', array(), array( $this->buttonBlockFromAnchor($element) ));
+            return $this->createBlock('core/buttons', array(), array( $this->buttonBlockFromAnchor($element) ), $element);
         }
 
         if ( 'button' === $tagName ) {
-            return $this->createBlock('core/buttons', array(), array( $this->createBlock('core/button', array_merge($this->presentationAttributes($element), array( 'text' => $this->innerHtml($element) ))) ));
+            return $this->createBlock('core/buttons', array(), array( $this->createBlock('core/button', array_merge($this->presentationAttributes($element), array( 'text' => $this->innerHtml($element) )), array(), $element) ), $element);
         }
 
         if ( 'form' === $tagName ) {
@@ -351,18 +362,18 @@ final class HtmlTransformer
         if ( in_array($tagName, array( 'article', 'body', 'div', 'main', 'section' ), true) ) {
             $buttonChildren = $this->buttonChildren($element);
             if ( array() !== $buttonChildren ) {
-                return $this->createBlock('core/buttons', $this->presentationAttributes($element), $buttonChildren);
+                return $this->createBlock('core/buttons', $this->presentationAttributes($element), $buttonChildren, $element);
             }
 
             $children = $this->convertChildren($element, $fallbacks, true);
             if ( 1 === count($children) ) {
                 if ( $this->shouldPreserveWrapper($element) && 'core/group' !== ($children[0]['blockName'] ?? '') ) {
-                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children);
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
                 }
                 return $children[0];
             }
             if ( array() !== $children ) {
-                return $this->createBlock('core/group', $this->presentationAttributes($element), $children);
+                return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
             }
             return null;
         }
@@ -405,8 +416,12 @@ final class HtmlTransformer
      * @param array<int, array<string, mixed>> $innerBlocks
      * @return array<string, mixed>
      */
-    private function createBlock(string $name, array $attrs = array(), array $innerBlocks = array()): array
+    private function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
+        if ( $sourceElement instanceof DOMElement ) {
+            $this->recordPresentationProvenance($name, $attrs, $sourceElement);
+        }
+
         return $this->blockFactory->create($name, $attrs, $innerBlocks);
     }
 
@@ -431,14 +446,64 @@ final class HtmlTransformer
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
     private function presentationAttributes(DOMElement $element): array
     {
         return array_filter(array(
             'className' => $this->attr($element, 'class'),
             'style'     => $this->attr($element, 'style'),
-        ), static fn (string $value): bool => '' !== trim($value));
+            'layout'    => $this->layoutAttribute($element),
+        ), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function layoutAttribute(DOMElement $element): array
+    {
+        $declared = trim($this->attr($element, 'data-layout'));
+        if ( '' === $declared ) {
+            $declared = trim($this->attr($element, 'data-wp-layout'));
+        }
+
+        if ( '' !== $declared ) {
+            $decoded = json_decode($declared, true);
+            $type = is_array($decoded) ? (string) ($decoded['type'] ?? '') : $declared;
+            if ( in_array($type, array( 'constrained', 'flex', 'flow', 'grid' ), true) ) {
+                return array( 'type' => $type );
+            }
+        }
+
+        $style = strtolower($this->attr($element, 'style'));
+        if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $style) ) {
+            return array( 'type' => 'flex' );
+        }
+        if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?grid\b/', $style) ) {
+            return array( 'type' => 'grid' );
+        }
+
+        return array();
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function recordPresentationProvenance(string $blockName, array $attrs, DOMElement $element): void
+    {
+        $signals = array_intersect_key($attrs, array_flip(array( 'className', 'style', 'layout' )));
+        $signals = array_filter($signals, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+        if ( array() === $signals ) {
+            return;
+        }
+
+        $this->presentationProvenance[] = array(
+            'block_name'        => $blockName,
+            'tag'               => strtolower($element->tagName),
+            'selector'          => $this->elementSelector($element),
+            'signals'           => $signals,
+            'source_attributes' => array_intersect_key($this->htmlAttributes($element), array_flip(array( 'class', 'style', 'data-layout', 'data-wp-layout' ))),
+        );
     }
 
     private function shouldPreserveWrapper(DOMElement $element): bool
@@ -616,7 +681,7 @@ final class HtmlTransformer
                 $prefix = '' !== trim($term) ? '<strong>' . $term . '</strong>' : '';
                 $items[] = $this->createBlock('core/list-item', array_merge($this->presentationAttributes($child), array(
                     'content' => trim($prefix . ( '' !== $prefix && '' !== trim($description) ? ' ' : '' ) . $description),
-                )));
+                )), array(), $child);
             }
         }
 
@@ -647,7 +712,7 @@ final class HtmlTransformer
             }
         }
 
-        return $this->createBlock('core/image', $attrs);
+        return $this->createBlock('core/image', $attrs, array(), $figure ?? $image);
     }
 
     private function buttonBlockFromAnchor(DOMElement $anchor): array
@@ -655,7 +720,7 @@ final class HtmlTransformer
         return $this->createBlock('core/button', array_filter(array_merge($this->presentationAttributes($anchor), array(
             'text' => $this->innerHtml($anchor),
             'url'  => $this->attr($anchor, 'href'),
-        )), static fn ($value): bool => '' !== $value));
+        )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $anchor);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
+++ b/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
@@ -13,14 +13,14 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<section class=\"hero-shell\"><h2>Only child</h2></section><svg class=\"badge\"><script>alert(1)</script><circle cx=\"1\" cy=\"1\" r=\"1\"></circle></svg>",
+    "content": "<section class=\"hero-shell\" style=\"padding: 2rem;\" data-layout=\"constrained\"><h2>Only child</h2></section><svg class=\"badge\"><script>alert(1)</script><circle cx=\"1\" cy=\"1\" r=\"1\"></circle></svg>",
     "options": {
       "source": "fixture:html-provenance-wrapper-safety",
       "source_scope": "parity"
     }
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-shell" } },
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-shell", "style": "padding: 2rem;", "layout": { "type": "constrained" } } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Only child", "level": 2 } }
   ],
   "expected_fallbacks": [
@@ -34,6 +34,12 @@
     { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script>" },
     { "path": "provenance.0.source", "assert": "equals", "value": "fixture:html-provenance-wrapper-safety" },
     { "path": "provenance.0.scope", "assert": "equals", "value": "parity" },
+    { "path": "source_reports.html.presentation_signals", "assert": "count", "count": 1 },
+    { "path": "source_reports.html.presentation_signals.0.selector", "assert": "equals", "value": "section:nth-of-type(1)" },
+    { "path": "source_reports.html.presentation_signals.0.signals.className", "assert": "equals", "value": "hero-shell" },
+    { "path": "source_reports.html.presentation_signals.0.signals.style", "assert": "equals", "value": "padding: 2rem;" },
+    { "path": "source_reports.html.presentation_signals.0.signals.layout.type", "assert": "equals", "value": "constrained" },
+    { "path": "source_reports.html.presentation_signals.0.source_attributes.data-layout", "assert": "equals", "value": "constrained" },
     { "path": "diagnostics.1.selector", "assert": "equals", "value": "svg:nth-of-type(1)" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
   ]


### PR DESCRIPTION
## Summary

Adds generic presentation provenance to the HTML transformer.

Changes include:

- Preserve useful `className`, inline `style`, and inferred `layout` signals on supported HTML blocks.
- Infer layout from `data-layout`, `data-wp-layout`, and inline `display:flex/grid`.
- Expose selector-level presentation signals at `source_reports.html.presentation_signals`.
- Extend parity fixture expectations and docs for the generic provenance contract.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the layout/style provenance slice, fixture/docs updates, and PR text. Chris remains responsible for review and final submission.
