### PR TITLE
Classify nav link lists as navigation blocks

### DIFF
--- a/php-transformer/tests/fixtures/parity/html-nav-list-signal-classification.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-list-signal-classification.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-list-signal-classification",
+  "description": "Classifies list-shaped navigation menus with generic nav/link class signals without collapsing surrounding header chrome.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-list-signal-classification.json",
+    "notes": "Generic fixture for imported static-site headers where a mixed nav wrapper contains logo chrome and a ul.nav-links menu."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"site-header\"><nav class=\"nav-inner\" aria-label=\"Main navigation\"><a class=\"nav-logo\" href=\"/\"><span>Acme Course</span></a><button class=\"nav-toggle\" aria-label=\"Toggle navigation\" aria-expanded=\"false\" aria-controls=\"nav-links\"><span></span><span></span><span></span></button><ul class=\"nav-links\" id=\"nav-links\"><li><a href=\"/curriculum\">Curriculum</a></li><li><a href=\"/pricing\">Pricing</a></li><li><a class=\"nav-cta\" href=\"/enroll\">Enroll Now</a></li></ul></nav></header>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "nav-inner" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "nav-logo" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "nav-links" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Curriculum", "url": "/curriculum", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Pricing", "url": "/pricing", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.2", "name": "core/navigation-link", "attrs": { "label": "Enroll Now", "url": "/enroll", "kind": "custom" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:list {\"className\":\"nav-links\"}" },
+    { "path": "source_reports.html.source_provenance.4.block_name", "assert": "equals", "value": "core/navigation-link" },
+    { "path": "source_reports.html.source_provenance.4.selector", "assert": "equals", "value": "header:nth-of-type(1) > nav:nth-of-type(1) > ul:nth-of-type(1) > li:nth-of-type(1) > a:nth-of-type(1)" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Classifies ul and ol elements with generic navigation signals as core/navigation when each list item resolves to one anchor.
- Preserves mixed header chrome wrappers so logos and toggles remain alongside the converted navigation block.
- Adds parity coverage for list-shaped nav menus inside mixed static-site headers.
- Updates the plugin bootstrap version contract to assert the declared version constant instead of a stale literal.

## Fixture evidence
- Before: the course education header menu imported as core/list with five core/list-item entries and zero navigation blocks.
- After: each page in the course education fixture imports one core/navigation block with five core/navigation-link entries for the header menu.
- Residual risk: the responsive hamburger toggle still imports as a button block; this PR focuses on recovering the primary menu as semantic navigation without changing interactive-chrome policy.

## Tests
- composer parity
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, implementation, parity fixture coverage, and validation.