### PR TITLE
Fix Figma root canvas origin offsets

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1287,7 +1287,7 @@ final class StaticHtmlEmitter
             return (float) $box[$dimension];
         }
 
-        if ( null !== $parentNode && (! isset($parentBox[$dimension]) || $this->shouldInferZeroRootOrigin($parentBox, $parentNode, $dimension)) ) {
+        if ( null !== $parentNode && (! isset($parentBox[$dimension]) || $this->shouldInferRootCanvasOrigin($parentBox, $parentNode, $dimension)) ) {
             $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
             if ( null !== $origin ) {
                 return (float) $box[$dimension] - $origin;
@@ -1298,15 +1298,15 @@ final class StaticHtmlEmitter
     }
 
     /**
-     * Figma plugin payloads can normalize a selected frame origin to 0 while
-     * preserving child coordinates in the original canvas space.
+     * Figma plugin payloads can preserve root children in source canvas coordinates
+     * while giving the selected root/page a normalized or unrelated absolute origin.
      *
      * @param array<string, mixed> $parentBox
      * @param array<string, mixed> $parentNode
      */
-    private function shouldInferZeroRootOrigin(array $parentBox, array $parentNode, string $dimension): bool
+    private function shouldInferRootCanvasOrigin(array $parentBox, array $parentNode, string $dimension): bool
     {
-        if ( ! isset($parentBox[$dimension]) || ! is_numeric($parentBox[$dimension]) || 0.0 !== (float) $parentBox[$dimension] ) {
+        if ( ! isset($parentBox[$dimension]) || ! is_numeric($parentBox[$dimension]) ) {
             return false;
         }
 
@@ -1315,8 +1315,16 @@ final class StaticHtmlEmitter
         }
 
         $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+        if ( null === $origin ) {
+            return false;
+        }
 
-        return null !== $origin && $origin < 0.0;
+        $parentOrigin = (float) $parentBox[$dimension];
+        if ( 0.0 === $parentOrigin ) {
+            return $origin < 0.0;
+        }
+
+        return $origin < 0.0 && ($parentOrigin - $origin) >= 100.0;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2285,6 +2285,40 @@ $zeroOriginSelectedFrameCss = $fileContent($zeroOriginSelectedFrameResult, 'styl
 $assert(str_contains($zeroOriginSelectedFrameCss, '.figma-node-zero-hero-hero{width:1200px;height:600px;position:absolute;left:0px;top:0px'), 'zero-origin-selected-frame-normalizes-first-child');
 $assert(str_contains($zeroOriginSelectedFrameCss, '.figma-node-zero-cta-cta{width:240px;height:40px;position:absolute;left:200px;top:400px'), 'zero-origin-selected-frame-normalizes-text-child');
 
+$nonzeroRootCanvasOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Nonzero Root Canvas Origin Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'canvas-origin:frame',
+            'type'                => 'FRAME',
+            'name'                => 'Canvas origin selected frame',
+            'absoluteBoundingBox' => array('x' => 4000, 'y' => 0, 'width' => 1200, 'height' => 800),
+            'children'            => array(
+                array(
+                    'id'                  => 'canvas-origin:hero',
+                    'type'                => 'FRAME',
+                    'name'                => 'Hero',
+                    'absoluteBoundingBox' => array('x' => -1333, 'y' => 0, 'width' => 1200, 'height' => 600),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+                array(
+                    'id'                  => 'canvas-origin:cta',
+                    'type'                => 'TEXT',
+                    'name'                => 'CTA',
+                    'characters'          => 'Visible copy',
+                    'absoluteBoundingBox' => array('x' => -1133, 'y' => 400, 'width' => 240, 'height' => 40),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+            ),
+        ),
+    ),
+));
+$nonzeroRootCanvasOriginCss = $fileContent($nonzeroRootCanvasOriginResult, 'style.css');
+$assert(str_contains($nonzeroRootCanvasOriginCss, '.figma-node-canvas-origin-hero-hero{width:1200px;height:600px;position:absolute;left:0px;top:0px'), 'nonzero-root-canvas-origin-normalizes-first-child');
+$assert(str_contains($nonzeroRootCanvasOriginCss, '.figma-node-canvas-origin-cta-cta{width:240px;height:40px;position:absolute;left:200px;top:400px'), 'nonzero-root-canvas-origin-normalizes-text-child');
+$nonzeroRootCanvasOriginDiagnostics = $nonzeroRootCanvasOriginResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$assert(0 === ($nonzeroRootCanvasOriginDiagnostics['layout']['large_negative_left_count'] ?? null), 'nonzero-root-canvas-origin-diagnostics-no-large-negative-left');
+
 $resolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Component Instance Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- Infer a root/page containing-block origin when absolute children clearly remain in source canvas coordinates under a normalized or unrelated root origin.
- Preserve existing local-coordinate and default horizontal scroll behavior; this only adjusts emitted offsets for top-level parent/child bounds that would otherwise produce large off-canvas-left CSS.
- Add a contract fixture covering a nonzero root origin that previously emitted large negative left values.

## Verification
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Figma transformer layout emission path, implementing the focused origin-offset fix, adding contract coverage, and running verification.