### PR TITLE
Release Figma transformer v0.1.2

### DIFF
--- a/figma-transformer/figma-transformer.php
+++ b/figma-transformer/figma-transformer.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blocks Engine Figma Transformer
  * Plugin URI: https://github.com/Automattic/blocks-engine/tree/trunk/figma-transformer
  * Description: PHP primitives for transforming Figma designs into static HTML website artifacts.
- * Version: 0.1.1
+ * Version: 0.1.2
  * Requires PHP: 8.1
  * Author: Automattic
  * License: GPL-3.0-or-later
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 if ( ! defined('BLOCKS_ENGINE_FIGMA_TRANSFORMER_VERSION') ) {
-    define('BLOCKS_ENGINE_FIGMA_TRANSFORMER_VERSION', '0.1.1');
+    define('BLOCKS_ENGINE_FIGMA_TRANSFORMER_VERSION', '0.1.2');
 }
 
 if ( ! defined('BLOCKS_ENGINE_FIGMA_TRANSFORMER_FILE') ) {


### PR DESCRIPTION
## Summary
- bump Blocks Engine Figma Transformer runtime version to `0.1.2`
- prepares a tagable release for the asset/vector fallback and transform diagnostics changes already merged to trunk

## Testing
- `php -l figma-transformer/figma-transformer.php`
- `php figma-transformer/tests/contract/run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Preparing and verifying the Figma transformer release version bump.