### PR TITLE
Improve placeholder and hero decor materialization

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -351,6 +351,11 @@ final class HtmlTransformer
             return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
         }
 
+        $placeholderMedia = $this->placeholderMediaBlockFromElement($element);
+        if ( null !== $placeholderMedia ) {
+            return $placeholderMedia;
+        }
+
         if ( $this->isInlineContentElement($tagName) ) {
             $dynamicText = $this->dynamicTextContent($element);
             if ( null !== $dynamicText ) {
@@ -576,6 +581,9 @@ final class HtmlTransformer
 
         if ( 'svg' === $tagName ) {
             if ( $this->isSafeDecorativeSvgElement($element) ) {
+                if ( $this->isVisualLayerElement($element) ) {
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
+                }
                 return null;
             }
 
@@ -1342,6 +1350,9 @@ final class HtmlTransformer
         if ( preg_match('/(?:^|[\s_-])(?:cards|grid|tiles|columns|collection|gallery)(?:$|[\s_-])/', $className) || preg_match('/(?:^|;)\s*(?:display\s*:\s*grid|grid-template-columns\s*:)/', $style) ) {
             $signals['grid_like'] = true;
         }
+        if ( $this->isVisualLayerElement($element) ) {
+            $signals['visual_layer'] = true;
+        }
 
         $itemCount = $this->cardLikeChildCount($element);
         if ( 1 < $itemCount ) {
@@ -1367,6 +1378,23 @@ final class HtmlTransformer
     {
         $className = strtolower($this->attr($element, 'class'));
         return 'article' === strtolower($element->tagName) || (bool) preg_match('/(?:^|[\s_-])(?:card|tile|panel|item)(?:$|[\s_-])/', $className);
+    }
+
+    private function isVisualLayerElement(DOMElement $element): bool
+    {
+        $context = strtolower(trim(implode(' ', array(
+            $this->attr($element, 'class'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'aria-label'),
+        ))));
+        $style = strtolower($this->attr($element, 'style'));
+
+        if ( preg_match('/(?:^|[\s_-])(?:hero|decor|decorative|layer|overlay|grain|noise|texture|glow|atmosphere|ambient|aura|orb|blob|backdrop|background|bg)(?:$|[\s_-])/', $context) ) {
+            return true;
+        }
+
+        return (bool) ( preg_match('/(?:^|;)\s*position\s*:\s*(?:fixed|absolute)\b/', $style)
+            && preg_match('/(?:^|;)\s*(?:inset|top|right|bottom|left|z-index|pointer-events|mix-blend-mode|opacity|filter|background|background-image)\s*:/', $style) );
     }
 
     private function safeSourceFragment(DOMElement $element): string
@@ -2742,6 +2770,76 @@ final class HtmlTransformer
         }
 
         return $height;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function placeholderMediaBlockFromElement(DOMElement $element): ?array
+    {
+        if ( ! $this->isPlaceholderMediaElement($element) ) {
+            return null;
+        }
+
+        $attrs = $this->presentationAttributes($element);
+        $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), 'blocks-engine-placeholder-media');
+
+        $style = trim((string) ($attrs['style'] ?? ''));
+        $ratio = $this->placeholderAspectRatio($element);
+        if ( '' !== $ratio && ! preg_match('/(?:^|;)\s*aspect-ratio\s*:/i', $style) ) {
+            $style = rtrim($style, ';') . ( '' !== $style ? ';' : '' ) . 'aspect-ratio:' . $ratio;
+        }
+        if ( '' !== $style ) {
+            $attrs['style'] = $style;
+        }
+
+        $label = $this->placeholderLabel($element);
+        $children = '' !== $label ? array( $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) )) ) : array();
+
+        return $this->createBlock('core/group', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $children, $element);
+    }
+
+    private function isPlaceholderMediaElement(DOMElement $element): bool
+    {
+        $className = strtolower($this->attr($element, 'class'));
+        if ( ! preg_match('/(?:^|\s)(?:ph|placeholder|media-placeholder|image-placeholder|video-placeholder)(?:\s|$)/', $className) && ! preg_match('/(?:^|\s)ratio-[0-9]+(?:x|:|-)[0-9]+(?:\s|$)/', $className) ) {
+            return false;
+        }
+
+        return '' !== $this->placeholderAspectRatio($element)
+            || preg_match('/(?:^|;)\s*aspect-ratio\s*:/i', $this->attr($element, 'style'))
+            || preg_match('/(?:^|\s)(?:media|image|video|thumb|thumbnail|poster|avatar)(?:\s|$)/', $className);
+    }
+
+    private function placeholderAspectRatio(DOMElement $element): string
+    {
+        if ( preg_match('/(?:^|;)\s*aspect-ratio\s*:\s*([0-9.]+\s*\/\s*[0-9.]+|[0-9.]+)\s*(?:;|$)/i', $this->attr($element, 'style'), $styleMatch) ) {
+            return preg_replace('/\s+/', '', $styleMatch[1]) ?? '';
+        }
+
+        $className = strtolower($this->attr($element, 'class'));
+        if ( preg_match('/(?:^|\s)ratio-([0-9]+)(?:x|:|-)([0-9]+)(?:\s|$)/', $className, $classMatch) ) {
+            return $classMatch[1] . '/' . $classMatch[2];
+        }
+
+        return '';
+    }
+
+    private function placeholderLabel(DOMElement $element): string
+    {
+        foreach ( $element->getElementsByTagName('span') as $span ) {
+            if ( ! $span instanceof DOMElement ) {
+                continue;
+            }
+
+            $className = strtolower($this->attr($span, 'class'));
+            if ( preg_match('/(?:^|\s)(?:label|caption|placeholder-label)(?:\s|$)/', $className) ) {
+                return trim(preg_replace('/\s+/', ' ', $span->textContent ?? '') ?? '');
+            }
+        }
+
+        $directText = trim(preg_replace('/\s+/', ' ', $element->textContent ?? '') ?? '');
+        return strlen($directText) <= 80 ? $directText : '';
     }
 
     private function convertMediaElement(DOMElement $element): ?array

