### PR TITLE
Convert semantic aside wrappers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -584,7 +584,7 @@ final class HtmlTransformer
             }
         }
 
-        if ( in_array($tagName, array( 'article', 'body', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
+        if ( in_array($tagName, array( 'article', 'aside', 'body', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
             $logo = $this->logoPattern->match(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),

--- a/php-transformer/tests/contract/plugin-bootstrap.php
+++ b/php-transformer/tests/contract/plugin-bootstrap.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 require dirname(__DIR__, 2) . '/php-transformer.php';
 
-assertSame('0.1.2', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
+assertSame('0.1.3', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
 assertSame(dirname(__DIR__, 2), blocks_engine_php_transformer_path(), 'Plugin helper exposes package path.');
 
 $htmlInput   = '<main><h1>Plugin bootstrap</h1><p>Ready.</p></main>';

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -112,7 +112,7 @@ $assert('' === ArtifactPath::resolveRelativePath('https://example.com/logo.png',
 $assert('' === ArtifactPath::resolveRelativePath('../../logo.png', 'pages/home.html'), 'artifact references reject traversal above the artifact root');
 
 $fixture = file_get_contents(dirname(__DIR__) . '/fixtures/simple-html.html');
-$result  = ( new HtmlTransformer() )->transform($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><aside>Fallback</aside>")->toArray();
+$result  = ( new HtmlTransformer() )->transform($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><x-panel>Fallback</x-panel>")->toArray();
 
 $assert(TransformerResult::SCHEMA === $result['schema'], 'result exposes schema');
 TransformerResult::assertCanonicalEnvelope($result);
@@ -140,7 +140,7 @@ $assertInvalidCanonicalEnvelope($missingConversionReport, 'source_reports.conver
 $assertInvalidCanonicalEnvelope($result, 'source_reports.materialization_plan', 'canonical validation can require materialization plans for downstream artifact consumers', true);
 
 $contextual = ( new HtmlTransformer() )->transform(
-    '<main><h1>Context</h1><aside>Fallback</aside></main>',
+    '<main><h1>Context</h1><x-panel>Fallback</x-panel></main>',
     array(
         'source'          => 'fixture:contextual-html',
         'source_scope'    => 'contract-test',
@@ -209,7 +209,7 @@ $unsafeInlineSvg = ( new HtmlTransformer() )->transform('<main><svg onload="aler
 $assert('html_unsafe_inline_svg' === ($unsafeInlineSvg['fallbacks'][0]['diagnostic_code'] ?? ''), 'unsafe inline SVG remains a fallback diagnostic');
 
 $normalizedFallbacks = ( new HtmlTransformer() )->transform(
-    '<main><svg><circle cx="5" cy="5" r="5"></circle></svg><svg><script>alert(1)</script></svg><script src="/app.js">init()</script><aside>Fallback</aside><iframe src="javascript:alert(1)"></iframe></main>'
+    '<main><svg><circle cx="5" cy="5" r="5"></circle></svg><svg><script>alert(1)</script></svg><script src="/app.js">init()</script><x-panel>Fallback</x-panel><iframe src="javascript:alert(1)"></iframe></main>'
 )->toArray();
 $normalizedDiagnostics = $normalizedFallbacks['source_reports']['conversion_report']['fallback_diagnostics'] ?? array();
 $diagnosticsByCode = array();
@@ -694,10 +694,10 @@ assertSame('unsupported_element', $result['fallbacks'][0]['type'], 'unsupported 
 assertSame('unsupported_element', $result['fallbacks'][0]['reason'], 'fallbacks should expose a stable generic reason.');
 assertSame('html_unsupported_element', $result['fallbacks'][0]['diagnostic_code'], 'fallbacks should expose a diagnostic code for cross-process consumers.');
 assertSame('html', $result['fallbacks'][0]['source_format'], 'fallbacks should expose the source format.');
-assertSame('aside', $result['fallbacks'][0]['tag'], 'fallback should identify the unsupported tag.');
+assertSame('x-panel', $result['fallbacks'][0]['tag'], 'fallback should identify the unsupported tag.');
 assertContains('html_to_blocks_core_slice', array_column($result['diagnostics'], 'code'), 'expanded core-slice conversion diagnostic should be present.');
 assertSame('html', $result['provenance'][0]['source_format'], 'source provenance should identify HTML input.');
-assertSame(strlen($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><aside>Fallback</aside>"), $result['metrics']['input_bytes'], 'HTML metrics should expose input bytes.');
+assertSame(strlen($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><x-panel>Fallback</x-panel>"), $result['metrics']['input_bytes'], 'HTML metrics should expose input bytes.');
 assertSame(strlen($result['serialized_blocks']), $result['metrics']['output_bytes'], 'HTML metrics should expose output bytes.');
 assertSame(6, $result['metrics']['block_count'], 'HTML metrics should count nested blocks.');
 assertSame(1, $result['metrics']['fallback_count'], 'HTML metrics should expose fallback count.');

--- a/php-transformer/tests/fixtures/parity/html-semantic-aside-wrapper.json
+++ b/php-transformer/tests/fixtures/parity/html-semantic-aside-wrapper.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-semantic-aside-wrapper",
+  "description": "Converts generic semantic aside/sidebar regions into readable group and navigation blocks instead of unsupported fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-semantic-aside-wrapper.json",
+    "notes": "Product-neutral fixture for documentation sidebars and complementary content regions."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><aside class=\"sidebar\" aria-label=\"Documentation navigation\"><div class=\"sidebar-section\"><p class=\"sidebar-label\">Navigation</p><nav class=\"sidebar-nav\"><a href=\"/docs\">Docs</a><a href=\"/api\">API Reference</a></nav></div><div class=\"sidebar-section\"><p class=\"sidebar-label\">Related Articles</p><a href=\"/troubleshooting\" class=\"related-card\"><strong>Fix route sync</strong><span>Common sync checks</span></a></div></aside><article><h1>Getting Started</h1><p>Install the app and create your first route.</p></article></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "sidebar" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "sidebar-section" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "sidebar-nav" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "sidebar-section" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Getting Started", "level": 1 } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1.attrs.label", "assert": "equals", "value": "API Reference" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-group sidebar\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<span class=\"wp-block-navigation-item__label\">API Reference</span>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "html_unsupported_element" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/unsupported-fallback.json
+++ b/php-transformer/tests/fixtures/parity/unsupported-fallback.json
@@ -13,20 +13,20 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<aside><p>Fallback content</p></aside>"
+    "content": "<x-panel><p>Fallback content</p></x-panel>"
   },
   "expected_blocks": [],
   "expected_fallbacks": [
-    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "aside", "selector": "aside:nth-of-type(1)", "child_count": 1 }
+    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "x-panel", "selector": "x-panel:nth-of-type(1)", "child_count": 1 }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 0 },
     { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "fallbacks.0.type", "assert": "equals", "value": "unsupported_element" },
-    { "path": "fallbacks.0.tag", "assert": "equals", "value": "aside" },
-    { "path": "fallbacks.0.selector", "assert": "equals", "value": "aside:nth-of-type(1)" },
-    { "path": "diagnostics.1.selector", "assert": "equals", "value": "aside:nth-of-type(1)" },
+    { "path": "fallbacks.0.tag", "assert": "equals", "value": "x-panel" },
+    { "path": "fallbacks.0.selector", "assert": "equals", "value": "x-panel:nth-of-type(1)" },
+    { "path": "diagnostics.1.selector", "assert": "equals", "value": "x-panel:nth-of-type(1)" },
     { "path": "diagnostics.0.code", "assert": "equals", "value": "html_to_blocks_core_slice" }
   ]
 }


### PR DESCRIPTION
## Summary
- Treat semantic `<aside>` elements as supported wrapper containers in the HTML transformer so documentation sidebars, TOCs, and related-content regions become readable group/navigation blocks instead of unsupported fallbacks.
- Add a product-neutral parity fixture covering sidebar aside conversion with nested navigation and related article content.
- Keep unsupported-element contracts by moving unsupported sentinel coverage to a custom `<x-panel>` element now that `<aside>` is supported.
- Refresh the plugin bootstrap version contract from 0.1.2 to the current 0.1.3 package version exposed by the branch tip.

## Fixture evidence
Assigned fixture: `/Users/chubes/Downloads/raw-html/5-documentation-knowledge-base`

Before this change, transformer fallback profile included unsupported aside fallbacks on every article page:
- `api-docs.html`: `blocks=236 fallbacks=2 {"aside:unsupported_element":1,"script:script_requires_runtime":1}`
- `contact.html`: `blocks=140 fallbacks=2 {"aside:unsupported_element":1,"script:script_requires_runtime":1}`
- `getting-started.html`: `blocks=227 fallbacks=2 {"aside:unsupported_element":1,"script:script_requires_runtime":1}`
- `release-notes.html`: `blocks=188 fallbacks=2 {"aside:unsupported_element":1,"script:script_requires_runtime":1}`
- `troubleshooting.html`: `blocks=175 fallbacks=8 {"aside:unsupported_element":1,"input:unsupported_element":6,"script:script_requires_runtime":1}`

After this change, aside fallbacks are gone and sidebar content is materialized as blocks:
- `api-docs.html`: `blocks=263 fallbacks=1 {"script:script_requires_runtime":1}`
- `contact.html`: `blocks=161 fallbacks=1 {"script:script_requires_runtime":1}`
- `getting-started.html`: `blocks=247 fallbacks=1 {"script:script_requires_runtime":1}`
- `release-notes.html`: `blocks=206 fallbacks=1 {"script:script_requires_runtime":1}`
- `troubleshooting.html`: `blocks=202 fallbacks=7 {"input:unsupported_element":6,"script:script_requires_runtime":1}`

## Tests
- `composer test:parity`
- `composer test`

## Residual visual risks
- Runtime scripts are still fallback metadata, so fixture search/drawer behavior is not recreated by this converter change.
- `troubleshooting.html` still has six standalone checklist checkbox inputs reported as unsupported controls.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, generic converter implementation, parity/contract coverage, test execution, and PR preparation.
