### PR TITLE
Preserve vector child fallback rendering

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -337,7 +337,8 @@ final class StaticHtmlEmitter
             $content = $this->vectorSvgMarkup($vectorSvg, $node, $type) . $content;
         }
 
-        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg && ! $hasVectorAssetFallback ) {
+        $hasRenderableVectorFallback = '' !== trim($content);
+        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg && ! $hasVectorAssetFallback && ! $hasRenderableVectorFallback ) {
             $diagnostics[] = array(
                 'severity' => 'warning',
                 'code'     => 'unsupported_vector_node_placeholder',
@@ -359,7 +360,7 @@ final class StaticHtmlEmitter
         if ( 'RECTANGLE' === $type && '' === $content ) {
             $attributes .= ' aria-hidden="true"';
         }
-        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg && ! $hasVectorAssetFallback ) {
+        if ( $this->isUnsupportedVectorType($type) && null === $vectorSvg && ! $hasVectorAssetFallback && ! $hasRenderableVectorFallback ) {
             $attributes .= ' data-figma-unsupported-vector="true" aria-hidden="true"';
         } elseif ( $hasVectorAssetFallback ) {
             $attributes .= ' role="img" aria-label="' . $this->sanitizeAttribute('' !== $name ? $name : $type) . '"';

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -539,6 +539,41 @@ $assert(str_contains($agenticChevronHtml, 'data-figma-node-id="chevron:bad-count
 $assert(str_contains($agenticChevronHtml, 'data-figma-node-id="chevron:unknown-signature"') && str_contains($agenticChevronHtml, 'data-figma-unsupported-vector="true"'), 'agentic-chevron-unknown-signature-placeholder');
 $assert(in_array('unsupported_vector_network_blob', $agenticChevronDiagnosticCodes, true), 'agentic-chevron-guarded-failures-diagnosed');
 
+$vectorChildFallbackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Vector Child Fallback Fixture',
+    'blobs' => array(array('bytes' => "\xff")),
+    'nodes' => array(
+        array(
+            'id'         => 'boolean:child-fallback',
+            'type'       => 'BOOLEAN_OPERATION',
+            'name'       => 'Boolean With Child Fallback',
+            'width'      => 20,
+            'height'     => 20,
+            'vectorData' => array('vectorNetworkBlob' => 0),
+            'children'   => array(
+                array(
+                    'id'         => 'boolean:child-fallback-ellipse',
+                    'type'       => 'ELLIPSE',
+                    'name'       => 'Fallback Ellipse',
+                    'width'      => 20,
+                    'height'     => 20,
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 1))),
+                ),
+            ),
+        ),
+    ),
+));
+$vectorChildFallbackHtml = $fileContent($vectorChildFallbackResult, 'index.html');
+$vectorChildFallbackDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $vectorChildFallbackResult['diagnostics'] ?? array()
+);
+$assert(str_contains($vectorChildFallbackHtml, 'data-figma-node-id="boolean:child-fallback"'), 'vector-child-fallback-parent-renders');
+$assert(str_contains($vectorChildFallbackHtml, 'data-figma-node-id="boolean:child-fallback-ellipse"') && str_contains($vectorChildFallbackHtml, '<ellipse '), 'vector-child-fallback-child-renders');
+$assert(! str_contains($vectorChildFallbackHtml, 'data-figma-unsupported-vector="true"'), 'vector-child-fallback-not-placeholder');
+$assert(in_array('unsupported_vector_network_blob', $vectorChildFallbackDiagnosticCodes, true), 'vector-child-fallback-network-diagnostic-kept');
+$assert(! in_array('unsupported_vector_node_placeholder', $vectorChildFallbackDiagnosticCodes, true), 'vector-child-fallback-no-placeholder-diagnostic');
+
 $matrixTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Matrix Transform Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- Preserve rendered child content for unsupported vector-like containers instead of clearing it into a placeholder when no decoded vector SVG is available.
- Keep unsupported vector network diagnostics intact so unknown vectorData.vectorNetworkBlob formats remain visible without guessing binary semantics.
- Add contract coverage for a BOOLEAN_OPERATION with an unsupported vector network blob and renderable child vector geometry.

## Verification
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the vector fallback path, implementing the focused emitter change, and adding contract coverage.