### PR TITLE
Promote static reveal classes in HTML conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -54,6 +54,11 @@ final class HtmlTransformer
      */
     private array $assetMetadata = array();
 
+    /**
+     * @var array<string, array<int, string>>
+     */
+    private array $staticClassPromotions = array();
+
     private int $nextSourceProvenanceId = 1;
 
     public function __construct(private readonly Runtime $runtime = new Runtime())
@@ -77,6 +82,7 @@ final class HtmlTransformer
         $this->sourceProvenance = array();
         $this->structureProvenance = array();
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
+        $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $this->nextSourceProvenanceId = 1;
         $provenance               = array(
             array_merge(array(
@@ -835,10 +841,66 @@ final class HtmlTransformer
     private function presentationAttributes(DOMElement $element): array
     {
         return array_filter(array(
-            'className' => $this->attr($element, 'class'),
+            'className' => $this->promotedClassName($this->attr($element, 'class')),
             'style'     => $this->attr($element, 'style'),
             'layout'    => $this->layoutAttribute($element),
         ), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    private function detectStaticClassPromotions(string $html): array
+    {
+        if ( ! str_contains($html, 'classList.add') || ! str_contains($html, 'querySelectorAll') ) {
+            return array();
+        }
+
+        if ( ! str_contains($html, 'IntersectionObserver') && ! str_contains($html, 'isIntersecting') ) {
+            return array();
+        }
+
+        preg_match_all('/querySelectorAll\s*\(\s*([\'"`])\.([A-Za-z0-9_-]+)\1\s*\)/', $html, $selectorMatches);
+        preg_match_all('/classList\.add\s*\(([^)]*)\)/', $html, $addMatches);
+
+        $triggerClasses = array_values(array_unique($selectorMatches[2] ?? array()));
+        $terminalClasses = array();
+        foreach ( $addMatches[1] ?? array() as $args ) {
+            preg_match_all('/[\'"`]([A-Za-z0-9_-]+)[\'"`]/', (string) $args, $classMatches);
+            foreach ( $classMatches[1] ?? array() as $className ) {
+                $terminalClasses[] = $className;
+            }
+        }
+
+        $terminalClasses = array_values(array_unique($terminalClasses));
+        if ( array() === $triggerClasses || array() === $terminalClasses ) {
+            return array();
+        }
+
+        $promotions = array();
+        foreach ( array_slice($triggerClasses, 0, 20) as $triggerClass ) {
+            $promotions[$triggerClass] = array_values(array_diff(array_slice($terminalClasses, 0, 20), array( $triggerClass )));
+        }
+
+        return array_filter($promotions, static fn (array $classes): bool => array() !== $classes);
+    }
+
+    private function promotedClassName(string $className): string
+    {
+        if ( '' === trim($className) || array() === $this->staticClassPromotions ) {
+            return $className;
+        }
+
+        $classes = preg_split('/\s+/', trim($className)) ?: array();
+        foreach ( $classes as $class ) {
+            foreach ( $this->staticClassPromotions[$class] ?? array() as $terminalClass ) {
+                if ( ! in_array($terminalClass, $classes, true) ) {
+                    $classes[] = $terminalClass;
+                }
+            }
+        }
+
+        return implode(' ', $classes);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-static-reveal-class-promotion.json
+++ b/php-transformer/tests/fixtures/parity/html-static-reveal-class-promotion.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-static-reveal-class-promotion",
+  "description": "Promotes simple script-driven reveal classes to their terminal static state when runtime scripts are preserved only as fallback metadata.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-static-reveal-class-promotion.json",
+    "notes": "Generic coverage for scroll/reveal animation content that would otherwise import hidden."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><div class=\"card reveal\"><h2>Visible after import</h2><p>Static block output should keep the reveal styling hook and include the terminal class.</p></div></section><script>const io = new IntersectionObserver((entries) => entries.forEach((entry) => { if (entry.isIntersecting) entry.target.classList.add('visible'); })); document.querySelectorAll('.reveal').forEach((el) => io.observe(el));</script>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "card reveal visible" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Visible after import" } }
+  ],
+  "expected_fallbacks": [
+    { "tag": "script", "reason": "script_requires_runtime", "diagnostic_code": "html_script_fallback" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.attrs.className", "assert": "equals", "value": "card reveal visible" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "card reveal visible" },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Promotes simple IntersectionObserver-driven reveal classes to their terminal static class during HTML-to-block conversion.
- Keeps the runtime script as fallback metadata while making static imports visible when source CSS starts reveal elements hidden.
- Updates the plugin bootstrap contract to compare against the package VERSION file, fixing the stale 0.1.2 assertion on the current 0.1.3 package.

## Fixture evidence
- Assigned fixture: `/Users/chubes/Downloads/raw-html/15-saas/index.html`.
- Before: 29 converted blocks retained `reveal` without `visible`, while the script that adds `visible` was preserved only as one `html_script_fallback`.
- After: 29/29 reveal blocks include `visible`; fallback count remains 1.

## Tests
- `php -l src/HtmlToBlocks/HtmlTransformer.php`
- `composer test:parity`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, implementation, parity coverage, and test verification.
