### PR TITLE
Recognize inline content wrappers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -656,6 +656,11 @@ final class HtmlTransformer
                 return $codeWindow;
             }
 
+            $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
+            if ( null !== $inlineContent ) {
+                return $inlineContent;
+            }
+
             $buttons = $this->buttonsPattern->matchContainer(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
@@ -960,12 +965,63 @@ final class HtmlTransformer
     private function hasBlockContentChildren(DOMElement $element): bool
     {
         foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement && ! in_array(strtolower($child->tagName), array( 'abbr', 'b', 'br', 'cite', 'code', 'em', 'i', 'mark', 'small', 'span', 'strong', 'sub', 'sup', 'time' ), true) ) {
+            $tagName = $child instanceof DOMElement ? strtolower($child->tagName) : '';
+            if ( $child instanceof DOMElement && 'br' !== $tagName && ! $this->isInlineContentElement($tagName) ) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function paragraphBlockFromInlineContentWrapper(DOMElement $element): ?array
+    {
+        if ( ! in_array(strtolower($element->tagName), array( 'article', 'div', 'footer', 'header', 'main', 'section' ), true) ) {
+            return null;
+        }
+
+        if ( ! $this->hasOnlyPhrasingChildren($element) ) {
+            return null;
+        }
+
+        $content = $this->innerHtml($element);
+        if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+            return null;
+        }
+
+        return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+    }
+
+    private function hasOnlyPhrasingChildren(DOMElement $element): bool
+    {
+        $nonAnchorText = false;
+
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                if ( '' !== trim($child->textContent ?? '') ) {
+                    $nonAnchorText = true;
+                }
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( 'a' === $tagName ) {
+                continue;
+            }
+
+            if ( 'br' === $tagName || $this->isInlineContentElement($tagName) ) {
+                $nonAnchorText = true;
+                continue;
+            }
+
+            return false;
+        }
+
+        return $nonAnchorText;
     }
 
     private function hasClass(DOMElement $element, string $className): bool

--- a/php-transformer/tests/fixtures/parity/html-inline-content-wrapper.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-content-wrapper.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-content-wrapper",
+  "description": "Converts generic block wrappers containing only phrasing content into one paragraph while preserving inline markup and line breaks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-content-wrapper.json",
+    "notes": "Synthetic coverage for static HTML rows such as menu prices, hours, and address details."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><div class=\"hours-row\"><span class=\"hours-day\">Tuesday</span><span class=\"hours-time\">5:00 pm</span></div><div class=\"address\"><strong>412 Coalyard Lane</strong> Pearl District<br>Portland, OR</div><div class=\"link-row\"><a href=\"/one\">One</a><a href=\"/two\">Two</a></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "hours-row", "content": "<span class=\"hours-day\">Tuesday</span><span class=\"hours-time\">5:00 pm</span>" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "address", "content": "<strong>412 Coalyard Lane</strong> Pearl District<br>Portland, OR" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/buttons" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<br>Portland, OR" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Convert generic block wrappers that contain only phrasing content into one paragraph block, preserving inline spans/strong text and <br> line breaks.
- Keeps pure link rows available for existing button/navigation recognition.
- Updates the PHP transformer plugin bootstrap contract to the current 0.1.3 package version so the full suite runs.

## Fixture evidence
- Fixture: /Users/chubes/Downloads/raw-html/14-restaurant
- Before profile: 185 blocks, 2 fallbacks (br:unsupported_element, script:script_requires_runtime).
- After profile: 152 blocks, 1 fallback (script:script_requires_runtime).
- Menu dish rows, visit address details, and hours rows are now preserved as inline paragraph blocks with their source classes and inline markup.

## Tests
- composer test:parity
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** fixture analysis and implementation
