### PR TITLE
Improve figure quote and media transforms

### DIFF
--- a/php-transformer/docs/html-transform-coverage.md
+++ b/php-transformer/docs/html-transform-coverage.md
@@ -10,10 +10,10 @@ Run the coverage fixtures with `composer parity` or as part of `composer test`.
 | --- | --- | --- |
 | Heading and paragraph | `simple-html.json`, `html-core-text-structure.json` | `core/heading`, `core/paragraph` |
 | Lists | `html-core-text-structure.json` | `core/list`, `core/list-item` |
-| Quotes | `html-core-text-structure.json` | `core/quote`, `core/pullquote` |
+| Quotes | `html-core-text-structure.json`, `html-figure-quote-media.json` | `core/quote`, `core/pullquote`, figure-wrapped testimonial quotes with `figcaption` citation |
 | Code | `html-core-text-structure.json` | `core/code`, `core/preformatted` |
 | Tables | `html-core-media-actions.json` | `core/table` with head/body/caption attrs |
-| Images | `html-core-media-actions.json` | `core/image` with URL, alt, dimensions, caption attrs |
+| Images | `html-core-media-actions.json`, `html-figure-quote-media.json` | `core/image` with URL, alt, dimensions, caption, identity, size, and class attrs |
 | Buttons | `html-core-media-actions.json` | `core/buttons` containing `core/button` children |
 | Shortcodes | `html-core-media-actions.json` | `core/shortcode` for standalone shortcode text |
 | Wrapper provenance and safety | `html-provenance-wrapper-safety.json` | Presentational semantic wrappers are preserved as `core/group`; unsupported fallback records include selector/source metadata and sanitized fallback HTML |

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -64,12 +64,12 @@ final class BlockFactory
 
         if ( 'core/quote' === $name ) {
             $closing = '' !== ($attrs['citation'] ?? '') ? '<cite>' . $attrs['citation'] . '</cite></blockquote>' : '</blockquote>';
-            return array( 'opening' => '<blockquote class="wp-block-quote">', 'closing' => $closing );
+            return array( 'opening' => '<blockquote' . $this->blockSupportAttrs($attrs, 'wp-block-quote') . '>', 'closing' => $closing );
         }
 
         if ( 'core/pullquote' === $name ) {
             $citation = '' !== ($attrs['citation'] ?? '') ? '<cite>' . $attrs['citation'] . '</cite>' : '';
-            return '<figure class="wp-block-pullquote"><blockquote>' . ($attrs['value'] ?? '') . $citation . '</blockquote></figure>';
+            return '<figure' . $this->blockSupportAttrs($attrs, 'wp-block-pullquote') . '><blockquote>' . ($attrs['value'] ?? '') . $citation . '</blockquote></figure>';
         }
 
         if ( 'core/code' === $name ) {
@@ -197,7 +197,7 @@ final class BlockFactory
      */
     private function blockSupportAttrs(array $attrs, string $baseClass = ''): string
     {
-        $classes = trim($baseClass . ' ' . (string) ($attrs['className'] ?? ''));
+        $classes = $this->mergeClassNames($baseClass, (string) ($attrs['className'] ?? ''));
         return $this->htmlAttrs(array(
             'class' => $classes,
             'style' => (string) ($attrs['style'] ?? ''),

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -290,26 +290,20 @@ final class HtmlTransformer
         }
 
         if ( 'blockquote' === $tagName ) {
-            $citation = '';
-            foreach ( $element->childNodes as $child ) {
-                if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'cite', 'footer' ), true) ) {
-                    $citation = $this->innerHtml($child);
-                }
-            }
-
+            $citation = $this->citationFromElement($element);
             $value = $this->innerHtmlWithoutTags($element, array( 'cite', 'footer' ));
             if ( '' === trim($this->runtime->stripAllTags($value)) ) {
                 return null;
             }
 
-            if ( $this->hasClass($element, 'wp-block-pullquote') || $this->closestTagName($element) === 'figure' ) {
+            if ( $this->hasClass($element, 'wp-block-pullquote') ) {
                 return $this->createBlock('core/pullquote', array_filter(array_merge($this->presentationAttributes($element), array(
                     'value'    => $value,
                     'citation' => $citation,
                 )), static fn ($value): bool => '' !== $value), array(), $element);
             }
 
-            $innerBlocks = $this->convertChildren($element, $fallbacks);
+            $innerBlocks = $this->convertChildrenWithoutTags($element, $fallbacks, array( 'cite', 'footer' ));
             if ( array() === $innerBlocks ) {
                 $innerBlocks[] = $this->createBlock('core/paragraph', array( 'content' => $value ));
             }
@@ -325,7 +319,7 @@ final class HtmlTransformer
 
             $blockquote = $this->firstChildElement($element, 'blockquote');
             if ( $blockquote instanceof DOMElement ) {
-                return $this->convertElement($blockquote, $fallbacks, $captureUnsupported);
+                return $this->convertFigureBlockquote($element, $blockquote, $fallbacks);
             }
         }
 
@@ -709,6 +703,48 @@ final class HtmlTransformer
         return trim($html);
     }
 
