### PR TITLE
Avoid fallback leakage in flex column probes

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2504,6 +2504,7 @@ final class HtmlTransformer
         }
 
         $columns = array();
+        $columnFallbacks = array();
         foreach ( $element->childNodes as $child ) {
             if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
                 continue;
@@ -2513,13 +2514,15 @@ final class HtmlTransformer
                 return null;
             }
 
-            $children = $this->convertChildren($child, $fallbacks, true);
+            $children = $this->convertChildren($child, $columnFallbacks, true);
             $columns[] = $this->createBlock('core/column', $this->presentationAttributes($child), $children, $child);
         }
 
         if ( count($columns) < 2 ) {
             return null;
         }
+
+        array_push($fallbacks, ...$columnFallbacks);
 
         return $this->createBlock('core/columns', $this->presentationAttributes($element), $columns, $element);
     }

--- a/php-transformer/tests/fixtures/parity/html-single-child-flex-svg-address.json
+++ b/php-transformer/tests/fixtures/parity/html-single-child-flex-svg-address.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-single-child-flex-svg-address",
+  "description": "Preserves single-child flex wrappers with safe inline SVG images and readable address line breaks without unsupported fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-single-child-flex-svg-address.json",
+    "notes": "Generic fixture for flex wrapper probing, inline SVG image conversion, and address/footer line-break handling."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><div class=\"illustration-frame\" style=\"display:flex;align-items:center;justify-content:center;\"><svg viewBox=\"0 0 40 20\" role=\"img\" aria-label=\"Storefront illustration\"><rect x=\"2\" y=\"8\" width=\"36\" height=\"10\" fill=\"#5D8A62\"></rect><path d=\"M2 8 L20 2 L38 8\" stroke=\"#243520\" fill=\"none\"></path></svg></div><address class=\"contact-card\">214 Maple Street<br>Benton Harbor, MI<br><a href=\"tel:+12695550193\">(269) 555-0193</a></address></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "illustration-frame", "style": "display:flex;align-items:center;justify-content:center;" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image", "attrs": { "alt": "Storefront illustration" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "contact-card", "content": "214 Maple Street<br>Benton Harbor, MI<br><a href=\"tel:+12695550193\">(269) 555-0193</a>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml," },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Storefront illustration" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- avoid leaking speculative fallbacks while probing flex containers for column conversion
- add parity coverage for a single-child flex SVG wrapper paired with readable address markup

## Fixture evidence
- Assigned fixture: `/Users/chubes/Downloads/raw-html/13-realistic-small-business`
- The generic fix keeps safe inline SVG image conversion and address text import clean while preventing failed column probes from reporting fallback noise.

## Testing
- `composer test`

## Residual visual risks
- Exact layout still depends on downstream CSS/materialization fidelity.
- Runtime scripts remain fallback metadata where present.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, generic converter implementation, parity coverage, and test execution.
