### PR TITLE
Document php-transformer release readiness

### DIFF
--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -99,3 +99,29 @@ Unsupported or unsafe artifact inputs are reported through diagnostics instead o
 ## Parity Checks
 
 Run the package contract and parity fixtures with `composer test`. The checked-in fixtures assert current transformer behavior.
+
+## Release Consumption
+
+The package lives in a subtree of the Blocks Engine repository. Consumers should require the Composer package name, not copy files from this repository or depend on the repository root:
+
+```sh
+composer require automattic/blocks-engine-php-transformer:^0.1.0
+```
+
+Before the first tag is available, review branches may use a Composer VCS or path repository with an inline alias. Merge-ready downstream PRs should replace those review-only constraints with the tagged package constraint.
+
+Homeboy owns the local release preflight for this package through `php-transformer/homeboy.json`. The only version target is `VERSION`, currently `0.1.0`; release automation should tag from the package subtree after the upstream PRs are merged, without adding wrapper-package names to this package metadata.
+
+Recommended post-merge dry-run:
+
+```sh
+homeboy release php-transformer --dry-run --skip-publish --no-github-release
+```
+
+Recommended first release command after the dry-run passes and the merge commit is ready to tag:
+
+```sh
+homeboy release php-transformer --skip-publish --no-github-release
+```
+
+Use `--skip-publish` because Composer/Packagist consumption should follow the repository tag, and use `--no-github-release` when GitHub Releases are not part of the first package publication path. Do not run release commands from downstream wrapper branches or while path repositories, unpublished branch constraints, or local-only evidence are still required by merge candidates.

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -3,6 +3,17 @@
   "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
   "type": "library",
   "license": "GPL-3.0-or-later",
+  "keywords": [
+    "blocks",
+    "html",
+    "markdown",
+    "wordpress"
+  ],
+  "homepage": "https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer",
+  "support": {
+    "issues": "https://github.com/Automattic/blocks-engine/issues",
+    "source": "https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer"
+  },
   "autoload": {
     "psr-4": {
       "Automattic\\BlocksEngine\\PhpTransformer\\": "src/"

--- a/php-transformer/docs/consumer-prs/packaging.md
+++ b/php-transformer/docs/consumer-prs/packaging.md
@@ -77,6 +77,18 @@ Old wrapper repositories may require `automattic/blocks-engine-php-transformer` 
 
 During review, downstream consumers may use either Composer VCS repositories or local path repositories.
 
+After the transformer release is tagged, downstream consumers should remove custom repository entries and require the package by tag constraint:
+
+```json
+{
+  "require": {
+    "automattic/blocks-engine-php-transformer": "^0.1.0"
+  }
+}
+```
+
+The package is rooted at `php-transformer/`; release and packaging checks should run from that directory. Do not package the full Blocks Engine repository as the Composer artifact, and do not move the transformer files into a downstream repository to make Composer resolution easier.
+
 Use a VCS repository when the consumer branch runs outside this machine or in CI:
 
 ```json
@@ -125,6 +137,26 @@ Downstream wrappers must support their current unprefixed development installs. 
 ## Versioning
 
 The first tagged release should be `0.1.0` unless maintainers choose a repo-wide release scheme before merge.
+
+Release readiness preflight before tagging:
+
+```sh
+cd "$BLOCKS_ENGINE_WORKTREE/php-transformer"
+composer validate --strict
+composer test
+
+cd "$BLOCKS_ENGINE_WORKTREE"
+homeboy component show php-transformer
+homeboy release php-transformer --dry-run --skip-publish --no-github-release
+```
+
+Recommended release command after upstream PRs are merged and the dry-run passes:
+
+```sh
+homeboy release php-transformer --skip-publish --no-github-release
+```
+
+Run the release from the merged Blocks Engine branch that should own the tag, not from a downstream wrapper branch. Keep `VERSION` as the Homeboy-managed package version source.
 
 Before `1.0.0`, public PHP class names, constructor signatures, result-envelope keys, diagnostic codes, and Composer package metadata may change between minor versions, but each change must include downstream migration notes and fixture updates.
 


### PR DESCRIPTION
## Summary

Improves `php-transformer` package discoverability and release guidance.

Changes include:

- Composer metadata: `keywords`, `homepage`, and `support`.
- Documentation for the tagged downstream consumption constraint: `automattic/blocks-engine-php-transformer:^0.1.0`.
- Subtree/path packaging guidance and release preflight steps.
- Recommended Homeboy dry-run and first release command.

## Verification

From `php-transformer/`:

- `composer validate --strict`
- `composer test`
- `homeboy component show php-transformer`

Release dry-run behavior:

- `homeboy release php-transformer --dry-run --skip-publish --no-github-release` reached Homeboy release preflight and refused from branch `cook/php-transformer-release-package-readiness` because releases must run from default branch `trunk`. No release/tag/GitHub Release was created.

Recommended after merge to `trunk` and successful dry-run:

```sh
homeboy release php-transformer --skip-publish --no-github-release
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing package metadata/docs and PR text. Chris remains responsible for review and final submission.
