### PR TITLE
Preserve linked CSS layout wrapper styles

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1062,7 +1062,7 @@ final class HtmlTransformer
             $this->attr($element, 'role'),
         ))));
 
-        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|card|tile|panel|pricing|price|product)(?:[^a-z0-9]|$)/', $tokens) ) {
+        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|card|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap)(?:[^a-z0-9]|$)/', $tokens) ) {
             return true;
         }
 
@@ -1133,10 +1133,17 @@ final class HtmlTransformer
             'border-width',
             'box-shadow',
             'color',
+            'align-items',
+            'column-gap',
             'display',
+            'flex-direction',
+            'flex-wrap',
             'font-size',
             'font-weight',
             'gap',
+            'grid-template-columns',
+            'grid-template-rows',
+            'justify-content',
             'line-height',
             'margin',
             'margin-bottom',
@@ -1148,6 +1155,7 @@ final class HtmlTransformer
             'padding-left',
             'padding-right',
             'padding-top',
+            'row-gap',
             'text-align',
             'text-decoration',
             'text-transform',

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
@@ -1,0 +1,39 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-linked-css-layout-wrapper-style-signals",
+  "description": "Applies safe visual declarations from linked class CSS to generic grid and flex layout wrappers.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json",
+    "notes": "Covers layout wrapper class CSS used by generated static HTML fixtures, such as grid columns and flexible card rows."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream CSS layout signal fixture has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<!doctype html><html><head><title>Layout wrappers</title><link rel=\"stylesheet\" href=\"assets/site.css\"></head><body><main><section class=\"hero-grid\"><div><h1>Plan the work</h1><p>Keep the lead and aside aligned.</p></div><aside><p>Side note</p></aside></section><section class=\"shift-card\"><span>1</span><div><h2>First shift</h2><p>Flexible card row.</p></div></section></main></body></html>"
+        },
+        {
+          "path": "assets/site.css",
+          "kind": "css",
+          "content": ".hero-grid{display:grid;grid-template-columns:1fr 420px;gap:clamp(24px,4vw,64px);align-items:center}.shift-card{display:grid;grid-template-columns:auto 1fr;gap:16px;align-items:start}"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "hero-grid" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "display:grid;grid-template-columns:1fr 420px;gap:clamp(24px,4vw,64px);align-items:center" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "shift-card" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "display:grid;grid-template-columns:auto 1fr;gap:16px;align-items:start" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve safe linked CSS layout declarations for generic layout wrappers.
- Covers grid/flex wrappers such as hero grids, card grids, rows, stacks, clusters, and columns.
- Add parity fixture coverage for linked CSS-driven layout wrapper styles.

## Testing
- composer parity
- git diff --check origin/trunk...HEAD

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode and subagent
- **Used for:** Visual parity triage, implementation, fixture coverage, and verification.