### PR TITLE
Infer grid layout for class-named card grids

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -857,7 +857,17 @@ final class HtmlTransformer
             return array( 'type' => 'grid' );
         }
 
+        if ( $this->hasGridLikeClass($element) && 1 < $this->cardLikeChildCount($element) ) {
+            return array( 'type' => 'grid' );
+        }
+
         return array();
+    }
+
+    private function hasGridLikeClass(DOMElement $element): bool
+    {
+        $className = strtolower($this->attr($element, 'class'));
+        return (bool) preg_match('/(?:^|[\s_-])(?:cards|grid|tiles|collection|gallery)(?:$|[\s_-])/', $className);
     }
 
     /**
@@ -1098,17 +1108,24 @@ final class HtmlTransformer
             $signals['grid_like'] = true;
         }
 
+        $itemCount = $this->cardLikeChildCount($element);
+        if ( 1 < $itemCount ) {
+            $signals['repeated_card_children'] = $itemCount;
+        }
+
+        return $signals;
+    }
+
+    private function cardLikeChildCount(DOMElement $element): int
+    {
         $itemCount = 0;
         foreach ( $element->childNodes as $child ) {
             if ( $child instanceof DOMElement && $this->isCardLikeElement($child) ) {
                 ++$itemCount;
             }
         }
-        if ( 1 < $itemCount ) {
-            $signals['repeated_card_children'] = $itemCount;
-        }
 
-        return $signals;
+        return $itemCount;
     }
 
     private function isCardLikeElement(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-class-grid-card-layout.json
+++ b/php-transformer/tests/fixtures/parity/html-class-grid-card-layout.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-class-grid-card-layout",
+  "description": "Infers a WordPress grid layout for generic class-named card grids without requiring inline display styles.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-class-grid-card-layout.json",
+    "notes": "Product-neutral fixture for repeated card/catalog grids that rely on external CSS class names."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"catalog-grid reveal-stagger\"><article class=\"catalog-card\"><h3>Maple Board</h3><p>Everyday prep board.</p></article><article class=\"catalog-card\"><h3>Walnut Tray</h3><p>Serving tray with handles.</p></article><article class=\"catalog-card\"><h3>Spice Rail</h3><p>Wall-mounted kitchen rail.</p></article></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "catalog-grid reveal-stagger", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "catalog-card" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "catalog-card" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/group", "attrs": { "className": "catalog-card" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "source_reports.html.structure_signals.3.signals.grid_like", "assert": "equals", "value": true },
+    { "path": "source_reports.html.structure_signals.3.signals.repeated_card_children", "assert": "equals", "value": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"catalog-grid reveal-stagger\",\"layout\":{\"type\":\"grid\"}} -->" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Infer `core/group` grid layout attributes for generic grid-like class containers with repeated card-like children.
- Reuse card-child counting for structure provenance and layout inference.
- Add parity coverage for external-CSS card grids that do not declare inline `display:grid`.

## Fixture evidence
- Assigned fixture: `/Users/chubes/Downloads/raw-html/19-product-catalog`.
- Before: `shop.html` imported `product-grid reveal-stagger` as a plain group with no `layout` attribute.
- After: `shop.html` imports `product-grid reveal-stagger` with `{"layout":{"type":"grid"}}` and preserves 10 product-card children.

## Tests
- `composer test:parity`
- `php tests/contract/run.php`
- `composer test:canonical` attempted; blocked by existing `tests/contract/plugin-bootstrap.php` expecting version `0.1.2` while the package reports `0.1.3`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis and implementation.
