### PR TITLE
Refine flex icon HTML conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -460,6 +460,10 @@ final class HtmlTransformer
             return $this->createBlock('core/separator', $this->presentationAttributes($element), array(), $element);
         }
 
+        if ( 'br' === $tagName ) {
+            return null;
+        }
+
         if ( 'details' === $tagName ) {
             return $this->detailsPattern->match(
                 $element,
@@ -2399,8 +2403,23 @@ final class HtmlTransformer
         $className = strtolower($this->attr($element, 'class'));
         $style = strtolower($this->attr($element, 'style'));
 
+        if ( preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?flex\b/', $style) && $this->hasDirectChildElement($element, 'svg') ) {
+            return false;
+        }
+
         return (bool) preg_match('/(?:^|[\s_-])columns?(?:$|[\s_-])/', $className)
             || preg_match('/(?:^|;)\s*(?:display\s*:\s*(?:inline-)?flex|grid-template-columns\s*:)/', $style);
+    }
+
+    private function hasDirectChildElement(DOMElement $element, string $tagName): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && $tagName === strtolower($child->tagName) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/tests/contract/plugin-bootstrap.php
+++ b/php-transformer/tests/contract/plugin-bootstrap.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 require dirname(__DIR__, 2) . '/php-transformer.php';
 
-assertSame('0.1.3', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
+assertSame(trim((string) file_get_contents(dirname(__DIR__, 2) . '/VERSION')), blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
 assertSame(dirname(__DIR__, 2), blocks_engine_php_transformer_path(), 'Plugin helper exposes package path.');
 
 $htmlInput   = '<main><h1>Plugin bootstrap</h1><p>Ready.</p></main>';

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -190,6 +190,16 @@ $assert(str_contains($serializedInlineSvgVisualWrapper, 'visual-region'), 'HTML 
 $assert(str_contains($serializedInlineSvgVisualWrapper, 'map-layer'), 'HTML transform preserves nested visual wrapper classes');
 $assert(str_contains($serializedInlineSvgVisualWrapper, 'map-image'), 'HTML transform preserves background-image visual leaf classes when inline SVG children are present');
 
+$flexIconRow = ( new HtmlTransformer() )->transform(
+    '<main><div class="notice-row" style="display: flex; gap: 1rem;"><svg aria-hidden="true" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5"></circle><path d="M2 5h6"></path></svg><div><strong>Venue address</strong><br>Asheville, NC</div></div></main>'
+)->toArray();
+$serializedFlexIconRow = (string) ($flexIconRow['serialized_blocks'] ?? '');
+$assert(array() === ($flexIconRow['fallbacks'] ?? array()), 'decorative SVG flex rows and standalone line breaks do not emit unsupported fallback diagnostics');
+$assert(str_contains($serializedFlexIconRow, 'notice-row'), 'decorative SVG flex rows preserve the CSS-addressable wrapper');
+$assert(str_contains($serializedFlexIconRow, 'Venue address'), 'decorative SVG flex rows preserve adjacent text content');
+$assert(str_contains($serializedFlexIconRow, 'Asheville, NC'), 'standalone line break siblings preserve following text content');
+$assert(! str_contains($serializedFlexIconRow, '<!-- wp:columns'), 'decorative SVG flex rows are not misclassified as columns');
+
 $safeInlineSvg = ( new HtmlTransformer() )->transform(
     '<main><section class="icon-row"><span class="icon"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M0 0h16v16H0z"></path></svg></span></section></main>',
     array(


### PR DESCRIPTION
## Summary
- Avoid classifying flex rows with direct decorative SVG children as columns, preserving the CSS-addressable wrapper and adjacent text instead of creating SVG child fallbacks.
- Consume standalone `<br>` elements so line-break siblings do not produce unsupported fallback diagnostics.
- Make the plugin bootstrap version contract read the package `VERSION` file instead of a stale literal.

## Fixture evidence
Assigned fixture: `/Users/chubes/Downloads/raw-html/7-event-conference`

Before:
- `schedule.html`: 4 fallbacks: 3 `html_unsupported_element` (`circle`/`path` from a decorative SVG flex row), 1 `html_script_fallback`
- `speakers.html`: 3 fallbacks: 2 `html_unsupported_element` (`br`), 1 `html_script_fallback`
- `tickets.html`: 3 fallbacks: 2 `html_unsupported_element` (`br`), 1 `html_script_fallback`
- `travel.html`: 2 fallbacks: 1 `html_unsupported_element` (`br`), 1 `html_script_fallback`

After:
- `faq.html`: blocks=188, fallbacks=1, codes={`html_script_fallback`:1}
- `index.html`: blocks=436, fallbacks=1, codes={`html_script_fallback`:1}
- `schedule.html`: blocks=326, fallbacks=1, codes={`html_script_fallback`:1}
- `speakers.html`: blocks=192, fallbacks=1, codes={`html_script_fallback`:1}
- `tickets.html`: blocks=274, fallbacks=1, codes={`html_script_fallback`:1}
- `travel.html`: blocks=202, fallbacks=1, codes={`html_script_fallback`:1}

## Tests
- `php tests/contract/run.php`
- `php tests/parity/run.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** fixture analysis and implementation
