### PR TITLE
Report native block source provenance

### DIFF
--- a/docs/contracts/php-transformer-parity-fixture.schema.json
+++ b/docs/contracts/php-transformer-parity-fixture.schema.json
@@ -65,7 +65,7 @@
           "path": { "type": "string", "minLength": 1 },
           "assert": {
             "type": "string",
-            "enum": ["equals", "contains", "count"]
+            "enum": ["equals", "contains", "not_contains", "count"]
           },
           "value": {},
           "count": { "type": "integer", "minimum": 0 }

--- a/docs/contracts/php-transformer-parity-fixtures.md
+++ b/docs/contracts/php-transformer-parity-fixtures.md
@@ -42,5 +42,6 @@ Product-shaped fixtures are compact contract slices inspired by representative p
 - Markdown conversion for nested mixed-source documents.
 - Artifact compilation for website artifact bundles and manifest files as preserved data assets.
 - Generic HTML wrapper presentation provenance for useful class, style, and layout signals. Supported blocks keep these signals in block attributes, while `source_reports.html.presentation_signals` records the source selector, tag, captured signals, and source attributes that produced them.
+- Generic HTML source provenance for converted native blocks. `source_reports.html.source_provenance` records each final block path with its block name, source selector, tag, safe source attributes, and a bounded source fragment with scripts, styles, event handlers, and `javascript:` URLs removed.
 
 The consuming product remains responsible for source discovery, route/link rewrites, import reports, product manifest validation, generated theme files, navigation entities, and visual/semantic parity gates.

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -24,6 +24,13 @@ final class HtmlTransformer
      */
     private array $presentationProvenance = array();
 
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $sourceProvenance = array();
+
+    private int $nextSourceProvenanceId = 1;
+
     public function __construct(private readonly Runtime $runtime = new Runtime())
     {
         $this->blockFactory = new BlockFactory();
@@ -38,6 +45,8 @@ final class HtmlTransformer
         $startedAt                = hrtime(true);
         $this->fallbackProvenance = TransformationOptions::provenance($options);
         $this->presentationProvenance = array();
+        $this->sourceProvenance = array();
+        $this->nextSourceProvenanceId = 1;
         $provenance               = array(
             array_merge(array(
                 'source_format' => 'html',
@@ -90,6 +99,7 @@ final class HtmlTransformer
 
         $fallbacks   = array();
         $blocks      = $this->convertChildren($body, $fallbacks, true);
+        $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $diagnostics = array(
             array(
@@ -122,6 +132,7 @@ final class HtmlTransformer
             sourceReports: array(
                 'html' => array(
                     'presentation_signals' => $this->presentationProvenance,
+                    'source_provenance'    => $sourceProvenance,
                 ),
             ),
             coverage: array(
@@ -129,6 +140,7 @@ final class HtmlTransformer
                     'supported_blocks' => array( 'core/button', 'core/buttons', 'core/code', 'core/details', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/shortcode', 'core/table' ),
                     'block_count'      => count($blocks),
                     'fallback_count'   => count($fallbacks),
+                    'source_provenance_count' => count($sourceProvenance),
                 ),
             ),
             context: $context,
@@ -339,7 +351,7 @@ final class HtmlTransformer
 
             return $this->createBlock('core/details', array_filter(array_merge($this->presentationAttributes($element), array(
                 'summary' => $summary instanceof DOMElement ? $this->innerHtml($summary) : '',
-            )), static fn ($value): bool => '' !== $value), $children);
+            )), static fn ($value): bool => '' !== $value), $children, $element);
         }
 
         if ( 'img' === $tagName ) {
@@ -374,7 +386,7 @@ final class HtmlTransformer
         if ( 'nav' === $tagName ) {
             $navigationLinks = $this->navigationLinks($element);
             if ( array() !== $navigationLinks ) {
-                return $this->createBlock('core/navigation', $this->presentationAttributes($element), $navigationLinks);
+                return $this->createBlock('core/navigation', $this->presentationAttributes($element), $navigationLinks, $element);
             }
         }
 
@@ -438,10 +450,63 @@ final class HtmlTransformer
     private function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
         if ( $sourceElement instanceof DOMElement ) {
+            $provenanceId = $this->nextSourceProvenanceId++;
             $this->recordPresentationProvenance($name, $attrs, $sourceElement);
+            $this->sourceProvenance[$provenanceId] = $this->sourceProvenanceEntry($name, $sourceElement);
         }
 
-        return $this->blockFactory->create($name, $attrs, $innerBlocks);
+        $block = $this->blockFactory->create($name, $attrs, $innerBlocks);
+        if ( isset($provenanceId) ) {
+            $block['_source_provenance_id'] = $provenanceId;
+        }
+
+        return $block;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<int, array<string, mixed>>
+     */
+    private function sourceProvenanceForBlocks(array &$blocks): array
+    {
+        $resolved = array();
+        $this->resolveSourceProvenancePaths($blocks, 'blocks', $resolved);
+        return $resolved;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $resolved
+     */
+    private function resolveSourceProvenancePaths(array &$blocks, string $path, array &$resolved): void
+    {
+        foreach ( $blocks as $index => &$block ) {
+            $blockPath = $path . '.' . $index;
+            $provenanceId = $block['_source_provenance_id'] ?? null;
+            if ( is_int($provenanceId) && isset($this->sourceProvenance[$provenanceId]) ) {
+                $resolved[] = array_merge(array( 'block_path' => $blockPath ), $this->sourceProvenance[$provenanceId]);
+            }
+            unset($block['_source_provenance_id']);
+
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $this->resolveSourceProvenancePaths($block['innerBlocks'], $blockPath . '.innerBlocks', $resolved);
+            }
+        }
+        unset($block);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourceProvenanceEntry(string $blockName, DOMElement $element): array
+    {
+        return array(
+            'block_name'        => $blockName,
+            'tag'               => strtolower($element->tagName),
+            'selector'          => $this->elementSelector($element),
+            'source_attributes' => $this->safeSourceAttributes($element),
+            'source_fragment'   => $this->safeSourceFragment($element),
+        );
     }
 
     private function innerHtml(DOMElement $element): string
@@ -571,6 +636,35 @@ final class HtmlTransformer
 
         ksort($attributes);
         return $attributes;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function safeSourceAttributes(DOMElement $element): array
+    {
+        $safe = array();
+        $allowed = array_flip(array( 'alt', 'class', 'data-layout', 'data-wp-layout', 'height', 'href', 'id', 'open', 'src', 'style', 'title', 'width' ));
+        foreach ( $this->htmlAttributes($element) as $name => $value ) {
+            if ( isset($allowed[$name]) && ! preg_match('/^\s*javascript\s*:/i', $value) ) {
+                $safe[$name] = $value;
+            }
+        }
+
+        return $safe;
+    }
+
+    private function safeSourceFragment(DOMElement $element): string
+    {
+        $html = $this->safeFallbackHtml($element);
+        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace('/\s+(href|src)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|javascript:[^\s>]+)/i', '', $html) ?? '';
+
+        if ( strlen($html) > 500 ) {
+            return substr($html, 0, 500) . '...';
+        }
+
+        return $html;
     }
 
     private function childElementCount(DOMElement $element): int
@@ -877,7 +971,7 @@ final class HtmlTransformer
                 'label' => $this->innerHtml($anchor),
                 'url'   => $this->attr($anchor, 'href'),
                 'kind'  => 'custom',
-            ), static fn ($value): bool => '' !== $value));
+            ), static fn ($value): bool => '' !== $value), array(), $anchor);
         }
 
         return $links;

