### PR TITLE
Normalize selected Figma frame origins

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -460,11 +460,11 @@ final class StaticHtmlEmitter
         $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
 
         if ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
-            $x += $this->positionOffset($box, $parentBox, 'x') ?? 0.0;
-            $y += $this->positionOffset($box, $parentBox, 'y') ?? 0.0;
+            $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
+            $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
         } elseif ( null !== $parentNode && 'absolute' === ($layout['positioning'] ?? null) ) {
-            $x += $this->relativeOffset($box, $parentBox, 'x') ?? 0.0;
-            $y += $this->relativeOffset($box, $parentBox, 'y') ?? 0.0;
+            $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
+            $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
         }
 
         $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
@@ -657,8 +657,8 @@ final class StaticHtmlEmitter
     {
         $styles = array();
         $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
-        $left = $this->positionOffset($box, $parentBox, 'x');
-        $top = $this->positionOffset($box, $parentBox, 'y');
+        $left = $this->positionOffset($box, $parentBox, 'x', $parentNode);
+        $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
         $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
 
         if ( null !== $left ) {
@@ -743,7 +743,7 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $box
      * @param array<string, mixed> $parentBox
      */
-    private function positionOffset(array $box, array $parentBox, string $dimension): ?float
+    private function positionOffset(array $box, array $parentBox, string $dimension, ?array $parentNode = null): ?float
     {
         if ( ! isset($box[$dimension]) || ! is_numeric($box[$dimension]) ) {
             return null;
@@ -753,7 +753,39 @@ final class StaticHtmlEmitter
             return (float) $box[$dimension];
         }
 
+        if ( ! isset($parentBox[$dimension]) && null !== $parentNode ) {
+            $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+            if ( null !== $origin ) {
+                return (float) $box[$dimension] - $origin;
+            }
+        }
+
         return $this->relativeOffset($box, $parentBox, $dimension);
+    }
+
+    /**
+     * Infer a root origin for selected frames that carry only size while their children remain in canvas coordinates.
+     *
+     * @param array<string, mixed> $parentNode
+     */
+    private function inferredContainingBlockOrigin(array $parentNode, string $dimension): ?float
+    {
+        $origin = null;
+        foreach ( $this->nodeList($parentNode) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            if ( 'local' === ($childBox['coordinate_space'] ?? null) || ! isset($childBox[$dimension]) || ! is_numeric($childBox[$dimension]) ) {
+                continue;
+            }
+
+            $value = (float) $childBox[$dimension];
+            $origin = null === $origin ? $value : min($origin, $value);
+        }
+
+        return $origin;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1440,6 +1440,39 @@ $assert(str_contains($plainFrameLayoutCss, '.figma-node-plain-frame-plain-layout
 $assert(str_contains($plainFrameLayoutCss, '.figma-node-plain-first-first-positioned-layer{width:90px;height:40px;position:absolute;left:20px;top:20px'), 'plain-frame-first-child-positioned-relative-to-parent');
 $assert(str_contains($plainFrameLayoutCss, '.figma-node-plain-second-second-positioned-text{width:120px;height:32px;position:absolute;left:200px;top:150px'), 'plain-frame-text-child-positioned-relative-to-parent');
 
+$selectedFrameOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Selected Frame Origin Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'origin:frame',
+            'type'     => 'FRAME',
+            'name'     => 'Selected frame',
+            'width'    => 1200,
+            'height'   => 800,
+            'children' => array(
+                array(
+                    'id'                  => 'origin:hero',
+                    'type'                => 'FRAME',
+                    'name'                => 'Hero',
+                    'absoluteBoundingBox' => array('x' => -1333, 'y' => -184, 'width' => 1200, 'height' => 600),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+                array(
+                    'id'                  => 'origin:cta',
+                    'type'                => 'TEXT',
+                    'name'                => 'CTA',
+                    'characters'          => 'Visible copy',
+                    'absoluteBoundingBox' => array('x' => -1133, 'y' => 216, 'width' => 240, 'height' => 40),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+            ),
+        ),
+    ),
+));
+$selectedFrameOriginCss = $fileContent($selectedFrameOriginResult, 'style.css');
+$assert(str_contains($selectedFrameOriginCss, '.figma-node-origin-hero-hero{width:1200px;height:600px;position:absolute;left:0px;top:0px'), 'selected-frame-origin-normalizes-first-child');
+$assert(str_contains($selectedFrameOriginCss, '.figma-node-origin-cta-cta{width:240px;height:40px;position:absolute;left:200px;top:400px'), 'selected-frame-origin-normalizes-text-child');
+
 $resolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Component Instance Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- infer a containing-block origin when selected/root Figma frames have size but no x/y coordinates
- normalize absolute child CSS and visual-node-map coordinates against that inferred origin
- add contract coverage for negative canvas-space child coordinates becoming visible root-relative offsets

## Testing
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Fisiostetic off-canvas import issue, implementing the transformer origin normalization fix, and adding regression coverage.