### PR TITLE
Materialize safe inline SVG assets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -33,10 +33,10 @@ final class ArtifactCompiler
         $entryPath = is_array($entry) ? (string) $entry['path'] : '';
         $html = is_array($entry) ? (string) $entry['content'] : '';
         $referenceReports = $this->referenceReports($normalized['files']);
-        $assets = $this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references']);
         $components = $this->detectComponents($normalized['files'], $entryPath, $documents['components']);
         $blockTypes = $this->detectBlockTypes($normalized['files'], $diagnostics);
         $entryBlocks = $this->compileEntryBlocks($html, $entryPath, $normalized['files']);
+        $assets = array_merge($this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references']), $entryBlocks['assets']);
         $diagnostics = array_merge($diagnostics, $entryBlocks['diagnostics']);
         $serializedBlocks = $entryBlocks['serialized_blocks'];
         if ( '' === $serializedBlocks && ! empty($documents['documents'][0]['block_markup']) ) {
@@ -124,7 +124,7 @@ final class ArtifactCompiler
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>}
      */
     private function compileEntryBlocks(string $html, string $entryPath, array $files): array
     {
@@ -135,12 +135,13 @@ final class ArtifactCompiler
             'serialized_blocks' => $result['serialized_blocks'],
             'diagnostics'       => $this->entryTransformDiagnostics($result['diagnostics']),
             'fallbacks'         => $result['fallbacks'],
+            'assets'            => $result['assets'],
         );
     }
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>}
      */
     private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope): array
     {
@@ -150,6 +151,7 @@ final class ArtifactCompiler
                 'serialized_blocks' => $html,
                 'diagnostics'       => array(),
                 'fallbacks'         => array(),
+                'assets'            => array(),
             );
         }
 
@@ -159,6 +161,7 @@ final class ArtifactCompiler
                 'serialized_blocks' => '',
                 'diagnostics'       => array(),
                 'fallbacks'         => array(),
+                'assets'            => array(),
             );
         }
 
@@ -173,6 +176,7 @@ final class ArtifactCompiler
             'serialized_blocks' => (string) ($result['serialized_blocks'] ?? ''),
             'diagnostics'       => is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array(),
             'fallbacks'         => is_array($result['fallbacks'] ?? null) ? $result['fallbacks'] : array(),
+            'assets'            => is_array($result['assets'] ?? null) ? $result['assets'] : array(),
         );
     }
 
@@ -294,7 +298,7 @@ final class ArtifactCompiler
      * @param array<int, array<string, mixed>> $blockTypes
      * @return array<string, mixed>
      */
