### PR TITLE
Recognize text-flow HTML line breaks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -702,6 +702,11 @@ final class HtmlTransformer
                 return $buttons;
             }
 
+            $textFlow = $this->textFlowBlockFromElement($element);
+            if ( null !== $textFlow ) {
+                return $textFlow;
+            }
+
             $children = $this->convertChildren($element, $fallbacks, true);
             if ( 1 === count($children) ) {
                 if ( $this->shouldPreserveWrapper($element) ) {
@@ -1058,6 +1063,42 @@ final class HtmlTransformer
         }
 
         return false;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function textFlowBlockFromElement(DOMElement $element): ?array
+    {
+        if ( 'div' !== strtolower($element->tagName) || '' !== trim($this->attr($element, 'id')) || '' !== trim($this->attr($element, 'role')) ) {
+            return null;
+        }
+
+        $hasLineBreak = false;
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( 'br' === $tagName ) {
+                $hasLineBreak = true;
+            }
+            if ( 'br' !== $tagName && ! $this->isInlineContentElement($tagName) && 'a' !== $tagName ) {
+                return null;
+            }
+        }
+
+        if ( ! $hasLineBreak ) {
+            return null;
+        }
+
+        $content = $this->innerHtml($element);
+        if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+            return null;
+        }
+
+        return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
     }
 
     private function paragraphBlockFromInlineContentWrapper(DOMElement $element): ?array

--- a/php-transformer/tests/fixtures/parity/html-text-flow-line-breaks.json
+++ b/php-transformer/tests/fixtures/parity/html-text-flow-line-breaks.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-text-flow-line-breaks",
+  "description": "Converts text-only wrapper divs with inline markup and line breaks into paragraphs without unsupported br fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-text-flow-line-breaks.json",
+    "notes": "Generic fixture for static text wrappers that use br-separated address or schedule copy."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture covers generic br and text-flow wrapper recognition."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><div class=\"event-time\">Thursday &mdash; Saturday<br>5:00 PM &ndash; 10:00 PM</div><div class=\"address\">The Dockyard Courtyard<br>72 Morrison Drive<br><em>Charleston, SC</em></div><div><br></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "event-time", "content": "Thursday — Saturday<br>5:00 PM – 10:00 PM" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "address", "content": "The Dockyard Courtyard<br>72 Morrison Drive<br><em>Charleston, SC</em>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Thursday — Saturday<br>5:00 PM – 10:00 PM" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "The Dockyard Courtyard<br>72 Morrison Drive<br><em>Charleston, SC</em>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Convert text-only div wrappers containing inline markup and br separators into paragraph blocks that preserve the inline HTML.
- Treat standalone br elements as static line-break markup instead of unsupported-element fallbacks.
- Add a generic parity fixture for address/schedule-style br-separated text wrappers.

## Fixture evidence
- Before: assigned fixture transformed to 226 blocks with 4 fallbacks: 3 unsupported br fallbacks plus 1 script runtime fallback.
- After: assigned fixture transforms to 177 blocks with 1 fallback: the script runtime fallback only.
- User-visible improvement: time/address text keeps br-separated line breaks inside paragraph content instead of fragmenting text and reporting unsupported br metadata.

## Tests
- composer run test:parity
- composer test (stops in existing plugin bootstrap contract mismatch: expected 0.1.2, actual 0.1.3)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, generic converter implementation, parity fixture coverage, and verification.