### PR TITLE
Preserve spacing in HTML-derived page titles

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -457,7 +457,8 @@ final class ArtifactCompiler
     private function titleFromHtml(string $html, string $path): string
     {
         if ( preg_match('/<h1\b[^>]*>(.*?)<\/h1>/is', $html, $match) || preg_match('/<title\b[^>]*>(.*?)<\/title>/is', $html, $match) ) {
-            $title = trim(html_entity_decode(strip_tags($match[1]), ENT_QUOTES | ENT_HTML5));
+            $titleHtml = preg_replace('/<\s*(?:br|\/\s*(?:div|h[1-6]|p))\b[^>]*>/i', ' ', $match[1]) ?? $match[1];
+            $title = trim(preg_replace('/\s+/', ' ', html_entity_decode(strip_tags($titleHtml), ENT_QUOTES | ENT_HTML5)) ?? '');
             if ( '' !== $title ) {
                 return $title;
             }

--- a/php-transformer/tests/fixtures/parity/artifact-html-heading-title-breaks.json
+++ b/php-transformer/tests/fixtures/parity/artifact-html-heading-title-breaks.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-html-heading-title-breaks",
+  "description": "Keeps human-readable spacing when materialized page titles come from HTML headings split by break tags.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-html-heading-title-breaks.json",
+    "notes": "Product-neutral fixture for generic static-site page title extraction."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This artifact metadata fixture has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "content": "<main><h1>Between the Fog<br>and the Fire</h1><p>Release page.</p></main>",
+          "mime_type": "text/html",
+          "role": "entry"
+        },
+        {
+          "path": "contact.html",
+          "content": "<main><h1>Say<br>Hello.</h1><p>Contact page.</p></main>",
+          "mime_type": "text/html"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.materialization_plan.pages", "assert": "count", "count": 2 },
+    { "path": "source_reports.materialization_plan.pages.0.title", "assert": "equals", "value": "Between the Fog and the Fire" },
+    { "path": "source_reports.materialization_plan.pages.1.title", "assert": "equals", "value": "Say Hello." },
+    { "path": "source_reports.conversion_report.source_summary.page_count", "assert": "equals", "value": 2 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve human-readable spacing when artifact page titles are derived from headings split by <br> or block-level separators.
- Add a parity fixture covering materialized page titles from split HTML headings.

## Fixture evidence
- Assigned fixture: /Users/chubes/Downloads/raw-html/3-artist-music
- Before: split headings produced compressed materialized titles such as `Carrysomethinghome.`, `SayHello.`, `Onthe Road`, and `Between the Fogand the Fire`.
- After: assigned fixture materialization titles are `Carry something home.`, `Say Hello.`, `On the Road`, and `Between the Fog and the Fire`.
- Remaining fixture status: `success_with_warnings` due to the existing `script_requires_runtime` fallback for the site script.

## Tests
- `composer test:parity` passed: 47 fixture(s).
- `composer test` blocked by existing `php tests/contract/plugin-bootstrap.php` version mismatch: expected `0.1.2`, actual `0.1.3`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis and implementation.