### PR TITLE
Improve commerce card HTML semantics

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -694,6 +694,11 @@ final class HtmlTransformer
                 return $codeWindow;
             }
 
+            $namePriceRow = $this->namePriceRowBlockFromElement($element, $fallbacks);
+            if ( null !== $namePriceRow ) {
+                return $namePriceRow;
+            }
+
             $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
             if ( null !== $inlineContent ) {
                 return $inlineContent;
@@ -1358,6 +1363,18 @@ final class HtmlTransformer
         if ( $this->isVisualLayerElement($element) ) {
             $signals['visual_layer'] = true;
         }
+        if ( $this->hasCommerceToken($element, array( 'badge', 'featured', 'popular', 'recommended' )) ) {
+            $signals['featured_badge_like'] = true;
+        }
+        if ( $this->hasCommerceToken($element, array( 'price', 'pricing', 'amount', 'cost' )) || $this->looksLikePriceText($element->textContent ?? '') ) {
+            $signals['price_like'] = true;
+        }
+        if ( $this->hasCommerceToken($element, array( 'product', 'menu', 'dish', 'plan', 'tier', 'name', 'title' )) ) {
+            $signals['commerce_content_like'] = true;
+        }
+        if ( $this->looksLikeNamePriceRow($element) ) {
+            $signals['name_price_row'] = true;
+        }
 
         $itemCount = $this->cardLikeChildCount($element);
         if ( 1 < $itemCount ) {
@@ -1400,6 +1417,33 @@ final class HtmlTransformer
 
         return (bool) ( preg_match('/(?:^|;)\s*position\s*:\s*(?:fixed|absolute)\b/', $style)
             && preg_match('/(?:^|;)\s*(?:inset|top|right|bottom|left|z-index|pointer-events|mix-blend-mode|opacity|filter|background|background-image)\s*:/', $style) );
+    }
+
+    /**
+     * @param array<int, string> $tokens
+     */
+    private function hasCommerceToken(DOMElement $element, array $tokens): bool
+    {
+        foreach ( array( 'class', 'id', 'itemprop' ) as $attribute ) {
+            $value = strtolower($this->attr($element, $attribute));
+            foreach ( preg_split('/[^a-z0-9]+/', $value) ?: array() as $token ) {
+                if ( in_array($token, $tokens, true) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function looksLikePriceText(string $text): bool
+    {
+        return (bool) preg_match('/(?:\p{Sc}\s?\d|\d+(?:[.,]\d{2})?\s?(?:usd|eur|gbp|cad|aud)\b)/iu', trim($text));
+    }
+
+    private function looksLikeNamePriceRow(DOMElement $element): bool
+    {
+        return null !== $this->namePriceChildren($element);
     }
 
     private function safeSourceFragment(DOMElement $element): string
@@ -2741,6 +2785,95 @@ final class HtmlTransformer
         }
 
         return $this->createBlock('core/gallery', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $images, $element);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function namePriceRowBlockFromElement(DOMElement $element, array &$fallbacks): ?array
+    {
+        $children = $this->namePriceChildren($element);
+        if ( null === $children ) {
+            return null;
+        }
+
+        $rowFallbacks = array();
+        $columns = array();
+        foreach ( $children as $child ) {
+            $converted = array_filter(array( $this->convertElement($child, $rowFallbacks, true) ));
+            if ( array() === $converted ) {
+                return null;
+            }
+
+            $columns[] = $this->createBlock('core/column', $this->presentationAttributes($child), $converted, $child);
+        }
+        array_push($fallbacks, ...$rowFallbacks);
+
+        return $this->createBlock('core/columns', $this->presentationAttributes($element), $columns, $element);
+    }
+
+    /**
+     * @return array<int, DOMElement>|null
+     */
+    private function namePriceChildren(DOMElement $element): ?array
+    {
+        if ( ! in_array(strtolower($element->tagName), array( 'div', 'header', 'section' ), true) ) {
+            return null;
+        }
+
+        $children = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+            if ( ! $child instanceof DOMElement ) {
+                return null;
+            }
+            if ( ! $this->isInlineCommerceRowChild($child) ) {
+                return null;
+            }
+            $children[] = $child;
+        }
+
+        if ( 2 !== count($children) ) {
+            return null;
+        }
+
+        $first = $children[0];
+        $second = $children[1];
+        $firstIsPrice = $this->isPriceElement($first);
+        $secondIsPrice = $this->isPriceElement($second);
+        if ( $firstIsPrice === $secondIsPrice ) {
+            return null;
+        }
+
+        $other = $firstIsPrice ? $second : $first;
+        if ( ! $this->isNameElement($other) && ! $this->hasCommerceToken($element, array( 'menu', 'product', 'pricing', 'price', 'plan', 'tier', 'dish', 'item', 'row' )) ) {
+            return null;
+        }
+
+        return $children;
+    }
+
+    private function isInlineCommerceRowChild(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( in_array($tagName, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'span', 'strong', 'em', 'small' ), true) ) {
+            return ! $this->hasBlockContentChildren($element);
+        }
+
+        return false;
+    }
+
+    private function isPriceElement(DOMElement $element): bool
+    {
+        return $this->hasCommerceToken($element, array( 'price', 'amount', 'cost' )) || $this->looksLikePriceText($element->textContent ?? '');
+    }
+
+    private function isNameElement(DOMElement $element): bool
+    {
+        return $this->hasCommerceToken($element, array( 'name', 'title', 'product', 'dish', 'item', 'plan', 'tier' )) || preg_match('/^h[1-6]$/', strtolower($element->tagName));
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-menu-name-price-description-row.json
+++ b/php-transformer/tests/fixtures/parity/html-menu-name-price-description-row.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-menu-name-price-description-row",
+  "description": "Preserves restaurant menu rows with item name, price, and description without flattening the name/price row.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-menu-name-price-description-row.json",
+    "notes": "Generic menu item coverage for name/price/description rows."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"menu-list\"><div class=\"menu-item\"><div class=\"menu-row\"><span class=\"item-name\">Roasted Carrots</span><span class=\"item-price\">$14</span></div><p class=\"item-description\">Harissa yogurt, herbs, toasted seeds.</p></div><div class=\"menu-item\"><div class=\"menu-row\"><span class=\"item-name\">Mushroom Tart</span><span class=\"item-price\">$18</span></div><p class=\"item-description\">Wild mushrooms, thyme, aged cheddar.</p></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "menu-list" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "menu-item" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/columns", "attrs": { "className": "menu-row" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/column", "attrs": { "className": "item-name" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/column", "attrs": { "className": "item-price" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "item-description", "content": "Harissa yogurt, herbs, toasted seeds." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"menu-row\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "item-description" },
+    { "path": "source_reports.html.structure_signals.2.signals.name_price_row", "assert": "equals", "value": true }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-pricing-card-grid-featured-tier.json
+++ b/php-transformer/tests/fixtures/parity/html-pricing-card-grid-featured-tier.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-pricing-card-grid-featured-tier",
+  "description": "Preserves pricing card grids with featured tier badges, name/price rows, and CTA buttons as standard blocks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-pricing-card-grid-featured-tier.json",
+    "notes": "Generic commerce card coverage based on class and text signals, not product-specific markup."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"pricing-card-grid\"><article class=\"pricing-card featured-tier\"><span class=\"tier-badge\">Most popular</span><div class=\"tier-price-row\"><h3 class=\"tier-name\">Pro</h3><span class=\"price\">$29</span></div><p>For growing teams.</p><a class=\"cta-button\" href=\"/checkout/pro\">Get started</a></article><article class=\"pricing-card\"><div class=\"tier-price-row\"><h3 class=\"tier-name\">Starter</h3><span class=\"price\">$9</span></div><p>For new projects.</p><a class=\"cta-button\" href=\"/checkout/starter\">Get started</a></article></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "pricing-card-grid", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "pricing-card featured-tier" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/columns", "attrs": { "className": "tier-price-row" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/column", "attrs": { "className": "tier-name" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/column", "attrs": { "className": "price" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.3.innerBlocks.0", "name": "core/button", "attrs": { "className": "cta-button", "text": "Get started", "url": "/checkout/pro" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/columns", "attrs": { "className": "tier-price-row" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "tier-badge" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"tier-price-row\"} -->" },
+    { "path": "source_reports.html.structure_signals.3.signals.name_price_row", "assert": "equals", "value": true },
+    { "path": "source_reports.html.structure_signals.10.signals.price_like", "assert": "equals", "value": true }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-product-card-svg-price-grid",
+  "description": "Preserves product cards with SVG imagery, product names, prices, and CTA buttons inside a card grid.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-product-card-svg-price-grid.json",
+    "notes": "Generic product-card coverage for image/name/price/action semantics."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div class=\"product-grid\"><article class=\"product-card\"><svg class=\"product-image\" role=\"img\" aria-label=\"Ceramic bowl\" viewBox=\"0 0 10 10\"><circle cx=\"5\" cy=\"5\" r=\"4\"></circle></svg><h3 class=\"product-name\">Ceramic Bowl</h3><p class=\"product-price\">$42</p><a class=\"product-cta\" href=\"/products/bowl\">Buy now</a></article><article class=\"product-card\"><svg class=\"product-image\" role=\"img\" aria-label=\"Linen towel\" viewBox=\"0 0 10 10\"><rect width=\"10\" height=\"10\"></rect></svg><h3 class=\"product-name\">Linen Towel</h3><p class=\"product-price\">$18</p><a class=\"product-cta\" href=\"/products/towel\">Buy now</a></article></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "product-grid", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "product-card" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image", "attrs": { "className": "product-image", "alt": "Ceramic bowl" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "className": "product-name", "content": "Ceramic Bowl", "level": 3 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "className": "product-price", "content": "$42" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.3.innerBlocks.0", "name": "core/button", "attrs": { "className": "product-cta", "text": "Buy now", "url": "/products/bowl" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "product-price" },
+    { "path": "source_reports.html.structure_signals.3.signals.price_like", "assert": "equals", "value": true },
+    { "path": "source_reports.html.structure_signals.14.signals.grid_like", "assert": "equals", "value": true }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve name/price rows as columns before inline wrapper flattening.
- Add structure signals for featured pricing cards, product cards, prices, and commerce rows.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the transformer fixture/fix and preparing this PR description.