### PR TITLE
Improve docs layout HTML conversion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -484,6 +484,11 @@ final class HtmlTransformer
             return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), $this->tableAttributes($element)), array(), $element);
         }
 
+        $parameterTable = $this->parameterTableBlockFromElement($element);
+        if ( null !== $parameterTable ) {
+            return $parameterTable;
+        }
+
         if ( 'hr' === $tagName ) {
             return $this->createBlock('core/separator', $this->presentationAttributes($element), array(), $element);
         }
@@ -667,6 +672,11 @@ final class HtmlTransformer
             $spacer = $this->spacerBlockFromElement($element);
             if ( null !== $spacer ) {
                 return $spacer;
+            }
+
+            $navigationSection = $this->navigationSectionBlockFromElement($element);
+            if ( null !== $navigationSection ) {
+                return $navigationSection;
             }
 
             $navigation = $this->navigationPattern->match(
@@ -1811,6 +1821,53 @@ final class HtmlTransformer
     }
 
     /**
+     * @return array<string, mixed>|null
+     */
+    private function parameterTableBlockFromElement(DOMElement $element): ?array
+    {
+        if ( ! $this->hasClass($element, 'param-table') ) {
+            return null;
+        }
+
+        $rows = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement || ! $this->hasClass($child, 'param-row') ) {
+                return null;
+            }
+
+            $name = $this->firstDirectChildWithClass($child, 'param-name');
+            $type = $this->firstDirectChildWithClass($child, 'param-type');
+            $desc = $this->firstDirectChildWithClass($child, 'param-desc');
+            if ( ! $name instanceof DOMElement || ! $type instanceof DOMElement || ! $desc instanceof DOMElement ) {
+                return null;
+            }
+
+            $rows[] = array( 'cells' => array(
+                array( 'content' => $this->innerHtml($name), 'tag' => 'td' ),
+                array( 'content' => $this->innerHtml($type), 'tag' => 'td' ),
+                array( 'content' => $this->innerHtml($desc), 'tag' => 'td' ),
+            ) );
+        }
+
+        if ( array() === $rows ) {
+            return null;
+        }
+
+        return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), array(
+            'head' => array( array( 'cells' => array(
+                array( 'content' => 'Parameter', 'tag' => 'th' ),
+                array( 'content' => 'Type', 'tag' => 'th' ),
+                array( 'content' => 'Description', 'tag' => 'th' ),
+            ) ) ),
+            'body' => $rows,
+        )), array(), $element);
+    }
+
+    /**
      * @return array<int, array<string, mixed>>
      */
     private function definitionListItems(DOMElement $list): array
@@ -2801,7 +2858,114 @@ final class HtmlTransformer
         }
 
         return (bool) preg_match('/(?:^|[\s_-])columns?(?:$|[\s_-])/', $className)
+            || ( $this->looksLikeDocumentationLayout($element) && $this->hasSidebarAndContentChildren($element) )
             || preg_match('/(?:^|;)\s*(?:display\s*:\s*(?:inline-)?flex|grid-template-columns\s*:)/', $style);
