### PR TITLE
Add php transformer plugin bootstrap

### DIFF
--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -6,6 +6,8 @@ This package is intentionally origin-clean: it exposes transformer primitives an
 
 This package's canonical identity is `automattic/blocks-engine-php-transformer`, exposed through the `Automattic\BlocksEngine\PhpTransformer\` namespace.
 
+For local WordPress consumers, the same directory can also be installed as a plugin. The plugin bootstrap is intentionally thin: it loads the canonical library and exposes helper functions that return the same result envelopes as the class APIs.
+
 ## Boundary
 
 PHP Transformer owns reusable transformation primitives:
@@ -64,6 +66,31 @@ $artifactResult = (new ArtifactCompiler())->compile(array(
     'generated_html' => '<main><h1>Hello</h1></main>',
 ))->toArray();
 ```
+
+### WordPress Plugin Usage
+
+Install or symlink the `php-transformer/` directory into `wp-content/plugins/blocks-engine-php-transformer/`, run `composer install --no-dev` inside the plugin directory when Markdown conversion is needed, and activate **Blocks Engine PHP Transformer**.
+
+The plugin does not register product workflows. It only makes the canonical transformer available to WordPress plugins that want to depend on it before Composer distribution is settled.
+
+```php
+$result = blocks_engine_php_transformer_transform_html('<h1>Hello</h1>', array(
+    'source' => 'plugin:consumer',
+    'scope'  => 'import-preview',
+));
+
+$artifact = blocks_engine_php_transformer_compile_artifact(array(
+    'generated_html' => '<main><h1>Hello</h1></main>',
+));
+```
+
+Available plugin helpers:
+
+- `blocks_engine_php_transformer_version()`
+- `blocks_engine_php_transformer_path()`
+- `blocks_engine_php_transformer_transform_html()`
+- `blocks_engine_php_transformer_convert_format()`
+- `blocks_engine_php_transformer_compile_artifact()`
 
 ### Diagnostics And Unsupported Paths
 

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -38,6 +38,7 @@
     "test:canonical": [
       "php tests/contract/runtime-no-wordpress.php",
       "php tests/contract/runtime-wordpress-stubs.php",
+      "php tests/contract/plugin-bootstrap.php",
       "php tests/contract/run.php"
     ],
     "test:parity": "php tests/parity/run.php",

--- a/php-transformer/php-transformer.php
+++ b/php-transformer/php-transformer.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Plugin Name: Blocks Engine PHP Transformer
+ * Plugin URI: https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer
+ * Description: Canonical PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.
+ * Version: 0.1.0
+ * Requires PHP: 8.1
+ * Author: Automattic
+ * License: GPL-3.0-or-later
+ * Text Domain: blocks-engine-php-transformer
+ *
+ * @package BlocksEnginePhpTransformer
+ */
+
+declare(strict_types=1);
+
+if ( ! defined('BLOCKS_ENGINE_PHP_TRANSFORMER_VERSION') ) {
+    define('BLOCKS_ENGINE_PHP_TRANSFORMER_VERSION', '0.1.0');
+}
+
+if ( ! defined('BLOCKS_ENGINE_PHP_TRANSFORMER_FILE') ) {
+    define('BLOCKS_ENGINE_PHP_TRANSFORMER_FILE', __FILE__);
+}
+
+if ( ! defined('BLOCKS_ENGINE_PHP_TRANSFORMER_DIR') ) {
+    define('BLOCKS_ENGINE_PHP_TRANSFORMER_DIR', __DIR__);
+}
+
+blocks_engine_php_transformer_load_autoloader();
+
+if ( function_exists('do_action') ) {
+    do_action('blocks_engine_php_transformer_loaded');
+}
+
+/**
+ * Load Composer when available, otherwise register a local source autoloader.
+ */
+function blocks_engine_php_transformer_load_autoloader(): void
+{
+    static $loaded = false;
+
+    if ( $loaded ) {
+        return;
+    }
+
+    $loaded = true;
+
+    $composerAutoload = __DIR__ . '/vendor/autoload.php';
+    if ( is_readable($composerAutoload) ) {
+        require_once $composerAutoload;
+        return;
+    }
+
+    spl_autoload_register(
+        static function (string $class): void {
+            $prefix = 'Automattic\\BlocksEngine\\PhpTransformer\\';
+            if ( 0 !== strncmp($class, $prefix, strlen($prefix)) ) {
+                return;
+            }
+
+            $relative = substr($class, strlen($prefix));
+            $path     = __DIR__ . '/src/' . str_replace('\\', '/', $relative) . '.php';
+
+            if ( is_readable($path) ) {
+                require_once $path;
+            }
+        }
+    );
+}
+
+/**
+ * Return the active transformer version.
+ */
+function blocks_engine_php_transformer_version(): string
+{
+    return BLOCKS_ENGINE_PHP_TRANSFORMER_VERSION;
+}
+
+/**
+ * Return the plugin/package directory.
+ */
+function blocks_engine_php_transformer_path(): string
+{
+    return BLOCKS_ENGINE_PHP_TRANSFORMER_DIR;
+}
+
+/**
+ * Transform HTML into the canonical result envelope.
+ *
+ * @param array<string, mixed> $options Transformation options.
+ * @return array<string, mixed>
+ */
+function blocks_engine_php_transformer_transform_html(string $html, array $options = array()): array
+{
+    return ( new Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer() )
+        ->transform($html, $options)
+        ->toArray();
+}
+
+/**
+ * Convert content between supported formats through the canonical result envelope.
+ *
+ * @param array<string, mixed> $options Transformation options.
+ * @return array<string, mixed>
+ */
+function blocks_engine_php_transformer_convert_format(string $content, string $fromFormat, string $toFormat, array $options = array()): array
+{
+    return ( new Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge() )
+        ->convertResult($content, $fromFormat, $toFormat, $options)
+        ->toArray();
+}
+
+/**
+ * Compile a generated website artifact into the canonical result envelope.
+ *
+ * @param array<string, mixed> $artifact Generated artifact input.
+ * @param array<string, mixed> $options Transformation options.
+ * @return array<string, mixed>
+ */
+function blocks_engine_php_transformer_compile_artifact(array $artifact, array $options = array()): array
+{
+    return ( new Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler() )
+        ->compile($artifact, $options)
+        ->toArray();
+}

--- a/php-transformer/tests/contract/plugin-bootstrap.php
+++ b/php-transformer/tests/contract/plugin-bootstrap.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/php-transformer.php';
+
+assertSame('0.1.0', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
+assertSame(dirname(__DIR__, 2), blocks_engine_php_transformer_path(), 'Plugin helper exposes package path.');
+
+$htmlResult = blocks_engine_php_transformer_transform_html(
+    '<main><h1>Plugin bootstrap</h1><p>Ready.</p></main>',
+    array(
+        'source' => 'fixture:plugin-bootstrap',
+        'scope'  => 'contract-test',
+    )
+);
+
+assertSame('success', $htmlResult['status'] ?? '', 'HTML helper returns a successful canonical result.');
+assertSame('fixture:plugin-bootstrap', $htmlResult['provenance'][0]['source'] ?? '', 'HTML helper preserves provenance source.');
+
+$formatResult = blocks_engine_php_transformer_convert_format('# Plugin bootstrap', 'markdown', 'blocks');
+assertSame('success', $formatResult['status'] ?? '', 'Format helper returns a successful canonical result.');
+
+$artifactResult = blocks_engine_php_transformer_compile_artifact(
+    array(
+        'generated_html' => '<main><h1>Plugin artifact</h1></main>',
+    )
+);
+
+assertSame('success', $artifactResult['status'] ?? '', 'Artifact helper returns a successful canonical result.');
+assertSame('index.html', $artifactResult['source_reports']['artifact']['entry_path'] ?? '', 'Artifact helper exposes canonical source reports.');
+
+fwrite(STDOUT, "Plugin bootstrap contract passed.\n");
+
+function assertSame(mixed $expected, mixed $actual, string $message): void
+{
+    if ( $expected !== $actual ) {
+        fwrite(STDERR, $message . "\nExpected: " . var_export($expected, true) . "\nActual: " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add a thin WordPress plugin bootstrap for php-transformer
- expose helper functions that return the canonical transformer result envelopes
- document plugin/symlink usage and add plugin bootstrap contract coverage

## Verification
- composer install --no-interaction
- composer validate --strict
- composer test
- composer run test:migration:examples
- composer run test:migration:legacy-parity
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the plugin bootstrap, contract smoke, documentation, and verification workflow.