### PR TITLE
Extract class CSS style signals for HTML controls

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -164,6 +164,7 @@ final class ArtifactCompiler
         $result = ( new HtmlTransformer() )->transform($this->safeHtmlDocumentImageHtml($html, $sourcePath, $files), array(
             'source'       => $sourcePath,
             'source_scope' => $sourceScope,
+            'static_css'   => $this->linkedStylesheetCss($html, $sourcePath, $files),
         ))->toArray();
 
         return array(
@@ -189,6 +190,48 @@ final class ArtifactCompiler
         }, $html) ?? $html;
 
         return preg_replace('/<figure\b[^>]*>\s*<\/figure>/i', '', $html) ?? $html;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     */
+    private function linkedStylesheetCss(string $html, string $sourcePath, array $files): string
+    {
+        if ( ! preg_match_all('/<link\b[^>]*>/i', $html, $matches) ) {
+            return '';
+        }
+
+        $css = array();
+        foreach ( $matches[0] as $tag ) {
+            $rel = $this->htmlAttribute((string) $tag, 'rel');
+            $href = $this->htmlAttribute((string) $tag, 'href');
+            if ( '' === $href || ! preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $rel) ) {
+                continue;
+            }
+
+            $path = ArtifactPath::resolveRelativePath($href, $sourcePath);
+            if ( '' === $path ) {
+                continue;
+            }
+
+            foreach ( $files as $file ) {
+                if ( $path === (string) ($file['path'] ?? '') && 'css' === ($file['kind'] ?? '') && is_string($file['content'] ?? null) ) {
+                    $css[] = (string) $file['content'];
+                    break;
+                }
+            }
+        }
+
+        return trim(implode("\n", $css));
+    }
+
+    private function htmlAttribute(string $tag, string $name): string
+    {
+        if ( preg_match('/\s' . preg_quote($name, '/') . '\s*=\s*(["\'])(.*?)\1/is', $tag, $match) ) {
+            return html_entity_decode((string) $match[2], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        }
+
+        return '';
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -59,6 +59,11 @@ final class HtmlTransformer
      */
     private array $staticClassPromotions = array();
 
+    /**
+     * @var array<int, array{selector: string, declarations: array<string, string>}>
+     */
+    private array $staticStyleRules = array();
+
     private int $nextSourceProvenanceId = 1;
 
     public function __construct(private readonly Runtime $runtime = new Runtime())
@@ -83,6 +88,7 @@ final class HtmlTransformer
         $this->structureProvenance = array();
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
+        $this->staticStyleRules = $this->staticStyleRules($html, (string) ($options['static_css'] ?? ''));
         $this->nextSourceProvenanceId = 1;
         $provenance               = array(
             array_merge(array(
@@ -1012,11 +1018,247 @@ final class HtmlTransformer
      */
     private function presentationAttributes(DOMElement $element): array
     {
+        $style = $this->mergedPresentationStyle($element);
+
         return array_filter(array(
             'className' => $this->promotedClassName($this->attr($element, 'class')),
-            'style'     => $this->attr($element, 'style'),
+            'style'     => $style,
             'layout'    => $this->layoutAttribute($element),
         ), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+    }
+
+    private function mergedPresentationStyle(DOMElement $element): string
+    {
+        $inlineStyle = $this->attr($element, 'style');
+        if ( array() === $this->staticStyleRules || ! $this->isHighValueStyledElement($element) ) {
+            return $inlineStyle;
+        }
+
+        $declarations = array();
+        foreach ( $this->staticStyleRules as $rule ) {
+            if ( $this->matchesCssSelector($element, $rule['selector']) ) {
+                $declarations = array_merge($declarations, $rule['declarations']);
+            }
+        }
+
+        if ( array() === $declarations ) {
+            return $inlineStyle;
+        }
+
+        $declarations = array_merge($declarations, $this->cssDeclarations($inlineStyle));
+        return $this->cssDeclarationString($declarations);
+    }
+
+    private function isHighValueStyledElement(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( in_array($tagName, array( 'button', 'nav', 'article' ), true) ) {
+            return true;
+        }
+
+        $tokens = strtolower(trim(implode(' ', array(
+            $this->attr($element, 'class'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'role'),
+        ))));
+
+        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|card|tile|panel|pricing|price|product)(?:[^a-z0-9]|$)/', $tokens) ) {
+            return true;
+        }
+
+        if ( 'a' === $tagName ) {
+            for ( $node = $element->parentNode; $node instanceof DOMElement; $node = $node->parentNode ) {
+                $ancestorTokens = strtolower($this->attr($node, 'class') . ' ' . $this->attr($node, 'id'));
+                if ( preg_match('/(?:^|[^a-z0-9])(?:nav|menu|card|tile|panel|pricing|product)(?:[^a-z0-9]|$)/', $ancestorTokens) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, array{selector: string, declarations: array<string, string>}>
+     */
+    private function staticStyleRules(string $html, string $linkedCss): array
+    {
+        $css = trim($linkedCss);
+        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
+            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map('trim', $matches[1]));
+        }
+
+        if ( '' === trim($css) ) {
+            return array();
+        }
+
+        $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
+        $rules = array();
+        if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        foreach ( $matches as $match ) {
+            $declarations = $this->safeVisualDeclarations($this->cssDeclarations((string) $match[2]));
+            if ( array() === $declarations ) {
+                continue;
+            }
+            foreach ( explode(',', (string) $match[1]) as $selector ) {
+                $selector = trim($selector);
+                if ( '' !== $selector && $this->isSupportedCssSelector($selector) ) {
+                    $rules[] = array(
+                        'selector' => $selector,
+                        'declarations' => $declarations,
+                    );
+                }
+            }
+        }
+
+        return array_slice($rules, 0, 200);
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @return array<string, string>
+     */
+    private function safeVisualDeclarations(array $declarations): array
+    {
+        $safe = array_flip(array(
+            'background',
+            'background-color',
+            'border',
+            'border-color',
+            'border-radius',
+            'border-style',
+            'border-width',
+            'box-shadow',
+            'color',
+            'display',
+            'font-size',
+            'font-weight',
+            'gap',
+            'line-height',
+            'margin',
+            'margin-bottom',
+            'margin-left',
+            'margin-right',
+            'margin-top',
+            'padding',
+            'padding-bottom',
+            'padding-left',
+            'padding-right',
+            'padding-top',
+            'text-align',
+            'text-decoration',
+            'text-transform',
+        ));
+
+        return array_intersect_key($declarations, $safe);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function cssDeclarations(string $style): array
+    {
+        $declarations = array();
+        foreach ( explode(';', $style) as $declaration ) {
+            if ( ! str_contains($declaration, ':') ) {
+                continue;
+            }
+            [$name, $value] = array_map('trim', explode(':', $declaration, 2));
+            $name = strtolower($name);
+            $value = preg_replace('/\s+/', ' ', $value) ?? $value;
+            if ( '' !== $name && '' !== $value && ! preg_match('/(?:expression\s*\(|javascript\s*:|url\s*\()/i', $value) ) {
+                $declarations[$name] = $value;
+            }
+        }
+
+        return $declarations;
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     */
+    private function cssDeclarationString(array $declarations): string
+    {
+        $parts = array();
+        foreach ( $declarations as $name => $value ) {
+            $parts[] = $name . ':' . $value;
+        }
+
+        return implode(';', $parts);
+    }
+
+    private function isSupportedCssSelector(string $selector): bool
+    {
+        $selector = $this->normalizeCssSelector($selector);
+        if ( '' === $selector || preg_match('/[>+~\[\]=]/', $selector) ) {
+            return false;
+        }
+
+        foreach ( preg_split('/\s+/', $selector) ?: array() as $part ) {
+            if ( ! preg_match('/^(?:[a-z][a-z0-9_-]*)?(?:\.[A-Za-z0-9_-]+)+$|^\.[A-Za-z0-9_-]+$/i', $part) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function matchesCssSelector(DOMElement $element, string $selector): bool
+    {
+        $parts = preg_split('/\s+/', $this->normalizeCssSelector($selector)) ?: array();
+        if ( array() === $parts ) {
+            return false;
+        }
+
+        if ( ! $this->matchesCssSelectorPart($element, $parts[count($parts) - 1]) ) {
+            return false;
+        }
+
+        $current = $element->parentNode instanceof DOMElement ? $element->parentNode : null;
+        for ( $index = count($parts) - 2; $index >= 0; --$index ) {
+            $matched = false;
+            for ( $node = $current; $node instanceof DOMElement; $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null ) {
+                if ( $this->matchesCssSelectorPart($node, $parts[$index]) ) {
+                    $matched = true;
+                    $current = $node->parentNode instanceof DOMElement ? $node->parentNode : null;
+                    break;
+                }
+            }
+            if ( ! $matched ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function normalizeCssSelector(string $selector): string
+    {
+        return trim(preg_replace('/:(?:hover|focus|active|visited|before|after|focus-visible)\b.*/', '', $selector) ?? $selector);
+    }
+
+    private function matchesCssSelectorPart(DOMElement $element, string $selector): bool
+    {
+        if ( ! preg_match('/^(?:(?<tag>[a-z][a-z0-9_-]*))?(?<classes>(?:\.[A-Za-z0-9_-]+)+)$/i', $selector, $match) ) {
+            return false;
+        }
+
+        if ( ! empty($match['tag']) && strtolower($match['tag']) !== strtolower($element->tagName) ) {
+            return false;
+        }
+
+        $classes = preg_split('/\./', ltrim((string) $match['classes'], '.')) ?: array();
+        $elementClasses = preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array();
+        foreach ( $classes as $class ) {
+            if ( ! in_array($class, $elementClasses, true) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -19,7 +19,7 @@ final class NavigationPattern
             return null;
         }
 
-        $links = $this->navigationBlocks($element, $innerHtml, $createBlock);
+        $links = $this->navigationBlocks($element, $presentationAttributes, $innerHtml, $createBlock);
 
         if ( array() === $links ) {
             return null;
@@ -41,12 +41,12 @@ final class NavigationPattern
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function navigationBlocks(DOMElement $element, callable $innerHtml, callable $createBlock): array
+    private function navigationBlocks(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock): array
     {
         $blocks = array();
         $allowsDirectItems = 'nav' === strtolower($element->tagName) || $this->hasNavigationSignal($element) || $this->hasSubmenuSignal($element) || in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true);
         if ( in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true) ) {
-            return $this->navigationBlocksFromList($element, $innerHtml, $createBlock);
+            return $this->navigationBlocksFromList($element, $presentationAttributes, $innerHtml, $createBlock);
         }
 
         foreach ( $element->childNodes as $child ) {
@@ -58,12 +58,12 @@ final class NavigationPattern
                 if ( ! $allowsDirectItems ) {
                     return array();
                 }
-                $blocks[] = $this->navigationLinkBlock($child, $innerHtml, $createBlock);
+                $blocks[] = $this->navigationLinkBlock($child, $presentationAttributes, $innerHtml, $createBlock);
                 continue;
             }
 
             if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'ul', 'ol' ), true) ) {
-                $listBlocks = $this->navigationBlocksFromList($child, $innerHtml, $createBlock);
+                $listBlocks = $this->navigationBlocksFromList($child, $presentationAttributes, $innerHtml, $createBlock);
                 if ( array() === $listBlocks ) {
                     return array();
                 }
@@ -75,7 +75,7 @@ final class NavigationPattern
                 if ( ! $allowsDirectItems ) {
                     return array();
                 }
-                $block = $this->navigationBlockFromItem($child, $innerHtml, $createBlock);
+                $block = $this->navigationBlockFromItem($child, $presentationAttributes, $innerHtml, $createBlock);
                 if ( null !== $block ) {
                     $blocks[] = $block;
                     continue;
@@ -91,7 +91,7 @@ final class NavigationPattern
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function navigationBlocksFromList(DOMElement $list, callable $innerHtml, callable $createBlock): array
+    private function navigationBlocksFromList(DOMElement $list, callable $presentationAttributes, callable $innerHtml, callable $createBlock): array
     {
         $blocks = array();
         foreach ( $list->childNodes as $item ) {
@@ -103,7 +103,7 @@ final class NavigationPattern
                 return array();
             }
 
-            $block = $this->navigationBlockFromItem($item, $innerHtml, $createBlock);
+            $block = $this->navigationBlockFromItem($item, $presentationAttributes, $innerHtml, $createBlock);
             if ( null === $block ) {
                 return array();
             }
@@ -114,7 +114,7 @@ final class NavigationPattern
         return $blocks;
     }
 
-    private function navigationBlockFromItem(DOMElement $element, callable $innerHtml, callable $createBlock): ?array
+    private function navigationBlockFromItem(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
     {
         $anchor = $this->primaryNavigationAnchor($element);
         if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
@@ -123,33 +123,33 @@ final class NavigationPattern
 
         $submenuBlocks = array();
         foreach ( $this->submenuContainers($element, $anchor) as $submenuContainer ) {
-            foreach ( $this->navigationBlocks($submenuContainer, $innerHtml, $createBlock) as $submenuBlock ) {
+            foreach ( $this->navigationBlocks($submenuContainer, $presentationAttributes, $innerHtml, $createBlock) as $submenuBlock ) {
                 $submenuBlocks[] = $submenuBlock;
             }
         }
 
         if ( array() !== $submenuBlocks ) {
-            return $createBlock('core/navigation-submenu', array_filter(array(
+            return $createBlock('core/navigation-submenu', array_filter(array_merge($presentationAttributes($anchor), array(
                 'label' => $innerHtml($anchor),
                 'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
                 'kind'  => 'custom',
-            ), static fn ($value): bool => '' !== $value), $submenuBlocks, $element);
+            )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), $submenuBlocks, $element);
         }
 
         if ( 1 !== count($this->anchorsExcludingSubmenus($element, $anchor)) ) {
             return null;
         }
 
-        return $this->navigationLinkBlock($anchor, $innerHtml, $createBlock);
+        return $this->navigationLinkBlock($anchor, $presentationAttributes, $innerHtml, $createBlock);
     }
 
-    private function navigationLinkBlock(DOMElement $anchor, callable $innerHtml, callable $createBlock): array
+    private function navigationLinkBlock(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $createBlock): array
     {
-        return $createBlock('core/navigation-link', array_filter(array(
+        return $createBlock('core/navigation-link', array_filter(array_merge($presentationAttributes($anchor), array(
             'label' => $innerHtml($anchor),
             'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
             'kind'  => 'custom',
-        ), static fn ($value): bool => '' !== $value), array(), $anchor);
+        )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $anchor);
     }
 
     private function primaryNavigationAnchor(DOMElement $element): ?DOMElement

--- a/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
+++ b/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
@@ -13,6 +13,7 @@ final class ButtonMenuVisualProbe
     public const SCHEMA = 'blocks-engine/php-transformer/visual-parity-probes/v1';
 
     private const STYLE_FIELDS = array(
+        'background',
         'background-color',
         'border',
         'border-bottom-color',
@@ -68,7 +69,8 @@ final class ButtonMenuVisualProbe
     {
         $document = new DOMDocument();
         $previous = libxml_use_internal_errors(true);
-        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $this->bodyHtml($html) . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $sourceHtml = preg_match('/<(?:!doctype|html|head|body)\b/i', $html) ? $html : '<body>' . $this->bodyHtml($html) . '</body>';
+        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?>' . $sourceHtml, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         libxml_clear_errors();
         libxml_use_internal_errors($previous);
 
@@ -496,8 +498,12 @@ final class ButtonMenuVisualProbe
     private function matchesSimpleSelector(DOMElement $element, string $selector): bool
     {
         $selector = trim(preg_replace('/:(hover|focus|active|visited|before|after)\b.*/', '', $selector) ?? $selector);
-        if ( '' === $selector || str_contains($selector, ' ') || str_contains($selector, '>') || str_contains($selector, '+') || str_contains($selector, '~') ) {
+        if ( '' === $selector || str_contains($selector, '>') || str_contains($selector, '+') || str_contains($selector, '~') ) {
             return false;
+        }
+
+        if ( str_contains($selector, ' ') ) {
+            return $this->matchesDescendantSelector($element, $selector);
         }
 
         if ( preg_match('/^#([A-Za-z0-9_-]+)$/', $selector, $match) ) {
@@ -525,6 +531,31 @@ final class ButtonMenuVisualProbe
         }
 
         return strtolower($selector) === strtolower($element->tagName);
+    }
+
+    private function matchesDescendantSelector(DOMElement $element, string $selector): bool
+    {
+        $parts = preg_split('/\s+/', trim($selector)) ?: array();
+        if ( array() === $parts || ! $this->matchesSimpleSelector($element, array_pop($parts)) ) {
+            return false;
+        }
+
+        $current = $element->parentNode instanceof DOMElement ? $element->parentNode : null;
+        for ( $index = count($parts) - 1; $index >= 0; --$index ) {
+            $matched = false;
+            for ( $node = $current; $node instanceof DOMElement; $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null ) {
+                if ( $this->matchesSimpleSelector($node, $parts[$index]) ) {
+                    $matched = true;
+                    $current = $node->parentNode instanceof DOMElement ? $node->parentNode : null;
+                    break;
+                }
+            }
+            if ( ! $matched ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function selector(DOMElement $element): string

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-button-card-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-button-card-style-signals.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-linked-css-button-card-style-signals",
+  "description": "Applies safe visual declarations from linked class CSS to high-value button, navigation CTA, and product card controls.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-linked-css-button-card-style-signals.json",
+    "notes": "Covers minimal linked CSS rule extraction for class-defined control and card visual styling."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream CSS style signal fixture has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<!doctype html><html><head><title>Styled CTAs</title><link rel=\"stylesheet\" href=\"assets/site.css\"></head><body><main><nav class=\"site-nav\"><a class=\"nav-cta\" href=\"/pricing\">Pricing</a></nav><a class=\"btn-primary\" href=\"/start\">Get started</a><article class=\"product-card\"><h2>Starter Kit</h2><a class=\"btn\" href=\"/buy\">Buy now</a></article></main></body></html>"
+        },
+        {
+          "path": "assets/site.css",
+          "kind": "css",
+          "content": ".btn-primary{background-color:#1257ff;color:#fff;padding:12px 20px;border-radius:999px}.nav-cta{background-color:#101827;color:white;padding:10px 16px;border-radius:8px}.product-card{border:1px solid #d8dee9;border-radius:16px;padding:24px}.product-card .btn{background:#0f766e;color:#ffffff;padding:11px 18px;border-radius:6px}"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "btn-primary" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background-color:#1257ff;color:#fff;padding:12px 20px;border-radius:999px" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "nav-cta" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background-color:#101827;color:white;padding:10px 16px;border-radius:8px" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "product-card" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "border:1px solid #d8dee9;border-radius:16px;padding:24px" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background:#0f766e;color:#ffffff;padding:11px 18px;border-radius:6px" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/visual-parity-class-css-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-class-css-style-signals.json
@@ -1,0 +1,28 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-class-css-style-signals",
+  "description": "Reports class-defined style metadata for button, navigation CTA, and descendant product-card button selectors.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-class-css-style-signals.json",
+    "notes": "Covers minimal class and descendant selector extraction in the button/menu visual probe."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Visual parity probe metadata is an upstream-only report contract."
+  },
+  "operation": "visual_parity_probe.extract",
+  "input": {
+    "content": "<!doctype html><html><head><style>.btn-primary{background-color:#1257ff;color:#fff;padding:12px 20px;border-radius:999px}.nav-cta{background-color:#101827;color:white;padding:10px 16px;border-radius:8px}.product-card .btn{background:#0f766e;color:#ffffff;padding:11px 18px;border-radius:6px}</style></head><body><main><nav><a class=\"nav-cta\" href=\"/pricing\">Pricing</a></nav><a class=\"btn-primary\" href=\"/start\">Get started</a><article class=\"product-card\"><a class=\"btn\" href=\"/buy\">Buy now</a></article></main></body></html>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "summary.total", "assert": "equals", "value": 3 },
+    { "path": "probes.0.style.background-color", "assert": "equals", "value": "#101827" },
+    { "path": "probes.0.style.border-radius", "assert": "equals", "value": "8px" },
+    { "path": "probes.1.style.background-color", "assert": "equals", "value": "#1257ff" },
+    { "path": "probes.1.style.padding", "assert": "equals", "value": "12px 20px" },
+    { "path": "probes.2.style.background", "assert": "equals", "value": "#0f766e" },
+    { "path": "probes.2.style.border-radius", "assert": "equals", "value": "6px" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Extract safe class-defined visual declarations for high-signal buttons, nav CTAs, and cards.
- Support simple class and descendant selectors without adding a full CSS engine.
- Add fixtures for linked CSS button/card style signals and visual parity probe style extraction.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing CSS style signal extraction, fixtures, verification, and preparing this PR description.