### PR TITLE
Preserve referenced canvas targets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -10,6 +10,8 @@ use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
+use DOMDocument;
+use DOMElement;
 
 final class ArtifactCompiler
 {
@@ -166,6 +168,7 @@ final class ArtifactCompiler
             'source'       => $sourcePath,
             'source_scope' => $sourceScope,
             'static_css'   => $this->linkedStylesheetCss($html, $sourcePath, $files),
+            'runtime_canvas_selectors' => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
         ))->toArray();
 
         return array(
@@ -255,6 +258,109 @@ final class ArtifactCompiler
         }
 
         return trim(implode("\n", $css));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, string>
+     */
+    private function runtimeCanvasSelectors(string $html, string $sourcePath, array $files): array
+    {
+        $canvasSelectors = $this->canvasSelectors($html);
+        if ( array() === $canvasSelectors ) {
+            return array();
+        }
+
+        $selectors = array();
+        foreach ( $this->documentScriptContents($html, $sourcePath, $files) as $script ) {
+            foreach ( $this->scriptDomSelectors($script) as $selector ) {
+                if ( isset($canvasSelectors[$selector]) ) {
+                    $selectors[$selector] = true;
+                }
+            }
+        }
+
+        return array_keys($selectors);
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function canvasSelectors(string $html): array
+    {
+        $selectors = array();
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if ( ! $loaded ) {
+            return array();
+        }
+
+        foreach ( $document->getElementsByTagName('canvas') as $canvas ) {
+            if ( ! $canvas instanceof DOMElement ) {
+                continue;
+            }
+            $id = trim($canvas->hasAttribute('id') ? $canvas->getAttribute('id') : '');
+            if ( '' !== $id ) {
+                $selectors['#' . $id] = true;
+            }
+            foreach ( preg_split('/\s+/', trim($canvas->hasAttribute('class') ? $canvas->getAttribute('class') : '')) ?: array() as $class ) {
+                if ( '' !== $class ) {
+                    $selectors['.' . $class] = true;
+                }
+            }
+        }
+
+        return $selectors;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, string>
+     */
+    private function documentScriptContents(string $html, string $sourcePath, array $files): array
+    {
+        $scripts = array();
+        if ( ! preg_match_all('/<script\b([^>]*)>(.*?)<\/script>/is', $html, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        foreach ( $matches as $match ) {
+            $src = $this->htmlAttribute((string) $match[1], 'src');
+            if ( '' === $src ) {
+                $scripts[] = (string) $match[2];
+                continue;
+            }
+
+            $asset = $this->findAssetByHtmlReference($src, $sourcePath, $files);
+            if ( is_array($asset) && $this->isMaterializedScriptAsset($asset) && is_string($asset['content'] ?? null) ) {
+                $scripts[] = (string) $asset['content'];
+            }
+        }
+
+        return $scripts;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function scriptDomSelectors(string $script): array
+    {
+        $selectors = array();
+        if ( preg_match_all('/document\s*\.\s*getElementById\s*\(\s*(["\'])([A-Za-z][A-Za-z0-9_-]*)\1\s*\)/', $script, $matches) ) {
+            foreach ( $matches[2] as $id ) {
+                $selectors['#' . (string) $id] = true;
+            }
+        }
+        if ( preg_match_all('/document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])([#.][A-Za-z][A-Za-z0-9_-]*)\1\s*\)/', $script, $matches) ) {
+            foreach ( $matches[2] as $selector ) {
+                $selectors[(string) $selector] = true;
+            }
+        }
+
+        return array_keys($selectors);
     }
 
     private function htmlAttribute(string $tag, string $name): string

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -69,6 +69,11 @@ final class HtmlTransformer
      */
     private array $staticStyleRules = array();
 
+    /**
+     * @var array<string, bool>
+     */
+    private array $runtimeCanvasSelectors = array();
+
     private int $nextSourceProvenanceId = 1;
 
     public function __construct(private readonly Runtime $runtime = new Runtime())
@@ -95,6 +100,7 @@ final class HtmlTransformer
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $this->staticStyleRules = $this->staticStyleRules($html, (string) ($options['static_css'] ?? ''));
+        $this->runtimeCanvasSelectors = $this->runtimeCanvasSelectorsFromOptions($options);
         $this->nextSourceProvenanceId = 1;
         $provenance               = array(
             array_merge(array(
@@ -1147,6 +1153,10 @@ final class HtmlTransformer
 
         if ( 'canvas' === $tagName ) {
             $this->captureCanvasFallback($element, $fallbacks);
+            if ( $this->isRuntimeCanvasTarget($element) ) {
+                $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
+                return $this->createBlock('core/html', array( 'content' => $boundedHtml['html'] ), array(), $element);
+            }
             return null;
         }
 
@@ -2903,6 +2913,38 @@ final class HtmlTransformer
             'html_bytes'             => $boundedHtml['bytes'],
             'html_truncated'         => $boundedHtml['truncated'],
         ), static fn (mixed $value): bool => '' !== $value && array() !== $value), $this->fallbackProvenance);
+    }
+
+    private function isRuntimeCanvasTarget(DOMElement $element): bool
+    {
+        $id = trim($this->attr($element, 'id'));
+        if ( '' !== $id && isset($this->runtimeCanvasSelectors['#' . $id]) ) {
+            return true;
+        }
+
+        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
+            if ( '' !== $class && isset($this->runtimeCanvasSelectors['.' . $class]) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, bool>
+     */
+    private function runtimeCanvasSelectorsFromOptions(array $options): array
+    {
+        $selectors = array();
+        foreach ( $options['runtime_canvas_selectors'] ?? array() as $selector ) {
+            if ( is_string($selector) && preg_match('/^[#.][A-Za-z][A-Za-z0-9_-]*$/', $selector) ) {
+                $selectors[$selector] = true;
+            }
+        }
+
+        return $selectors;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -590,8 +590,8 @@ $runtimeDependencySite = $compiler->compile(
     array(
         'entrypoint' => 'index.html',
         'files'      => array(
-            'index.html' => '<main><canvas id="canvas"></canvas><div id="status-container"><h2>Status</h2><p>Ready</p></div><script src="js/script.js"></script><script src="js/rum.js"></script></main>',
-            'js/script.js' => 'const canvas = document.getElementById("canvas"); canvas.getContext("2d"); const status = document.querySelector("#status-container"); status.addEventListener("click", function () {});',
+            'index.html' => '<main><canvas id="canvas" class="stage"></canvas><canvas id="unused-canvas"></canvas><div id="status-container"><h2>Status</h2><p>Ready</p></div><script src="js/script.js"></script><script src="js/rum.js"></script></main>',
+            'js/script.js' => 'const canvas = document.getElementById("canvas"); canvas.getContext("2d"); const stage = document.querySelector(".stage"); stage.getContext("2d"); const status = document.querySelector("#status-container"); status.addEventListener("click", function () {});',
             'js/rum.js' => 'document.querySelector("#netlify-rum-target");',
         ),
     )
@@ -609,24 +609,34 @@ foreach ( $runtimeFindings as $finding ) {
         $rumFinding = $finding;
     }
 }
+$canvasDependency = null;
+$stageDependency = null;
 $statusDependency = null;
 foreach ( $runtimeDependencyReport['dependencies'] ?? array() as $dependency ) {
+    if ( '#canvas' === ($dependency['selector'] ?? '') ) {
+        $canvasDependency = $dependency;
+    }
+    if ( '.stage' === ($dependency['selector'] ?? '') ) {
+        $stageDependency = $dependency;
+    }
     if ( '#status-container' === ($dependency['selector'] ?? '') ) {
         $statusDependency = $dependency;
     }
 }
+$runtimeDependencyMarkup = (string) ($runtimeDependencySite['serialized_blocks'] ?? '');
 $assert('blocks-engine/php-transformer/runtime-dependency-parity/v1' === ($runtimeDependencyReport['schema'] ?? ''), 'runtime dependency parity report exposes schema');
 $assert($runtimeDependencyReport === $runtimeDependencyConversionReport, 'conversion report projects runtime dependency parity');
-$assert('runtime_dependency_target_missing' === ($canvasFinding['code'] ?? ''), 'runtime dependency parity reports missing canvas DOM target');
-$assert('index.html' === ($canvasFinding['source_path'] ?? ''), 'runtime dependency parity reports source path for missing canvas DOM target');
-$assert('canvas' === ($canvasFinding['target_id'] ?? ''), 'runtime dependency parity reports missing canvas target id');
-$assert('canvas' === ($canvasFinding['target_kind'] ?? ''), 'runtime dependency parity identifies canvas source target kind');
-$assert(true === ($canvasFinding['canvas_api'] ?? null), 'runtime dependency parity flags canvas 2d API usage');
-$assert('warning' === ($canvasFinding['severity'] ?? ''), 'first-party missing runtime dependency target is warning severity');
-$assert('runtime_canvas_target_preservation' === ($canvasFinding['repair_bucket'] ?? ''), 'runtime dependency parity reports repair bucket for missing canvas DOM target');
-$assert('runtime_canvas' === ($canvasFinding['suggested_primitive'] ?? ''), 'runtime dependency parity reports suggested primitive for missing canvas DOM target');
-$assert(isset($canvasFinding['actionability']) && '' !== $canvasFinding['actionability'], 'runtime dependency parity reports actionability for missing canvas DOM target');
-$assert(isset($canvasFinding['materialization_hint']) && '' !== $canvasFinding['materialization_hint'], 'runtime dependency parity reports materialization hint for missing canvas DOM target');
+$assert(null === $canvasFinding, 'runtime dependency parity does not report preserved canvas DOM target as missing');
+$assert(null !== $canvasDependency, 'runtime dependency parity records canvas id dependency');
+$assert('index.html' === ($canvasDependency['source_path'] ?? ''), 'runtime dependency parity records source path for canvas DOM target');
+$assert('canvas' === ($canvasDependency['target_id'] ?? ''), 'runtime dependency parity records canvas target id');
+$assert('canvas' === ($canvasDependency['target_kind'] ?? ''), 'runtime dependency parity identifies canvas source target kind');
+$assert(true === ($canvasDependency['canvas_api'] ?? null), 'runtime dependency parity flags canvas 2d API usage');
+$assert(true === ($canvasDependency['generated_present'] ?? null), 'runtime dependency parity passes preserved canvas id target');
+$assert(null !== $stageDependency, 'runtime dependency parity records canvas class querySelector dependency');
+$assert(true === ($stageDependency['generated_present'] ?? null), 'runtime dependency parity passes preserved canvas class target');
+$assert(str_contains($runtimeDependencyMarkup, '<canvas id="canvas" class="stage"></canvas>'), 'artifact compiler emits referenced canvas runtime target markup');
+$assert(! str_contains($runtimeDependencyMarkup, 'unused-canvas'), 'artifact compiler does not preserve unreferenced canvas markup');
 $assert(null !== $statusDependency, 'runtime dependency parity records preserved status container dependency');
 $assert('index.html' === ($statusDependency['source_path'] ?? ''), 'runtime dependency parity records source path for preserved DOM dependency');
 $assert(true === ($statusDependency['generated_present'] ?? null), 'runtime dependency parity passes preserved div id target');


### PR DESCRIPTION
## Summary
- Detect source canvas ids/classes referenced by first-party document scripts.
- Preserve only matched canvas runtime targets in generated output using bounded safe canvas markup.
- Keep unreferenced canvas elements omitted and retain runtime dependency parity diagnostics for true gaps.

## Testing
- `cd php-transformer && composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests for generic Blocks Engine canvas target preservation; Chris reviews and owns the change.