### PR TITLE
Extract inline HTML styles as artifact assets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -42,7 +42,7 @@ final class ArtifactNormalizer
             }
         }
 
-        $rawFiles = $this->rawFiles($artifact);
+        $rawFiles = $this->withInlineStyleFiles($this->rawFiles($artifact));
         $safeEntrypoints = array();
         foreach ( array_unique($entrypoints) as $entrypoint ) {
             $path = ArtifactPath::safeRelativePath($entrypoint);
@@ -201,6 +201,71 @@ final class ArtifactNormalizer
         }
 
         return $files;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, array<string, mixed>>
+     */
+    private function withInlineStyleFiles(array $files): array
+    {
+        $expanded = array();
+        foreach ( $files as $file ) {
+            $expanded[] = $file;
+
+            $content = is_string($file['content'] ?? null) ? (string) $file['content'] : '';
+            if ( '' === trim($content) || ! $this->isHtmlLikeFile($file) || ! preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $content, $matches) ) {
+                continue;
+            }
+
+            $css = trim(implode("\n", array_filter(array_map(
+                static fn (string $style): string => trim($style),
+                $matches[1]
+            ), static fn (string $style): bool => '' !== $style)));
+            if ( '' === $css ) {
+                continue;
+            }
+
+            $expanded[] = array(
+                'path'      => $this->inlineStylePath((string) ($file['path'] ?? 'index.html')),
+                'content'   => $css,
+                'kind'      => 'css',
+                'mime_type' => 'text/css',
+                'role'      => 'stylesheet',
+                'intent'    => 'style',
+                'source'    => 'inline-style',
+            );
+        }
+
+        return $expanded;
+    }
+
+    /**
+     * @param array<string, mixed> $file
+     */
+    private function isHtmlLikeFile(array $file): bool
+    {
+        $kind = strtolower((string) ($file['kind'] ?? $file['type'] ?? ''));
+        $mimeType = strtolower((string) ($file['mime_type'] ?? $file['mime'] ?? $file['media_type'] ?? ''));
+        $path = strtolower((string) ($file['path'] ?? ''));
+
+        return ( in_array($kind, array( '', 'html' ), true) || str_contains($kind, 'html') )
+            && ( '' === $mimeType || str_contains($mimeType, 'html') )
+            && ( '' === $path || preg_match('/\.html?$/', $path) || 'index.html' === $path );
+    }
+
+    private function inlineStylePath(string $htmlPath): string
+    {
+        $path = ArtifactPath::safeRelativePath($htmlPath);
+        if ( '' === $path ) {
+            return 'inline-styles.css';
+        }
+
+        $directory = trim((string) pathinfo($path, PATHINFO_DIRNAME), '.');
+        $filename = pathinfo($path, PATHINFO_FILENAME);
+        $stylePath = ('' === $filename ? 'inline' : $filename) . '.inline.css';
+
+        return '' === $directory ? $stylePath : $directory . '/' . $stylePath;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/artifact-inline-style-extraction.json
+++ b/php-transformer/tests/fixtures/parity/artifact-inline-style-extraction.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-inline-style-extraction",
+  "description": "Extracts inline stylesheet rules from full HTML documents into materializable CSS assets while preserving block conversion.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-inline-style-extraction.json",
+    "notes": "Generic coverage for full-document HTML artifacts that carry their visual system in head style tags."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream artifact primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "files": [
+        {
+          "path": "index.html",
+          "content": "<!doctype html><html><head><title>Styled Portfolio</title><style>:root{--accent:#c4a35a}.hero{min-height:100vh;color:var(--accent)}.work-grid{display:grid;grid-template-columns:repeat(3,1fr)}</style></head><body><main><section class=\"hero\"><h1>Styled Portfolio</h1><p>Visual classes need their stylesheet.</p></section><section class=\"work-grid\"><article><h2>Case Study</h2></article></section></main></body></html>",
+          "kind": "html"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "assets", "assert": "count", "count": 1 },
+    { "path": "assets.0.path", "assert": "equals", "value": "index.inline.css" },
+    { "path": "assets.0.kind", "assert": "equals", "value": "css" },
+    { "path": "assets.0.role", "assert": "equals", "value": "stylesheet" },
+    { "path": "assets.0.content", "assert": "contains", "value": ".hero{min-height:100vh" },
+    { "path": "source_reports.artifact.files_by_source.inline-style", "assert": "equals", "value": 1 },
+    { "path": "source_reports.artifact.files_by_intent.style", "assert": "equals", "value": 1 },
+    { "path": "source_reports.compiled_site.theme.stylesheets.0", "assert": "equals", "value": "index.inline.css" },
+    { "path": "source_reports.materialization_plan.assets.0.target_path", "assert": "equals", "value": "index.inline.css" },
+    { "path": "source_reports.materialization_plan.assets.0.content", "assert": "contains", "value": ".work-grid{display:grid" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Styled Portfolio" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "hero" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Extract non-empty inline \<style> blocks from HTML artifact files into materializable CSS assets.
- Preserve the generated stylesheet as a normal artifact asset so compiled-site theme stylesheets and materialization plans can carry full-document visual systems.
- Add parity coverage for a full HTML document whose portfolio-like classes depend on head CSS.

## Fixture evidence
- Before: full-document conversion kept portfolio classes but dropped the head stylesheet before block conversion, leaving the imported result structurally present but visually unstyled.
- After: compiling /Users/chubes/Downloads/raw-html/12-portfolio as an artifact produces index.inline.css as a stylesheet asset, includes it in compiled_site.theme.stylesheets, and materializes it as text/css.
- Final profile: status success_with_warnings, block_count 225, fallback_count 1 script runtime fallback, stylesheet asset index.inline.css, bytes 25083, CSS contains .hero and --font-display.

## Tests
- php -l src/ArtifactCompiler/ArtifactNormalizer.php
- composer test:parity
- composer test:packaging
- composer test: fails in existing plugin-bootstrap version contract: expected 0.1.2, actual 0.1.3

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis and implementation