### PR TITLE
Respect linked CSS flex layout for card groups

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1098,7 +1098,7 @@ final class HtmlTransformer
         return array_filter(array(
             'className' => $this->promotedClassName($this->attr($element, 'class')),
             'style'     => $style,
-            'layout'    => $this->layoutAttribute($element),
+            'layout'    => $this->layoutAttribute($element, $style),
         ), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
     }
 
@@ -1137,7 +1137,7 @@ final class HtmlTransformer
             $this->attr($element, 'role'),
         ))));
 
-        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|card|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap)(?:[^a-z0-9]|$)/', $tokens) ) {
+        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|cards?|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap)(?:[^a-z0-9]|$)/', $tokens) ) {
             return true;
         }
 
@@ -1403,7 +1403,7 @@ final class HtmlTransformer
     /**
      * @return array<string, string>
      */
-    private function layoutAttribute(DOMElement $element): array
+    private function layoutAttribute(DOMElement $element, string $mergedStyle = ''): array
     {
         $declared = trim($this->attr($element, 'data-layout'));
         if ( '' === $declared ) {
@@ -1418,7 +1418,7 @@ final class HtmlTransformer
             }
         }
 
-        $style = strtolower($this->attr($element, 'style'));
+        $style = strtolower('' !== trim($mergedStyle) ? $mergedStyle : $this->attr($element, 'style'));
         if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $style) ) {
             return array( 'type' => 'flex' );
         }

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
@@ -18,12 +18,12 @@
         {
           "path": "index.html",
           "kind": "html",
-          "content": "<!doctype html><html><head><title>Layout wrappers</title><link rel=\"stylesheet\" href=\"assets/site.css\"></head><body><main><section class=\"hero-grid\"><div><h1>Plan the work</h1><p>Keep the lead and aside aligned.</p></div><aside><p>Side note</p></aside></section><section class=\"shift-card\"><span>1</span><div><h2>First shift</h2><p>Flexible card row.</p></div></section></main></body></html>"
+          "content": "<!doctype html><html><head><title>Layout wrappers</title><link rel=\"stylesheet\" href=\"assets/site.css\"></head><body><main><section class=\"hero-grid\"><div><h1>Plan the work</h1><p>Keep the lead and aside aligned.</p></div><aside><p>Side note</p></aside></section><section class=\"shift-card\"><span>1</span><div><h2>First shift</h2><p>Flexible card row.</p></div></section><section class=\"services-cards\"><article><h2>One</h2><p>First service.</p></article><article><h2>Two</h2><p>Second service.</p></article><article><h2>Three</h2><p>Third service.</p></article></section></main></body></html>"
         },
         {
           "path": "assets/site.css",
           "kind": "css",
-          "content": ".hero-grid{display:grid;grid-template-columns:1fr 420px;gap:clamp(24px,4vw,64px);align-items:center}.shift-card{display:grid;grid-template-columns:auto 1fr;gap:16px;align-items:start}"
+          "content": ".hero-grid{display:grid;grid-template-columns:1fr 420px;gap:clamp(24px,4vw,64px);align-items:center}.shift-card{display:grid;grid-template-columns:auto 1fr;gap:16px;align-items:start}.services-cards{display:flex;gap:24px;align-items:stretch}"
         }
       ]
     }
@@ -34,6 +34,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "display:grid;grid-template-columns:1fr 420px;gap:clamp(24px,4vw,64px);align-items:center" },
     { "path": "serialized_blocks", "assert": "contains", "value": "shift-card" },
     { "path": "serialized_blocks", "assert": "contains", "value": "display:grid;grid-template-columns:auto 1fr;gap:16px;align-items:start" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"services-cards\",\"style\":\"display:flex;gap:24px;align-items:stretch\",\"layout\":{\"type\":\"flex\"}} -->" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]
 }


### PR DESCRIPTION
## Summary
- Use merged source presentation CSS when inferring WordPress group layout attributes.
- Treat plural card wrapper classes as high-value styled elements so linked CSS can override broad class-name grid heuristics.
- Add parity fixture coverage for a `services-cards` wrapper whose linked CSS declares `display:flex`.

## Root cause
Figma/static HTML can use class names like `*-cards` for flex rows. The PHP transformer previously inferred WordPress `layout.type=grid` from the class name before considering linked stylesheet declarations, which can make imported WordPress blocks collapse/overlap even when source CSS uses flex.

## Testing
- `php tests/parity/run.php`
- `php tests/contract/run.php`
- Verified the Fisiostetic fixture's affected `servicr-cards` wrappers serialize with source flex styles instead of WordPress grid layout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, patch drafting, regression fixture, and local verification.