### PR TITLE
Handle inline SVG fallbacks safely

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -366,6 +366,11 @@ final class HtmlTransformer
             return $this->createBlock('core/buttons', array(), array( $this->createBlock('core/button', array_merge($this->presentationAttributes($element), array( 'text' => $this->innerHtml($element) )), array(), $element) ), $element);
         }
 
+        if ( 'svg' === $tagName ) {
+            $this->captureInlineSvgFallback($element, $fallbacks);
+            return null;
+        }
+
         if ( 'form' === $tagName ) {
             $fallbacks[] = array_merge(array(
                 'type'            => 'html',
@@ -835,7 +840,74 @@ final class HtmlTransformer
 
     private function safeFallbackHtml(DOMElement $element): string
     {
-        return trim(preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '');
+        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '';
+        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace('/\s+(?:href|src|xlink:href)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|javascript:[^\s>]+)/i', '', $html) ?? '';
+
+        return trim($html);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    private function captureInlineSvgFallback(DOMElement $element, array &$fallbacks): void
+    {
+        $rawHtml = $this->outerHtml($element);
+        $safe = $this->isSafeSvgContent($rawHtml);
+        $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
+
+        $fallbacks[] = array_merge(array(
+            'type'            => 'inline_svg',
+            'reason'          => $safe ? 'inline_svg_fallback' : 'unsafe_inline_svg',
+            'diagnostic_code' => $safe ? 'html_inline_svg_fallback' : 'html_unsafe_inline_svg',
+            'message'         => $safe ? 'Inline SVG was preserved as sanitized bounded fallback metadata.' : 'Inline SVG contains scriptable content and was preserved only as sanitized bounded fallback metadata.',
+            'source_format'   => 'html',
+            'tag'             => 'svg',
+            'selector'        => $this->elementSelector($element),
+            'attributes'      => $this->safeSvgAttributes($element),
+            'text_length'     => strlen(trim($element->textContent ?? '')),
+            'child_count'     => $this->childElementCount($element),
+            'html'            => $boundedHtml['html'],
+            'html_bytes'      => $boundedHtml['bytes'],
+            'html_truncated'  => $boundedHtml['truncated'],
+        ), $this->fallbackProvenance);
+    }
+
+    /**
+     * @return array{html: string, bytes: int, truncated: bool}
+     */
+    private function boundedFallbackHtml(string $html): array
+    {
+        $bytes = strlen($html);
+        if ( $bytes > 2000 ) {
+            return array(
+                'html'      => substr($html, 0, 2000) . '...',
+                'bytes'     => $bytes,
+                'truncated' => true,
+            );
+        }
+
+        return array(
+            'html'      => $html,
+            'bytes'     => $bytes,
+            'truncated' => false,
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function safeSvgAttributes(DOMElement $element): array
+    {
+        $attributes = array();
+        foreach ( $this->htmlAttributes($element) as $name => $value ) {
+            if ( preg_match('/^on[a-z]+$/i', $name) || preg_match('/javascript\s*:/i', $value) ) {
+                continue;
+            }
+            $attributes[$name] = strlen($value) > 200 ? substr($value, 0, 200) . '...' : $value;
+        }
+
+        return $attributes;
     }
 
     private function convertImageElement(DOMElement $image, ?DOMElement $figure = null): ?array

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-fallback",
+  "description": "Represents safe inline SVG as bounded sanitized fallback metadata while preserving supported siblings.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-fallback.json",
+    "notes": "Product-neutral fixture for generic inline SVG fallback handling."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><h2>Icon row</h2><svg viewBox=\"0 0 10 10\" role=\"img\" aria-label=\"Status\"><title>Status</title><circle cx=\"5\" cy=\"5\" r=\"4\"></circle></svg></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/heading", "attrs": { "content": "Icon row", "level": 2 } }
+  ],
+  "expected_fallbacks": [
+    { "type": "inline_svg", "reason": "inline_svg_fallback", "tag": "svg", "diagnostic_code": "html_inline_svg_fallback", "selector": "section:nth-of-type(1) > svg:nth-of-type(1)", "child_count": 2 }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.attributes.viewbox", "assert": "equals", "value": "0 0 10 10" },
+    { "path": "fallbacks.0.attributes.role", "assert": "equals", "value": "img" },
+    { "path": "fallbacks.0.html", "assert": "contains", "value": "<svg viewbox=\"0 0 10 10\"" },
+    { "path": "fallbacks.0.html", "assert": "contains", "value": "<circle cx=\"5\" cy=\"5\" r=\"4\"></circle>" },
+    { "path": "fallbacks.0.html_truncated", "assert": "equals", "value": false },
+    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_inline_svg_fallback" },
+    { "path": "diagnostics.1.selector", "assert": "equals", "value": "section:nth-of-type(1) > svg:nth-of-type(1)" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-unsafe.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-unsafe.json
@@ -1,0 +1,42 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-unsafe",
+  "description": "Diagnoses unsafe inline SVG and exposes only sanitized bounded fallback metadata.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-unsafe.json",
+    "notes": "Product-neutral fixture for script, event handler, and javascript URL stripping from inline SVG fallback metadata."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<svg viewBox=\"0 0 20 20\" onclick=\"alert(1)\"><script>alert(2)</script><a xlink:href=\"javascript:alert(3)\"><circle onmouseover=\"alert(4)\" cx=\"10\" cy=\"10\" r=\"8\"></circle></a></svg><p>After</p>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/paragraph", "attrs": { "content": "After" } }
+  ],
+  "expected_fallbacks": [
+    { "type": "inline_svg", "reason": "unsafe_inline_svg", "tag": "svg", "diagnostic_code": "html_unsafe_inline_svg", "selector": "svg:nth-of-type(1)", "child_count": 2 }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.attributes.onclick", "assert": "equals", "value": null },
+    { "path": "fallbacks.0.attributes.viewbox", "assert": "equals", "value": "0 0 20 20" },
+    { "path": "fallbacks.0.html", "assert": "contains", "value": "<svg viewbox=\"0 0 20 20\">" },
+    { "path": "fallbacks.0.html", "assert": "contains", "value": "<circle cx=\"10\" cy=\"10\" r=\"8\"></circle>" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "onclick" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "onmouseover" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "javascript:" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "alert(" },
+    { "path": "fallbacks.0.html_truncated", "assert": "equals", "value": false },
+    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_unsafe_inline_svg" },
+    { "path": "diagnostics.1.reason", "assert": "equals", "value": "unsafe_inline_svg" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
+++ b/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
@@ -24,7 +24,7 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Only child", "level": 2 } }
   ],
   "expected_fallbacks": [
-    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "svg", "diagnostic_code": "html_unsupported_element", "selector": "svg:nth-of-type(1)", "source": "fixture:html-provenance-wrapper-safety", "scope": "parity" }
+    { "type": "inline_svg", "reason": "unsafe_inline_svg", "tag": "svg", "diagnostic_code": "html_unsafe_inline_svg", "selector": "svg:nth-of-type(1)", "source": "fixture:html-provenance-wrapper-safety", "scope": "parity" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
@@ -32,6 +32,7 @@
     { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "fallbacks.0.html", "assert": "contains", "value": "<svg class=\"badge\">" },
     { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script>" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "alert(1)" },
     { "path": "provenance.0.source", "assert": "equals", "value": "fixture:html-provenance-wrapper-safety" },
     { "path": "provenance.0.scope", "assert": "equals", "value": "parity" },
     { "path": "source_reports.html.presentation_signals", "assert": "count", "count": 1 },


### PR DESCRIPTION
## Summary

Adds dedicated inline SVG fallback handling to `php-transformer`.

Changes include:

- Safe inline SVG is preserved as bounded, sanitized `inline_svg` fallback metadata.
- Unsafe inline SVG emits `html_unsafe_inline_svg` diagnostics and sanitized metadata.
- Generic fallback sanitization now strips event attributes and `javascript:` URL attributes.
- Adds parity fixtures for safe and unsafe inline SVG.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing inline SVG fallback handling, parity fixtures, verification, and PR text. Chris remains responsible for review and final submission.
