### PR TITLE
Extend compiled site document contract

### DIFF
--- a/php-transformer/docs/contracts/result-envelope.md
+++ b/php-transformer/docs/contracts/result-envelope.md
@@ -34,7 +34,7 @@ Required top-level keys for successful transformations:
 
 `status` is one of `success`, `success_with_warnings`, or `failed`. Artifact compiler callers should use `source_reports.artifact` for normalized input metadata such as entry path, accepted/rejected file counts, MIME/kind/role counts, and source HTML metrics.
 
-Artifact compiler callers that need a compiled site view should read `source_reports.compiled_site`. It exposes a generic `blocks-engine/php-transformer/compiled-site/v1` report with normalized `pages`, `assets`, and `theme` buckets for stylesheets, scripts, fonts, images, and generated block types. Product adapters should map from this report plus the top-level `documents` and `assets` arrays instead of depending on product-specific artifact semantics.
+Artifact compiler callers that need a compiled site view should read `source_reports.compiled_site`. It exposes a generic `blocks-engine/php-transformer/compiled-site/v1` report with normalized `pages`, per-page `metadata`, full page `block_markup`, `assets`, `template_parts`, `visual_repair`, and `theme` buckets for stylesheets, scripts, fonts, images, template parts, and generated block types. Product adapters should map from this report plus the top-level `documents` and `assets` arrays instead of depending on product-specific artifact semantics.
 
 `components` contains inspectable component candidates discovered before materialization. `block_types` contains generated block type artifacts promoted from `block.json` roots. `legacy_mapping` is transitional metadata for consumer-owned migration mappers and is not a long-term package feature commitment.
 

--- a/php-transformer/docs/html-transform-coverage.md
+++ b/php-transformer/docs/html-transform-coverage.md
@@ -19,7 +19,7 @@ Run the coverage fixtures with `composer parity` or as part of `composer test`.
 | Wrapper provenance and safety | `html-provenance-wrapper-safety.json` | Presentational semantic wrappers are preserved as `core/group`; unsupported fallback records include selector/source metadata and sanitized fallback HTML |
 | Unsupported fallback | `unsupported-fallback.json`, `html-unsupported-context-required.json` | Unsupported elements are reported in `fallbacks` and do not fail supported siblings |
 | Website artifact bundle | `website-artifact-bundle.json` | HTML, CSS, and JS artifact inputs compile into the shared result envelope |
