### PR TITLE
Normalize button labels for valid block markup

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -7,6 +7,8 @@ use DOMElement;
 
 final class ButtonsPattern
 {
+    private const BLOCK_LEVEL_LABEL_TAGS = 'address|article|aside|blockquote|div|dl|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|main|nav|ol|p|pre|section|table|ul';
+
     /**
      * @param callable(DOMElement): array<string, mixed>|null $fileBlockFromAnchor
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
@@ -38,7 +40,7 @@ final class ButtonsPattern
     public function matchButton(DOMElement $button, callable $presentationAttributes, callable $innerHtml, callable $createBlock): array
     {
         return $createBlock('core/buttons', array(), array(
-            $createBlock('core/button', array_merge($this->buttonPresentationAttributes($button, $presentationAttributes), array( 'text' => $innerHtml($button) )), array(), $button),
+            $createBlock('core/button', array_merge($this->buttonPresentationAttributes($button, $presentationAttributes), array( 'text' => $this->buttonText($innerHtml($button)) )), array(), $button),
         ), $button);
     }
 
@@ -76,9 +78,16 @@ final class ButtonsPattern
     private function buttonBlockFromAnchor(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $attr, callable $createBlock): array
     {
         return $createBlock('core/button', array_filter(array_merge($this->buttonPresentationAttributes($anchor, $presentationAttributes), array(
-            'text' => $innerHtml($anchor),
+            'text' => $this->buttonText($innerHtml($anchor)),
             'url'  => $attr($anchor, 'href'),
         )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $anchor);
+    }
+
+    private function buttonText(string $html): string
+    {
+        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>\s*<\/\1>/i', '', $html) ?? $html;
+        $html = preg_replace('/<\/?(?:' . self::BLOCK_LEVEL_LABEL_TAGS . ')\b[^>]*>/i', '', $html) ?? $html;
+        return trim($html);
     }
 
     /**

--- a/php-transformer/src/WordPress/BlockValidityValidator.php
+++ b/php-transformer/src/WordPress/BlockValidityValidator.php
@@ -147,6 +147,27 @@ final class BlockValidityValidator
                 array('attribute_url' => $expectedUrl, 'markup_url' => $actualUrl)
             );
         }
+
+        $linkInnerHtml = $this->firstAnchorInnerHtml($html);
+        if ( '' !== $linkInnerHtml && preg_match('/<(?:address|article|aside|blockquote|div|dl|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|main|nav|ol|p|pre|section|table|ul)\b/i', $linkInnerHtml) ) {
+            $this->addFinding(
+                $findings,
+                $kind . '_block_level_link_markup',
+                'warning',
+                $path,
+                $blockName,
+                'Serialized link text contains block-level markup that WordPress static link blocks do not save as valid inline RichText.'
+            );
+        }
+    }
+
+    private function firstAnchorInnerHtml(string $html): string
+    {
+        if ( preg_match('/<a\b[^>]*>(.*?)<\/a>/is', $html, $matches) ) {
+            return (string) ($matches[1] ?? '');
+        }
+
+        return '';
     }
 
     private function normalizeText(string $text): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -240,8 +240,10 @@ $buttonResult = ( new HtmlTransformer() )->transform(
 $buttonBlocks = $buttonResult['blocks'][0]['innerBlocks'] ?? array();
 $assert('core/buttons' === ($buttonBlocks[0]['blockName'] ?? ''), 'anchor converts to buttons block');
 $assert(str_contains((string) ($buttonBlocks[0]['innerBlocks'][0]['attrs']['text'] ?? ''), 'Reserve now'), 'anchor button text preserves visible label');
+$assert('Reserve now' === ($buttonBlocks[0]['innerBlocks'][0]['attrs']['text'] ?? ''), 'anchor button text unwraps block-level label markup for valid inline RichText');
 $assert(str_contains((string) ($buttonBlocks[1]['innerBlocks'][0]['attrs']['text'] ?? ''), 'Call us'), 'button text preserves visible label');
 $assert(! str_contains((string) $buttonResult['serialized_blocks'], '\\u003c'), 'button serialization avoids escaped nested HTML attrs');
+$assert(! str_contains((string) $buttonResult['serialized_blocks'], '<h3>Reserve now</h3>'), 'button serialization avoids block-level markup inside link text');
 $assert('pass' === ($buttonResult['source_reports']['wp_block_validity']['status'] ?? ''), 'HTML transform exposes passing WordPress block validity report for generated buttons');
 
 $rubyResult = ( new HtmlTransformer() )->transform(
@@ -286,6 +288,19 @@ $assert('blocks-engine/php-transformer/wp-block-validity-report/v1' === ($invali
 $assert('warning' === ($invalidButtonReport['status'] ?? ''), 'runtime warns on button attribute/markup mismatches');
 $assert(in_array('button_text_markup_mismatch', $invalidButtonCodes, true), 'runtime reports invalid button text serialization');
 $assert(in_array('button_url_markup_mismatch', $invalidButtonCodes, true), 'runtime reports invalid button URL serialization');
+
+$invalidBlockLevelButtonBlocks = array(
+    array(
+        'blockName'    => 'core/button',
+        'attrs'        => array('text' => 'Book now', 'url' => '/book'),
+        'innerBlocks'  => array(),
+        'innerHTML'    => '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/book"><h3>Book now</h3></a></div>',
+        'innerContent' => array('<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/book"><h3>Book now</h3></a></div>'),
+    ),
+);
+$invalidBlockLevelButtonReport = ( new \Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime() )->validateBlockSerialization($invalidBlockLevelButtonBlocks);
+$invalidBlockLevelButtonCodes = array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $invalidBlockLevelButtonReport['findings'] ?? array());
+$assert(in_array('button_block_level_link_markup', $invalidBlockLevelButtonCodes, true), 'runtime reports invalid block-level button link markup');
 
 $inlineSvgVisualWrapper = ( new HtmlTransformer() )->transform(
     '<main><section class="visual-region"><div class="map-layer"><div class="map-image" style="background-image:url(assets/map.png)"><svg><path d="M0 0h1v1z"></path></svg></div></div></section></main>'

--- a/php-transformer/tests/fixtures/contract/wp-block-validity.json
+++ b/php-transformer/tests/fixtures/contract/wp-block-validity.json
@@ -17,6 +17,14 @@
       ]
     },
     {
+      "name": "invalid-button-block-level-link-markup",
+      "input": "<!-- wp:button {\"text\":\"Book now\",\"url\":\"/book\"} --><div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button\" href=\"/book\"><h3>Book now</h3></a></div><!-- /wp:button -->",
+      "expected_status": "warning",
+      "expected_codes": [
+        "button_block_level_link_markup"
+      ]
+    },
+    {
       "name": "invalid-navigation-serialized-child-comments",
       "blocks": [
         {

--- a/php-transformer/tests/fixtures/parity/html-button-block-label-inline-richtext.json
+++ b/php-transformer/tests/fixtures/parity/html-button-block-label-inline-richtext.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-block-label-inline-richtext",
+  "description": "Converts button-like anchors with block-level visual label wrappers into valid inline core/button saved markup.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-block-label-inline-richtext.json",
+    "notes": "Covers SSI button labels that use heading wrappers and decorative hidden spans inside anchors."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers WordPress block-validity normalization beyond the legacy converter behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"primary-button\" href=\"/book\"><h3>Reserve now</h3><span aria-hidden=\"true\"></span></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "primary-button", "text": "Reserve now", "url": "/book" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-button__link wp-element-button primary-button\" href=\"/book\">Reserve now</a>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<h3>Reserve now</h3>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "aria-hidden=\"true\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Normalize button labels by unwrapping block-level label tags and dropping empty decorative hidden spans before emitting `core/button` text.
- Add block validity detection for block-level markup inside serialized button links.
- Add contract/parity coverage for invalid button label markup.

## Testing
- `cd php-transformer && composer test`
- Parity validity enumeration: `invalid_html_transformer_fixture_count=0`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted implementation and tests for generic Blocks Engine block-validity parity; Chris reviews and owns the change.