### PR TITLE
Add Figma import quality diagnostics

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -609,9 +609,17 @@ final class FigmaTransformer
      */
     private function mergePageTransformDiagnostics(array $pageReports, array $assetReport): array
     {
-        $images = array('paint_refs' => 0, 'node_refs' => 0, 'resolved_assets' => 0, 'missing_assets' => array());
+        $images = array('paint_refs' => 0, 'node_refs' => 0, 'resolved_assets' => 0, 'image_block_count' => 0, 'image_block_nodes' => array(), 'missing_assets' => array());
         $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'placeholders' => 0, 'placeholder_nodes' => array());
-        $layout = array('large_negative_left_count' => 0, 'decorative_underlays' => array('count' => 0, 'nodes' => array()));
+        $layout = array(
+            'large_negative_left_count' => 0,
+            'fixed_root_width_count' => 0,
+            'fixed_root_width_nodes' => array(),
+            'large_absolute_offset_count' => 0,
+            'large_absolute_offset_nodes' => array(),
+            'decorative_underlays' => array('count' => 0, 'nodes' => array()),
+            'image_heavy_landmark_candidates' => array(),
+        );
         $fontFamilies = array();
         $missingCss = array();
         $fontCssSupplied = false;
@@ -629,8 +637,13 @@ final class FigmaTransformer
             $pages[] = array_merge($pageContext, array('transform_diagnostics' => $diagnostics));
 
             $pageImages = is_array($diagnostics['images'] ?? null) ? $diagnostics['images'] : array();
-            foreach ( array('paint_refs', 'node_refs', 'resolved_assets') as $key ) {
+            foreach ( array('paint_refs', 'node_refs', 'resolved_assets', 'image_block_count') as $key ) {
                 $images[$key] += (int) ($pageImages[$key] ?? 0);
+            }
+            foreach ( is_array($pageImages['image_block_nodes'] ?? null) ? $pageImages['image_block_nodes'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $images['image_block_nodes'][] = array_merge($pageContext, $item);
+                }
             }
             foreach ( is_array($pageImages['missing_assets'] ?? null) ? $pageImages['missing_assets'] : array() as $item ) {
                 if ( is_array($item) ) {
@@ -656,10 +669,27 @@ final class FigmaTransformer
 
             $pageLayout = is_array($diagnostics['layout'] ?? null) ? $diagnostics['layout'] : array();
             $layout['large_negative_left_count'] += (int) ($pageLayout['large_negative_left_count'] ?? 0);
+            $layout['fixed_root_width_count'] += (int) ($pageLayout['fixed_root_width_count'] ?? 0);
+            $layout['large_absolute_offset_count'] += (int) ($pageLayout['large_absolute_offset_count'] ?? 0);
+            foreach ( is_array($pageLayout['fixed_root_width_nodes'] ?? null) ? $pageLayout['fixed_root_width_nodes'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $layout['fixed_root_width_nodes'][] = array_merge($pageContext, $item);
+                }
+            }
+            foreach ( is_array($pageLayout['large_absolute_offset_nodes'] ?? null) ? $pageLayout['large_absolute_offset_nodes'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $layout['large_absolute_offset_nodes'][] = array_merge($pageContext, $item);
+                }
+            }
             $underlays = is_array($pageLayout['decorative_underlays']['nodes'] ?? null) ? $pageLayout['decorative_underlays']['nodes'] : array();
             foreach ( $underlays as $item ) {
                 if ( is_array($item) ) {
                     $layout['decorative_underlays']['nodes'][] = array_merge($pageContext, $item);
+                }
+            }
+            foreach ( is_array($pageLayout['image_heavy_landmark_candidates'] ?? null) ? $pageLayout['image_heavy_landmark_candidates'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $layout['image_heavy_landmark_candidates'][] = array_merge($pageContext, $item);
                 }
             }
 
@@ -724,6 +754,21 @@ final class FigmaTransformer
         if ( ! empty($layout['large_negative_left_count']) ) {
             $signals[] = array('severity' => 'warning', 'code' => 'off_canvas_left_css', 'count' => (int) $layout['large_negative_left_count']);
         }
+        if ( ! empty($layout['fixed_root_width_count']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'fixed_root_width', 'count' => (int) $layout['fixed_root_width_count']);
+        }
+        if ( ! empty($layout['large_absolute_offset_count']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'large_absolute_offsets', 'count' => (int) $layout['large_absolute_offset_count']);
+        }
+        if ( ! empty($layout['image_heavy_landmark_candidates']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'image_heavy_landmark_candidate', 'count' => count($layout['image_heavy_landmark_candidates']));
+        }
+        if ( (int) ($images['image_block_count'] ?? 0) >= 12 ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'excessive_image_blocks', 'count' => (int) $images['image_block_count']);
+        }
+        if ( (int) ($vectors['rendered_asset_fallbacks'] ?? 0) >= 8 ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'excessive_vector_image_fallbacks', 'count' => (int) $vectors['rendered_asset_fallbacks']);
+        }
         if ( (int) ($generatedSvgAssets['bytes'] ?? 0) > 1048576 ) {
             $signals[] = array(
                 'severity' => 'info',
@@ -744,9 +789,14 @@ final class FigmaTransformer
                 'vector_placeholders' => (int) ($vectors['placeholders'] ?? 0),
                 'missing_font_css' => count($fonts['missing_css'] ?? array()),
                 'emitted_asset_files' => (int) ($assets['emitted_files'] ?? 0),
+                'image_block_count' => (int) ($images['image_block_count'] ?? 0),
+                'vector_image_fallbacks' => (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
                 'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
+                'fixed_root_width_count' => (int) ($layout['fixed_root_width_count'] ?? 0),
+                'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
+                'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
             ),
         );
     }

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -660,6 +660,8 @@ final class StaticHtmlEmitter
             'paint_refs'      => 0,
             'node_refs'       => 0,
             'resolved_assets' => 0,
+            'image_block_count' => 0,
+            'image_block_nodes' => array(),
             'missing_assets'  => array(),
         );
         $vectors = array(
@@ -671,10 +673,15 @@ final class StaticHtmlEmitter
         );
         $layout = array(
             'large_negative_left_count' => preg_match_all('/left:-[0-9]{3,}/', $css),
+            'fixed_root_width_count'    => 0,
+            'fixed_root_width_nodes'    => array(),
+            'large_absolute_offset_count' => 0,
+            'large_absolute_offset_nodes' => array(),
             'decorative_underlays'      => array(
                 'count' => 0,
                 'nodes' => array(),
             ),
+            'image_heavy_landmark_candidates' => array(),
         );
 
         foreach ( $nodes as $node ) {
@@ -684,9 +691,13 @@ final class StaticHtmlEmitter
         }
 
         $image['missing_assets'] = array_values($image['missing_assets']);
