### PR TITLE
Preserve imported button styles

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -153,7 +153,12 @@ final class BlockFactory
 
         if ( 'core/button' === $name ) {
             $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
-            return '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"' . $href . '>' . ($attrs['text'] ?? '') . '</a></div>';
+            $wrapperClass = $this->mergeClassNames('wp-block-button', in_array('is-style-outline', preg_split('/\s+/', (string) ($attrs['className'] ?? '')) ?: array(), true) ? 'is-style-outline' : '');
+            $linkAttrs = array(
+                'class' => $this->mergeClassNames('wp-block-button__link wp-element-button', (string) ($attrs['className'] ?? '')),
+                'style' => (string) ($attrs['style'] ?? ''),
+            );
+            return '<div class="' . htmlspecialchars($wrapperClass, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"><a' . $this->htmlAttrs($linkAttrs) . $href . '>' . ($attrs['text'] ?? '') . '</a></div>';
         }
 
         if ( 'core/navigation' === $name ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -38,7 +38,7 @@ final class ButtonsPattern
     public function matchButton(DOMElement $button, callable $presentationAttributes, callable $innerHtml, callable $createBlock): array
     {
         return $createBlock('core/buttons', array(), array(
-            $createBlock('core/button', array_merge($presentationAttributes($button), array( 'text' => $innerHtml($button) )), array(), $button),
+            $createBlock('core/button', array_merge($this->buttonPresentationAttributes($button, $presentationAttributes), array( 'text' => $innerHtml($button) )), array(), $button),
         ), $button);
     }
 
@@ -75,10 +75,38 @@ final class ButtonsPattern
      */
     private function buttonBlockFromAnchor(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $attr, callable $createBlock): array
     {
-        return $createBlock('core/button', array_filter(array_merge($presentationAttributes($anchor), array(
+        return $createBlock('core/button', array_filter(array_merge($this->buttonPresentationAttributes($anchor, $presentationAttributes), array(
             'text' => $innerHtml($anchor),
             'url'  => $attr($anchor, 'href'),
         )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $anchor);
+    }
+
+    /**
+     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @return array<string, mixed>
+     */
+    private function buttonPresentationAttributes(DOMElement $element, callable $presentationAttributes): array
+    {
+        $attrs = $presentationAttributes($element);
+        if ( $this->hasOutlineSignal($element, (string) ($attrs['style'] ?? '')) ) {
+            $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' is-style-outline');
+        }
+
+        return $attrs;
+    }
+
+    private function hasOutlineSignal(DOMElement $element, string $style): bool
+    {
+        if ( $this->hasAnyToken($element, array( 'outline', 'ghost', 'hollow', 'bordered' )) ) {
+            return true;
+        }
+
+        $normalized = strtolower($style);
+        if ( ! preg_match('/(?:^|;)\s*border(?:-[a-z-]+)?\s*:\s*[^;]+/', $normalized) ) {
+            return false;
+        }
+
+        return preg_match('/(?:^|;)\s*background(?:-color)?\s*:\s*(?:transparent|none|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))/i', $normalized) === 1;
     }
 
     private function hasButtonSignal(DOMElement $anchor): bool

--- a/php-transformer/tests/fixtures/parity/html-button-custom-filled-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-custom-filled-cta-style.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-custom-filled-cta-style",
+  "description": "Preserves custom filled CTA button classes and inline presentation styles on the rendered WordPress button link.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-custom-filled-cta-style.json",
+    "notes": "Generic transformer boundary fixture for source CTA visual semantics."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New upstream button style preservation behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><div class=\"cta-actions\"><a class=\"hero-cta brand-primary\" href=\"/start\" style=\"background-color:#135e96;color:#fff;border:2px solid #135e96;border-radius:999px;padding:14px 28px;font-weight:700;text-transform:uppercase\">Get started</a><a class=\"hero-cta alt\" href=\"/demo\" style=\"background-color:#0f172a;color:#fff;border:2px solid #0f172a;border-radius:999px;padding:14px 28px;font-weight:700;text-transform:uppercase\">Book now</a></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Get started", "url": "/start", "className": "hero-cta brand-primary", "style": "background-color:#135e96;color:#fff;border:2px solid #135e96;border-radius:999px;padding:14px 28px;font-weight:700;text-transform:uppercase" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button hero-cta brand-primary\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"background-color:#135e96;color:#fff;border:2px solid #135e96;border-radius:999px;padding:14px 28px;font-weight:700;text-transform:uppercase\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color:#f7f7f7" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-outline-ghost-cta-style",
+  "description": "Preserves outline/ghost CTA visual semantics, including transparent background, currentColor border, radius, padding, and outline style class.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-outline-ghost-cta-style.json",
+    "notes": "Generic transformer boundary fixture for source outline CTA visual semantics."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New upstream button style preservation behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><div class=\"cta-actions\"><a class=\"cta ghost-link\" href=\"/learn\" style=\"background-color:transparent;color:#135e96;border:2px solid currentColor;border-radius:8px;padding:12px 24px;font-weight:600;text-transform:none\">Learn more</a><a class=\"cta ghost-link\" href=\"/contact\" style=\"background-color:transparent;color:#135e96;border:2px solid currentColor;border-radius:8px;padding:12px 24px;font-weight:600;text-transform:none\">Contact us</a></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "cta ghost-link is-style-outline", "style": "background-color:transparent;color:#135e96;border:2px solid currentColor;border-radius:8px;padding:12px 24px;font-weight:600;text-transform:none" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button cta ghost-link is-style-outline\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background-color:transparent;color:#135e96;border:2px solid currentColor;border-radius:8px;padding:12px 24px;font-weight:600;text-transform:none" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-source-styled-button-preserves-style.json
+++ b/php-transformer/tests/fixtures/parity/html-source-styled-button-preserves-style.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-source-styled-button-preserves-style",
+  "description": "Preserves source styled button element presentation so it does not serialize as an unstyled default grey WordPress button.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-source-styled-button-preserves-style.json",
+    "notes": "Generic transformer boundary fixture for native button visual semantics."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New upstream button style preservation behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><button class=\"checkout-button\" style=\"background-color:#111827;color:#f9fafb;border:0;border-radius:6px;padding:10px 20px;font-weight:800;text-transform:uppercase\">Buy now</button></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Buy now", "className": "checkout-button", "style": "background-color:#111827;color:#f9fafb;border:0;border-radius:6px;padding:10px 20px;font-weight:800;text-transform:uppercase" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button checkout-button\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"background-color:#111827;color:#f9fafb;border:0;border-radius:6px;padding:10px 20px;font-weight:800;text-transform:uppercase\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color:#f7f7f7" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/visual-parity-styled-button-no-default-watch.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-styled-button-no-default-watch.json
@@ -1,0 +1,27 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-styled-button-no-default-watch",
+  "description": "Verifies styled rendered WordPress button links are not flagged with default-button-style-watch when source visual semantics are present.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-styled-button-no-default-watch.json",
+    "notes": "Generic visual probe fixture for imported styled CTA rendering."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Probe output is a diagnostic surface for downstream browser parity validation."
+  },
+  "operation": "visual_parity_probe.extract",
+  "input": {
+    "content": "<main><div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button checkout-button\" href=\"/buy\" style=\"background-color:#111827;color:#f9fafb;border:0;border-radius:6px;padding:10px 20px;font-weight:800;text-transform:uppercase\">Buy now</a></div></main>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "summary.total", "assert": "equals", "value": 1 },
+    { "path": "summary.by_kind.cta", "assert": "equals", "value": 1 },
+    { "path": "probes.0.style.background-color", "assert": "equals", "value": "#111827" },
+    { "path": "probes.0.style.border-radius", "assert": "equals", "value": "6px" },
+    { "path": "probes.0.style.padding", "assert": "equals", "value": "10px 20px" },
+    { "path": "probes.0.signals", "assert": "count", "count": 3 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve source button/CTA classes and inline visual styles on generated core/button output.
- Carry outline/ghost styling with  when source signals indicate outline variants.
- Add fixtures for filled CTAs, outline/ghost CTAs, styled native buttons, and no default-grey-watch on preserved styled buttons.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing button style preservation, parity fixtures, verification, and preparing this PR description.