### PR TITLE
Add asset metadata support for HTML image transforms

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -35,6 +35,11 @@ final class HtmlTransformer
      */
     private array $structureProvenance = array();
 
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $assetMetadata = array();
+
     private int $nextSourceProvenanceId = 1;
 
     public function __construct(private readonly Runtime $runtime = new Runtime())
@@ -53,6 +58,7 @@ final class HtmlTransformer
         $this->presentationProvenance = array();
         $this->sourceProvenance = array();
         $this->structureProvenance = array();
+        $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->nextSourceProvenanceId = 1;
         $provenance               = array(
             array_merge(array(
@@ -1667,6 +1673,7 @@ final class HtmlTransformer
         )), static fn ($value): bool => '' !== $value);
 
         $attrs = array_filter(array_merge($attrs, $this->imageIdentityAttributes($image, $figure)), static fn ($value): bool => '' !== $value);
+        $attrs = array_filter(array_merge($attrs, $this->assetMetadataImageAttributes($url)), static fn ($value): bool => '' !== $value);
 
         if ( $figure instanceof DOMElement ) {
             $caption = $this->firstChildElement($figure, 'figcaption');
@@ -1814,6 +1821,103 @@ final class HtmlTransformer
         }
 
         return $url;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, array<string, mixed>>
+     */
+    private function assetMetadataFromOptions(array $options): array
+    {
+        $metadata = array();
+
+        foreach ( array( $options['provenance'] ?? null, $options['context'] ?? null, $options ) as $container ) {
+            if ( ! is_array($container) || ! isset($container['asset_metadata']) || ! is_array($container['asset_metadata']) ) {
+                continue;
+            }
+
+            foreach ( $container['asset_metadata'] as $path => $asset ) {
+                if ( ! is_string($path) || '' === trim($path) || ! is_array($asset) ) {
+                    continue;
+                }
+
+                $metadata[trim($path)] = $asset;
+            }
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    private function assetMetadataImageAttributes(string $url): array
+    {
+        $asset = $this->assetMetadataForUrl($url);
+        if ( null === $asset ) {
+            return array();
+        }
+
+        $attrs = array();
+        if ( isset($asset['id']) && ( is_int($asset['id']) || ( is_string($asset['id']) && ctype_digit($asset['id']) ) ) ) {
+            $attrs['id'] = (int) $asset['id'];
+        }
+
+        if ( isset($asset['url']) && is_string($asset['url']) ) {
+            $resolvedUrl = $this->safeResolvedAssetImageUrl(trim($asset['url']));
+            if ( '' !== $resolvedUrl ) {
+                $attrs['url'] = $resolvedUrl;
+            }
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function assetMetadataForUrl(string $url): ?array
+    {
+        foreach ( $this->assetMetadataLookupKeys($url) as $key ) {
+            if ( isset($this->assetMetadata[$key]) ) {
+                return $this->assetMetadata[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function assetMetadataLookupKeys(string $url): array
+    {
+        $keys = array();
+        foreach ( array( trim($url), ltrim(trim($url), '/') ) as $key ) {
+            if ( '' !== $key && ! in_array($key, $keys, true) ) {
+                $keys[] = $key;
+            }
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        if ( is_string($path) ) {
+            foreach ( array( $path, ltrim($path, '/') ) as $key ) {
+                if ( '' !== $key && ! in_array($key, $keys, true) ) {
+                    $keys[] = $key;
+                }
+            }
+        }
+
+        return $keys;
+    }
+
+    private function safeResolvedAssetImageUrl(string $url): string
+    {
+        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
+            return '';
+        }
+
+        return $this->safeImageUrl($url);
     }
 
     private function isSafeSvgContent(string $content): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -72,6 +72,30 @@ $assert(false === ($contextual['context']['allow_fallbacks'] ?? null), 'HTML tra
 $assert('fixture:contextual-html' === ($contextual['provenance'][0]['source'] ?? ''), 'HTML provenance exposes generic source metadata');
 $assert('contract-test' === ($contextual['provenance'][0]['scope'] ?? ''), 'HTML provenance exposes generic scope metadata');
 
+$assetMetadataOptions = array(
+    'context' => array(
+        'asset_metadata' => array(
+            'assets/hero.jpg' => array(
+                'id'  => 42,
+                'url' => 'https://example.test/wp-content/uploads/hero.jpg',
+            ),
+        ),
+    ),
+);
+$resolvedImage = ( new HtmlTransformer() )->transform('<main><img src="assets/hero.jpg" alt="Hero alt"></main>', $assetMetadataOptions)->toArray();
+$resolvedImageAttrs = $resolvedImage['blocks'][0]['attrs'] ?? array();
+$assert(42 === ($resolvedImageAttrs['id'] ?? null), 'HTML image transform applies resolved asset id from context metadata');
+$assert('https://example.test/wp-content/uploads/hero.jpg' === ($resolvedImageAttrs['url'] ?? ''), 'HTML image transform applies resolved asset URL from context metadata');
+$assert('Hero alt' === ($resolvedImageAttrs['alt'] ?? ''), 'HTML image transform preserves original alt text while resolving asset metadata');
+$assert(str_contains((string) ($resolvedImage['serialized_blocks'] ?? ''), 'src="https://example.test/wp-content/uploads/hero.jpg"'), 'HTML image transform serializes resolved asset URL');
+$assert(str_contains((string) ($resolvedImage['serialized_blocks'] ?? ''), 'class="wp-image-42"'), 'HTML image transform serializes resolved image id class');
+
+$bridgeImageBlocks = ( new FormatBridge() )->toBlocks('<main><img src="assets/hero.jpg" alt="Hero alt"></main>', 'html', $assetMetadataOptions);
+$bridgeImageAttrs = $bridgeImageBlocks[0]['attrs'] ?? array();
+$assert(42 === ($bridgeImageAttrs['id'] ?? null), 'FormatBridge HTML adapter applies resolved asset id from context metadata');
+$assert('https://example.test/wp-content/uploads/hero.jpg' === ($bridgeImageAttrs['url'] ?? ''), 'FormatBridge HTML adapter applies resolved asset URL from context metadata');
+$assert('Hero alt' === ($bridgeImageAttrs['alt'] ?? ''), 'FormatBridge HTML adapter preserves original alt text while resolving asset metadata');
+
 $compiler = new ArtifactCompiler();
 
 $simple = $compiler->compile(


### PR DESCRIPTION
## Summary
- Resolve generic per-call `asset_metadata` for HTML image transforms from options, context, or provenance.
- Apply matched image asset `id` and resolved `url` to `core/image` attrs and serialized output while preserving source alt text.
- Add contract coverage for direct `HtmlTransformer` and `FormatBridge` HTML adapter paths.

## Testing
- `php -l src/HtmlToBlocks/HtmlTransformer.php && php -l tests/contract/run.php`
- `composer test:canonical`
- `composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the PHP transformer change, adding contract coverage, and running verification.