-    private function compiledSiteReport(array $artifact, string $entryPath, array $documents, array $assets, array $blockTypes, string $serializedBlocks): array
+    private function compiledSiteReport(array $artifact, string $entryPath, array $documents, array &$assets, array $blockTypes, string $serializedBlocks): array
     {
         $pages = array();
         foreach ( $artifact['files'] as $file ) {
@@ -307,8 +311,13 @@ final class ArtifactCompiler
             $slug = $this->slugFromPath($path);
             $content = (string) ($file['content'] ?? '');
             $compiledBlocks = $path === $entryPath
-                ? array('serialized_blocks' => $serializedBlocks)
+                ? array('serialized_blocks' => $serializedBlocks, 'assets' => array())
                 : $this->compileHtmlDocumentBlocks($content, $path, $artifact['files'], 'artifact-document');
+            foreach ( $compiledBlocks['assets'] ?? array() as $generatedAsset ) {
+                if ( is_array($generatedAsset) ) {
+                    $assets[] = $generatedAsset;
+                }
+            }
             $blockMarkup = (string) ($compiledBlocks['serialized_blocks'] ?? '');
             if ( '' === $blockMarkup && '' !== trim($content) ) {
                 $blockMarkup = $this->htmlDocumentBlockMarkup($content);

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -60,6 +60,11 @@ final class HtmlTransformer
     private array $assetMetadata = array();
 
     /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $generatedAssets = array();
+
+    /**
      * @var array<string, array<int, string>>
      */
     private array $staticClassPromotions = array();
@@ -93,6 +98,7 @@ final class HtmlTransformer
         $this->structureProvenance = array();
         $this->scriptMetadata = array();
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
+        $this->generatedAssets = array();
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $this->staticStyleRules = $this->staticStyleRules($html, (string) ($options['static_css'] ?? ''));
         $this->nextSourceProvenanceId = 1;
@@ -248,6 +254,7 @@ final class HtmlTransformer
             status: $this->statusForFallbacks($fallbacks, $context),
             blocks: $blocks,
             serializedBlocks: $serializedBlocks,
+            assets: array_values($this->generatedAssets),
             diagnostics: $diagnostics,
             fallbacks: $fallbacks,
             provenance: $provenance,
@@ -2812,7 +2819,7 @@ final class HtmlTransformer
         }
 
         $attrs = array_filter(array_merge($this->presentationAttributes($element), array(
-            'url'    => 'data:image/svg+xml,' . rawurlencode($html),
+            'url'    => $this->materializeInlineSvgAsset($html, $element),
             'alt'    => $this->inlineSvgAltText($element),
             'title'  => $this->inlineSvgTitleText($element),
             'width'  => $this->attr($element, 'width'),
@@ -2820,6 +2827,39 @@ final class HtmlTransformer
         )), static fn ($value): bool => '' !== $value);
 
         return $this->createBlock('core/image', $attrs, array(), $element);
+    }
+
+    private function materializeInlineSvgAsset(string $html, DOMElement $element): string
+    {
+        $hash = hash('sha256', $html);
+        $path = 'assets/inline-svg-' . substr($hash, 0, 16) . '.svg';
+
+        if ( ! isset($this->generatedAssets[$path]) ) {
+            $this->generatedAssets[$path] = array(
+                'source'           => 'html-inline-svg',
+                'path'             => $path,
+                'target_path'      => $path,
+                'kind'             => 'image',
+                'role'             => 'image',
+                'media_type'       => 'image/svg+xml',
+                'mime_type'        => 'image/svg+xml',
+                'bytes'            => strlen($html),
+                'binary'           => false,
+                'encoding'         => 'text',
+                'content_encoding' => 'text',
+                'content'          => $html,
+                'hash'             => $hash,
+                'references'       => array(
+                    array_filter(array(
+                        'selector'  => $this->elementSelector($element),
+                        'element'   => 'svg',
+                        'attribute' => 'generated-inline-svg',
+                    )),
+                ),
+            );
+        }
+
+        return $path;
     }
 
     private function inlineSvgAltText(DOMElement $element): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -320,6 +320,15 @@ $assert(! str_contains($safeInlineSvgSerialized, '<!-- wp:html'), 'safe inline S
 $assert(! str_contains($safeInlineSvgSerialized, 'data:image/svg+xml,'), 'decorative inline SVG avoids image data URI noise');
 $assert(! str_contains(rawurldecode($safeInlineSvgSerialized), '<svg'), 'decorative inline SVG markup is omitted from serialized blocks');
 
+$safeInlineSvgAsset = ( new HtmlTransformer() )->transform(
+    '<svg role="img" aria-label="Status badge" viewBox="0 0 10 10"><title>Status badge</title><circle cx="5" cy="5" r="4"></circle></svg>'
+)->toArray();
+$safeInlineSvgAssetPath = (string) ($safeInlineSvgAsset['blocks'][0]['attrs']['url'] ?? '');
+$assert(str_starts_with($safeInlineSvgAssetPath, 'assets/inline-svg-'), 'safe accessible inline SVG image references a generated SVG asset');
+$assert('image/svg+xml' === ($safeInlineSvgAsset['assets'][0]['mime_type'] ?? ''), 'safe accessible inline SVG exposes a materializable SVG asset');
+$assert(str_contains((string) ($safeInlineSvgAsset['assets'][0]['content'] ?? ''), 'aria-label="Status badge"'), 'safe accessible inline SVG asset preserves accessible label');
+$assert(! str_contains((string) ($safeInlineSvgAsset['serialized_blocks'] ?? ''), 'data:image/svg+xml,'), 'safe accessible inline SVG avoids data URI serialization');
+
 $unsafeInlineSvg = ( new HtmlTransformer() )->transform('<main><svg onload="alert(1)"><path d="M0 0h1v1z"></path></svg></main>')->toArray();
 $assert('html_unsafe_inline_svg' === ($unsafeInlineSvg['fallbacks'][0]['diagnostic_code'] ?? ''), 'unsafe inline SVG remains a fallback diagnostic');
 
@@ -513,6 +522,35 @@ $assert(0 === ($simple['metrics']['diagnostic_count'] ?? null), 'artifact metric
 $assert(is_float($simple['metrics']['transform_duration_ms'] ?? null), 'artifact metrics expose transform duration');
 $assert(MaterializationPlanBuilder::SCHEMA === ($simple['source_reports']['materialization_plan']['schema'] ?? ''), 'artifact exposes canonical materialization plan');
 $assert('index.html' === ($simple['source_reports']['materialization_plan']['entry_path'] ?? ''), 'materialization plan exposes entry path');
+
+$artifactInlineSvg = $compiler->compile(
+    array(
+        'schema'         => ArtifactCompiler::INPUT_SCHEMA,
+        'generated_html' => '<svg role="img" aria-label="Inline logo" viewBox="0 0 12 12"><title>Inline logo</title><path d="M0 0h12v12H0z"></path></svg>',
+    )
+)->toArray();
+$artifactInlineSvgPath = (string) ($artifactInlineSvg['blocks'][0]['attrs']['url'] ?? '');
+$artifactInlineSvgAsset = $artifactInlineSvg['source_reports']['materialization_plan']['assets'][0] ?? array();
+$assert(str_starts_with($artifactInlineSvgPath, 'assets/inline-svg-'), 'artifact safe inline SVG block references a generated SVG asset');
+$assert($artifactInlineSvgPath === ($artifactInlineSvgAsset['path'] ?? ''), 'artifact materialization plan includes generated inline SVG asset path');
+$assert('image/svg+xml' === ($artifactInlineSvgAsset['mime_type'] ?? ''), 'artifact generated inline SVG asset has SVG MIME type');
+$assert(str_contains((string) ($artifactInlineSvgAsset['content'] ?? ''), 'aria-label="Inline logo"'), 'artifact generated inline SVG asset preserves sanitized SVG content');
+$assert(! str_contains((string) ($artifactInlineSvg['serialized_blocks'] ?? ''), 'data:image/svg+xml,'), 'artifact safe inline SVG avoids data URI serialization');
+
+$artifactNonEntryInlineSvg = $compiler->compile(
+    array(
+        'entry' => 'index.html',
+        'files' => array(
+            'index.html' => '<main><h1>Home</h1></main>',
+            'about.html' => '<main><svg role="img" aria-label="About icon" viewBox="0 0 8 8"><title>About icon</title><circle cx="4" cy="4" r="3"></circle></svg></main>',
+        ),
+    )
+)->toArray();
+$artifactNonEntryInlineSvgPage = $artifactNonEntryInlineSvg['source_reports']['materialization_plan']['pages'][1] ?? array();
+$artifactNonEntryInlineSvgAsset = $artifactNonEntryInlineSvg['source_reports']['materialization_plan']['assets'][0] ?? array();
+$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), 'assets/inline-svg-'), 'non-entry artifact page references generated inline SVG asset');
+$assert('image/svg+xml' === ($artifactNonEntryInlineSvgAsset['mime_type'] ?? ''), 'non-entry artifact generated inline SVG asset is materialized');
+$assert(str_contains((string) ($artifactNonEntryInlineSvgAsset['content'] ?? ''), 'aria-label="About icon"'), 'non-entry artifact generated inline SVG asset preserves safe SVG content');
 $assert(1 === ($simple['source_reports']['materialization_plan']['totals']['pages'] ?? null), 'materialization plan counts pages');
 $assert('index' === ($simple['source_reports']['materialization_plan']['pages'][0]['slug'] ?? ''), 'materialization plan exposes page slug');
 $assert('blocks' === ($simple['source_reports']['materialization_plan']['pages'][0]['body_format'] ?? ''), 'materialization plan exposes converted block body format');

