### PR TITLE
Report artifact local links and asset references

### DIFF
--- a/docs/contracts/php-transformer-parity-fixtures.md
+++ b/docs/contracts/php-transformer-parity-fixtures.md
@@ -41,6 +41,7 @@ Product-shaped fixtures are compact contract slices inspired by representative p
 - HTML-to-block conversion for representative hero/action and product-card structures.
 - Markdown conversion for nested mixed-source documents.
 - Artifact compilation for website artifact bundles and manifest files as preserved data assets.
+- Generic artifact-local reference reports for internal page links and asset references discovered in anchors, images, scripts, linked stylesheets, and stylesheet `url(...)` values. These reports expose normalized source path, selector, element, attribute, URL, resolved artifact path, and matched file metadata so downstream adapters can decide how to import or rewrite assets without embedding product policy in php-transformer.
 - Generic HTML wrapper presentation provenance for useful class, style, and layout signals. Supported blocks keep these signals in block attributes, while `source_reports.html.presentation_signals` records the source selector, tag, captured signals, and source attributes that produced them.
 - Generic HTML source provenance for converted native blocks. `source_reports.html.source_provenance` records each final block path with its block name, source selector, tag, safe source attributes, and a bounded source fragment with scripts, styles, event handlers, and `javascript:` URLs removed.
 

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -28,6 +28,7 @@ final class ArtifactCompiler
         $entryPath = is_array($entry) ? (string) $entry['path'] : '';
         $html = is_array($entry) ? (string) $entry['content'] : '';
         $assets = $this->assetManifest($normalized['files'], $entryPath);
+        $referenceReports = $this->referenceReports($normalized['files']);
         $components = $this->detectComponents($normalized['files'], $entryPath, $documents['components']);
         $blockTypes = $this->detectBlockTypes($normalized['files'], $diagnostics);
         $entryBlocks = $this->compileEntryBlocks($html, $entryPath, $normalized['files']);
@@ -64,7 +65,9 @@ final class ArtifactCompiler
                     'bytes'         => strlen($html),
                     'element_count' => preg_match_all('/<\s*[a-z][a-z0-9:-]*(?:\s|>|\/)/i', $html),
                 ),
-                'image_references' => $this->imageReferenceReport($html, $entryPath, $normalized['files']),
+                'internal_links'    => $referenceReports['internal_links'],
+                'asset_references'  => $referenceReports['asset_references'],
+                'image_references'  => $referenceReports['image_references'],
             ),
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
@@ -186,36 +189,276 @@ final class ArtifactCompiler
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array<int, array<string, mixed>>
+     * @return array{internal_links: array<int, array<string, mixed>>, asset_references: array<int, array<string, mixed>>, image_references: array<int, array<string, mixed>>}
      */
