### PR TITLE
Ignore php-transformer build artifacts

### DIFF
--- a/php-transformer/.gitignore
+++ b/php-transformer/.gitignore
@@ -1,1 +1,2 @@
+/build/
 /vendor/


### PR DESCRIPTION
## Summary
- ignore php-transformer generated build artifacts
- keep generated release notes out of the working tree status

## Testing
- git check-ignore -v php-transformer/build/php-transformer-v0.1.15-release-notes.md

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting generated artifact status, adding the ignore rule, and validating the rule.