### PR TITLE
Add PHP transformer spacer HTML parity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -96,6 +96,13 @@ final class BlockFactory
             return '<hr' . $this->blockSupportAttrs($attrs, 'wp-block-separator') . ' />';
         }
 
+        if ( 'core/spacer' === $name ) {
+            $height = (string) ($attrs['height'] ?? '');
+            $style = trim('' !== $height ? 'height:' . $height : (string) ($attrs['style'] ?? ''));
+            $attrs['style'] = $style;
+            return '<div' . $this->blockSupportAttrs($attrs, 'wp-block-spacer') . ' aria-hidden="true"></div>';
+        }
+
         if ( 'core/columns' === $name ) {
             return array( 'opening' => '<div' . $this->blockSupportAttrs($attrs, 'wp-block-columns') . '>', 'closing' => '</div>' );
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -124,7 +124,7 @@ final class HtmlTransformer
         $diagnostics = array(
             array(
                 'code'    => 'html_to_blocks_core_slice',
-                'message' => 'Converted supported core text, layout, media, gallery, embed, file, table, button, shortcode, definition-list, details, navigation, and wrapper elements; unsupported elements are reported as fallbacks.',
+                'message' => 'Converted supported core text, layout, media, gallery, embed, file, table, button, shortcode, spacer, definition-list, details, navigation, and wrapper elements; unsupported elements are reported as fallbacks.',
                 'source'  => self::class,
             ),
         );
@@ -162,7 +162,7 @@ final class HtmlTransformer
             sourceReports: $sourceReports,
             coverage: array(
                 array(
-                    'supported_blocks' => array( 'core/audio', 'core/button', 'core/buttons', 'core/code', 'core/column', 'core/columns', 'core/details', 'core/embed', 'core/file', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/separator', 'core/shortcode', 'core/table', 'core/video' ),
+                    'supported_blocks' => array( 'core/audio', 'core/button', 'core/buttons', 'core/code', 'core/column', 'core/columns', 'core/details', 'core/embed', 'core/file', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/separator', 'core/shortcode', 'core/spacer', 'core/table', 'core/video' ),
                     'block_count'      => count($blocks),
                     'fallback_count'   => count($fallbacks),
                     'source_provenance_count' => count($sourceProvenance),
@@ -459,6 +459,11 @@ final class HtmlTransformer
         }
 
         if ( in_array($tagName, array( 'article', 'body', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
+            $spacer = $this->spacerBlockFromElement($element);
+            if ( null !== $spacer ) {
+                return $spacer;
+            }
+
             $columns = $this->columnsBlockFromElement($element, $fallbacks);
             if ( null !== $columns ) {
                 return $columns;
@@ -1563,6 +1568,45 @@ final class HtmlTransformer
 
         return (bool) preg_match('/(?:^|[\s_-])columns?(?:$|[\s_-])/', $className)
             || preg_match('/(?:^|;)\s*(?:display\s*:\s*(?:inline-)?flex|grid-template-columns\s*:)/', $style);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function spacerBlockFromElement(DOMElement $element): ?array
+    {
+        if ( '' !== trim($element->textContent ?? '') || 0 !== $this->childElementCount($element) ) {
+            return null;
+        }
+
+        $height = $this->spacerHeightFromStyle($this->attr($element, 'style'));
+        if ( '' === $height ) {
+            return null;
+        }
+
+        if ( ! $this->hasClass($element, 'wp-block-spacer') && ! $this->hasClass($element, 'spacer') ) {
+            return null;
+        }
+
+        $attrs = $this->presentationAttributes($element);
+        $attrs['height'] = $height;
+        unset($attrs['style']);
+
+        return $this->createBlock('core/spacer', $attrs, array(), $element);
+    }
+
+    private function spacerHeightFromStyle(string $style): string
+    {
+        if ( ! preg_match('/(?:^|;)\s*height\s*:\s*([^;]+)/i', $style, $matches) ) {
+            return '';
+        }
+
+        $height = trim($matches[1]);
+        if ( '' === $height || preg_match('/[{}]/', $height) || strlen($height) > 80 ) {
+            return '';
+        }
+
+        return $height;
     }
 
     private function convertMediaElement(DOMElement $element): ?array

--- a/php-transformer/tests/fixtures/parity/html-spacer-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-spacer-primitives.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-spacer-primitives",
+  "description": "Converts clear empty spacer-like HTML into core/spacer while preserving surrounding layout wrappers.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-spacer-primitives.json",
+    "notes": "Product-neutral fixture for upstream spacer HTML parity."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"layout\"><h2>Before</h2><div class=\"spacer\" style=\"height: 48px\"></div><div class=\"wp-block-columns\"><div><p>Left</p></div><div><p>Right</p></div></div><div class=\"wp-block-spacer extra\" style=\"height:2rem\"></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "layout" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Before", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/spacer", "attrs": { "className": "spacer", "height": "48px" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/columns", "attrs": { "className": "wp-block-columns" } },
+    { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/column" },
+    { "path": "blocks.0.innerBlocks.2.innerBlocks.1", "name": "core/column" },
+    { "path": "blocks.0.innerBlocks.3", "name": "core/spacer", "attrs": { "className": "wp-block-spacer extra", "height": "2rem" } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 4 },
+    { "path": "blocks.0.innerBlocks.1.innerHTML", "assert": "contains", "value": "class=\"wp-block-spacer spacer\"" },
+    { "path": "blocks.0.innerBlocks.1.innerHTML", "assert": "contains", "value": "style=\"height:48px\"" },
+    { "path": "blocks.0.innerBlocks.1.innerHTML", "assert": "contains", "value": "aria-hidden=\"true\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.supported_blocks.23", "assert": "equals", "value": "core/spacer" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add PHP transformer support for converting clear empty spacer-like HTML into core/spacer.
- Serialize core/spacer blocks with WordPress spacer markup and aria-hidden=true.
- Add a parity fixture covering the reported generic <div class="spacer" style="height: 48px"></div> case plus canonical wp-block-spacer markup alongside columns/group layout.

## Rationale
Generic spacer conversion belongs upstream when the source element is empty and explicitly spacer-like. This PR keeps the heuristic narrow: it requires an explicit height style plus either wp-block-spacer or spacer class, avoiding downstream/product-specific selectors.

## Verification
- composer test from php-transformer/
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, fixture authoring, and local verification.