--- a/php-transformer/tests/fixtures/parity/html-flex-media-text-columns.json
+++ b/php-transformer/tests/fixtures/parity/html-flex-media-text-columns.json
@@ -28,8 +28,8 @@
     { "path": "metrics.block_count", "assert": "equals", "value": 5 },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml" },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "WIDTH" },
+    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "assets/inline-svg-" },
+    { "path": "assets.0.content", "assert": "contains", "value": "WIDTH" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
@@ -24,8 +24,9 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
-    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": "data:image/svg+xml," },
-    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": "aria-label%3D%22Acme%20integration%22" },
+    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": "assets/inline-svg-" },
+    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": ".svg" },
+    { "path": "assets.0.content", "assert": "contains", "value": "aria-label=\"Acme integration\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
@@ -23,8 +23,10 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "blocks.0.innerBlocks.1.attrs.url", "assert": "contains", "value": "data:image/svg+xml," },
-    { "path": "blocks.0.innerBlocks.1.attrs.url", "assert": "contains", "value": "aria-label%3D%22Status%22" },
+    { "path": "blocks.0.innerBlocks.1.attrs.url", "assert": "contains", "value": "assets/inline-svg-" },
+    { "path": "blocks.0.innerBlocks.1.attrs.url", "assert": "contains", "value": ".svg" },
+    { "path": "assets.0.mime_type", "assert": "equals", "value": "image/svg+xml" },
+    { "path": "assets.0.content", "assert": "contains", "value": "aria-label=\"Status\"" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-single-child-flex-svg-address.json
+++ b/php-transformer/tests/fixtures/parity/html-single-child-flex-svg-address.json
@@ -25,7 +25,8 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml," },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "assets/inline-svg-" },
+    { "path": "assets.0.content", "assert": "contains", "value": "Storefront illustration" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Storefront illustration" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-single-child-flex-svg.json
+++ b/php-transformer/tests/fixtures/parity/html-single-child-flex-svg.json
@@ -25,8 +25,8 @@
     { "path": "metrics.block_count", "assert": "equals", "value": 2 },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml" },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "GIRTH" },
+    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "assets/inline-svg-" },
+    { "path": "assets.0.content", "assert": "contains", "value": "GIRTH" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
   ]


### PR DESCRIPTION
## Summary
- Materialize safe accessible inline SVGs as generated SVG assets instead of serialized data URIs.
- Propagate generated inline SVG assets into artifact materialization plans for entry and non-entry pages.
- Keep decorative/unsafe SVG behavior bounded and covered by existing diagnostics.

## Testing
- `php -l src/HtmlToBlocks/HtmlTransformer.php`
- `php -l src/ArtifactCompiler/ArtifactCompiler.php`
- `php -l tests/contract/run.php`
- `cd php-transformer && composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests for generic Blocks Engine SVG parity; Chris reviews and owns the change.