### PR TITLE
Add visual parity probe scaffold

### DIFF
--- a/php-transformer/tools/visual-parity/.gitignore
+++ b/php-transformer/tools/visual-parity/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/tmp/

--- a/php-transformer/tools/visual-parity/README.md
+++ b/php-transformer/tools/visual-parity/README.md
@@ -1,0 +1,57 @@
+# Visual Parity Probe Engine
+
+Generic probe extraction for comparing a source static HTML fixture against a transformed or materialized target output. The utility is product-neutral and does not require WordPress.
+
+## Install
+
+```sh
+npm install
+npx playwright install chromium
+```
+
+Run from `php-transformer/tools/visual-parity/`.
+
+## CLI
+
+```sh
+node bin/visual-parity.mjs \
+  --source tests/fixtures/source.html \
+  --target tests/fixtures/target.html \
+  --viewport 390x844 \
+  --viewport desktop=1280x720 \
+  --selector primary=.primary-link \
+  --output tmp/visual-parity-smoke.json
+```
+
+Equivalent JSON config:
+
+```json
+{
+  "source": "tests/fixtures/source.html",
+  "target": "tests/fixtures/target.html",
+  "viewports": [
+    { "name": "mobile", "width": 390, "height": 844 },
+    { "name": "desktop", "width": 1280, "height": 720 }
+  ],
+  "selectors": [
+    { "name": "primary", "selector": ".primary-link" }
+  ],
+  "output": "tmp/visual-parity-smoke.json"
+}
+```
+
+Then run:
+
+```sh
+node bin/visual-parity.mjs --config visual-parity.config.json
+```
+
+## Output
+
+The JSON report includes normalized config, source and target probe snapshots, and a deterministic comparison summary. Default probes cover button, link, nav/menu, and card-like candidates. Each match records text, href, bounding box, and computed styles for display, color, background color, border, border radius, padding, font size, and font weight.
+
+## Smoke Test
+
+```sh
+npm test
+```