--- a/php-transformer/tests/fixtures/parity/html-interactive-chrome-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-interactive-chrome-primitives.json
@@ -36,6 +36,13 @@
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:details" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link" },
+    { "path": "source_reports.html.source_provenance", "assert": "count", "count": 9 },
+    { "path": "source_reports.html.source_provenance.3.block_path", "assert": "equals", "value": "blocks.0.innerBlocks.1.innerBlocks.0" },
+    { "path": "source_reports.html.source_provenance.3.block_name", "assert": "equals", "value": "core/navigation-link" },
+    { "path": "source_reports.html.source_provenance.3.selector", "assert": "equals", "value": "header:nth-of-type(1) > nav:nth-of-type(1) > ul:nth-of-type(1) > li:nth-of-type(1) > a:nth-of-type(1)" },
+    { "path": "source_reports.html.source_provenance.5.block_path", "assert": "equals", "value": "blocks.1" },
+    { "path": "source_reports.html.source_provenance.5.block_name", "assert": "equals", "value": "core/details" },
+    { "path": "source_reports.html.source_provenance.5.selector", "assert": "equals", "value": "main:nth-of-type(1) > details:nth-of-type(1)" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
+++ b/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
@@ -13,7 +13,7 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<section class=\"hero-shell\" style=\"padding: 2rem;\" data-layout=\"constrained\"><h2>Only child</h2></section><svg class=\"badge\"><script>alert(1)</script><circle cx=\"1\" cy=\"1\" r=\"1\"></circle></svg>",
+    "content": "<section class=\"hero-shell\" style=\"padding: 2rem;\" data-layout=\"constrained\" onclick=\"alert(1)\"><h2>Only child</h2></section><svg class=\"badge\"><script>alert(1)</script><circle cx=\"1\" cy=\"1\" r=\"1\"></circle></svg>",
     "options": {
       "source": "fixture:html-provenance-wrapper-safety",
       "source_scope": "parity"
@@ -40,7 +40,18 @@
     { "path": "source_reports.html.presentation_signals.0.signals.style", "assert": "equals", "value": "padding: 2rem;" },
     { "path": "source_reports.html.presentation_signals.0.signals.layout.type", "assert": "equals", "value": "constrained" },
     { "path": "source_reports.html.presentation_signals.0.source_attributes.data-layout", "assert": "equals", "value": "constrained" },
+    { "path": "source_reports.html.source_provenance", "assert": "count", "count": 2 },
+    { "path": "source_reports.html.source_provenance.0.block_path", "assert": "equals", "value": "blocks.0" },
+    { "path": "source_reports.html.source_provenance.0.block_name", "assert": "equals", "value": "core/group" },
+    { "path": "source_reports.html.source_provenance.0.selector", "assert": "equals", "value": "section:nth-of-type(1)" },
+    { "path": "source_reports.html.source_provenance.0.source_attributes.class", "assert": "equals", "value": "hero-shell" },
+    { "path": "source_reports.html.source_provenance.0.source_fragment", "assert": "contains", "value": "<section class=\"hero-shell\"" },
+    { "path": "source_reports.html.source_provenance.0.source_fragment", "assert": "not_contains", "value": "onclick" },
+    { "path": "source_reports.html.source_provenance.1.block_path", "assert": "equals", "value": "blocks.0.innerBlocks.0" },
+    { "path": "source_reports.html.source_provenance.1.block_name", "assert": "equals", "value": "core/heading" },
+    { "path": "source_reports.html.source_provenance.1.selector", "assert": "equals", "value": "section:nth-of-type(1) > h2:nth-of-type(1)" },
     { "path": "diagnostics.1.selector", "assert": "equals", "value": "svg:nth-of-type(1)" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 },
+    { "path": "coverage.0.source_provenance_count", "assert": "equals", "value": 2 }
   ]
 }


### PR DESCRIPTION
## Summary

Adds generic source provenance reporting for converted native HTML blocks.

`source_reports.html.source_provenance` now maps converted blocks back to their source selectors/fragments with bounded, sanitized evidence. The report includes block path, block name, tag, selector, safe source attributes, and sanitized source fragments.

Also adds `coverage.0.source_provenance_count` and fixture/schema coverage.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing native block provenance reporting, fixture/schema coverage, verification, and PR text. Chris remains responsible for review and final submission.
