### PR TITLE
Convert readable range inputs

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3508,7 +3508,7 @@ final class HtmlTransformer
             return true;
         }
 
-        return 'button' === $tagName || ( 'input' === $tagName && in_array($this->formControlType($control), array( 'checkbox', 'email', 'number', 'radio', 'search', 'submit', 'tel', 'text', 'url' ), true) );
+        return 'button' === $tagName || ( 'input' === $tagName && in_array($this->formControlType($control), array( 'checkbox', 'email', 'number', 'radio', 'range', 'search', 'submit', 'tel', 'text', 'url' ), true) );
     }
 
     private function readableFormControlText(DOMElement $control): string
@@ -3548,6 +3548,22 @@ final class HtmlTransformer
             }
             if ( array() !== $selected ) {
                 $details[] = 'selected: ' . implode(', ', $selected);
+            }
+        } elseif ( 'range' === $type ) {
+            $value = trim($this->attr($control, 'value'));
+            if ( '' !== $value ) {
+                $details[] = $value;
+            }
+
+            $bounds = array();
+            foreach ( array( 'min', 'max', 'step' ) as $attribute ) {
+                $value = trim($this->attr($control, $attribute));
+                if ( '' !== $value ) {
+                    $bounds[] = $attribute . ' ' . $value;
+                }
+            }
+            if ( array() !== $bounds ) {
+                $details[] = implode(', ', $bounds);
             }
         } else {
             foreach ( array( 'value', 'placeholder' ) as $attribute ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -234,6 +234,14 @@ $assert(true === ($formDiagnostic['controls'][0]['required'] ?? null), 'conversi
 $assert('support' === ($formDiagnostic['controls'][1]['options'][0]['value'] ?? ''), 'conversion report exposes select option values');
 $assert(is_int($formDiagnostic['html_bytes'] ?? null), 'conversion report exposes bounded fallback HTML byte size');
 
+$rangeControlResult = ( new HtmlTransformer() )->transform(
+    '<main><section><label for="density">Density</label><input type="range" id="density" min="6" max="60" step="2" value="28"></section></main>'
+)->toArray();
+$rangeControlText = (string) ($rangeControlResult['blocks'][0]['innerBlocks'][1]['attrs']['content'] ?? '');
+$assert(array() === ($rangeControlResult['fallbacks'] ?? array()), 'standalone readable range input converts without unsupported-element fallback');
+$assert(str_contains($rangeControlText, 'Density: 28'), 'range input summary preserves current value');
+$assert(str_contains($rangeControlText, 'min 6, max 60, step 2'), 'range input summary preserves bounds');
+
 $buttonResult = ( new HtmlTransformer() )->transform(
     '<main><a class="primary-button" href="#"><h3>Reserve now</h3><span aria-hidden="true"></span></a><button><strong>Call us</strong></button></main>'
 )->toArray();


### PR DESCRIPTION
## Summary
- Treat `input[type=range]` as a readable static form control so standalone sliders convert to paragraph summaries instead of unsupported fallback metadata.
- Include current value plus min/max/step bounds in the readable summary.
- Add contract coverage proving standalone range inputs avoid `unsupported_element` fallbacks.

## Fallback cluster evidence
From `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-finding-packets-0.1.15.json`:
- `canvas_requires_runtime`: 18 findings, clustered around native canvas runtime surfaces in `41-generative-art-studio`, `43-interactive-space-explorer`, and `saveweb2zip-com-liquidbonsai-com`.
- `script_requires_runtime`: 16 findings, first page-level runtime scripts across multiple fixtures.
- `generated_document_contains_core_html`: 14 findings, all canvas-backed `core/html` materializations.
- `form_requires_runtime`: 6 findings, runtime form submissions in `40-job-board` and `mockup`.
- `unsupported_element`: 6 findings, all duplicate reporting for three standalone `input[type=range]` controls in `41-generative-art-studio/index.html`.

## Expected matrix impact
- Removes the three underlying standalone range-input unsupported fallbacks from fixture `41-generative-art-studio/index.html`; packet duplication should reduce the six `unsupported_element` findings.
- Does not suppress diagnostics. Canvas, script, and runtime form findings remain truthful runtime fallbacks.

## Verification
- `php php-transformer/tests/contract/run.php`
- `composer test:canonical --working-dir=php-transformer`
- Manual fixture check: transforming `fixtures/websites/41-generative-art-studio/index.html` now reports only `canvas_requires_runtime|canvas => 7` and `script_requires_runtime|script => 2`, with no `unsupported_element|input` fallbacks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** fallback packet clustering, implementation, tests, and verification.