### PR TITLE
Report Figma transform diagnostics

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -50,6 +50,7 @@ final class StaticHtmlEmitter
             $body .= $this->emitNode($node, $cssRules, $diagnostics, $nodeStyleDiagnostics, 0, null);
         }
 
+        $css = ('' !== $fontCss ? $fontCss . "\n" : '') . implode("\n", $cssRules) . "\n";
         $files = array(
             array(
                 'path'      => 'index.html',
@@ -61,7 +62,7 @@ final class StaticHtmlEmitter
                 'path'      => 'style.css',
                 'role'      => 'stylesheet',
                 'mime_type' => 'text/css',
-                'content'   => ('' !== $fontCss ? $fontCss . "\n" : '') . implode("\n", $cssRules) . "\n",
+                'content'   => $css,
             ),
         );
 
@@ -71,6 +72,7 @@ final class StaticHtmlEmitter
 
         $visualNodeMap = $this->visualNodeMap($nodes);
         $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
+        $transformDiagnostics = $this->transformDiagnostics($nodes, $assetFiles, $fontFamilies, $fontCss, $css, $diagnostics);
         if ( '' === $fontCss ) {
             foreach ( $fontFamilies as $fontFamily ) {
                 if ( $this->isWebSafeFontFamily($fontFamily) ) {
@@ -103,6 +105,7 @@ final class StaticHtmlEmitter
                 'font_usage'                   => $this->fontUsage($nodeStyleDiagnostics),
                 'font_css_supplied'            => '' !== $fontCss,
                 'render_text_glyph_paths'      => $this->renderTextGlyphPaths,
+                'transform_diagnostics'        => $transformDiagnostics,
             ),
             'metrics'       => array(
                 'node_count'  => $this->countNodes($nodes),
@@ -451,6 +454,174 @@ final class StaticHtmlEmitter
         }
 
         return $map;
+    }
+
+    /**
+     * Build production-transform diagnostics for Figma import development.
+     *
+     * @param array<int, array<string, mixed>> $nodes
+     * @param array<int, array<string, mixed>> $assetFiles
+     * @param array<int, string> $fontFamilies
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<string, mixed>
+     */
+    private function transformDiagnostics(array $nodes, array $assetFiles, array $fontFamilies, string $fontCss, string $css, array $diagnostics): array
+    {
+        $image = array(
+            'paint_refs'      => 0,
+            'node_refs'       => 0,
+            'resolved_assets' => 0,
+            'missing_assets'  => array(),
+        );
+        $vectors = array(
+            'nodes'                    => 0,
+            'rendered_paths'           => 0,
+            'rendered_asset_fallbacks' => 0,
+            'placeholders'             => 0,
+            'placeholder_nodes'        => array(),
+        );
+
+        foreach ( $nodes as $node ) {
+            if ( is_array($node) ) {
+                $this->collectTransformDiagnostics($node, $image, $vectors);
+            }
+        }
+
+        $image['missing_assets'] = array_values($image['missing_assets']);
+        $vectors['placeholder_nodes'] = array_values($vectors['placeholder_nodes']);
+
+        return array(
+            'schema' => 'blocks-engine/figma-transformer/transform-diagnostics/v1',
+            'images' => $image,
+            'vectors' => $vectors,
+            'fonts' => array(
+                'families'      => $fontFamilies,
+                'count'         => count($fontFamilies),
+                'css_supplied'  => '' !== $fontCss,
+                'materialized'  => '' !== $fontCss,
+                'missing_css'   => '' === $fontCss ? array_values(array_filter($fontFamilies, fn (string $family): bool => ! $this->isWebSafeFontFamily($family))) : array(),
+            ),
+            'assets' => array(
+                'emitted_files' => count($assetFiles),
+                'paths'         => array_values(array_map(static fn (array $file): string => (string) ($file['path'] ?? ''), $assetFiles)),
+            ),
+            'layout' => array(
+                'large_negative_left_count' => preg_match_all('/left:-[0-9]{3,}/', $css),
+            ),
+            'diagnostic_codes' => $this->diagnosticCodeCounts($diagnostics),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $image
+     * @param array<string, mixed> $vectors
+     */
+    private function collectTransformDiagnostics(array $node, array &$image, array &$vectors): void
+    {
+        $imagePaints = $this->nodeImagePaints($node);
+        if ( ! empty($imagePaints) ) {
+            $image['paint_refs'] += count($imagePaints);
+        }
+
+        $assetReferences = $this->explicitNodeAssetReferences($node);
+        $hasAssetExpectation = ! empty($assetReferences) || ! empty($imagePaints);
+        if ( $hasAssetExpectation ) {
+            ++$image['node_refs'];
+            if ( null !== $this->nodeAssetPath($node) ) {
+                ++$image['resolved_assets'];
+            } else {
+                $image['missing_assets'][] = array(
+                    'node_id' => (string) ($node['id'] ?? ''),
+                    'name'    => (string) ($node['name'] ?? ''),
+                    'type'    => strtoupper((string) ($node['type'] ?? '')),
+                    'refs'    => array_values(array_unique(array_merge($assetReferences, $this->imagePaintReferences($node)))),
+                );
+            }
+        }
+
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( $this->isUnsupportedVectorType($type) ) {
+            ++$vectors['nodes'];
+            if ( null !== $this->supportedVectorSvg($node, $type) ) {
+                ++$vectors['rendered_paths'];
+            } elseif ( null !== $this->nodeAssetPath($node) ) {
+                ++$vectors['rendered_asset_fallbacks'];
+            } else {
+                ++$vectors['placeholders'];
+                $vectors['placeholder_nodes'][] = array(
+                    'node_id' => (string) ($node['id'] ?? ''),
+                    'name'    => (string) ($node['name'] ?? ''),
+                    'type'    => $type,
+                );
+            }
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $this->collectTransformDiagnostics($child, $image, $vectors);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function explicitNodeAssetReferences(array $node): array
+    {
+        $references = array();
+        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
+                $references[] = (string) $node[$key];
+            }
+        }
+        if ( is_array($node['image'] ?? null) ) {
+            foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+                if ( isset($node['image'][$key]) && is_scalar($node['image'][$key]) && '' !== (string) $node['image'][$key] ) {
+                    $references[] = (string) $node['image'][$key];
+                }
+            }
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function imagePaintReferences(array $node): array
+    {
+        $references = array();
+        foreach ( $this->nodeImagePaints($node) as $paint ) {
+            foreach ( array('ref', 'imageRef', 'imageHash', 'asset_id', 'image_ref') as $key ) {
+                if ( isset($paint[$key]) && is_scalar($paint[$key]) && '' !== (string) $paint[$key] ) {
+                    $references[] = (string) $paint[$key];
+                }
+            }
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<string, int>
+     */
+    private function diagnosticCodeCounts(array $diagnostics): array
+    {
+        $counts = array();
+        foreach ( $diagnostics as $diagnostic ) {
+            $code = is_array($diagnostic) ? (string) ($diagnostic['code'] ?? '') : '';
+            if ( '' === $code ) {
+                continue;
+            }
+            $counts[$code] = ($counts[$code] ?? 0) + 1;
+        }
+        ksort($counts);
+
+        return $counts;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1235,6 +1235,12 @@ $assert(array('Example Sans') === ($metadataWithFontCssResult['source_reports'][
 $assert(array(array('family' => 'Example Sans', 'weights' => array(600))) === ($metadataResult['source_reports']['figma']['html']['font_usage'] ?? null), 'font-usage-reports-source-family-weights');
 $assert(array(array('family' => 'Example Sans', 'weights' => array(600))) === ($metadataResult['source_reports']['compiled_site']['theme']['font_usage'] ?? null), 'compiled-site-theme-promotes-figma-font-usage');
 $assert(true === ($metadataWithFontCssResult['source_reports']['figma']['html']['font_css_supplied'] ?? null), 'font-css-supplied-report');
+$metadataTransformDiagnostics = $metadataResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$metadataWithFontCssTransformDiagnostics = $metadataWithFontCssResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$assert(array('Example Sans') === ($metadataTransformDiagnostics['fonts']['families'] ?? null), 'transform-diagnostics-font-families');
+$assert(false === ($metadataTransformDiagnostics['fonts']['materialized'] ?? null), 'transform-diagnostics-font-not-materialized-without-css');
+$assert(array('Example Sans') === ($metadataTransformDiagnostics['fonts']['missing_css'] ?? null), 'transform-diagnostics-font-missing-css');
+$assert(true === ($metadataWithFontCssTransformDiagnostics['fonts']['materialized'] ?? null), 'transform-diagnostics-font-materialized-with-css');
 $styleDiagnostics = $metadataResult['source_reports']['figma']['html']['node_style_diagnostics'] ?? array();
 $mixedTextStyleDiagnostic = null;
 $frameStyleDiagnostic = null;
@@ -1329,6 +1335,12 @@ $assert(str_contains($assetReferenceHtml, '<path d="M 1 1 L 23 1 L 12 23 Z" fill
 $assert(str_contains($assetReferenceHtml, 'data-figma-unsupported-vector="true"'), 'unsupported-vector-placeholder-html');
 $assert(str_contains($assetReferenceHtml, 'Unsupported Figma VECTOR'), 'unsupported-vector-placeholder-text');
 $assert(in_array('unsupported_vector_node_placeholder', $assetReferenceDiagnosticCodes, true), 'unsupported-vector-diagnostic');
+$assetReferenceTransformDiagnostics = $assetReferenceResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$assert(1 === ($assetReferenceTransformDiagnostics['images']['resolved_assets'] ?? null), 'asset-reference-diagnostics-image-resolved');
+$assert(2 === ($assetReferenceTransformDiagnostics['vectors']['nodes'] ?? null), 'asset-reference-diagnostics-vector-count');
+$assert(1 === ($assetReferenceTransformDiagnostics['vectors']['rendered_paths'] ?? null), 'asset-reference-diagnostics-vector-path-count');
+$assert(1 === ($assetReferenceTransformDiagnostics['vectors']['placeholders'] ?? null), 'asset-reference-diagnostics-vector-placeholder-count');
+$assert('4:3' === ($assetReferenceTransformDiagnostics['vectors']['placeholder_nodes'][0]['node_id'] ?? null), 'asset-reference-diagnostics-vector-placeholder-node');
 
 $pluginAssetResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'   => 'Plugin Asset Fixture',
@@ -1393,6 +1405,16 @@ $assert(str_contains($pluginAssetCss, '.figma-node-plugin-vector-plugin-icon{wid
 $assert(! str_contains($pluginAssetHtml, 'Unsupported Figma VECTOR'), 'plugin-vector-fallback-avoids-unsupported-placeholder');
 $assert(str_contains($pluginAssetHtml, 'data-figma-node-id="plugin:vector"') && ! str_contains($pluginAssetHtml, 'data-figma-unsupported-vector="true"'), 'plugin-vector-fallback-not-marked-unsupported');
 $assert(str_contains($pluginAssetFileContent($pluginAssetFiles, 'assets/plugin-icon.svg'), '<svg xmlns="http://www.w3.org/2000/svg"'), 'plugin-content-base64-vector-asset-file');
+$pluginTransformDiagnostics = $pluginAssetResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$assert('blocks-engine/figma-transformer/transform-diagnostics/v1' === ($pluginTransformDiagnostics['schema'] ?? null), 'plugin-transform-diagnostics-schema');
+$assert(2 === ($pluginTransformDiagnostics['images']['paint_refs'] ?? null), 'plugin-transform-diagnostics-image-paint-refs');
+$assert(1 === ($pluginTransformDiagnostics['images']['resolved_assets'] ?? null), 'plugin-transform-diagnostics-image-resolved-assets');
+$assert(array() === ($pluginTransformDiagnostics['images']['missing_assets'] ?? null), 'plugin-transform-diagnostics-no-missing-image-assets');
+$assert(1 === ($pluginTransformDiagnostics['vectors']['nodes'] ?? null), 'plugin-transform-diagnostics-vector-node-count');
+$assert(1 === ($pluginTransformDiagnostics['vectors']['rendered_asset_fallbacks'] ?? null), 'plugin-transform-diagnostics-vector-asset-fallback');
+$assert(0 === ($pluginTransformDiagnostics['vectors']['placeholders'] ?? null), 'plugin-transform-diagnostics-no-vector-placeholders');
+$assert(in_array('assets/plugin-icon.svg', $pluginTransformDiagnostics['assets']['paths'] ?? array(), true), 'plugin-transform-diagnostics-asset-paths-vector');
+$assert(0 === ($pluginTransformDiagnostics['layout']['large_negative_left_count'] ?? null), 'plugin-transform-diagnostics-layout-no-large-negative-left');
 
 $layoutFidelityResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Layout Fidelity Fixture',


### PR DESCRIPTION
## Summary
- add `source_reports.figma.html.transform_diagnostics` to every Figma transform result
- report image paint refs, resolved/missing asset refs, vector path/fallback/placeholder counts, font materialization gaps, emitted asset paths, layout red flags, and diagnostic code counts
- add contract coverage for font CSS gaps, unsupported vector placeholders, and plugin-provided asset fallbacks

## Diagnostic shape
```json
{
  "schema": "blocks-engine/figma-transformer/transform-diagnostics/v1",
  "images": { "paint_refs": 0, "node_refs": 0, "resolved_assets": 0, "missing_assets": [] },
  "vectors": { "nodes": 0, "rendered_paths": 0, "rendered_asset_fallbacks": 0, "placeholders": 0, "placeholder_nodes": [] },
  "fonts": { "families": [], "count": 0, "css_supplied": false, "materialized": false, "missing_css": [] },
  "assets": { "emitted_files": 0, "paths": [] },
  "layout": { "large_negative_left_count": 0 },
  "diagnostic_codes": {}
}
```

## Testing
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the transform diagnostics report and contract coverage.