### PR TITLE
Recognize list-based navigation menus

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -366,6 +366,16 @@ final class HtmlTransformer
         }
 
         if ( 'ul' === $tagName || 'ol' === $tagName ) {
+            $navigation = $this->navigationPattern->match(
+                $element,
+                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
+            );
+            if ( null !== $navigation ) {
+                return $navigation;
+            }
+
             $items = $this->listItems($element, $fallbacks);
 
             if ( array() === $items ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -51,8 +51,19 @@ final class NavigationPattern
     private function directNavigationAnchors(DOMElement $element): array
     {
         $anchors = array();
+        $isListRoot = in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true);
         foreach ( $element->childNodes as $child ) {
             if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( $isListRoot && $child instanceof DOMElement && 'li' === strtolower($child->tagName) ) {
+                $anchor = $this->singleNavigationAnchor($child);
+                if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
+                    return array();
+                }
+
+                $anchors[] = $anchor;
                 continue;
             }
 

--- a/php-transformer/tests/fixtures/parity/html-list-navigation-classification.json
+++ b/php-transformer/tests/fixtures/parity/html-list-navigation-classification.json
@@ -1,0 +1,39 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-list-navigation-classification",
+  "description": "Classifies list elements with navigation/menu/link signals as core navigation instead of plain lists while leaving ordinary content lists unchanged.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-list-navigation-classification.json",
+    "notes": "Generic fixture for common ul/ol navigation menus embedded in broader header chrome."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"site-header\"><a class=\"site-logo\" href=\"/\">Acme</a><ul class=\"site-nav\" role=\"list\"><li><a href=\"/\" class=\"active\">Home</a></li><li><a href=\"/services\">Services</a></li><li><a href=\"/contact\"><span>Contact</span></a></li></ul><div class=\"nav-cta\"><a href=\"tel:555\">Call</a></div></header><main><ul class=\"features\"><li>Fast response</li><li>Licensed team</li></ul></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph" },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "site-nav" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "/", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Services", "url": "/services", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.2", "name": "core/navigation-link", "attrs": { "label": "<span>Contact</span>", "url": "/contact", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "nav-cta" } },
+    { "path": "blocks.1", "name": "core/list", "attrs": { "className": "features" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.1.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"className\":\"site-nav\"}" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:list {\"className\":\"features\"}" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Recognize nav/menu/list classed ul/ol menus as core/navigation before falling back to core/list.
- Allow navigation pattern extraction from list-root li > a structures.
- Add parity coverage proving signaled menu lists become navigation while ordinary content lists stay lists.

## Fixture evidence
- Assigned fixture: /Users/chubes/Downloads/raw-html/8-local-service-business
- Before: each page imported only 1 core/navigation-link; the primary site-nav remained a plain core/list.
- After: each page imports 7 core/navigation-link blocks; primary site-nav is core/navigation and fallback counts are unchanged.

## Tests
- composer test:parity
- php tests/contract/run.php
- php tests/packaging/install-proof.php
- composer test attempted; stops in existing plugin bootstrap version assertion expecting 0.1.2 while package reports 0.1.3.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis and implementation.