### PR TITLE
Add raw HTML semantic parity navigation report

### DIFF
--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -28,6 +28,7 @@ final class ConversionReportProjection
             'fallback_diagnostics'  => self::fallbackDiagnostics($fallbacks),
             'asset_refs'            => self::assetReferences($blocks, $sourceReports),
             'navigation_candidates' => self::navigationCandidates($blocks, $sourceReports),
+            'semantic_parity'       => self::semanticParity($sourceReports),
             'interaction_candidates' => self::interactionCandidates($sourceReports),
             'presentation_gaps'     => self::presentationGaps($sourceReports),
             'metrics'               => $metrics,
@@ -270,6 +271,16 @@ final class ConversionReportProjection
         }
 
         return self::dedupeRows(array_values(array_filter($candidates, static fn (mixed $candidate): bool => is_array($candidate))));
+    }
+
+    /**
+     * @param array<string, mixed> $sourceReports
+     * @return array<string, mixed>
+     */
+    private static function semanticParity(array $sourceReports): array
+    {
+        $report = $sourceReports['semantic_parity'] ?? array();
+        return is_array($report) ? $report : array();
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -165,6 +165,7 @@ final class HtmlTransformer
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
+        $semanticParityReport = $this->semanticParityReport($body, $blocks, $sourceProvenance);
         $diagnostics = array(
             array(
                 'code'    => 'html_to_blocks_core_slice',
@@ -213,10 +214,25 @@ final class HtmlTransformer
             );
         }
 
+        foreach ( $semanticParityReport['findings'] ?? array() as $finding ) {
+            if ( ! is_array($finding) ) {
+                continue;
+            }
+
+            $diagnostics[] = array(
+                'code'     => 'html_semantic_parity_' . (string) ($finding['code'] ?? 'warning'),
+                'message'  => (string) ($finding['summary'] ?? 'Generated blocks differ from source semantic structure.'),
+                'source'   => self::class,
+                'severity' => $finding['severity'] ?? 'warning',
+                'selector' => $finding['selector'] ?? null,
+            );
+        }
+
         $metrics = $this->metrics($html, $blocks, $serializedBlocks, $fallbacks, $diagnostics, $startedAt);
         $sourceReports = array(
             'interaction_candidates' => $interactionCandidates,
             'wp_block_validity' => $blockValidityReport,
+            'semantic_parity' => $semanticParityReport,
             'html' => array(
                 'presentation_signals' => $this->presentationProvenance,
                 'source_provenance'    => $sourceProvenance,
@@ -290,6 +306,345 @@ final class HtmlTransformer
     {
         $seen = array();
         return $this->deduplicateNavigationBlocksRecursive($blocks, $seen);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     * @return array<string, mixed>
+     */
+    private function semanticParityReport(DOMElement $body, array $blocks, array $sourceProvenance): array
+    {
+        $sourceLandmarks = $this->sourceLandmarkReport($body);
+        $blockLandmarks = $this->blockLandmarkReport($blocks, $sourceProvenance, $sourceLandmarks);
+        $sourceMenus = $this->sourceNavigationMenus($body);
+        $blockMenus = $this->blockNavigationMenus($blocks);
+        $findings = $this->semanticParityFindings($sourceLandmarks, $blockLandmarks, $sourceMenus, $blockMenus);
+
+        return array(
+            'schema' => 'blocks-engine/php-transformer/semantic-parity/v1',
+            'status' => array() === $findings ? 'pass' : 'warning',
+            'landmarks' => array(
+                'source' => $sourceLandmarks['counts'],
+                'blocks' => $blockLandmarks['counts'],
+            ),
+            'navigation_menus' => array(
+                'source' => $sourceMenus,
+                'blocks' => $blockMenus,
+            ),
+            'findings' => $findings,
+        );
+    }
+
+    /**
+     * @return array{counts: array<string, int>, selectors: array<string, array<int, string>>}
+     */
+    private function sourceLandmarkReport(DOMElement $body): array
+    {
+        $counts = array('header' => 0, 'nav' => 0, 'main' => 0, 'footer' => 0);
+        $selectors = array('header' => array(), 'nav' => array(), 'main' => array(), 'footer' => array());
+        $this->collectSourceLandmarks($body, $counts, $selectors);
+
+        return array('counts' => $counts, 'selectors' => $selectors);
+    }
+
+    /**
+     * @param array<string, int> $counts
+     * @param array<string, array<int, string>> $selectors
+     */
+    private function collectSourceLandmarks(DOMElement $element, array &$counts, array &$selectors): void
+    {
+        $landmark = $this->landmarkKindForElement($element);
+        if ( '' !== $landmark ) {
+            ++$counts[$landmark];
+            $selectors[$landmark][] = $this->elementSelector($element);
+        }
+
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                $this->collectSourceLandmarks($child, $counts, $selectors);
+            }
+        }
+    }
+
+    private function landmarkKindForElement(DOMElement $element): string
+    {
+        $tagName = strtolower($element->tagName);
+        if ( in_array($tagName, array( 'header', 'nav', 'main', 'footer' ), true) ) {
+            return 'nav' === $tagName ? 'nav' : $tagName;
+        }
+
+        return match ( strtolower($this->attr($element, 'role')) ) {
+            'banner' => 'header',
+            'navigation' => 'nav',
+            'main' => 'main',
+            'contentinfo' => 'footer',
+            default => '',
+        };
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     * @param array{counts: array<string, int>, selectors: array<string, array<int, string>>} $sourceLandmarks
+     * @return array{counts: array<string, int>, selectors: array<string, array<int, string>>}
+     */
+    private function blockLandmarkReport(array $blocks, array $sourceProvenance, array $sourceLandmarks): array
+    {
+        $counts = array('header' => 0, 'nav' => 0, 'main' => 0, 'footer' => 0);
+        $selectors = array('header' => array(), 'nav' => array(), 'main' => array(), 'footer' => array());
+        $this->collectBlockNavigationLandmarks($blocks, $counts);
+
+        foreach ( array( 'header', 'main', 'footer' ) as $kind ) {
+            foreach ( $sourceLandmarks['selectors'][$kind] ?? array() as $sourceSelector ) {
+                if ( $this->sourceSelectorHasBlockRepresentation((string) $sourceSelector, $sourceProvenance) ) {
+                    $selectors[$kind][] = (string) $sourceSelector;
+                }
+            }
+            $counts[$kind] = count($selectors[$kind]);
+        }
+
+        return array('counts' => $counts, 'selectors' => $selectors);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     */
+    private function sourceSelectorHasBlockRepresentation(string $sourceSelector, array $sourceProvenance): bool
+    {
+        if ( '' === $sourceSelector ) {
+            return false;
+        }
+
+        foreach ( $sourceProvenance as $entry ) {
+            if ( ! is_array($entry) ) {
+                continue;
+            }
+
+            $blockSelector = (string) ($entry['selector'] ?? '');
+            if ( $sourceSelector === $blockSelector || str_starts_with($blockSelector, $sourceSelector . ' > ') ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<string, int> $counts
+     */
+    private function collectBlockNavigationLandmarks(array $blocks, array &$counts): void
+    {
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            if ( 'core/navigation' === ($block['blockName'] ?? '') ) {
+                ++$counts['nav'];
+            }
+
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $this->collectBlockNavigationLandmarks($block['innerBlocks'], $counts);
+            }
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function sourceNavigationMenus(DOMElement $body): array
+    {
+        $menus = array();
+        $this->collectSourceNavigationMenus($body, $menus);
+        return $menus;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $menus
+     */
+    private function collectSourceNavigationMenus(DOMElement $element, array &$menus): void
+    {
+        if ( 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->attr($element, 'role')) ) {
+            $items = array();
+            foreach ( $element->getElementsByTagName('a') as $anchor ) {
+                if ( $anchor instanceof DOMElement ) {
+                    $label = $this->normalizedNavigationLabel($anchor->textContent ?? '');
+                    if ( '' !== $label ) {
+                        $items[] = array(
+                            'label' => $label,
+                            'url' => $this->safeNavigationUrl($this->attr($anchor, 'href')),
+                        );
+                    }
+                }
+            }
+
+            $menus[] = array(
+                'selector' => $this->elementSelector($element),
+                'item_count' => count($items),
+                'items' => $items,
+            );
+        }
+
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                $this->collectSourceNavigationMenus($child, $menus);
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<int, array<string, mixed>>
+     */
+    private function blockNavigationMenus(array $blocks): array
+    {
+        $menus = array();
+        $this->collectBlockNavigationMenus($blocks, 'blocks', $menus);
+        return $menus;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $menus
+     */
+    private function collectBlockNavigationMenus(array $blocks, string $path, array &$menus): void
+    {
+        foreach ( $blocks as $index => $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            $blockPath = $path . '.' . $index;
+            if ( 'core/navigation' === ($block['blockName'] ?? '') ) {
+                $items = array();
+                $this->collectBlockNavigationItems(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array(), $items);
+                $menus[] = array(
+                    'block_path' => $blockPath,
+                    'represented_as_core_navigation' => true,
+                    'item_count' => count($items),
+                    'items' => $items,
+                );
+            }
+
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $this->collectBlockNavigationMenus($block['innerBlocks'], $blockPath . '.innerBlocks', $menus);
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, string>> $items
+     */
+    private function collectBlockNavigationItems(array $blocks, array &$items): void
+    {
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            if ( in_array($block['blockName'] ?? '', array( 'core/navigation-link', 'core/navigation-submenu' ), true) ) {
+                $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+                $items[] = array(
+                    'label' => $this->normalizedNavigationLabel((string) ($attrs['label'] ?? '')),
+                    'url' => (string) ($attrs['url'] ?? ''),
+                );
+            }
+
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $this->collectBlockNavigationItems($block['innerBlocks'], $items);
+            }
+        }
+    }
+
+    private function normalizedNavigationLabel(string $label): string
+    {
+        return trim(preg_replace('/\s+/', ' ', html_entity_decode($this->runtime->stripAllTags($label), ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? $label);
+    }
+
+    /**
+     * @param array{counts: array<string, int>, selectors: array<string, array<int, string>>} $sourceLandmarks
+     * @param array{counts: array<string, int>, selectors: array<string, array<int, string>>} $blockLandmarks
+     * @param array<int, array<string, mixed>> $sourceMenus
+     * @param array<int, array<string, mixed>> $blockMenus
+     * @return array<int, array<string, mixed>>
+     */
+    private function semanticParityFindings(array $sourceLandmarks, array $blockLandmarks, array $sourceMenus, array $blockMenus): array
+    {
+        $findings = array();
+        foreach ( array( 'header', 'nav', 'main', 'footer' ) as $kind ) {
+            $sourceCount = (int) ($sourceLandmarks['counts'][$kind] ?? 0);
+            $blockCount = (int) ($blockLandmarks['counts'][$kind] ?? 0);
+            if ( $sourceCount > $blockCount ) {
+                $findings[] = array_filter(array(
+                    'code' => 'landmark_count_mismatch',
+                    'severity' => 'warning',
+                    'kind' => $kind,
+                    'source_count' => $sourceCount,
+                    'block_count' => $blockCount,
+                    'selector' => $sourceLandmarks['selectors'][$kind][0] ?? '',
+                    'summary' => 'Source ' . $kind . ' landmarks exceed generated core block representation.',
+                ), static fn (mixed $value): bool => '' !== $value);
+            }
+        }
+
+        foreach ( $sourceMenus as $index => $sourceMenu ) {
+            $blockMenu = $blockMenus[$index] ?? null;
+            if ( ! is_array($blockMenu) ) {
+                $findings[] = array(
+                    'code' => 'navigation_menu_missing',
+                    'severity' => 'warning',
+                    'selector' => $sourceMenu['selector'] ?? '',
+                    'source_item_count' => $sourceMenu['item_count'] ?? 0,
+                    'block_item_count' => 0,
+                    'summary' => 'Source navigation menu was not represented as a core/navigation block.',
+                );
+                continue;
+            }
+
+            if ( true !== ($blockMenu['represented_as_core_navigation'] ?? false) ) {
+                $findings[] = array(
+                    'code' => 'navigation_core_block_missing',
+                    'severity' => 'warning',
+                    'selector' => $sourceMenu['selector'] ?? '',
+                    'summary' => 'Generated navigation menu is not represented by core/navigation.',
+                );
+            }
+
+            $sourceItems = is_array($sourceMenu['items'] ?? null) ? array_values($sourceMenu['items']) : array();
+            $blockItems = is_array($blockMenu['items'] ?? null) ? array_values($blockMenu['items']) : array();
+            if ( count($sourceItems) !== count($blockItems) ) {
+                $findings[] = array(
+                    'code' => 'navigation_item_count_mismatch',
+                    'severity' => 'warning',
+                    'selector' => $sourceMenu['selector'] ?? '',
+                    'source_item_count' => count($sourceItems),
+                    'block_item_count' => count($blockItems),
+                    'summary' => 'Source navigation item count differs from generated core navigation items.',
+                );
+                continue;
+            }
+
+            foreach ( $sourceItems as $itemIndex => $sourceItem ) {
+                $blockItem = $blockItems[$itemIndex] ?? array();
+                if ( ($sourceItem['label'] ?? '') !== ($blockItem['label'] ?? '') || ($sourceItem['url'] ?? '') !== ($blockItem['url'] ?? '') ) {
+                    $findings[] = array(
+                        'code' => 'navigation_item_mismatch',
+                        'severity' => 'warning',
+                        'selector' => $sourceMenu['selector'] ?? '',
+                        'item_index' => $itemIndex,
+                        'source_item' => $sourceItem,
+                        'block_item' => $blockItem,
+                        'summary' => 'Source navigation item label or URL differs from generated core navigation item.',
+                    );
+                    break;
+                }
+            }
+        }
+
+        return $findings;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -336,6 +336,37 @@ $assert(array() === ($asideContainer['fallbacks'] ?? array()), 'semantic aside c
 $assert(str_contains($asideSerialized, 'sidebar'), 'semantic aside container preserves CSS-addressable sidebar class');
 $assert(str_contains($asideSerialized, '<!-- wp:navigation'), 'semantic aside container preserves nested navigation patterns');
 
+$nonprofitNavigation = ( new HtmlTransformer() )->transform(
+    '<header><nav aria-label="Main navigation"><ul><li><a href="/">Home</a></li><li><a href="/the-measure/">The Measure</a></li><li><a href="/supporters/">Supporters</a></li><li><a href="/volunteer/">Volunteer</a></li><li><a href="/donate/">Donate</a></li><li><a href="/faq/">FAQ</a></li><li><a href="/vote-yes/">Vote YES</a></li></ul></nav></header><main><h1>Campaign</h1></main><footer>Paid for by neighbors.</footer>',
+    array(
+        'strict'          => true,
+        'allow_fallbacks' => false,
+    )
+)->toArray();
+$nonprofitSemanticParity = $nonprofitNavigation['source_reports']['semantic_parity'] ?? array();
+$nonprofitConversionSemanticParity = $nonprofitNavigation['source_reports']['conversion_report']['semantic_parity'] ?? array();
+$nonprofitBlockMenu = $nonprofitSemanticParity['navigation_menus']['blocks'][0] ?? array();
+$assert('success' === ($nonprofitNavigation['status'] ?? ''), 'nonprofit-style navigation converts without strict fallback failures', (string) ($nonprofitNavigation['status'] ?? ''));
+$assert('pass' === ($nonprofitSemanticParity['status'] ?? ''), 'semantic parity passes for nonprofit-style source navigation');
+$assert('pass' === ($nonprofitConversionSemanticParity['status'] ?? ''), 'conversion report projects semantic parity status');
+$assert(1 === ($nonprofitSemanticParity['landmarks']['source']['nav'] ?? null), 'semantic parity counts source nav landmarks');
+$assert(1 === ($nonprofitSemanticParity['landmarks']['blocks']['nav'] ?? null), 'semantic parity counts generated core navigation landmarks');
+$assert(7 === ($nonprofitBlockMenu['item_count'] ?? null), 'semantic parity counts generated core navigation menu items');
+$assert(true === ($nonprofitBlockMenu['represented_as_core_navigation'] ?? null), 'semantic parity reports menus represented as core/navigation');
+$assert('The Measure' === ($nonprofitBlockMenu['items'][1]['label'] ?? ''), 'semantic parity preserves navigation item labels');
+$assert('/vote-yes/' === ($nonprofitBlockMenu['items'][6]['url'] ?? ''), 'semantic parity preserves navigation item URLs');
+
+$unmappedNavigation = ( new HtmlTransformer() )->transform(
+    '<main><nav aria-label="Main navigation"><ul><li><a href="/">Home</a></li></ul><p>Unexpected helper copy</p></nav></main>'
+)->toArray();
+$unmappedSemanticParity = $unmappedNavigation['source_reports']['semantic_parity'] ?? array();
+$unmappedFinding = $unmappedSemanticParity['findings'][0] ?? array();
+$assert('warning' === ($unmappedSemanticParity['status'] ?? ''), 'semantic parity warns when source nav is not represented as core navigation');
+$assert('landmark_count_mismatch' === ($unmappedFinding['code'] ?? ''), 'semantic parity reports a precise missing nav landmark finding');
+$assert('nav' === ($unmappedFinding['kind'] ?? ''), 'semantic parity missing landmark finding names the nav kind');
+$assert(1 === ($unmappedFinding['source_count'] ?? null), 'semantic parity missing landmark finding exposes source count');
+$assert(0 === ($unmappedFinding['block_count'] ?? null), 'semantic parity missing landmark finding exposes generated block count');
+
 $assertNoInnerContentChildCountMismatch = static function (array $result, string $message) use ($assert): void {
     $findingCodes = array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $result['source_reports']['wp_block_validity']['findings'] ?? array());
     $assert(! in_array('inner_content_child_count_mismatch', $findingCodes, true), $message, implode(', ', $findingCodes));


### PR DESCRIPTION
## Summary
- Add an HTML semantic parity report for source landmarks and generated block landmarks.
- Report source navigation menus alongside generated core/navigation menus, including item counts, labels, URLs, and core navigation representation.
- Surface semantic parity findings in diagnostics and conversion_report for downstream import diagnostics.
- Add contract coverage for a nonprofit-style seven-item nav pass and a precise missing-core-navigation warning.

## Tests
- php tests/contract/run.php
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the semantic parity report, adding contract tests, and drafting this PR description.