### PR TITLE
Add Figma transformer fixture matrix rig

### DIFF
--- a/figma-transformer/fixtures/.gitignore
+++ b/figma-transformer/fixtures/.gitignore
@@ -1,0 +1,4 @@
+# Local/private Figma fixtures can be large and may contain unreleased designs.
+*
+!.gitignore
+!README.md

--- a/figma-transformer/fixtures/README.md
+++ b/figma-transformer/fixtures/README.md
@@ -1,0 +1,5 @@
+# Local Figma Fixtures
+
+This directory is for local `.fig` files used while developing the Figma transformer.
+
+The fixture files themselves are gitignored because they can be large and may contain private or unreleased designs. Keep small synthetic fixtures in tests instead.

--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -1,0 +1,426 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__, 2);
+$figmaRoot = $root . '/figma-transformer';
+$options = matrix_options($argv);
+$fixtureDir = $options['fixture_dir'] ?? ($figmaRoot . '/fixtures');
+$defaultOutputRoot = getenv('HOMEBOY_ARTIFACT_ROOT') ?: sys_get_temp_dir();
+$outputDir = $options['output_dir'] ?? ($defaultOutputRoot . '/figma-transformer-fixture-matrix-' . gmdate('Ymd-His'));
+$zstdCommand = $options['zstd_command'] ?? (getenv('FIGMA_TRANSFORMER_ZSTD_COMMAND') ?: matrix_default_zstd_command());
+$maxNodes = (int) ($options['max_nodes'] ?? 5000);
+$maxPages = (int) ($options['max_pages'] ?? 3);
+$inspectLimit = (int) ($options['inspect_limit'] ?? 40);
+$dryRun = true === ($options['dry_run'] ?? false);
+$inspectOnly = true === ($options['inspect_only'] ?? false);
+$only = isset($options['only']) ? array_filter(array_map('trim', explode(',', (string) $options['only']))) : array();
+$adHocFixtures = matrix_list_option($options['fixture'] ?? array());
+
+$fixtures = matrix_discover_fixtures($fixtureDir);
+foreach ( $adHocFixtures as $fixturePath ) {
+    $fixtures[] = matrix_fixture_from_path($fixturePath, true);
+}
+
+$fixtures = matrix_unique_fixtures($fixtures);
+
+if ( isset($options['frame_ids']) ) {
+    $globalFrameIds = array_values(array_filter(array_map('trim', explode(',', (string) $options['frame_ids']))));
+    foreach ( $fixtures as $index => $fixture ) {
+        $fixtures[$index]['mode'] = 'transform';
+        $fixtures[$index]['frame_ids'] = $globalFrameIds;
+        $fixtures[$index]['entry_frame_id'] = (string) ($options['entry_frame_id'] ?? ($globalFrameIds[0] ?? ''));
+    }
+}
+
+if ( ! empty($only) ) {
+    $fixtures = array_values(array_filter($fixtures, static fn (array $fixture): bool => in_array($fixture['id'], $only, true)));
+}
+
+if ( empty($fixtures) ) {
+    fwrite(STDERR, "No fixtures selected.\n");
+    exit(1);
+}
+
+$summary = array(
+    'schema' => 'blocks-engine/figma-transformer/fixture-matrix/v1',
+    'fixture_dir' => $fixtureDir,
+    'output_dir' => $outputDir,
+    'zstd_command' => $zstdCommand,
+    'max_nodes' => $maxNodes,
+    'max_pages' => $maxPages,
+    'inspect_limit' => $inspectLimit,
+    'dry_run' => $dryRun,
+    'inspect_only' => $inspectOnly,
+    'fixtures' => array(),
+);
+
+if ( ! $dryRun && ! is_dir($outputDir) && ! mkdir($outputDir, 0777, true) && ! is_dir($outputDir) ) {
+    fwrite(STDERR, "Unable to create output directory: {$outputDir}\n");
+    exit(1);
+}
+
+foreach ( $fixtures as $fixture ) {
+    $fixturePath = (string) ($fixture['path'] ?? ($fixtureDir . '/' . $fixture['file']));
+    $record = array(
+        'id' => $fixture['id'],
+        'mode' => $fixture['mode'] ?? 'auto',
+        'path' => $fixturePath,
+        'exists' => is_file($fixturePath),
+    );
+
+    if ( ! is_file($fixturePath) ) {
+        $record['status'] = 'missing_fixture';
+        $summary['fixtures'][] = $record;
+        continue;
+    }
+
+    $fixtureOutputDir = $outputDir . '/' . $fixture['id'];
+    $inspectPath = $outputDir . '/' . $fixture['id'] . '-inspect.json';
+    $resultPath = $outputDir . '/' . $fixture['id'] . '-result.json';
+    $inspectCommand = matrix_inspect_command($figmaRoot, $fixturePath, $inspectPath, $zstdCommand, $inspectLimit);
+    $record['inspect_command'] = $inspectCommand;
+    $record['inspect_path'] = $inspectPath;
+    $record['result_path'] = $resultPath;
+    $record['artifact_dir'] = $fixtureOutputDir;
+
+    if ( $dryRun ) {
+        $record['status'] = 'planned';
+        $record['selection'] = isset($fixture['frame_ids']) ? 'manual_frame_ids' : 'auto_from_inspection';
+        $summary['fixtures'][] = $record;
+        continue;
+    }
+
+    $startedAt = microtime(true);
+    passthru($inspectCommand, $inspectExitCode);
+    $record['inspect_exit_code'] = $inspectExitCode;
+    $record['inspect_duration_ms'] = (int) round((microtime(true) - $startedAt) * 1000);
+    if ( 0 !== $inspectExitCode || ! is_file($inspectPath) ) {
+        $record['status'] = 'inspect_failed';
+        $summary['fixtures'][] = $record;
+        continue;
+    }
+
+    $inspection = json_decode((string) file_get_contents($inspectPath), true);
+    $record['inspection'] = matrix_inspection_summary(is_array($inspection) ? $inspection : array());
+    $frameIds = isset($fixture['frame_ids']) && is_array($fixture['frame_ids']) ? $fixture['frame_ids'] : matrix_select_frame_ids(is_array($inspection) ? $inspection : array(), $maxPages);
+    $record['selected_frame_ids'] = $frameIds;
+    $record['selected_frames'] = matrix_selected_frame_records(is_array($inspection) ? $inspection : array(), $frameIds);
+    $record['entry_frame_id'] = (string) ($fixture['entry_frame_id'] ?? ($frameIds[0] ?? ''));
+
+    if ( $inspectOnly ) {
+        $record['status'] = 'inspected';
+        $summary['fixtures'][] = $record;
+        continue;
+    }
+
+    if ( empty($frameIds) ) {
+        $record['status'] = 'no_frame_candidates';
+        $summary['fixtures'][] = $record;
+        continue;
+    }
+
+    $command = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes);
+    $record['command'] = $command;
+    passthru($command, $exitCode);
+    $record['exit_code'] = $exitCode;
+    $record['duration_ms'] = (int) round((microtime(true) - $startedAt) * 1000);
+    $record['status'] = 0 === $exitCode ? 'completed' : 'failed';
+
+    if ( 0 === $exitCode && is_file($resultPath) ) {
+        $result = json_decode((string) file_get_contents($resultPath), true);
+        if ( is_array($result) ) {
+            $record['result_status'] = $result['status'] ?? null;
+            $record['metrics'] = $result['metrics'] ?? array();
+            $diagnostics = $result['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+            if ( is_array($diagnostics) ) {
+                $record['diagnostic_codes'] = $diagnostics['diagnostic_codes'] ?? array();
+                $record['vector_placeholders'] = $diagnostics['vectors']['placeholders'] ?? null;
+                $record['generated_svg_assets'] = $diagnostics['generated_svg_assets'] ?? null;
+            }
+        }
+    }
+
+    $summary['fixtures'][] = $record;
+}
+
+if ( ! $dryRun ) {
+    file_put_contents($outputDir . '/summary.json', json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+}
+
+echo json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+
+function matrix_options(array $argv): array
+{
+    $options = array();
+    foreach ( array_slice($argv, 1) as $arg ) {
+        if ( '--dry-run' === $arg ) {
+            $options['dry_run'] = true;
+            continue;
+        }
+
+        if ( '--inspect-only' === $arg ) {
+            $options['inspect_only'] = true;
+            continue;
+        }
+
+        if ( ! str_starts_with($arg, '--') || ! str_contains($arg, '=') ) {
+            continue;
+        }
+
+        [$name, $value] = explode('=', substr($arg, 2), 2);
+        $key = str_replace('-', '_', $name);
+        if ( 'fixture' === $key ) {
+            $options[$key] ??= array();
+            $options[$key][] = $value;
+            continue;
+        }
+
+        $options[$key] = $value;
+    }
+
+    return $options;
+}
+
+/**
+ * @param mixed $value
+ * @return array<int, string>
+ */
+function matrix_list_option(mixed $value): array
+{
+    if ( is_array($value) ) {
+        return array_values(array_filter(array_map('strval', $value), static fn (string $item): bool => '' !== trim($item)));
+    }
+
+    if ( is_scalar($value) && '' !== trim((string) $value) ) {
+        return array((string) $value);
+    }
+
+    return array();
+}
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function matrix_discover_fixtures(string $fixtureDir): array
+{
+    $paths = glob(rtrim($fixtureDir, '/') . '/*.fig') ?: array();
+    sort($paths, SORT_NATURAL | SORT_FLAG_CASE);
+
+    return array_map(static fn (string $path): array => matrix_fixture_from_path($path, false), $paths);
+}
+
+/**
+ * @param array<int, array<string, mixed>> $fixtures
+ * @return array<int, array<string, mixed>>
+ */
+function matrix_unique_fixtures(array $fixtures): array
+{
+    $unique = array();
+    foreach ( $fixtures as $fixture ) {
+        $path = isset($fixture['path']) && is_scalar($fixture['path']) ? (string) $fixture['path'] : '';
+        $key = (string) ($fixture['id'] ?? '') . '|' . ($path ? (realpath($path) ?: $path) : '');
+        $unique[$key] = $fixture;
+    }
+
+    return array_values($unique);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function matrix_fixture_from_path(string $path, bool $adHoc): array
+{
+    $id = matrix_fixture_id($path);
+    return array(
+        'id' => $id,
+        'file' => basename($path),
+        'path' => $path,
+        'mode' => 'auto',
+        'inspect_limit' => 40,
+        'ad_hoc' => $adHoc,
+    );
+}
+
+function matrix_fixture_id(string $path): string
+{
+    $base = preg_replace('/\.fig$/i', '', basename($path)) ?? basename($path);
+    $id = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '-', $base));
+    return trim($id, '-') ?: 'fixture';
+}
+
+function matrix_default_zstd_command(): string
+{
+    foreach ( array('/opt/homebrew/bin/zstd', '/usr/local/bin/zstd', '/usr/bin/zstd') as $candidate ) {
+        if ( is_file($candidate) && is_executable($candidate) ) {
+            return $candidate;
+        }
+    }
+
+    $path = trim((string) shell_exec('command -v zstd 2>/dev/null'));
+    return '' !== $path ? $path : 'zstd';
+}
+
+function matrix_inspect_command(string $figmaRoot, string $fixturePath, string $resultPath, string $zstdCommand, int $inspectLimit): string
+{
+    $parts = array(
+        escapeshellarg(PHP_BINARY),
+        '-d',
+        'memory_limit=1536M',
+        escapeshellarg($figmaRoot . '/bin/figma-transformer'),
+        escapeshellarg($fixturePath),
+        '--zstd-command=' . escapeshellarg($zstdCommand),
+    );
+
+    $parts[] = '--inspect-frames=' . $inspectLimit;
+
+    return implode(' ', $parts) . ' > ' . escapeshellarg($resultPath);
+}
+
+/**
+ * @param array<int, string> $frameIds
+ */
+function matrix_transform_command(string $figmaRoot, string $fixturePath, array $frameIds, string $entryFrameId, string $fixtureOutputDir, string $resultPath, string $zstdCommand, int $maxNodes): string
+{
+    $parts = array(
+        escapeshellarg(PHP_BINARY),
+        '-d',
+        'memory_limit=1536M',
+        escapeshellarg($figmaRoot . '/bin/figma-transformer'),
+        escapeshellarg($fixturePath),
+        '--zstd-command=' . escapeshellarg($zstdCommand),
+        '--multi-page',
+        '--frame-ids=' . escapeshellarg(implode(',', $frameIds)),
+        '--entry-frame-id=' . escapeshellarg($entryFrameId),
+        '--max-nodes=' . $maxNodes,
+        '--output-dir=' . escapeshellarg($fixtureOutputDir),
+    );
+
+    return implode(' ', $parts) . ' > ' . escapeshellarg($resultPath);
+}
+
+/**
+ * @param array<string, mixed> $inspection
+ * @return array<string, mixed>
+ */
+function matrix_inspection_summary(array $inspection): array
+{
+    return array(
+        'status' => $inspection['status'] ?? null,
+        'node_count' => $inspection['node_count'] ?? null,
+        'candidate_count' => $inspection['candidate_count'] ?? null,
+        'returned_count' => $inspection['returned_count'] ?? null,
+    );
+}
+
+/**
+ * @param array<string, mixed> $inspection
+ * @return array<int, string>
+ */
+function matrix_select_frame_ids(array $inspection, int $maxPages): array
+{
+    $candidates = is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array();
+    usort($candidates, static fn (mixed $a, mixed $b): int => matrix_candidate_rank(is_array($b) ? $b : array()) <=> matrix_candidate_rank(is_array($a) ? $a : array()));
+
+    $selected = array();
+    foreach ( $candidates as $candidate ) {
+        if ( count($selected) >= $maxPages || ! is_array($candidate) ) {
+            break;
+        }
+
+        $id = isset($candidate['id']) && is_scalar($candidate['id']) ? (string) $candidate['id'] : '';
+        if ( '' === $id || ! matrix_is_page_like_candidate($candidate) ) {
+            continue;
+        }
+
+        $selected[] = $id;
+    }
+
+    if ( empty($selected) ) {
+        foreach ( $candidates as $candidate ) {
+            if ( count($selected) >= $maxPages || ! is_array($candidate) ) {
+                break;
+            }
+
+            $id = isset($candidate['id']) && is_scalar($candidate['id']) ? (string) $candidate['id'] : '';
+            if ( '' !== $id ) {
+                $selected[] = $id;
+            }
+        }
+    }
+
+    return $selected;
+}
+
+/**
+ * @param array<string, mixed> $inspection
+ * @param array<int, string> $frameIds
+ * @return array<int, array<string, mixed>>
+ */
+function matrix_selected_frame_records(array $inspection, array $frameIds): array
+{
+    $byId = array();
+    foreach ( is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array() as $candidate ) {
+        if ( ! is_array($candidate) || ! isset($candidate['id']) || ! is_scalar($candidate['id']) ) {
+            continue;
+        }
+
+        $byId[(string) $candidate['id']] = array(
+            'id' => (string) $candidate['id'],
+            'name' => (string) ($candidate['name'] ?? ''),
+            'page' => (string) ($candidate['page']['name'] ?? ''),
+            'width' => $candidate['width'] ?? null,
+            'height' => $candidate['height'] ?? null,
+            'score' => $candidate['score'] ?? null,
+            'rank' => matrix_candidate_rank($candidate),
+        );
+    }
+
+    return array_values(array_filter(array_map(static fn (string $id): ?array => $byId[$id] ?? null, $frameIds)));
+}
+
+/**
+ * @param array<string, mixed> $candidate
+ */
+function matrix_candidate_rank(array $candidate): int
+{
+    $score = isset($candidate['score']) && is_numeric($candidate['score']) ? (int) $candidate['score'] : 0;
+    $name = strtolower((string) ($candidate['name'] ?? ''));
+    $pageName = strtolower((string) ($candidate['page']['name'] ?? ''));
+    $parentType = strtoupper((string) ($candidate['parent']['type'] ?? ''));
+
+    if ( in_array($parentType, array('CANVAS', 'SECTION'), true) ) {
+        $score += 100;
+    }
+    if ( 1 === preg_match('/\b(home|homepage|desktop|page|website|landing|lp|archive|single|blog|theme|build)\b/', $name . ' ' . $pageName) ) {
+        $score += 200;
+    }
+    if ( 1 === preg_match('/\b(style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
+        $score -= 250;
+    }
+
+    return $score;
+}
+
+/**
+ * @param array<string, mixed> $candidate
+ */
+function matrix_is_page_like_candidate(array $candidate): bool
+{
+    $name = strtolower((string) ($candidate['name'] ?? ''));
+    $pageName = strtolower((string) ($candidate['page']['name'] ?? ''));
+    $width = isset($candidate['width']) && is_numeric($candidate['width']) ? (float) $candidate['width'] : 0.0;
+    $height = isset($candidate['height']) && is_numeric($candidate['height']) ? (float) $candidate['height'] : 0.0;
+    $textCount = isset($candidate['text_count']) && is_numeric($candidate['text_count']) ? (int) $candidate['text_count'] : 0;
+    $parentType = strtoupper((string) ($candidate['parent']['type'] ?? ''));
+
+    if ( 1 === preg_match('/\b(style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
+        return false;
+    }
+    if ( 1 === preg_match('/\b(style tile|style tiles|presentation|template|templates|components)\b/', $pageName) ) {
+        return false;
+    }
+
+    return $width >= 900.0 && $height >= 500.0 && $textCount > 0 && in_array($parentType, array('CANVAS', 'SECTION'), true);
+}

--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -12,7 +12,7 @@ $outputDir = $options['output_dir'] ?? ($defaultOutputRoot . '/figma-transformer
 $zstdCommand = $options['zstd_command'] ?? (getenv('FIGMA_TRANSFORMER_ZSTD_COMMAND') ?: matrix_default_zstd_command());
 $maxNodes = (int) ($options['max_nodes'] ?? 5000);
 $maxPages = (int) ($options['max_pages'] ?? 3);
-$inspectLimit = (int) ($options['inspect_limit'] ?? 40);
+$inspectLimit = (int) ($options['inspect_limit'] ?? 100);
 $dryRun = true === ($options['dry_run'] ?? false);
 $inspectOnly = true === ($options['inspect_only'] ?? false);
 $only = isset($options['only']) ? array_filter(array_map('trim', explode(',', (string) $options['only']))) : array();
@@ -138,6 +138,7 @@ foreach ( $fixtures as $fixture ) {
                 $record['diagnostic_codes'] = $diagnostics['diagnostic_codes'] ?? array();
                 $record['vector_placeholders'] = $diagnostics['vectors']['placeholders'] ?? null;
                 $record['generated_svg_assets'] = $diagnostics['generated_svg_assets'] ?? null;
+                $record['artifact_quality'] = $diagnostics['artifact_quality'] ?? null;
             }
         }
     }
@@ -324,6 +325,8 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
     usort($candidates, static fn (mixed $a, mixed $b): int => matrix_candidate_rank(is_array($b) ? $b : array()) <=> matrix_candidate_rank(is_array($a) ? $a : array()));
 
     $selected = array();
+    $selectedBuckets = array();
+    $deferred = array();
     foreach ( $candidates as $candidate ) {
         if ( count($selected) >= $maxPages || ! is_array($candidate) ) {
             break;
@@ -334,7 +337,25 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
             continue;
         }
 
+        $bucket = matrix_candidate_bucket($candidate);
+        if ( isset($selectedBuckets[$bucket]) ) {
+            $deferred[] = $candidate;
+            continue;
+        }
+
         $selected[] = $id;
+        $selectedBuckets[$bucket] = true;
+    }
+
+    foreach ( $deferred as $candidate ) {
+        if ( count($selected) >= $maxPages || ! is_array($candidate) ) {
+            break;
+        }
+
+        $id = isset($candidate['id']) && is_scalar($candidate['id']) ? (string) $candidate['id'] : '';
+        if ( '' !== $id && ! in_array($id, $selected, true) ) {
+            $selected[] = $id;
+        }
     }
 
     if ( empty($selected) ) {
@@ -349,6 +370,41 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
             }
         }
     }
