### PR TITLE
Improve generic navigation and address HTML recognition

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -416,6 +416,15 @@ final class HtmlTransformer
             return $this->createBlock('core/quote', array_filter(array_merge($this->presentationAttributes($element), array( 'citation' => $citation )), static fn ($value): bool => '' !== $value), $innerBlocks, $element);
         }
 
+        if ( 'address' === $tagName ) {
+            $content = $this->innerHtml($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        }
+
         if ( 'figure' === $tagName ) {
             $gallery = $this->galleryBlockFromElement($element, $fallbacks);
             if ( null !== $gallery ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -51,19 +51,12 @@ final class NavigationPattern
     private function directNavigationAnchors(DOMElement $element): array
     {
         $anchors = array();
-        $isListRoot = in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true);
+        if ( in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true) ) {
+            return $this->navigationAnchorsFromList($element);
+        }
+
         foreach ( $element->childNodes as $child ) {
             if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
-                continue;
-            }
-
-            if ( $isListRoot && $child instanceof DOMElement && 'li' === strtolower($child->tagName) ) {
-                $anchor = $this->singleNavigationAnchor($child);
-                if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
-                    return array();
-                }
-
-                $anchors[] = $anchor;
                 continue;
             }
 
@@ -93,6 +86,32 @@ final class NavigationPattern
             }
 
             return array();
+        }
+
+        return $anchors;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function navigationAnchorsFromList(DOMElement $list): array
+    {
+        $anchors = array();
+        foreach ( $list->childNodes as $item ) {
+            if ( XML_TEXT_NODE === $item->nodeType && '' === trim($item->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( ! $item instanceof DOMElement || 'li' !== strtolower($item->tagName) ) {
+                return array();
+            }
+
+            $anchor = $this->singleNavigationAnchor($item);
+            if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
+                return array();
+            }
+
+            $anchors[] = $anchor;
         }
 
         return $anchors;

--- a/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-expanded-primitives",
-  "description": "Preserves common generic HTML primitives including definition lists, inline marks, presentational wrapper attrs, and safe form fallback diagnostics.",
+  "description": "Preserves common generic HTML primitives including definition lists, address content, inline marks, presentational wrapper attrs, and safe form fallback diagnostics.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-expanded-primitives.json",
@@ -13,7 +13,7 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<main><section class=\"feature-strip\" style=\"padding:2rem\"><h2 class=\"eyebrow\" style=\"color:red\">Specs</h2><p>Use <span class=\"tone\" style=\"font-weight:700\"><mark>inline</mark></span> marks.</p><dl class=\"definitions\"><dt>Latency</dt><dd><span class=\"metric\">Low</span> response time</dd><dt>Fallback</dt><dd>Preserved safely</dd></dl></section><form action=\"/subscribe\"><label>Email <input name=\"email\"></label><script>alert(1)</script></form></main>"
+    "content": "<main><section class=\"feature-strip\" style=\"padding:2rem\"><h2 class=\"eyebrow\" style=\"color:red\">Specs</h2><p>Use <span class=\"tone\" style=\"font-weight:700\"><mark>inline</mark></span> marks.</p><dl class=\"definitions\"><dt>Latency</dt><dd><span class=\"metric\">Low</span> response time</dd><dt>Fallback</dt><dd>Preserved safely</dd></dl><address class=\"contact-card\"><strong>Studio</strong><br>142 Bay Street<br>Eureka, CA</address></section><form action=\"/subscribe\"><label>Email <input name=\"email\"></label><script>alert(1)</script></form></main>"
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-strip", "style": "padding:2rem" } },
@@ -21,7 +21,8 @@
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Use <span class=\"tone\" style=\"font-weight:700\"><mark>inline</mark></span> marks." } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/list", "attrs": { "className": "definitions" } },
     { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<strong>Latency</strong> <span class=\"metric\">Low</span> response time" } },
