### PR TITLE
Flag default grey button visual regressions

### DIFF
--- a/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
+++ b/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
@@ -14,6 +14,7 @@ final class ButtonMenuVisualProbe
 
     private const STYLE_FIELDS = array(
         'background-color',
+        'border',
         'border-bottom-color',
         'border-bottom-left-radius',
         'border-bottom-right-radius',
@@ -284,11 +285,39 @@ final class ButtonMenuVisualProbe
         if ( $this->hasRegressionRiskSignal($element) ) {
             $signals[] = 'plain-link-regression-watch';
         }
+        if ( $this->hasDefaultButtonStyleRisk($element) ) {
+            $signals[] = 'default-button-style-watch';
+        }
         if ( $element->hasAttribute('style') ) {
             $signals[] = 'inline-style';
         }
 
         return array_values(array_unique($signals));
+    }
+
+    private function hasDefaultButtonStyleRisk(DOMElement $element): bool
+    {
+        if ( ! $this->hasButtonSignal($element) && ! $this->hasCtaSignal($element) && 'button' !== strtolower($element->tagName) ) {
+            return false;
+        }
+
+        $style = $this->computedStyle($element, $this->styleRules($element->ownerDocument));
+        $background = strtolower($style['background-color'] ?? '');
+        $border = strtolower(trim(implode(' ', array(
+            $style['border'] ?? '',
+            $style['border-color'] ?? '',
+            $style['border-top-color'] ?? '',
+            $style['border-right-color'] ?? '',
+            $style['border-bottom-color'] ?? '',
+            $style['border-left-color'] ?? '',
+        ))));
+        $radius = strtolower($style['border-radius'] ?? '');
+
+        $defaultGreyBackground = in_array($background, array( '#f7f7f7', '#eee', '#eeeeee', '#e5e5e5', '#ddd', '#dddddd', 'rgb(247, 247, 247)', 'rgb(238, 238, 238)', 'rgb(229, 229, 229)', 'rgb(221, 221, 221)' ), true);
+        $defaultGreyBorder = '' !== $border && ( str_contains($border, '#ccc') || str_contains($border, '#cccccc') || str_contains($border, 'rgb(204, 204, 204)') );
+        $unstyledButton = '' === $background && '' === $radius && '' === trim((string) ($style['padding'] ?? ''));
+
+        return $unstyledButton || $defaultGreyBackground || $defaultGreyBorder;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/visual-parity-default-grey-button-watch.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-default-grey-button-watch.json
@@ -1,0 +1,27 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-default-grey-button-watch",
+  "description": "Flags rendered default-grey WordPress button styling as a visual parity risk for source CTAs that should preserve custom shape, color, border, and hierarchy.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-default-grey-button-watch.json",
+    "notes": "Generic probe for imported CTA regressions where a custom source button renders as default WordPress grey."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Probe output is a diagnostic surface for downstream browser parity validation."
+  },
+  "operation": "visual_parity_probe.extract",
+  "input": {
+    "content": "<style>.wp-block-button__link{background-color:#f7f7f7;color:#333;border:1px solid #ccc;border-radius:0;padding:8px 12px}.hero-cta{font-weight:700}</style><main><div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button hero-cta\" href=\"/book\">Book now</a></div></main>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "summary.total", "assert": "equals", "value": 1 },
+    { "path": "summary.by_kind.cta", "assert": "equals", "value": 1 },
+    { "path": "probes.0.href", "assert": "equals", "value": "/book" },
+    { "path": "probes.0.style.background-color", "assert": "equals", "value": "#f7f7f7" },
+    { "path": "probes.0.style.border", "assert": "equals", "value": "1px solid #ccc" },
+    { "path": "probes.0.signals.2", "assert": "equals", "value": "default-button-style-watch" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Retain border shorthand in button/menu visual probes.
- Add a default-button-style-watch signal for button-like targets that render as unstyled/default grey buttons.
- Add fixture coverage for imported CTA regressions where a custom source button becomes a default WordPress grey button.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the probe signal, fixture coverage, verification, and preparing this PR description.