### PR TITLE
Convert readable form controls

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -525,6 +525,11 @@ final class HtmlTransformer
                 return $searchBlock;
             }
 
+            $readableFormBlock = $this->readableFormBlockFromForm($element);
+            if ( null !== $readableFormBlock ) {
+                return $readableFormBlock;
+            }
+
             $controls = $this->formControls($element);
             $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
             $fallbacks[] = FallbackDiagnostic::build(array(
@@ -629,6 +634,11 @@ final class HtmlTransformer
                 return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
             }
             return null;
+        }
+
+        $readableControlBlock = $this->readableFormControlBlockFromElement($element);
+        if ( null !== $readableControlBlock ) {
+            return $readableControlBlock;
         }
 
         if ( $captureUnsupported ) {
@@ -1777,9 +1787,17 @@ final class HtmlTransformer
             return null;
         }
 
+        if ( 0 < $form->getElementsByTagName('script')->length || array() !== $this->eventMetadata($form) ) {
+            return null;
+        }
+
         $textInput = null;
         $submitControl = null;
         foreach ( $this->formControlElements($form) as $control ) {
+            if ( array() !== $this->eventMetadata($control) ) {
+                return null;
+            }
+
             $tagName = strtolower($control->tagName);
             $type = $this->formControlType($control);
             if ( 'input' === $tagName && in_array($type, array( 'text', 'search' ), true) ) {
@@ -1801,7 +1819,7 @@ final class HtmlTransformer
             return null;
         }
 
-        if ( ! $textInput instanceof DOMElement || ! $submitControl instanceof DOMElement || ! $this->hasSearchFormSignal($form, $textInput) ) {
+        if ( ! $textInput instanceof DOMElement || ! $this->hasSearchFormSignal($form, $textInput) ) {
             return null;
         }
 
@@ -1811,11 +1829,195 @@ final class HtmlTransformer
             array(
                 'label'       => '' !== $inputLabel ? $inputLabel : 'Search',
                 'placeholder' => $this->attr($textInput, 'placeholder'),
-                'buttonText'  => $this->submitButtonText($submitControl),
+                'buttonText'  => $submitControl instanceof DOMElement ? $this->submitButtonText($submitControl) : '',
             )
         ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
 
         return $this->createBlock('core/search', $attrs, array(), $form);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function readableFormBlockFromForm(DOMElement $form): ?array
+    {
+        if ( 0 < $form->getElementsByTagName('script')->length || array() !== $this->eventMetadata($form) ) {
+            return null;
+        }
+
+        $contentBlocks = array();
+        $buttonBlocks = array();
+        foreach ( $this->formControlElements($form) as $control ) {
+            if ( array() !== $this->eventMetadata($control) || ! $this->isReadableFormControl($control) ) {
+                return null;
+            }
+
+            if ( 'submit' === $this->formControlType($control) ) {
+                $buttonBlocks[] = $this->createBlock('core/button', array_merge($this->presentationAttributes($control), array(
+                    'text' => $this->runtime->escapeHtml($this->readableSubmitText($control)),
+                )), array(), $control);
+                continue;
+            }
+
+            $summary = $this->readableFormControlText($control);
+            if ( '' !== $summary ) {
+                $contentBlocks[] = $this->createBlock('core/paragraph', array( 'content' => $summary ), array(), $control);
+            }
+        }
+
+        if ( array() !== $buttonBlocks ) {
+            $contentBlocks[] = $this->createBlock('core/buttons', array(), $buttonBlocks, $form);
+        }
+
+        if ( array() === $contentBlocks ) {
+            return null;
+        }
+
+        return $this->createBlock('core/group', $this->presentationAttributes($form), $contentBlocks, $form);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function readableFormControlBlockFromElement(DOMElement $element): ?array
+    {
+        $tagName = strtolower($element->tagName);
+        if ( 'label' === $tagName ) {
+            $controls = $this->formControlElements($element);
+            if ( array() !== $controls ) {
+                $blocks = array();
+                foreach ( $controls as $control ) {
+                    if ( ! $this->isReadableFormControl($control) || array() !== $this->eventMetadata($control) ) {
+                        return null;
+                    }
+
+                    $summary = $this->readableFormControlText($control);
+                    if ( '' !== $summary ) {
+                        $blocks[] = $this->createBlock('core/paragraph', array( 'content' => $summary ), array(), $control);
+                    }
+                }
+
+                if ( 1 === count($blocks) ) {
+                    return $blocks[0];
+                }
+
+                return array() !== $blocks ? $this->createBlock('core/group', $this->presentationAttributes($element), $blocks, $element) : null;
+            }
+
+            $label = $this->normalizedControlLabelText($element);
+            if ( '' === $label ) {
+                $label = trim(preg_replace('/\s+/', ' ', $element->textContent ?? '') ?? '');
+            }
+
+            return '' !== $label ? $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $element) : null;
+        }
+
+        if ( ! $this->isFormControlElement($element) || ! $this->isReadableFormControl($element) || array() !== $this->eventMetadata($element) ) {
+            return null;
+        }
+
+        if ( 'input' === $tagName && 'search' === $this->formControlType($element) ) {
+            $label = $this->formControlLabel($element);
+            if ( '' === $label ) {
+                $label = $this->attr($element, 'aria-label');
+            }
+            if ( '' === $label ) {
+                $label = 'Search';
+            }
+
+            $attrs = array_filter(array_merge(
+                $this->presentationAttributes($element),
+                array(
+                    'label'       => $label,
+                    'placeholder' => $this->attr($element, 'placeholder'),
+                )
+            ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+
+            return $this->createBlock('core/search', $attrs, array(), $element);
+        }
+
+        $summary = $this->readableFormControlText($element);
+        return '' !== $summary ? $this->createBlock('core/paragraph', array( 'content' => $summary ), array(), $element) : null;
+    }
+
+    private function isReadableFormControl(DOMElement $control): bool
+    {
+        $tagName = strtolower($control->tagName);
+        if ( in_array($tagName, array( 'select', 'textarea' ), true) ) {
+            return true;
+        }
+
+        return 'button' === $tagName || ( 'input' === $tagName && in_array($this->formControlType($control), array( 'email', 'number', 'search', 'submit', 'tel', 'text', 'url' ), true) );
+    }
+
+    private function readableFormControlText(DOMElement $control): string
+    {
+        $label = $this->formControlLabel($control);
+        if ( '' === $label ) {
+            $label = $this->attr($control, 'aria-label');
+        }
+        if ( '' === $label ) {
+            $label = $this->attr($control, 'placeholder');
+        }
+        if ( '' === $label ) {
+            $label = $this->attr($control, 'name');
+        }
+
+        $type = $this->formControlType($control);
+        if ( '' === $label ) {
+            $label = 'select' === $type ? 'Select option' : ucfirst($type);
+        }
+
+        $details = array();
+        if ( 'select' === strtolower($control->tagName) ) {
+            $options = array();
+            $selected = array();
+            foreach ( $this->selectOptions($control) as $option ) {
+                $optionLabel = (string) ($option['label'] ?? '');
+                if ( '' === $optionLabel ) {
+                    continue;
+                }
+                $options[] = $optionLabel;
+                if ( true === ($option['selected'] ?? false) ) {
+                    $selected[] = $optionLabel;
+                }
+            }
+            if ( array() !== $options ) {
+                $details[] = implode(', ', $options);
+            }
+            if ( array() !== $selected ) {
+                $details[] = 'selected: ' . implode(', ', $selected);
+            }
+        } else {
+            foreach ( array( 'value', 'placeholder' ) as $attribute ) {
+                $value = trim($this->attr($control, $attribute));
+                if ( '' !== $value ) {
+                    $details[] = $value;
+                    break;
+                }
+            }
+        }
+
+        $text = $label;
+        if ( array() !== $details ) {
+            $text .= ': ' . implode(' (', $details) . ( count($details) > 1 ? ')' : '' );
+        }
+        if ( $control->hasAttribute('required') ) {
+            $text .= ' (required)';
+        }
+
+        return $this->runtime->escapeHtml($text);
+    }
+
+    private function readableSubmitText(DOMElement $control): string
+    {
+        $text = trim(preg_replace('/\s+/', ' ', $control->textContent ?? '') ?? '');
+        if ( '' !== $text ) {
+            return $text;
+        }
+
+        $value = trim($this->attr($control, 'value'));
+        return '' !== $value ? $value : 'Submit';
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -155,7 +155,7 @@ $assert('fixture:contextual-html' === ($contextual['provenance'][0]['source'] ??
 $assert('contract-test' === ($contextual['provenance'][0]['scope'] ?? ''), 'HTML provenance exposes generic scope metadata');
 
 $formFallback = ( new HtmlTransformer() )->transform(
-    '<main><form action="/contact" method="post"><label for="email">Email</label><input id="email" name="email" type="email" required><select name="topic"><option value="support" selected>Support</option></select><button type="submit">Send</button></form></main>'
+    '<main><form action="/contact" method="post" data-action="contact-submit"><label for="email">Email</label><input id="email" name="email" type="email" required><select name="topic"><option value="support" selected>Support</option></select><button type="submit">Send</button></form></main>'
 )->toArray();
 $formDiagnostic = $formFallback['source_reports']['conversion_report']['fallback_diagnostics'][0] ?? array();
 $assert(array() === ($formFallback['blocks'] ?? array()), 'form fallback does not synthesize canonical blocks');

--- a/php-transformer/tests/fixtures/parity/html-form-control-fallback-metadata.json
+++ b/php-transformer/tests/fixtures/parity/html-form-control-fallback-metadata.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-form-control-fallback-metadata",
-  "description": "Reports generic form-control metadata while preserving safe HTML fallback output.",
+  "description": "Reports complex form fallback metadata while converting standalone readable controls.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-form-control-fallback-metadata.json",
-    "notes": "Product-neutral fixture for form/input/select/textarea/button fallback metadata."
+    "notes": "Product-neutral fixture for preserving risky form metadata and rendering standalone controls without raw HTML fallback."
   },
   "legacy_comparison": {
     "skip": true,
@@ -15,15 +15,16 @@
   "input": {
     "content": "<form action=\"/contact\" method=\"post\"><label for=\"email\">Email address</label><input id=\"email\" name=\"email\" type=\"email\" required placeholder=\"you@example.com\"><label>Plan <select name=\"plan\"><option value=\"basic\">Basic</option><option value=\"pro\" selected>Pro</option></select></label><textarea name=\"message\" aria-label=\"Message\"></textarea><button name=\"intent\" value=\"send\">Send</button><script>alert(1)</script></form><input name=\"standalone\" value=\"outside\">"
   },
-  "expected_blocks": [],
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/paragraph", "attrs": { "content": "standalone: outside" } }
+  ],
   "expected_fallbacks": [
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "child_count": 6 },
-    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "input", "diagnostic_code": "html_unsupported_element", "child_count": 0 }
+    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "child_count": 6 }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "blocks", "assert": "count", "count": 0 },
-    { "path": "fallbacks", "assert": "count", "count": 2 },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "fallbacks.0.html", "assert": "contains", "value": "<form action=\"/contact\" method=\"post\">" },
     { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script>" },
     { "path": "fallbacks.0.controls", "assert": "count", "count": 4 },
@@ -51,10 +52,8 @@
     { "path": "fallbacks.0.controls.3.name", "assert": "equals", "value": "intent" },
     { "path": "fallbacks.0.controls.3.type", "assert": "equals", "value": "submit" },
     { "path": "fallbacks.0.controls.3.value", "assert": "equals", "value": "send" },
-    { "path": "fallbacks.1.control.tag", "assert": "equals", "value": "input" },
-    { "path": "fallbacks.1.control.name", "assert": "equals", "value": "standalone" },
-    { "path": "fallbacks.1.control.type", "assert": "equals", "value": "text" },
-    { "path": "fallbacks.1.control.value", "assert": "equals", "value": "outside" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+    { "path": "serialized_blocks", "assert": "contains", "value": "standalone: outside" },
+    { "path": "coverage.0.block_count", "assert": "equals", "value": 1 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-readable-form-controls.json
+++ b/php-transformer/tests/fixtures/parity/html-readable-form-controls.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-readable-form-controls",
+  "description": "Converts safe search, select, and standalone donation controls to readable native-ish blocks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-readable-form-controls.json",
+    "notes": "Covers search forms with decorative icons and no submit button, label-wrapped select controls, and standalone donation amount inputs."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<form class=\"bp-search\" role=\"search\" action=\"#\"><svg viewBox=\"0 0 20 20\" aria-hidden=\"true\"><circle cx=\"9\" cy=\"9\" r=\"6\"></circle></svg><label for=\"q\">Search recipes</label><input id=\"q\" type=\"search\" name=\"q\" placeholder=\"Search the menu\"></form><label>Gift amount <select name=\"gift\"><option>$25</option><option selected>$50</option></select></label><input type=\"number\" placeholder=\"Custom amount\" value=\"35\" aria-label=\"Enter custom donation amount\" min=\"1\">"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/search", "attrs": { "className": "bp-search", "label": "Search recipes", "placeholder": "Search the menu" } },
+    { "path": "blocks.1", "name": "core/paragraph", "attrs": { "content": "Gift amount: $25, $50 (selected: $50)" } },
+    { "path": "blocks.2", "name": "core/paragraph", "attrs": { "content": "Enter custom donation amount: 35" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:search" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Gift amount: $25, $50 (selected: $50)" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Enter custom donation amount: 35" },
+    { "path": "coverage.0.block_count", "assert": "equals", "value": 3 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-runtime-form-fallback-metadata",
-  "description": "Keeps contact and newsletter forms as structured runtime fallbacks without child control fallback noise.",
+  "description": "Converts simple contact and newsletter forms into readable grouped blocks without pretending submission behavior works.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-runtime-form-fallback-metadata.json",
-    "notes": "Non-search forms remain runtime candidates with form/control metadata."
+    "notes": "Simple non-search forms become readable labels and inert button blocks when no script or event handler requires runtime preservation."
   },
   "legacy_comparison": {
     "skip": true,
@@ -15,29 +15,20 @@
   "input": {
     "content": "<main><form action=\"/contact\" method=\"post\"><label>Name <input name=\"name\" required></label><label>Email <input name=\"email\" type=\"email\"></label><textarea name=\"message\" aria-label=\"Message\"></textarea><button type=\"submit\">Send</button></form><form action=\"/newsletter\" method=\"post\" class=\"newsletter\"><label>Email <input type=\"email\" name=\"email\" placeholder=\"you@example.com\"></label><button type=\"submit\" value=\"subscribe\">Subscribe</button></form></main>"
   },
-  "expected_blocks": [],
-  "expected_fallbacks": [
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "control_count": 4 },
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "control_count": 2 }
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "newsletter" } }
   ],
+  "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "blocks", "assert": "count", "count": 0 },
-    { "path": "fallbacks", "assert": "count", "count": 2 },
-    { "path": "fallbacks.0.form.action", "assert": "equals", "value": "/contact" },
-    { "path": "fallbacks.0.form.method", "assert": "equals", "value": "post" },
-    { "path": "fallbacks.0.controls", "assert": "count", "count": 4 },
-    { "path": "fallbacks.0.controls.0.name", "assert": "equals", "value": "name" },
-    { "path": "fallbacks.0.controls.0.required", "assert": "equals", "value": true },
-    { "path": "fallbacks.0.controls.1.type", "assert": "equals", "value": "email" },
-    { "path": "fallbacks.0.controls.2.tag", "assert": "equals", "value": "textarea" },
-    { "path": "fallbacks.0.controls.2.label", "assert": "equals", "value": "Message" },
-    { "path": "fallbacks.1.form.action", "assert": "equals", "value": "/newsletter" },
-    { "path": "fallbacks.1.form.method", "assert": "equals", "value": "post" },
-    { "path": "fallbacks.1.controls", "assert": "count", "count": 2 },
-    { "path": "fallbacks.1.controls.0.placeholder", "assert": "equals", "value": "you@example.com" },
-    { "path": "fallbacks.1.controls.1.type", "assert": "equals", "value": "submit" },
-    { "path": "fallbacks.1.html", "assert": "contains", "value": "class=\"newsletter\"" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Name (required)" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Email: you@example.com" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Subscribe" },
+    { "path": "coverage.0.block_count", "assert": "equals", "value": 1 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-unsupported-context-required.json
+++ b/php-transformer/tests/fixtures/parity/html-unsupported-context-required.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-unsupported-context-required",
-  "description": "Captures unsupported and context-required HTML as fallback metadata while preserving supported siblings.",
+  "description": "Captures unsupported HTML as fallback metadata while converting safe form-control siblings.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/smoke-unsupported-html-fallback-hook.php",
@@ -16,18 +16,19 @@
     "content": "<main><h2>Supported sibling</h2><custom-card><span>Unsupported nested content</span></custom-card><form><input name=\"email\"></form></main>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/heading", "attrs": { "content": "Supported sibling", "level": 2 } }
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Supported sibling", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group" }
   ],
   "expected_fallbacks": [
-    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "custom-card", "selector": "main:nth-of-type(1) > custom-card:nth-of-type(1)", "child_count": 1 },
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "selector": "main:nth-of-type(1) > form:nth-of-type(1)", "child_count": 1 }
+    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "custom-card", "selector": "main:nth-of-type(1) > custom-card:nth-of-type(1)", "child_count": 1 }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "diagnostics.1.selector", "assert": "equals", "value": "main:nth-of-type(1) > custom-card:nth-of-type(1)" },
-    { "path": "diagnostics.2.reason", "assert": "equals", "value": "form_requires_runtime" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+    { "path": "serialized_blocks", "assert": "contains", "value": "email" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
   ]
 }


### PR DESCRIPTION
## Summary
- Converts simple non-scripted forms into readable group/button/paragraph block content instead of raw form fallbacks.
- Expands search-form conversion to tolerate decorative icon/label markup and missing submit buttons.
- Converts standalone readable controls such as text/email/number/search inputs, selects, textareas, and labels to readable native block content.
- Keeps scripted or event-bound forms as fallbacks to avoid implying unsupported submission behavior works.

## Corpus profile
Compared against current trunk on /Users/chubes/Downloads/raw-html:
- fallbacks: 191 -> 82
- html_form_fallback: 9 -> 1
- label/select/input unsupported tags: removed from profile
- fixtures: 23/23 success_with_warnings

Profile artifact: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/raw-html-profile-form.json

## Testing
- php -l src/HtmlToBlocks/HtmlTransformer.php
- composer test:parity
- composer test
- raw HTML corpus profiler against 23 fixtures

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Profiling fixture fallbacks, implementing focused form/control conversion, running verification, and drafting this PR description.