### PR TITLE
Preserve runtime target containers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -677,10 +677,6 @@ final class HtmlTransformer
                 }
             }
 
-            if ( 'core/group' === ($block['blockName'] ?? '') && empty($block['innerBlocks']) && $this->isMobileNavigationWrapperAttrs($block['attrs'] ?? array()) ) {
-                continue;
-            }
-
             $deduplicated[] = $block;
         }
 
@@ -755,24 +751,6 @@ final class HtmlTransformer
                 $this->collectNavigationBlockLinks($innerBlock, $links);
             }
         }
-    }
-
-    /**
-     * @param array<string, mixed> $attrs
-     */
-    private function isMobileNavigationWrapperAttrs(array $attrs): bool
-    {
-        $className = strtolower((string) ($attrs['className'] ?? ''));
-        if ( '' === $className ) {
-            return false;
-        }
-
-        if ( preg_match('/(?:^|[\s_-])(?:mobile|drawer|offcanvas)(?:$|[\s_-])/', $className) ) {
-            return true;
-        }
-
-        return (bool) preg_match('/(?:^|[\s_-])(?:overlay|panel|dialog)(?:$|[\s_-])/', $className)
-            && preg_match('/(?:^|[\s_-])(?:nav|menu|drawer|offcanvas)(?:$|[\s_-])/', $className);
     }
 
     private function normalizeHtml5VoidElements(string $html): string
@@ -1232,14 +1210,16 @@ final class HtmlTransformer
                 return $navigationSection;
             }
 
-            $navigation = $this->navigationPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
-            if ( null !== $navigation ) {
-                return $navigation;
+            if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
+                $navigation = $this->navigationPattern->match(
+                    $element,
+                    fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+                    fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
+                );
+                if ( null !== $navigation ) {
+                    return $navigation;
+                }
             }
 
             $columns = $this->columnsBlockFromElement($element, $fallbacks);
@@ -1854,6 +1834,28 @@ final class HtmlTransformer
     private function shouldPreserveWrapper(DOMElement $element): bool
     {
         return in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) && ( array() !== $this->presentationAttributes($element) || array() !== $this->structureSignals($element, array()) );