-    { "path": "blocks.0.innerBlocks.2.innerBlocks.1", "name": "core/list-item", "attrs": { "content": "<strong>Fallback</strong> Preserved safely" } }
+    { "path": "blocks.0.innerBlocks.2.innerBlocks.1", "name": "core/list-item", "attrs": { "content": "<strong>Fallback</strong> Preserved safely" } },
+    { "path": "blocks.0.innerBlocks.3", "name": "core/paragraph", "attrs": { "className": "contact-card", "content": "<strong>Studio</strong><br>142 Bay Street<br>Eureka, CA" } }
   ],
   "expected_fallbacks": [
     { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback" }
@@ -29,7 +30,7 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 4 },
     { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "fallbacks.0.html", "assert": "contains", "value": "<form action=\"/subscribe\">" },
     { "path": "fallbacks.0.html", "assert": "contains", "value": "<input name=\"email\">" },

--- a/php-transformer/tests/fixtures/parity/html-logo-nav-button-classification.json
+++ b/php-transformer/tests/fixtures/parity/html-logo-nav-button-classification.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-logo-nav-button-classification",
-  "description": "Classifies logo anchors, wrapped navigation links, footer list navigation, and ordinary anchors without turning every standalone link into a button.",
+  "description": "Classifies logo anchors, wrapped navigation links, standalone navigation lists, footer list navigation, and ordinary anchors without turning every standalone link into a button.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-logo-nav-button-classification.json",
@@ -13,7 +13,7 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<header class=\"site-header\"><a class=\"site-logo\" href=\"/\"><svg viewBox=\"0 0 10 10\" aria-hidden=\"true\"><path d=\"M0 0h10v10H0z\"></path></svg><span>Acme</span></a><nav class=\"primary-nav\"><ul><li><a href=\"/docs\"><span>Docs</span><i aria-hidden=\"true\"></i></a></li><li><span class=\"nav-item\"><a href=\"/pricing\"><span>Pricing</span></a></span></li></ul></nav></header><main><a href=\"/about\">About us</a><a class=\"cta\" href=\"/start\">Start now</a></main><footer><ul class=\"footer-links\"><li><a href=\"/privacy\"><span>Privacy</span></a></li><li><a href=\"/terms\"><span class=\"icon\" aria-hidden=\"true\"></span><span>Terms</span></a></li></ul></footer>"
+    "content": "<header class=\"site-header\"><a class=\"site-logo\" href=\"/\"><svg viewBox=\"0 0 10 10\" aria-hidden=\"true\"><path d=\"M0 0h10v10H0z\"></path></svg><span>Acme</span></a><nav class=\"primary-nav\"><ul><li><a href=\"/docs\"><span>Docs</span><i aria-hidden=\"true\"></i></a></li><li><span class=\"nav-item\"><a href=\"/pricing\"><span>Pricing</span></a></span></li></ul></nav></header><main><a href=\"/about\">About us</a><a class=\"cta\" href=\"/start\">Start now</a></main><footer><ul class=\"footer-links\"><li><a href=\"/privacy\"><span>Privacy</span></a></li><li><a href=\"/terms\"><span class=\"icon\" aria-hidden=\"true\"></span><span>Terms</span></a></li></ul></footer><ul class=\"nav-links\" role=\"list\"><li><a href=\"#menu\">Menu</a></li><li><a href=\"#hours\">Hours</a></li></ul>"
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
@@ -27,18 +27,22 @@
     { "path": "blocks.1.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "text": "Start now", "url": "/start", "className": "cta" } },
     { "path": "blocks.2", "name": "core/navigation" },
     { "path": "blocks.2.innerBlocks.0", "name": "core/navigation-link", "attrs": { "url": "/privacy", "kind": "custom" } },
-    { "path": "blocks.2.innerBlocks.1", "name": "core/navigation-link", "attrs": { "url": "/terms", "kind": "custom" } }
+    { "path": "blocks.2.innerBlocks.1", "name": "core/navigation-link", "attrs": { "url": "/terms", "kind": "custom" } },
+    { "path": "blocks.3", "name": "core/navigation", "attrs": { "className": "nav-links" } },
+    { "path": "blocks.3.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Menu", "url": "#menu", "kind": "custom" } },
+    { "path": "blocks.3.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Hours", "url": "#hours", "kind": "custom" } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "blocks", "assert": "count", "count": 4 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
     { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "site-logo" },
     { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<svg" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 2 },
     { "path": "blocks.1.innerBlocks", "assert": "count", "count": 2 },
     { "path": "blocks.2.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.3.innerBlocks", "assert": "count", "count": 2 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:button" },


### PR DESCRIPTION
## Summary
- Recognize navigation-signaled list elements as core/navigation before falling back to generic list conversion.
- Convert readable address elements into paragraph blocks with presentation attributes instead of unsupported fallback metadata.
- Extend parity fixtures for standalone navigation lists and address content.

## Fixture evidence
Assigned fixture: /Users/chubes/Downloads/raw-html/2-onepager-coffee

Before profile:
- status: success
- block_count: 197
- fallback_count: 3
- notable fallbacks: 2 address unsupported-element fallbacks, 1 script runtime fallback
- navigation links imported as regular list blocks in the main nav

After profile:
- status: success
- block_count: 200
- fallback_count: 1
- remaining fallback: script runtime fallback
- navigation output includes 2 core/navigation blocks and 9 core/navigation-link blocks

## Tests
- composer test:parity
- composer test:packaging
- git diff --check

## Known test issue
- composer test:canonical currently fails in plugin-bootstrap.php because the test expects version 0.1.2 while VERSION and php-transformer.php report 0.1.3. This branch does not change version files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** fixture analysis and implementation
