### PR TITLE
Bridge Figma font usage into materialization

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -346,6 +346,7 @@ final class FigmaTransformer
                     'scenegraph' => $normalized['source_report'],
                     'html'       => $artifact['source_report'],
                 ),
+                'compiled_site' => $this->compiledSiteSourceReport($artifact),
             ),
             $parity,
             array(
@@ -357,5 +358,25 @@ final class FigmaTransformer
                 'transform_duration_ms'  => (int) round((microtime(true) - $startedAt) * 1000),
             )
         );
+    }
+
+    /**
+     * Project Figma's static artifact into the generic compiled-site metadata contract.
+     *
+     * @param array<string, mixed> $artifact Static HTML emitter result.
+     * @return array<string, mixed>
+     */
+    private function compiledSiteSourceReport(array $artifact): array
+    {
+        $htmlReport = is_array($artifact['source_report'] ?? null) ? $artifact['source_report'] : array();
+        $fontUsage  = is_array($htmlReport['font_usage'] ?? null) ? $htmlReport['font_usage'] : array();
+
+        return array_filter(array(
+            'schema'     => 'blocks-engine/figma-transformer/compiled-site/v1',
+            'entry_path' => 'index.html',
+            'theme'      => array_filter(array(
+                'font_usage' => $fontUsage,
+            ), static fn (mixed $value): bool => array() !== $value && '' !== $value),
+        ), static fn (mixed $value): bool => array() !== $value && '' !== $value);
     }
 }

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -100,6 +100,7 @@ final class StaticHtmlEmitter
                 'visual_node_count'            => count($visualNodeMap),
                 'visual_node_map'              => $visualNodeMap,
                 'font_families'                => $fontFamilies,
+                'font_usage'                   => $this->fontUsage($nodeStyleDiagnostics),
                 'font_css_supplied'            => '' !== $fontCss,
                 'render_text_glyph_paths'      => $this->renderTextGlyphPaths,
             ),
@@ -392,6 +393,39 @@ final class StaticHtmlEmitter
 
         sort($families);
         return array_values(array_unique($families));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $nodeStyleDiagnostics
