### PR TITLE
Improve static content checklist conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1007,7 +1007,7 @@ final class HtmlTransformer
 
     private function shouldPreserveWrapper(DOMElement $element): bool
     {
-        return in_array(strtolower($element->tagName), array( 'article', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) && ( array() !== $this->presentationAttributes($element) || array() !== $this->structureSignals($element, array()) );
+        return in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) && ( array() !== $this->presentationAttributes($element) || array() !== $this->structureSignals($element, array()) );
     }
 
     private function shouldPreserveEmptyVisualElement(DOMElement $element): bool
@@ -2200,7 +2200,7 @@ final class HtmlTransformer
             return true;
         }
 
-        return 'button' === $tagName || ( 'input' === $tagName && in_array($this->formControlType($control), array( 'email', 'number', 'search', 'submit', 'tel', 'text', 'url' ), true) );
+        return 'button' === $tagName || ( 'input' === $tagName && in_array($this->formControlType($control), array( 'checkbox', 'email', 'number', 'radio', 'search', 'submit', 'tel', 'text', 'url' ), true) );
     }
 
     private function readableFormControlText(DOMElement $control): string

--- a/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
@@ -28,6 +28,9 @@
     { "path": "blocks.0.innerBlocks.3.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<span class=\"accent\">Child</span>" } },
     { "path": "blocks.0.innerBlocks.4", "name": "core/group", "attrs": { "className": "local-widget" } },
     { "path": "blocks.0.innerBlocks.4.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Signup", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.4.innerBlocks.1", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.4.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Email: you@example.com" } },
+    { "path": "blocks.0.innerBlocks.4.innerBlocks.1.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Agree: yes (required)" } },
     { "path": "blocks.0.innerBlocks.5", "name": "core/group", "attrs": { "className": "code-window" } },
     { "path": "blocks.0.innerBlocks.5.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "theme.json" } },
     { "path": "blocks.0.innerBlocks.5.innerBlocks.1", "name": "core/code", "attrs": { "className": "language-json", "content": "{\"version\":2}" } },
@@ -36,30 +39,23 @@
     { "path": "blocks.0.innerBlocks.6.innerBlocks.1", "name": "core/code", "attrs": { "className": "language-php", "content": "<?php add_action();" } }
   ],
   "expected_fallbacks": [
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback" },
     { "type": "html", "reason": "script_requires_runtime", "tag": "script", "diagnostic_code": "html_script_fallback" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 7 },
-    { "path": "fallbacks", "assert": "count", "count": 2 },
-    { "path": "fallbacks.0.controls.0.placeholder", "assert": "equals", "value": "you@example.com" },
-    { "path": "fallbacks.0.controls.1.type", "assert": "equals", "value": "checkbox" },
-    { "path": "fallbacks.0.controls.1.label", "assert": "equals", "value": "Agree" },
-    { "path": "fallbacks.0.controls.1.required", "assert": "equals", "value": true },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.attributes.src", "assert": "equals", "value": "/widget.js" },
     { "path": "fallbacks.0.context.parent_tag", "assert": "equals", "value": "section" },
-    { "path": "fallbacks.1.attributes.src", "assert": "equals", "value": "/widget.js" },
-    { "path": "fallbacks.1.context.parent_tag", "assert": "equals", "value": "section" },
-    { "path": "fallbacks.1.html", "assert": "equals", "value": "" },
-    { "path": "fallbacks.1.body", "assert": "equals", "value": "hydrate()" },
-    { "path": "fallbacks.1.body_truncated", "assert": "equals", "value": false },
+    { "path": "fallbacks.0.html", "assert": "equals", "value": "" },
+    { "path": "fallbacks.0.body", "assert": "equals", "value": "hydrate()" },
+    { "path": "fallbacks.0.body_truncated", "assert": "equals", "value": false },
     { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-image is-resized\"><img src=\"logo.svg\" alt=\"Logo\" width=\"120\" height=\"80\"/></figure>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<li>Parent<!-- wp:list -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "theme.json" },
     { "path": "serialized_blocks", "assert": "contains", "value": "functions.php" },
-    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_form_fallback" },
-    { "path": "diagnostics.2.code", "assert": "equals", "value": "html_script_fallback" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_script_fallback" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-readable-checklist-callouts.json
+++ b/php-transformer/tests/fixtures/parity/html-readable-checklist-callouts.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-readable-checklist-callouts",
+  "description": "Converts generic label-wrapped checklist controls and aside callouts into readable blocks without unsupported fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-readable-checklist-callouts.json",
+    "notes": "Product-neutral fixture for static content libraries that use labels as checklist rows and asides as informational sidebars."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><section class=\"checklist\"><h2>Launch checklist</h2><label class=\"checklist-item\" for=\"task-1\"><input type=\"checkbox\" id=\"task-1\" aria-label=\"Confirm meeting room\"><span>Confirm meeting room</span><small>Call the venue before printing flyers.</small></label><label><input type=\"radio\" name=\"format\" value=\"in-person\"> In-person meeting</label></section><aside class=\"callout callout--tip\" aria-label=\"Field tip\"><p><strong>Tip:</strong> Keep the sign-in sheet by the entrance.</p></aside></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "checklist" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Launch checklist", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Confirm meeting room" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "In-person meeting: in-person" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "callout callout--tip" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "<strong>Tip:</strong> Keep the sign-in sheet by the entrance." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Confirm meeting room" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "callout callout--tip" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Treat `aside` as a generic content wrapper so callouts/sidebars materialize as groups instead of unsupported fallbacks.
- Treat readable checkbox/radio inputs as readable form controls, preserving label-wrapped checklist rows as paragraph content.
- Add parity coverage for label-wrapped checklist controls and aside callouts; update affected generic contracts.

## Fixture evidence
Assigned fixture: `18-static-content-library`

Before this change, transformer fallback profile:
- `outreach-checklist.html`: 105 blocks, 40 fallbacks (`aside`: 2, `label`: 37, `script`: 1)
- `meeting-agenda.html`: 323 blocks, 2 fallbacks (`aside`: 1, `script`: 1)
- `grant-readiness.html`: 237 blocks, 2 fallbacks (`aside`: 1, `script`: 1)

After this change, transformer fallback profile:
- `outreach-checklist.html`: 184 blocks, 1 fallback (`script`: 1)
- `meeting-agenda.html`: 361 blocks, 1 fallback (`script`: 1)
- `grant-readiness.html`: 271 blocks, 1 fallback (`script`: 1)
- Other sampled pages remain script-only or existing script fallbacks (`index.html`: 1, `resources.html`: 2, `about.html`: 1).

## Tests
- `composer validate` from `php-transformer/`
- `composer test:parity` from `php-transformer/`
- `composer test` from `php-transformer/` was attempted but is currently blocked by an existing plugin-bootstrap version mismatch: expected `0.1.2`, actual `0.1.3`.

## Residual visual risks
- Runtime JavaScript remains intentionally reported as script fallbacks; this change does not rebuild interactive behavior.
- Checkbox/radio controls are represented as readable static text rather than live checked controls, which improves imported content visibility but does not preserve checklist interactivity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, generic transformer implementation, parity fixture updates, and test/PR preparation.