+
+    return matrix_order_selected_frame_ids($selected, $candidates);
+}
+
+/**
+ * @param array<int, string> $selected
+ * @param array<int, mixed>  $candidates
+ * @return array<int, string>
+ */
+function matrix_order_selected_frame_ids(array $selected, array $candidates): array
+{
+    $byId = array();
+    $positions = array();
+    foreach ( $selected as $index => $id ) {
+        $positions[$id] = $index;
+    }
+
+    foreach ( $candidates as $candidate ) {
+        if ( is_array($candidate) && isset($candidate['id']) && is_scalar($candidate['id']) ) {
+            $byId[(string) $candidate['id']] = $candidate;
+        }
+    }
+
+    usort(
+        $selected,
+        static function (string $left, string $right) use ($byId, $positions): int {
+            $leftBucket = isset($byId[$left]) ? matrix_candidate_bucket($byId[$left]) : '';
+            $rightBucket = isset($byId[$right]) ? matrix_candidate_bucket($byId[$right]) : '';
+            if ( 'homepage' === $leftBucket || 'homepage' === $rightBucket ) {
+                return ('homepage' === $leftBucket ? 0 : 1) <=> ('homepage' === $rightBucket ? 0 : 1);
+            }
+
+            return ((int) ($positions[$left] ?? 0)) <=> ((int) ($positions[$right] ?? 0));
+        }
+    );
 
     return $selected;
 }
