### PR TITLE
Support semantic aside wrappers in HTML conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -584,7 +584,7 @@ final class HtmlTransformer
             }
         }
 
-        if ( in_array($tagName, array( 'article', 'body', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
+        if ( in_array($tagName, array( 'article', 'aside', 'body', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
             $logo = $this->logoPattern->match(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
@@ -881,7 +881,7 @@ final class HtmlTransformer
 
     private function shouldPreserveWrapper(DOMElement $element): bool
     {
-        return in_array(strtolower($element->tagName), array( 'article', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) && ( array() !== $this->presentationAttributes($element) || array() !== $this->structureSignals($element, array()) );
+        return in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) && ( array() !== $this->presentationAttributes($element) || array() !== $this->structureSignals($element, array()) );
     }
 
     private function shouldPreserveEmptyVisualElement(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -112,7 +112,7 @@ $assert('' === ArtifactPath::resolveRelativePath('https://example.com/logo.png',
 $assert('' === ArtifactPath::resolveRelativePath('../../logo.png', 'pages/home.html'), 'artifact references reject traversal above the artifact root');
 
 $fixture = file_get_contents(dirname(__DIR__) . '/fixtures/simple-html.html');
-$result  = ( new HtmlTransformer() )->transform($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><aside>Fallback</aside>")->toArray();
+$result  = ( new HtmlTransformer() )->transform($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><custom-panel>Fallback</custom-panel>")->toArray();
 
 $assert(TransformerResult::SCHEMA === $result['schema'], 'result exposes schema');
 TransformerResult::assertCanonicalEnvelope($result);
@@ -140,7 +140,7 @@ $assertInvalidCanonicalEnvelope($missingConversionReport, 'source_reports.conver
 $assertInvalidCanonicalEnvelope($result, 'source_reports.materialization_plan', 'canonical validation can require materialization plans for downstream artifact consumers', true);
 
 $contextual = ( new HtmlTransformer() )->transform(
-    '<main><h1>Context</h1><aside>Fallback</aside></main>',
+    '<main><h1>Context</h1><custom-panel>Fallback</custom-panel></main>',
     array(
         'source'          => 'fixture:contextual-html',
         'source_scope'    => 'contract-test',
@@ -209,7 +209,7 @@ $unsafeInlineSvg = ( new HtmlTransformer() )->transform('<main><svg onload="aler
 $assert('html_unsafe_inline_svg' === ($unsafeInlineSvg['fallbacks'][0]['diagnostic_code'] ?? ''), 'unsafe inline SVG remains a fallback diagnostic');
 
 $normalizedFallbacks = ( new HtmlTransformer() )->transform(
-    '<main><svg><circle cx="5" cy="5" r="5"></circle></svg><svg><script>alert(1)</script></svg><script src="/app.js">init()</script><aside>Fallback</aside><iframe src="javascript:alert(1)"></iframe></main>'
+    '<main><svg><circle cx="5" cy="5" r="5"></circle></svg><svg><script>alert(1)</script></svg><script src="/app.js">init()</script><custom-panel>Fallback</custom-panel><iframe src="javascript:alert(1)"></iframe></main>'
 )->toArray();
 $normalizedDiagnostics = $normalizedFallbacks['source_reports']['conversion_report']['fallback_diagnostics'] ?? array();
 $diagnosticsByCode = array();
@@ -694,10 +694,10 @@ assertSame('unsupported_element', $result['fallbacks'][0]['type'], 'unsupported 
 assertSame('unsupported_element', $result['fallbacks'][0]['reason'], 'fallbacks should expose a stable generic reason.');
 assertSame('html_unsupported_element', $result['fallbacks'][0]['diagnostic_code'], 'fallbacks should expose a diagnostic code for cross-process consumers.');
 assertSame('html', $result['fallbacks'][0]['source_format'], 'fallbacks should expose the source format.');
-assertSame('aside', $result['fallbacks'][0]['tag'], 'fallback should identify the unsupported tag.');
+assertSame('custom-panel', $result['fallbacks'][0]['tag'], 'fallback should identify the unsupported tag.');
 assertContains('html_to_blocks_core_slice', array_column($result['diagnostics'], 'code'), 'expanded core-slice conversion diagnostic should be present.');
 assertSame('html', $result['provenance'][0]['source_format'], 'source provenance should identify HTML input.');
-assertSame(strlen($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><aside>Fallback</aside>"), $result['metrics']['input_bytes'], 'HTML metrics should expose input bytes.');
+assertSame(strlen($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><custom-panel>Fallback</custom-panel>"), $result['metrics']['input_bytes'], 'HTML metrics should expose input bytes.');
 assertSame(strlen($result['serialized_blocks']), $result['metrics']['output_bytes'], 'HTML metrics should expose output bytes.');
 assertSame(6, $result['metrics']['block_count'], 'HTML metrics should count nested blocks.');
 assertSame(1, $result['metrics']['fallback_count'], 'HTML metrics should expose fallback count.');

--- a/php-transformer/tests/fixtures/parity/html-semantic-aside-wrapper.json
+++ b/php-transformer/tests/fixtures/parity/html-semantic-aside-wrapper.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-semantic-aside-wrapper",
+  "description": "Converts semantic aside callout/sidebar wrappers into grouped block content instead of unsupported fallback metadata.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-semantic-aside-wrapper.json",
+    "notes": "Generic fixture for semantic aside wrapper recognition."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><aside class=\"notice-panel\" aria-label=\"Election facts\"><h2>Election facts</h2><p>Polls open 7am.</p><a class=\"btn\" href=\"/vote\">Find your polling place</a></aside><p>After panel.</p></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "notice-panel" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Election facts", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Polls open 7am." } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.0", "name": "core/button", "attrs": { "text": "Find your polling place", "url": "/vote", "className": "btn" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "After panel." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-group notice-panel" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Find your polling place" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/unsupported-fallback.json
+++ b/php-transformer/tests/fixtures/parity/unsupported-fallback.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "unsupported-html-fallback",
-  "description": "Reports unsupported top-level HTML as fallback metadata without failing the transform.",
+  "description": "Reports unsupported custom top-level HTML as fallback metadata without failing the transform.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/smoke-unsupported-html-fallback-hook.php",
@@ -13,20 +13,20 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<aside><p>Fallback content</p></aside>"
+    "content": "<custom-panel><p>Fallback content</p></custom-panel>"
   },
   "expected_blocks": [],
   "expected_fallbacks": [
-    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "aside", "selector": "aside:nth-of-type(1)", "child_count": 1 }
+    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "custom-panel", "selector": "custom-panel:nth-of-type(1)", "child_count": 1 }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 0 },
     { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "fallbacks.0.type", "assert": "equals", "value": "unsupported_element" },
-    { "path": "fallbacks.0.tag", "assert": "equals", "value": "aside" },
-    { "path": "fallbacks.0.selector", "assert": "equals", "value": "aside:nth-of-type(1)" },
-    { "path": "diagnostics.1.selector", "assert": "equals", "value": "aside:nth-of-type(1)" },
+    { "path": "fallbacks.0.tag", "assert": "equals", "value": "custom-panel" },
+    { "path": "fallbacks.0.selector", "assert": "equals", "value": "custom-panel:nth-of-type(1)" },
+    { "path": "diagnostics.1.selector", "assert": "equals", "value": "custom-panel:nth-of-type(1)" },
     { "path": "diagnostics.0.code", "assert": "equals", "value": "html_to_blocks_core_slice" }
   ]
 }


### PR DESCRIPTION
## Summary
- Convert semantic `<aside>` wrappers through the existing generic group-wrapper path instead of treating them as unsupported fallback metadata.
- Add parity coverage for aside callout/sidebar content preserving heading, paragraph, CTA button, and class styling hooks.
- Keep unsupported fallback coverage by moving the sentinel fixture/contract input to a custom element.

## Fixture evidence
- Before: nonprofit campaign artifact compile returned `fallback_count: 3` with `aside: 2` and `script: 1`; hero date panel and stake visual/sidebar content were absent from serialized block output.
- After: artifact compile returns `fallback_count: 1` with only `script: 1`; serialized block output contains `hero__date-panel` and `stake__visual`.
- Block count increased from `118` to `148`, preserving sidebar/panel content that was previously fallback-only.

## Tests
- `composer test:parity`
- `php tests/contract/run.php`
- `git diff --check origin/trunk...HEAD`
- `composer test` currently stops in `tests/contract/plugin-bootstrap.php` on the existing version expectation mismatch: expected `0.1.2`, actual `0.1.3`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** fixture analysis and implementation
