### PR TITLE
Add form control fallback metadata

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -376,6 +376,7 @@ final class HtmlTransformer
                 'tag'             => $tagName,
                 'selector'        => $this->elementSelector($element),
                 'attributes'      => $this->htmlAttributes($element),
+                'controls'        => $this->formControls($element),
                 'text_length'     => strlen(trim($element->textContent ?? '')),
                 'child_count'     => $this->childElementCount($element),
                 'html'            => $this->safeFallbackHtml($element),
@@ -410,7 +411,7 @@ final class HtmlTransformer
         }
 
         if ( $captureUnsupported ) {
-            $fallbacks[] = array_merge(array(
+            $fallback = array(
                 'type'            => 'unsupported_element',
                 'reason'          => 'unsupported_element',
                 'diagnostic_code' => 'html_unsupported_element',
@@ -421,7 +422,14 @@ final class HtmlTransformer
                 'text_length'     => strlen(trim($element->textContent ?? '')),
                 'child_count'     => $this->childElementCount($element),
                 'html'            => $this->safeFallbackHtml($element),
-            ), $this->fallbackProvenance);
+            );
+
+            $control = $this->formControlMetadata($element);
+            if ( array() !== $control ) {
+                $fallback['control'] = $control;
+            }
+
+            $fallbacks[] = array_merge($fallback, $this->fallbackProvenance);
         }
 
         return null;
