### PR TITLE
Fix dataviz fixture rounded rectangle radius

### DIFF
--- a/fixtures/websites/67-dataviz-studio/js/chart.js
+++ b/fixtures/websites/67-dataviz-studio/js/chart.js
@@ -723,7 +723,7 @@
      ================================================================== */
   function roundRect(ctx, x, y, w, h, r) {
     if (w < 0) { x += w; w = -w; } if (h < 0) { y += h; h = -h; }
-    r = Math.min(r, w / 2, h / 2);
+    r = Math.max(0, Math.min(r, w / 2, h / 2));
     ctx.beginPath();
     ctx.moveTo(x + r, y); ctx.arcTo(x + w, y, x + w, y + h, r);
     ctx.arcTo(x + w, y + h, x, y + h, r); ctx.arcTo(x, y + h, x, y, r);


### PR DESCRIPTION
## Summary
- refresh the website fixture corpus with the Downloads-side dataviz fix
- clamp rounded-rectangle radius to non-negative before drawing chart shapes

## Testing
- node --check fixtures/websites/67-dataviz-studio/js/chart.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Comparing fixture corpora, applying the fixture refresh, and running validation.