### PR TITLE
Preserve phrasing blockquote line breaks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -414,7 +414,10 @@ final class HtmlTransformer
                 )), static fn ($value): bool => '' !== $value), array(), $element);
             }
 
-            $innerBlocks = $this->convertChildrenWithoutTags($element, $fallbacks, array( 'cite', 'footer' ));
+            $innerBlocks = $this->phrasingQuoteChildren($element, $value);
+            if ( array() === $innerBlocks ) {
+                $innerBlocks = $this->convertChildrenWithoutTags($element, $fallbacks, array( 'cite', 'footer' ));
+            }
             if ( array() === $innerBlocks ) {
                 $innerBlocks[] = $this->createBlock('core/paragraph', array( 'content' => $value ));
             }
@@ -1100,6 +1103,33 @@ final class HtmlTransformer
         }
 
         return $nonAnchorText;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function phrasingQuoteChildren(DOMElement $element, string $value): array
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                continue;
+            }
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( in_array($tagName, array( 'cite', 'footer' ), true) ) {
+                continue;
+            }
+            if ( 'br' === $tagName || $this->isInlineContentElement($tagName) ) {
+                continue;
+            }
+
+            return array();
+        }
+
+        return array( $this->createBlock('core/paragraph', array( 'content' => $value )) );
     }
 
     private function hasClass(DOMElement $element, string $className): bool

--- a/php-transformer/tests/fixtures/parity/html-phrasing-blockquote-line-breaks.json
+++ b/php-transformer/tests/fixtures/parity/html-phrasing-blockquote-line-breaks.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-phrasing-blockquote-line-breaks",
+  "description": "Preserves phrasing-only blockquotes with inline emphasis and line breaks as one quote paragraph without unsupported br fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-phrasing-blockquote-line-breaks.json",
+    "notes": "Product-neutral coverage for stylized testimonial and editorial quotes."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<blockquote class=\"ethos-quote\">We do not invent scent.<br>We <em>listen</em> to the garden,<br>then carry it carefully into glass.<cite>The distiller</cite></blockquote>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/quote", "attrs": { "className": "ethos-quote", "citation": "The distiller" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "We do not invent scent.<br>We <em>listen</em> to the garden,<br>then carry it carefully into glass." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "We do not invent scent.<br>We <em>listen</em> to the garden,<br>then carry it carefully into glass." },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve phrasing-only blockquotes as a single quote paragraph when they contain inline tags and <br> line breaks.
- Keep existing blockquote child conversion for quotes containing structural child elements.
- Add a parity fixture covering inline emphasis, <br> line breaks, citation extraction, and zero fallback noise.

## Fixture evidence
- Assigned fixture: /Users/chubes/Downloads/raw-html/22-fast-beautiful-website
- Before: index.html transformed the ethos quote into 5 separate quote paragraphs and produced 3 fallbacks: 2 unsupported br elements plus 1 script fallback.
- After: index.html transforms the ethos quote into 1 quote paragraph preserving the original <br> line breaks and produces 1 remaining script fallback.
- After all fixture pages: about/contact/collection/index each have only the script fallback; journal has form + script fallbacks.

## Tests
- composer run test:parity
- php tests/contract/runtime-no-wordpress.php && php tests/contract/runtime-wordpress-stubs.php && php tests/contract/run.php
- composer run test:packaging
- composer test was attempted but failed in php tests/contract/plugin-bootstrap.php because the existing test expects version 0.1.2 while php-transformer.php and VERSION are 0.1.3.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** fixture analysis and implementation