@@ -374,6 +430,8 @@ function matrix_selected_frame_records(array $inspection, array $frameIds): arra
             'height' => $candidate['height'] ?? null,
             'score' => $candidate['score'] ?? null,
             'rank' => matrix_candidate_rank($candidate),
+            'bucket' => matrix_candidate_bucket($candidate),
+            'selection_reasons' => matrix_candidate_selection_reasons($candidate),
         );
     }
 
@@ -388,19 +446,107 @@ function matrix_candidate_rank(array $candidate): int
     $score = isset($candidate['score']) && is_numeric($candidate['score']) ? (int) $candidate['score'] : 0;
     $name = strtolower((string) ($candidate['name'] ?? ''));
     $pageName = strtolower((string) ($candidate['page']['name'] ?? ''));
+    $type = strtoupper((string) ($candidate['type'] ?? ''));
     $parentType = strtoupper((string) ($candidate['parent']['type'] ?? ''));
 
+    if ( 'FRAME' === $type ) {
+        $score += 160;
+    } elseif ( in_array($type, array('COMPONENT', 'INSTANCE'), true) ) {
+        $score -= 400;
+    }
     if ( in_array($parentType, array('CANVAS', 'SECTION'), true) ) {
         $score += 100;
     }
-    if ( 1 === preg_match('/\b(home|homepage|desktop|page|website|landing|lp|archive|single|blog|theme|build)\b/', $name . ' ' . $pageName) ) {
+    if ( 1 === preg_match('/\b(home|homepage|desktop|page|website|landing|lp|archive|single|blog|theme|build|hosts?|agenc(?:y|ies)|pricing|features?|about|contact)\b/', $name . ' ' . $pageName) ) {
         $score += 200;
     }
-    if ( 1 === preg_match('/\b(style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
+    if ( 1 === preg_match('/\b(website comps?|pages?|screens?|final|production|dev handoff)\b/', $pageName) ) {
+        $score += 240;
+    }
+    if ( 1 === preg_match('/\b(for hosts?|for agenc(?:y|ies)|pricing|features?|about|contact)\b/', $name) ) {
+        $score += 160;
+    }
+    if ( 1 === preg_match('/\blp\s*i\s*([0-9]+)\b/', $name, $nameMatches) && 1 === preg_match('/\bi\s*([0-9]+)\b/', $pageName, $pageMatches) && $nameMatches[1] !== $pageMatches[1] ) {
+        $score -= 90;
+    }
+    if ( 1 === preg_match('/\b(style guide|style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
         $score -= 250;
+    }
+    if ( 1 === preg_match('/\b(playground|presentation|addit?ional links?|graphics|imageries|exploration|scratch|old|deprecated|archive copy|copy\b|wip)\b/', $name . ' ' . $pageName) ) {
+        $score -= 320;
     }
 
     return $score;
+}
+
+/**
+ * @param array<string, mixed> $candidate
+ */
+function matrix_candidate_bucket(array $candidate): string
+{
+    $name = strtolower((string) ($candidate['name'] ?? ''));
+    $pageName = strtolower((string) ($candidate['page']['name'] ?? ''));
+    $haystack = $name . ' ' . $pageName;
+
+    if ( 1 === preg_match('/\blp\s*i\s*([0-9]+)\b/', $haystack, $matches) ) {
+        return 'landing:i' . $matches[1];
+    }
+    if ( 1 === preg_match('/\blp\b.*\bnew\b/', $haystack) ) {
+        return 'landing:new';
+    }
+    if ( 1 === preg_match('/\bi\s*([0-9]+)\b/', $pageName, $matches) && 1 === preg_match('/\blp\b/', $name) ) {
+        return 'landing:i' . $matches[1];
+    }
+
+    foreach ( array(
+        'homepage' => '/\b(home|homepage)\b/',
+        'hosts' => '/\bhosts?\b/',
+        'agencies' => '/\bagenc(?:y|ies)\b/',
+        'pricing' => '/\bpricing\b/',
+        'features' => '/\bfeatures?\b/',
+        'about' => '/\babout\b/',
+        'contact' => '/\bcontact\b/',
+        'archive' => '/\barchive\b/',
+        'single' => '/\b(single|post page)\b/',
+        'theme' => '/\b(theme|build)\b/',
+        'landing' => '/\b(landing|lp)\b/',
+    ) as $bucket => $pattern ) {
+        if ( 1 === preg_match($pattern, $haystack) ) {
+            return $bucket;
+        }
+    }
+
+    $normalized = preg_replace('/\b(desktop|mobile|tablet|copy|wip|new|old|v\d+|i\d+)\b/', '', $name) ?? $name;
+    $normalized = trim(preg_replace('/[^a-z0-9]+/', '-', $normalized) ?? '');
+    return '' !== $normalized ? 'frame:' . $normalized : 'generic';
+}
+
+/**
+ * @param array<string, mixed> $candidate
+ * @return array<int, string>
+ */
+function matrix_candidate_selection_reasons(array $candidate): array
+{
+    $reasons = array();
+    $name = strtolower((string) ($candidate['name'] ?? ''));
+    $pageName = strtolower((string) ($candidate['page']['name'] ?? ''));
+    $type = strtoupper((string) ($candidate['type'] ?? ''));
+    $parentType = strtoupper((string) ($candidate['parent']['type'] ?? ''));
+
+    if ( 'FRAME' === $type ) {
+        $reasons[] = 'transformable_frame';
+    }
+    if ( in_array($parentType, array('CANVAS', 'SECTION'), true) ) {
+        $reasons[] = 'top_level_candidate';
+    }
+    if ( 1 === preg_match('/\b(home|homepage|website|landing|lp|archive|single|blog|theme|build|hosts?|agenc(?:y|ies)|pricing|features?|about|contact)\b/', $name . ' ' . $pageName) ) {
+        $reasons[] = 'page_like_name';
+    }
+    if ( 1 === preg_match('/\b(website comps?|pages?|screens?|final|production|dev handoff)\b/', $pageName) ) {
+        $reasons[] = 'page_collection';
+    }
+
+    return $reasons;
 }
 
 /**
@@ -410,15 +556,19 @@ function matrix_is_page_like_candidate(array $candidate): bool
 {
     $name = strtolower((string) ($candidate['name'] ?? ''));
     $pageName = strtolower((string) ($candidate['page']['name'] ?? ''));
+    $type = strtoupper((string) ($candidate['type'] ?? ''));
     $width = isset($candidate['width']) && is_numeric($candidate['width']) ? (float) $candidate['width'] : 0.0;
     $height = isset($candidate['height']) && is_numeric($candidate['height']) ? (float) $candidate['height'] : 0.0;
     $textCount = isset($candidate['text_count']) && is_numeric($candidate['text_count']) ? (int) $candidate['text_count'] : 0;
     $parentType = strtoupper((string) ($candidate['parent']['type'] ?? ''));
 
-    if ( 1 === preg_match('/\b(style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
+    if ( 'FRAME' !== $type ) {
         return false;
     }
-    if ( 1 === preg_match('/\b(style tile|style tiles|presentation|template|templates|components)\b/', $pageName) ) {
+    if ( 1 === preg_match('/\b(style guide|style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
+        return false;
+    }
+    if ( 1 === preg_match('/\b(style guide|style tile|style tiles|presentation|template|templates|components)\b/', $pageName) ) {
         return false;
     }
 

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -671,6 +671,18 @@ final class FigmaTransformer
 
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
         ksort($diagnosticCodes);
+        $fonts = array(
+            'families' => $fontFamilies,
+            'count' => count($fontFamilies),
+            'css_supplied' => $fontCssSupplied,
+            'materialized' => $fontMaterialized,
+            'missing_css' => $missingCss,
+        );
+        $assets = array(
+            'emitted_files' => count($assetReport),
+            'paths' => array_values(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $assetReport)),
+        );
+        $generatedSvgAssets = $this->generatedSvgAssetsFromReport($assetReport);
 
         return array(
             'schema' => 'blocks-engine/figma-transformer/transform-diagnostics/v1',
@@ -678,20 +690,64 @@ final class FigmaTransformer
             'pages' => $pages,
             'images' => $images,
             'vectors' => $vectors,
-            'fonts' => array(
-                'families' => $fontFamilies,
-                'count' => count($fontFamilies),
-                'css_supplied' => $fontCssSupplied,
-                'materialized' => $fontMaterialized,
-                'missing_css' => $missingCss,
-            ),
-            'assets' => array(
-                'emitted_files' => count($assetReport),
-                'paths' => array_values(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $assetReport)),
-            ),
-            'generated_svg_assets' => $this->generatedSvgAssetsFromReport($assetReport),
+            'fonts' => $fonts,
+            'assets' => $assets,
+            'generated_svg_assets' => $generatedSvgAssets,
             'layout' => $layout,
+            'artifact_quality' => $this->artifactQualityDiagnostics($images, $vectors, $fonts, $assets, $generatedSvgAssets, $layout),
             'diagnostic_codes' => $diagnosticCodes,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $images
+     * @param array<string, mixed> $vectors
+     * @param array<string, mixed> $fonts
+     * @param array<string, mixed> $assets
+     * @param array<string, mixed> $generatedSvgAssets
+     * @param array<string, mixed> $layout
+     * @return array<string, mixed>
+     */
+    private function artifactQualityDiagnostics(array $images, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout): array
+    {
+        $signals = array();
+
+        if ( ! empty($images['missing_assets']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'missing_render_assets', 'count' => count($images['missing_assets']));
+        }
+        if ( ! empty($vectors['placeholders']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'vector_placeholders', 'count' => (int) $vectors['placeholders']);
+        }
+        if ( ! empty($fonts['missing_css']) ) {
+            $signals[] = array('severity' => 'info', 'code' => 'font_css_missing', 'count' => count($fonts['missing_css']));
+        }
+        if ( ! empty($layout['large_negative_left_count']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'off_canvas_left_css', 'count' => (int) $layout['large_negative_left_count']);
+        }
+        if ( (int) ($generatedSvgAssets['bytes'] ?? 0) > 1048576 ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'large_generated_svg_assets',
+                'count' => (int) ($generatedSvgAssets['count'] ?? 0),
+                'bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
+            );
+        }
+
+        $warningCount = count(array_filter($signals, static fn (array $signal): bool => 'warning' === ($signal['severity'] ?? null)));
+
+        return array(
+            'schema' => 'blocks-engine/figma-transformer/artifact-quality/v1',
+            'status' => $warningCount > 0 ? 'needs_review' : (empty($signals) ? 'clean' : 'info'),
+            'signals' => $signals,
+            'summary' => array(
+                'missing_asset_nodes' => count($images['missing_assets'] ?? array()),
+                'vector_placeholders' => (int) ($vectors['placeholders'] ?? 0),
+                'missing_font_css' => count($fonts['missing_css'] ?? array()),
+                'emitted_asset_files' => (int) ($assets['emitted_files'] ?? 0),
+                'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
+                'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
+                'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
+            ),
         );
     }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1538,10 +1538,34 @@ final class StaticHtmlEmitter
         }
 
         if ( isset($text['characters']) && is_scalar($text['characters']) ) {
-            return $this->sanitizeText($this->derivedLineBreakText((string) $text['characters'], $text));
+            $characters = (string) $text['characters'];
+            if ( $this->isUnresolvedComponentPlaceholderText($node, $characters) ) {
+                return '';
+            }
+
+            return $this->sanitizeText($this->derivedLineBreakText($characters, $text));
         }
 
-        return $this->sanitizeText((string) ($node['characters'] ?? $node['text'] ?? ''));
+        $characters = (string) ($node['characters'] ?? $node['text'] ?? '');
+        if ( $this->isUnresolvedComponentPlaceholderText($node, $characters) ) {
+            return '';
+        }
+
+        return $this->sanitizeText($characters);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isUnresolvedComponentPlaceholderText(array $node, string $characters): bool
+    {
+        $placeholder = strtolower(trim($characters));
+        if ( ! in_array($placeholder, array('button label'), true) ) {
+            return false;
+        }
+
+        $id = (string) ($node['id'] ?? '');
+        return str_contains($id, '/') || isset($node['figma_component_source_id']);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -687,25 +687,97 @@ final class StaticHtmlEmitter
         $vectors['placeholder_nodes'] = array_values($vectors['placeholder_nodes']);
         $layout['decorative_underlays']['nodes'] = array_values($layout['decorative_underlays']['nodes']);
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
+        $generatedSvgAssets = $this->generatedSvgAssetDiagnostics($assetFiles);
+        $assets = array(
+            'emitted_files' => count($assetFiles),
+            'paths'         => array_values(array_map(static fn (array $file): string => (string) ($file['path'] ?? ''), $assetFiles)),
+        );
+        $fonts = array(
+            'families'      => $fontFamilies,
+            'count'         => count($fontFamilies),
+            'css_supplied'  => '' !== $fontCss,
+            'materialized'  => '' !== $fontCss,
+            'missing_css'   => '' === $fontCss ? array_values(array_filter($fontFamilies, fn (string $family): bool => ! $this->isWebSafeFontFamily($family))) : array(),
+        );
 
         return array(
             'schema' => 'blocks-engine/figma-transformer/transform-diagnostics/v1',
             'images' => $image,
             'vectors' => $vectors,
-            'fonts' => array(
-                'families'      => $fontFamilies,
-                'count'         => count($fontFamilies),
-                'css_supplied'  => '' !== $fontCss,
-                'materialized'  => '' !== $fontCss,
-                'missing_css'   => '' === $fontCss ? array_values(array_filter($fontFamilies, fn (string $family): bool => ! $this->isWebSafeFontFamily($family))) : array(),
-            ),
-            'assets' => array(
-                'emitted_files' => count($assetFiles),
-                'paths'         => array_values(array_map(static fn (array $file): string => (string) ($file['path'] ?? ''), $assetFiles)),
-            ),
-            'generated_svg_assets' => $this->generatedSvgAssetDiagnostics($assetFiles),
+            'fonts' => $fonts,
+            'assets' => $assets,
+            'generated_svg_assets' => $generatedSvgAssets,
             'layout' => $layout,
+            'artifact_quality' => $this->artifactQualityDiagnostics($image, $vectors, $fonts, $assets, $generatedSvgAssets, $layout),
             'diagnostic_codes' => $this->diagnosticCodeCounts($diagnostics),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $image
+     * @param array<string, mixed> $vectors
+     * @param array<string, mixed> $fonts
+     * @param array<string, mixed> $assets
+     * @param array<string, mixed> $generatedSvgAssets
+     * @param array<string, mixed> $layout
+     * @return array<string, mixed>
+     */
+    private function artifactQualityDiagnostics(array $image, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout): array
+    {
+        $signals = array();
+
+        if ( ! empty($image['missing_assets']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'missing_render_assets',
+                'count' => count($image['missing_assets']),
+            );
+        }
+        if ( ! empty($vectors['placeholders']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'vector_placeholders',
+                'count' => (int) $vectors['placeholders'],
+            );
+        }
+        if ( ! empty($fonts['missing_css']) ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'font_css_missing',
+                'count' => count($fonts['missing_css']),
+            );
+        }
+        if ( ! empty($layout['large_negative_left_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'off_canvas_left_css',
+                'count' => (int) $layout['large_negative_left_count'],
+            );
+        }
+        if ( (int) ($generatedSvgAssets['bytes'] ?? 0) > 1048576 ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'large_generated_svg_assets',
+                'count' => (int) ($generatedSvgAssets['count'] ?? 0),
+                'bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
+            );
+        }
+
+        $warningCount = count(array_filter($signals, static fn (array $signal): bool => 'warning' === ($signal['severity'] ?? null)));
+
+        return array(
+            'schema' => 'blocks-engine/figma-transformer/artifact-quality/v1',
+            'status' => $warningCount > 0 ? 'needs_review' : (empty($signals) ? 'clean' : 'info'),
+            'signals' => $signals,
+            'summary' => array(
+                'missing_asset_nodes' => count($image['missing_assets'] ?? array()),
+                'vector_placeholders' => (int) ($vectors['placeholders'] ?? 0),
+                'missing_font_css' => count($fonts['missing_css'] ?? array()),
+                'emitted_asset_files' => (int) ($assets['emitted_files'] ?? 0),
+                'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
+                'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
+                'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
+            ),
         );
     }
 

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -955,7 +955,7 @@ final class ScenegraphNormalizer
 
             $id = (string) ($child['id'] ?? '');
             $hasOverride = false;
-            $overrideFields = $overrides[$id] ?? array();
+            $overrideFields = $this->instanceOverrideFieldsForChild($child, $overrides);
             foreach ( $overrideFields as $field => $value ) {
                 $hasOverride = true;
                 $child[$field] = $value;
@@ -975,6 +975,55 @@ final class ScenegraphNormalizer
         }
 
         return $children;
+    }
+
+    /**
+     * @param array<string, mixed> $child
+     * @param array<string, array<string, mixed>> $overrides
+     * @return array<string, mixed>
+     */
+    private function instanceOverrideFieldsForChild(array $child, array $overrides): array
+    {
+        $fields = array();
+        foreach ( $this->instanceChildOverrideAliases($child) as $alias ) {
+            if ( isset($overrides[$alias]) && is_array($overrides[$alias]) ) {
+                $fields = array_merge($fields, $overrides[$alias]);
+            }
+
+            foreach ( $overrides as $target => $overrideFields ) {
+                if ( ! is_string($target) || ! is_array($overrideFields) || ! str_contains($target, '/') ) {
+                    continue;
+                }
+
+                $parts = explode('/', $target);
+                if ( $alias === end($parts) ) {
+                    $fields = array_merge($fields, $overrideFields);
+                }
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param array<string, mixed> $child
+     * @return array<int, string>
+     */
+    private function instanceChildOverrideAliases(array $child): array
+    {
+        $aliases = array();
+        foreach ( array('id', 'figma_component_source_id') as $key ) {
+            if ( isset($child[$key]) && is_scalar($child[$key]) && '' !== (string) $child[$key] ) {
+                $aliases[] = (string) $child[$key];
+            }
+        }
+
+        $guidId = $this->readGuidId($child['guid'] ?? null);
+        if ( null !== $guidId ) {
+            $aliases[] = $guidId;
+        }
+
+        return array_values(array_unique($aliases));
     }
 
     /**
@@ -1090,6 +1139,14 @@ final class ScenegraphNormalizer
             $text['style'] = $style;
         }
 
+        if ( isset($text['characters']) && is_scalar($text['characters']) ) {
+            $iconFallback = $this->fontAwesomeIconNameFallback((string) $text['characters'], $style);
+            if ( null !== $iconFallback ) {
+                $text['icon_name'] = (string) $text['characters'];
+                $text['characters'] = $iconFallback;
+            }
+        }
+
         $derivedLayout = $this->normalizeDerivedTextLayout($node, $blobs, $nodeId, $diagnostics);
         if ( ! empty($derivedLayout) ) {
             $text['derived_layout'] = $derivedLayout;
@@ -1101,6 +1158,31 @@ final class ScenegraphNormalizer
         }
 
         return $text;
+    }
+
+    /**
+     * @param array<string, mixed> $style
+     */
+    private function fontAwesomeIconNameFallback(string $characters, array $style): ?string
+    {
+        $fontFamily = strtolower((string) ($style['font_family'] ?? ''));
+        $postscript = strtolower((string) ($style['font_postscript_name'] ?? ''));
+        if ( ! str_contains($fontFamily, 'font awesome') && ! str_contains($postscript, 'fontawesome') ) {
+            return null;
+        }
+
+        return match ( strtolower(trim($characters)) ) {
+            'sparkle', 'sparkles' => '✦',
+            'circle-check', 'check-circle' => '✓',
+            'circle', 'circle-small' => '●',
+            'arrow-right' => '→',
+            'arrow-left' => '←',
+            'arrow-up' => '↑',
+            'arrow-down' => '↓',
+            'chevron-right' => '›',
+            'chevron-left' => '‹',
+            default => null,
+        };
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2327,6 +2327,93 @@ $assert(array() === ($resolvedInstanceReport['unresolved_component_references'] 
 $assert(str_contains($resolvedInstanceHtml, 'data-figma-node-id="instance:button"'), 'resolved-instance-preserves-instance-id');
 $assert(str_contains($resolvedInstanceHtml, 'Buy now'), 'resolved-instance-applies-text-override');
 
+$guidOverrideInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'GUID Override Instance Fixture',
+    'nodes' => array(
+        array(
+            'guid'     => array('sessionID' => 47, 'localID' => 25),
+            'type'     => 'COMPONENT',
+            'name'     => 'Menu item component',
+            'children' => array(
+                array(
+                    'guid'       => array('sessionID' => 180, 'localID' => 6416),
+                    'type'       => 'TEXT',
+                    'name'       => 'Menu label',
+                    'characters' => 'Default menu label',
+                ),
+            ),
+        ),
+        array(
+            'id'         => 'instance:menu-item',
+            'type'       => 'INSTANCE',
+            'name'       => 'NewMenuItem',
+            'symbolData' => array(
+                'symbolID' => array('sessionID' => 47, 'localID' => 25),
+                'symbolOverrides' => array(
+                    array(
+                        'guidPath' => array('guids' => array(array('sessionID' => 180, 'localID' => 6416))),
+                        'textData' => array('characters' => 'Learn'),
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$guidOverrideInstanceHtml = $fileContent($guidOverrideInstanceResult, 'index.html');
+$assert(str_contains($guidOverrideInstanceHtml, 'Learn'), 'guid-override-instance-applies-text');
+$assert(str_contains($guidOverrideInstanceHtml, 'data-figma-node-id="instance:menu-item/180:6416"') && str_contains($guidOverrideInstanceHtml, '>Learn<'), 'guid-override-instance-replaces-default-text');
+
+$fontAwesomeIconNameResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Font Awesome Icon Name Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'text:sparkles',
+            'type'     => 'TEXT',
+            'name'     => 'sparkles',
+            'textData' => array('characters' => 'sparkles'),
+            'fontName' => array('family' => 'Font Awesome 7 Pro', 'style' => 'Solid', 'postscript' => 'FontAwesome7Pro-Solid'),
+        ),
+        array(
+            'id'       => 'text:circle-check',
+            'type'     => 'TEXT',
+            'name'     => 'circle-check',
+            'textData' => array('characters' => 'circle-check'),
+            'fontName' => array('family' => 'Font Awesome 7 Pro', 'style' => 'Regular', 'postscript' => 'FontAwesome7Pro-Regular'),
+        ),
+    ),
+));
+$fontAwesomeIconNameHtml = $fileContent($fontAwesomeIconNameResult, 'index.html');
+$assert(str_contains($fontAwesomeIconNameHtml, '✦') && ! str_contains($fontAwesomeIconNameHtml, '>sparkles<'), 'font-awesome-sparkles-name-fallback');
+$assert(str_contains($fontAwesomeIconNameHtml, '✓') && ! str_contains($fontAwesomeIconNameHtml, '>circle-check<'), 'font-awesome-circle-check-name-fallback');
+
+$componentPlaceholderTextResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Component Placeholder Text Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'component:placeholder-button',
+            'type'     => 'COMPONENT',
+            'name'     => 'Placeholder button component',
+            'key'      => 'placeholder-button-key',
+            'children' => array(
+                array(
+                    'id'         => 'component:placeholder-button-label',
+                    'type'       => 'TEXT',
+                    'name'       => 'Button label',
+                    'characters' => 'Button label',
+                ),
+            ),
+        ),
+        array(
+            'id'          => 'instance:placeholder-button',
+            'type'        => 'INSTANCE',
+            'name'        => 'Button-color',
+            'componentId' => 'placeholder-button-key',
+        ),
+    ),
+), array('frame_id' => 'instance:placeholder-button'));
+$componentPlaceholderTextHtml = $fileContent($componentPlaceholderTextResult, 'index.html');
+$assert(str_contains($componentPlaceholderTextHtml, 'data-figma-node-id="instance:placeholder-button/component:placeholder-button-label" data-figma-node-name="Button label"></p>'), 'component-placeholder-button-label-hidden');
+
 $unresolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Unresolved Component Instance Fixture',
     'nodes' => array(

--- a/rigs/figma-transformer-fixture-matrix/rig.json
+++ b/rigs/figma-transformer-fixture-matrix/rig.json
@@ -1,0 +1,40 @@
+{
+  "id": "figma-transformer-fixture-matrix",
+  "description": "Repo-local Figma transformer fixture matrix rig. Runs large local .fig fixtures through the PHP transformer and captures HTML/result artifacts for fidelity review.",
+  "components": {
+    "blocks-engine": {
+      "path": "${package.root}/../..",
+      "branch": "trunk",
+      "extensions": {}
+    }
+  },
+  "resources": {
+    "paths": [
+      "${components.blocks-engine.path}"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "check",
+        "label": "Figma fixture matrix runner exists",
+        "file": "${components.blocks-engine.path}/figma-transformer/scripts/figma-fixture-matrix.php"
+      },
+      {
+        "kind": "command",
+        "label": "Figma fixture matrix dry run",
+        "cwd": "${components.blocks-engine.path}",
+        "command": "php figma-transformer/scripts/figma-fixture-matrix.php --dry-run"
+      }
+    ],
+    "up": [
+      {
+        "kind": "command",
+        "label": "Run Figma fixture matrix",
+        "cwd": "${components.blocks-engine.path}",
+        "command": "php figma-transformer/scripts/figma-fixture-matrix.php"
+      }
+    ],
+    "down": []
+  }
+}


### PR DESCRIPTION
## Summary
- add a repo-local Homeboy rig for Figma transformer fixture matrix runs
- add a matrix runner that discovers `.fig` files from `figma-transformer/fixtures/` and accepts ad-hoc `--fixture=<path>` inputs
- auto-inspect each fixture, select page-like frame candidates, and transform selected frames without hardcoded fixture-specific frame IDs
- add a gitignored local fixture directory for private `.fig` files
- improve artifact fidelity by applying GUID-path instance overrides, replacing known Font Awesome icon-name text with symbol fallbacks, and hiding unresolved component placeholder text like `Button label` inside instances
- improve corpus-driven frame auto-selection with page buckets, selection reasons, homepage entry ordering, and demotion of style guides/playgrounds/reference frames
- add `artifact_quality` diagnostics to single-page, multipage, and fixture-matrix summaries

## Private Fixture Handling
- The `.fig` files are intentionally not committed.
- `figma-transformer/fixtures/.gitignore` ignores fixture contents while preserving directory docs.
- Local private fixture symlinks remain ignored.

## Latest Matrix Evidence
- Commit under test: `7ddb13b`
- Full offloaded runner matrix: `runner-exec-homeboy-lab-ee2f3d98-b924-42c6-8536-34c1b72b66bc`
- Evidence command: `homeboy runs evidence runner-exec-homeboy-lab-ee2f3d98-b924-42c6-8536-34c1b72b66bc`
- Status: pass

Selected frames from the latest full matrix:
- Agentic Commerce WIP: `361:4410` LP i3 visuals, `72:546` LP i1 Dense, `148:1608` LP new
- FSE Pilot Build Theme: `3468:1038` Home Page Desktop, `3468:1118` Blog Post Desktop, `4194:2032` Page Desktop
- Games Hotline Blog Updates: `8:111` Blog Archive Page, `966:421` Post Page
- WP.Cloud 2.0: `5145:7945` Homepage, `5145:6474` For Hosts, `6218:946` For Agencies

Artifact-quality summary from the latest full matrix:
- Agentic: `needs_review`; 12 vector placeholders, 6 missing font CSS families, 5 off-canvas-left CSS signals
- FSE Pilot: `needs_review`; 15 vector placeholders, 6 missing font CSS families
- Games Hotline: `info`; 1 missing font CSS family, 0 vector placeholders
- WP.Cloud: `needs_review`; 1 vector placeholder, 1 missing font CSS family, 6 off-canvas-left CSS signals, 6 generated SVG assets / 4,979,072 bytes

## Verification
- `php -l figma-transformer/scripts/figma-fixture-matrix.php`
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/src/FigmaTransformer.php`
- `php figma-transformer/tests/contract/run.php`
- `homeboy rig check figma-transformer-fixture-matrix --force-hot --allow-local-hot`
- full offloaded Homeboy runner matrix listed above

## AI Assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, fixture-matrix workflow design, verification, and PR preparation
