### PR TITLE
Preserve source button controls semantically

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -165,6 +165,22 @@ final class BlockFactory
         }
 
         if ( 'core/button' === $name ) {
+            if ( 'button' === ($attrs['tagName'] ?? '') ) {
+                $buttonAttrs = array_intersect_key($attrs, array_flip(array( 'type', 'role', 'aria-label', 'aria-controls', 'aria-expanded', 'aria-haspopup' )));
+                foreach ( $attrs as $attrName => $attrValue ) {
+                    if ( is_string($attrName) && str_starts_with(strtolower($attrName), 'data-') ) {
+                        $buttonAttrs[$attrName] = (string) $attrValue;
+                    }
+                }
+                $buttonAttrs = array_merge(array(
+                    'id'    => (string) ($attrs['anchor'] ?? ''),
+                    'class' => $this->mergeClassNames('wp-block-button__link wp-element-button', (string) ($attrs['className'] ?? '')),
+                    'style' => (string) ($attrs['style'] ?? ''),
+                ), $buttonAttrs);
+
+                return '<div class="wp-block-button"><button' . $this->htmlAttrs($buttonAttrs) . '>' . ($attrs['text'] ?? '') . '</button></div>';
+            }
+
             $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
             $wrapperClass = $this->mergeClassNames('wp-block-button', in_array('is-style-outline', preg_split('/\s+/', (string) ($attrs['className'] ?? '')) ?: array(), true) ? 'is-style-outline' : '');
             $linkAttrs = array(

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1116,10 +1116,6 @@ final class HtmlTransformer
         }
 
         if ( 'button' === $tagName ) {
-            if ( $this->isNonContentRuntimeControl($element) ) {
-                return $this->createBlock('core/html', array( 'content' => $this->outerHtml($element) ), array(), $element);
-            }
-
             return $this->buttonsPattern->matchButton(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
@@ -1871,17 +1867,6 @@ final class HtmlTransformer
         }
 
         return in_array(strtolower($this->attr($element, 'role')), array( 'presentation', 'none' ), true) || 'true' === strtolower($this->attr($element, 'aria-hidden'));
-    }
-
-    private function isNonContentRuntimeControl(DOMElement $element): bool
-    {
-        if ( '' !== trim($element->textContent ?? '') ) {
-            return false;
-        }
-
-        return '' !== trim($this->attr($element, 'aria-controls'))
-            || '' !== trim($this->attr($element, 'aria-expanded'))
-            || array() !== array_intersect_key($this->safeDataAttributes($element), array_flip(array( 'data-action', 'data-on', 'data-event' )));
     }
 
     private function isInlineContentElement(string $tagName): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -38,7 +38,14 @@ final class ButtonsPattern
     public function matchButton(DOMElement $button, callable $presentationAttributes, callable $innerHtml, callable $createBlock): array
     {
         return $createBlock('core/buttons', array(), array(
-            $createBlock('core/button', array_merge($this->buttonPresentationAttributes($button, $presentationAttributes), array( 'text' => $innerHtml($button) )), array(), $button),
+            $createBlock('core/button', array_merge(
+                $this->buttonPresentationAttributes($button, $presentationAttributes),
+                $this->buttonRuntimeAttributes($button),
+                array(
+                    'tagName' => 'button',
+                    'text'    => $innerHtml($button),
+                )
+            ), array(), $button),
         ), $button);
     }
 
@@ -90,6 +97,27 @@ final class ButtonsPattern
         $attrs = $presentationAttributes($element);
         if ( $this->hasOutlineSignal($element, (string) ($attrs['style'] ?? '')) ) {
             $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' is-style-outline');
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buttonRuntimeAttributes(DOMElement $button): array
+    {
+        $attrs = array();
+        foreach ( array( 'type', 'role', 'aria-label', 'aria-controls', 'aria-expanded', 'aria-haspopup' ) as $name ) {
+            if ( $button->hasAttribute($name) ) {
+                $attrs[$name] = $button->getAttribute($name);
+            }
+        }
+
+        foreach ( $button->attributes ?? array() as $attribute ) {
+            if ( str_starts_with(strtolower($attribute->nodeName), 'data-') ) {
+                $attrs[$attribute->nodeName] = $attribute->nodeValue ?? '';
+            }
         }
 
         return $attrs;

--- a/php-transformer/tests/fixtures/parity/html-address-and-toggle-controls.json
+++ b/php-transformer/tests/fixtures/parity/html-address-and-toggle-controls.json
@@ -13,11 +13,12 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<header><button class=\"hamburger\" aria-label=\"Open navigation menu\" aria-expanded=\"false\" aria-controls=\"site-menu\"><span></span><span></span><span></span></button><nav><ul id=\"site-menu\"><li><a href=\"/about\">About</a></li></ul></nav></header><footer><address class=\"footer-address\">48 Elm Street<br><a href=\"mailto:hello@example.com\">hello@example.com</a></address></footer>"
+    "content": "<header><button id=\"nav-toggle\" class=\"hamburger nav-toggle\" aria-label=\"Open navigation menu\" aria-expanded=\"false\" aria-controls=\"site-menu\" data-action=\"toggle-menu\"><span></span><span></span><span></span></button><nav><ul id=\"site-menu\"><li><a href=\"/about\">About</a></li></ul></nav></header><footer><address class=\"footer-address\">48 Elm Street<br><a href=\"mailto:hello@example.com\">hello@example.com</a></address></footer>"
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/html" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/button", "attrs": { "anchor": "nav-toggle", "className": "hamburger nav-toggle", "tagName": "button", "aria-label": "Open navigation menu", "aria-expanded": "false", "aria-controls": "site-menu", "data-action": "toggle-menu" } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/navigation" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "About", "url": "/about" } },
     { "path": "blocks.1", "name": "core/paragraph", "attrs": { "className": "footer-address", "content": "48 Elm Street<br><a href=\"mailto:hello@example.com\">hello@example.com</a>" } }
@@ -31,8 +32,13 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "footer-address" },
     { "path": "serialized_blocks", "assert": "contains", "value": "hello@example.com" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Open navigation menu" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "id=\"nav-toggle\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button hamburger nav-toggle\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "aria-controls=\"site-menu\"" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:button" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "data-action=\"toggle-menu\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<span></span><span></span><span></span>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp:button" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:html" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-nav-list-signal-classification.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-list-signal-classification.json
@@ -19,7 +19,8 @@
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "nav-inner" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "nav-logo" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/html" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "className": "nav-toggle", "tagName": "button", "aria-label": "Toggle navigation", "aria-expanded": "false", "aria-controls": "nav-links" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "nav-links" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Curriculum", "url": "/curriculum", "kind": "custom" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Pricing", "url": "/pricing", "kind": "custom" } },
@@ -35,9 +36,12 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link" },
     { "path": "serialized_blocks", "assert": "contains", "value": "nav-toggle" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "aria-controls=\"nav-links\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<span></span><span></span><span></span>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:list {\"className\":\"nav-links\"}" },
-    { "path": "source_reports.html.source_provenance.5.block_name", "assert": "equals", "value": "core/navigation-link" },
-    { "path": "source_reports.html.source_provenance.5.selector", "assert": "equals", "value": "header:nth-of-type(1) > nav:nth-of-type(1) > ul:nth-of-type(1) > li:nth-of-type(1) > a:nth-of-type(1)" },
+    { "path": "source_reports.html.source_provenance.6.block_name", "assert": "equals", "value": "core/navigation-link" },
+    { "path": "source_reports.html.source_provenance.6.selector", "assert": "equals", "value": "header:nth-of-type(1) > nav:nth-of-type(1) > ul:nth-of-type(1) > li:nth-of-type(1) > a:nth-of-type(1)" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-nav-menu-flat-list.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-menu-flat-list.json
@@ -19,7 +19,8 @@
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-nav" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "nav-inner" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "nav-logo" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/html" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "className": "hamburger", "tagName": "button", "aria-label": "Open navigation menu", "aria-expanded": "false", "aria-controls": "nav-menu" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "nav-menu" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "index.html", "kind": "custom", "anchorClassName": "nav-link" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.4", "name": "core/navigation-link", "attrs": { "label": "Join Us", "url": "membership.html", "kind": "custom", "anchorClassName": "nav-cta" } }
@@ -32,6 +33,9 @@
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks", "assert": "count", "count": 5 },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:navigation-submenu" },
     { "path": "serialized_blocks", "assert": "contains", "value": "hamburger" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "aria-controls=\"nav-menu\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<span></span><span></span><span></span>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]
 }


### PR DESCRIPTION
## Summary
- Convert source `<button>` controls through `core/buttons` / `core/button` instead of avoidable `core/html` fallback.
- Preserve button id/class/style, nested span bars, selected ARIA attributes, `type`/`role`, and `data-*` runtime hooks on emitted button markup.
- Update nav-toggle/hamburger parity fixtures to assert semantic button output and no html fallback.

## Testing
- `cd php-transformer && composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests for generic Blocks Engine button/nav-toggle parity; Chris reviews and owns the change.