### PR TITLE
Expand interaction candidate fixtures

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1012,12 +1012,12 @@ final class HtmlTransformer
             $candidates[] = $this->interactionCandidate($element, 'modal', $this->modalTriggerHint($element), $this->targetForElement($element), array_filter(array('modal_like', 'dialog' === $tagName ? 'dialog_element' : '', '' !== $role ? 'role:' . $role : '')), 'medium', 'modal_runtime');
         }
 
-        if ( 'tablist' === $role || 'tab' === $role ) {
-            $candidates[] = $this->interactionCandidate($element, 'tabs', 'tab' === $role ? 'tab_select' : 'tablist', $this->controlledTarget($element), array_filter(array('role:' . $role, '' !== $this->attr($element, 'aria-controls') ? 'aria-controls' : '')), 'high', 'tab_state');
+        if ( in_array($role, array('tablist', 'tab', 'tabpanel'), true) ) {
+            $candidates[] = $this->interactionCandidate($element, 'tabs', 'tab' === $role ? 'tab_select' : $role, $this->controlledTarget($element), array_filter(array('role:' . $role, '' !== $this->attr($element, 'aria-controls') ? 'aria-controls' : '')), 'high', 'tab_state');
         }
 
-        if ( ( in_array($tagName, array('button', 'a'), true) || '' !== $role ) && preg_match('/(?:^|[\s_-])accordion(?:$|[\s_-])/', $nameText) ) {
-            $candidates[] = $this->interactionCandidate($element, 'accordion', $this->controlTrigger($element, $events), $this->controlledTarget($element), array_filter(array('accordion_like', '' !== $this->attr($element, 'aria-expanded') ? 'aria-expanded' : '')), 'medium', 'accordion_state');
+        if ( ( in_array($tagName, array('button', 'a'), true) || '' !== $role ) && ( preg_match('/(?:^|[\s_-])accordion(?:$|[\s_-])/', $nameText) || ( $hasAriaControl && 'tab' !== $role && '' !== trim($this->attr($element, 'aria-expanded')) ) ) ) {
+            $candidates[] = $this->interactionCandidate($element, 'accordion', $this->controlTrigger($element, $events), $this->controlledTarget($element), array_filter(array('accordion_like', '' !== $this->attr($element, 'aria-expanded') ? 'aria-expanded' : '', '' !== $this->attr($element, 'aria-controls') ? 'aria-controls' : '')), 'medium', 'accordion_state');
         }
 
         if ( preg_match('/(?:^|[\s_-])(?:carousel|slider|slideshow|swiper)(?:$|[\s_-])/', $nameText) ) {

--- a/php-transformer/tests/fixtures/parity/html-interaction-candidates-report.json
+++ b/php-transformer/tests/fixtures/parity/html-interaction-candidates-report.json
@@ -13,28 +13,35 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<main><details id=\"faq\"><summary>FAQ</summary><p>Answer.</p></details><form action=\"/contact\" method=\"post\"><input name=\"email\"><button type=\"submit\">Send</button></form><button class=\"accordion-toggle\" aria-controls=\"panel\" aria-expanded=\"false\" data-action=\"toggle\">Toggle panel</button><section id=\"panel\">Panel</section><div role=\"tablist\"><button role=\"tab\" aria-controls=\"tab-one\">One</button></div><div id=\"tab-one\">Tab one</div><dialog id=\"signup-modal\">Join</dialog><div class=\"hero-carousel\" data-event=\"slide\"><button class=\"carousel-next\">Next</button></div><a href=\"#signup-modal\" onclick=\"openSignup()\">Open signup</a></main>"
+    "content": "<main><details id=\"faq\"><summary>FAQ</summary><p>Answer.</p></details><form action=\"/contact\" method=\"post\"><input name=\"email\"><button type=\"submit\">Send</button></form><section class=\"faq-list\"><h2><button id=\"faq-trigger\" aria-controls=\"faq-panel\" aria-expanded=\"false\">Shipping</button></h2><div id=\"faq-panel\" role=\"region\">Shipping details.</div></section><div role=\"tablist\" aria-label=\"Product tabs\"><button id=\"tab-one\" role=\"tab\" aria-controls=\"panel-one\" aria-selected=\"true\">Overview</button></div><section id=\"panel-one\" role=\"tabpanel\" aria-labelledby=\"tab-one\">Overview panel.</section><dialog id=\"signup-modal\" open>Join</dialog><div id=\"promo-modal\" role=\"dialog\" aria-modal=\"true\">Promo modal</div><div id=\"hero-carousel\" class=\"carousel\"><div class=\"carousel-indicators\"><button data-bs-target=\"#hero-carousel\" data-bs-slide-to=\"0\" aria-label=\"Slide 1\">1</button></div><div class=\"carousel-item active\" id=\"slide-one\">Slide one</div><button class=\"carousel-next\" data-action=\"carousel#next\">Next</button></div><button id=\"menu-button\" data-controller=\"menu\" data-action=\"menu#toggle\" aria-controls=\"menu-panel\">Menu</button><div id=\"menu-panel\" data-menu-target=\"panel\">Menu panel</div></main>"
   },
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "source_reports.interaction_candidates", "assert": "count", "count": 11 },
+    { "path": "source_reports.interaction_candidates", "assert": "count", "count": 17 },
     { "path": "source_reports.interaction_candidates.0.kind", "assert": "equals", "value": "details" },
     { "path": "source_reports.interaction_candidates.0.target", "assert": "equals", "value": "#faq" },
     { "path": "source_reports.interaction_candidates.1.kind", "assert": "equals", "value": "form" },
     { "path": "source_reports.interaction_candidates.1.trigger", "assert": "equals", "value": "submit" },
     { "path": "source_reports.interaction_candidates.1.target", "assert": "equals", "value": "/contact" },
     { "path": "source_reports.interaction_candidates.2.kind", "assert": "equals", "value": "control" },
-    { "path": "source_reports.interaction_candidates.2.target", "assert": "equals", "value": "#panel" },
+    { "path": "source_reports.interaction_candidates.2.target", "assert": "equals", "value": "#faq-panel" },
     { "path": "source_reports.interaction_candidates.3.kind", "assert": "equals", "value": "accordion" },
     { "path": "source_reports.interaction_candidates.4.kind", "assert": "equals", "value": "tabs" },
     { "path": "source_reports.interaction_candidates.5.kind", "assert": "equals", "value": "control" },
-    { "path": "source_reports.interaction_candidates.5.target", "assert": "equals", "value": "#tab-one" },
+    { "path": "source_reports.interaction_candidates.5.target", "assert": "equals", "value": "#panel-one" },
     { "path": "source_reports.interaction_candidates.6.kind", "assert": "equals", "value": "tabs" },
-    { "path": "source_reports.interaction_candidates.7.kind", "assert": "equals", "value": "modal" },
-    { "path": "source_reports.interaction_candidates.8.kind", "assert": "equals", "value": "carousel" },
-    { "path": "source_reports.interaction_candidates.9.kind", "assert": "equals", "value": "carousel" },
-    { "path": "source_reports.interaction_candidates.10.kind", "assert": "equals", "value": "control" },
-    { "path": "source_reports.conversion_report.interaction_candidates", "assert": "count", "count": 11 },
-    { "path": "source_reports.conversion_report.interaction_candidates.10.evidence.0", "assert": "equals", "value": "onclick" }
+    { "path": "source_reports.interaction_candidates.7.kind", "assert": "equals", "value": "tabs" },
+    { "path": "source_reports.interaction_candidates.7.trigger", "assert": "equals", "value": "tabpanel" },
+    { "path": "source_reports.interaction_candidates.8.kind", "assert": "equals", "value": "modal" },
+    { "path": "source_reports.interaction_candidates.9.kind", "assert": "equals", "value": "modal" },
+    { "path": "source_reports.interaction_candidates.10.kind", "assert": "equals", "value": "carousel" },
+    { "path": "source_reports.interaction_candidates.11.kind", "assert": "equals", "value": "carousel" },
+    { "path": "source_reports.interaction_candidates.12.kind", "assert": "equals", "value": "carousel" },
+    { "path": "source_reports.interaction_candidates.13.kind", "assert": "equals", "value": "carousel" },
+    { "path": "source_reports.interaction_candidates.14.kind", "assert": "equals", "value": "control" },
+    { "path": "source_reports.interaction_candidates.15.kind", "assert": "equals", "value": "carousel" },
+    { "path": "source_reports.interaction_candidates.16.kind", "assert": "equals", "value": "control" },
+    { "path": "source_reports.conversion_report.interaction_candidates", "assert": "count", "count": 17 },
+    { "path": "source_reports.conversion_report.interaction_candidates.16.evidence.0", "assert": "equals", "value": "data-action" }
   ]
 }


### PR DESCRIPTION
## Summary
- Expand static interaction candidate fixture coverage for ARIA accordions, tabs, dialogs, carousels, and data-action controls.
- Lightly tune static heuristics for tab panels and accordion candidates.
- Keep browser/runtime behavior out of scope.

## Verification
- composer test:parity
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the code/test changes.