+     * @return array<int, array{family:string,weights:array<int,int>}>
+     */
+    private function fontUsage(array $nodeStyleDiagnostics): array
+    {
+        $weightsByFamily = array();
+        foreach ( $nodeStyleDiagnostics as $diagnostic ) {
+            $expected = is_array($diagnostic['expected'] ?? null) ? $diagnostic['expected'] : array();
+            if ( ! isset($expected['font_family']) || ! is_scalar($expected['font_family']) ) {
+                continue;
+            }
+
+            $family = trim((string) $expected['font_family'], " \t\n\r\0\x0B\"");
+            if ( '' === $family ) {
+                continue;
+            }
+
+            $weight = isset($expected['font_weight']) && is_numeric($expected['font_weight']) ? (int) $expected['font_weight'] : 400;
+            $weightsByFamily[$family][] = $weight;
+        }
+
+        ksort($weightsByFamily);
+        $usage = array();
+        foreach ( $weightsByFamily as $family => $weights ) {
+            $weights = array_values(array_unique($weights));
+            sort($weights);
+            $usage[] = array('family' => $family, 'weights' => $weights);
+        }
+
+        return $usage;
     }
 
     private function isWebSafeFontFamily(string $family): bool

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1232,6 +1232,8 @@ $assert(! in_array('unsupported_figma_effect_type', $metadataDiagnosticCodes, tr
 $assert(in_array('font_css_missing_for_source_font', $metadataDiagnosticCodes, true), 'missing-font-css-diagnostic');
 $assert(str_starts_with($metadataWithFontCss, '@font-face{font-family:"Example Sans";src:url("assets/example-sans.woff2") format("woff2")}'), 'font-css-prepended-when-supplied');
 $assert(array('Example Sans') === ($metadataWithFontCssResult['source_reports']['figma']['html']['font_families'] ?? null), 'font-family-inventory-reports-source-fonts');
+$assert(array(array('family' => 'Example Sans', 'weights' => array(600))) === ($metadataResult['source_reports']['figma']['html']['font_usage'] ?? null), 'font-usage-reports-source-family-weights');
+$assert(array(array('family' => 'Example Sans', 'weights' => array(600))) === ($metadataResult['source_reports']['compiled_site']['theme']['font_usage'] ?? null), 'compiled-site-theme-promotes-figma-font-usage');
 $assert(true === ($metadataWithFontCssResult['source_reports']['figma']['html']['font_css_supplied'] ?? null), 'font-css-supplied-report');
 $styleDiagnostics = $metadataResult['source_reports']['figma']['html']['node_style_diagnostics'] ?? array();
 $mixedTextStyleDiagnostic = null;

--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization;
+
+final class FontMaterializationPlanBuilder
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/font-materialization-plan/v1';
+
+    /**
+     * @param array<int,array<string,mixed>> $fontUsage
+     * @return array<string,mixed>
+     */
+    public function googleFonts(array $fontUsage): array
+    {
+        $fonts = $this->normalizeFontUsage($fontUsage);
+        $css = $this->googleFontsCss($fonts);
+
+        return array_filter(array(
+            'schema' => self::SCHEMA,
+            'provider' => 'google_fonts',
+            'fonts' => $fonts,
+            'css' => $css,
+            'stylesheets' => '' === $css ? array() : array(
+                array(
+                    'path' => 'assets/css/fonts.css',
+                    'role' => 'stylesheet',
+                    'mime_type' => 'text/css',
+                    'content' => $css . "\n",
+                ),
+            ),
+        ), static fn (mixed $value): bool => array() !== $value && '' !== $value);
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $fontUsage
+     * @return array<int,array{family:string,weights:array<int,int>}>
+     */
+    private function normalizeFontUsage(array $fontUsage): array
+    {
+        $weightsByFamily = array();
+        foreach ( $fontUsage as $font ) {
+            if ( ! is_array($font) ) {
+                continue;
+            }
+
+            $family = $this->normalizeFamily((string) ($font['family'] ?? $font['font_family'] ?? ''));
+            if ( '' === $family || $this->isWebSafeFontFamily($family) ) {
+                continue;
+            }
+
+            $weights = $font['weights'] ?? $font['font_weights'] ?? $font['weight'] ?? $font['font_weight'] ?? array(400);
+            $weights = is_array($weights) ? $weights : array($weights);
+            foreach ( $weights as $weight ) {
+                $weight = is_numeric($weight) ? (int) $weight : 400;
+                if ( $weight > 0 ) {
+                    $weightsByFamily[$family][] = $weight;
+                }
+            }
+        }
+
+        ksort($weightsByFamily);
+        $fonts = array();
+        foreach ( $weightsByFamily as $family => $weights ) {
+            $weights = array_values(array_unique($weights));
+            sort($weights);
+            $fonts[] = array(
+                'family' => $family,
+                'weights' => $weights,
+            );
+        }
+
+        return $fonts;
+    }
+
+    /**
+     * @param array<int,array{family:string,weights:array<int,int>}> $fonts
+     */
+    private function googleFontsCss(array $fonts): string
+    {
+        $families = array();
+        foreach ( $fonts as $font ) {
+            $weights = empty($font['weights']) ? array(400) : $font['weights'];
+            $families[] = 'family=' . str_replace('%20', '+', rawurlencode($font['family'])) . ':wght@' . implode(';', $weights);
+        }
+
+        if ( empty($families) ) {
+            return '';
+        }
+
+        return '@import url("https://fonts.googleapis.com/css2?' . implode('&', $families) . '&display=swap");';
+    }
+
+    private function normalizeFamily(string $family): string
+    {
+        return trim($family, " \t\n\r\0\x0B\"'");
+    }
+
+    private function isWebSafeFontFamily(string $family): bool
+    {
+        return in_array(strtolower($family), array('arial', 'courier new', 'georgia', 'helvetica', 'monospace', 'sans-serif', 'serif', 'system-ui', 'times new roman', 'verdana'), true);
+    }
+}

--- a/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\StaticSite;
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 
 final class MaterializationPlanBuilder
 {
@@ -303,10 +304,17 @@ final class MaterializationPlanBuilder
      */
     private function theme(array $theme, array $templateParts, array $assets, array $visualRepair): array
     {
+        $fontMaterialization = is_array($theme['font_materialization'] ?? null) ? $theme['font_materialization'] : array();
+        if ( empty($fontMaterialization) && is_array($theme['font_usage'] ?? null) ) {
+            $fontMaterialization = ( new FontMaterializationPlanBuilder() )->googleFonts($theme['font_usage']);
+        }
+
         return array_filter(array(
             'stylesheets' => $theme['stylesheets'] ?? $this->assetPathsByRole($assets, 'stylesheet'),
             'scripts' => $theme['scripts'] ?? $this->assetPathsByRole($assets, 'script'),
             'fonts' => $theme['fonts'] ?? $this->assetPathsByRole($assets, 'font'),
+            'font_usage' => is_array($theme['font_usage'] ?? null) ? $theme['font_usage'] : array(),
+            'font_materialization' => $fontMaterialization,
             'images' => $theme['images'] ?? $this->assetPathsByRole($assets, 'image'),
             'template_parts' => array_values(array_map(static fn (array $part): string => (string) ($part['source_path'] ?? ''), $templateParts)),
             'visual_repair_css' => (string) ($visualRepair['css'] ?? ''),

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -11,6 +11,7 @@ use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatAdapterInterface;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationView;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
 
@@ -487,6 +488,27 @@ $neutralPlan = ( new MaterializationPlanBuilder() )->fromCompiledSite(
     )
 );
 $assert(! array_key_exists('products', $neutralPlan), 'materialization plan omits product-specific manifest buckets');
+
+$fontMaterializationPlan = ( new FontMaterializationPlanBuilder() )->googleFonts(array(
+    array('family' => 'Open Sans', 'weights' => array(400, 700)),
+    array('family' => 'Poppins', 'weights' => array(500)),
+    array('family' => 'Arial', 'weights' => array(400)),
+));
+$assert('blocks-engine/php-transformer/font-materialization-plan/v1' === ($fontMaterializationPlan['schema'] ?? null), 'font materialization exposes schema');
+$assert('@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Poppins:wght@500&display=swap");' === ($fontMaterializationPlan['css'] ?? null), 'font materialization builds deterministic google fonts css');
+$assert('assets/css/fonts.css' === ($fontMaterializationPlan['stylesheets'][0]['path'] ?? null), 'font materialization emits stylesheet asset plan');
+
+$fontAwarePlan = ( new MaterializationPlanBuilder() )->fromCompiledSite(array(
+    'theme' => array(
+        'font_usage' => array(
+            array('family' => 'Open Sans', 'weights' => array(400, 700)),
+            array('family' => 'Poppins', 'weights' => array(500)),
+        ),
+    ),
+));
+$assert(array(array('family' => 'Open Sans', 'weights' => array(400, 700)), array('family' => 'Poppins', 'weights' => array(500))) === ($fontAwarePlan['theme']['font_usage'] ?? null), 'materialization plan preserves theme font usage');
+$assert('blocks-engine/php-transformer/font-materialization-plan/v1' === ($fontAwarePlan['theme']['font_materialization']['schema'] ?? null), 'materialization plan builds font materialization plan');
+$assert('@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Poppins:wght@500&display=swap");' === ($fontAwarePlan['theme']['font_materialization']['css'] ?? null), 'materialization plan builds google font css from usage');
 
 $fragment = $compiler->compileFragment('<main><h2>Fragment</h2><p>Copy</p></main>', 'fixture:fragment')->toArray();
 $assert('success' === $fragment['status'], 'fragment compiles successfully', (string) $fragment['status']);


### PR DESCRIPTION
## Summary
- report neutral Figma font usage from emitted text style diagnostics
- promote Figma font usage into compiled-site theme metadata
- materialize theme font usage into a deterministic Google Fonts stylesheet plan

## Testing
- php figma-transformer/tests/contract/run.php
- php php-transformer/tests/contract/run.php
- composer validate --working-dir=figma-transformer --strict
- composer validate --working-dir=php-transformer --strict
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implemented the Figma font usage bridge, shared font materialization builder, and contract coverage.