### PR TITLE
Reduce decorative inline SVG fallbacks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -505,6 +505,10 @@ final class HtmlTransformer
         }
 
         if ( 'svg' === $tagName ) {
+            if ( $this->isSafeDecorativeSvgElement($element) ) {
+                return null;
+            }
+
             $svgBlock = $this->inlineSvgBlockFromElement($element);
             if ( null !== $svgBlock ) {
                 return $svgBlock;
@@ -1705,7 +1709,7 @@ final class HtmlTransformer
     private function isPassiveSvgMarkup(DOMElement $element): bool
     {
         $allowedTags = array_flip(array( 'circle', 'clippath', 'defs', 'desc', 'ellipse', 'g', 'line', 'lineargradient', 'mask', 'path', 'polygon', 'polyline', 'radialgradient', 'rect', 'stop', 'svg', 'title' ));
-        $allowedAttributes = array_flip(array( 'aria-hidden', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd', 'fill', 'fill-opacity', 'fill-rule', 'height', 'id', 'offset', 'opacity', 'points', 'r', 'role', 'rx', 'ry', 'stroke', 'stroke-dasharray', 'stroke-linecap', 'stroke-linejoin', 'stroke-opacity', 'stroke-width', 'style', 'transform', 'viewbox', 'width', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2' ));
+        $allowedAttributes = array_flip(array( 'aria-hidden', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd', 'fill', 'fill-opacity', 'fill-rule', 'gradienttransform', 'gradientunits', 'height', 'id', 'offset', 'opacity', 'points', 'preserveaspectratio', 'r', 'role', 'rx', 'ry', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'style', 'transform', 'viewbox', 'width', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2' ));
 
         foreach ( $element->getElementsByTagName('*') as $child ) {
             if ( ! $child instanceof DOMElement || ! $this->isPassiveSvgElement($child, $allowedTags, $allowedAttributes) ) {
@@ -1728,7 +1732,10 @@ final class HtmlTransformer
 
         foreach ( $this->htmlAttributes($element) as $name => $value ) {
             $name = strtolower($name);
-            if ( ! isset($allowedAttributes[$name]) || preg_match('/^on[a-z]+$|(?:^|:)href$/i', $name) || preg_match('/javascript\s*:|\b(?:expression|behavior)\s*:|\burl\s*\(/i', $value) ) {
+            if ( ! isset($allowedAttributes[$name]) || preg_match('/^on[a-z]+$|(?:^|:)href$/i', $name) || preg_match('/javascript\s*:|\b(?:expression|behavior)\s*:/i', $value) ) {
+                return false;
+            }
+            if ( preg_match('/\burl\s*\((?!\s*["\']?#[-_a-z0-9]+["\']?\s*\))/i', $value) ) {
                 return false;
             }
         }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -199,11 +199,11 @@ $safeInlineSvg = ( new HtmlTransformer() )->transform(
 )->toArray();
 $safeInlineSvgSerialized = (string) ($safeInlineSvg['serialized_blocks'] ?? '');
 $assert('success' === ($safeInlineSvg['status'] ?? ''), 'safe inline SVG does not trip strict fallback gates', (string) ($safeInlineSvg['status'] ?? ''));
-$assert(array() === ($safeInlineSvg['fallbacks'] ?? array()), 'safe inline SVG is converted instead of recorded as fallback metadata');
-$assert('core/image' === ($safeInlineSvg['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? ''), 'safe inline SVG converts to a Gutenberg-renderable image block');
+$assert(array() === ($safeInlineSvg['fallbacks'] ?? array()), 'safe decorative inline SVG is consumed instead of recorded as fallback metadata');
+$assert('core/group' === ($safeInlineSvg['blocks'][0]['blockName'] ?? ''), 'decorative inline SVG preserves its CSS-addressable wrapper when present');
 $assert(! str_contains($safeInlineSvgSerialized, '<!-- wp:html'), 'safe inline SVG conversion avoids raw HTML blocks');
-$assert(str_contains($safeInlineSvgSerialized, 'data:image/svg+xml,'), 'safe inline SVG is serialized as an image data URI');
-$assert(str_contains(rawurldecode($safeInlineSvgSerialized), '<svg viewbox="0 0 16 16" aria-hidden="true"><path d="M0 0h16v16H0z"></path></svg>'), 'safe inline SVG markup is preserved in serialized image data');
+$assert(! str_contains($safeInlineSvgSerialized, 'data:image/svg+xml,'), 'decorative inline SVG avoids image data URI noise');
+$assert(! str_contains(rawurldecode($safeInlineSvgSerialized), '<svg'), 'decorative inline SVG markup is omitted from serialized blocks');
 
 $unsafeInlineSvg = ( new HtmlTransformer() )->transform('<main><svg onload="alert(1)"><path d="M0 0h1v1z"></path></svg></main>')->toArray();
 $assert('html_unsafe_inline_svg' === ($unsafeInlineSvg['fallbacks'][0]['diagnostic_code'] ?? ''), 'unsafe inline SVG remains a fallback diagnostic');
@@ -227,10 +227,10 @@ $safeDecorativeSvg = ( new HtmlTransformer() )->transform(
 )->toArray();
 $safeDecorativeDiagnostics = $safeDecorativeSvg['source_reports']['conversion_report']['fallback_diagnostics'] ?? array();
 $assert(array() === $safeDecorativeDiagnostics, 'safe decorative inline SVGs do not emit fallback diagnostics');
-$assert(2 <= ($safeDecorativeSvg['metrics']['block_count'] ?? 0), 'safe decorative inline SVGs materialize as blocks');
-$assert(str_contains((string) ($safeDecorativeSvg['serialized_blocks'] ?? ''), 'data:image/svg+xml,'), 'safe decorative inline SVGs serialize as image data URIs');
-$assert(str_contains(rawurldecode((string) ($safeDecorativeSvg['serialized_blocks'] ?? '')), '<svg aria-hidden="true" viewbox="0 0 10 10"><circle cx="5" cy="5" r="5"></circle></svg>'), 'safe aria-hidden inline SVG markup is preserved');
-$assert(str_contains((string) ($safeDecorativeSvg['serialized_blocks'] ?? ''), 'site-logo') && str_contains(rawurldecode((string) ($safeDecorativeSvg['serialized_blocks'] ?? '')), '<path d="M0 0h10v10H0z"></path>'), 'safe logo-like inline SVG context is preserved');
+$assert(1 <= ($safeDecorativeSvg['metrics']['block_count'] ?? 0), 'safe decorative inline SVG wrappers still materialize when they carry presentation signals');
+$assert(! str_contains((string) ($safeDecorativeSvg['serialized_blocks'] ?? ''), 'data:image/svg+xml,'), 'safe decorative inline SVGs do not serialize as image data URIs');
+$assert(! str_contains(rawurldecode((string) ($safeDecorativeSvg['serialized_blocks'] ?? '')), '<svg'), 'safe decorative inline SVG markup is omitted');
+$assert(str_contains((string) ($safeDecorativeSvg['serialized_blocks'] ?? ''), 'site-logo'), 'safe logo-like inline SVG context preserves its wrapper class');
 
 $unsafeDecorativeSvg = ( new HtmlTransformer() )->transform(
     '<main><svg aria-hidden="true" viewBox="0 0 10 10"><script>alert(1)</script><circle onclick="alert(1)" cx="5" cy="5" r="5"></circle></svg></main>'

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-decorative",
+  "description": "Consumes safe decorative inline SVG separators and icons without fallback noise while preserving meaningful accessible SVGs as image blocks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-decorative.json",
+    "notes": "Product-neutral fixture for decorative wave separators and accessible logo/icon SVG handling."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><h2>Before</h2><svg class=\"wave-divider\" viewBox=\"0 0 1200 120\" preserveAspectRatio=\"none\" aria-hidden=\"true\"><defs><linearGradient id=\"wave-g\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"0\" gradientUnits=\"objectBoundingBox\"><stop offset=\"0%\" stop-color=\"#f7efe0\" stop-opacity=\"0.95\"></stop><stop offset=\"100%\" stop-color=\"#e4c77b\"></stop></linearGradient></defs><path d=\"M0 60 C 180 20 360 100 540 60 S 900 20 1200 60 V120 H0 Z\" fill=\"url(#wave-g)\"></path></svg><p>After</p><svg viewBox=\"0 0 32 32\" role=\"img\" aria-label=\"Acme integration\"><title>Acme integration</title><rect width=\"32\" height=\"32\" rx=\"8\" fill=\"#111\"></rect><path d=\"M8 17 C12 10 20 10 24 17\" stroke=\"#fff\" stroke-width=\"2\" fill=\"none\" stroke-linecap=\"round\"></path></svg></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Before", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "After" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/image", "attrs": { "alt": "Acme integration", "title": "Acme integration" } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": "data:image/svg+xml," },
+    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": "aria-label%3D%22Acme%20integration%22" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Consumes safe decorative inline SVGs without emitting fallback blocks.
- Broadens passive SVG detection for common safe gradient and local paint-reference attributes.
- Keeps accessible/meaningful safe SVGs on the existing core/image data URI path.

## Corpus profile
Compared against current trunk on /Users/chubes/Downloads/raw-html:
- fallbacks: 191 -> 101
- html_inline_svg_fallback: 67 -> 0
- html_unsupported_element: 91 -> 68
- fixtures: 23/23 success_with_warnings

Profile artifact: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/raw-html-profile-svg.json

## Testing
- composer install
- php tests/parity/run.php
- php tests/contract/run.php
- raw HTML corpus profiler against 23 fixtures

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Profiling fixture fallbacks, implementing focused SVG fallback reduction, running verification, and drafting this PR description.