### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/php-transformer.yml
+++ b/.github/workflows/php-transformer.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
         with:
           php-version: "8.1"
           coverage: none


### PR DESCRIPTION
Pins the third-party action in `.github/workflows/php-transformer.yml` to a commit SHA.

`shivammathur/setup-php@v2` -> `f3e473d116dcccaddc5834248c87452386958240` (2.37.2), the commit `@v2` currently resolves to. `actions/checkout` is GitHub-owned, out of scope for this third-party pass.

Verify:

    gh api repos/shivammathur/setup-php/commits/v2 --jq .sha
    # => f3e473d116dcccaddc5834248c87452386958240

Tracking: DEVPROD-1072.