+        $image['image_block_nodes'] = array_values($image['image_block_nodes']);
         $vectors['placeholder_nodes'] = array_values($vectors['placeholder_nodes']);
         $layout['decorative_underlays']['nodes'] = array_values($layout['decorative_underlays']['nodes']);
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
+        $layout['fixed_root_width_nodes'] = array_values($layout['fixed_root_width_nodes']);
+        $layout['large_absolute_offset_nodes'] = array_values($layout['large_absolute_offset_nodes']);
+        $layout['image_heavy_landmark_candidates'] = array_values($layout['image_heavy_landmark_candidates']);
         $generatedSvgAssets = $this->generatedSvgAssetDiagnostics($assetFiles);
         $assets = array(
             'emitted_files' => count($assetFiles),
@@ -754,6 +765,41 @@ final class StaticHtmlEmitter
                 'count' => (int) $layout['large_negative_left_count'],
             );
         }
+        if ( ! empty($layout['fixed_root_width_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'fixed_root_width',
+                'count' => (int) $layout['fixed_root_width_count'],
+            );
+        }
+        if ( ! empty($layout['large_absolute_offset_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'large_absolute_offsets',
+                'count' => (int) $layout['large_absolute_offset_count'],
+            );
+        }
+        if ( ! empty($layout['image_heavy_landmark_candidates']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'image_heavy_landmark_candidate',
+                'count' => count($layout['image_heavy_landmark_candidates']),
+            );
+        }
+        if ( (int) ($image['image_block_count'] ?? 0) >= 12 ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'excessive_image_blocks',
+                'count' => (int) $image['image_block_count'],
+            );
+        }
+        if ( (int) ($vectors['rendered_asset_fallbacks'] ?? 0) >= 8 ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'excessive_vector_image_fallbacks',
+                'count' => (int) $vectors['rendered_asset_fallbacks'],
+            );
+        }
         if ( (int) ($generatedSvgAssets['bytes'] ?? 0) > 1048576 ) {
             $signals[] = array(
                 'severity' => 'info',
@@ -774,9 +820,14 @@ final class StaticHtmlEmitter
                 'vector_placeholders' => (int) ($vectors['placeholders'] ?? 0),
                 'missing_font_css' => count($fonts['missing_css'] ?? array()),
                 'emitted_asset_files' => (int) ($assets['emitted_files'] ?? 0),
+                'image_block_count' => (int) ($image['image_block_count'] ?? 0),
+                'vector_image_fallbacks' => (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
                 'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
+                'fixed_root_width_count' => (int) ($layout['fixed_root_width_count'] ?? 0),
+                'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
+                'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
             ),
         );
     }
