### PR TITLE
Normalize navigation labels for block validity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -7,6 +7,8 @@ use DOMElement;
 
 final class NavigationPattern
 {
+    private const BLOCK_LEVEL_LABEL_TAGS = 'address|article|aside|blockquote|div|dl|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|main|nav|ol|p|pre|section|table|ul';
+
     /**
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
      * @param callable(DOMElement): string $innerHtml
@@ -143,7 +145,7 @@ final class NavigationPattern
 
         if ( array() !== $submenuBlocks ) {
             $submenuAttrs = array(
-                'label' => $innerHtml($anchor),
+                'label' => $this->navigationLabel($innerHtml($anchor)),
                 'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
                 'kind'  => 'custom',
             );
@@ -161,10 +163,17 @@ final class NavigationPattern
     private function navigationLinkBlock(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?DOMElement $item = null): array
     {
         return $createBlock('core/navigation-link', $this->navigationItemAttributes($item ?? $anchor, $anchor, null, array(
-            'label' => $innerHtml($anchor),
+            'label' => $this->navigationLabel($innerHtml($anchor)),
             'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
             'kind'  => 'custom',
         ), $presentationAttributes), array(), $anchor);
+    }
+
+    private function navigationLabel(string $html): string
+    {
+        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>\s*<\/\1>/i', '', $html) ?? $html;
+        $html = preg_replace('/<\/?(?:' . self::BLOCK_LEVEL_LABEL_TAGS . ')\b[^>]*>/i', '', $html) ?? $html;
+        return trim($html);
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -380,6 +380,17 @@ $assert(true === ($nonprofitBlockMenu['represented_as_core_navigation'] ?? null)
 $assert('The Measure' === ($nonprofitBlockMenu['items'][1]['label'] ?? ''), 'semantic parity preserves navigation item labels');
 $assert('/vote-yes/' === ($nonprofitBlockMenu['items'][6]['url'] ?? ''), 'semantic parity preserves navigation item URLs');
 
+$navigationLabelResult = ( new HtmlTransformer() )->transform(
+    '<header><nav><a href="/docs"><h3>Docs</h3><span aria-hidden="true"></span></a><ul><li><a href="/guides"><div>Guides</div></a><ul><li><a href="/api"><p>API</p></a></li></ul></li></ul></nav></header>'
+)->toArray();
+$navigationLabelBlocks = $navigationLabelResult['blocks'][0]['innerBlocks'] ?? array();
+$assert('Docs' === ($navigationLabelBlocks[0]['attrs']['label'] ?? ''), 'direct navigation link label unwraps block-level markup for valid inline RichText');
+$assert('Guides' === ($navigationLabelBlocks[1]['attrs']['label'] ?? ''), 'navigation submenu label unwraps block-level markup for valid inline RichText');
+$assert('API' === ($navigationLabelBlocks[1]['innerBlocks'][0]['attrs']['label'] ?? ''), 'nested navigation link label unwraps block-level markup for valid inline RichText');
+$assert(! str_contains((string) ($navigationLabelResult['serialized_blocks'] ?? ''), '<h3>Docs</h3>'), 'navigation serialization avoids heading markup inside link text');
+$assert(! str_contains((string) ($navigationLabelResult['serialized_blocks'] ?? ''), '<div>Guides</div>'), 'navigation serialization avoids div markup inside submenu link text');
+$assert('pass' === ($navigationLabelResult['source_reports']['wp_block_validity']['status'] ?? ''), 'navigation labels with block-level source markup pass WordPress block validity');
+
 $unmappedNavigation = ( new HtmlTransformer() )->transform(
     '<main><nav aria-label="Main navigation"><ul><li><a href="/">Home</a></li></ul><p>Unexpected helper copy</p></nav></main>'
 )->toArray();


### PR DESCRIPTION
## Summary
- Normalize HTML navigation labels before serializing core/navigation-link and core/navigation-submenu blocks.
- Strip block-level wrapper tags and empty aria-hidden icon elements from navigation labels, matching the existing button label normalization behavior.
- Add contract coverage for direct nav links, submenu labels, and nested nav links sourced from block-level label markup.

## Matrix cluster summary
- Missing core/navigation representation: 20 findings across header/footer/sidebar/main nav landmarks.
- Navigation item count mismatch: 27 findings across ul/li/a, direct nav > a, footer/sidebar navs, and nested menus.
- Nav landmark under-representation: 12 findings where source nav landmarks exceed generated core navigation blocks.
- Item label/URL mismatch: 2 findings.
- Navigation block validity: 5 findings from block-level markup inside serialized link labels.
- Mobile drawer/runtime duplication also appears through runtime target diagnostics and existing dedupe coverage, but was not the smallest safe fix here.

## Chosen fix
The clearest small, generic, high-confidence fix is navigation label normalization. It directly targets the wp_block_validity_navigation_block_level_link_markup history without fixture selectors and improves generated navigation validity for direct links, list menus, and nested submenu labels.

## Verification
- composer test

## Expected matrix impact
- Expected to clear or reduce the 5 navigation block validity findings with reason: Serialized link text contains block-level markup that WordPress static link blocks do not save as valid inline RichText.
- Not expected to materially change missing menu, item count mismatch, or landmark mismatch buckets; those need broader navigation recognition/projection work.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finding packet clustering, implementation, regression test drafting, and verification.