### PR TITLE
Canonicalize generated vector SVG paths

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2873,7 +2873,32 @@ final class StaticHtmlEmitter
             return null;
         }
 
-        return preg_match('/^[MmZzLlHhVvCcSsQqTtAa0-9,\.\-+\s]+$/', $path) ? $path : null;
+        if ( ! preg_match('/^[MmZzLlHhVvCcSsQqTtAa0-9,\.\-+\s]+$/', $path) ) {
+            return null;
+        }
+
+        return $this->canonicalSvgPathData($path);
+    }
+
+    private function canonicalSvgPathData(string $path): ?string
+    {
+        preg_match_all('/[MmZzLlHhVvCcSsQqTtAa]|[-+]?(?:\d*\.\d+|\d+\.?)(?:e[-+]?\d+)?/i', $path, $matches);
+        $tokens = $matches[0] ?? array();
+        if ( empty($tokens) ) {
+            return null;
+        }
+
+        $canonical = array();
+        foreach ( $tokens as $token ) {
+            if ( 1 === strlen($token) && preg_match('/^[MmZzLlHhVvCcSsQqTtAa]$/', $token) ) {
+                $canonical[] = $token;
+                continue;
+            }
+
+            $canonical[] = $this->number((float) $token);
+        }
+
+        return implode(' ', $canonical);
     }
 
     private function svgPathDataByteLimit(mixed $rawPath): int

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -393,7 +393,8 @@ $assert(str_contains($largeDecodedVectorHtml, 'data-figma-node-id="vector:large-
 $assert(str_contains($largeDecodedVectorHtml, 'data-figma-node-id="vector:large-raw"') && str_contains($largeDecodedVectorHtml, 'data-figma-unsupported-vector="true"'), 'large-raw-vector-path-remains-capped');
 $assert(in_array('unsupported_vector_node_placeholder', $largeDecodedVectorDiagnosticCodes, true), 'large-raw-vector-placeholder-diagnostic');
 
-$externalizedVectorPath = 'M 0 0' . str_repeat(' L 10 10', 9000) . ' Z';
+$externalizedVectorPath = 'M 0.0000 0.0000' . str_repeat(' L 10.000001 10.000001', 9000) . ' Z';
+$externalizedEquivalentVectorPath = 'M0,0' . str_repeat('L10,10', 9000) . 'Z';
 $externalizedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Externalized Vector Fixture',
     'nodes' => array(
@@ -411,7 +412,7 @@ $externalizedVectorResult = blocks_engine_figma_transformer_transform_scenegraph
             'name'               => 'Externalized Vector',
             'width'              => 10,
             'height'             => 10,
-            'figma_vector_paths' => array(array('data' => $externalizedVectorPath, 'source' => 'strokeGeometry')),
+            'figma_vector_paths' => array(array('data' => $externalizedEquivalentVectorPath, 'source' => 'strokeGeometry')),
         ),
     ),
 ));
@@ -424,7 +425,10 @@ $externalizedVectorAssets = array_values(array_filter(
 $assert(2 === substr_count($externalizedVectorHtml, 'class="figma-vector-asset"'), 'large-vector-externalized-img-references');
 $assert(1 === count($externalizedVectorAssets), 'large-vector-externalized-deduped-asset');
 $assert(str_contains($externalizedVectorCss, '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}'), 'large-vector-asset-css');
-$assert(str_contains($fileContent($externalizedVectorResult, (string) ($externalizedVectorAssets[0]['path'] ?? '')), '<svg '), 'large-vector-externalized-svg-content');
+$externalizedVectorAssetContent = $fileContent($externalizedVectorResult, (string) ($externalizedVectorAssets[0]['path'] ?? ''));
+$assert(str_contains($externalizedVectorAssetContent, '<svg '), 'large-vector-externalized-svg-content');
+$assert(str_contains($externalizedVectorAssetContent, 'd="M 0 0 L 10 10'), 'large-vector-path-data-canonicalized');
+$assert(! str_contains($externalizedVectorAssetContent, '10.000001'), 'large-vector-path-data-precision-reduced');
 $externalizedVectorDiagnostics = $externalizedVectorResult['source_reports']['figma']['html']['transform_diagnostics']['generated_svg_assets'] ?? array();
 $assert('blocks-engine/figma-transformer/generated-svg-assets/v1' === ($externalizedVectorDiagnostics['schema'] ?? null), 'generated-svg-assets-diagnostics-schema');
 $assert(1 === ($externalizedVectorDiagnostics['count'] ?? null), 'generated-svg-assets-diagnostics-count');


### PR DESCRIPTION
## Summary
- Canonicalize accepted generated SVG path data before serialization and hashing.
- Reduce emitted path precision through the existing number formatter and normalize equivalent command/number separators for better generated SVG deduplication.
- Keep existing large generated SVG diagnostics intact and extend the contract test to cover canonical dedupe/precision reduction.

## Verification
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`
- `git diff --check origin/trunk...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Figma transformer SVG emission path, implementing canonical SVG path serialization, updating focused contract coverage, and running verification.