--- a/php-transformer/tests/fixtures/parity/html-aspect-ratio-placeholder-card.json
+++ b/php-transformer/tests/fixtures/parity/html-aspect-ratio-placeholder-card.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-aspect-ratio-placeholder-card",
+  "description": "Materializes class-based aspect-ratio placeholder media boxes as visual groups instead of plain text paragraphs.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-aspect-ratio-placeholder-card.json",
+    "notes": "Product-neutral fixture for static HTML media placeholder cards."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<article class=\"feature-card\"><div class=\"ph ratio-16x9 placeholder\"><span class=\"label\">Image placeholder</span></div><h2>Feature card</h2><p>Copy stays readable.</p></article>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-card" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "ph ratio-16x9 placeholder blocks-engine-placeholder-media", "style": "aspect-ratio:16/9" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Image placeholder" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Feature card", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Copy stays readable." } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "blocks-engine-placeholder-media" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "aspect-ratio:16/9" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-decorative-fixed-overlay-grain.json
+++ b/php-transformer/tests/fixtures/parity/html-decorative-fixed-overlay-grain.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-decorative-fixed-overlay-grain",
+  "description": "Preserves visually meaningful fixed decorative overlay layers as empty presentation groups without adding content text.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-decorative-fixed-overlay-grain.json",
+    "notes": "Product-neutral fixture for static HTML grain/noise overlay layers."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"hero\"><h1>Atmospheric hero</h1><div class=\"fixed grain-overlay\" aria-hidden=\"true\" style=\"position:fixed;inset:0;pointer-events:none;opacity:.14;background-image:url(noise.png)\"></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Atmospheric hero", "level": 1 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "fixed grain-overlay", "style": "position:fixed;inset:0;pointer-events:none;opacity:.14;background-image:url(noise.png)" } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "grain-overlay" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "aria-hidden" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-hero-decorative-wave-layer.json
+++ b/php-transformer/tests/fixtures/parity/html-hero-decorative-wave-layer.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-hero-decorative-wave-layer",
+  "description": "Preserves visually meaningful decorative hero wave SVG layers as presentation groups while omitting SVG markup and fallback noise.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-hero-decorative-wave-layer.json",
+    "notes": "Product-neutral fixture for decorative aria-hidden hero SVG layers."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"hero atmosphere\"><h1>Wave hero</h1><svg class=\"hero-wave layer\" viewBox=\"0 0 1200 160\" preserveAspectRatio=\"none\" aria-hidden=\"true\" style=\"position:absolute;left:0;right:0;bottom:0;opacity:.7\"><path d=\"M0 90 C240 10 420 170 660 90 S1020 10 1200 90 V160 H0 Z\" fill=\"#f4d06f\"></path></svg><p>Real copy remains content.</p></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero atmosphere" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Wave hero", "level": 1 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "hero-wave layer", "style": "position:absolute;left:0;right:0;bottom:0;opacity:.7" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Real copy remains content." } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "hero-wave layer" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "data:image/svg+xml" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<svg" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Materialize aspect-ratio placeholder media elements as visual groups.
- Preserve meaningful decorative hero layers without turning aria-hidden internals into content.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the transformer fixture/fix and preparing this PR description.