+    }
+
+    private function shouldDeferNavigationPatternToChildren(DOMElement $element): bool
+    {
+        if ( 'nav' === strtolower($element->tagName) || ! $this->shouldPreserveWrapper($element) ) {
+            return false;
+        }
+
+        $hasNavigationDescendant = false;
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( in_array(strtolower($child->tagName), array( 'a', 'ul', 'ol' ), true) ) {
+                return false;
+            }
+
+            $hasNavigationDescendant = $hasNavigationDescendant || 'nav' === strtolower($child->tagName) || 0 < $child->getElementsByTagName('a')->length;
+        }
+
+        return $hasNavigationDescendant;
     }
 
     private function shouldPreserveEmptyVisualElement(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -392,7 +392,9 @@ $deduplicatedMobileNavigation = ( new HtmlTransformer() )->transform(
 $assert('pass' === ($deduplicatedMobileNavigation['source_reports']['wp_block_validity']['status'] ?? ''), 'deduplicated desktop/mobile navigation passes WordPress block validity');
 $assertNoInnerContentChildCountMismatch($deduplicatedMobileNavigation, 'deduplicated desktop/mobile navigation does not report innerContent child-count mismatch');
 $assertPlaceholderCountsMatchChildren($deduplicatedMobileNavigation['blocks'] ?? array());
-$assert(1 === count($deduplicatedMobileNavigation['blocks'][0]['innerBlocks'] ?? array()), 'deduplicated desktop/mobile navigation removes duplicate drawer navigation children');
+$assert(2 === count($deduplicatedMobileNavigation['blocks'][0]['innerBlocks'] ?? array()), 'deduplicated desktop/mobile navigation preserves drawer target wrapper');
+$assert(str_contains((string) ($deduplicatedMobileNavigation['serialized_blocks'] ?? ''), 'mobile-nav'), 'deduplicated desktop/mobile navigation preserves mobile navigation target class');
+$assert(! str_contains((string) ($deduplicatedMobileNavigation['serialized_blocks'] ?? ''), 'drawer-nav'), 'deduplicated desktop/mobile navigation removes duplicate drawer navigation children');
 
 $deduplicatedNestedNavigation = ( new HtmlTransformer() )->transform(
     '<main><section class="shell"><div class="desktop-wrap"><nav><a href="/">Home</a><a href="/services">Services</a></nav></div><div class="mobile-nav drawer"><div class="drawer-panel"><nav><a href="/">Home</a><a href="/services">Services</a></nav></div></div><article><h2>Services</h2><p>Copy</p></article></section></main>'
@@ -632,6 +634,27 @@ $assert('index.html' === ($statusDependency['source_path'] ?? ''), 'runtime depe
 $assert(true === ($statusDependency['generated_present'] ?? null), 'runtime dependency parity passes preserved div id target');
 $assert(! empty($statusDependency['events'] ?? array()), 'runtime dependency parity records simple addEventListener usage');
 $assert('info' === ($rumFinding['severity'] ?? ''), 'telemetry-like runtime dependency misses are info severity');
+
+$runtimeTargetContainerSite = $compiler->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><section class="reveal"><h2>Reveal</h2></section><header><nav class="primary-nav"><a href="/">Home</a></nav><div class="mobile-nav-overlay"><div class="mobile-nav"><nav class="drawer-nav"><a href="/">Home</a></nav></div></div></header><div class="faq-item"><h3>Question</h3><p>Answer</p></div><div class="filter-bar"><button class="filter-btn">All</button><div class="filter-chips"><span>Popular</span></div></div><section id="contact-form"><h2>Contact</h2></section><div id="form-success"></div><script src="js/app.js"></script></main>',
+            'js/app.js' => 'document.querySelectorAll(".reveal"); document.querySelector(".mobile-nav-overlay"); document.querySelector(".mobile-nav"); document.querySelector(".faq-item"); document.querySelector(".filter-btn").addEventListener("click", function () {}); document.querySelector(".filter-bar"); document.querySelector(".filter-chips"); document.getElementById("contact-form"); document.getElementById("form-success");',
+        ),
+    )
+)->toArray();
+$runtimeTargetContainerReport = $runtimeTargetContainerSite['source_reports']['runtime_dependency_parity'] ?? array();
+$runtimeTargetDependencies = array();
+foreach ( $runtimeTargetContainerReport['dependencies'] ?? array() as $dependency ) {
+    $runtimeTargetDependencies[$dependency['selector'] ?? ''] = $dependency;
+}
+$assert('pass' === ($runtimeTargetContainerReport['status'] ?? ''), 'runtime dependency parity passes generic preserved JS target containers');
+foreach ( array( '.reveal', '.mobile-nav-overlay', '.mobile-nav', '.faq-item', '.filter-btn', '.filter-bar', '.filter-chips', '#contact-form', '#form-success' ) as $selector ) {
+    $assert(true === ($runtimeTargetDependencies[$selector]['generated_present'] ?? null), 'runtime dependency parity records preserved target ' . $selector);
+}
+$assert(str_contains((string) ($runtimeTargetContainerSite['serialized_blocks'] ?? ''), 'mobile-nav-overlay'), 'artifact block markup preserves mobile nav overlay target class after navigation dedupe');
+$assert(! str_contains((string) ($runtimeTargetContainerSite['serialized_blocks'] ?? ''), 'drawer-nav'), 'artifact block markup still removes duplicate drawer navigation links after preserving target wrapper');
 
 $legacyFrontPageSite = $compiler->compile(
     array(

--- a/php-transformer/tests/fixtures/parity/artifact-runtime-target-container-preservation.json
+++ b/php-transformer/tests/fixtures/parity/artifact-runtime-target-container-preservation.json
@@ -1,0 +1,47 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-runtime-target-container-preservation",
+  "description": "Preserves generic DOM target containers referenced by first-party JavaScript while still converting content to blocks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-runtime-target-container-preservation.json",
+    "notes": "Covers runtime dependency parity for classes and IDs used by common UI scripts without fixture-specific selector preservation."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<main><section class=\"reveal\"><h2>Reveal</h2></section><header><nav class=\"primary-nav\"><a href=\"/\">Home</a></nav><div class=\"mobile-nav-overlay\"><div class=\"mobile-nav\"><nav class=\"drawer-nav\"><a href=\"/\">Home</a></nav></div></div></header><div class=\"faq-item\"><h3>Question</h3><p>Answer</p></div><div class=\"filter-bar\"><button class=\"filter-btn\">All</button><div class=\"filter-chips\"><span>Popular</span></div></div><section id=\"contact-form\"><h2>Contact</h2></section><div id=\"form-success\"></div><script src=\"js/app.js\"></script></main>"
+        },
+        {
+          "path": "js/app.js",
+          "kind": "js",
+          "content": "document.querySelectorAll('.reveal'); document.querySelector('.mobile-nav-overlay'); document.querySelector('.mobile-nav'); document.querySelector('.faq-item'); document.querySelector('.filter-btn').addEventListener('click', function () {}); document.querySelector('.filter-bar'); document.querySelector('.filter-chips'); document.getElementById('contact-form'); document.getElementById('form-success');"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" },
+    { "path": "source_reports.runtime_dependency_parity.dependencies", "assert": "count", "count": 9 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "reveal" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "mobile-nav-overlay" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "mobile-nav" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "faq-item" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "filter-btn" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "filter-bar" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "filter-chips" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "contact-form" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "form-success" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "drawer-nav" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-mobile-drawer-nav-dedup.json
+++ b/php-transformer/tests/fixtures/parity/html-mobile-drawer-nav-dedup.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-mobile-drawer-nav-dedup",
-  "description": "Deduplicates mobile drawer navigation that repeats the primary navigation so drawer wrappers are not emitted as extra visible body content.",
+  "description": "Deduplicates mobile drawer navigation that repeats the primary navigation while preserving the drawer wrapper as a runtime target.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-mobile-drawer-nav-dedup.json",
@@ -20,17 +20,21 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "/", "kind": "custom" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Shop", "url": "/shop", "kind": "custom" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/navigation-link", "attrs": { "label": "Contact", "url": "/contact", "kind": "custom" } }
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/navigation-link", "attrs": { "label": "Contact", "url": "/contact", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "mobile-nav overlay" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "mobile-nav-panel" } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
     { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks", "assert": "count", "count": 0 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "drawer-nav" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "mobile-nav" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "mobile-nav" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }


### PR DESCRIPTION
## Summary
- Preserve generic JS target containers referenced by source scripts instead of dropping empty/runtime-critical wrappers.
- Keep duplicate mobile drawer navigation links deduped while retaining target shells such as mobile nav wrappers.
- Add artifact/compiler parity coverage for common class/id runtime targets.

## Testing
- `cd php-transformer && composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests for generic Blocks Engine runtime target preservation; Chris reviews and owns the change.