+    private function citationFromElement(DOMElement $element): string
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'cite', 'footer', 'figcaption' ), true) ) {
+                return $this->innerHtml($child);
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertFigureBlockquote(DOMElement $figure, DOMElement $blockquote, array &$fallbacks): ?array
+    {
+        $citation = $this->citationFromElement($blockquote);
+        $caption = $this->firstChildElement($figure, 'figcaption');
+        if ( '' === $citation && $caption instanceof DOMElement ) {
+            $citation = $this->innerHtml($caption);
+        }
+
+        $value = $this->innerHtmlWithoutTags($blockquote, array( 'cite', 'footer' ));
+        if ( '' === trim($this->runtime->stripAllTags($value)) ) {
+            return null;
+        }
+
+        $attrs = array_filter(array_merge($this->presentationAttributes($figure), array( 'citation' => $citation )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value);
+
+        if ( $this->hasClass($figure, 'wp-block-pullquote') || $this->hasClass($blockquote, 'wp-block-pullquote') ) {
+            return $this->createBlock('core/pullquote', array_merge($attrs, array( 'value' => $value )), array(), $figure);
+        }
+
+        $innerBlocks = $this->convertChildrenWithoutTags($blockquote, $fallbacks, array( 'cite', 'footer' ));
+        if ( array() === $innerBlocks ) {
+            $innerBlocks[] = $this->createBlock('core/paragraph', array( 'content' => $value ));
+        }
+
+        return $this->createBlock('core/quote', $attrs, $innerBlocks, $figure);
+    }
+
     /**
      * @param array<int, string> $excludedTags
      * @param array<int, array<string, mixed>> $fallbacks
@@ -862,7 +898,7 @@ final class HtmlTransformer
             'height' => $height,
         )), static fn ($value): bool => '' !== $value);
 
-        $attrs = array_filter(array_merge($attrs, $this->imageIdentityAttributes($image)), static fn ($value): bool => '' !== $value);
+        $attrs = array_filter(array_merge($attrs, $this->imageIdentityAttributes($image, $figure)), static fn ($value): bool => '' !== $value);
 
         if ( $figure instanceof DOMElement ) {
             $caption = $this->firstChildElement($figure, 'figcaption');
@@ -906,19 +942,19 @@ final class HtmlTransformer
     {
         $attrs = $this->presentationAttributes($figure ?? $image);
         if ( $figure instanceof DOMElement ) {
-            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->nonCoreImageClassName($image));
+            $attrs['className'] = $this->mergeClassNames($this->nonCoreImageFigureClassName($figure), $this->nonCoreImageClassName($image));
         }
 
-        return array_filter($attrs, static fn (string $value): bool => '' !== trim($value));
+        return array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
     }
 
     /**
      * @return array<string, int|string>
      */
-    private function imageIdentityAttributes(DOMElement $image): array
+    private function imageIdentityAttributes(DOMElement $image, ?DOMElement $figure = null): array
     {
         $attrs = array();
-        $className = $this->attr($image, 'class');
+        $className = trim($this->attr($image, 'class') . ' ' . ( $figure instanceof DOMElement ? $this->attr($figure, 'class') : '' ));
         if ( preg_match('/(?:^|\s)wp-image-(\d+)(?:\s|$)/', $className, $matches) ) {
             $attrs['id'] = (int) $matches[1];
         }
@@ -933,6 +969,15 @@ final class HtmlTransformer
     {
         $classes = array_filter(preg_split('/\s+/', trim($this->attr($image, 'class'))) ?: array(), static function (string $className): bool {
             return ! preg_match('/^(?:wp-image-\d+|size-[a-z0-9_-]+)$/i', $className);
+        });
+
+        return implode(' ', $classes);
+    }
+
+    private function nonCoreImageFigureClassName(DOMElement $figure): string
+    {
+        $classes = array_filter(preg_split('/\s+/', trim($this->attr($figure, 'class'))) ?: array(), static function (string $className): bool {
+            return ! preg_match('/^(?:wp-block-image|size-[a-z0-9_-]+)$/i', $className);
         });
 
         return implode(' ', $classes);

--- a/php-transformer/tests/fixtures/parity/html-figure-quote-media.json
+++ b/php-transformer/tests/fixtures/parity/html-figure-quote-media.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-figure-quote-media",
+  "description": "Converts generic figure-wrapped quote, pullquote, and image media structures with captions and classes.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-figure-quote-media.json",
+    "notes": "Product-neutral coverage for figure media and quote parity."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<figure class=\"testimonial-card\"><blockquote><p>Build with care.</p></blockquote><figcaption><strong>Ada</strong>, Founder</figcaption></figure><figure class=\"wp-block-pullquote alignwide\"><blockquote><p>Pull this.</p></blockquote><figcaption>Editor</figcaption></figure><figure class=\"wp-block-image aligncenter size-large framed\" style=\"margin:0\"><img class=\"wp-image-42 rounded\" src=\"https://example.com/photo.jpg\" alt=\"Photo\" width=\"800\" height=\"600\"><figcaption>Image <em>caption</em></figcaption></figure>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/quote", "attrs": { "className": "testimonial-card", "citation": "<strong>Ada</strong>, Founder" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Build with care." } },
+    { "path": "blocks.1", "name": "core/pullquote", "attrs": { "className": "wp-block-pullquote alignwide", "citation": "Editor", "value": "<p>Pull this.</p>" } },
+    { "path": "blocks.2", "name": "core/image", "attrs": { "className": "aligncenter framed rounded is-resized", "style": "margin:0", "url": "https://example.com/photo.jpg", "alt": "Photo", "width": "800", "height": "600", "caption": "Image <em>caption</em>", "id": 42, "sizeSlug": "large" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<blockquote class=\"wp-block-quote testimonial-card\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<cite><strong>Ada</strong>, Founder</cite></blockquote>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-pullquote alignwide\"><blockquote><p>Pull this.</p><cite>Editor</cite></blockquote></figure>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-image aligncenter framed rounded is-resized size-large\" style=\"margin:0\"><img src=\"https://example.com/photo.jpg\" alt=\"Photo\" width=\"800\" height=\"600\" class=\"wp-image-42\"/><figcaption class=\"wp-element-caption\">Image <em>caption</em></figcaption></figure>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Improves generic figure quote/media handling in the HTML transformer.

Changes include:

- Figure-wrapped testimonial quotes map to `core/quote` with sibling `figcaption` as citation.
- Pullquote figures keep `core/pullquote` and preserve `figcaption` citation.
- Quote and pullquote serialization preserve class/style attributes.
- Image figures preserve useful figure/image classes, captions, size slugs, and image identity.
- Adds a generic parity fixture.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing figure quote/media transforms, parity fixture/docs, verification, and PR text. Chris remains responsible for review and final submission.
