### PR TITLE
Cover canonical format conversion envelopes

### DIFF
--- a/php-transformer/tests/fixtures/parity/artifact-generated-html.json
+++ b/php-transformer/tests/fixtures/parity/artifact-generated-html.json
@@ -18,6 +18,10 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "source_reports.artifact.entry_path", "assert": "equals", "value": "index.html" },
     { "path": "components.0.name", "assert": "equals", "value": "hero" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:html -->" }
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:html -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<h1>Hello artifact</h1>" },
+    { "path": "source_reports.artifact.html.element_count", "assert": "equals", "value": 3 },
+    { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 },
+    { "path": "provenance.0.source_format", "assert": "equals", "value": "artifact" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/blocks-to-markdown-conversion.json
+++ b/php-transformer/tests/fixtures/parity/blocks-to-markdown-conversion.json
@@ -17,6 +17,12 @@
     { "path": "converted", "assert": "contains", "value": "# Hello" },
     { "path": "converted", "assert": "contains", "value": "Body" },
     { "path": "blocks", "assert": "count", "count": 2 },
-    { "path": "supported_formats", "assert": "equals", "value": ["blocks", "html", "markdown"] }
+    { "path": "supported_formats", "assert": "equals", "value": ["blocks", "html", "markdown"] },
+    { "path": "result.schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
+    { "path": "result.status", "assert": "equals", "value": "success" },
+    { "path": "result.documents.0.format", "assert": "equals", "value": "markdown" },
+    { "path": "result.documents.0.content", "assert": "contains", "value": "# Hello" },
+    { "path": "result.provenance.0.source_format", "assert": "equals", "value": "blocks" },
+    { "path": "result.provenance.0.target_format", "assert": "equals", "value": "markdown" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/markdown-conversion.json
+++ b/php-transformer/tests/fixtures/parity/markdown-conversion.json
@@ -18,6 +18,14 @@
     { "path": "converted", "assert": "contains", "value": "<strong>strong</strong>" },
     { "path": "blocks", "assert": "count", "count": 3 },
     { "path": "blocks.0.blockName", "assert": "equals", "value": "core/heading" },
-    { "path": "blocks.2.blockName", "assert": "equals", "value": "core/list" }
+    { "path": "blocks.2.blockName", "assert": "equals", "value": "core/list" },
+    { "path": "result.schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
+    { "path": "result.status", "assert": "equals", "value": "success" },
+    { "path": "result.documents.0.format", "assert": "equals", "value": "html" },
+    { "path": "result.documents.0.content", "assert": "contains", "value": "<h1>Title</h1>" },
+    { "path": "result.blocks.0.blockName", "assert": "equals", "value": "core/heading" },
+    { "path": "result.diagnostics.0.code", "assert": "equals", "value": "format_bridge_conversion_completed" },
+    { "path": "result.provenance.0.source_format", "assert": "equals", "value": "markdown" },
+    { "path": "result.provenance.0.target_format", "assert": "equals", "value": "html" }
   ]
 }

--- a/php-transformer/tests/parity/run.php
+++ b/php-transformer/tests/parity/run.php
@@ -229,6 +229,7 @@ function runFixture(array $fixture): array
         return array(
             'converted' => $bridge->convert((string) ($input['content'] ?? ''), (string) ($input['from'] ?? ''), (string) ($input['to'] ?? '')),
             'blocks' => $bridge->toBlocks((string) ($input['content'] ?? ''), (string) ($input['from'] ?? '')),
+            'result' => $bridge->convertResult((string) ($input['content'] ?? ''), (string) ($input['from'] ?? ''), (string) ($input['to'] ?? ''))->toArray(),
             'supported_formats' => $bridge->supportedFormats(),
         );
     }


### PR DESCRIPTION
## Summary
- expose `FormatBridge::convertResult()` in the parity fixture runner for format conversion fixtures
- add positive result-envelope assertions for Markdown-to-HTML and blocks-to-Markdown conversion
- strengthen artifact-generated HTML coverage with serialized content, artifact report, fallback metric, and provenance assertions

## Testing
- `composer install --no-interaction`
- `composer validate --strict`
- `composer run test:migration:examples`
- `composer run test:migration:legacy-parity`
- `composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting fixture coverage, running verification, and preparing the PR.