@@ -836,6 +844,166 @@ final class HtmlTransformer
     private function safeFallbackHtml(DOMElement $element): string
     {
         return trim(preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function formControls(DOMElement $form): array
+    {
+        $controls = array();
+        foreach ( $form->getElementsByTagName('*') as $control ) {
+            if ( ! $control instanceof DOMElement || ! $this->isFormControlElement($control) ) {
+                continue;
+            }
+
+            $metadata = $this->formControlMetadata($control);
+            if ( array() !== $metadata ) {
+                $controls[] = $metadata;
+            }
+        }
+
+        return $controls;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formControlMetadata(DOMElement $control): array
+    {
+        if ( ! $this->isFormControlElement($control) ) {
+            return array();
+        }
+
+        $tagName = strtolower($control->tagName);
+        $metadata = array_filter(array(
+            'tag'         => $tagName,
+            'name'        => $this->attr($control, 'name'),
+            'type'        => $this->formControlType($control),
+            'label'       => $this->formControlLabel($control),
+            'placeholder' => $this->attr($control, 'placeholder'),
+        ), static fn (string $value): bool => '' !== $value);
+
+        if ( $control->hasAttribute('required') ) {
+            $metadata['required'] = true;
+        }
+        if ( $control->hasAttribute('disabled') ) {
+            $metadata['disabled'] = true;
+        }
+
+        $value = $this->attr($control, 'value');
+        if ( '' !== $value && 'select' !== $tagName ) {
+            $metadata['value'] = $value;
+        }
+
+        if ( 'select' === $tagName ) {
+            $options = $this->selectOptions($control);
+            if ( array() !== $options ) {
+                $metadata['options'] = $options;
+            }
+        }
+
+        return $metadata;
+    }
+
+    private function isFormControlElement(DOMElement $element): bool
+    {
+        return in_array(strtolower($element->tagName), array( 'button', 'input', 'select', 'textarea' ), true);
+    }
+
+    private function formControlType(DOMElement $control): string
+    {
+        $tagName = strtolower($control->tagName);
+        if ( 'input' === $tagName ) {
+            $type = strtolower(trim($this->attr($control, 'type')));
+            return '' !== $type ? $type : 'text';
+        }
+        if ( 'button' === $tagName ) {
+            $type = strtolower(trim($this->attr($control, 'type')));
+            return '' !== $type ? $type : 'submit';
+        }
+        if ( 'select' === $tagName && $control->hasAttribute('multiple') ) {
+            return 'select-multiple';
+        }
+
+        return $tagName;
+    }
+
+    private function formControlLabel(DOMElement $control): string
+    {
+        $ariaLabel = trim($this->attr($control, 'aria-label'));
+        if ( '' !== $ariaLabel ) {
+            return $ariaLabel;
+        }
+
+        $id = $this->attr($control, 'id');
+        if ( '' !== $id && $control->ownerDocument instanceof DOMDocument ) {
+            foreach ( $control->ownerDocument->getElementsByTagName('label') as $label ) {
+                if ( $label instanceof DOMElement && $id === $this->attr($label, 'for') ) {
+                    return $this->normalizedControlLabelText($label);
+                }
+            }
+        }
+
+        for ( $parent = $control->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
+            if ( 'label' === strtolower($parent->tagName) ) {
+                return $this->normalizedControlLabelText($parent);
+            }
+        }
+
+        return '';
+    }
+
+    private function normalizedControlLabelText(DOMElement $label): string
+    {
+        return trim(preg_replace('/\s+/', ' ', $this->labelTextWithoutControls($label)) ?? '');
+    }
+
+    private function labelTextWithoutControls(DOMNode $node): string
+    {
+        if ( XML_TEXT_NODE === $node->nodeType ) {
+            return $node->textContent ?? '';
+        }
+
+        if ( $node instanceof DOMElement && $this->isFormControlElement($node) ) {
+            return '';
+        }
+
+        $text = '';
+        foreach ( $node->childNodes as $child ) {
+            $text .= $this->labelTextWithoutControls($child);
+        }
+
+        return $text;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function selectOptions(DOMElement $select): array
+    {
+        $options = array();
+        foreach ( $select->getElementsByTagName('option') as $option ) {
+            if ( ! $option instanceof DOMElement ) {
+                continue;
+            }
+
+            $value = $this->attr($option, 'value');
+            $optionMetadata = array(
+                'label' => trim(preg_replace('/\s+/', ' ', $option->textContent ?? '') ?? ''),
+                'value' => '' !== $value ? $value : trim($option->textContent ?? ''),
+            );
+            if ( $option->hasAttribute('selected') ) {
+                $optionMetadata['selected'] = true;
+            }
+            if ( $option->hasAttribute('disabled') ) {
+                $optionMetadata['disabled'] = true;
+            }
+
+            $options[] = $optionMetadata;
+        }
+
+        return $options;
     }
 
     private function convertImageElement(DOMElement $image, ?DOMElement $figure = null): ?array

--- a/php-transformer/tests/fixtures/parity/html-form-control-fallback-metadata.json
+++ b/php-transformer/tests/fixtures/parity/html-form-control-fallback-metadata.json
@@ -1,0 +1,60 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-form-control-fallback-metadata",
+  "description": "Reports generic form-control metadata while preserving safe HTML fallback output.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-form-control-fallback-metadata.json",
+    "notes": "Product-neutral fixture for form/input/select/textarea/button fallback metadata."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<form action=\"/contact\" method=\"post\"><label for=\"email\">Email address</label><input id=\"email\" name=\"email\" type=\"email\" required placeholder=\"you@example.com\"><label>Plan <select name=\"plan\"><option value=\"basic\">Basic</option><option value=\"pro\" selected>Pro</option></select></label><textarea name=\"message\" aria-label=\"Message\"></textarea><button name=\"intent\" value=\"send\">Send</button><script>alert(1)</script></form><input name=\"standalone\" value=\"outside\">"
+  },
+  "expected_blocks": [],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "child_count": 6 },
+    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "input", "diagnostic_code": "html_unsupported_element", "child_count": 0 }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.html", "assert": "contains", "value": "<form action=\"/contact\" method=\"post\">" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script>" },
+    { "path": "fallbacks.0.controls", "assert": "count", "count": 4 },
+    { "path": "fallbacks.0.controls.0.tag", "assert": "equals", "value": "input" },
+    { "path": "fallbacks.0.controls.0.name", "assert": "equals", "value": "email" },
+    { "path": "fallbacks.0.controls.0.type", "assert": "equals", "value": "email" },
+    { "path": "fallbacks.0.controls.0.label", "assert": "equals", "value": "Email address" },
+    { "path": "fallbacks.0.controls.0.required", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.controls.0.placeholder", "assert": "equals", "value": "you@example.com" },
+    { "path": "fallbacks.0.controls.1.tag", "assert": "equals", "value": "select" },
+    { "path": "fallbacks.0.controls.1.name", "assert": "equals", "value": "plan" },
+    { "path": "fallbacks.0.controls.1.type", "assert": "equals", "value": "select" },
+    { "path": "fallbacks.0.controls.1.label", "assert": "equals", "value": "Plan" },
+    { "path": "fallbacks.0.controls.1.options", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.controls.1.options.0.label", "assert": "equals", "value": "Basic" },
+    { "path": "fallbacks.0.controls.1.options.0.value", "assert": "equals", "value": "basic" },
+    { "path": "fallbacks.0.controls.1.options.1.label", "assert": "equals", "value": "Pro" },
+    { "path": "fallbacks.0.controls.1.options.1.value", "assert": "equals", "value": "pro" },
+    { "path": "fallbacks.0.controls.1.options.1.selected", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.controls.2.tag", "assert": "equals", "value": "textarea" },
+    { "path": "fallbacks.0.controls.2.name", "assert": "equals", "value": "message" },
+    { "path": "fallbacks.0.controls.2.type", "assert": "equals", "value": "textarea" },
+    { "path": "fallbacks.0.controls.2.label", "assert": "equals", "value": "Message" },
+    { "path": "fallbacks.0.controls.3.tag", "assert": "equals", "value": "button" },
+    { "path": "fallbacks.0.controls.3.name", "assert": "equals", "value": "intent" },
+    { "path": "fallbacks.0.controls.3.type", "assert": "equals", "value": "submit" },
+    { "path": "fallbacks.0.controls.3.value", "assert": "equals", "value": "send" },
+    { "path": "fallbacks.1.control.tag", "assert": "equals", "value": "input" },
+    { "path": "fallbacks.1.control.name", "assert": "equals", "value": "standalone" },
+    { "path": "fallbacks.1.control.type", "assert": "equals", "value": "text" },
+    { "path": "fallbacks.1.control.value", "assert": "equals", "value": "outside" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds structured form/control fallback metadata to the HTML transformer.

Changes include:

- Form fallbacks include generic `controls` metadata for `input`, `select`, `textarea`, and `button`.
- Standalone unsupported form controls include generic `control` metadata.
- Metadata captures names, types/default types, labels, placeholders, values, required/disabled flags, and select options.
- Safe HTML fallback behavior is preserved.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing form/control fallback metadata, parity fixtures, verification, and PR text. Chris remains responsible for review and final submission.
