### PR TITLE
Bound glyph command blob diagnostics

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -59,6 +59,7 @@ final class ScenegraphNormalizer
         $textInventory   = $this->buildTextInventory($nodeMap);
         $assetReferences = $this->buildAssetReferences($nodeMap);
         $sourceName      = $this->readSourceName($source, $renderNodes);
+        $diagnostics     = $this->compactGlyphCommandBlobDiagnostics($diagnostics);
 
         return array(
             'schema'              => 'blocks-engine/figma-transformer/scenegraph/v1',
@@ -151,6 +152,58 @@ final class ScenegraphNormalizer
         );
 
         return $index;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    private function compactGlyphCommandBlobDiagnostics(array $diagnostics): array
+    {
+        $compacted = array();
+        $count = 0;
+        $nodeIds = array();
+        $sampleGlyphs = array();
+
+        foreach ( $diagnostics as $diagnostic ) {
+            if ( ! is_array($diagnostic) || 'unsupported_text_glyph_command_blob' !== ($diagnostic['code'] ?? null) ) {
+                $compacted[] = $diagnostic;
+                continue;
+            }
+
+            $count++;
+            $context = is_array($diagnostic['context'] ?? null) ? $diagnostic['context'] : array();
+            $nodeId = isset($context['node_id']) && is_scalar($context['node_id']) ? (string) $context['node_id'] : '';
+            if ( '' !== $nodeId ) {
+                $nodeIds[$nodeId] = true;
+            }
+            if ( count($sampleGlyphs) < 10 ) {
+                $sampleGlyphs[] = array(
+                    'node_id'     => $nodeId,
+                    'glyph_index' => isset($context['glyph_index']) && is_numeric($context['glyph_index']) ? (int) $context['glyph_index'] : null,
+                );
+            }
+        }
+
+        if ( 0 === $count ) {
+            return $compacted;
+        }
+
+        $sampleNodeIds = array_slice(array_keys($nodeIds), 0, 10);
+        $compacted[] = array(
+            'severity' => 'warning',
+            'code'     => 'unsupported_text_glyph_command_blob',
+            'message'  => 'Unsupported Figma text glyph command blobs were omitted from derived glyph metadata.',
+            'source'   => 'ScenegraphNormalizer',
+            'context'  => array(
+                'total_count'         => $count,
+                'affected_node_count' => count($nodeIds),
+                'sample_node_ids'     => $sampleNodeIds,
+                'sample_glyphs'       => $sampleGlyphs,
+            ),
+        );
+
+        return $compacted;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -890,6 +890,47 @@ $assert('dom_text' === ($derivedTextVisualNode['text']['glyph_rendering'] ?? nul
 $assert(false === ($derivedTextLayoutResult['source_reports']['figma']['html']['render_text_glyph_paths'] ?? null), 'derived-text-glyph-rendering-default-disabled');
 $assert(! str_contains($fileContent($derivedTextLayoutResult, 'index.html'), 'data-figma-text-glyphs="true"'), 'derived-text-default-avoids-glyph-svg');
 
+$unsupportedGlyphScenegraph = array(
+    'name'  => 'Unsupported Glyph Diagnostic Fixture',
+    'blobs' => array(array('bytes' => chr(9))),
+    'nodes' => array(
+        array(
+            'id'              => 'text:unsupported-glyph-a',
+            'type'            => 'TEXT',
+            'characters'      => 'Unsupported glyph A',
+            'derivedTextData' => array(
+                'glyphs' => array(
+                    array('firstCharacter' => 0, 'commandsBlob' => 0),
+                    array('firstCharacter' => 1, 'commandsBlob' => 0),
+                    array('firstCharacter' => 2, 'commandsBlob' => 0),
+                ),
+            ),
+        ),
+        array(
+            'id'              => 'text:unsupported-glyph-b',
+            'type'            => 'TEXT',
+            'characters'      => 'Unsupported glyph B',
+            'derivedTextData' => array(
+                'glyphs' => array(
+                    array('firstCharacter' => 0, 'commandsBlob' => 0),
+                    array('firstCharacter' => 1, 'commandsBlob' => 0),
+                ),
+            ),
+        ),
+    ),
+);
+$unsupportedGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($unsupportedGlyphScenegraph);
+$unsupportedGlyphDiagnostics = array_values(array_filter(
+    $unsupportedGlyphResult['diagnostics'] ?? array(),
+    static fn (array $diagnostic): bool => 'unsupported_text_glyph_command_blob' === ($diagnostic['code'] ?? null)
+));
+$assert(1 === count($unsupportedGlyphDiagnostics), 'unsupported-glyph-diagnostics-bounded');
+$assert(5 === ($unsupportedGlyphDiagnostics[0]['context']['total_count'] ?? null), 'unsupported-glyph-diagnostics-total-count');
+$assert(2 === ($unsupportedGlyphDiagnostics[0]['context']['affected_node_count'] ?? null), 'unsupported-glyph-diagnostics-node-count');
+$assert(array('text:unsupported-glyph-a', 'text:unsupported-glyph-b') === ($unsupportedGlyphDiagnostics[0]['context']['sample_node_ids'] ?? null), 'unsupported-glyph-diagnostics-sample-node-ids');
+$assert(str_contains($fileContent($unsupportedGlyphResult, 'index.html'), 'Unsupported glyph A'), 'unsupported-glyph-diagnostics-preserve-text-a');
+$assert(str_contains($fileContent($unsupportedGlyphResult, 'index.html'), 'Unsupported glyph B'), 'unsupported-glyph-diagnostics-preserve-text-b');
+
 $derivedTextGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($derivedTextLayoutScenegraph, array('render_text_glyph_paths' => true));
 $derivedTextGlyphHtml = $fileContent($derivedTextGlyphResult, 'index.html');
 $derivedTextGlyphCss = $fileContent($derivedTextGlyphResult, 'style.css');


### PR DESCRIPTION
## Summary
- Aggregate repeated unsupported text glyph command blob diagnostics into one bounded warning per scenegraph normalization.
- Preserve real coverage in diagnostic context with total count, affected node count, sampled node IDs, and sampled glyph indexes.
- Add contract coverage that unsupported glyph diagnostics stay bounded while DOM text output remains intact.

## Verification
- php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the focused diagnostics aggregation change and contract coverage.