### PR TITLE
Keep flat nav menus out of submenus

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -19,6 +19,10 @@ final class NavigationPattern
             return null;
         }
 
+        if ( $this->hasNavigationChrome($element) ) {
+            return null;
+        }
+
         $links = $this->navigationBlocks($element, $presentationAttributes, $innerHtml, $createBlock);
 
         if ( array() === $links ) {
@@ -72,9 +76,14 @@ final class NavigationPattern
             }
 
             if ( $child instanceof DOMElement ) {
+                if ( $this->isMenuToggleControl($child) ) {
+                    continue;
+                }
+
                 if ( ! $allowsDirectItems ) {
                     return array();
                 }
+
                 $block = $this->navigationBlockFromItem($child, $presentationAttributes, $innerHtml, $createBlock);
                 if ( null !== $block ) {
                     $blocks[] = $block;
@@ -223,9 +232,74 @@ final class NavigationPattern
         foreach ( array( 'class', 'id', 'role' ) as $attribute ) {
             $value = $element->hasAttribute($attribute) ? $element->getAttribute($attribute) : '';
             foreach ( preg_split('/[^a-z0-9]+/', strtolower($value)) ?: array() as $token ) {
-                if ( in_array($token, array( 'dropdown', 'submenu', 'subnav', 'flyout', 'menu' ), true) ) {
+                if ( in_array($token, array( 'dropdown', 'submenu', 'subnav', 'flyout' ), true) ) {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    private function isMenuToggleControl(DOMElement $element): bool
+    {
+        if ( 'button' !== strtolower($element->tagName) ) {
+            return false;
+        }
+
+        if ( $element->hasAttribute('aria-controls') || $element->hasAttribute('aria-expanded') ) {
+            return true;
+        }
+
+        foreach ( preg_split('/[^a-z0-9]+/', strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-label'))) ?: array() as $token ) {
+            if ( in_array($token, array( 'hamburger', 'menu', 'toggle' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasNavigationChrome(DOMElement $element): bool
+    {
+        $hasToggle = false;
+        foreach ( $element->getElementsByTagName('button') as $button ) {
+            if ( $button instanceof DOMElement && $this->isMenuToggleControl($button) ) {
+                $hasToggle = true;
+                break;
+            }
+        }
+
+        if ( ! $hasToggle ) {
+            return false;
+        }
+
+        $hasList = false;
+        foreach ( $element->getElementsByTagName('ul') as $list ) {
+            if ( $list instanceof DOMElement && $this->hasNavigationSignal($list) ) {
+                $hasList = true;
+                break;
+            }
+        }
+
+        if ( ! $hasList ) {
+            return false;
+        }
+
+        foreach ( $element->getElementsByTagName('a') as $anchor ) {
+            if ( $anchor instanceof DOMElement && ! $this->hasListAncestor($anchor, $element) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasListAncestor(DOMElement $element, DOMElement $boundary): bool
+    {
+        for ( $node = $element->parentNode; $node instanceof DOMElement && ! $node->isSameNode($boundary); $node = $node->parentNode ) {
+            if ( in_array(strtolower($node->tagName), array( 'ul', 'ol' ), true) ) {
+                return true;
             }
         }
 

--- a/php-transformer/tests/fixtures/parity/html-nav-menu-flat-list.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-menu-flat-list.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-menu-flat-list",
+  "description": "Keeps flat nav-menu lists as sibling navigation links instead of rolling them into a dropdown submenu.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-menu-flat-list.json",
+    "notes": "Common Table-style header fixture where menu is a visible flat nav list, not a submenu panel."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<nav class=\"site-nav\" role=\"navigation\" aria-label=\"Main navigation\"><div class=\"nav-inner\"><a href=\"index.html\" class=\"nav-logo\">Common Table</a><button class=\"hamburger\" aria-label=\"Open navigation menu\" aria-expanded=\"false\" aria-controls=\"nav-menu\"><span></span><span></span><span></span></button><ul class=\"nav-menu\" id=\"nav-menu\" role=\"list\"><li><a href=\"index.html\" class=\"nav-link\">Home</a></li><li><a href=\"gatherings.html\" class=\"nav-link\">Gatherings</a></li><li><a href=\"organizers.html\" class=\"nav-link\">Organizers</a></li><li><a href=\"stories.html\" class=\"nav-link\">Stories</a></li><li><a href=\"membership.html\" class=\"nav-cta\">Join Us</a></li></ul></div></nav>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-nav" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "nav-inner" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "nav-logo" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "nav-menu" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "index.html", "kind": "custom", "anchorClassName": "nav-link" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.4", "name": "core/navigation-link", "attrs": { "label": "Join Us", "url": "membership.html", "kind": "custom", "anchorClassName": "nav-cta" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 5 },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:navigation-submenu" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Keep mixed header chrome such as logo + hamburger + ul.nav-menu out of the core/navigation matcher.
- Remove generic menu as a submenu signal so nav-menu does not imply dropdown behavior.
- Ignore hamburger/menu-toggle buttons while parsing actual navigation items.
- Add a Common Table-style regression fixture that asserts nav-menu remains a flat navigation list and does not serialize navigation-submenu.

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Common Table flat menu regression, implementing the heuristic fix, adding regression coverage, running verification, and preparing this PR description.