### PR TITLE
Improve code and navigation block parity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -114,12 +114,12 @@ final class BlockFactory
         }
 
         if ( 'core/navigation' === $name ) {
-            return array( 'opening' => '<nav' . $this->blockSupportAttrs($attrs, 'wp-block-navigation') . '>', 'closing' => '</nav>' );
+            return array( 'opening' => '<nav' . $this->blockSupportAttrs($attrs, 'wp-block-navigation') . '><ul class="wp-block-navigation__container">', 'closing' => '</ul></nav>' );
         }
 
         if ( 'core/navigation-link' === $name ) {
             $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
-            return '<a class="wp-block-navigation-item__content"' . $href . '>' . ($attrs['label'] ?? '') . '</a>';
+            return '<li' . $this->blockSupportAttrs($attrs, 'wp-block-navigation-item wp-block-navigation-link') . '><a class="wp-block-navigation-item__content"' . $href . '><span class="wp-block-navigation-item__label">' . ($attrs['label'] ?? '') . '</span></a></li>';
         }
 
         if ( 'core/shortcode' === $name ) {

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -342,10 +342,10 @@ final class HtmlTransformer
         if ( 'pre' === $tagName ) {
             $code = $this->firstChildElement($element, 'code');
             if ( $code instanceof DOMElement ) {
-                return $this->createBlock('core/code', array_merge($this->presentationAttributes($element), array( 'content' => $code->textContent ?? '' )), array(), $element);
+                return $this->createBlock('core/code', array_merge($this->codePresentationAttributes($element, $code), array( 'content' => $code->textContent ?? '' )), array(), $element);
             }
 
-            return $this->createBlock('core/preformatted', array_merge($this->presentationAttributes($element), array( 'content' => $this->innerHtml($element) )), array(), $element);
+            return $this->createBlock('core/preformatted', array_merge($this->presentationAttributes($element), array( 'content' => $this->innerHtmlPreservingWhitespace($element) )), array(), $element);
         }
 
         if ( 'table' === $tagName ) {
@@ -553,6 +553,16 @@ final class HtmlTransformer
         }
 
         return trim($html);
+    }
+
+    private function innerHtmlPreservingWhitespace(DOMElement $element): string
+    {
+        $html = '';
+        foreach ( $element->childNodes as $child ) {
+            $html .= $element->ownerDocument->saveHTML($child);
+        }
+
+        return $html;
     }
 
     private function outerHtml(DOMElement $element): string
@@ -1468,6 +1478,20 @@ final class HtmlTransformer
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    private function codePresentationAttributes(DOMElement $pre, DOMElement $code): array
+    {
+        $attrs = $this->presentationAttributes($pre);
+        $codeClassName = $this->attr($code, 'class');
+        if ( '' !== trim($codeClassName) ) {
+            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $codeClassName);
+        }
+
+        return array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+    }
+
+    /**
      * @return array<int, array<string, mixed>>
      */
     private function navigationLinks(DOMElement $element): array
@@ -1476,12 +1500,22 @@ final class HtmlTransformer
         foreach ( $this->directNavigationAnchors($element) as $anchor ) {
             $links[] = $this->createBlock('core/navigation-link', array_filter(array(
                 'label' => $this->innerHtml($anchor),
-                'url'   => $this->attr($anchor, 'href'),
+                'url'   => $this->safeNavigationUrl($this->attr($anchor, 'href')),
                 'kind'  => 'custom',
             ), static fn ($value): bool => '' !== $value), array(), $anchor);
         }
 
         return $links;
+    }
+
+    private function safeNavigationUrl(string $url): string
+    {
+        $url = trim($url);
+        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
+            return '';
+        }
+
+        return $url;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-code-pre-nav-shape.json
+++ b/php-transformer/tests/fixtures/parity/html-code-pre-nav-shape.json
@@ -1,0 +1,42 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-code-pre-nav-shape",
+  "description": "Converts generic code, preformatted, inline code, and navigation HTML into safe core block output shapes.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-code-pre-nav-shape.json",
+    "notes": "Product-neutral fixture for code/preformatted and navigation output shape coverage."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><pre class=\"code-frame\"><code class=\"language-php\">&lt;?php echo &quot;Hi&quot;;</code></pre><pre>  alpha\n    beta\n</pre><p>Use <code>inline()</code> safely.</p><code>standalone()</code><nav class=\"primary\"><a href=\"/alpha\">Alpha</a><a href=\"javascript:alert(1)\">Unsafe</a></nav></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/code", "attrs": { "content": "<?php echo \"Hi\";", "className": "code-frame language-php" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/preformatted", "attrs": { "content": "  alpha\n    beta\n" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Use <code>inline()</code> safely." } },
+    { "path": "blocks.0.innerBlocks.3", "name": "core/paragraph", "attrs": { "content": "<code>standalone()</code>" } },
+    { "path": "blocks.0.innerBlocks.4", "name": "core/navigation", "attrs": { "className": "primary" } },
+    { "path": "blocks.0.innerBlocks.4.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Alpha", "url": "/alpha", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.4.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Unsafe", "kind": "custom" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 5 },
+    { "path": "blocks.0.innerBlocks.4.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks.0.innerBlocks.4.innerBlocks.1.attrs.url", "assert": "equals", "value": null },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<ul class=\"wp-block-navigation__container\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<li class=\"wp-block-navigation-item wp-block-navigation-link\"><a class=\"wp-block-navigation-item__content\" href=\"/alpha\"><span class=\"wp-block-navigation-item__label\">Alpha</span></a></li>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<li class=\"wp-block-navigation-item wp-block-navigation-link\"><a class=\"wp-block-navigation-item__content\"><span class=\"wp-block-navigation-item__label\">Unsafe</span></a></li>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "javascript:alert" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Improves generic code/preformatted and navigation output parity in `php-transformer`.

Changes include:

- Preserve whitespace in plain `<pre>` content.
- Carry `<code>` class names into `core/code` attrs for `<pre><code>`.
- Keep standalone inline `<code>` as paragraph inline markup.
- Serialize navigation as `<nav><ul><li><a><span>…</span></a></li></ul></nav>`.
- Sanitize unsafe `javascript:` navigation URLs while preserving safe navigation link shape.

## Verification

From `php-transformer/`:

- `composer install`
- `composer test`

Passed with 30 parity fixtures.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing code/pre/nav parity improvements, fixture coverage, verification, and PR text. Chris remains responsible for review and final submission.
