### PR TITLE
Convert safe anchor image patterns

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -226,6 +226,18 @@ final class BlockFactory
         );
 
         $img = '<img' . $this->htmlAttrs($imageAttrs, array( 'alt' )) . '/>';
+        if ( ! empty($attrs['href']) ) {
+            $linkAttrs = array(
+                'href'        => (string) $attrs['href'],
+                'target'      => (string) ($attrs['linkTarget'] ?? ''),
+                'rel'         => (string) ($attrs['rel'] ?? ''),
+                'class'       => (string) ($attrs['linkClass'] ?? ''),
+                'aria-label'  => (string) ($attrs['linkAriaLabel'] ?? ''),
+                'aria-hidden' => (string) ($attrs['linkAriaHidden'] ?? ''),
+                'tabindex'    => (string) ($attrs['linkTabIndex'] ?? ''),
+            );
+            $img = '<a' . $this->htmlAttrs($linkAttrs) . '>' . $img . '</a>';
+        }
         $caption = ! empty($attrs['caption']) ? '<figcaption class="wp-element-caption">' . $attrs['caption'] . '</figcaption>' : '';
         return '<figure' . $this->blockSupportAttrs($figureAttrs, 'wp-block-image') . '>' . $img . $caption . '</figure>';
     }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -468,7 +468,20 @@ final class HtmlTransformer
             return $this->convertMediaElement($element);
         }
 
-        if ( 'a' === $tagName && '' !== trim($element->textContent ?? '') ) {
+        if ( 'a' === $tagName ) {
+            $linkedImage = $this->imageBlockFromAnchor($element);
+            if ( null !== $linkedImage ) {
+                return $linkedImage;
+            }
+
+            if ( '' === trim($element->textContent ?? '') && '' !== $this->safeLinkUrl($this->attr($element, 'href')) && '' !== trim($this->attr($element, 'aria-label')) ) {
+                return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $this->outerHtml($element) )), array(), $element);
+            }
+
+            if ( '' === trim($element->textContent ?? '') ) {
+                return null;
+            }
+
             $logo = $this->logoPattern->match(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
@@ -2224,7 +2237,44 @@ final class HtmlTransformer
         return $this->convertImageElement($image, $figure ?? $picture, $picture);
     }
 
-    private function convertImageElement(DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null): ?array
+    private function imageBlockFromAnchor(DOMElement $anchor): ?array
+    {
+        $href = $this->safeLinkUrl($this->attr($anchor, 'href'));
+        if ( '' === $href || ! $this->isImageOnlyAnchor($anchor) ) {
+            return null;
+        }
+
+        $picture = $this->firstChildElement($anchor, 'picture');
+        if ( $picture instanceof DOMElement ) {
+            $image = $this->firstChildElement($picture, 'img');
+            return $image instanceof DOMElement ? $this->convertImageElement($image, null, $picture, $anchor) : null;
+        }
+
+        $image = $this->firstChildElement($anchor, 'img');
+        return $image instanceof DOMElement ? $this->convertImageElement($image, null, null, $anchor) : null;
+    }
+
+    private function isImageOnlyAnchor(DOMElement $anchor): bool
+    {
+        $imageChildren = 0;
+        foreach ( $anchor->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                if ( ! in_array(strtolower($child->tagName), array( 'img', 'picture' ), true) ) {
+                    return false;
+                }
+                ++$imageChildren;
+                continue;
+            }
+
+            if ( '' !== trim($child->textContent ?? '') ) {
+                return false;
+            }
+        }
+
+        return 1 === $imageChildren;
+    }
+
+    private function convertImageElement(DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array
     {
         $url = $this->safeImageUrl($this->attr($image, 'src'));
         if ( '' === $url ) {
@@ -2262,7 +2312,40 @@ final class HtmlTransformer
             }
         }
 
+        if ( $link instanceof DOMElement ) {
+            $attrs = array_filter(array_merge($attrs, $this->imageLinkAttributes($link)), static fn ($value): bool => '' !== $value);
+        }
+
         return $this->createBlock('core/image', $attrs, array(), $figure ?? $image);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function imageLinkAttributes(DOMElement $link): array
+    {
+        $attrs = array(
+            'href'            => $this->safeLinkUrl($this->attr($link, 'href')),
+            'linkDestination' => 'custom',
+            'linkTarget'      => $this->attr($link, 'target'),
+            'rel'             => $this->attr($link, 'rel'),
+            'linkClass'       => $this->attr($link, 'class'),
+            'linkAriaLabel'   => $this->attr($link, 'aria-label'),
+            'linkAriaHidden'  => $this->attr($link, 'aria-hidden'),
+            'linkTabIndex'    => $this->attr($link, 'tabindex'),
+        );
+
+        return array_filter($attrs, static fn (string $value): bool => '' !== trim($value));
+    }
+
+    private function safeLinkUrl(string $url): string
+    {
+        $url = trim($url);
+        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
+            return '';
+        }
+
+        return $url;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-anchor-inline-patterns.json
+++ b/php-transformer/tests/fixtures/parity/html-anchor-inline-patterns.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-anchor-inline-patterns",
+  "description": "Converts safe image-only and empty labeled anchors without unsupported-element fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-anchor-inline-patterns.json",
+    "notes": "Covers raw fixture corpus anchor fallbacks for linked thumbnails and empty logo/home anchors."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers a PHP transformer fallback reduction beyond the legacy converter behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a href=\"single.html\" tabindex=\"-1\" aria-hidden=\"true\"><img src=\"assets/photos/thumb-stop-motion.png\" alt=\"\"></a><a class=\"bp-logo\" href=\"index.html\" aria-label=\"The Baseplate - home\"></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/image", "attrs": { "url": "assets/photos/thumb-stop-motion.png", "href": "single.html", "linkDestination": "custom", "linkAriaHidden": "true", "linkTabIndex": "-1" } },
+    { "path": "blocks.1", "name": "core/paragraph", "attrs": { "className": "bp-logo", "content": "<a class=\"bp-logo\" href=\"index.html\" aria-label=\"The Baseplate - home\"></a>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"single.html\" aria-hidden=\"true\" tabindex=\"-1\"><img src=\"assets/photos/thumb-stop-motion.png\" alt=\"\"/></a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"bp-logo\" href=\"index.html\" aria-label=\"The Baseplate - home\"></a>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Converts safe image-only anchors into linked core/image blocks instead of unsupported HTML fallbacks.
- Converts empty anchors with safe href and aria-label into paragraph inline anchor markup.
- Preserves link URL and common link accessibility attributes in serialized output.

## Corpus profile
Compared against current trunk on /Users/chubes/Downloads/raw-html:
- fallbacks: 191 -> 64
- html_unsupported_element: 91 -> 31
- html_inline_svg_fallback: 67 -> 0 in this branch profile
- fixtures: 23/23 success_with_warnings

Profile artifact: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/raw-html-profile-anchor.json

## Testing
- composer install
- composer test
- raw HTML corpus profiler against 23 fixtures

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Profiling fixture fallbacks, implementing focused anchor pattern handling, running verification, and drafting this PR description.