### PR TITLE
Preserve navigation visual semantics

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -162,13 +162,13 @@ final class BlockFactory
 
         if ( 'core/navigation-link' === $name ) {
             $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
-            return '<li' . $this->blockSupportAttrs($attrs, 'wp-block-navigation-item wp-block-navigation-link') . '><a class="wp-block-navigation-item__content"' . $href . '><span class="wp-block-navigation-item__label">' . ($attrs['label'] ?? '') . '</span></a></li>';
+            return '<li' . $this->blockSupportAttrs($attrs, 'wp-block-navigation-item wp-block-navigation-link') . '><a' . $this->navigationAnchorAttrs($attrs, $href) . '><span class="wp-block-navigation-item__label">' . ($attrs['label'] ?? '') . '</span></a></li>';
         }
 
         if ( 'core/navigation-submenu' === $name ) {
             $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
             return array(
-                'opening' => '<li' . $this->blockSupportAttrs($attrs, 'wp-block-navigation-item has-child wp-block-navigation-submenu') . '><a class="wp-block-navigation-item__content"' . $href . '><span class="wp-block-navigation-item__label">' . ($attrs['label'] ?? '') . '</span></a><ul class="wp-block-navigation__submenu-container">',
+                'opening' => '<li' . $this->blockSupportAttrs($attrs, 'wp-block-navigation-item has-child wp-block-navigation-submenu') . '><a' . $this->navigationAnchorAttrs($attrs, $href) . '><span class="wp-block-navigation-item__label">' . ($attrs['label'] ?? '') . '</span></a><ul' . $this->navigationSubmenuAttrs($attrs) . '>',
                 'closing' => '</ul></li>',
             );
         }
