### PR TITLE
Support Figma plugin asset fallbacks

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -128,6 +128,8 @@ final class StaticHtmlEmitter
         $children = $this->nodeList($node);
         $content = $text;
         $vectorSvg = $this->supportedVectorSvg($node, $type);
+        $assetPath = $this->nodeAssetPath($node);
+        $hasVectorAssetFallback = $this->isUnsupportedVectorType($type) && null !== $assetPath;
 
         if ( ! ( 'BOOLEAN_OPERATION' === $type && null !== $vectorSvg ) ) {
             foreach ( $children as $child ) {
@@ -141,7 +143,7 @@ final class StaticHtmlEmitter
             $content = $vectorSvg . $content;
         }
 
-        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg ) {
+        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg && ! $hasVectorAssetFallback ) {
             $diagnostics[] = array(
                 'severity' => 'warning',
                 'code'     => 'unsupported_vector_node_placeholder',
@@ -165,8 +167,10 @@ final class StaticHtmlEmitter
         if ( 'RECTANGLE' === $type && '' === $content ) {
             $attributes .= ' aria-hidden="true"';
         }
-        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg ) {
+        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg && ! $hasVectorAssetFallback ) {
             $attributes .= ' data-figma-unsupported-vector="true" role="img" aria-label="Unsupported Figma ' . $this->sanitizeAttribute($type) . ' node"';
+        } elseif ( $hasVectorAssetFallback ) {
+            $attributes .= ' role="img" aria-label="' . $this->sanitizeAttribute('' !== $name ? $name : $type) . '"';
         }
 
         return sprintf("<%1\$s%2\$s>%3\$s</%1\$s>\n", $tag, $attributes, $content);
@@ -753,7 +757,7 @@ final class StaticHtmlEmitter
             return (float) $box[$dimension];
         }
 
