### PR TITLE
Move Figma fixture matrix rig into transformer package

### DIFF
--- a/figma-transformer/rigs/fixture-matrix/rig.json
+++ b/figma-transformer/rigs/fixture-matrix/rig.json
@@ -1,9 +1,9 @@
 {
   "id": "figma-transformer-fixture-matrix",
-  "description": "Repo-local Figma transformer fixture matrix rig. Runs large local .fig fixtures through the PHP transformer and captures HTML/result artifacts for fidelity review.",
+  "description": "Figma transformer fixture matrix rig. Runs large local .fig fixtures through the PHP transformer and captures HTML/result artifacts for fidelity review.",
   "components": {
     "blocks-engine": {
-      "path": "${package.root}/../..",
+      "path": "${package.root}/../../..",
       "branch": "trunk",
       "extensions": {}
     }


### PR DESCRIPTION
## Summary
- Move the Figma fixture matrix rig under `figma-transformer/rigs/fixture-matrix`.
- Remove the misplaced root-level `rigs/` package path.
- Adjust the rig component path for the new package-local location.

## Verification
- `homeboy rig check figma-transformer-fixture-matrix --force-hot --allow-local-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Moving the rig package, updating the path, and running verification.