### PR TITLE
Configure php-transformer changelog target

### DIFF
--- a/php-transformer/homeboy.json
+++ b/php-transformer/homeboy.json
@@ -1,5 +1,6 @@
 {
   "auto_cleanup": false,
+  "changelog_target": "CHANGELOG.md",
   "id": "php-transformer",
   "remote_path": "",
   "version_targets": [


### PR DESCRIPTION
## Summary

Configures the Homeboy changelog target for the independently released `php-transformer` component.

Homeboy release planning refused without a `changelog_target`; this adds `CHANGELOG.md` to `php-transformer/homeboy.json`.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `homeboy component show php-transformer`

Release dry-run after this change reaches the expected default-branch preflight from this feature branch.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Detecting the Homeboy release config gap, adding the changelog target, running verification, and drafting PR text. Chris remains responsible for review and final submission.