-| Compiled site contract | `compiled-site-contract.json` | Generic site artifacts expose normalized pages, assets, and theme buckets in `source_reports.compiled_site` |
+| Compiled site contract | `compiled-site-contract.json` | Generic site artifacts expose normalized pages, document metadata, full page block markup, template parts, visual-repair stylesheets, assets, and theme buckets in `source_reports.compiled_site` |
 | Generated store artifacts | `generated-store-inferred-html.json`, `generated-store-manifest-valid-artifact.json`, `generated-store-manifest-invalid-artifact.json` | Product-shaped generated artifacts preserve files, manifests, components, and diagnostics without owning product validation |
 | Mixed source markdown | `mixed-source-markdown.json` | Markdown documents compile into transformer document output |
 

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -229,24 +229,29 @@ final class ArtifactCompiler
     {
         $pages = array();
         foreach ( $artifact['files'] as $file ) {
-            if ( 'html' !== ($file['kind'] ?? '') ) {
+            if ( 'html' !== ($file['kind'] ?? '') || $this->isTemplatePartFile($file) ) {
                 continue;
             }
 
             $path = (string) ($file['path'] ?? '');
+            $title = $this->titleFromHtml((string) ($file['content'] ?? ''), $path);
+            $slug = $this->slugFromPath($path);
+            $blockMarkup = $path === $entryPath ? $serializedBlocks : $this->htmlDocumentBlockMarkup((string) ($file['content'] ?? ''));
             $pages[] = array_filter(
                 array(
                     'source_path'    => $path,
                     'kind'           => 'html',
                     'role'           => $file['role'] ?? 'document',
                     'entrypoint'     => $path === $entryPath || ! empty($file['entrypoint']),
-                    'slug'           => $this->slugFromPath($path),
-                    'title'          => $this->titleFromHtml((string) ($file['content'] ?? ''), $path),
+                    'slug'           => $slug,
+                    'title'          => $title,
+                    'metadata'       => $this->documentMetadata($path, 'html', (string) ($file['role'] ?? 'document'), $slug, $title, 'html'),
+                    'html'           => $file['content'] ?? '',
                     'body_format'    => 'html',
-                    'block_markup'   => $path === $entryPath ? $serializedBlocks : '',
+                    'block_markup'   => $blockMarkup,
                     'bytes'          => $file['bytes'] ?? 0,
                     'mime_type'      => $file['mime_type'] ?? 'text/html',
-                    'asset_references' => $path === $entryPath ? $this->assetReferencePaths($assets) : array(),
+                    'asset_references' => $this->assetReferencePaths($assets),
                     'provenance'     => $file['provenance'] ?? array(),
                 ),
                 static fn (mixed $value): bool => array() !== $value
@@ -262,6 +267,15 @@ final class ArtifactCompiler
                     'entrypoint'   => false,
                     'slug'         => $document['slug'] ?? '',
                     'title'        => $document['title'] ?? '',
+                    'metadata'     => $this->documentMetadata(
+                        (string) ($document['source_path'] ?? ''),
+                        (string) ($document['kind'] ?? 'document'),
+                        'document',
+                        (string) ($document['slug'] ?? ''),
+                        (string) ($document['title'] ?? ''),
+                        (string) ($document['body_format'] ?? ''),
+                        $document
+                    ),
                     'body_format'  => $document['body_format'] ?? '',
                     'block_markup' => $document['block_markup'] ?? '',
                     'provenance'   => $document['provenance'] ?? array(),
@@ -276,11 +290,17 @@ final class ArtifactCompiler
             'entry_path'  => $entryPath,
             'pages'       => $pages,
             'assets'      => $this->compiledSiteAssets($assets),
+            'template_parts' => $this->compiledSiteTemplateParts($artifact['files']),
+            'visual_repair' => $this->compiledSiteVisualRepair($assets),
             'theme'       => array(
                 'stylesheets' => $this->assetPathsByIntentOrRole($assets, 'style', 'stylesheet'),
                 'scripts'     => $this->assetPathsByIntentOrRole($assets, 'behavior', 'script'),
                 'fonts'       => $this->assetPathsByRole($assets, 'font'),
                 'images'      => $this->assetPathsByRole($assets, 'image'),
+                'template_parts' => array_values(array_map(
+                    static fn (array $part): string => (string) ($part['source_path'] ?? ''),
+                    $this->compiledSiteTemplateParts($artifact['files'])
+                )),
                 'block_types' => array_values(array_map(
                     static fn (array $blockType): string => (string) ($blockType['name'] ?? ''),
                     $blockTypes
@@ -292,6 +312,139 @@ final class ArtifactCompiler
                 'input_bytes' => $artifact['bytes'],
             ),
         );
+    }
+
+    private function htmlDocumentBlockMarkup(string $html): string
+    {
+        if ( '' === trim($html) ) {
+            return '';
+        }
+        if ( $this->containsBlockMarkup($html) ) {
+            return $html;
+        }
+
+        return '<!-- wp:html -->' . "\n" . $html . "\n" . '<!-- /wp:html -->';
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     * @return array<string, mixed>
+     */
+    private function documentMetadata(string $sourcePath, string $kind, string $role, string $slug, string $title, string $bodyFormat, array $document = array()): array
+    {
+        return array_filter(
+            array(
+                'source_path' => $sourcePath,
+                'kind'        => $kind,
+                'role'        => $role,
+                'post_type'   => $document['post_type'] ?? ('document' === $role ? 'page' : ''),
+                'slug'        => $slug,
+                'title'       => $title,
+                'excerpt'     => $document['excerpt'] ?? '',
+                'date'        => $document['date'] ?? '',
+                'template'    => $document['template'] ?? '',
+                'taxonomies'  => $document['taxonomies'] ?? array(),
+                'body_format' => $bodyFormat,
+            ),
+            static fn (mixed $value): bool => '' !== $value && array() !== $value
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, array<string, mixed>>
+     */
+    private function compiledSiteTemplateParts(array $files): array
+    {
+        $parts = array();
+        foreach ( $files as $file ) {
+            $path = (string) ($file['path'] ?? '');
+            if ( ! $this->isTemplatePartFile($file) ) {
+                continue;
+            }
+
+            $slug = $this->slugFromPath($path);
+            $parts[] = array_filter(
+                array(
+                    'source_path'  => $path,
+                    'slug'         => $slug,
+                    'title'        => $this->titleFromPath($path),
+                    'area'         => $this->templatePartArea($path, (string) ($file['role'] ?? '')),
+                    'body_format'  => (string) ($file['kind'] ?? ''),
+                    'block_markup' => $this->htmlDocumentBlockMarkup((string) ($file['content'] ?? '')),
+                    'bytes'        => $file['bytes'] ?? 0,
+                    'provenance'   => $file['provenance'] ?? array(),
+                ),
+                static fn (mixed $value): bool => '' !== $value && array() !== $value
+            );
+        }
+
+        return $parts;
+    }
+
+    /**
+     * @param array<string, mixed> $file
+     */
+    private function isTemplatePartFile(array $file): bool
+    {
+        $path = (string) ($file['path'] ?? '');
+        $role = (string) ($file['role'] ?? '');
+        return 'html' === ($file['kind'] ?? '') && ('template-part' === $role || preg_match('#(^|/)(parts|template-parts)/[^/]+\.html?$#i', $path));
+    }
+
+    private function templatePartArea(string $path, string $role): string
+    {
+        if ( preg_match('/\b(header|footer|sidebar|navigation)\b/i', $path . ' ' . $role, $match) ) {
+            return strtolower($match[1]);
+        }
+
+        return 'uncategorized';
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     * @return array<string, mixed>
+     */
+    private function compiledSiteVisualRepair(array $assets): array
+    {
+        $stylesheets = array_values(array_filter($assets, fn (array $asset): bool => $this->isVisualRepairStylesheet($asset)));
+        $css = '';
+        foreach ( $stylesheets as $asset ) {
+            if ( isset($asset['content']) && is_string($asset['content']) ) {
+                $css .= ('' === $css ? '' : "\n") . $asset['content'];
+            }
+        }
+
+        return array_filter(
+            array(
+                'stylesheets' => array_values(array_map(
+                    static fn (array $asset): array => array_filter(
+                        array(
+                            'path'      => $asset['path'] ?? '',
+                            'role'      => $asset['role'] ?? '',
+                            'intent'    => $asset['intent'] ?? '',
+                            'mime_type' => $asset['mime_type'] ?? '',
+                            'bytes'     => $asset['bytes'] ?? 0,
+                        ),
+                        static fn (mixed $value): bool => '' !== $value
+                    ),
+                    $stylesheets
+                )),
+                'css'         => $css,
+            ),
+            static fn (mixed $value): bool => '' !== $value && array() !== $value
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $asset
+     */
+    private function isVisualRepairStylesheet(array $asset): bool
+    {
+        $path = (string) ($asset['path'] ?? '');
+        $role = (string) ($asset['role'] ?? '');
+        $intent = (string) ($asset['intent'] ?? '');
+        return 'css' === ($asset['kind'] ?? '') && ('visual-repair' === $role || 'visual-repair' === $intent || preg_match('/(?:^|[-_\/])visual[-_]repair(?:[-_\/]|\.)/i', $path));
     }
 
     private function titleFromHtml(string $html, string $path): string
@@ -542,6 +695,9 @@ final class ArtifactCompiler
             );
             if ( ! empty($file['content_base64']) ) {
                 $asset['content_base64'] = $file['content_base64'];
+            }
+            if ( 'css' === ($file['kind'] ?? '') && empty($file['binary']) ) {
+                $asset['content'] = $file['content'];
             }
             if ( 'image/svg+xml' === ($file['mime_type'] ?? '') && empty($file['binary']) && $this->isSafeSvgContent((string) ($file['content'] ?? '')) ) {
                 $asset['content'] = $file['content'];

--- a/php-transformer/tests/fixtures/parity/compiled-site-contract.json
+++ b/php-transformer/tests/fixtures/parity/compiled-site-contract.json
@@ -25,9 +25,20 @@
           "content": "<main><h1>About The Site</h1><p>Secondary page.</p></main>"
         },
         {
+          "path": "public/parts/header.html",
+          "content": "<header><nav><a href=\"/\">Home</a></nav></header>",
+          "role": "template-part"
+        },
+        {
           "path": "public/assets/site.css",
           "content": "main{max-width:60rem;margin:auto}",
           "kind": "css"
+        },
+        {
+          "path": "public/assets/visual-repair.css",
+          "content": ".wp-site-blocks{min-height:100vh}",
+          "kind": "css",
+          "intent": "visual-repair"
         },
         {
           "path": "public/assets/site.js",
@@ -41,7 +52,7 @@
         },
         {
           "path": "content/guide.md",
-          "content": "---\ntitle: Guide Page\nslug: guide\n---\n\n# Guide Page\n\nMarkdown source page."
+          "content": "---\ntitle: Guide Page\nslug: guide\ntemplate: page-guide\n---\n\n# Guide Page\n\nMarkdown source page."
         }
       ]
     }
@@ -55,13 +66,21 @@
     { "path": "source_reports.compiled_site.pages", "assert": "count", "count": 3 },
     { "path": "source_reports.compiled_site.pages.0.title", "assert": "equals", "value": "Compiled Site" },
     { "path": "source_reports.compiled_site.pages.0.entrypoint", "assert": "equals", "value": true },
+    { "path": "source_reports.compiled_site.pages.0.metadata.body_format", "assert": "equals", "value": "html" },
     { "path": "source_reports.compiled_site.pages.1.slug", "assert": "equals", "value": "about" },
+    { "path": "source_reports.compiled_site.pages.1.block_markup", "assert": "contains", "value": "<!-- wp:html -->" },
     { "path": "source_reports.compiled_site.pages.2.slug", "assert": "equals", "value": "guide" },
-    { "path": "source_reports.compiled_site.assets", "assert": "count", "count": 5 },
+    { "path": "source_reports.compiled_site.pages.2.metadata.template", "assert": "equals", "value": "page-guide" },
+    { "path": "source_reports.compiled_site.assets", "assert": "count", "count": 7 },
     { "path": "source_reports.compiled_site.theme.stylesheets.0", "assert": "equals", "value": "public/assets/site.css" },
     { "path": "source_reports.compiled_site.theme.scripts.0", "assert": "equals", "value": "public/assets/site.js" },
     { "path": "source_reports.compiled_site.theme.images.0", "assert": "equals", "value": "public/assets/hero.svg" },
+    { "path": "source_reports.compiled_site.theme.template_parts.0", "assert": "equals", "value": "public/parts/header.html" },
+    { "path": "source_reports.compiled_site.template_parts.0.area", "assert": "equals", "value": "header" },
+    { "path": "source_reports.compiled_site.template_parts.0.block_markup", "assert": "contains", "value": "<header>" },
+    { "path": "source_reports.compiled_site.visual_repair.stylesheets.0.path", "assert": "equals", "value": "public/assets/visual-repair.css" },
+    { "path": "source_reports.compiled_site.visual_repair.css", "assert": "contains", "value": "min-height:100vh" },
     { "path": "documents.0.slug", "assert": "equals", "value": "guide" },
-    { "path": "assets.3.path", "assert": "equals", "value": "public/assets/hero.svg" }
+    { "path": "assets.5.path", "assert": "equals", "value": "public/assets/hero.svg" }
   ]
 }


### PR DESCRIPTION
## Summary

Extends the generic `source_reports.compiled_site` contract with richer document and theme-adjacent data for product adapters.

Changes include:

- Per-page metadata.
- Full page `block_markup`.
- Template parts and template-part theme references.
- Visual repair CSS surfaced through generic report data.
- Stylesheet asset CSS content preserved for generic consumers.

The contract remains product-neutral and does not add importer-specific semantics.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the generic compiled-site contract extension, fixture/docs updates, verification, and PR text. Chris remains responsible for review and final submission.
