### PR TITLE
Recognize data-target counter text

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -352,6 +352,11 @@ final class HtmlTransformer
         }
 
         if ( $this->isInlineContentElement($tagName) ) {
+            $dynamicText = $this->dynamicTextContent($element);
+            if ( null !== $dynamicText ) {
+                return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $this->runtime->escapeHtml($dynamicText) )), array(), $element);
+            }
+
             $content = $this->outerHtml($element);
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
                 $children = $this->convertChildren($element, $fallbacks, true);
@@ -1130,6 +1135,21 @@ final class HtmlTransformer
         }
 
         return array( $this->createBlock('core/paragraph', array( 'content' => $value )) );
+    }
+
+    private function dynamicTextContent(DOMElement $element): ?string
+    {
+        $target = trim($this->attr($element, 'data-target'));
+        if ( '' === $target || ! is_numeric($target) ) {
+            return null;
+        }
+
+        $isFloat = 'true' === strtolower(trim($this->attr($element, 'data-float'))) || str_contains($target, '.');
+        $value = $isFloat
+            ? number_format((float) $target, 1, '.', ',')
+            : number_format((float) $target, 0, '.', ',');
+
+        return $this->attr($element, 'data-prefix') . $value . $this->attr($element, 'data-suffix');
     }
 
     private function hasClass(DOMElement $element, string $className): bool

--- a/php-transformer/tests/fixtures/parity/html-dynamic-counter-text.json
+++ b/php-transformer/tests/fixtures/parity/html-dynamic-counter-text.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-dynamic-counter-text",
+  "description": "Uses data-target counter metadata as static text so generated imports do not freeze pre-animation placeholder values.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-dynamic-counter-text.json",
+    "notes": "Generic fixture for animated counter/static import parity."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"impact\"><div class=\"metric-card\"><span class=\"metric-number\" data-target=\"47200\" data-float=\"false\" data-prefix=\"\" data-suffix=\"\">0</span><span class=\"metric-unit\" aria-hidden=\"true\">+</span><p>Households reached</p></div><div class=\"metric-card\"><span class=\"metric-number\" data-target=\"8.4\" data-float=\"true\" data-prefix=\"$\" data-suffix=\"M\">$0</span><p>Resources mobilized</p></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "impact" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "metric-card" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "metric-number", "content": "47,200" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "<span class=\"metric-unit\" aria-hidden=\"true\">+</span>" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "metric-number", "content": "$8.4M" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "47,200" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "$8.4M" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": ">$0<" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Recognize inline `data-target` counter metadata as static text during HTML-to-block conversion.
- Preserve generated/stat-counter final values such as `47,200`, `$8.4M`, and `89%` instead of importing pre-animation placeholders like `0` or `$0`.
- Add parity coverage for generic animated counter markup.
- Fix the plugin bootstrap contract to assert against `BLOCKS_ENGINE_PHP_TRANSFORMER_VERSION`, matching the current plugin metadata and avoiding version drift.

## Fixture evidence
Assigned fixture: `/Users/chubes/Downloads/raw-html/10-nonprofit`

Before:
- Current conversion froze metric values as placeholders: `0`, `0`, `$0`, `0`.
- Artifact compiler profile: `status=success_with_warnings`, `block_count=265`, `fallback_count=1`, assets `css/style.css` and `js/main.js`.

After:
- Nonprofit metric numbers import as final static values: `47,200`, `23`, `$8.4M`, `89%`.
- HTML transformer profile remains `status=success`, `block_count=265`, `fallback_count=1`; the remaining fallback is the runtime `<script>`.

## Tests
- `composer parity`
- `composer test`

## Residual visual risks
- Runtime-only behaviors are still represented statically: the FAQ accordion, donation amount interactions, reveal animations, budget bar animation, sticky/mobile navigation JS, and wave parallax still depend on script behavior and are not fully reproduced by block conversion.
- Inline decorative/run styling can still be split into separate paragraph blocks in some stat/card layouts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, generic converter implementation, parity fixture coverage, and verification.