-    private function imageReferenceReport(string $html, string $entryPath, array $files): array
+    private function referenceReports(array $files): array
     {
-        if ( '' === trim($html) || ! preg_match_all('/<img\s+[^>]*src\s*=\s*(["\'])([^"\']+)\1[^>]*>/i', $html, $matches, PREG_SET_ORDER) ) {
+        $internalLinks = array();
+        $assetReferences = array();
+        $imageReferences = array();
+
+        foreach ( $files as $file ) {
+            if ( ! empty($file['binary']) ) {
+                continue;
+            }
+
+            if ( 'html' === ($file['kind'] ?? '') || 'blocks' === ($file['kind'] ?? '') ) {
+                foreach ( $this->htmlReferenceCandidates((string) ($file['content'] ?? ''), (string) ($file['path'] ?? '')) as $candidate ) {
+                    if ( '' === $candidate['url'] || ! $this->isArtifactLocalReference($candidate['url']) ) {
+                        continue;
+                    }
+
+                    $reference = $this->normalizeReferenceCandidate($candidate, $files);
+                    $target = $reference['target'] ?? null;
+                    if ( is_array($target) && $this->isLinkableDocument($target) && 'a' === $candidate['element'] ) {
+                        unset($reference['target']);
+                        $internalLinks[] = $reference;
+                        continue;
+                    }
+
+                    if ( is_array($target) && ! $this->isLinkableDocument($target) ) {
+                        unset($reference['target']);
+                        $assetReferences[] = $reference;
+                        if ( 'img' === $candidate['element'] && 'src' === $candidate['attribute'] ) {
+                            $imageReferences[] = $this->legacyImageReference($reference, count($imageReferences));
+                        }
+                    }
+                }
+            }
+
+            if ( 'css' === ($file['kind'] ?? '') ) {
+                foreach ( $this->cssUrlReferenceCandidates((string) ($file['content'] ?? ''), (string) ($file['path'] ?? '')) as $candidate ) {
+                    if ( '' === $candidate['url'] || ! $this->isArtifactLocalReference($candidate['url']) ) {
+                        continue;
+                    }
+
+                    $reference = $this->normalizeReferenceCandidate($candidate, $files);
+                    $target = $reference['target'] ?? null;
+                    if ( is_array($target) && ! $this->isLinkableDocument($target) ) {
+                        unset($reference['target']);
+                        $assetReferences[] = $reference;
+                    }
+                }
+            }
+        }
+
+        return array(
+            'internal_links'   => $internalLinks,
+            'asset_references' => $assetReferences,
+            'image_references' => $imageReferences,
+        );
+    }
+
+    /**
+     * @return array<int, array{source_path: string, selector: string, element: string, attribute: string, value: string, url: string}>
+     */
+    private function htmlReferenceCandidates(string $html, string $sourcePath): array
+    {
+        if ( '' === trim($html) || ! preg_match_all('/<\s*(a|img|script|link)\b([^>]*)>/i', $html, $matches, PREG_SET_ORDER) ) {
             return array();
         }
 
-        $references = array();
-        foreach ( $matches as $index => $match ) {
-            $src = (string) $match[2];
-            $asset = $this->findAssetByHtmlReference($src, $entryPath, $files);
-            $reference = array(
-                'source_path'   => $entryPath,
-                'selector'      => 'img:nth-of-type(' . ($index + 1) . ')',
-                'src'           => $src,
-                'resolved_path' => $this->resolveHtmlReferencePath($src, $entryPath),
-            );
+        $candidates = array();
+        $counts = array();
+        foreach ( $matches as $match ) {
+            $element = strtolower((string) $match[1]);
+            $attributes = $this->htmlAttributes((string) $match[2]);
+            $counts[$element] = ($counts[$element] ?? 0) + 1;
+            $selector = $element . ':nth-of-type(' . $counts[$element] . ')';
 
-            if ( is_array($asset) ) {
-                $reference['asset_path'] = $asset['path'];
-                $reference['mime_type'] = $asset['mime_type'];
-                $reference['bytes'] = $asset['bytes'];
-                $reference['safe'] = $this->isSafeImageAsset($asset);
+            foreach ( $this->referenceAttributesForElement($element, $attributes) as $attribute ) {
+                $value = (string) ($attributes[$attribute] ?? '');
+                foreach ( $this->urlsFromAttributeValue($attribute, $value) as $url ) {
+                    $candidates[] = array(
+                        'source_path' => $sourcePath,
+                        'selector'    => $selector,
+                        'element'     => $element,
+                        'attribute'   => $attribute,
+                        'value'       => $value,
+                        'url'         => $url,
+                    );
+                }
             }
-
-            $references[] = $reference;
         }
 
-        return $references;
+        return $candidates;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function htmlAttributes(string $attributeText): array
+    {
+        $attributes = array();
+        if ( ! preg_match_all('/([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:(["\'])(.*?)\2|([^\s"\'>]+))/s', $attributeText, $matches, PREG_SET_ORDER) ) {
+            return $attributes;
+        }
+
+        foreach ( $matches as $match ) {
+            $attributes[strtolower((string) $match[1])] = html_entity_decode((string) ('' !== ($match[3] ?? '') ? $match[3] : ($match[4] ?? '')), ENT_QUOTES | ENT_HTML5);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param array<string, string> $attributes
+     * @return array<int, string>
+     */
+    private function referenceAttributesForElement(string $element, array $attributes): array
+    {
+        $attributesByElement = array(
+            'a'      => array('href'),
+            'img'    => array('src', 'srcset'),
+            'script' => array('src'),
+            'link'   => array('href'),
+        );
+
+        return array_values(array_filter(
+            $attributesByElement[$element] ?? array(),
+            static fn (string $attribute): bool => isset($attributes[$attribute])
+        ));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function urlsFromAttributeValue(string $attribute, string $value): array
+    {
+        if ( 'srcset' !== $attribute ) {
+            return array(trim($value));
+        }
+
+        $urls = array();
+        foreach ( explode(',', $value) as $candidate ) {
+            $parts = preg_split('/\s+/', trim($candidate));
+            if ( is_array($parts) && '' !== ($parts[0] ?? '') ) {
+                $urls[] = $parts[0];
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * @return array<int, array{source_path: string, selector: string, element: string, attribute: string, value: string, url: string}>
+     */
+    private function cssUrlReferenceCandidates(string $css, string $sourcePath): array
+    {
+        if ( '' === trim($css) || ! preg_match_all('/url\(\s*(["\']?)([^"\')]+)\1\s*\)/i', $css, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        $candidates = array();
+        foreach ( $matches as $index => $match ) {
+            $url = html_entity_decode(trim((string) $match[2]), ENT_QUOTES | ENT_HTML5);
+            $candidates[] = array(
+                'source_path' => $sourcePath,
+                'selector'    => 'css:url(' . ($index + 1) . ')',
+                'element'     => 'style',
+                'attribute'   => 'url',
+                'value'       => $url,
+                'url'         => $url,
+            );
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param array{source_path: string, selector: string, element: string, attribute: string, value: string, url: string} $candidate
+     * @param array<int, array<string, mixed>> $files
+     * @return array<string, mixed>
+     */
+    private function normalizeReferenceCandidate(array $candidate, array $files): array
+    {
+        $resolvedPath = $this->resolveHtmlReferencePath($candidate['url'], $candidate['source_path']);
+        $target = '' === $resolvedPath ? null : $this->findFileByPath($resolvedPath, $files);
+        $reference = array_filter(
+            array(
+                'source_path'   => $candidate['source_path'],
+                'selector'      => $candidate['selector'],
+                'element'       => $candidate['element'],
+                'attribute'     => $candidate['attribute'],
+                'value'         => $candidate['value'],
+                'url'           => $candidate['url'],
+                'resolved_path' => $resolvedPath,
+            ),
+            static fn (mixed $value): bool => '' !== $value
+        );
+
+        if ( is_array($target) ) {
+            $targetPath = (string) ($target['path'] ?? '');
+            if ( $this->isLinkableDocument($target) ) {
+                $reference['target_path'] = $targetPath;
+            } else {
+                $reference['asset_path'] = $targetPath;
+            }
+            $reference['kind'] = $target['kind'] ?? '';
+            $reference['role'] = $target['role'] ?? '';
+            $reference['mime_type'] = $target['mime_type'] ?? '';
+            $reference['bytes'] = $target['bytes'] ?? 0;
+            if ( str_starts_with((string) ($target['mime_type'] ?? ''), 'image/') ) {
+                $reference['safe'] = $this->isSafeImageAsset($target);
+            }
+            $reference['target'] = $target;
+        }
+
+        return $reference;
+    }
+
+    /**
+     * @param array<string, mixed> $file
+     */
+    private function isLinkableDocument(array $file): bool
+    {
+        return in_array($file['kind'] ?? '', array('html', 'blocks'), true) && ! $this->isTemplatePartFile($file);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<string, mixed>|null
+     */
+    private function findFileByPath(string $path, array $files): ?array
+    {
+        foreach ( $files as $file ) {
+            if ( $path === ($file['path'] ?? '') ) {
+                return $file;
+            }
+        }
+
+        return null;
+    }
+
+    private function isArtifactLocalReference(string $reference): bool
+    {
+        $reference = trim($reference);
+        if ( '' === $reference || str_starts_with($reference, '#') || str_starts_with($reference, '//') ) {
+            return false;
+        }
+
+        return ! preg_match('#^[a-z][a-z0-9+.-]*:#i', $reference);
+    }
+
+    /**
+     * @param array<string, mixed> $reference
+     * @return array<string, mixed>
+     */
+    private function legacyImageReference(array $reference, int $index): array
+    {
+        return array_filter(
+            array(
+                'source_path'   => $reference['source_path'] ?? '',
+                'selector'      => 'img:nth-of-type(' . ($index + 1) . ')',
+                'src'           => $reference['url'] ?? '',
+                'resolved_path' => $reference['resolved_path'] ?? '',
+                'asset_path'    => $reference['asset_path'] ?? '',
+                'mime_type'     => $reference['mime_type'] ?? '',
+                'bytes'         => $reference['bytes'] ?? 0,
+                'safe'          => $reference['safe'] ?? null,
+            ),
+            static fn (mixed $value): bool => null !== $value && '' !== $value
+        );
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/artifact-local-link-asset-reports.json
+++ b/php-transformer/tests/fixtures/parity/artifact-local-link-asset-reports.json
@@ -1,0 +1,85 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-local-link-asset-reports",
+  "description": "Reports artifact-local internal links and asset references without applying product rewrite or import policy.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-local-link-asset-reports.json",
+    "notes": "Covers generic reporting for anchors, images, scripts, linked stylesheets, and stylesheet URL assets."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This generic artifact reference report has no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "pages/home.html",
+      "files": [
+        {
+          "path": "pages/home.html",
+          "content": "<main><a href=\"about.html\">About</a><a href=\"../assets/menu.pdf\">Menu</a><img src=\"../assets/hero.png\" srcset=\"../assets/hero-small.png 480w, ../assets/hero.png 960w\" alt=\"Hero\"><script src=\"../assets/app.js\"></script><link rel=\"stylesheet\" href=\"../assets/site.css\"></main>",
+          "mime_type": "text/html",
+          "role": "entry"
+        },
+        {
+          "path": "pages/about.html",
+          "content": "<main><h1>About</h1></main>",
+          "mime_type": "text/html"
+        },
+        {
+          "path": "assets/menu.pdf",
+          "content_base64": "JVBERi0xLjQK",
+          "mime_type": "application/pdf"
+        },
+        {
+          "path": "assets/hero.png",
+          "content_base64": "iVBORw0KGgo=",
+          "mime_type": "image/png"
+        },
+        {
+          "path": "assets/hero-small.png",
+          "content_base64": "iVBORw0KGgo=",
+          "mime_type": "image/png"
+        },
+        {
+          "path": "assets/app.js",
+          "content": "document.documentElement.dataset.fixture = 'asset-report';",
+          "mime_type": "application/javascript"
+        },
+        {
+          "path": "assets/site.css",
+          "content": "body{background-image:url('./bg.png')}",
+          "mime_type": "text/css"
+        },
+        {
+          "path": "assets/bg.png",
+          "content_base64": "iVBORw0KGgo=",
+          "mime_type": "image/png"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.artifact.internal_links", "assert": "count", "count": 1 },
+    { "path": "source_reports.artifact.internal_links.0.source_path", "assert": "equals", "value": "pages/home.html" },
+    { "path": "source_reports.artifact.internal_links.0.selector", "assert": "equals", "value": "a:nth-of-type(1)" },
+    { "path": "source_reports.artifact.internal_links.0.target_path", "assert": "equals", "value": "pages/about.html" },
+    { "path": "source_reports.artifact.asset_references", "assert": "count", "count": 7 },
+    { "path": "source_reports.artifact.asset_references.0.element", "assert": "equals", "value": "a" },
+    { "path": "source_reports.artifact.asset_references.0.asset_path", "assert": "equals", "value": "assets/menu.pdf" },
+    { "path": "source_reports.artifact.asset_references.1.element", "assert": "equals", "value": "img" },
+    { "path": "source_reports.artifact.asset_references.1.attribute", "assert": "equals", "value": "src" },
+    { "path": "source_reports.artifact.asset_references.2.attribute", "assert": "equals", "value": "srcset" },
+    { "path": "source_reports.artifact.asset_references.2.asset_path", "assert": "equals", "value": "assets/hero-small.png" },
+    { "path": "source_reports.artifact.asset_references.4.element", "assert": "equals", "value": "script" },
+    { "path": "source_reports.artifact.asset_references.4.asset_path", "assert": "equals", "value": "assets/app.js" },
+    { "path": "source_reports.artifact.asset_references.5.element", "assert": "equals", "value": "link" },
+    { "path": "source_reports.artifact.asset_references.5.asset_path", "assert": "equals", "value": "assets/site.css" },
+    { "path": "source_reports.artifact.asset_references.6.element", "assert": "equals", "value": "style" },
+    { "path": "source_reports.artifact.asset_references.6.asset_path", "assert": "equals", "value": "assets/bg.png" },
+    { "path": "source_reports.artifact.image_references", "assert": "count", "count": 1 },
+    { "path": "source_reports.artifact.image_references.0.asset_path", "assert": "equals", "value": "assets/hero.png" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds generic artifact-local link and asset reference reports to `ArtifactCompiler`.

Changes include:

- `source_reports.artifact.internal_links`.
- `source_reports.artifact.asset_references`.
- Artifact-local references from anchors, images/srcset, scripts, linked stylesheets, and CSS `url(...)`.
- Existing image reference parity remains preserved.

This reports data for product adapters to consume; it does not implement product rewrite/import policy.

## Verification

From `php-transformer/`:

- `composer install`
- `composer test`
- `git diff --check`

All passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing artifact reference reports, fixture/docs coverage, verification, and PR text. Chris remains responsible for review and final submission.