--- a/php-transformer/tools/visual-parity/bin/visual-parity.mjs
+++ b/php-transformer/tools/visual-parity/bin/visual-parity.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+import { chromium } from 'playwright';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_VIEWPORTS = [
+  { name: 'desktop', width: 1280, height: 720 },
+];
+
+const DEFAULT_SELECTORS = [
+  { name: 'buttons', selector: 'button, a[role="button"], input[type="button"], input[type="submit"], .button, .btn, [class*="button"], [class*="btn"]' },
+  { name: 'links', selector: 'a[href]' },
+  { name: 'nav', selector: 'nav, [role="navigation"], header nav, .nav, [class*="nav"]' },
+  { name: 'menu', selector: 'menu, [role="menu"], .menu, [class*="menu"]' },
+  { name: 'cards', selector: 'article, [class*="card"], [class*="tile"], [class*="panel"], [data-card]' },
+];
+
+const STYLE_PROPERTIES = [
+  'display',
+  'color',
+  'background-color',
+  'border-top-color',
+  'border-top-style',
+  'border-top-width',
+  'border-right-color',
+  'border-right-style',
+  'border-right-width',
+  'border-bottom-color',
+  'border-bottom-style',
+  'border-bottom-width',
+  'border-left-color',
+  'border-left-style',
+  'border-left-width',
+  'border-radius',
+  'padding-top',
+  'padding-right',
+  'padding-bottom',
+  'padding-left',
+  'font-size',
+  'font-weight',
+];
+
+const BORDER_KEYS = [
+  'border-top-color',
+  'border-top-style',
+  'border-top-width',
+  'border-right-color',
+  'border-right-style',
+  'border-right-width',
+  'border-bottom-color',
+  'border-bottom-style',
+  'border-bottom-width',
+  'border-left-color',
+  'border-left-style',
+  'border-left-width',
+];
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});
+
+async function main() {
+  const config = await loadConfig(process.argv.slice(2));
+  validateConfig(config);
+
+  const browser = await chromium.launch();
+  try {
+    const source = await captureSubject(browser, 'source', config.source, config);
+    const target = await captureSubject(browser, 'target', config.target, config);
+    const report = {
+      schema: 'blocks-engine.visual-parity.probes.v1',
+      config: publicConfig(config),
+      source,
+      target,
+      comparison: compareSubjects(source, target),
+    };
+
+    await writeJson(config.output, report);
+    console.log(`Visual parity report written to ${config.output}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+async function loadConfig(args) {
+  const cli = parseArgs(args);
+  let config = {};
+
+  if (cli.config) {
+    const raw = await readFile(cli.config, 'utf8');
+    config = JSON.parse(raw);
+  }
+
+  return normalizeConfig({ ...config, ...cli });
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  const viewports = [];
+  const selectors = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const next = args[index + 1];
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const [rawKey, inlineValue] = arg.slice(2).split('=', 2);
+    const value = inlineValue ?? next;
+    if (inlineValue === undefined) {
+      index += 1;
+    }
+
+    if (!value) {
+      throw new Error(`Missing value for --${rawKey}`);
+    }
+
+    if (rawKey === 'viewport') {
+      viewports.push(value);
+      continue;
+    }
+
+    if (rawKey === 'selector' || rawKey === 'probe') {
+      selectors.push(value);
+      continue;
+    }
+
+    parsed[toCamelCase(rawKey)] = value;
+  }
+
+  if (viewports.length > 0) {
+    parsed.viewports = viewports;
+  }
+  if (selectors.length > 0) {
+    parsed.selectors = selectors;
+  }
+
+  return parsed;
+}
+
+function normalizeConfig(config) {
+  return {
+    source: config.source,
+    target: config.target,
+    output: config.output ?? 'visual-parity-report.json',
+    viewports: normalizeViewports(config.viewports ?? config.viewport ?? DEFAULT_VIEWPORTS),
+    selectors: normalizeSelectors(config.selectors ?? config.probes ?? DEFAULT_SELECTORS),
+    maxMatchesPerSelector: Number(config.maxMatchesPerSelector ?? 50),
+    waitUntil: config.waitUntil ?? 'load',
+  };
+}
+
+function normalizeViewports(viewports) {
+  const list = Array.isArray(viewports) ? viewports : [viewports];
+  return list.map((viewport, index) => {
+    if (typeof viewport === 'object' && viewport !== null) {
+      return {
+        name: String(viewport.name ?? `viewport-${index + 1}`),
+        width: Number(viewport.width),
+        height: Number(viewport.height),
+      };
+    }
+
+    const value = String(viewport);
+    const [maybeName, size] = value.includes('=') ? value.split('=', 2) : [`viewport-${index + 1}`, value];
+    const [width, height] = size.toLowerCase().split('x').map((part) => Number(part));
+    return { name: maybeName, width, height };
+  });
+}
+
+function normalizeSelectors(selectors) {
+  const list = Array.isArray(selectors) ? selectors : [selectors];
+  return list.map((selector, index) => {
+    if (typeof selector === 'object' && selector !== null) {
+      return {
+        name: String(selector.name ?? `probe-${index + 1}`),
+        selector: String(selector.selector ?? ''),
+      };
+    }
+
+    const value = String(selector);
+    const [name, cssSelector] = value.includes('=') ? value.split('=', 2) : [`probe-${index + 1}`, value];
+    return { name, selector: cssSelector };
+  });
+}
+
+function validateConfig(config) {
+  for (const key of ['source', 'target', 'output']) {
+    if (!config[key]) {
+      throw new Error(`Missing required config value: ${key}`);
+    }
+  }
+
+  for (const viewport of config.viewports) {
+    if (!viewport.name || !Number.isFinite(viewport.width) || !Number.isFinite(viewport.height) || viewport.width <= 0 || viewport.height <= 0) {
+      throw new Error(`Invalid viewport: ${JSON.stringify(viewport)}`);
+    }
+  }
+
+  for (const probe of config.selectors) {
+    if (!probe.name || !probe.selector) {
+      throw new Error(`Invalid selector probe: ${JSON.stringify(probe)}`);
+    }
+  }
+}
+
+async function captureSubject(browser, role, input, config) {
+  const context = await browser.newContext();
+  try {
+    const pages = [];
+    for (const viewport of config.viewports) {
+      const page = await context.newPage();
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(toNavigableUrl(input), { waitUntil: config.waitUntil });
+      pages.push({
+        viewport,
+        url: page.url(),
+        probes: await extractProbes(page, config.selectors, config.maxMatchesPerSelector),
+      });
+      await page.close();
+    }
+
+    return { role, input, snapshots: pages };
+  } finally {
+    await context.close();
+  }
+}
+
+async function extractProbes(page, selectors, maxMatchesPerSelector) {
+  return page.evaluate(({ selectors: selectorConfigs, maxMatches, styleProperties, borderKeys }) => {
+    return selectorConfigs.map((probe) => {
+      const elements = Array.from(document.querySelectorAll(probe.selector)).slice(0, maxMatches);
+      return {
+        name: probe.name,
+        selector: probe.selector,
+        count: elements.length,
+        matches: elements.map((element, index) => serializeElement(element, index, styleProperties, borderKeys)),
+      };
+    });
+
+    function serializeElement(element, index, styleProperties, borderKeys) {
+      const rect = element.getBoundingClientRect();
+      const computed = window.getComputedStyle(element);
+      const styles = Object.fromEntries(styleProperties.map((property) => [property, computed.getPropertyValue(property)]));
+      const border = Object.fromEntries(borderKeys.map((property) => [property, styles[property]]));
+
+      return {
+        index,
+        tag: element.tagName.toLowerCase(),
+        text: normalizeText(element.textContent || ''),
+        href: element instanceof HTMLAnchorElement ? element.getAttribute('href') : null,
+        role: element.getAttribute('role'),
+        classes: Array.from(element.classList),
+        bounding_box: {
+          x: round(rect.x),
+          y: round(rect.y),
+          width: round(rect.width),
+          height: round(rect.height),
+        },
+        display: styles.display,
+        color: styles.color,
+        'background-color': styles['background-color'],
+        border,
+        'border-radius': styles['border-radius'],
+        padding: {
+          top: styles['padding-top'],
+          right: styles['padding-right'],
+          bottom: styles['padding-bottom'],
+          left: styles['padding-left'],
+        },
+        'font-size': styles['font-size'],
+        'font-weight': styles['font-weight'],
+      };
+    }
+
+    function normalizeText(value) {
+      return value.replace(/\s+/g, ' ').trim();
+    }
+
+    function round(value) {
+      return Math.round(value * 100) / 100;
+    }
+  }, {
+    selectors,
+    maxMatches: maxMatchesPerSelector,
+    styleProperties: STYLE_PROPERTIES,
+    borderKeys: BORDER_KEYS,
+  });
+}
+
+function compareSubjects(source, target) {
+  return source.snapshots.map((sourceSnapshot, index) => {
+    const targetSnapshot = target.snapshots[index];
+    return {
+      viewport: sourceSnapshot.viewport,
+      probes: sourceSnapshot.probes.map((sourceProbe) => {
+        const targetProbe = targetSnapshot.probes.find((probe) => probe.name === sourceProbe.name);
+        return {
+          name: sourceProbe.name,
+          selector: sourceProbe.selector,
+          source_count: sourceProbe.count,
+          target_count: targetProbe?.count ?? 0,
+          count_delta: (targetProbe?.count ?? 0) - sourceProbe.count,
+        };
+      }),
+    };
+  });
+}
+
+async function writeJson(outputPath, data) {
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+function toNavigableUrl(value) {
+  if (/^https?:\/\//.test(value) || value.startsWith('file://')) {
+    return value;
+  }
+
+  return pathToFileURL(path.resolve(value)).href;
+}
+
+function publicConfig(config) {
+  return {
+    source: config.source,
+    target: config.target,
+    output: config.output,
+    viewports: config.viewports,
+    selectors: config.selectors,
+    maxMatchesPerSelector: config.maxMatchesPerSelector,
+    waitUntil: config.waitUntil,
+  };
+}
+
+function toCamelCase(value) {
+  return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}

--- a/php-transformer/tools/visual-parity/package-lock.json
+++ b/php-transformer/tools/visual-parity/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "@automattic/blocks-engine-visual-parity",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@automattic/blocks-engine-visual-parity",
+      "version": "0.0.0",
+      "bin": {
+        "blocks-engine-visual-parity": "bin/visual-parity.mjs"
+      },
+      "devDependencies": {
+        "playwright": "^1.56.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/php-transformer/tools/visual-parity/package.json
+++ b/php-transformer/tools/visual-parity/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@automattic/blocks-engine-visual-parity",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Generic visual parity probe extractor for static HTML and materialized output fixtures.",
+  "type": "module",
+  "bin": {
+    "blocks-engine-visual-parity": "bin/visual-parity.mjs"
+  },
+  "scripts": {
+    "test": "node tests/smoke.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.56.0"
+  }
+}

--- a/php-transformer/tools/visual-parity/tests/fixtures/source.html
+++ b/php-transformer/tools/visual-parity/tests/fixtures/source.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Visual Parity Source Fixture</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 24px; color: rgb(24, 24, 24); }
+    nav { display: flex; gap: 16px; padding: 12px; background: rgb(245, 245, 245); }
+    a { color: rgb(20, 83, 160); font-size: 16px; font-weight: 600; }
+    .hero-card { width: 280px; padding: 20px; border: 2px solid rgb(20, 83, 160); border-radius: 12px; background: rgb(255, 255, 255); }
+    .primary-link { display: inline-block; padding: 10px 14px; border: 1px solid rgb(20, 83, 160); border-radius: 6px; background: rgb(20, 83, 160); color: rgb(255, 255, 255); text-decoration: none; }
+    button { padding: 8px 12px; border: 1px solid rgb(34, 34, 34); border-radius: 4px; background: rgb(250, 250, 250); color: rgb(34, 34, 34); font-size: 14px; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <nav class="site-menu" aria-label="Primary">
+    <a href="/about">About</a>
+    <a href="/contact">Contact</a>
+  </nav>
+  <main>
+    <article class="hero-card">
+      <h1>Fixture Card</h1>
+      <p>Reusable static HTML source fixture.</p>
+      <a class="primary-link" href="/start">Get Started</a>
+      <button type="button">Compare</button>
+    </article>
+  </main>
+</body>
+</html>

--- a/php-transformer/tools/visual-parity/tests/fixtures/target.html
+++ b/php-transformer/tools/visual-parity/tests/fixtures/target.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Visual Parity Target Fixture</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 24px; color: rgb(24, 24, 24); }
+    nav { display: flex; gap: 16px; padding: 12px; background: rgb(245, 245, 245); }
+    a { color: rgb(20, 83, 160); font-size: 16px; font-weight: 600; }
+    .hero-card { width: 280px; padding: 20px; border: 2px solid rgb(20, 83, 160); border-radius: 12px; background: rgb(255, 255, 255); }
+    .primary-link { display: inline-block; padding: 10px 14px; border: 1px solid rgb(20, 83, 160); border-radius: 6px; background: rgb(20, 83, 160); color: rgb(255, 255, 255); text-decoration: none; }
+    button { padding: 8px 12px; border: 1px solid rgb(34, 34, 34); border-radius: 4px; background: rgb(250, 250, 250); color: rgb(34, 34, 34); font-size: 14px; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <nav class="site-menu" aria-label="Primary">
+    <a href="/about">About</a>
+    <a href="/contact">Contact</a>
+  </nav>
+  <main>
+    <article class="hero-card">
+      <h1>Fixture Card</h1>
+      <p>Reusable materialized target fixture.</p>
+      <a class="primary-link" href="/start">Get Started</a>
+      <button type="button">Compare</button>
+    </article>
+  </main>
+</body>
+</html>

--- a/php-transformer/tools/visual-parity/tests/smoke.mjs
+++ b/php-transformer/tools/visual-parity/tests/smoke.mjs
@@ -1,0 +1,51 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const outputDir = path.join(root, 'tmp');
+const output = path.join(outputDir, 'visual-parity-smoke.json');
+
+await mkdir(outputDir, { recursive: true });
+
+await run(process.execPath, [
+  path.join(root, 'bin/visual-parity.mjs'),
+  '--source', path.join(root, 'tests/fixtures/source.html'),
+  '--target', path.join(root, 'tests/fixtures/target.html'),
+  '--viewport', 'smoke=390x844',
+  '--selector', 'primary=.primary-link',
+  '--output', output,
+], root);
+
+const report = JSON.parse(await readFile(output, 'utf8'));
+assert(report.schema === 'blocks-engine.visual-parity.probes.v1', 'report schema is stable');
+assert(report.source.snapshots[0].probes.length === 1, 'custom selector overrides default probes');
+assert(report.source.snapshots[0].probes[0].matches[0].text === 'Get Started', 'extracts link text');
+assert(report.source.snapshots[0].probes[0].matches[0].href === '/start', 'extracts link href');
+assert(report.source.snapshots[0].probes[0].matches[0].display === 'inline-block', 'extracts computed display');
+assert(report.source.snapshots[0].probes[0].matches[0].padding.top === '10px', 'extracts computed padding');
+assert(report.comparison[0].probes[0].count_delta === 0, 'compares source and target counts');
+
+await rm(output, { force: true });
+console.log('Visual parity smoke test passed.');
+
+function run(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} exited with ${code}`));
+    });
+  });
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
## Summary
- Add an optional product-neutral visual parity CLI scaffold under php-transformer tooling.
- Support source/target local HTML or URL captures across configurable viewports.
- Extract default button/link/nav/menu/card candidate computed-style snapshots for comparison.

## Testing
- npm test from php-transformer/tools/visual-parity
- composer test from php-transformer
- Manual CLI verification with default probes

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the visual parity scaffold, smoke fixture, verification, and preparing this PR description.