+    }
+
+    private function looksLikeDocumentationLayout(DOMElement $element): bool
+    {
+        $name = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id')));
+        return (bool) preg_match('/(?:^|[\s_-])(?:docs?|documentation|article|content)(?:[\s_-]+(?:layout|shell|page|with[\s_-]+sidebar)|$)|(?:^|[\s_-])sidebar[\s_-]+layout(?:$|[\s_-])/', $name);
+    }
+
+    private function hasSidebarAndContentChildren(DOMElement $element): bool
+    {
+        $hasSidebar = false;
+        $hasContent = false;
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $name = strtolower(trim($child->tagName . ' ' . $this->attr($child, 'class') . ' ' . $this->attr($child, 'id') . ' ' . $this->attr($child, 'role')));
+            $hasSidebar = $hasSidebar || (bool) preg_match('/(?:^|[\s_-])(?:aside|sidebar|toc|table[\s_-]+of[\s_-]+contents)(?:$|[\s_-])/', $name);
+            $hasContent = $hasContent || in_array(strtolower($child->tagName), array( 'article', 'main', 'section' ), true)
+                || (bool) preg_match('/(?:^|[\s_-])(?:main|content|article|docs?[\s_-]+content|documentation[\s_-]+content)(?:$|[\s_-])/', $name);
+        }
+
+        return $hasSidebar && $hasContent;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function navigationSectionBlockFromElement(DOMElement $element): ?array
+    {
+        if ( ! $this->hasNavigationContainerSignal($element) ) {
+            return null;
+        }
+
+        $heading = null;
+        $anchors = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( $child instanceof DOMElement && preg_match('/^h[1-6]$/i', $child->tagName) ) {
+                if ( $heading instanceof DOMElement ) {
+                    return null;
+                }
+                $heading = $child;
+                continue;
+            }
+
+            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') ) {
+                $anchors[] = $child;
+                continue;
+            }
+
+            return null;
+        }
+
+        if ( ! $heading instanceof DOMElement || array() === $anchors ) {
+            return null;
+        }
+
+        $sectionFallbacks = array();
+        $blocks = array( $this->convertElement($heading, $sectionFallbacks, true) );
+        $links = array();
+        foreach ( $anchors as $anchor ) {
+            $links[] = $this->createBlock('core/navigation-link', array_filter(array(
+                'label' => $this->innerHtml($anchor),
+                'url'   => $this->safeNavigationUrl($this->attr($anchor, 'href')),
+                'kind'  => 'custom',
+            ), static fn ($value): bool => '' !== $value), array(), $anchor);
+        }
+        $blocks[] = $this->createBlock('core/navigation', array(), $links, $element);
+
+        return $this->createBlock('core/group', $this->presentationAttributes($element), array_values(array_filter($blocks)), $element);
+    }
+
+    private function hasNavigationContainerSignal(DOMElement $element): bool
+    {
+        if ( 'navigation' === strtolower($this->attr($element, 'role')) ) {
+            return true;
+        }
+
+        $name = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id')));
+        return (bool) preg_match('/(?:^|[\s_-])(?:nav|navbar|navigation|menu|links)(?:$|[\s_-])/', $name);
+    }
+
+    private function safeNavigationUrl(string $url): string
+    {
+        $url = trim($url);
+        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
+            return '';
+        }
+
+        return $url;
+    }
+
+    private function firstDirectChildWithClass(DOMElement $element, string $className): ?DOMElement
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && $this->hasClass($child, $className) ) {
+                return $child;
+            }
+        }
+
+        return null;
     }
 
     private function hasDirectChildElement(DOMElement $element, string $tagName): bool

--- a/php-transformer/tests/fixtures/parity/html-api-endpoint-card-param-table.json
+++ b/php-transformer/tests/fixtures/parity/html-api-endpoint-card-param-table.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-api-endpoint-card-param-table",
+  "description": "Converts div-based API parameter tables into core table semantics instead of flattening each row as generic groups.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-api-endpoint-card-param-table.json",
+    "notes": "Generic fixture for endpoint documentation cards using param-table/param-row div markup."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"endpoint-card\"><h2>GET /v1/posts</h2><p>Returns posts matching the supplied filters.</p><div class=\"param-table\"><div class=\"param-row\"><div class=\"param-name\"><code>search</code></div><div class=\"param-type\">string</div><div class=\"param-desc\">Search query text.</div></div><div class=\"param-row\"><div class=\"param-name\"><code>page</code></div><div class=\"param-type\">integer</div><div class=\"param-desc\">Page number for pagination.</div></div></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "endpoint-card" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "GET /v1/posts", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Returns posts matching the supplied filters." } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/table", "attrs": { "className": "param-table" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.2.attrs.head.0.cells", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.2.attrs.body", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<th>Parameter</th><th>Type</th><th>Description</th>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<td><code>search</code></td><td>string</td><td>Search query text.</td>" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-docs-sidebar-layout-nav-sections.json
+++ b/php-transformer/tests/fixtures/parity/html-docs-sidebar-layout-nav-sections.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-docs-sidebar-layout-nav-sections",
+  "description": "Preserves documentation pages with a sidebar and main content as columns, including labeled sidebar navigation sections.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-docs-sidebar-layout-nav-sections.json",
+    "notes": "Generic fixture for docs/search layouts that otherwise flatten sidebar navigation structure."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div class=\"docs-layout\"><aside class=\"docs-sidebar\"><div class=\"docs-nav-section\"><h2>Guides</h2><a href=\"/docs/start\">Getting started</a><a href=\"/docs/search\">Search</a></div><div class=\"docs-nav-section\"><h2>API</h2><a href=\"/docs/api/users\">Users API</a></div></aside><main class=\"docs-content\"><h1>Search documentation</h1><p>Use filters to narrow the result set.</p></main></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/columns", "attrs": { "className": "docs-layout" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/column", "attrs": { "className": "docs-sidebar" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "docs-nav-section" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Guides", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Getting started", "url": "/docs/start", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Users API", "url": "/docs/api/users", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/column", "attrs": { "className": "docs-content" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Search documentation", "level": 1 } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Use filters to narrow the result set." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"docs-layout\"}" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"Getting started\",\"url\":\"/docs/start\",\"kind\":\"custom\"}" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Convert docs/sidebar layouts into column structures.
- Convert labeled nav sections into grouped heading + navigation blocks.
- Convert div-based API parameter tables into semantic tables.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the transformer fixture/fix and preparing this PR description.