### PR TITLE
Ignore materialized script assets in artifact fallbacks

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -161,7 +161,7 @@ final class ArtifactCompiler
             );
         }
 
-        $result = ( new HtmlTransformer() )->transform($this->safeHtmlDocumentImageHtml($html, $sourcePath, $files), array(
+        $result = ( new HtmlTransformer() )->transform($this->safeHtmlDocumentHtml($html, $sourcePath, $files), array(
             'source'       => $sourcePath,
             'source_scope' => $sourceScope,
             'static_css'   => $this->linkedStylesheetCss($html, $sourcePath, $files),
@@ -178,8 +178,9 @@ final class ArtifactCompiler
     /**
      * @param array<int, array<string, mixed>> $files
      */
-    private function safeHtmlDocumentImageHtml(string $html, string $entryPath, array $files): string
+    private function safeHtmlDocumentHtml(string $html, string $entryPath, array $files): string
     {
+        $html = $this->withoutMaterializedScriptTags($html, $entryPath, $files);
         $html = preg_replace_callback('/<img\s+[^>]*src\s*=\s*(["\'])([^"\']+)\1[^>]*>/i', function (array $matches) use ($entryPath, $files): string {
             $asset = $this->findAssetByHtmlReference((string) $matches[2], $entryPath, $files);
             if ( is_array($asset) && 'image/svg+xml' === ($asset['mime_type'] ?? '') && ! $this->isSafeImageAsset($asset) ) {
@@ -190,6 +191,36 @@ final class ArtifactCompiler
         }, $html) ?? $html;
 
         return preg_replace('/<figure\b[^>]*>\s*<\/figure>/i', '', $html) ?? $html;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     */
+    private function withoutMaterializedScriptTags(string $html, string $entryPath, array $files): string
+    {
+        return preg_replace_callback('/<script\b([^>]*)>\s*<\/script>/i', function (array $matches) use ($entryPath, $files): string {
+            $src = $this->htmlAttribute((string) $matches[1], 'src');
+            if ( '' === $src ) {
+                return (string) $matches[0];
+            }
+
+            $asset = $this->findAssetByHtmlReference($src, $entryPath, $files);
+            if ( ! is_array($asset) || ! $this->isMaterializedScriptAsset($asset) ) {
+                return (string) $matches[0];
+            }
+
+            return '';
+        }, $html) ?? $html;
+    }
+
+    /**
+     * @param array<string, mixed> $asset
+     */
+    private function isMaterializedScriptAsset(array $asset): bool
+    {
+        return in_array($asset['kind'] ?? '', array('js', 'mjs'), true)
+            || 'script' === ($asset['role'] ?? '')
+            || in_array($asset['mime_type'] ?? '', array('application/javascript', 'text/javascript', 'application/ecmascript', 'text/ecmascript'), true);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/artifact-local-link-asset-reports.json
+++ b/php-transformer/tests/fixtures/parity/artifact-local-link-asset-reports.json
@@ -87,15 +87,12 @@
     { "path": "source_reports.conversion_report.selector_summary.source_paths", "assert": "count", "count": 2 },
     { "path": "source_reports.conversion_report.asset_refs", "assert": "count", "count": 7 },
     { "path": "source_reports.conversion_report.asset_refs.5.asset_path", "assert": "equals", "value": "assets/site.css" },
+    { "path": "source_reports.compiled_site.theme.scripts.0", "assert": "equals", "value": "assets/app.js" },
+    { "path": "source_reports.materialization_plan.theme.scripts.0", "assert": "equals", "value": "assets/app.js" },
     { "path": "source_reports.conversion_report.navigation_candidates", "assert": "count", "count": 1 },
     { "path": "source_reports.conversion_report.navigation_candidates.0.target_path", "assert": "equals", "value": "pages/about.html" }
   ],
   "expected_fallbacks": [
-    {
-      "diagnostic_code": "html_script_fallback",
-      "tag": "script",
-      "reason": "script_requires_runtime"
-    },
     {
       "diagnostic_code": "html_unsupported_element",
       "tag": "link",

--- a/php-transformer/tests/fixtures/parity/artifact-materialized-script-asset-no-fallback.json
+++ b/php-transformer/tests/fixtures/parity/artifact-materialized-script-asset-no-fallback.json
@@ -1,0 +1,42 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-materialized-script-asset-no-fallback",
+  "description": "Treats bundled external script tags as materialized theme script assets while preserving inline runtime scripts as fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-materialized-script-asset-no-fallback.json",
+    "notes": "Covers raw static-site artifacts that include same-site JavaScript files referenced from entry HTML."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream script asset materialization fixture has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<!doctype html><html><head><title>Script Asset</title></head><body><main><h1>Script Asset</h1><p>Content remains block-convertible.</p></main><script src=\"assets/site.js\" defer></script><script>window.inlineRuntime = true;</script></body></html>"
+        },
+        {
+          "path": "assets/site.js",
+          "kind": "js",
+          "content": "document.documentElement.classList.add('ready');"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_script_fallback" },
+    { "path": "fallbacks.0.body", "assert": "equals", "value": "window.inlineRuntime = true;" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Content remains block-convertible." },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "assets/site.js" },
+    { "path": "source_reports.compiled_site.theme.scripts.0", "assert": "equals", "value": "assets/site.js" },
+    { "path": "source_reports.materialization_plan.theme.scripts.0", "assert": "equals", "value": "assets/site.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Do not count same-artifact external JS files as HTML script fallbacks during artifact compilation.
- Keep inline, remote, missing, and non-script assets on the existing fallback path.
- Add parity coverage for materialized script assets.

## Evidence
Raw SSI corpus profile improved from 25 fallbacks / 26 diagnostics to 9 fallbacks / 10 diagnostics, with success fixtures improving from 1 to 14.

## Testing
- php tests/parity/run.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode and subagent
- **Used for:** Corpus metrics triage, implementation, fixture coverage, and verification.