### PR TITLE
Add gallery and embed media transforms

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -95,6 +95,15 @@ final class BlockFactory
             return $this->imageHtml($attrs);
         }
 
+        if ( 'core/gallery' === $name ) {
+            $caption = ! empty($attrs['caption']) ? '<figcaption class="blocks-gallery-caption wp-element-caption">' . $attrs['caption'] . '</figcaption>' : '';
+            return array( 'opening' => '<figure' . $this->blockSupportAttrs($attrs, 'wp-block-gallery') . '>', 'closing' => $caption . '</figure>' );
+        }
+
+        if ( 'core/embed' === $name ) {
+            return $this->embedHtml($attrs);
+        }
+
         if ( 'core/buttons' === $name ) {
             return array( 'opening' => '<div' . $this->blockSupportAttrs($attrs, 'wp-block-buttons') . '>', 'closing' => '</div>' );
         }
@@ -176,6 +185,27 @@ final class BlockFactory
         $img = '<img' . $this->htmlAttrs($imageAttrs, array( 'alt' )) . '/>';
         $caption = ! empty($attrs['caption']) ? '<figcaption class="wp-element-caption">' . $attrs['caption'] . '</figcaption>' : '';
         return '<figure' . $this->blockSupportAttrs($figureAttrs, 'wp-block-image') . '>' . $img . $caption . '</figure>';
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function embedHtml(array $attrs): string
+    {
+        $url = htmlspecialchars((string) ($attrs['url'] ?? ''), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $classes = array('wp-block-embed');
+        if ( ! empty($attrs['type']) ) {
+            $classes[] = 'is-type-' . (string) $attrs['type'];
+        }
+        if ( ! empty($attrs['providerNameSlug']) ) {
+            $classes[] = 'is-provider-' . (string) $attrs['providerNameSlug'];
+            $classes[] = 'wp-block-embed-' . (string) $attrs['providerNameSlug'];
+        }
+
+        $figureAttrs = $attrs;
+        $figureAttrs['className'] = $this->mergeClassNames(implode(' ', $classes), (string) ($attrs['className'] ?? ''));
+
+        return '<figure' . $this->blockSupportAttrs($figureAttrs) . '><div class="wp-block-embed__wrapper">' . $url . '</div></figure>';
     }
 
     private function mergeClassNames(string ...$classNames): string

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -55,9 +55,10 @@ final class HtmlTransformer
             ), $this->fallbackProvenance),
         );
 
+        $normalizedHtml = $this->normalizeHtml5VoidElements($html);
         $document = new DOMDocument();
         $previous = libxml_use_internal_errors(true);
-        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $normalizedHtml . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         libxml_clear_errors();
         libxml_use_internal_errors($previous);
 
@@ -104,7 +105,7 @@ final class HtmlTransformer
         $diagnostics = array(
             array(
                 'code'    => 'html_to_blocks_core_slice',
-                'message' => 'Converted supported core text, media, table, button, shortcode, definition-list, details, navigation, and wrapper elements; unsupported elements are reported as fallbacks.',
+                'message' => 'Converted supported core text, media, gallery, embed, table, button, shortcode, definition-list, details, navigation, and wrapper elements; unsupported elements are reported as fallbacks.',
                 'source'  => self::class,
             ),
         );
