### PR TITLE
Improve generic address and toggle HTML conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -336,6 +336,15 @@ final class HtmlTransformer
             return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
         }
 
+        if ( 'address' === $tagName ) {
+            $content = $this->innerHtml($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        }
+
         if ( $this->isInlineContentElement($tagName) ) {
             $content = $this->outerHtml($element);
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
@@ -509,6 +518,10 @@ final class HtmlTransformer
         }
 
         if ( 'button' === $tagName ) {
+            if ( $this->isNonContentRuntimeControl($element) ) {
+                return null;
+            }
+
             return $this->buttonsPattern->matchButton(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
@@ -899,6 +912,17 @@ final class HtmlTransformer
         }
 
         return in_array(strtolower($this->attr($element, 'role')), array( 'presentation', 'none' ), true) || 'true' === strtolower($this->attr($element, 'aria-hidden'));
+    }
+
+    private function isNonContentRuntimeControl(DOMElement $element): bool
+    {
+        if ( '' !== trim($element->textContent ?? '') ) {
+            return false;
+        }
+
+        return '' !== trim($this->attr($element, 'aria-controls'))
+            || '' !== trim($this->attr($element, 'aria-expanded'))
+            || array() !== array_intersect_key($this->safeDataAttributes($element), array_flip(array( 'data-action', 'data-on', 'data-event' )));
     }
 
     private function isInlineContentElement(string $tagName): bool

--- a/php-transformer/tests/contract/plugin-bootstrap.php
+++ b/php-transformer/tests/contract/plugin-bootstrap.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 require dirname(__DIR__, 2) . '/php-transformer.php';
 
-assertSame('0.1.2', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
+assertSame('0.1.3', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
 assertSame(dirname(__DIR__, 2), blocks_engine_php_transformer_path(), 'Plugin helper exposes package path.');
 
 $htmlInput   = '<main><h1>Plugin bootstrap</h1><p>Ready.</p></main>';

--- a/php-transformer/tests/fixtures/parity/html-address-and-toggle-controls.json
+++ b/php-transformer/tests/fixtures/parity/html-address-and-toggle-controls.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-address-and-toggle-controls",
+  "description": "Preserves semantic address content and omits empty runtime-only toggle controls from static block output.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-address-and-toggle-controls.json",
+    "notes": "Generic fixture for semantic address text and navigation/menu toggle chrome."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header><button class=\"hamburger\" aria-label=\"Open navigation menu\" aria-expanded=\"false\" aria-controls=\"site-menu\"><span></span><span></span><span></span></button><nav><ul id=\"site-menu\"><li><a href=\"/about\">About</a></li></ul></nav></header><footer><address class=\"footer-address\">48 Elm Street<br><a href=\"mailto:hello@example.com\">hello@example.com</a></address></footer>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/navigation" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "About", "url": "/about" } },
+    { "path": "blocks.1", "name": "core/paragraph", "attrs": { "className": "footer-address", "content": "48 Elm Street<br><a href=\"mailto:hello@example.com\">hello@example.com</a>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.interaction_candidates.0.kind", "assert": "equals", "value": "control" },
+    { "path": "source_reports.interaction_candidates.0.target", "assert": "equals", "value": "#site-menu" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "footer-address" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "hello@example.com" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "Open navigation menu" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:button" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Convert semantic `<address>` content into paragraph blocks with presentation attributes instead of dropping it as unsupported HTML.
- Omit empty ARIA/data-controlled runtime toggle buttons from static block output so hamburger/menu chrome does not become an empty WordPress button.
- Add a generic parity fixture covering address preservation, toggle suppression, and interaction-candidate reporting.
- Refresh the plugin bootstrap contract version expectation to match the existing `0.1.3` plugin metadata.

## Fixture evidence
Assigned fixture: `/Users/chubes/Downloads/raw-html/9-membership-community`.

Before (`index.html` transform): `status=success blocks=175 fallbacks=2`; fallbacks were `html_unsupported_element/address` and `html_script_fallback/script`; serialized output included the `hamburger` empty button and omitted `footer-address`.

After (`index.html` transform): `status=success blocks=174 fallbacks=1`; remaining fallback is `html_script_fallback/script`; serialized output has `has_hamburger_button=no`, `has_footer_address=yes`, `has_footer_email=yes`.

After all fixture pages:
- `faq.html`: `status=success blocks=137 fallbacks=1 hasAddress=yes hasHamburger=no`
- `gatherings.html`: `status=success blocks=133 fallbacks=2 hasAddress=yes hasHamburger=no`
- `index.html`: `status=success blocks=174 fallbacks=1 hasAddress=yes hasHamburger=no`
- `membership.html`: `status=success blocks=125 fallbacks=1 hasAddress=yes hasHamburger=no`
- `organizers.html`: `status=success blocks=95 fallbacks=1 hasAddress=yes hasHamburger=no`
- `stories.html`: `status=success blocks=163 fallbacks=1 hasAddress=yes hasHamburger=no`

## Tests
- `composer test:parity`
- `composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** fixture analysis and implementation