@@ -825,8 +876,34 @@ final class StaticHtmlEmitter
      */
     private function collectTransformDiagnostics(array $node, array &$image, array &$vectors, array &$layout, ?array $parentNode = null): void
     {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $nodeLayout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+
+        if ( null === $parentNode && isset($box['width']) && is_numeric($box['width']) && (float) $box['width'] >= 1024.0 && 'FILL' !== strtoupper((string) ($nodeLayout['sizing_horizontal'] ?? '')) ) {
+            ++$layout['fixed_root_width_count'];
+            $layout['fixed_root_width_nodes'][] = array(
+                'node_id' => (string) ($node['id'] ?? ''),
+                'name'    => (string) ($node['name'] ?? ''),
+                'type'    => strtoupper((string) ($node['type'] ?? '')),
+                'width'   => $this->reportNumericValue($box['width'] ?? null),
+            );
+        }
+
+        if ( null !== $parentNode ) {
+            $offset = $this->largeAbsoluteOffsetDiagnostic($node, $parentNode);
+            if ( null !== $offset ) {
+                ++$layout['large_absolute_offset_count'];
+                $layout['large_absolute_offset_nodes'][] = $offset;
+            }
+        }
+
         if ( null !== $parentNode && $this->isDecorativeFlexUnderlay($node, $parentNode) ) {
             $layout['decorative_underlays']['nodes'][] = $this->decorativeUnderlayDiagnostic($node, $parentNode);
+        }
+
+        $landmarkCandidate = $this->imageHeavyLandmarkCandidate($node);
+        if ( null !== $landmarkCandidate ) {
+            $layout['image_heavy_landmark_candidates'][] = $landmarkCandidate;
         }
 
         $imagePaints = $this->nodeImagePaints($node);
@@ -840,6 +917,12 @@ final class StaticHtmlEmitter
             ++$image['node_refs'];
             if ( null !== $this->nodeAssetPath($node) ) {
                 ++$image['resolved_assets'];
+                ++$image['image_block_count'];
+                $image['image_block_nodes'][] = array(
+                    'node_id' => (string) ($node['id'] ?? ''),
+                    'name'    => (string) ($node['name'] ?? ''),
+                    'type'    => strtoupper((string) ($node['type'] ?? '')),
+                );
             } else {
                 $image['missing_assets'][] = array(
                     'node_id' => (string) ($node['id'] ?? ''),
@@ -872,6 +955,98 @@ final class StaticHtmlEmitter
                 $this->collectTransformDiagnostics($child, $image, $vectors, $layout, $node);
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $parentNode
+     * @return array<string, mixed>|null
+     */
+    private function largeAbsoluteOffsetDiagnostic(array $node, array $parentNode): ?array
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        if ( 'absolute' !== ($layout['positioning'] ?? null) && ! $this->isFreeformContainer($parentNode) && ! $this->isDecorativeFlexUnderlay($node, $parentNode) ) {
+            return null;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        $left = $this->positionOffset($box, $parentBox, 'x', $parentNode);
+        $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
+        $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : 0.0;
+        $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : 0.0;
+        $parentWidth = isset($parentBox['width']) && is_numeric($parentBox['width']) ? (float) $parentBox['width'] : null;
+        $parentHeight = isset($parentBox['height']) && is_numeric($parentBox['height']) ? (float) $parentBox['height'] : null;
+        $offCanvas = (null !== $left && ($left < -100.0 || (null !== $parentWidth && $left > $parentWidth + 100.0) || $left + $width < -100.0))
+            || (null !== $top && ($top < -100.0 || (null !== $parentHeight && $top > $parentHeight + 100.0) || $top + $height < -100.0));
+
+        if ( ! $offCanvas ) {
+            return null;
+        }
+
+        return array(
+            'node_id' => (string) ($node['id'] ?? ''),
+            'name' => (string) ($node['name'] ?? ''),
+            'type' => strtoupper((string) ($node['type'] ?? '')),
+            'parent_id' => (string) ($parentNode['id'] ?? ''),
+            'left' => null === $left ? null : $this->reportNumericValue($left),
+            'top' => null === $top ? null : $this->reportNumericValue($top),
+            'parent_width' => null === $parentWidth ? null : $this->reportNumericValue($parentWidth),
+            'parent_height' => null === $parentHeight ? null : $this->reportNumericValue($parentHeight),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>|null
+     */
+    private function imageHeavyLandmarkCandidate(array $node): ?array
+    {
+        $name = strtolower((string) ($node['name'] ?? ''));
+        $role = str_contains($name, 'header') ? 'header' : (str_contains($name, 'footer') ? 'footer' : null);
+        if ( null === $role ) {
+            return null;
+        }
+
+        $summary = $this->subtreeVisualSummary($node);
+        if ( $summary['image_nodes'] < 3 || $summary['image_nodes'] < max(1, $summary['text_nodes'] * 2) ) {
+            return null;
+        }
+
+        return array(
+            'node_id' => (string) ($node['id'] ?? ''),
+            'name' => (string) ($node['name'] ?? ''),
+            'role' => $role,
+            'image_nodes' => $summary['image_nodes'],
+            'text_nodes' => $summary['text_nodes'],
+            'total_nodes' => $summary['total_nodes'],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array{image_nodes: int, text_nodes: int, total_nodes: int}
+     */
+    private function subtreeVisualSummary(array $node): array
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        $summary = array(
+            'image_nodes' => null !== $this->nodeAssetPath($node) || ! empty($this->nodeImagePaints($node)) ? 1 : 0,
+            'text_nodes' => 'TEXT' === $type ? 1 : 0,
+            'total_nodes' => 1,
+        );
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            $childSummary = $this->subtreeVisualSummary($child);
+            $summary['image_nodes'] += $childSummary['image_nodes'];
+            $summary['text_nodes'] += $childSummary['text_nodes'];
+            $summary['total_nodes'] += $childSummary['total_nodes'];
+        }
+
+        return $summary;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -146,6 +146,13 @@ $diagnosticCodes = array_map(
     static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
     $result['diagnostics'] ?? array()
 );
+$artifactQualitySignalCodes = static function (array $result): array {
+    $signals = $result['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
+    return array_values(array_map(
+        static fn (array $signal): string => (string) ($signal['code'] ?? ''),
+        is_array($signals) ? $signals : array()
+    ));
+};
 
 $assert('blocks-engine/figma-transformer/result/v1' === ($result['schema'] ?? null), 'result-schema');
 $assert('success' === ($result['status'] ?? null), 'scenegraph-transform-success');
@@ -208,6 +215,74 @@ $assert(str_contains($css, '.figma-root{position:relative;width:max-content;min-
 $assert(! str_contains($css, 'overflow-x:hidden'), 'css-static-page-allows-horizontal-scroll');
 $assert(! str_contains($css, 'order:'), 'css-avoids-source-order');
 $assert(! str_contains($css, 'font-family:Inter') && ! str_contains($css, 'body{margin:0;background') && ! str_contains($css, 'body{margin:0;color'), 'css-avoids-hardcoded-theme-style');
+
+$qualityAssets = array();
+for ( $i = 1; $i <= 20; $i++ ) {
+    $qualityAssets['quality-image-' . $i] = array('mime_type' => 'image/png', 'content' => 'image ' . $i);
+}
+$qualityChildren = array(
+    array(
+        'id'       => 'quality:header',
+        'type'     => 'GROUP',
+        'name'     => 'Site Header Raster Group',
+        'width'    => 1440,
+        'height'   => 120,
+        'children' => array(
+            array('id' => 'quality:header:1', 'type' => 'RECTANGLE', 'name' => 'Header slice 1', 'width' => 300, 'height' => 80, 'asset_id' => 'quality-image-1'),
+            array('id' => 'quality:header:2', 'type' => 'RECTANGLE', 'name' => 'Header slice 2', 'width' => 300, 'height' => 80, 'asset_id' => 'quality-image-2'),
+            array('id' => 'quality:header:3', 'type' => 'RECTANGLE', 'name' => 'Header slice 3', 'width' => 300, 'height' => 80, 'asset_id' => 'quality-image-3'),
+        ),
+    ),
+    array('id' => 'quality:offcanvas', 'type' => 'RECTANGLE', 'name' => 'Off canvas promo', 'x' => 2000, 'y' => -180, 'width' => 200, 'height' => 100, 'layoutPositioning' => 'ABSOLUTE', 'asset_id' => 'quality-image-4'),
+);
+for ( $i = 5; $i <= 12; $i++ ) {
+    $qualityChildren[] = array('id' => 'quality:image:' . $i, 'type' => 'RECTANGLE', 'name' => 'Raster card ' . $i, 'width' => 80, 'height' => 60, 'asset_id' => 'quality-image-' . $i);
+}
+for ( $i = 13; $i <= 20; $i++ ) {
+    $qualityChildren[] = array('id' => 'quality:vector:' . $i, 'type' => 'VECTOR', 'name' => 'Vector fallback ' . $i, 'width' => 24, 'height' => 24, 'asset_id' => 'quality-image-' . $i);
+}
+$qualityDiagnosticsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'   => 'Quality Diagnostics Fixture',
+    'assets' => $qualityAssets,
+    'nodes'  => array(
+        array(
+            'id'       => 'quality:root',
+            'type'     => 'FRAME',
+            'name'     => 'Desktop fixed root',
+            'width'    => 1440,
+            'height'   => 1200,
+            'layoutMode' => 'VERTICAL',
+            'children' => $qualityChildren,
+        ),
+    ),
+));
+$qualitySignalCodes = $artifactQualitySignalCodes($qualityDiagnosticsResult);
+$assert(in_array('fixed_root_width', $qualitySignalCodes, true), 'quality-diagnostics-fixed-root-width');
+$assert(in_array('large_absolute_offsets', $qualitySignalCodes, true), 'quality-diagnostics-large-absolute-offsets');
+$assert(in_array('image_heavy_landmark_candidate', $qualitySignalCodes, true), 'quality-diagnostics-image-heavy-landmark');
+$assert(in_array('excessive_image_blocks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-image-blocks');
+$assert(in_array('excessive_vector_image_fallbacks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-vector-fallbacks');
+$assert('needs_review' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-status-needs-review');
+
+$cleanQualityResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Clean Quality Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'clean:root',
+            'type'     => 'FRAME',
+            'name'     => 'Simple content',
+            'width'    => 720,
+            'height'   => 320,
+            'layoutMode' => 'VERTICAL',
+            'children' => array(
+                array('id' => 'clean:title', 'type' => 'TEXT', 'name' => 'Page title', 'characters' => 'Clean page', 'fontSize' => 24),
+                array('id' => 'clean:copy', 'type' => 'TEXT', 'name' => 'Page copy', 'characters' => 'A simple responsive-friendly page.', 'fontSize' => 16),
+            ),
+        ),
+    ),
+));
+$assert(array() === $artifactQualitySignalCodes($cleanQualityResult), 'quality-diagnostics-clean-page-no-signals');
+$assert('clean' === ($cleanQualityResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-clean-page-status');
 
 $decorativeUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Decorative Underlay Fixture',


### PR DESCRIPTION
## Summary
- Add generic Figma transformer quality diagnostics for fixed-width roots, large/off-canvas absolute offsets, image-heavy header/footer landmark candidates, excessive image blocks, and vector image fallbacks.
- Surface the signals in the existing transform diagnostics and artifact quality source reports for both single-page and multi-page transforms.
- Add synthetic contract coverage for bad quality inputs and a clean simple page with no signals.

## Testing
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, synthetic contract tests, and PR preparation.