### PR TITLE
Add Figma transformer artifact output directory

### DIFF
--- a/figma-transformer/bin/figma-transformer
+++ b/figma-transformer/bin/figma-transformer
@@ -12,12 +12,13 @@ if ( is_readable($autoload) ) {
 
 $path = $argv[1] ?? '';
 if ( '' === $path || '--help' === $path || '-h' === $path ) {
-    fwrite(STDERR, "Usage: figma-transformer <path-to-fig-or-scenegraph-json> [--zstd-command=<path>] [--frame-id=<id>] [--font-css=<css>] [--font-css-file=<path>] [--render-text-glyph-paths] [--parity-status=<status>] [--parity-source-screenshot-url=<url>] [--parity-source-screenshot-path=<path>] [--parity-generated-screenshot-artifact=<artifact>] [--parity-diff-image-artifact=<artifact>] [--parity-pixel-mismatch-count=<count>] [--parity-pixel-mismatch-ratio=<ratio>] [--parity-threshold=<ratio>] [--parity-viewport=<width>x<height>]\n");
+    fwrite(STDERR, "Usage: figma-transformer <path-to-fig-or-scenegraph-json> [--output-dir=<dir>] [--zstd-command=<path>] [--frame-id=<id>] [--font-css=<css>] [--font-css-file=<path>] [--render-text-glyph-paths] [--parity-status=<status>] [--parity-source-screenshot-url=<url>] [--parity-source-screenshot-path=<path>] [--parity-generated-screenshot-artifact=<artifact>] [--parity-diff-image-artifact=<artifact>] [--parity-pixel-mismatch-count=<count>] [--parity-pixel-mismatch-ratio=<ratio>] [--parity-threshold=<ratio>] [--parity-viewport=<width>x<height>]\n");
     exit(1);
 }
 
 $options = array();
 $zstdCommand = getenv('FIGMA_TRANSFORMER_ZSTD_COMMAND') ?: null;
+$outputDir = null;
 foreach ( array_slice($argv, 2) as $argument ) {
     if ( ! str_starts_with($argument, '--') ) {
         continue;
@@ -29,6 +30,11 @@ foreach ( array_slice($argv, 2) as $argument ) {
 
     if ( 'zstd-command' === $name ) {
         $zstdCommand = $value;
+        continue;
+    }
+
+    if ( 'output-dir' === $name ) {
+        $outputDir = $value;
         continue;
     }
 
@@ -88,12 +94,25 @@ foreach ( array_slice($argv, 2) as $argument ) {
     }
 }
 
+if ( is_string($outputDir) && '' !== $outputDir ) {
+    $outputDir = rtrim($outputDir, DIRECTORY_SEPARATOR);
+}
+
 $transformer = blocks_engine_figma_transformer_cli_transformer(is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null);
 if ( str_ends_with(strtolower($path), '.json') ) {
     $decoded = json_decode((string) file_get_contents($path), true);
     $result = $transformer->transformScenegraph(is_array($decoded) ? $decoded : array(), $options)->toArray();
 } else {
     $result = $transformer->transformFile($path, $options)->toArray();
+}
+
+if ( is_string($outputDir) && '' !== $outputDir ) {
+    $writeResult = blocks_engine_figma_transformer_cli_write_output_dir($result, $outputDir);
+    if ( ! empty($writeResult['diagnostics']) ) {
+        $result['diagnostics'] = array_merge($result['diagnostics'] ?? array(), $writeResult['diagnostics']);
+    }
+    $result['files'] = blocks_engine_figma_transformer_cli_file_manifest($result['files'] ?? array());
+    $result['output'] = $writeResult['output'];
 }
 
 fwrite(STDOUT, blocks_engine_figma_transformer_cli_json_encode($result) . "\n");
@@ -128,6 +147,111 @@ function blocks_engine_figma_transformer_cli_transformer(?string $zstdCommand): 
         new Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader(
             new Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiParser($zstd)
         )
+    );
+}
+
+/**
+ * @param array<string, mixed> $result
+ * @return array{output: array<string, mixed>, diagnostics: array<int, array<string, mixed>>}
+ */
+function blocks_engine_figma_transformer_cli_write_output_dir(array $result, string $outputDir): array
+{
+    $diagnostics = array();
+    $written = array();
+
+    if ( ! is_dir($outputDir) && ! mkdir($outputDir, 0777, true) && ! is_dir($outputDir) ) {
+        return array(
+            'output' => array(
+                'directory' => $outputDir,
+                'files'     => array(),
+            ),
+            'diagnostics' => array(blocks_engine_figma_transformer_cli_diagnostic('figma_transformer_cli_output_dir_create_failed', 'Output directory could not be created.', array('directory' => $outputDir))),
+        );
+    }
+
+    foreach ( $result['files'] ?? array() as $file ) {
+        if ( ! is_array($file) ) {
+            continue;
+        }
+
+        $path = isset($file['path']) && is_scalar($file['path']) ? (string) $file['path'] : '';
+        if ( '' === $path || ! blocks_engine_figma_transformer_cli_safe_output_path($path) ) {
+            $diagnostics[] = blocks_engine_figma_transformer_cli_diagnostic('figma_transformer_cli_output_path_unsafe', 'Generated artifact file path is not safe to write.', array('path' => $path));
+            continue;
+        }
+
+        $target = $outputDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $path);
+        $targetDir = dirname($target);
+        if ( ! is_dir($targetDir) && ! mkdir($targetDir, 0777, true) && ! is_dir($targetDir) ) {
+            $diagnostics[] = blocks_engine_figma_transformer_cli_diagnostic('figma_transformer_cli_output_file_dir_create_failed', 'Generated artifact file directory could not be created.', array('path' => $path, 'directory' => $targetDir));
+            continue;
+        }
+
+        $content = isset($file['content']) && is_scalar($file['content']) ? (string) $file['content'] : '';
+        if ( false === file_put_contents($target, $content) ) {
+            $diagnostics[] = blocks_engine_figma_transformer_cli_diagnostic('figma_transformer_cli_output_file_write_failed', 'Generated artifact file could not be written.', array('path' => $path, 'target' => $target));
+            continue;
+        }
+
+        $written[] = $path;
+    }
+
+    return array(
+        'output' => array(
+            'directory' => $outputDir,
+            'files'     => $written,
+        ),
+        'diagnostics' => $diagnostics,
+    );
+}
+
+/**
+ * @param mixed $files
+ * @return array<int, array<string, mixed>>
+ */
+function blocks_engine_figma_transformer_cli_file_manifest(mixed $files): array
+{
+    $manifest = array();
+
+    foreach ( is_array($files) ? $files : array() as $file ) {
+        if ( ! is_array($file) ) {
+            continue;
+        }
+
+        unset($file['content']);
+        $manifest[] = $file;
+    }
+
+    return $manifest;
+}
+
+function blocks_engine_figma_transformer_cli_safe_output_path(string $path): bool
+{
+    if ( '' === $path || str_starts_with($path, '/') || str_starts_with($path, '\\') || str_contains($path, "\0") ) {
+        return false;
+    }
+
+    foreach ( explode('/', str_replace('\\', '/', $path)) as $part ) {
+        if ( '' === $part || '.' === $part || '..' === $part ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @param array<string, mixed> $context
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_transformer_cli_diagnostic(string $code, string $message, array $context = array()): array
+{
+    return array(
+        'severity' => 'warning',
+        'code'     => $code,
+        'message'  => $message,
+        'source'   => 'figma-transformer-cli',
+        'context'  => $context,
     );
 }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -160,6 +160,46 @@ $assert(str_contains($css, '.figma-node-1-1-hero-section{width:1200px;height:600
 $assert(str_contains($css, '.figma-node-1-2-hero-title{font-size:48px;font-weight:700;color:#1a334d;flex-shrink:0}'), 'css-text-style');
 $assert(str_contains($css, '.figma-node-1-4-hero-image-rectangle{width:320px;height:180px;position:absolute;left:10px;top:20px;background:#ff0000;background-image:url("assets/hero-image.svg")'), 'css-rectangle-asset-style');
 $assert(str_contains($css, '.figma-node-1-5-nested-image-paint{') && str_contains($css, 'background-image:url("assets/fixture-photo.jpg")'), 'css-nested-image-hash-asset-style');
+$assert('fixture image bytes' === $fileContent($result, 'assets/fixture-photo.jpg'), 'asset-content-preserved');
+
+$cliOutputRoot = sys_get_temp_dir() . '/figma-transformer-cli-output-' . getmypid() . '-' . bin2hex(random_bytes(4));
+$cliScenegraphPath = $cliOutputRoot . '/scenegraph.json';
+$cliScenegraph = array(
+    'name'   => 'CLI Output Fixture',
+    'assets' => array(
+        'cli-image' => array(
+            'name'      => 'CLI Image',
+            'mime_type' => 'image/svg+xml',
+            'content'   => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"></svg>',
+        ),
+    ),
+    'nodes'  => array(
+        array(
+            'id'       => 'cli:1',
+            'type'     => 'RECTANGLE',
+            'name'     => 'CLI Card',
+            'width'    => 40,
+            'height'   => 20,
+            'asset_id' => 'cli-image',
+        ),
+    ),
+);
+mkdir($cliOutputRoot, 0777, true);
+file_put_contents($cliScenegraphPath, json_encode($cliScenegraph, JSON_UNESCAPED_SLASHES));
+$cliCommand = escapeshellarg(PHP_BINARY)
+    . ' ' . escapeshellarg(__DIR__ . '/../../bin/figma-transformer')
+    . ' ' . escapeshellarg($cliScenegraphPath)
+    . ' --output-dir=' . escapeshellarg($cliOutputRoot . '/artifact');
+$cliJson = shell_exec($cliCommand);
+$cliResult = is_string($cliJson) ? json_decode($cliJson, true) : null;
+$assert(is_array($cliResult), 'cli-output-dir-json-result');
+$assert('success' === ($cliResult['status'] ?? null), 'cli-output-dir-transform-success');
+$assert($cliOutputRoot . '/artifact' === ($cliResult['output']['directory'] ?? null), 'cli-output-dir-report-directory');
+$assert(! isset($cliResult['files'][0]['content']), 'cli-output-dir-omits-file-content-from-json');
+$assert(is_file($cliOutputRoot . '/artifact/index.html'), 'cli-output-dir-writes-index');
+$assert(is_file($cliOutputRoot . '/artifact/style.css'), 'cli-output-dir-writes-style');
+$assert('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"></svg>' === file_get_contents($cliOutputRoot . '/artifact/assets/cli-image.svg'), 'cli-output-dir-preserves-asset-content');
+$assert(str_contains((string) file_get_contents($cliOutputRoot . '/artifact/style.css'), 'background-image:url("assets/cli-image.svg")'), 'cli-output-dir-preserves-asset-reference');
 $assert(str_contains($html, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 11 11"'), 'html-vector-blob-svg');
 $assert(str_contains($html, 'd="M 0 0 L 10 0 L 10 10 Z"'), 'html-vector-blob-path');
 $assert(! str_contains($css, 'order:'), 'css-avoids-source-order');


### PR DESCRIPTION
## Summary
- Add a `--output-dir` option to the Figma transformer CLI so generated HTML, CSS, and asset files are written directly to disk.
- Return a manifest-only JSON result when `--output-dir` is used, avoiding large/binary `files[].content` payloads on stdout.
- Cover the CLI path with a contract test that verifies emitted files and asset references.

## Verification
- `composer test` from `figma-transformer/`
- Ran `/Users/chubes/Downloads/Fisiostetic.fig` through the new CLI output path with zstd and font CSS; output had 22 assets, 0 missing local CSS refs, and Google Fonts present.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Figma artifact extraction failure, implementing the CLI output-dir path, adding contract coverage, and running verification.