-        if ( ! isset($parentBox[$dimension]) && null !== $parentNode ) {
+        if ( null !== $parentNode && (! isset($parentBox[$dimension]) || $this->shouldInferZeroRootOrigin($parentBox, $parentNode, $dimension)) ) {
             $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
             if ( null !== $origin ) {
                 return (float) $box[$dimension] - $origin;
@@ -761,6 +765,28 @@ final class StaticHtmlEmitter
         }
 
         return $this->relativeOffset($box, $parentBox, $dimension);
+    }
+
+    /**
+     * Figma plugin payloads can normalize a selected frame origin to 0 while
+     * preserving child coordinates in the original canvas space.
+     *
+     * @param array<string, mixed> $parentBox
+     * @param array<string, mixed> $parentNode
+     */
+    private function shouldInferZeroRootOrigin(array $parentBox, array $parentNode, string $dimension): bool
+    {
+        if ( ! isset($parentBox[$dimension]) || ! is_numeric($parentBox[$dimension]) || 0.0 !== (float) $parentBox[$dimension] ) {
+            return false;
+        }
+
+        if ( ! empty($parentNode['_parent_id']) ) {
+            return false;
+        }
+
+        $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+
+        return null !== $origin && $origin < 0.0;
     }
 
     /**
@@ -1426,6 +1452,10 @@ final class StaticHtmlEmitter
             $id = (string) ($asset['id'] ?? $key);
             $content = $asset['content'] ?? $asset['data'] ?? null;
             $source = (string) ($asset['url'] ?? $asset['src'] ?? '');
+            $mimeType = (string) ($asset['mime_type'] ?? $asset['mimeType'] ?? 'application/octet-stream');
+            $decodedAsset = $this->decodeInlineAssetContent($asset, $content, $mimeType);
+            $content = $decodedAsset['content'];
+            $mimeType = $decodedAsset['mime_type'];
 
             if ( null === $content ) {
                 if ( preg_match('/^https?:\/\//', $source) ) {
@@ -1439,7 +1469,6 @@ final class StaticHtmlEmitter
                 continue;
             }
 
-            $mimeType = (string) ($asset['mime_type'] ?? $asset['mimeType'] ?? 'application/octet-stream');
             $path = 'assets/' . $this->slug((string) ($asset['name'] ?? $id)) . '.' . $this->extensionForMimeType($mimeType);
             $file = array(
                 'path'      => $path,
@@ -1461,6 +1490,56 @@ final class StaticHtmlEmitter
         );
 
         return $files;
+    }
+
+    /**
+     * @param array<string, mixed> $asset
+     * @return array{content: mixed, mime_type: string}
+     */
+    private function decodeInlineAssetContent(array $asset, mixed $content, string $mimeType): array
+    {
+        if ( null !== $content ) {
+            return array('content' => $content, 'mime_type' => $mimeType);
+        }
+
+        foreach ( array('dataUrl', 'dataURL', 'data_url') as $key ) {
+            if ( ! isset($asset[$key]) || ! is_scalar($asset[$key]) ) {
+                continue;
+            }
+
+            $dataUrl = (string) $asset[$key];
+            if ( 1 !== preg_match('/^data:([^;,]+)?(;base64)?,(.*)$/s', $dataUrl, $matches) ) {
+                continue;
+            }
+
+            $data = rawurldecode($matches[3]);
+            if ( ';base64' === ($matches[2] ?? '') ) {
+                $decoded = base64_decode($data, true);
+                if ( false === $decoded ) {
+                    continue;
+                }
+                $data = $decoded;
+            }
+
+            $dataUrlMimeType = (string) ($matches[1] ?? '');
+            return array(
+                'content'   => $data,
+                'mime_type' => '' !== $dataUrlMimeType ? $dataUrlMimeType : $mimeType,
+            );
+        }
+
+        foreach ( array('content_base64', 'contentBase64', 'base64') as $key ) {
+            if ( ! isset($asset[$key]) || ! is_scalar($asset[$key]) ) {
+                continue;
+            }
+
+            $decoded = base64_decode((string) $asset[$key], true);
+            if ( false !== $decoded ) {
+                return array('content' => $decoded, 'mime_type' => $mimeType);
+            }
+        }
+
+        return array('content' => null, 'mime_type' => $mimeType);
     }
 
     /**
@@ -1732,10 +1811,14 @@ final class StaticHtmlEmitter
     private function assetAliases(array $asset, string $id): array
     {
         $aliases = array($id);
-        foreach ( array('hash', 'imageRef', 'imageHash', 'asset_id', 'image_ref', 'source_id') as $key ) {
+        foreach ( array('hash', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref', 'source_id', 'node_id', 'nodeId', 'name', 'fileName', 'filename') as $key ) {
             if ( isset($asset[$key]) && is_scalar($asset[$key]) ) {
                 $aliases[] = (string) $asset[$key];
             }
+        }
+
+        foreach ( $aliases as $alias ) {
+            $aliases[] = $this->slug($alias);
         }
 
         if ( isset($asset['path']) && is_scalar($asset['path']) ) {
@@ -1755,10 +1838,14 @@ final class StaticHtmlEmitter
     private function nodeAssetReferences(array $node): array
     {
         $references = array();
-        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref', 'id', 'name') as $key ) {
             if ( isset($node[$key]) && is_scalar($node[$key]) ) {
                 $references[] = (string) $node[$key];
             }
+        }
+
+        foreach ( $references as $reference ) {
+            $references[] = $this->slug($reference);
         }
 
         foreach ( array('fills', 'strokes', 'background') as $paintKey ) {

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1330,6 +1330,70 @@ $assert(str_contains($assetReferenceHtml, 'data-figma-unsupported-vector="true"'
 $assert(str_contains($assetReferenceHtml, 'Unsupported Figma VECTOR'), 'unsupported-vector-placeholder-text');
 $assert(in_array('unsupported_vector_node_placeholder', $assetReferenceDiagnosticCodes, true), 'unsupported-vector-diagnostic');
 
+$pluginAssetResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'   => 'Plugin Asset Fixture',
+    'assets' => array(
+        'plugin-photo-asset' => array(
+            'id'        => 'plugin-photo-asset',
+            'name'      => 'Plugin Photo',
+            'imageHash' => 'plugin-image-hash',
+            'dataUrl'   => 'data:image/png;base64,' . base64_encode('plugin-png-bytes'),
+        ),
+        'plugin-icon-asset'  => array(
+            'id'             => 'plugin-icon-asset',
+            'name'           => 'Plugin Icon',
+            'node_id'        => 'plugin:vector',
+            'mime_type'      => 'image/svg+xml',
+            'content_base64' => base64_encode('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="M0 0h8v8z"/></svg>'),
+        ),
+    ),
+    'nodes'  => array(
+        array(
+            'id'       => 'plugin:frame',
+            'type'     => 'FRAME',
+            'name'     => 'Plugin frame',
+            'children' => array(
+                array(
+                    'id'     => 'plugin:image',
+                    'type'   => 'RECTANGLE',
+                    'name'   => 'Plugin image',
+                    'width'  => 40,
+                    'height' => 30,
+                    'fills'  => array(
+                        array('type' => 'IMAGE', 'imageRef' => 'plugin-image-hash'),
+                    ),
+                ),
+                array(
+                    'id'     => 'plugin:vector',
+                    'type'   => 'VECTOR',
+                    'name'   => 'Plugin Icon',
+                    'width'  => 8,
+                    'height' => 8,
+                ),
+            ),
+        ),
+    ),
+));
+$pluginAssetCss = $fileContent($pluginAssetResult, 'style.css');
+$pluginAssetHtml = $fileContent($pluginAssetResult, 'index.html');
+$pluginAssetFiles = $pluginAssetResult['files'] ?? array();
+$pluginAssetFileContent = static function (array $files, string $path): string {
+    foreach ( $files as $file ) {
+        if ( is_array($file) && $path === ($file['path'] ?? null) ) {
+            return (string) ($file['content'] ?? '');
+        }
+    }
+
+    return '';
+};
+
+$assert(str_contains($pluginAssetCss, '.figma-node-plugin-image-plugin-image{width:40px;height:30px;position:absolute;background-image:url("assets/plugin-photo.png")'), 'plugin-data-url-image-background-css');
+$assert('plugin-png-bytes' === $pluginAssetFileContent($pluginAssetFiles, 'assets/plugin-photo.png'), 'plugin-data-url-image-asset-file');
+$assert(str_contains($pluginAssetCss, '.figma-node-plugin-vector-plugin-icon{width:8px;height:8px;position:absolute;background-image:url("assets/plugin-icon.svg")'), 'plugin-vector-fallback-background-css');
+$assert(! str_contains($pluginAssetHtml, 'Unsupported Figma VECTOR'), 'plugin-vector-fallback-avoids-unsupported-placeholder');
+$assert(str_contains($pluginAssetHtml, 'data-figma-node-id="plugin:vector"') && ! str_contains($pluginAssetHtml, 'data-figma-unsupported-vector="true"'), 'plugin-vector-fallback-not-marked-unsupported');
+$assert(str_contains($pluginAssetFileContent($pluginAssetFiles, 'assets/plugin-icon.svg'), '<svg xmlns="http://www.w3.org/2000/svg"'), 'plugin-content-base64-vector-asset-file');
+
 $layoutFidelityResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Layout Fidelity Fixture',
     'nodes' => array(
@@ -1472,6 +1536,38 @@ $selectedFrameOriginResult = blocks_engine_figma_transformer_transform_scenegrap
 $selectedFrameOriginCss = $fileContent($selectedFrameOriginResult, 'style.css');
 $assert(str_contains($selectedFrameOriginCss, '.figma-node-origin-hero-hero{width:1200px;height:600px;position:absolute;left:0px;top:0px'), 'selected-frame-origin-normalizes-first-child');
 $assert(str_contains($selectedFrameOriginCss, '.figma-node-origin-cta-cta{width:240px;height:40px;position:absolute;left:200px;top:400px'), 'selected-frame-origin-normalizes-text-child');
+
+$zeroOriginSelectedFrameResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Zero Origin Selected Frame Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'zero:frame',
+            'type'                => 'FRAME',
+            'name'                => 'Zero origin selected frame',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 1200, 'height' => 800),
+            'children'            => array(
+                array(
+                    'id'                  => 'zero:hero',
+                    'type'                => 'FRAME',
+                    'name'                => 'Hero',
+                    'absoluteBoundingBox' => array('x' => -1333, 'y' => -184, 'width' => 1200, 'height' => 600),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+                array(
+                    'id'                  => 'zero:cta',
+                    'type'                => 'TEXT',
+                    'name'                => 'CTA',
+                    'characters'          => 'Visible copy',
+                    'absoluteBoundingBox' => array('x' => -1133, 'y' => 216, 'width' => 240, 'height' => 40),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+            ),
+        ),
+    ),
+));
+$zeroOriginSelectedFrameCss = $fileContent($zeroOriginSelectedFrameResult, 'style.css');
+$assert(str_contains($zeroOriginSelectedFrameCss, '.figma-node-zero-hero-hero{width:1200px;height:600px;position:absolute;left:0px;top:0px'), 'zero-origin-selected-frame-normalizes-first-child');
+$assert(str_contains($zeroOriginSelectedFrameCss, '.figma-node-zero-cta-cta{width:240px;height:40px;position:absolute;left:200px;top:400px'), 'zero-origin-selected-frame-normalizes-text-child');
 
 $resolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Component Instance Fixture',


### PR DESCRIPTION
## Summary
- decode plugin-provided inline assets from `dataUrl` and base64 payloads
- alias assets by image/node identifiers so Figma image paints resolve to CSS backgrounds
- render exported vector fallback assets instead of unsupported vector placeholders
- preserve the zero-origin selected-frame regression coverage

## Testing
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the transformer asset fallback implementation and regression tests.