### PR TITLE
Improve HTML navigation conversion

### DIFF
--- a/php-transformer/src/FormatBridge/MarkdownAdapter.php
+++ b/php-transformer/src/FormatBridge/MarkdownAdapter.php
@@ -209,6 +209,7 @@ final class MarkdownAdapter implements FormatAdapterInterface
             'core/list-item',
             'core/navigation',
             'core/navigation-link',
+            'core/navigation-submenu',
             'core/paragraph',
             'core/preformatted',
             'core/pullquote',

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -165,6 +165,14 @@ final class BlockFactory
             return '<li' . $this->blockSupportAttrs($attrs, 'wp-block-navigation-item wp-block-navigation-link') . '><a class="wp-block-navigation-item__content"' . $href . '><span class="wp-block-navigation-item__label">' . ($attrs['label'] ?? '') . '</span></a></li>';
         }
 
+        if ( 'core/navigation-submenu' === $name ) {
+            $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
+            return array(
+                'opening' => '<li' . $this->blockSupportAttrs($attrs, 'wp-block-navigation-item has-child wp-block-navigation-submenu') . '><a class="wp-block-navigation-item__content"' . $href . '><span class="wp-block-navigation-item__label">' . ($attrs['label'] ?? '') . '</span></a><ul class="wp-block-navigation__submenu-container">',
+                'closing' => '</ul></li>',
+            );
+        }
+
         if ( 'core/shortcode' === $name ) {
             return '<div class="wp-block-shortcode">' . ($attrs['text'] ?? '') . '</div>';
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -149,7 +149,7 @@ final class HtmlTransformer
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
-        $blocks      = $this->convertChildren($body, $fallbacks, true);
+        $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $diagnostics = array(
@@ -194,7 +194,7 @@ final class HtmlTransformer
             sourceReports: $sourceReports,
             coverage: array(
                 array(
-                    'supported_blocks' => array( 'core/audio', 'core/button', 'core/buttons', 'core/code', 'core/column', 'core/columns', 'core/details', 'core/embed', 'core/file', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/separator', 'core/shortcode', 'core/spacer', 'core/table', 'core/video', 'core/search' ),
+                    'supported_blocks' => array( 'core/audio', 'core/button', 'core/buttons', 'core/code', 'core/column', 'core/columns', 'core/details', 'core/embed', 'core/file', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/separator', 'core/shortcode', 'core/spacer', 'core/navigation-submenu', 'core/table', 'core/video', 'core/search' ),
                     'block_count'      => count($blocks),
                     'fallback_count'   => count($fallbacks),
                     'source_provenance_count' => count($sourceProvenance),
@@ -238,6 +238,99 @@ final class HtmlTransformer
         }
 
         return $count;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<int, array<string, mixed>>
+     */
+    private function deduplicateNavigationBlocks(array $blocks): array
+    {
+        $seen = array();
+        return $this->deduplicateNavigationBlocksRecursive($blocks, $seen);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<string, bool> $seen
+     * @return array<int, array<string, mixed>>
+     */
+    private function deduplicateNavigationBlocksRecursive(array $blocks, array &$seen): array
+    {
+        $deduplicated = array();
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $block['innerBlocks'] = $this->deduplicateNavigationBlocksRecursive($block['innerBlocks'], $seen);
+            }
+
+            if ( 'core/navigation' === ($block['blockName'] ?? '') ) {
+                $signature = $this->navigationBlockSignature($block);
+                if ( '' !== $signature && isset($seen[$signature]) ) {
+                    continue;
+                }
+                if ( '' !== $signature ) {
+                    $seen[$signature] = true;
+                }
+            }
+
+            if ( 'core/group' === ($block['blockName'] ?? '') && empty($block['innerBlocks']) && $this->isMobileNavigationWrapperAttrs($block['attrs'] ?? array()) ) {
+                continue;
+            }
+
+            $deduplicated[] = $block;
+        }
+
+        return $deduplicated;
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     */
+    private function navigationBlockSignature(array $block): string
+    {
+        $links = array();
+        $this->collectNavigationBlockLinks($block, $links);
+        return implode('|', $links);
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     * @param array<int, string> $links
+     */
+    private function collectNavigationBlockLinks(array $block, array &$links): void
+    {
+        if ( in_array($block['blockName'] ?? '', array( 'core/navigation-link', 'core/navigation-submenu' ), true) ) {
+            $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+            $links[] = trim((string) ($attrs['label'] ?? '')) . '>' . trim((string) ($attrs['url'] ?? ''));
+        }
+
+        foreach ( is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array() as $innerBlock ) {
+            if ( is_array($innerBlock) ) {
+                $this->collectNavigationBlockLinks($innerBlock, $links);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function isMobileNavigationWrapperAttrs(array $attrs): bool
+    {
+        $className = strtolower((string) ($attrs['className'] ?? ''));
+        if ( '' === $className ) {
+            return false;
+        }
+
+        if ( preg_match('/(?:^|[\s_-])(?:mobile|drawer|offcanvas)(?:$|[\s_-])/', $className) ) {
+            return true;
+        }
+
+        return (bool) preg_match('/(?:^|[\s_-])(?:overlay|panel|dialog)(?:$|[\s_-])/', $className)
+            && preg_match('/(?:^|[\s_-])(?:nav|menu|drawer|offcanvas)(?:$|[\s_-])/', $className);
     }
 
     private function normalizeHtml5VoidElements(string $html): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -19,14 +19,7 @@ final class NavigationPattern
             return null;
         }
 
-        $links = array();
-        foreach ( $this->directNavigationAnchors($element) as $anchor ) {
-            $links[] = $createBlock('core/navigation-link', array_filter(array(
-                'label' => $innerHtml($anchor),
-                'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
-                'kind'  => 'custom',
-            ), static fn ($value): bool => '' !== $value), array(), $anchor);
-        }
+        $links = $this->navigationBlocks($element, $innerHtml, $createBlock);
 
         if ( array() === $links ) {
             return null;
@@ -46,13 +39,14 @@ final class NavigationPattern
     }
 
     /**
-     * @return array<int, DOMElement>
+     * @return array<int, array<string, mixed>>
      */
-    private function directNavigationAnchors(DOMElement $element): array
+    private function navigationBlocks(DOMElement $element, callable $innerHtml, callable $createBlock): array
     {
-        $anchors = array();
+        $blocks = array();
+        $allowsDirectItems = 'nav' === strtolower($element->tagName) || $this->hasNavigationSignal($element) || $this->hasSubmenuSignal($element) || in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true);
         if ( in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true) ) {
-            return $this->navigationAnchorsFromList($element);
+            return $this->navigationBlocksFromList($element, $innerHtml, $createBlock);
         }
 
         foreach ( $element->childNodes as $child ) {
@@ -61,42 +55,45 @@ final class NavigationPattern
             }
 
             if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') ) {
-                $anchors[] = $child;
+                if ( ! $allowsDirectItems ) {
+                    return array();
+                }
+                $blocks[] = $this->navigationLinkBlock($child, $innerHtml, $createBlock);
                 continue;
             }
 
             if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'ul', 'ol' ), true) ) {
-                foreach ( $child->childNodes as $item ) {
-                    if ( XML_TEXT_NODE === $item->nodeType && '' === trim($item->textContent ?? '') ) {
-                        continue;
-                    }
-
-                    if ( ! $item instanceof DOMElement || 'li' !== strtolower($item->tagName) ) {
-                        return array();
-                    }
-
-                    $anchor = $this->singleNavigationAnchor($item);
-                    if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
-                        return array();
-                    }
-
-                    $anchors[] = $anchor;
+                $listBlocks = $this->navigationBlocksFromList($child, $innerHtml, $createBlock);
+                if ( array() === $listBlocks ) {
+                    return array();
                 }
+                $blocks = array_merge($blocks, $listBlocks);
                 continue;
+            }
+
+            if ( $child instanceof DOMElement ) {
+                if ( ! $allowsDirectItems ) {
+                    return array();
+                }
+                $block = $this->navigationBlockFromItem($child, $innerHtml, $createBlock);
+                if ( null !== $block ) {
+                    $blocks[] = $block;
+                    continue;
+                }
             }
 
             return array();
         }
 
-        return $anchors;
+        return $blocks;
     }
 
     /**
-     * @return array<int, DOMElement>
+     * @return array<int, array<string, mixed>>
      */
-    private function navigationAnchorsFromList(DOMElement $list): array
+    private function navigationBlocksFromList(DOMElement $list, callable $innerHtml, callable $createBlock): array
     {
-        $anchors = array();
+        $blocks = array();
         foreach ( $list->childNodes as $item ) {
             if ( XML_TEXT_NODE === $item->nodeType && '' === trim($item->textContent ?? '') ) {
                 continue;
@@ -106,30 +103,134 @@ final class NavigationPattern
                 return array();
             }
 
-            $anchor = $this->singleNavigationAnchor($item);
-            if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
+            $block = $this->navigationBlockFromItem($item, $innerHtml, $createBlock);
+            if ( null === $block ) {
                 return array();
             }
 
-            $anchors[] = $anchor;
+            $blocks[] = $block;
         }
 
-        return $anchors;
+        return $blocks;
     }
 
-    private function singleNavigationAnchor(DOMElement $element): ?DOMElement
+    private function navigationBlockFromItem(DOMElement $element, callable $innerHtml, callable $createBlock): ?array
+    {
+        $anchor = $this->primaryNavigationAnchor($element);
+        if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
+            return null;
+        }
+
+        $submenuBlocks = array();
+        foreach ( $this->submenuContainers($element, $anchor) as $submenuContainer ) {
+            foreach ( $this->navigationBlocks($submenuContainer, $innerHtml, $createBlock) as $submenuBlock ) {
+                $submenuBlocks[] = $submenuBlock;
+            }
+        }
+
+        if ( array() !== $submenuBlocks ) {
+            return $createBlock('core/navigation-submenu', array_filter(array(
+                'label' => $innerHtml($anchor),
+                'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
+                'kind'  => 'custom',
+            ), static fn ($value): bool => '' !== $value), $submenuBlocks, $element);
+        }
+
+        if ( 1 !== count($this->anchorsExcludingSubmenus($element, $anchor)) ) {
+            return null;
+        }
+
+        return $this->navigationLinkBlock($anchor, $innerHtml, $createBlock);
+    }
+
+    private function navigationLinkBlock(DOMElement $anchor, callable $innerHtml, callable $createBlock): array
+    {
+        return $createBlock('core/navigation-link', array_filter(array(
+            'label' => $innerHtml($anchor),
+            'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
+            'kind'  => 'custom',
+        ), static fn ($value): bool => '' !== $value), array(), $anchor);
+    }
+
+    private function primaryNavigationAnchor(DOMElement $element): ?DOMElement
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( 'a' === strtolower($child->tagName) ) {
+                return $child;
+            }
+
+            if ( in_array(strtolower($child->tagName), array( 'span', 'div', 'p' ), true) ) {
+                $anchor = $this->primaryNavigationAnchor($child);
+                if ( $anchor instanceof DOMElement ) {
+                    return $anchor;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function submenuContainers(DOMElement $element, DOMElement $primaryAnchor): array
+    {
+        $containers = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement || $child->isSameNode($primaryAnchor) ) {
+                continue;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( in_array($tagName, array( 'ul', 'ol' ), true) || $this->hasSubmenuSignal($child) ) {
+                $containers[] = $child;
+            }
+        }
+
+        return $containers;
+    }
+
+    private function hasSubmenuSignal(DOMElement $element): bool
+    {
+        foreach ( array( 'class', 'id', 'role' ) as $attribute ) {
+            $value = $element->hasAttribute($attribute) ? $element->getAttribute($attribute) : '';
+            foreach ( preg_split('/[^a-z0-9]+/', strtolower($value)) ?: array() as $token ) {
+                if ( in_array($token, array( 'dropdown', 'submenu', 'subnav', 'flyout', 'menu' ), true) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function anchorsExcludingSubmenus(DOMElement $element, DOMElement $primaryAnchor): array
     {
         $anchors = array();
-        $this->collectAnchors($element, $anchors);
-
-        return 1 === count($anchors) ? $anchors[0] : null;
+        $submenuContainers = $this->submenuContainers($element, $primaryAnchor);
+        $this->collectAnchorsExcluding($element, $anchors, $submenuContainers);
+        return $anchors;
     }
 
     /**
      * @param array<int, DOMElement> $anchors
+     * @param array<int, DOMElement> $excluded
      */
-    private function collectAnchors(DOMElement $element, array &$anchors): void
+    private function collectAnchorsExcluding(DOMElement $element, array &$anchors, array $excluded): void
     {
+        foreach ( $excluded as $excludedElement ) {
+            if ( $element->isSameNode($excludedElement) ) {
+                return;
+            }
+        }
+
         foreach ( $element->childNodes as $child ) {
             if ( ! $child instanceof DOMElement ) {
                 continue;
@@ -140,8 +241,8 @@ final class NavigationPattern
                 continue;
             }
 
-            if ( in_array(strtolower($child->tagName), array( 'span', 'div', 'p' ), true) ) {
-                $this->collectAnchors($child, $anchors);
+            if ( in_array(strtolower($child->tagName), array( 'span', 'div', 'p' ), true) || $this->hasSubmenuSignal($child) ) {
+                $this->collectAnchorsExcluding($child, $anchors, $excluded);
             }
         }
     }

--- a/php-transformer/tests/fixtures/parity/html-mobile-drawer-nav-dedup.json
+++ b/php-transformer/tests/fixtures/parity/html-mobile-drawer-nav-dedup.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-mobile-drawer-nav-dedup",
+  "description": "Deduplicates mobile drawer navigation that repeats the primary navigation so drawer wrappers are not emitted as extra visible body content.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-mobile-drawer-nav-dedup.json",
+    "notes": "Generic fixture for mobile-nav overlay/panel wrappers that duplicate primary navigation links."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"site-header\"><nav class=\"primary-nav\"><a href=\"/\">Home</a><a href=\"/shop\">Shop</a><a href=\"/contact\">Contact</a></nav><div class=\"mobile-nav overlay\"><div class=\"mobile-nav-panel\"><nav class=\"drawer-nav\"><a href=\"/\">Home</a><a href=\"/shop\">Shop</a><a href=\"/contact\">Contact</a></nav></div></div></header>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "/", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Shop", "url": "/shop", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/navigation-link", "attrs": { "label": "Contact", "url": "/contact", "kind": "custom" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "drawer-nav" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "mobile-nav" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nav-dropdown-submenu.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-dropdown-submenu.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-dropdown-submenu",
+  "description": "Preserves desktop dropdown navigation relationships as nested navigation submenu blocks instead of flattening child links.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-dropdown-submenu.json",
+    "notes": "Generic fixture for .nav-item > a + .dropdown desktop navigation patterns."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<nav class=\"primary-nav\"><div class=\"nav-item\"><a href=\"/services\">Services</a><div class=\"dropdown\"><a href=\"/services/design\">Design</a><a href=\"/services/build\">Build</a></div></div><div class=\"nav-item\"><a href=\"/about\">About</a></div></nav>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-submenu", "attrs": { "label": "Services", "url": "/services", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Design", "url": "/services/design", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Build", "url": "/services/build", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "About", "url": "/about", "kind": "custom" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-submenu" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Convert dropdown navigation structures into navigation submenu blocks.
- Deduplicate repeated mobile drawer navigation wrappers from visible body content.

## Testing
- composer test
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the transformer fixture/fix and preparing this PR description.