### PR TITLE
Avoid collapsing complex brand containers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -21,6 +21,10 @@ final class LogoPattern
         }
 
         $tagName = strtolower($element->tagName);
+        if ( 'a' !== $tagName && $this->containsBlockContent($element) ) {
+            return null;
+        }
+
         $content = 'a' === $tagName ? $outerHtml($element) : $innerHtml($element);
         if ( '' === trim($content) ) {
             return null;
@@ -45,5 +49,59 @@ final class LogoPattern
         }
 
         return false;
+    }
+
+    private function containsBlockContent(DOMElement $element): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( $this->isBlockContentTag(strtolower($child->tagName)) ) {
+                return true;
+            }
+
+            if ( $this->containsBlockContent($child) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isBlockContentTag(string $tagName): bool
+    {
+        return in_array($tagName, array(
+            'address',
+            'article',
+            'aside',
+            'blockquote',
+            'details',
+            'div',
+            'dl',
+            'fieldset',
+            'figcaption',
+            'figure',
+            'footer',
+            'form',
+            'h1',
+            'h2',
+            'h3',
+            'h4',
+            'h5',
+            'h6',
+            'header',
+            'hr',
+            'li',
+            'main',
+            'nav',
+            'ol',
+            'p',
+            'pre',
+            'section',
+            'table',
+            'ul',
+        ), true);
     }
 }

--- a/php-transformer/tests/fixtures/parity/html-complex-brand-container.json
+++ b/php-transformer/tests/fixtures/parity/html-complex-brand-container.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-complex-brand-container",
+  "description": "Keeps complex brand/footer containers editable instead of collapsing every brand-like wrapper into one logo paragraph.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-complex-brand-container.json",
+    "notes": "Product-neutral fixture for generic brand/logo pattern recognition."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<footer><div class=\"footer-brand\"><a href=\"/\" class=\"site-logo\"><span>Northstar</span><span>Pantry</span></a><p class=\"tagline\">Dinner plans for busy families.</p><form class=\"newsletter-form\" aria-label=\"Newsletter\"><input type=\"email\" placeholder=\"you@example.com\" aria-label=\"Email address\" required><button class=\"btn btn-primary\">Subscribe</button></form><p class=\"success\">You are in.</p></div><div class=\"brand\"><span>Simple</span><span>Mark</span></div></footer>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "footer-brand" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "site-logo" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "tagline", "content": "Dinner plans for busy families." } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/group", "attrs": { "className": "newsletter-form" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/paragraph", "attrs": { "className": "success", "content": "You are in." } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "brand", "content": "<span>Simple</span><span>Mark</span>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 4 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"footer-brand\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Dinner plans for busy families." },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Email address: you@example.com (required)" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Tightens generic logo/brand pattern recognition so brand-like containers with block children remain editable groups instead of collapsing into one raw paragraph.
- Adds a parity fixture covering complex footer brand columns with logo, tagline, readable newsletter form, and a simple inline brand mark that still collapses as a logo paragraph.

## Fixture evidence
- Assigned fixture: /Users/chubes/Downloads/raw-html/17-markdown-blog-launch-site
- Before: homepage footer .footer-brand converted as a single core/paragraph containing logo, tagline, form markup, and success paragraph.
- After: homepage footer .footer-brand converts as core/group with separate logo paragraph, tagline paragraph, readable newsletter form group, and success paragraph.
- After all fixture pages: founder-story.html, how-it-works.html, index.html, pantry-staples.html, pricing.html, and weekly-menu.html all transform with status success and one script runtime fallback each.

## Tests
- composer test:parity
- php tests/contract/runtime-no-wordpress.php && php tests/contract/runtime-wordpress-stubs.php && php tests/contract/run.php && php tests/packaging/install-proof.php
- composer test attempted, but existing plugin-bootstrap contract fails before this change with expected 0.1.2 vs actual 0.1.3.

## Residual visual risks
- This does not attempt to recreate the fixture CSS design system in block styles; it only preserves better editable structure for complex brand/footer columns.
- Inline SVG logo art inside anchor logo paragraphs remains raw inline SVG markup, matching the existing generic logo behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, generic converter implementation, parity fixture drafting, and test/PR workflow.