### PR TITLE
Preserve linked card hrefs in HTML conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -554,7 +554,7 @@ final class HtmlTransformer
             if ( $this->hasBlockContentChildren($element) ) {
                 $children = $this->convertChildren($element, $fallbacks, true);
                 if ( array() !== $children ) {
-                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+                    return $this->createBlock('core/group', array_merge($this->presentationAttributes($element), $this->cardLinkAttributes($element)), $children, $element);
                 }
             }
 
@@ -2926,6 +2926,24 @@ final class HtmlTransformer
         }
 
         return $url;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function cardLinkAttributes(DOMElement $anchor): array
+    {
+        $href = $this->safeLinkUrl($this->attr($anchor, 'href'));
+        if ( '' === $href ) {
+            return array();
+        }
+
+        return array_filter(array(
+            'href'      => $href,
+            'target'    => $this->attr($anchor, 'target'),
+            'rel'       => $this->attr($anchor, 'rel'),
+            'ariaLabel' => $this->attr($anchor, 'aria-label'),
+        ), static fn (string $value): bool => '' !== trim($value));
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-linked-overlay-category-card.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-overlay-category-card.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-linked-overlay-category-card",
+  "description": "Preserves linked overlay/category card hrefs when anchors wrap background and content regions.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-linked-overlay-category-card.json",
+    "notes": "Generic coverage for overlay cards with card__bg and category-card content."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div class=\"category-grid\"><a class=\"category-card overlay-card\" href=\"/category/design\" aria-label=\"Read design category\"><div class=\"card__bg\"><img src=\"/images/design.jpg\" alt=\"Design desk\"></div><div class=\"overlay\"><p class=\"category-card__label\">Design</p><h2>Sharp Visual Systems</h2><p>Patterns for expressive page sections.</p></div></a><a class=\"category-card overlay-card\" href=\"/category/build\"><div class=\"card__bg\"><img src=\"/images/build.jpg\" alt=\"Build tools\"></div><div class=\"content\"><p class=\"category-card__label\">Build</p><h2>Production Workflows</h2><p>Ship reliable experiences from compiled artifacts.</p></div></a></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "category-grid", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "category-card overlay-card", "href": "/category/design", "ariaLabel": "Read design category" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "card__bg" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "overlay" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "category-card overlay-card", "href": "/category/build" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "card__bg" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/group", "attrs": { "className": "content" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/category/design\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/category/build\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "card__bg" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-linked-resource-card-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-resource-card-grid.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-linked-resource-card-grid",
+  "description": "Preserves card-level hrefs when anchors wrap resource-card content in a grid.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-linked-resource-card-grid.json",
+    "notes": "Product-neutral coverage for resource/card grids where the whole card is an anchor."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"resource-grid\"><a class=\"resource-card\" href=\"/resources/block-patterns\"><div class=\"resource-card__media\"><img src=\"/assets/patterns.jpg\" alt=\"Pattern examples\"></div><div class=\"resource-card__content\"><p class=\"resource-card__eyebrow\">Guide</p><h3>Block Pattern Basics</h3><p>Learn how reusable layouts are assembled.</p></div></a><a class=\"resource-card\" href=\"/resources/site-launch\" target=\"_blank\" rel=\"noopener\"><div class=\"resource-card__content\"><p class=\"resource-card__eyebrow\">Checklist</p><h3>Launch Review</h3><p>Confirm content, navigation, and assets.</p></div></a></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "resource-grid", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "resource-card", "href": "/resources/block-patterns" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "resource-card__media" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "resource-card__content" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "resource-card", "href": "/resources/site-launch", "target": "_blank", "rel": "noopener" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/resources/block-patterns\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/resources/site-launch\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<p><a class=\"resource-card\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve safe link metadata for anchor-wrapped card content.
- Cover resource-card and overlay category-card patterns that otherwise lose card-level href intent.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the transformer fixture/fix and preparing this PR description.