### PR TITLE
Add static site materialization plan

### DIFF
--- a/php-transformer/homeboy.json
+++ b/php-transformer/homeboy.json
@@ -7,6 +7,14 @@
     {
       "file": "VERSION",
       "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+)$"
+    },
+    {
+      "file": "php-transformer.php",
+      "pattern": "Version: ([0-9]+\\.[0-9]+\\.[0-9]+)"
+    },
+    {
+      "file": "php-transformer.php",
+      "pattern": "BLOCKS_ENGINE_PHP_TRANSFORMER_VERSION', '([0-9]+\\.[0-9]+\\.[0-9]+)'"
     }
   ]
 }

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
 
 final class ArtifactCompiler
 {
@@ -73,6 +74,7 @@ final class ArtifactCompiler
             ),
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
+        $sourceReports['materialization_plan'] = ( new MaterializationPlanBuilder() )->fromCompiledSite($sourceReports['compiled_site']);
         $provenance = array(
             array(
                 'source_format' => 'artifact',
@@ -117,6 +119,20 @@ final class ArtifactCompiler
             provenance: $provenance,
             metrics: $metrics
         );
+    }
+
+    /**
+     * Compile a standalone source fragment through the canonical format bridge.
+     *
+     * @param array<string,mixed> $options Transformer context/provenance options.
+     */
+    public function compileFragment(string $content, string $source = 'fragment', string $format = 'html', array $options = array()): TransformerResult
+    {
+        $bridge = new FormatBridge();
+        return $bridge->convertResult($content, $format, 'blocks', array_merge(array(
+            'source'       => $source,
+            'source_scope' => 'artifact-fragment',
+        ), $options));
     }
 
     /**

--- a/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
@@ -1,0 +1,199 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\StaticSite;
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+
+final class MaterializationPlanBuilder
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/materialization-plan/v1';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function fromResult(TransformerResult|array $result): array
+    {
+        $data = $result instanceof TransformerResult ? $result->toArray() : $result;
+        $compiledSite = $data['source_reports']['compiled_site'] ?? array();
+        return is_array($compiledSite) ? $this->fromCompiledSite($compiledSite) : $this->emptyPlan();
+    }
+
+    /**
+     * @param array<string,mixed> $compiledSite
+     * @return array<string,mixed>
+     */
+    public function fromCompiledSite(array $compiledSite): array
+    {
+        $pages = $this->pages((array) ($compiledSite['pages'] ?? array()));
+        $templateParts = $this->templateParts((array) ($compiledSite['template_parts'] ?? array()));
+        $assets = $this->assets((array) ($compiledSite['assets'] ?? array()));
+        $visualRepair = is_array($compiledSite['visual_repair'] ?? null) ? $compiledSite['visual_repair'] : array();
+
+        return array(
+            'schema'         => self::SCHEMA,
+            'source_schema'  => (string) ($compiledSite['schema'] ?? ''),
+            'source_hash'    => (string) ($compiledSite['source_hash'] ?? ''),
+            'entry_path'     => (string) ($compiledSite['entry_path'] ?? ''),
+            'pages'          => $pages,
+            'template_parts' => $templateParts,
+            'assets'         => $assets,
+            'theme'          => $this->theme((array) ($compiledSite['theme'] ?? array()), $templateParts, $assets, $visualRepair),
+            'rewrite_candidates' => $this->rewriteCandidates($pages, $assets),
+            'totals'         => array(
+                'pages'          => count($pages),
+                'template_parts' => count($templateParts),
+                'assets'         => count($assets),
+            ),
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function emptyPlan(): array
+    {
+        return array(
+            'schema' => self::SCHEMA,
+            'pages' => array(),
+            'template_parts' => array(),
+            'assets' => array(),
+            'theme' => array(),
+            'rewrite_candidates' => array(),
+            'totals' => array('pages' => 0, 'template_parts' => 0, 'assets' => 0),
+        );
+    }
+
+    /**
+     * @param array<int,mixed> $pages
+     * @return array<int,array<string,mixed>>
+     */
+    private function pages(array $pages): array
+    {
+        $planned = array();
+        foreach ( $pages as $page ) {
+            if ( ! is_array($page) ) {
+                continue;
+            }
+            $planned[] = array_filter(array(
+                'source_path' => (string) ($page['source_path'] ?? ''),
+                'slug'        => (string) ($page['slug'] ?? ''),
+                'title'       => (string) ($page['title'] ?? ''),
+                'post_type'   => (string) (($page['metadata']['post_type'] ?? '') ?: 'page'),
+                'body_format' => (string) ($page['body_format'] ?? ''),
+                'block_markup' => (string) ($page['block_markup'] ?? ''),
+                'entrypoint'  => ! empty($page['entrypoint']),
+                'metadata'    => is_array($page['metadata'] ?? null) ? $page['metadata'] : array(),
+            ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
+        }
+        return $planned;
+    }
+
+    /**
+     * @param array<int,mixed> $templateParts
+     * @return array<int,array<string,mixed>>
+     */
+    private function templateParts(array $templateParts): array
+    {
+        $planned = array();
+        foreach ( $templateParts as $part ) {
+            if ( ! is_array($part) ) {
+                continue;
+            }
+            $planned[] = array_filter(array(
+                'source_path' => (string) ($part['source_path'] ?? ''),
+                'slug'        => (string) ($part['slug'] ?? ''),
+                'title'       => (string) ($part['title'] ?? ''),
+                'area'        => (string) ($part['area'] ?? 'uncategorized'),
+                'body_format' => (string) ($part['body_format'] ?? ''),
+                'block_markup' => (string) ($part['block_markup'] ?? ''),
+            ), static fn (mixed $value): bool => '' !== $value);
+        }
+        return $planned;
+    }
+
+    /**
+     * @param array<int,mixed> $assets
+     * @return array<int,array<string,mixed>>
+     */
+    private function assets(array $assets): array
+    {
+        $planned = array();
+        foreach ( $assets as $asset ) {
+            if ( ! is_array($asset) ) {
+                continue;
+            }
+            $planned[] = array_filter(array(
+                'path'      => (string) ($asset['path'] ?? ''),
+                'kind'      => (string) ($asset['kind'] ?? ''),
+                'role'      => (string) ($asset['role'] ?? ''),
+                'intent'    => (string) ($asset['intent'] ?? ''),
+                'mime_type' => (string) ($asset['mime_type'] ?? ''),
+                'bytes'     => (int) ($asset['bytes'] ?? 0),
+                'binary'    => ! empty($asset['binary']),
+            ), static fn (mixed $value): bool => '' !== $value && 0 !== $value && false !== $value);
+        }
+        return $planned;
+    }
+
+    /**
+     * @param array<string,mixed> $theme
+     * @param array<int,array<string,mixed>> $templateParts
+     * @param array<int,array<string,mixed>> $assets
+     * @param array<string,mixed> $visualRepair
+     * @return array<string,mixed>
+     */
+    private function theme(array $theme, array $templateParts, array $assets, array $visualRepair): array
+    {
+        return array_filter(array(
+            'stylesheets' => $theme['stylesheets'] ?? $this->assetPathsByRole($assets, 'stylesheet'),
+            'scripts' => $theme['scripts'] ?? $this->assetPathsByRole($assets, 'script'),
+            'fonts' => $theme['fonts'] ?? $this->assetPathsByRole($assets, 'font'),
+            'images' => $theme['images'] ?? $this->assetPathsByRole($assets, 'image'),
+            'template_parts' => array_values(array_map(static fn (array $part): string => (string) ($part['source_path'] ?? ''), $templateParts)),
+            'visual_repair_css' => (string) ($visualRepair['css'] ?? ''),
+        ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $assets
+     * @return array<int,string>
+     */
+    private function assetPathsByRole(array $assets, string $role): array
+    {
+        $paths = array();
+        foreach ( $assets as $asset ) {
+            if ( $role === ($asset['role'] ?? '') && '' !== ($asset['path'] ?? '') ) {
+                $paths[] = (string) $asset['path'];
+            }
+        }
+        return $paths;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $pages
+     * @param array<int,array<string,mixed>> $assets
+     * @return array<int,array<string,mixed>>
+     */
+    private function rewriteCandidates(array $pages, array $assets): array
+    {
+        $assetPaths = array_values(array_filter(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $assets)));
+        if ( array() === $assetPaths ) {
+            return array();
+        }
+
+        $candidates = array();
+        foreach ( $pages as $page ) {
+            $markup = (string) ($page['block_markup'] ?? '');
+            foreach ( $assetPaths as $assetPath ) {
+                if ( '' !== $markup && str_contains($markup, $assetPath) ) {
+                    $candidates[] = array(
+                        'source_path' => (string) ($page['source_path'] ?? ''),
+                        'asset_path'  => $assetPath,
+                    );
+                }
+            }
+        }
+        return $candidates;
+    }
+}

--- a/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
@@ -29,23 +29,34 @@ final class MaterializationPlanBuilder
         $templateParts = $this->templateParts((array) ($compiledSite['template_parts'] ?? array()));
         $assets = $this->assets((array) ($compiledSite['assets'] ?? array()));
         $visualRepair = is_array($compiledSite['visual_repair'] ?? null) ? $compiledSite['visual_repair'] : array();
+        $assetRewriteCandidates = $this->assetRewriteCandidates($pages, $templateParts, $assets);
 
-        return array(
+        $plan = array(
             'schema'         => self::SCHEMA,
             'source_schema'  => (string) ($compiledSite['schema'] ?? ''),
             'source_hash'    => (string) ($compiledSite['source_hash'] ?? ''),
             'entry_path'     => (string) ($compiledSite['entry_path'] ?? ''),
             'pages'          => $pages,
             'template_parts' => $templateParts,
+            'template_part_writes' => $this->templatePartWrites($templateParts),
             'assets'         => $assets,
             'theme'          => $this->theme((array) ($compiledSite['theme'] ?? array()), $templateParts, $assets, $visualRepair),
-            'rewrite_candidates' => $this->rewriteCandidates($pages, $assets),
+            'visual_repair_css' => (string) ($visualRepair['css'] ?? ''),
+            'asset_rewrite_candidates' => $assetRewriteCandidates,
+            'rewrite_candidates' => $assetRewriteCandidates,
+            'products'       => is_array($compiledSite['products'] ?? null) ? $compiledSite['products'] : array(),
             'totals'         => array(
                 'pages'          => count($pages),
                 'template_parts' => count($templateParts),
                 'assets'         => count($assets),
             ),
         );
+
+        if ( array() === $plan['products'] ) {
+            unset($plan['products']);
+        }
+
+        return $plan;
     }
 
     /**
@@ -57,8 +68,10 @@ final class MaterializationPlanBuilder
             'schema' => self::SCHEMA,
             'pages' => array(),
             'template_parts' => array(),
+            'template_part_writes' => array(),
             'assets' => array(),
             'theme' => array(),
+            'asset_rewrite_candidates' => array(),
             'rewrite_candidates' => array(),
             'totals' => array('pages' => 0, 'template_parts' => 0, 'assets' => 0),
         );
@@ -107,9 +120,30 @@ final class MaterializationPlanBuilder
                 'area'        => (string) ($part['area'] ?? 'uncategorized'),
                 'body_format' => (string) ($part['body_format'] ?? ''),
                 'block_markup' => (string) ($part['block_markup'] ?? ''),
-            ), static fn (mixed $value): bool => '' !== $value);
+                'metadata'    => is_array($part['metadata'] ?? null) ? $part['metadata'] : array(),
+            ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
         }
         return $planned;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $templateParts
+     * @return array<int,array<string,mixed>>
+     */
+    private function templatePartWrites(array $templateParts): array
+    {
+        $writes = array();
+        foreach ( $templateParts as $part ) {
+            $writes[] = array_filter(array(
+                'type'        => 'wp_template_part',
+                'source_path' => (string) ($part['source_path'] ?? ''),
+                'slug'        => (string) ($part['slug'] ?? ''),
+                'title'       => (string) ($part['title'] ?? ''),
+                'area'        => (string) ($part['area'] ?? 'uncategorized'),
+                'content'     => (string) ($part['block_markup'] ?? ''),
+            ), static fn (mixed $value): bool => '' !== $value);
+        }
+        return $writes;
     }
 
     /**
@@ -172,10 +206,11 @@ final class MaterializationPlanBuilder
 
     /**
      * @param array<int,array<string,mixed>> $pages
+     * @param array<int,array<string,mixed>> $templateParts
      * @param array<int,array<string,mixed>> $assets
      * @return array<int,array<string,mixed>>
      */
-    private function rewriteCandidates(array $pages, array $assets): array
+    private function assetRewriteCandidates(array $pages, array $templateParts, array $assets): array
     {
         $assetPaths = array_values(array_filter(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $assets)));
         if ( array() === $assetPaths ) {
@@ -183,17 +218,24 @@ final class MaterializationPlanBuilder
         }
 
         $candidates = array();
-        foreach ( $pages as $page ) {
-            $markup = (string) ($page['block_markup'] ?? '');
-            foreach ( $assetPaths as $assetPath ) {
-                if ( '' !== $markup && str_contains($markup, $assetPath) ) {
-                    $candidates[] = array(
-                        'source_path' => (string) ($page['source_path'] ?? ''),
+        foreach ( array('page' => $pages, 'template_part' => $templateParts) as $scope => $documents ) {
+            foreach ( $documents as $document ) {
+                $markup = (string) ($document['block_markup'] ?? '');
+                foreach ( $assetPaths as $assetPath ) {
+                    if ( '' === $markup || ! str_contains($markup, $assetPath) ) {
+                        continue;
+                    }
+
+                    $candidates[] = array_filter(array(
+                        'scope'       => $scope,
+                        'source_path' => (string) ($document['source_path'] ?? ''),
+                        'slug'        => (string) ($document['slug'] ?? ''),
                         'asset_path'  => $assetPath,
-                    );
+                    ), static fn (mixed $value): bool => '' !== $value);
                 }
             }
         }
+
         return $candidates;
     }
 }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatAdapterInterface;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
 
 if ( ! function_exists('serialize_blocks') ) {
     /**
@@ -89,6 +90,16 @@ $assert(0 === ($simple['metrics']['block_count'] ?? null), 'artifact metrics exp
 $assert(0 === ($simple['metrics']['fallback_count'] ?? null), 'artifact metrics expose fallback count');
 $assert(0 === ($simple['metrics']['diagnostic_count'] ?? null), 'artifact metrics expose diagnostic count');
 $assert(is_float($simple['metrics']['transform_duration_ms'] ?? null), 'artifact metrics expose transform duration');
+$assert(MaterializationPlanBuilder::SCHEMA === ($simple['source_reports']['materialization_plan']['schema'] ?? ''), 'artifact exposes canonical materialization plan');
+$assert('index.html' === ($simple['source_reports']['materialization_plan']['entry_path'] ?? ''), 'materialization plan exposes entry path');
+$assert(1 === ($simple['source_reports']['materialization_plan']['totals']['pages'] ?? null), 'materialization plan counts pages');
+$assert('index' === ($simple['source_reports']['materialization_plan']['pages'][0]['slug'] ?? ''), 'materialization plan exposes page slug');
+
+$fragment = $compiler->compileFragment('<main><h2>Fragment</h2><p>Copy</p></main>', 'fixture:fragment')->toArray();
+$assert('success' === $fragment['status'], 'fragment compiles successfully', (string) $fragment['status']);
+$assert('fixture:fragment' === ($fragment['provenance'][0]['source'] ?? ''), 'fragment compile exposes source provenance');
+$assert('artifact-fragment' === ($fragment['provenance'][0]['scope'] ?? ''), 'fragment compile exposes source scope');
+$assert(str_contains((string) $fragment['serialized_blocks'], '<!-- wp:heading'), 'fragment compile serializes heading block');
 
 $missing = $compiler->compile(array('files' => array()))->toArray();
 $assert('failed' === $missing['status'], 'missing HTML fails explicitly', (string) $missing['status']);

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -95,6 +95,35 @@ $assert('index.html' === ($simple['source_reports']['materialization_plan']['ent
 $assert(1 === ($simple['source_reports']['materialization_plan']['totals']['pages'] ?? null), 'materialization plan counts pages');
 $assert('index' === ($simple['source_reports']['materialization_plan']['pages'][0]['slug'] ?? ''), 'materialization plan exposes page slug');
 
+$staticSite = $compiler->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><img src="assets/logo.png" alt="Logo"></main>',
+            'parts/header.html' => '<header><img src="assets/logo.png" alt="Logo"></header>',
+            'assets/logo.png' => array(
+                'content_base64' => base64_encode("\x89PNG\r\n\x1a\n"),
+                'mime_type'      => 'image/png',
+            ),
+            'visual-repair.css' => '.wp-site-blocks{min-height:100vh}',
+        ),
+    )
+)->toArray();
+$staticPlan = $staticSite['source_reports']['materialization_plan'] ?? array();
+$assert('parts/header.html' === ($staticPlan['template_part_writes'][0]['source_path'] ?? ''), 'materialization plan exposes template part writes');
+$assert('wp_template_part' === ($staticPlan['template_part_writes'][0]['type'] ?? ''), 'template part writes identify the WordPress write target');
+$assert(str_contains((string) ($staticPlan['visual_repair_css'] ?? ''), 'min-height:100vh'), 'materialization plan exposes visual repair CSS');
+$assert(! empty(array_filter($staticPlan['asset_rewrite_candidates'] ?? array(), static fn (array $candidate): bool => 'template_part' === ($candidate['scope'] ?? '') && 'assets/logo.png' === ($candidate['asset_path'] ?? ''))), 'materialization plan exposes template part asset rewrite candidates');
+
+$productsPlan = ( new MaterializationPlanBuilder() )->fromCompiledSite(
+    array(
+        'products' => array(
+            array('sku' => 'shirt-001', 'name' => 'Shirt'),
+        ),
+    )
+);
+$assert('shirt-001' === ($productsPlan['products'][0]['sku'] ?? ''), 'materialization plan preserves compiled site products manifest when present');
+
 $fragment = $compiler->compileFragment('<main><h2>Fragment</h2><p>Copy</p></main>', 'fixture:fragment')->toArray();
 $assert('success' === $fragment['status'], 'fragment compiles successfully', (string) $fragment['status']);
 $assert('fixture:fragment' === ($fragment['provenance'][0]['source'] ?? ''), 'fragment compile exposes source provenance');


### PR DESCRIPTION
## Summary
- add a canonical Blocks Engine static-site materialization plan schema
- expose the plan from artifact compiler results under `source_reports.materialization_plan`
- add `ArtifactCompiler::compileFragment()` as the upstream fragment API for BAC/SSI facades

## Why
This starts collapsing SSI/BAC ownership into Blocks Engine. Downstream repos should consume this upstream plan instead of owning their own page/template/asset materialization contracts.

## Testing
- `composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Adding the upstream materialization API, contract coverage, and verification.