@@ -331,6 +331,28 @@ final class BlockFactory
         return $this->htmlAttrs(array(
             'class' => $classes,
             'style' => (string) ($attrs['style'] ?? ''),
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function navigationAnchorAttrs(array $attrs, string $href): string
+    {
+        return $this->htmlAttrs(array(
+            'class' => $this->mergeClassNames('wp-block-navigation-item__content', (string) ($attrs['anchorClassName'] ?? '')),
+            'style' => (string) ($attrs['anchorStyle'] ?? ''),
+        )) . $href;
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function navigationSubmenuAttrs(array $attrs): string
+    {
+        return $this->htmlAttrs(array(
+            'class' => $this->mergeClassNames('wp-block-navigation__submenu-container', (string) ($attrs['submenuClassName'] ?? '')),
+            'style' => (string) ($attrs['submenuStyle'] ?? ''),
         ));
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -58,7 +58,7 @@ final class NavigationPattern
                 if ( ! $allowsDirectItems ) {
                     return array();
                 }
-                $blocks[] = $this->navigationLinkBlock($child, $innerHtml, $createBlock);
+                $blocks[] = $this->navigationLinkBlock($child, $innerHtml, $createBlock, $child);
                 continue;
             }
 
@@ -129,27 +129,52 @@ final class NavigationPattern
         }
 
         if ( array() !== $submenuBlocks ) {
-            return $createBlock('core/navigation-submenu', array_filter(array(
+            $submenuAttrs = array(
                 'label' => $innerHtml($anchor),
                 'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
                 'kind'  => 'custom',
-            ), static fn ($value): bool => '' !== $value), $submenuBlocks, $element);
+            );
+            $submenuContainer = $this->submenuContainers($element, $anchor)[0] ?? null;
+            return $createBlock('core/navigation-submenu', $this->navigationItemAttributes($element, $anchor, $submenuContainer, $submenuAttrs), $submenuBlocks, $element);
         }
 
         if ( 1 !== count($this->anchorsExcludingSubmenus($element, $anchor)) ) {
             return null;
         }
 
-        return $this->navigationLinkBlock($anchor, $innerHtml, $createBlock);
+        return $this->navigationLinkBlock($anchor, $innerHtml, $createBlock, $element);
     }
 
-    private function navigationLinkBlock(DOMElement $anchor, callable $innerHtml, callable $createBlock): array
+    private function navigationLinkBlock(DOMElement $anchor, callable $innerHtml, callable $createBlock, ?DOMElement $item = null): array
     {
-        return $createBlock('core/navigation-link', array_filter(array(
+        return $createBlock('core/navigation-link', $this->navigationItemAttributes($item ?? $anchor, $anchor, null, array(
             'label' => $innerHtml($anchor),
             'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
             'kind'  => 'custom',
-        ), static fn ($value): bool => '' !== $value), array(), $anchor);
+        )), array(), $anchor);
+    }
+
+    /**
+     * @param array<string, mixed> $baseAttrs
+     * @return array<string, mixed>
+     */
+    private function navigationItemAttributes(DOMElement $item, DOMElement $anchor, ?DOMElement $submenuContainer, array $baseAttrs): array
+    {
+        $itemClass = $item->isSameNode($anchor) ? '' : $this->attr($item, 'class');
+        $itemStyle = $item->isSameNode($anchor) ? '' : $this->attr($item, 'style');
+        return array_filter(array_merge($baseAttrs, array(
+            'className'        => $itemClass,
+            'style'            => $itemStyle,
+            'anchorClassName'  => $this->attr($anchor, 'class'),
+            'anchorStyle'      => $this->attr($anchor, 'style'),
+            'submenuClassName' => $submenuContainer instanceof DOMElement ? $this->attr($submenuContainer, 'class') : '',
+            'submenuStyle'     => $submenuContainer instanceof DOMElement ? $this->attr($submenuContainer, 'style') : '',
+        )), static fn ($value): bool => '' !== $value);
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
     }
 
     private function primaryNavigationAnchor(DOMElement $element): ?DOMElement

--- a/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
+++ b/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
@@ -15,6 +15,7 @@ final class ButtonMenuVisualProbe
     private const STYLE_FIELDS = array(
         'background-color',
         'border',
+        'border-bottom',
         'border-bottom-color',
         'border-bottom-left-radius',
         'border-bottom-right-radius',
@@ -35,6 +36,7 @@ final class ButtonMenuVisualProbe
         'border-top-style',
         'border-top-width',
         'border-width',
+        'box-shadow',
         'color',
         'display',
         'font-size',
@@ -279,6 +281,15 @@ final class ButtonMenuVisualProbe
         if ( $this->isMenuItem($element) ) {
             $signals[] = 'menu-ancestor';
         }
+        if ( $this->hasCurrentSignal($element) ) {
+            $signals[] = 'current-active';
+        }
+        if ( $this->hasSeparatorSignal($element) ) {
+            $signals[] = 'separator-rule';
+        }
+        if ( null !== $this->submenuPanel($element) ) {
+            $signals[] = 'submenu-panel';
+        }
         if ( $this->isLinkedCard($element) ) {
             $signals[] = 'linked-card-content';
         }
@@ -320,6 +331,38 @@ final class ButtonMenuVisualProbe
         return $unstyledButton || $defaultGreyBackground || $defaultGreyBorder;
     }
 
+    private function hasCurrentSignal(DOMElement $element): bool
+    {
+        if ( '' !== trim($element->hasAttribute('aria-current') ? $element->getAttribute('aria-current') : '') ) {
+            return true;
+        }
+
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $this->hasAnyToken($node, array( 'active', 'current', 'current-menu-item', 'current_page_item', 'is-active', 'selected' )) ) {
+                return true;
+            }
+            if ( in_array(strtolower($node->tagName), array( 'nav', 'body' ), true) ) {
+                break;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasSeparatorSignal(DOMElement $element): bool
+    {
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $this->hasAnyToken($node, array( 'separator', 'divider', 'rule' )) ) {
+                return true;
+            }
+            if ( in_array(strtolower($node->tagName), array( 'nav', 'body' ), true) ) {
+                break;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -340,7 +383,39 @@ final class ButtonMenuVisualProbe
             'menu_depth' => $listDepth,
             'parent_text' => $parentItem,
             'has_submenu' => $this->hasSubmenu($element),
+            'submenu_panel' => $this->submenuPanelSnapshot($element),
         ), static fn ($value): bool => null !== $value && '' !== $value && false !== $value);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function submenuPanelSnapshot(DOMElement $element): ?array
+    {
+        $panel = $this->submenuPanel($element);
+        if ( ! $panel instanceof DOMElement ) {
+            return null;
+        }
+
+        return array_filter(array(
+            'tag' => strtolower($panel->tagName),
+            'classes' => $this->tokens($panel->hasAttribute('class') ? $panel->getAttribute('class') : ''),
+            'style' => $this->computedStyle($panel, $this->styleRules($panel->ownerDocument)),
+        ), static fn ($value): bool => array() !== $value && '' !== $value);
+    }
+
+    private function submenuPanel(DOMElement $element): ?DOMElement
+    {
+        for ( $node = $element->parentNode; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( in_array(strtolower($node->tagName), array( 'ul', 'ol', 'div' ), true) && $this->hasAnyToken($node, array( 'dropdown', 'submenu', 'subnav', 'flyout', 'menu-panel', 'dropdown-panel', 'wp-block-navigation__submenu-container' )) ) {
+                return $node;
+            }
+            if ( 'nav' === strtolower($node->tagName) ) {
+                break;
+            }
+        }
+
+        return null;
     }
 
     private function menuDepth(DOMElement $element): int

--- a/php-transformer/tests/fixtures/parity/html-nav-cta-vs-plain-links.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-cta-vs-plain-links.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-cta-vs-plain-links",
+  "description": "Preserves CTA pill classes/styles on navigation anchors without applying them to plain menu links.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-cta-vs-plain-links.json",
+    "notes": "Generic navigation fixture for styled CTA anchors alongside ordinary links."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<nav class=\"site-nav\"><a href=\"/services\">Services</a><a class=\"btn btn-primary cta\" style=\"border-radius:999px;padding:12px 20px;background:#111;color:#fff\" href=\"/book\">Book Now</a></nav>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "site-nav" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Services", "url": "/services", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Book Now", "url": "/book", "kind": "custom", "anchorClassName": "btn btn-primary cta", "anchorStyle": "border-radius:999px;padding:12px 20px;background:#111;color:#fff" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-navigation-item__content btn btn-primary cta\" style=\"border-radius:999px;padding:12px 20px;background:#111;color:#fff\" href=\"/book\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-navigation-item__content\" href=\"/services\">" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nav-dropdown-panel-styling.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-dropdown-panel-styling.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-dropdown-panel-styling",
+  "description": "Preserves dropdown submenu panel classes and material styles in serialized navigation submenu markup.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-dropdown-panel-styling.json",
+    "notes": "Generic dropdown panel fixture for submenu background, shadow, and radius styles."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<nav class=\"primary-nav\"><ul><li class=\"menu-item has-dropdown\"><a href=\"/services\">Services</a><ul class=\"dropdown-panel shadow-lg surface\" style=\"background:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px\"><li><a href=\"/services/design\">Design</a></li><li><a href=\"/services/build\">Build</a></li></ul></li></ul></nav>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-submenu", "attrs": { "label": "Services", "url": "/services", "kind": "custom", "className": "menu-item has-dropdown", "submenuClassName": "dropdown-panel shadow-lg surface", "submenuStyle": "background:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<ul class=\"wp-block-navigation__submenu-container dropdown-panel shadow-lg surface\" style=\"background:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px\">" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/visual-parity-current-nav-item-underline.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-current-nav-item-underline.json
@@ -1,0 +1,27 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-current-nav-item-underline",
+  "description": "Extracts current/active and separator/rule signals from styled navigation items.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-current-nav-item-underline.json",
+    "notes": "Generic visual parity probe fixture for current menu underline and rule classes."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Probe output is a new upstream diagnostic surface."
+  },
+  "operation": "visual_parity_probe.extract",
+  "input": {
+    "content": "<nav class=\"primary-menu\"><ul><li class=\"current-menu-item nav-rule\"><a class=\"is-active\" aria-current=\"page\" style=\"border-bottom:3px solid #111;padding-bottom:6px\" href=\"/\">Home</a></li><li><a href=\"/about\">About</a></li></ul></nav>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "summary.total", "assert": "equals", "value": 2 },
+    { "path": "probes.0.kind", "assert": "equals", "value": "menu_item" },
+    { "path": "probes.0.signals.1", "assert": "equals", "value": "current-active" },
+    { "path": "probes.0.signals.2", "assert": "equals", "value": "separator-rule" },
+    { "path": "probes.0.style.border-bottom", "assert": "equals", "value": "3px solid #111" },
+    { "path": "probes.1.kind", "assert": "equals", "value": "menu_item" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/visual-parity-dropdown-panel-styling.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-dropdown-panel-styling.json
@@ -1,0 +1,27 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-dropdown-panel-styling",
+  "description": "Extracts submenu panel class and material style signals for dropdown navigation items.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-dropdown-panel-styling.json",
+    "notes": "Generic visual parity probe fixture for submenu panel background and shadow."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Probe output is a new upstream diagnostic surface."
+  },
+  "operation": "visual_parity_probe.extract",
+  "input": {
+    "content": "<style>.dropdown-panel{background-color:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px}</style><nav class=\"primary-nav\"><ul><li><a href=\"/services\">Services</a><ul class=\"dropdown-panel shadow-lg\"><li><a href=\"/services/design\">Design</a></li></ul></li></ul></nav>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "summary.total", "assert": "equals", "value": 2 },
+    { "path": "probes.1.kind", "assert": "equals", "value": "submenu_item" },
+    { "path": "probes.1.signals.1", "assert": "equals", "value": "submenu-panel" },
+    { "path": "probes.1.hierarchy.submenu_panel.classes.0", "assert": "equals", "value": "dropdown-panel" },
+    { "path": "probes.1.hierarchy.submenu_panel.style.background-color", "assert": "equals", "value": "#fff" },
+    { "path": "probes.1.hierarchy.submenu_panel.style.box-shadow", "assert": "equals", "value": "0 16px 40px rgba(0,0,0,.18)" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve navigation item, CTA, current, separator, and submenu panel visual classes/styles.
- Extend visual probes with active/current, separator/rule, submenu panel, border-bottom, and box-shadow signals.
- Add fixtures for nav CTA differentiation, current item underline/rule signals, and dropdown panel styling.

## Testing
- composer test:parity
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s)::** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing navigation visual semantics, fixtures, verification, and preparing this PR description.