### PR TITLE
Add WordPress block validity diagnostics

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -152,6 +152,7 @@ final class HtmlTransformer
         $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
+        $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
         $diagnostics = array(
             array(
                 'code'    => 'html_to_blocks_core_slice',
@@ -173,9 +174,25 @@ final class HtmlTransformer
             }
         }
 
+        foreach ( $blockValidityReport['findings'] ?? array() as $finding ) {
+            if ( ! is_array($finding) ) {
+                continue;
+            }
+
+            $diagnostics[] = array(
+                'code'       => 'wp_block_validity_' . (string) ($finding['code'] ?? 'warning'),
+                'message'    => (string) ($finding['summary'] ?? 'Generated block serialization may trigger WordPress block invalidity warnings.'),
+                'source'     => Runtime::class,
+                'severity'   => $finding['severity'] ?? 'warning',
+                'block_name' => $finding['block_name'] ?? null,
+                'path'       => $finding['path'] ?? null,
+            );
+        }
+
         $metrics = $this->metrics($html, $blocks, $serializedBlocks, $fallbacks, $diagnostics, $startedAt);
         $sourceReports = array(
             'interaction_candidates' => $interactionCandidates,
+            'wp_block_validity' => $blockValidityReport,
             'html' => array(
                 'presentation_signals' => $this->presentationProvenance,
                 'source_provenance'    => $sourceProvenance,

--- a/php-transformer/src/WordPress/BlockValidityValidator.php
+++ b/php-transformer/src/WordPress/BlockValidityValidator.php
@@ -1,0 +1,206 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\WordPress;
+
+final class BlockValidityValidator
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/wp-block-validity-report/v1';
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<string, mixed>
+     */
+    public function validateBlocks(array $blocks): array
+    {
+        $findings = array();
+        $checkedBlockTypes = array();
+
+        foreach ( $blocks as $index => $block ) {
+            if ( is_array($block) ) {
+                $this->validateBlock($block, 'blocks.' . $index, $findings, $checkedBlockTypes);
+            }
+        }
+
+        sort($checkedBlockTypes);
+
+        return array(
+            'schema'   => self::SCHEMA,
+            'status'   => array() === $findings ? 'pass' : 'warning',
+            'summary'  => array(
+                'block_count'         => $this->countBlocks($blocks),
+                'finding_count'       => count($findings),
+                'checked_block_types' => $checkedBlockTypes,
+            ),
+            'findings' => $findings,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     * @param array<int, array<string, mixed>> $findings
+     * @param array<string, string> $checkedBlockTypes
+     */
+    private function validateBlock(array $block, string $path, array &$findings, array &$checkedBlockTypes): void
+    {
+        $blockName = is_string($block['blockName'] ?? null) ? $block['blockName'] : null;
+        if ( null !== $blockName ) {
+            $checkedBlockTypes[$blockName] = $blockName;
+        }
+
+        $innerBlocks = is_array($block['innerBlocks'] ?? null) ? array_values($block['innerBlocks']) : array();
+        $innerContent = is_array($block['innerContent'] ?? null) ? $block['innerContent'] : null;
+        $innerHTML = is_string($block['innerHTML'] ?? null) ? $block['innerHTML'] : null;
+
+        if ( null === $innerContent ) {
+            $this->addFinding($findings, 'missing_inner_content', 'warning', $path, $blockName, 'Block is missing innerContent, so serialization cannot prove child placeholder boundaries.');
+        } else {
+            $nullCount = 0;
+            $staticInnerHTML = '';
+            foreach ( $innerContent as $part ) {
+                if ( null === $part ) {
+                    ++$nullCount;
+                    continue;
+                }
+
+                $part = (string) $part;
+                $staticInnerHTML .= $part;
+                if ( str_contains($part, '<!-- wp:') ) {
+                    $this->addFinding($findings, 'serialized_block_comment_in_inner_content', 'warning', $path, $blockName, 'innerContent contains serialized block comments instead of null child placeholders.');
+                }
+            }
+
+            if ( count($innerBlocks) !== $nullCount ) {
+                $this->addFinding(
+                    $findings,
+                    'inner_content_child_count_mismatch',
+                    'warning',
+                    $path,
+                    $blockName,
+                    'innerContent null placeholders must match innerBlocks count.',
+                    array('inner_block_count' => count($innerBlocks), 'placeholder_count' => $nullCount)
+                );
+            }
+
+            if ( null !== $innerHTML && $staticInnerHTML !== $innerHTML ) {
+                $this->addFinding($findings, 'inner_html_inner_content_mismatch', 'warning', $path, $blockName, 'innerHTML must equal the non-child string parts of innerContent.');
+            }
+
+            if ( array() !== $innerBlocks && 0 === $nullCount ) {
+                $this->addFinding($findings, 'missing_child_placeholders', 'warning', $path, $blockName, 'Block has innerBlocks but no null placeholders in innerContent.');
+            }
+        }
+
+        if ( null !== $innerHTML && str_contains($innerHTML, '<!-- wp:') ) {
+            $this->addFinding($findings, 'serialized_block_comment_in_inner_html', 'warning', $path, $blockName, 'innerHTML contains serialized child block comments; WordPress expects child blocks to be represented through innerBlocks and innerContent placeholders.');
+        }
+
+        if ( 'core/button' === $blockName ) {
+            $this->validateLinkLikeBlock($block, $path, $findings, 'text', 'url', 'button');
+        }
+
+        if ( in_array($blockName, array('core/navigation-link', 'core/navigation-submenu'), true) ) {
+            $this->validateLinkLikeBlock($block, $path, $findings, 'label', 'url', 'navigation');
+        }
+
+        foreach ( $innerBlocks as $index => $innerBlock ) {
+            if ( is_array($innerBlock) ) {
+                $this->validateBlock($innerBlock, $path . '.innerBlocks.' . $index, $findings, $checkedBlockTypes);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     * @param array<int, array<string, mixed>> $findings
+     */
+    private function validateLinkLikeBlock(array $block, string $path, array &$findings, string $textAttr, string $urlAttr, string $kind): void
+    {
+        $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+        $html = is_string($block['innerHTML'] ?? null) ? $block['innerHTML'] : '';
+        $blockName = is_string($block['blockName'] ?? null) ? $block['blockName'] : null;
+
+        $expectedText = $this->normalizeText(strip_tags((string) ($attrs[$textAttr] ?? '')));
+        $actualText = $this->normalizeText(strip_tags($html));
+        if ( '' !== $expectedText && '' !== $actualText && $expectedText !== $actualText ) {
+            $this->addFinding(
+                $findings,
+                $kind . '_text_markup_mismatch',
+                'warning',
+                $path,
+                $blockName,
+                'Serialized markup text does not match the block attribute text WordPress will validate against.',
+                array('attribute_text' => $expectedText, 'markup_text' => $actualText)
+            );
+        }
+
+        $expectedUrl = (string) ($attrs[$urlAttr] ?? '');
+        $actualUrl = $this->firstHref($html);
+        if ( '' !== $expectedUrl && '' !== $actualUrl && $expectedUrl !== $actualUrl ) {
+            $this->addFinding(
+                $findings,
+                $kind . '_url_markup_mismatch',
+                'warning',
+                $path,
+                $blockName,
+                'Serialized markup href does not match the block URL attribute WordPress will validate against.',
+                array('attribute_url' => $expectedUrl, 'markup_url' => $actualUrl)
+            );
+        }
+    }
+
+    private function normalizeText(string $text): string
+    {
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        return trim(preg_replace('/\s+/', ' ', $text) ?? $text);
+    }
+
+    private function firstHref(string $html): string
+    {
+        if ( preg_match('/<a\b[^>]*\shref=("([^"]*)"|\'([^\']*)\'|([^\s>]+))/i', $html, $matches) ) {
+            return html_entity_decode($matches[2] ?? $matches[3] ?? $matches[4] ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     */
+    private function countBlocks(array $blocks): int
+    {
+        $count = 0;
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            ++$count;
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $count += $this->countBlocks($block['innerBlocks']);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $findings
+     * @param array<string, mixed> $details
+     */
+    private function addFinding(array &$findings, string $code, string $severity, string $path, ?string $blockName, string $summary, array $details = array()): void
+    {
+        $findings[] = array_filter(
+            array(
+                'code'       => $code,
+                'severity'   => $severity,
+                'category'   => 'wp_block_validity',
+                'path'       => $path,
+                'block_name' => $blockName,
+                'summary'    => $summary,
+                'details'    => $details,
+            ),
+            static fn (mixed $value): bool => null !== $value && array() !== $value
+        );
+    }
+}

--- a/php-transformer/src/WordPress/Runtime.php
+++ b/php-transformer/src/WordPress/Runtime.php
@@ -160,6 +160,34 @@ final class Runtime
         return $html;
     }
 
+    /**
+     * @param string|array<int, array<string, mixed>> $serializedBlocksOrBlocks
+     * @return array<string, mixed>
+     */
+    public function validateBlockSerialization(string|array $serializedBlocksOrBlocks): array
+    {
+        if ( is_string($serializedBlocksOrBlocks) ) {
+            $blocks = $this->parseBlocks($serializedBlocksOrBlocks);
+            $report = ( new BlockValidityValidator() )->validateBlocks($blocks);
+
+            if ( array() === $blocks && str_contains($serializedBlocksOrBlocks, '<!-- wp:') ) {
+                $report['status'] = 'warning';
+                $report['summary']['finding_count'] = ((int) ($report['summary']['finding_count'] ?? 0)) + 1;
+                $report['findings'][] = array(
+                    'code'     => 'serialized_blocks_parse_failed',
+                    'severity' => 'warning',
+                    'category' => 'wp_block_validity',
+                    'path'     => 'serialized_blocks',
+                    'summary'  => 'Serialized block comments were present but could not be parsed into a balanced block tree.',
+                );
+            }
+
+            return $report;
+        }
+
+        return ( new BlockValidityValidator() )->validateBlocks($serializedBlocksOrBlocks);
+    }
+
     public function stripAllTags(string $text, bool $removeBreaks = false): string
     {
         $this->diagnostics = array();

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -242,6 +242,23 @@ $assert('core/buttons' === ($buttonBlocks[0]['blockName'] ?? ''), 'anchor conver
 $assert(str_contains((string) ($buttonBlocks[0]['innerBlocks'][0]['attrs']['text'] ?? ''), 'Reserve now'), 'anchor button text preserves visible label');
 $assert(str_contains((string) ($buttonBlocks[1]['innerBlocks'][0]['attrs']['text'] ?? ''), 'Call us'), 'button text preserves visible label');
 $assert(! str_contains((string) $buttonResult['serialized_blocks'], '\\u003c'), 'button serialization avoids escaped nested HTML attrs');
+$assert('pass' === ($buttonResult['source_reports']['wp_block_validity']['status'] ?? ''), 'HTML transform exposes passing WordPress block validity report for generated buttons');
+
+$invalidButtonBlocks = array(
+    array(
+        'blockName'    => 'core/button',
+        'attrs'        => array('text' => 'Book now', 'url' => '/book'),
+        'innerBlocks'  => array(),
+        'innerHTML'    => '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/contact">Contact us</a></div>',
+        'innerContent' => array('<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/contact">Contact us</a></div>'),
+    ),
+);
+$invalidButtonReport = ( new \Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime() )->validateBlockSerialization($invalidButtonBlocks);
+$invalidButtonCodes = array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $invalidButtonReport['findings'] ?? array());
+$assert('blocks-engine/php-transformer/wp-block-validity-report/v1' === ($invalidButtonReport['schema'] ?? ''), 'runtime exposes WordPress block validity report schema');
+$assert('warning' === ($invalidButtonReport['status'] ?? ''), 'runtime warns on button attribute/markup mismatches');
+$assert(in_array('button_text_markup_mismatch', $invalidButtonCodes, true), 'runtime reports invalid button text serialization');
+$assert(in_array('button_url_markup_mismatch', $invalidButtonCodes, true), 'runtime reports invalid button URL serialization');
 
 $inlineSvgVisualWrapper = ( new HtmlTransformer() )->transform(
     '<main><section class="visual-region"><div class="map-layer"><div class="map-image" style="background-image:url(assets/map.png)"><svg><path d="M0 0h1v1z"></path></svg></div></div></section></main>'

--- a/php-transformer/tests/contract/runtime-no-wordpress.php
+++ b/php-transformer/tests/contract/runtime-no-wordpress.php
@@ -21,6 +21,19 @@ $html = $runtime->renderBlocks($blocks);
 assertSame('<p>Hello</p>', $html, 'Fallback renderer should render static block HTML.');
 assertSame('wordpress_render_block_unavailable', $runtime->diagnostics()[0]['code'] ?? null, 'Fallback renderer should expose a diagnostic.');
 
+$validityFixture = json_decode((string) file_get_contents(dirname(__DIR__) . '/fixtures/contract/wp-block-validity.json'), true);
+assertSame('blocks-engine/php-transformer/wp-block-validity-fixture/v1', $validityFixture['schema'] ?? null, 'Block validity fixture should expose its schema.');
+foreach ( $validityFixture['cases'] as $case ) {
+    $report = $runtime->validateBlockSerialization($case['input'] ?? $case['blocks']);
+    assertSame('blocks-engine/php-transformer/wp-block-validity-report/v1', $report['schema'] ?? null, 'Block validity report should expose its schema.');
+    assertSame($case['expected_status'], $report['status'] ?? null, 'Block validity report status should match fixture case ' . $case['name']);
+    $codes = array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $report['findings'] ?? array());
+    sort($codes);
+    $expectedCodes = $case['expected_codes'];
+    sort($expectedCodes);
+    assertSame($expectedCodes, $codes, 'Block validity report finding codes should match fixture case ' . $case['name']);
+}
+
 assertSame('Safe text', $runtime->stripAllTags('<script>alert(1)</script><p>Safe <em>text</em></p>'), 'Fallback tag stripping should remove scripts and tags.');
 assertSame('wordpress_strip_all_tags_unavailable', $runtime->diagnostics()[0]['code'] ?? null, 'Fallback tag stripping should expose a diagnostic.');
 

--- a/php-transformer/tests/fixtures/contract/wp-block-validity.json
+++ b/php-transformer/tests/fixtures/contract/wp-block-validity.json
@@ -1,0 +1,54 @@
+{
+  "schema": "blocks-engine/php-transformer/wp-block-validity-fixture/v1",
+  "cases": [
+    {
+      "name": "valid-button",
+      "input": "<!-- wp:button {\"text\":\"Book now\",\"url\":\"/book\"} --><div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\" href=\"/book\">Book now</a></div><!-- /wp:button -->",
+      "expected_status": "pass",
+      "expected_codes": []
+    },
+    {
+      "name": "invalid-button-markup-mismatch",
+      "input": "<!-- wp:button {\"text\":\"Book now\",\"url\":\"/book\"} --><div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\" href=\"/contact\">Contact us</a></div><!-- /wp:button -->",
+      "expected_status": "warning",
+      "expected_codes": [
+        "button_text_markup_mismatch",
+        "button_url_markup_mismatch"
+      ]
+    },
+    {
+      "name": "invalid-navigation-serialized-child-comments",
+      "blocks": [
+        {
+          "blockName": "core/navigation",
+          "attrs": {},
+          "innerBlocks": [
+            {
+              "blockName": "core/navigation-link",
+              "attrs": {
+                "label": "Home",
+                "url": "/"
+              },
+              "innerBlocks": [],
+              "innerHTML": "<li class=\"wp-block-navigation-item wp-block-navigation-link\"><a class=\"wp-block-navigation-item__content\" href=\"/\"><span class=\"wp-block-navigation-item__label\">Home</span></a></li>",
+              "innerContent": [
+                "<li class=\"wp-block-navigation-item wp-block-navigation-link\"><a class=\"wp-block-navigation-item__content\" href=\"/\"><span class=\"wp-block-navigation-item__label\">Home</span></a></li>"
+              ]
+            }
+          ],
+          "innerHTML": "<nav class=\"wp-block-navigation\"><ul class=\"wp-block-navigation__container\"><!-- wp:navigation-link {\"label\":\"Home\",\"url\":\"/\"} /--></ul></nav>",
+          "innerContent": [
+            "<nav class=\"wp-block-navigation\"><ul class=\"wp-block-navigation__container\"><!-- wp:navigation-link {\"label\":\"Home\",\"url\":\"/\"} /--></ul></nav>"
+          ]
+        }
+      ],
+      "expected_status": "warning",
+      "expected_codes": [
+        "inner_content_child_count_mismatch",
+        "missing_child_placeholders",
+        "serialized_block_comment_in_inner_content",
+        "serialized_block_comment_in_inner_html"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a generic WordPress block validity report for generated block output.
- Validate serialized block arrays/markup for common editor-invalid patterns before downstream importers materialize content.
- Surface validity findings in transformer source reports and diagnostics.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the validator/report shape, fixtures, verification, and preparing this PR description.