### PR TITLE
Materialize readable forms and search controls

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -629,7 +629,7 @@ final class HtmlTransformer
                 'html_truncated'  => $boundedHtml['truncated'],
             ), $this->fallbackProvenance);
 
-            return null;
+            return $this->shouldMaterializeReadableRuntimeForm($element) ? $readableFormBlock : null;
         }
 
         if ( 'nav' === $tagName ) {
@@ -689,6 +689,11 @@ final class HtmlTransformer
             $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
             if ( null !== $inlineContent ) {
                 return $inlineContent;
+            }
+
+            $standaloneSearch = $this->searchBlockFromStandaloneControl($element);
+            if ( null !== $standaloneSearch ) {
+                return $standaloneSearch;
             }
 
             $buttons = $this->buttonsPattern->matchContainer(
@@ -2202,6 +2207,57 @@ final class HtmlTransformer
     /**
      * @return array<string, mixed>|null
      */
+    private function searchBlockFromStandaloneControl(DOMElement $element): ?array
+    {
+        if ( 0 < $element->getElementsByTagName('form')->length || 0 < $element->getElementsByTagName('script')->length || array() !== $this->eventMetadata($element) ) {
+            return null;
+        }
+
+        $inputs = array();
+        foreach ( $element->getElementsByTagName('input') as $input ) {
+            if ( $input instanceof DOMElement && $input->parentNode === $element && 'search' === $this->formControlType($input) ) {
+                $inputs[] = $input;
+            }
+        }
+        if ( 1 !== count($inputs) || array() !== $this->eventMetadata($inputs[0]) ) {
+            return null;
+        }
+
+        $controls = $this->formControlElements($element);
+        if ( 1 !== count($controls) ) {
+            return null;
+        }
+
+        $searchInput = $inputs[0];
+        if ( ! $this->hasStandaloneSearchSignal($element, $searchInput) ) {
+            return null;
+        }
+
+        $label = $this->formControlLabel($searchInput);
+        if ( '' === $label ) {
+            $label = $this->attr($searchInput, 'aria-label');
+        }
+        if ( '' === $label ) {
+            $label = $this->attr($searchInput, 'placeholder');
+        }
+        if ( '' === $label ) {
+            $label = 'Search';
+        }
+
+        $attrs = array_filter(array_merge(
+            $this->presentationAttributes($element),
+            array(
+                'label'       => $label,
+                'placeholder' => $this->attr($searchInput, 'placeholder'),
+            )
+        ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+
+        return $this->createBlock('core/search', $attrs, array(), $element);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
     private function readableFormBlockFromForm(DOMElement $form, bool $allowFormEvents = false): ?array
     {
         if ( 0 < $form->getElementsByTagName('script')->length || ( ! $allowFormEvents && array() !== $this->eventMetadata($form) ) ) {
@@ -2301,6 +2357,12 @@ final class HtmlTransformer
 
         $summary = $this->readableFormControlText($element);
         return '' !== $summary ? $this->createBlock('core/paragraph', array( 'content' => $summary ), array(), $element) : null;
+    }
+
+    private function shouldMaterializeReadableRuntimeForm(DOMElement $form): bool
+    {
+        $metadata = $this->formMetadata($form);
+        return '' === ($metadata['action'] ?? '') && '' === ($metadata['method'] ?? '') && '' === ($metadata['enctype'] ?? '');
     }
 
     private function isReadableFormControl(DOMElement $control): bool
@@ -2414,6 +2476,26 @@ final class HtmlTransformer
             $this->attr($form, 'aria-label'),
             $this->attr($form, 'id'),
             $this->attr($form, 'class'),
+        )));
+
+        return str_contains($haystack, 'search');
+    }
+
+    private function hasStandaloneSearchSignal(DOMElement $element, DOMElement $input): bool
+    {
+        if ( 'search' === $this->formControlType($input) || 'search' === strtolower(trim($this->attr($element, 'role'))) ) {
+            return true;
+        }
+
+        $haystack = strtolower(implode(' ', array(
+            $this->attr($element, 'aria-label'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'class'),
+            $this->attr($input, 'aria-label'),
+            $this->attr($input, 'id'),
+            $this->attr($input, 'class'),
+            $this->attr($input, 'name'),
+            $this->attr($input, 'placeholder'),
         )));
 
         return str_contains($haystack, 'search');

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-runtime-form-readable-controls",
-  "description": "Keeps runtime-backed forms available as readable fallback metadata while preserving canonical block semantics.",
+  "description": "Keeps runtime-backed forms visible as readable blocks while preserving fallback metadata for submit behavior.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-runtime-form-readable-controls.json",
@@ -16,7 +16,9 @@
     "content": "<section><h2>Newsletter</h2><form class=\"signup\" onsubmit=\"return subscribe(event)\"><input type=\"email\" required placeholder=\"you@example.com\" aria-label=\"Email address\"><button class=\"btn\">Subscribe</button></form></section>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/heading", "attrs": { "content": "Newsletter", "level": 2 } }
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Newsletter", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group" }
   ],
   "expected_fallbacks": [
     { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback", "tag": "form", "control_count": 2 }
@@ -25,6 +27,8 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
     { "path": "fallbacks.0.events.0.type", "assert": "equals", "value": "submit" },
     { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.blockName", "assert": "equals", "value": "core/group" },
     { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },

--- a/php-transformer/tests/fixtures/parity/html-standalone-search-wrapper.json
+++ b/php-transformer/tests/fixtures/parity/html-standalone-search-wrapper.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-standalone-search-wrapper",
+  "description": "Converts a static search wrapper with one search input into a core/search block instead of flattening chrome and control text.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-standalone-search-wrapper.json",
+    "notes": "Product-neutral coverage for documentation and knowledge-base hero search controls that are not wrapped in a form."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><h1>Knowledge base</h1><div class=\"search-wrap animate-in\"><svg class=\"search-icon\" aria-hidden=\"true\" viewBox=\"0 0 24 24\"><path d=\"M21 21l-4-4\"></path></svg><input type=\"search\" class=\"search-input\" id=\"hero-search\" placeholder=\"Search articles\" aria-label=\"Search documentation\"><span class=\"search-shortcut\" aria-hidden=\"true\">⌘K</span></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Knowledge base", "level": 1 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/search", "attrs": { "className": "search-wrap animate-in", "label": "Search documentation", "placeholder": "Search articles" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:search" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"label\":\"Search documentation\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "⌘K" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Materialize local/runtime form controls as readable blocks while preserving form fallback metadata.
- Convert standalone search wrappers with a single search input into core/search.

## Testing
- composer test
- git diff --check
- raw HTML corpus profile for this branch

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the transformer fixture/fix, verification, and preparing this PR description.