### PR TITLE
Improve linked card anchor conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -505,6 +505,13 @@ final class HtmlTransformer
                 return $button;
             }
 
+            if ( $this->hasBlockContentChildren($element) ) {
+                $children = $this->convertChildren($element, $fallbacks, true);
+                if ( array() !== $children ) {
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+                }
+            }
+
             return $this->createBlock('core/paragraph', array( 'content' => $this->outerHtml($element) ), array(), $element);
         }
 
@@ -904,6 +911,17 @@ final class HtmlTransformer
     private function isInlineContentElement(string $tagName): bool
     {
         return in_array($tagName, array( 'abbr', 'b', 'cite', 'code', 'em', 'i', 'mark', 'small', 'span', 'strong', 'sub', 'sup', 'time' ), true);
+    }
+
+    private function hasBlockContentChildren(DOMElement $element): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && ! in_array(strtolower($child->tagName), array( 'abbr', 'b', 'br', 'cite', 'code', 'em', 'i', 'mark', 'small', 'span', 'strong', 'sub', 'sup', 'time' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function hasClass(DOMElement $element, string $className): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -106,6 +106,9 @@ final class ButtonsPattern
 				if ( 'a' !== strtolower($child->tagName) || '' === trim($child->textContent ?? '') ) {
 					return false;
 				}
+				if ( ! $this->isSimpleAnchor($child) ) {
+					return false;
+				}
 				++$anchors;
 				if ( $this->hasButtonSignal($child) ) {
 					++$buttonSignals;
@@ -119,6 +122,25 @@ final class ButtonsPattern
 		}
 
 		return $anchors > 1 && 0 === $buttonSignals;
+	}
+
+	private function isSimpleAnchor(DOMElement $anchor): bool
+	{
+		foreach ( $anchor->childNodes as $child ) {
+			if ( ! $child instanceof DOMElement ) {
+				continue;
+			}
+
+			if ( ! in_array(strtolower($child->tagName), array( 'abbr', 'b', 'br', 'cite', 'code', 'em', 'i', 'mark', 'small', 'span', 'strong', 'sub', 'sup', 'time' ), true) ) {
+				return false;
+			}
+
+			if ( ! $this->isSimpleAnchor($child) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
     /**

--- a/php-transformer/tests/contract/plugin-bootstrap.php
+++ b/php-transformer/tests/contract/plugin-bootstrap.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 require dirname(__DIR__, 2) . '/php-transformer.php';
 
-assertSame('0.1.2', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
+assertSame('0.1.3', blocks_engine_php_transformer_version(), 'Plugin helper exposes version.');
 assertSame(dirname(__DIR__, 2), blocks_engine_php_transformer_path(), 'Plugin helper exposes package path.');
 
 $htmlInput   = '<main><h1>Plugin bootstrap</h1><p>Ready.</p></main>';

--- a/php-transformer/tests/fixtures/parity/html-linked-card-anchor-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-card-anchor-grid.json
@@ -1,0 +1,44 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-linked-card-anchor-grid",
+  "description": "Converts linked card grids with complex anchor contents into grouped card blocks without misclassifying them as button rows.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-linked-card-anchor-grid.json",
+    "notes": "Generic coverage for editorial/product card grids where the whole card is an anchor."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><div class=\"article-grid\"><a href=\"/story-one\" class=\"article-card featured\"><div class=\"article-thumb\"><svg viewBox=\"0 0 10 10\" aria-hidden=\"true\"><path d=\"M0 0h10v10H0z\"></path></svg></div><div class=\"article-card-body\"><span class=\"kicker\">Politics</span><h3 class=\"article-headline\">City Hall Rewrites the Map</h3><p class=\"article-excerpt\">A reported story with several nested card regions.</p></div></a><a href=\"/story-two\" class=\"article-card\"><div class=\"article-card-body\"><span class=\"kicker\">Food</span><h3 class=\"article-headline\">A New Market Opens</h3><p class=\"article-excerpt\">The grid item is content, not a call-to-action button.</p></div></a></div><div class=\"link-row\"><a href=\"/start\">Start</a><a href=\"/more\">More</a></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-grid" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-card featured" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-thumb" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "article-card-body" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/heading", "attrs": { "className": "article-headline", "content": "City Hall Rewrites the Map", "level": 3 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "article-card" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/buttons", "attrs": { "className": "link-row" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "text": "Start", "url": "/start" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/button", "attrs": { "text": "More", "url": "/more" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.innerBlocks.1.blockName", "assert": "equals", "value": "core/buttons" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "article-card featured" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<p><a href=\"/story-one\" class=\"article-card featured\">" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- avoid treating complex linked card grids as generic button rows
- convert anchors with block-level card contents into grouped inner blocks instead of paragraph-wrapped raw anchor HTML
- add parity coverage for linked card grids while preserving simple direct-anchor button rows
- update the plugin bootstrap version assertion to match the current 0.1.3 package declaration so the full test script passes

## Fixture evidence
Assigned fixture: `/Users/chubes/Downloads/raw-html/6-editorial-magazine`.

Before, `index.html` transformed article grids into button groups:
- `core/buttons`: 9
- `core/button`: 15
- `core/group`: 77
- `core/heading`: 12
- `core/image`: 2
- `fallback_count`: 1 (`html_script_fallback` for `js/main.js`)

After, linked editorial cards are grouped content instead of button clusters:
- `core/buttons`: 6
- `core/button`: 6
- `core/group`: 132
- `core/heading`: 24
- `core/image`: 14
- `article_grid_buttons`: 0
- `article_card_groups`: 24
- `paragraph_wrapped_article_cards`: 0
- `fallback_count`: 1 (`html_script_fallback` for `js/main.js`)

## Tests
- `composer test:parity`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** fixture analysis and implementation
