### PR TITLE
Use canonical Markdown bridge in artifact compiler

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 
 final class ArtifactCompiler
@@ -839,19 +840,35 @@ final class ArtifactCompiler
      */
     private function convertMarkdownToBlocks(string $markdown): array
     {
-        if ( function_exists('bfb_convert') ) {
-            $blockMarkup = (string) bfb_convert($markdown, 'markdown', 'blocks');
+        $result = ( new FormatBridge() )->convertResult(
+            $markdown,
+            'markdown',
+            'blocks',
+            array(
+                'source'  => 'artifact_compiler',
+                'context' => array(
+                    'source_format' => 'markdown',
+                    'target_format' => 'blocks',
+                ),
+            )
+        )->toArray();
+
+        if ( 'failed' !== (string) ( $result['status'] ?? '' ) ) {
             return array(
-                'serialized_blocks' => $blockMarkup,
-                'diagnostics'       => array(),
+                'serialized_blocks' => (string) ( $result['serialized_blocks'] ?? '' ),
+                'diagnostics'       => array_values(array_filter(
+                    is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array(),
+                    static fn (array $diagnostic): bool => 'format_bridge_conversion_completed' !== (string) ($diagnostic['code'] ?? '')
+                )),
             );
         }
 
+        $diagnostics = is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array();
+        $diagnostics[] = $this->diagnostic('markdown_adapter_unavailable', 'warning', 'A Markdown adapter is unavailable; preserved source Markdown as a core/html fallback.');
+
         return array(
             'serialized_blocks' => '<!-- wp:html -->' . "\n" . $markdown . "\n" . '<!-- /wp:html -->',
-            'diagnostics'       => array(
-                $this->diagnostic('markdown_adapter_unavailable', 'warning', 'A Markdown adapter is unavailable; preserved source Markdown as a core/html fallback.'),
-            ),
+            'diagnostics'       => $diagnostics,
         );
     }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -253,7 +253,7 @@ $documents = $compiler->compile(
         ),
     )
 )->toArray();
-$assert('success_with_warnings' === $documents['status'], 'document-only Markdown compiles with fallback warning', (string) $documents['status']);
+$assert('success' === $documents['status'], 'document-only Markdown compiles through canonical Markdown adapter', (string) $documents['status']);
 $assert(1 === count($documents['documents']), 'Markdown source document is exposed');
 $assert('content/about.md' === ($documents['documents'][0]['source_path'] ?? ''), 'document source path is preserved');
 $assert('markdown' === ($documents['documents'][0]['body_format'] ?? ''), 'Markdown body format is exposed');
@@ -265,9 +265,9 @@ $assert('2026-06-19' === ($documents['documents'][0]['date'] ?? ''), 'frontmatte
 $assert('page-wide' === ($documents['documents'][0]['template'] ?? ''), 'frontmatter template is parsed');
 $assert(array( 'News', 'Updates' ) === ($documents['documents'][0]['taxonomies']['categories'] ?? null), 'frontmatter category list is parsed');
 $assert('launch, artifact' === ($documents['documents'][0]['taxonomies']['tags'] ?? ''), 'frontmatter taxonomy scalar hints are preserved');
-$assert(str_contains((string) ($documents['documents'][0]['block_markup'] ?? ''), '<!-- wp:html -->'), 'Markdown fallback block markup is exposed');
+$assert(str_contains((string) ($documents['documents'][0]['block_markup'] ?? ''), '<!-- wp:heading'), 'Markdown heading block markup is exposed');
 $assert(str_contains((string) $documents['serialized_blocks'], 'Markdown body.'), 'document fallback supplies serialized blocks when HTML is absent');
-$assert('markdown_adapter_unavailable' === ($documents['documents'][0]['diagnostics'][0]['code'] ?? ''), 'missing Markdown adapter diagnostic is attached to document');
+$assert(array() === ($documents['documents'][0]['diagnostics'] ?? null), 'Markdown document conversion does not depend on ambient wrapper diagnostics');
 
 $mdx = $compiler->compile(
     array(

--- a/php-transformer/tests/fixtures/parity/compiled-site-contract.json
+++ b/php-transformer/tests/fixtures/parity/compiled-site-contract.json
@@ -59,7 +59,7 @@
   },
   "expect": [
     { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
-    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
+    { "path": "status", "assert": "equals", "value": "success" },
     { "path": "source_reports.artifact.schema", "assert": "equals", "value": "blocks-engine/php-transformer/site-artifact/v1" },
     { "path": "source_reports.compiled_site.schema", "assert": "equals", "value": "blocks-engine/php-transformer/compiled-site/v1" },
     { "path": "source_reports.compiled_site.entry_path", "assert": "equals", "value": "public/index.html" },
@@ -71,6 +71,7 @@
     { "path": "source_reports.compiled_site.pages.1.block_markup", "assert": "contains", "value": "<!-- wp:html -->" },
     { "path": "source_reports.compiled_site.pages.2.slug", "assert": "equals", "value": "guide" },
     { "path": "source_reports.compiled_site.pages.2.metadata.template", "assert": "equals", "value": "page-guide" },
+    { "path": "source_reports.compiled_site.pages.2.block_markup", "assert": "contains", "value": "<!-- wp:heading" },
     { "path": "source_reports.compiled_site.assets", "assert": "count", "count": 7 },
     { "path": "source_reports.compiled_site.theme.stylesheets.0", "assert": "equals", "value": "public/assets/site.css" },
     { "path": "source_reports.compiled_site.theme.scripts.0", "assert": "equals", "value": "public/assets/site.js" },


### PR DESCRIPTION
Removes the artifact compiler's ambient dependency on the old Block Format Bridge global function for Markdown source documents.

Changes:
- Route Markdown document conversion through the canonical `FormatBridge::convertResult()` path.
- Keep the existing fallback only for failed bridge conversion.
- Update document contract expectations from core/html fallback warning to real Markdown block output.
- Update the compiled-site fixture to expect successful canonical Markdown conversion.

Verification:
- `composer test`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Fleet audit, upstream boundary fix, fixture update, and targeted verification.