@@ -137,7 +138,7 @@ final class HtmlTransformer
             ),
             coverage: array(
                 array(
-                    'supported_blocks' => array( 'core/button', 'core/buttons', 'core/code', 'core/details', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/shortcode', 'core/table' ),
+                    'supported_blocks' => array( 'core/button', 'core/buttons', 'core/code', 'core/details', 'core/embed', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/shortcode', 'core/table' ),
                     'block_count'      => count($blocks),
                     'fallback_count'   => count($fallbacks),
                     'source_provenance_count' => count($sourceProvenance),
@@ -181,6 +182,11 @@ final class HtmlTransformer
         }
 
         return $count;
+    }
+
+    private function normalizeHtml5VoidElements(string $html): string
+    {
+        return preg_replace('/<source\b([^>]*?)(?<!\/)\s*>/i', '<source$1></source>', $html) ?? $html;
     }
 
     /**
@@ -312,9 +318,19 @@ final class HtmlTransformer
         }
 
         if ( 'figure' === $tagName ) {
+            $gallery = $this->galleryBlockFromElement($element, $fallbacks);
+            if ( null !== $gallery ) {
+                return $gallery;
+            }
+
             $image = $this->firstChildElement($element, 'img');
             if ( $image instanceof DOMElement ) {
                 return $this->convertImageElement($image, $element);
+            }
+
+            $picture = $this->firstChildElement($element, 'picture');
+            if ( $picture instanceof DOMElement ) {
+                return $this->convertPictureElement($picture, $element);
             }
 
             $blockquote = $this->firstChildElement($element, 'blockquote');
@@ -350,6 +366,14 @@ final class HtmlTransformer
 
         if ( 'img' === $tagName ) {
             return $this->convertImageElement($element);
+        }
+
+        if ( 'picture' === $tagName ) {
+            return $this->convertPictureElement($element);
+        }
+
+        if ( 'iframe' === $tagName ) {
+            return $this->convertIframeElement($element, $fallbacks);
         }
 
         if ( 'a' === $tagName && '' !== trim($element->textContent ?? '') ) {
@@ -391,6 +415,11 @@ final class HtmlTransformer
         }
 
         if ( in_array($tagName, array( 'article', 'body', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
+            $gallery = $this->galleryBlockFromElement($element, $fallbacks);
+            if ( null !== $gallery ) {
+                return $gallery;
+            }
+
             $buttonChildren = $this->buttonChildren($element);
             if ( array() !== $buttonChildren ) {
                 return $this->createBlock('core/buttons', $this->presentationAttributes($element), $buttonChildren, $element);
@@ -651,7 +680,7 @@ final class HtmlTransformer
     private function safeSourceAttributes(DOMElement $element): array
     {
         $safe = array();
-        $allowed = array_flip(array( 'alt', 'class', 'data-layout', 'data-wp-layout', 'height', 'href', 'id', 'open', 'src', 'style', 'title', 'width' ));
+        $allowed = array_flip(array( 'alt', 'class', 'data-layout', 'data-wp-layout', 'height', 'href', 'id', 'media', 'open', 'sizes', 'src', 'srcset', 'style', 'title', 'type', 'width' ));
         foreach ( $this->htmlAttributes($element) as $name => $value ) {
             if ( isset($allowed[$name]) && ! preg_match('/^\s*javascript\s*:/i', $value) ) {
                 $safe[$name] = $value;
@@ -887,6 +916,7 @@ final class HtmlTransformer
         $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '';
         $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
         $html = preg_replace('/\s+(?:href|src|xlink:href)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|javascript:[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace('/\s+srcdoc\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
 
         return trim($html);
     }
@@ -1114,7 +1144,79 @@ final class HtmlTransformer
         return $options;
     }
 
-    private function convertImageElement(DOMElement $image, ?DOMElement $figure = null): ?array
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function galleryBlockFromElement(DOMElement $element, array &$fallbacks): ?array
+    {
+        $images = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement ) {
+                return null;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( 'figcaption' === $tagName ) {
+                continue;
+            }
+
+            if ( 'figure' === $tagName ) {
+                $image = $this->firstChildElement($child, 'img');
+                if ( $image instanceof DOMElement ) {
+                    $images[] = $this->convertImageElement($image, $child);
+                    continue;
+                }
+
+                $picture = $this->firstChildElement($child, 'picture');
+                if ( $picture instanceof DOMElement ) {
+                    $images[] = $this->convertPictureElement($picture, $child);
+                    continue;
+                }
+            }
+
+            if ( 'img' === $tagName ) {
+                $images[] = $this->convertImageElement($child);
+                continue;
+            }
+
+            if ( 'picture' === $tagName ) {
+                $images[] = $this->convertPictureElement($child);
+                continue;
+            }
+
+            return null;
+        }
+
+        $images = array_values(array_filter($images));
+        if ( count($images) < 2 ) {
+            return null;
+        }
+
+        $attrs = $this->presentationAttributes($element);
+        $caption = $this->firstChildElement($element, 'figcaption');
+        if ( $caption instanceof DOMElement ) {
+            $attrs['caption'] = $this->innerHtml($caption);
+        }
+
+        return $this->createBlock('core/gallery', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $images, $element);
+    }
+
+    private function convertPictureElement(DOMElement $picture, ?DOMElement $figure = null): ?array
+    {
+        $image = $this->firstChildElement($picture, 'img');
+        if ( ! $image instanceof DOMElement ) {
+            return null;
+        }
+
+        return $this->convertImageElement($image, $figure ?? $picture, $picture);
+    }
+
+    private function convertImageElement(DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null): ?array
     {
         $url = $this->safeImageUrl($this->attr($image, 'src'));
         if ( '' === $url ) {
@@ -1122,8 +1224,12 @@ final class HtmlTransformer
         }
 
         $attrs = $this->imagePresentationAttributes($image, $figure);
+        if ( null !== $picture && ! $figure instanceof DOMElement ) {
+            $attrs = array_merge($this->presentationAttributes($picture), $attrs);
+        }
         $width = $this->attr($image, 'width');
         $height = $this->attr($image, 'height');
+        $sourceAttrs = $picture instanceof DOMElement ? $this->pictureSourceAttributes($picture) : array();
         if ( '' !== $width || '' !== $height ) {
             $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), 'is-resized');
         }
@@ -1132,8 +1238,8 @@ final class HtmlTransformer
             'url'    => $url,
             'alt'    => $this->attr($image, 'alt'),
             'title'  => $this->attr($image, 'title'),
-            'srcset' => $this->attr($image, 'srcset'),
-            'sizes'  => $this->attr($image, 'sizes'),
+            'srcset' => '' !== $this->attr($image, 'srcset') ? $this->attr($image, 'srcset') : (string) ($sourceAttrs['srcset'] ?? ''),
+            'sizes'  => '' !== $this->attr($image, 'sizes') ? $this->attr($image, 'sizes') : (string) ($sourceAttrs['sizes'] ?? ''),
             'width'  => $width,
             'height' => $height,
         )), static fn ($value): bool => '' !== $value);
@@ -1148,6 +1254,122 @@ final class HtmlTransformer
         }
 
         return $this->createBlock('core/image', $attrs, array(), $figure ?? $image);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function pictureSourceAttributes(DOMElement $picture): array
+    {
+        foreach ( $picture->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement || 'source' !== strtolower($child->tagName) ) {
+                continue;
+            }
+
+            $srcset = $this->attr($child, 'srcset');
+            if ( '' === $srcset || preg_match('/javascript\s*:/i', $srcset) ) {
+                continue;
+            }
+
+            return array_filter(array(
+                'srcset' => $srcset,
+                'sizes'  => $this->attr($child, 'sizes'),
+            ), static fn (string $value): bool => '' !== $value);
+        }
+
+        return array();
+    }
+
+    private function safeEmbedUrl(string $url): string
+    {
+        $url = trim($url);
+        if ( '' === $url || ! preg_match('#^https?://#i', $url) ) {
+            return '';
+        }
+
+        return preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ? '' : $url;
+    }
+
+    private function canonicalEmbedUrl(string $url): string
+    {
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        $path = (string) parse_url($url, PHP_URL_PATH);
+
+        if ( str_ends_with($host, 'youtube.com') && preg_match('~^/embed/([^/?#]+)~', $path, $matches) ) {
+            return 'https://www.youtube.com/watch?v=' . $matches[1];
+        }
+
+        if ( 'youtu.be' === $host && '' !== trim($path, '/') ) {
+            return 'https://www.youtube.com/watch?v=' . trim($path, '/');
+        }
+
+        if ( str_ends_with($host, 'vimeo.com') && preg_match('#/(?:video/)?(\d+)#', $path, $matches) ) {
+            return 'https://vimeo.com/' . $matches[1];
+        }
+
+        return $url;
+    }
+
+    private function embedProviderSlug(string $url): string
+    {
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        if ( str_ends_with($host, 'youtube.com') || 'youtu.be' === $host ) {
+            return 'youtube';
+        }
+        if ( str_ends_with($host, 'vimeo.com') ) {
+            return 'vimeo';
+        }
+
+        return '';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function safeEmbedAttributes(DOMElement $element): array
+    {
+        $safe = array();
+        $allowed = array_flip(array( 'allow', 'allowfullscreen', 'class', 'height', 'loading', 'referrerpolicy', 'sandbox', 'src', 'title', 'width' ));
+        foreach ( $this->htmlAttributes($element) as $name => $value ) {
+            if ( isset($allowed[$name]) && ! preg_match('/javascript\s*:/i', $value) ) {
+                $safe[$name] = strlen($value) > 300 ? substr($value, 0, 300) . '...' : $value;
+            }
+        }
+
+        return $safe;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertIframeElement(DOMElement $iframe, array &$fallbacks): ?array
+    {
+        $url = $this->safeEmbedUrl($this->attr($iframe, 'src'));
+        if ( '' !== $url ) {
+            return $this->createBlock('core/embed', array_filter(array_merge($this->presentationAttributes($iframe), array(
+                'url'              => $this->canonicalEmbedUrl($url),
+                'type'             => 'video',
+                'providerNameSlug' => $this->embedProviderSlug($url),
+            )), static fn ($value): bool => '' !== $value), array(), $iframe);
+        }
+
+        $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($iframe));
+        $fallbacks[] = array_merge(array(
+            'type'            => 'html',
+            'reason'          => 'iframe_embed_fallback',
+            'diagnostic_code' => 'html_iframe_embed_fallback',
+            'message'         => 'Iframe embed HTML was preserved as sanitized bounded fallback metadata.',
+            'source_format'   => 'html',
+            'tag'             => 'iframe',
+            'selector'        => $this->elementSelector($iframe),
+            'attributes'      => $this->safeEmbedAttributes($iframe),
+            'html'            => $boundedHtml['html'],
+            'html_bytes'      => $boundedHtml['bytes'],
+            'html_truncated'  => $boundedHtml['truncated'],
+        ), $this->fallbackProvenance);
+
+        return null;
     }
 
     private function safeImageUrl(string $url): string

--- a/php-transformer/tests/fixtures/parity/html-embed-iframe-media.json
+++ b/php-transformer/tests/fixtures/parity/html-embed-iframe-media.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-embed-iframe-media",
+  "description": "Converts clear URL-based iframe embeds to core/embed and preserves unsafe or non-URL iframe HTML as sanitized fallback metadata.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-embed-iframe-media.json",
+    "notes": "Product-neutral embed and iframe fallback coverage."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<iframe class=\"video-frame\" src=\"https://www.youtube.com/embed/abc123\" title=\"Demo video\"></iframe><iframe src=\"about:blank\" srcdoc=\"<script>alert(1)</script><p>Inline</p>\" onload=\"alert(1)\"></iframe>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/embed", "attrs": { "className": "video-frame", "url": "https://www.youtube.com/watch?v=abc123", "type": "video", "providerNameSlug": "youtube" } }
+  ],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "iframe_embed_fallback", "tag": "iframe", "selector": "iframe:nth-of-type(2)" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube video-frame\"><div class=\"wp-block-embed__wrapper\">https://www.youtube.com/watch?v=abc123</div></figure>" },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "srcdoc" },
+    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "onload" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-picture-gallery-media.json
+++ b/php-transformer/tests/fixtures/parity/html-picture-gallery-media.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-picture-gallery-media",
+  "description": "Converts responsive picture images and gallery-like figure groups into generic core media blocks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-picture-gallery-media.json",
+    "notes": "Product-neutral media coverage for picture/source and repeated figure image groups."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<picture class=\"hero-picture\"><source media=\"(min-width: 800px)\" srcset=\"https://example.com/hero-large.jpg 1200w\" sizes=\"100vw\"><img src=\"https://example.com/hero.jpg\" alt=\"Hero\"></picture><div class=\"gallery-grid\" data-layout=\"grid\"><figure><picture><source srcset=\"https://example.com/one-large.jpg 900w\"><img src=\"https://example.com/one.jpg\" alt=\"One\"></picture><figcaption>One caption</figcaption></figure><figure class=\"tile\"><img src=\"https://example.com/two.jpg\" alt=\"Two\" width=\"400\" height=\"300\"><figcaption>Two caption</figcaption></figure><figcaption>Gallery caption</figcaption></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/image", "attrs": { "className": "hero-picture", "url": "https://example.com/hero.jpg", "alt": "Hero", "srcset": "https://example.com/hero-large.jpg 1200w", "sizes": "100vw" } },
+    { "path": "blocks.1", "name": "core/gallery", "attrs": { "className": "gallery-grid", "layout": { "type": "grid" }, "caption": "Gallery caption" } },
+    { "path": "blocks.1.innerBlocks.0", "name": "core/image", "attrs": { "url": "https://example.com/one.jpg", "alt": "One", "srcset": "https://example.com/one-large.jpg 900w", "caption": "One caption" } },
+    { "path": "blocks.1.innerBlocks.1", "name": "core/image", "attrs": { "className": "tile is-resized", "url": "https://example.com/two.jpg", "alt": "Two", "width": "400", "height": "300", "caption": "Two caption" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:gallery" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<figcaption class=\"blocks-gallery-caption wp-element-caption\">Gallery caption</figcaption>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds generic gallery and embed media handling to `php-transformer`.

Changes include:

- `core/gallery` and `core/embed` serialization.
- `<picture>/<source>` handling with `srcset`/`sizes` propagation.
- Gallery-like figure/image group detection.
- URL-based iframe conversion to `core/embed` for clear HTTP(S) embeds, with narrow YouTube/Vimeo canonicalization.
- Sanitized iframe fallback metadata for unsafe/non-URL iframe cases.

## Verification

From `php-transformer/`:

- `composer install --no-interaction`
- `composer validate --strict`
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing gallery/embed media transforms, fixture coverage, verification, and PR text. Chris remains responsible for review and final submission.
