### PR TITLE
Promote CTA container button styles

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1517,7 +1517,7 @@ final class HtmlTransformer
         if ( 'a' === $tagName ) {
             for ( $node = $element->parentNode; $node instanceof DOMElement; $node = $node->parentNode ) {
                 $ancestorTokens = strtolower($this->attr($node, 'class') . ' ' . $this->attr($node, 'id'));
-                if ( preg_match('/(?:^|[^a-z0-9])(?:nav|menu|card|tile|panel|pricing|product)(?:[^a-z0-9]|$)/', $ancestorTokens) ) {
+                if ( preg_match('/(?:^|[^a-z0-9])(?:actions?|btns?|buttons?|cta|nav|menu|card|tile|panel|pricing|product)(?:[^a-z0-9]|$)/', $ancestorTokens) ) {
                     return true;
                 }
             }

--- a/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-cta-container-static-css-button-style-signals",
+  "description": "Promotes static CSS styles for CTA container anchors that become core/button output even when the anchor classes are generic variant names.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json",
+    "notes": "Covers generic CTA/action container style preservation without fixture-specific selectors."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New upstream button style preservation behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<!doctype html><html><head><style>.cta-row .primary{background-color:#2563eb;color:#fff;border:2px solid #2563eb;border-radius:999px;padding:14px 28px;font-weight:700}.cta-row .secondary{background-color:transparent;color:#2563eb;border:2px solid currentColor;border-radius:999px;padding:14px 28px;font-weight:700}</style></head><body><main><div class=\"cta-row\"><a class=\"primary\" href=\"/book\">Book now</a><a class=\"secondary\" href=\"/learn\">Learn more</a></div></main></body></html>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Book now", "url": "/book", "className": "primary", "style": "background-color:#2563eb;color:#fff;border:2px solid #2563eb;border-radius:999px;padding:14px 28px;font-weight:700" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "secondary is-style-outline", "style": "background-color:transparent;color:#2563eb;border:2px solid currentColor;border-radius:999px;padding:14px 28px;font-weight:700" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button primary\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background-color:#2563eb;color:#fff;border:2px solid #2563eb;border-radius:999px;padding:14px 28px;font-weight:700" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button is-style-outline\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button secondary is-style-outline\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background-color:transparent;color:#2563eb;border:2px solid currentColor;border-radius:999px;padding:14px 28px;font-weight:700" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Broaden static CSS promotion for anchors inside CTA/action/button-like containers.
- Preserve source CSS button shape/style signals for generic variant classes such as primary/secondary links.
- Add parity coverage for CTA row classification and style preservation including outline secondary CTAs.

## Testing
- `cd php-transformer && composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests for generic Blocks Engine button style parity; Chris reviews and owns the change.