### PR TITLE
Convert simple search forms to core/search

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -184,7 +184,7 @@ final class HtmlTransformer
             sourceReports: $sourceReports,
             coverage: array(
                 array(
-                    'supported_blocks' => array( 'core/audio', 'core/button', 'core/buttons', 'core/code', 'core/column', 'core/columns', 'core/details', 'core/embed', 'core/file', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/separator', 'core/shortcode', 'core/spacer', 'core/table', 'core/video' ),
+                    'supported_blocks' => array( 'core/audio', 'core/button', 'core/buttons', 'core/code', 'core/column', 'core/columns', 'core/details', 'core/embed', 'core/file', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/separator', 'core/shortcode', 'core/spacer', 'core/table', 'core/video', 'core/search' ),
                     'block_count'      => count($blocks),
                     'fallback_count'   => count($fallbacks),
                     'source_provenance_count' => count($sourceProvenance),
@@ -460,6 +460,11 @@ final class HtmlTransformer
         }
 
         if ( 'form' === $tagName ) {
+            $searchBlock = $this->searchBlockFromForm($element);
+            if ( null !== $searchBlock ) {
+                return $searchBlock;
+            }
+
             $controls = $this->formControls($element);
             $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
             $fallbacks[] = FallbackDiagnostic::build(array(
@@ -1528,11 +1533,7 @@ final class HtmlTransformer
     private function formControls(DOMElement $form): array
     {
         $controls = array();
-        foreach ( $form->getElementsByTagName('*') as $control ) {
-            if ( ! $control instanceof DOMElement || ! $this->isFormControlElement($control) ) {
-                continue;
-            }
-
+        foreach ( $this->formControlElements($form) as $control ) {
             $metadata = $this->formControlMetadata($control);
             if ( array() !== $metadata ) {
                 $controls[] = $metadata;
@@ -1555,6 +1556,104 @@ final class HtmlTransformer
             ),
             static fn (string $value): bool => '' !== $value
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function searchBlockFromForm(DOMElement $form): ?array
+    {
+        $method = strtolower(trim($this->attr($form, 'method')));
+        if ( '' !== $method && 'get' !== $method ) {
+            return null;
+        }
+
+        $textInput = null;
+        $submitControl = null;
+        foreach ( $this->formControlElements($form) as $control ) {
+            $tagName = strtolower($control->tagName);
+            $type = $this->formControlType($control);
+            if ( 'input' === $tagName && in_array($type, array( 'text', 'search' ), true) ) {
+                if ( null !== $textInput ) {
+                    return null;
+                }
+                $textInput = $control;
+                continue;
+            }
+
+            if ( ( 'button' === $tagName || 'input' === $tagName ) && 'submit' === $type ) {
+                if ( null !== $submitControl ) {
+                    return null;
+                }
+                $submitControl = $control;
+                continue;
+            }
+
+            return null;
+        }
+
+        if ( ! $textInput instanceof DOMElement || ! $submitControl instanceof DOMElement || ! $this->hasSearchFormSignal($form, $textInput) ) {
+            return null;
+        }
+
+        $inputLabel = $this->formControlLabel($textInput);
+        $attrs = array_filter(array_merge(
+            $this->presentationAttributes($form),
+            array(
+                'label'       => '' !== $inputLabel ? $inputLabel : 'Search',
+                'placeholder' => $this->attr($textInput, 'placeholder'),
+                'buttonText'  => $this->submitButtonText($submitControl),
+            )
+        ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+
+        return $this->createBlock('core/search', $attrs, array(), $form);
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function formControlElements(DOMElement $form): array
+    {
+        $controls = array();
+        foreach ( $form->getElementsByTagName('*') as $control ) {
+            if ( $control instanceof DOMElement && $this->isFormControlElement($control) ) {
+                $controls[] = $control;
+            }
+        }
+
+        return $controls;
+    }
+
+    private function hasSearchFormSignal(DOMElement $form, DOMElement $input): bool
+    {
+        if ( 'search' === $this->formControlType($input) || 'search' === strtolower(trim($this->attr($form, 'role'))) ) {
+            return true;
+        }
+
+        $queryName = strtolower(trim($this->attr($input, 'name')));
+        if ( in_array($queryName, array( 's', 'q', 'query', 'search' ), true) ) {
+            return true;
+        }
+
+        $haystack = strtolower(implode(' ', array(
+            $this->attr($form, 'action'),
+            $this->attr($form, 'aria-label'),
+            $this->attr($form, 'id'),
+            $this->attr($form, 'class'),
+        )));
+
+        return str_contains($haystack, 'search');
+    }
+
+    private function submitButtonText(DOMElement $control): string
+    {
+        $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
+        if ( '' !== $text ) {
+            return $text;
+        }
+
+        $value = trim($this->attr($control, 'value'));
+        return '' !== $value ? $value : 'Search';
     }
 
     /**

--- a/php-transformer/tests/contract/plugin-bootstrap.php
+++ b/php-transformer/tests/contract/plugin-bootstrap.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 require dirname(__DIR__, 2) . '/php-transformer.php';
 
-assertSame('0.1.0', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
+assertSame('0.1.1', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
 assertSame(dirname(__DIR__, 2), blocks_engine_php_transformer_path(), 'Plugin helper exposes package path.');
 
 $htmlInput   = '<main><h1>Plugin bootstrap</h1><p>Ready.</p></main>';

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
@@ -1,0 +1,43 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-runtime-form-fallback-metadata",
+  "description": "Keeps contact and newsletter forms as structured runtime fallbacks without child control fallback noise.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-runtime-form-fallback-metadata.json",
+    "notes": "Non-search forms remain runtime candidates with form/control metadata."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><form action=\"/contact\" method=\"post\"><label>Name <input name=\"name\" required></label><label>Email <input name=\"email\" type=\"email\"></label><textarea name=\"message\" aria-label=\"Message\"></textarea><button type=\"submit\">Send</button></form><form action=\"/newsletter\" method=\"post\" class=\"newsletter\"><label>Email <input type=\"email\" name=\"email\" placeholder=\"you@example.com\"></label><button type=\"submit\" value=\"subscribe\">Subscribe</button></form></main>"
+  },
+  "expected_blocks": [],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "control_count": 4 },
+    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "control_count": 2 }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.form.action", "assert": "equals", "value": "/contact" },
+    { "path": "fallbacks.0.form.method", "assert": "equals", "value": "post" },
+    { "path": "fallbacks.0.controls", "assert": "count", "count": 4 },
+    { "path": "fallbacks.0.controls.0.name", "assert": "equals", "value": "name" },
+    { "path": "fallbacks.0.controls.0.required", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.controls.1.type", "assert": "equals", "value": "email" },
+    { "path": "fallbacks.0.controls.2.tag", "assert": "equals", "value": "textarea" },
+    { "path": "fallbacks.0.controls.2.label", "assert": "equals", "value": "Message" },
+    { "path": "fallbacks.1.form.action", "assert": "equals", "value": "/newsletter" },
+    { "path": "fallbacks.1.form.method", "assert": "equals", "value": "post" },
+    { "path": "fallbacks.1.controls", "assert": "count", "count": 2 },
+    { "path": "fallbacks.1.controls.0.placeholder", "assert": "equals", "value": "you@example.com" },
+    { "path": "fallbacks.1.controls.1.type", "assert": "equals", "value": "submit" },
+    { "path": "fallbacks.1.html", "assert": "contains", "value": "class=\"newsletter\"" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-search-form-conversion.json
+++ b/php-transformer/tests/fixtures/parity/html-search-form-conversion.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-search-form-conversion",
+  "description": "Converts a simple GET search form into a core/search block without form-control fallback noise.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-search-form-conversion.json",
+    "notes": "Search form conversion should preserve user-facing label, placeholder, button text, and presentation classes."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<form role=\"search\" action=\"/\" method=\"get\" class=\"site-search\"><label for=\"site-search-field\">Find articles</label><input id=\"site-search-field\" type=\"search\" name=\"s\" placeholder=\"Search posts\"><button type=\"submit\">Go</button></form>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/search", "attrs": { "className": "site-search", "label": "Find articles", "placeholder": "Search posts", "buttonText": "Go" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:search" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"label\":\"Find articles\"" },
+    { "path": "coverage.0.block_count", "assert": "equals", "value": 1 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Convert unambiguous simple GET/default search forms with one text/search input and one submit control to core/search.
- Keep contact/newsletter and other runtime forms as structured html_form_fallback diagnostics with form/control metadata.
- Avoid redundant child-control unsupported fallbacks when the form is handled as either a search block or a form runtime fallback.
- Add parity fixtures for search conversion and contact/newsletter runtime fallback metadata.
- Align the plugin bootstrap contract version assertion with the current 0.1.1 plugin version so the full transformer suite passes.

## Tests
- composer test:parity
- composer test

## Compatibility notes
- Search conversion is intentionally conservative: method must be omitted or GET, controls must be exactly one text/search input plus one submit control, and the form/input must carry a search signal such as role=search, type=search, a search-like query name, or search-like form metadata.
- Forms with extra controls, POST methods, contact/newsletter fields, hidden fields, selects, textareas, or non-search signals continue to emit structured runtime fallback diagnostics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the form/search conversion change, adding fixtures, running tests, and drafting this PR description.