### PR TITLE
Improve direct SVG flex row conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2533,28 +2533,38 @@ final class HtmlTransformer
             return null;
         }
 
-        $columns = array();
-        $columnFallbacks = array();
-        foreach ( $element->childNodes as $child ) {
-            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
-                continue;
+		$elementChildren = array();
+		foreach ( $element->childNodes as $child ) {
+			if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+				continue;
             }
 
             if ( ! $child instanceof DOMElement ) {
                 return null;
             }
+			$elementChildren[] = $child;
+		}
 
-            $children = $this->convertChildren($child, $columnFallbacks, true);
-            $columns[] = $this->createBlock('core/column', $this->presentationAttributes($child), $children, $child);
-        }
+		if ( count($elementChildren) < 2 ) {
+			return null;
+		}
 
-        if ( count($columns) < 2 ) {
-            return null;
-        }
+		$columns = array();
+		$columnFallbacks = array();
+		foreach ( $elementChildren as $child ) {
+			$children = $this->isColumnWrapperElement($child)
+				? $this->convertChildren($child, $columnFallbacks, true)
+				: array_filter(array( $this->convertElement($child, $columnFallbacks, true) ));
+			$columns[] = $this->createBlock('core/column', $this->presentationAttributes($child), $children, $child);
+		}
+		array_push($fallbacks, ...$columnFallbacks);
 
-        array_push($fallbacks, ...$columnFallbacks);
+		return $this->createBlock('core/columns', $this->presentationAttributes($element), $columns, $element);
+	}
 
-        return $this->createBlock('core/columns', $this->presentationAttributes($element), $columns, $element);
+    private function isColumnWrapperElement(DOMElement $element): bool
+    {
+        return in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true);
     }
 
     private function looksLikeColumnsContainer(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-flex-media-text-columns.json
+++ b/php-transformer/tests/fixtures/parity/html-flex-media-text-columns.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-flex-media-text-columns",
+  "description": "Converts two-child flex media/text rows with direct SVG children as flex groups without unsupported primitive fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-flex-media-text-columns.json",
+    "notes": "Covers generic flex rows whose visual column is a direct media element rather than a wrapper."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This covers current PHP transformer wrapper classification behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div style=\"display:flex;gap:2rem;align-items:flex-start\"><svg viewBox=\"0 0 20 20\" aria-label=\"Paw width diagram\"><rect x=\"1\" y=\"1\" width=\"18\" height=\"18\" fill=\"#eee\" /><text x=\"10\" y=\"12\" text-anchor=\"middle\" font-family=\"monospace\" font-size=\"6\">WIDTH</text></svg><div><h3>Paw Width</h3><p>Measure the widest point while standing.</p></div></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "layout": { "type": "flex" } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "alt": "Paw width diagram" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Paw Width", "level": 3 } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Measure the widest point while standing." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "metrics.block_count", "assert": "equals", "value": 5 },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml" },
+    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "WIDTH" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-single-child-flex-svg.json
+++ b/php-transformer/tests/fixtures/parity/html-single-child-flex-svg.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-single-child-flex-svg",
+  "description": "Converts a single visual SVG inside a flex centering wrapper without leaking failed column-probe fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-single-child-flex-svg.json",
+    "notes": "Covers generic flex wrappers that are visual alignment containers, not multi-column layouts."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This covers current PHP transformer wrapper classification behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div style=\"display:flex;justify-content:center\"><svg viewBox=\"0 0 20 20\" aria-label=\"Measurement diagram\"><text x=\"10\" y=\"10\" text-anchor=\"middle\" font-family=\"monospace\" font-size=\"8\">GIRTH</text><line x1=\"2\" y1=\"15\" x2=\"18\" y2=\"15\" stroke=\"currentColor\" /></svg></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "layout": { "type": "flex" } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "alt": "Measurement diagram" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "metrics.block_count", "assert": "equals", "value": 2 },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml" },
+    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "GIRTH" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- avoid treating flex rows with direct SVG media as fake columns
- convert direct media/text flex rows and single-child flex SVG wrappers without unsupported SVG fallback noise
- add parity coverage for both direct SVG flex media rows and single-child SVG flex wrappers

## Fixture evidence
- Assigned fixture: `/Users/chubes/Downloads/raw-html/20-switchback-woocommerce-extra-hard`
- Direct SVG visual rows now remain editable flex groups with image/text blocks instead of leaking fallback diagnostics during column probing.

## Testing
- `composer test`

## Residual visual risks
- Product/shop semantics still need downstream SSI/entity materialization work.
- Exact card/product layout still depends on CSS/materialization fidelity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture analysis, generic converter implementation, parity coverage, and test execution.
