### PR TITLE
Normalize selected Figma page frame output

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -56,8 +56,8 @@ final class StaticHtmlEmitter
         $cssRules = array(
             'html{box-sizing:border-box}',
             '*,*::before,*::after{box-sizing:inherit}',
-            'body{margin:0;overflow-x:auto}',
-            '.figma-root{position:relative;width:max-content;min-width:100%;overflow-x:visible}',
+            'body{margin:0;overflow-x:hidden}',
+            '.figma-root{position:relative;width:100%;max-width:100%;overflow-x:hidden}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -161,8 +161,8 @@ final class StaticHtmlEmitter
         $cssRules = array(
             'html{box-sizing:border-box}',
             '*,*::before,*::after{box-sizing:inherit}',
-            'body{margin:0;overflow-x:auto}',
-            '.figma-root{position:relative;width:max-content;min-width:100%;overflow-x:visible}',
+            'body{margin:0;overflow-x:hidden}',
+            '.figma-root{position:relative;width:100%;max-width:100%;overflow-x:hidden}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -1064,6 +1064,12 @@ final class StaticHtmlEmitter
             } elseif ( 'FILL' === $sizing ) {
                 $styles[] = $dimension . ':100%';
             } elseif ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
+                if ( true === ($node['_selected_frame_root'] ?? false) && null === $parentNode && 'width' === $dimension ) {
+                    $styles[] = 'width:100%';
+                    $styles[] = 'max-width:' . $this->number((float) $box[$dimension]) . 'px';
+                    continue;
+                }
+
                 $property = null === $parentNode && 'height' === $dimension && 'flex' === ($layout['display'] ?? null) ? 'min-height' : $dimension;
                 $styles[] = $property . ':' . $this->number((float) $box[$dimension]) . 'px';
             }

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -36,8 +36,9 @@ final class ScenegraphNormalizer
         $topLevelIds = $index['top_level_node_ids'];
         $frameIds    = $this->selectTopLevelFrameIds($topLevelIds, $nodeMap);
 
+        $explicitSelectedFrameId = isset($options['frame_id']) && is_scalar($options['frame_id']) && isset($nodeMap[(string) $options['frame_id']]);
         $selectedFrameId = null;
-        if ( isset($options['frame_id']) && is_scalar($options['frame_id']) && isset($nodeMap[(string) $options['frame_id']]) ) {
+        if ( $explicitSelectedFrameId ) {
             $selectedFrameId = (string) $options['frame_id'];
         } elseif ( ! empty($frameIds) ) {
             $selectedFrameId = $frameIds[0];
@@ -52,7 +53,11 @@ final class ScenegraphNormalizer
         $renderNodes = array();
         foreach ( $renderIds as $id ) {
             if ( isset($nodeMap[$id]) ) {
-                $renderNodes[] = $this->refreshResolvedTree($nodeMap[$id], $nodeMap);
+                $node = $this->refreshResolvedTree($nodeMap[$id], $nodeMap);
+                if ( $explicitSelectedFrameId && $id === $selectedFrameId ) {
+                    $node = $this->rebaseSelectedFrameToOrigin($node);
+                }
+                $renderNodes[] = $node;
             }
         }
 
@@ -567,6 +572,72 @@ final class ScenegraphNormalizer
             $node['children'][$index] = $this->refreshResolvedTree($child, $nodeMap, $trail);
         }
 
+        return $node;
+    }
+
+    /**
+     * Treat an explicitly selected page frame as the emitted document origin instead of preserving Figma canvas offsets.
+     *
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function rebaseSelectedFrameToOrigin(array $node): array
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $originX = isset($box['x']) && is_numeric($box['x']) ? (float) $box['x'] : 0.0;
+        $originY = isset($box['y']) && is_numeric($box['y']) ? (float) $box['y'] : 0.0;
+        $node['_selected_frame_root'] = true;
+
+        return $this->rebaseNodeCoordinates($node, $originX, $originY, true);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function rebaseNodeCoordinates(array $node, float $originX, float $originY, bool $isRoot = false): array
+    {
+        $node = $this->rebaseNodeBox($node, 'box', $originX, $originY, $isRoot);
+        $node = $this->rebaseNodeBox($node, 'figma_box', $originX, $originY, $isRoot);
+
+        foreach ( array('children', 'nodes') as $childrenKey ) {
+            if ( ! is_array($node[$childrenKey] ?? null) ) {
+                continue;
+            }
+
+            foreach ( $node[$childrenKey] as $index => $child ) {
+                if ( is_array($child) ) {
+                    $node[$childrenKey][$index] = $this->rebaseNodeCoordinates($child, $originX, $originY);
+                }
+            }
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function rebaseNodeBox(array $node, string $boxKey, float $originX, float $originY, bool $isRoot): array
+    {
+        if ( ! is_array($node[$boxKey] ?? null) ) {
+            return $node;
+        }
+
+        $box = $node[$boxKey];
+        $coordinateSpace = (string) ($box['coordinate_space'] ?? 'absolute');
+        if ( $isRoot || 'absolute' === $coordinateSpace ) {
+            if ( isset($box['x']) && is_numeric($box['x']) ) {
+                $box['x'] = $isRoot ? 0.0 : (float) $box['x'] - $originX;
+            }
+            if ( isset($box['y']) && is_numeric($box['y']) ) {
+                $box['y'] = $isRoot ? 0.0 : (float) $box['y'] - $originY;
+            }
+            $box['coordinate_space'] = 'local';
+        }
+
+        $node[$boxKey] = $box;
         return $node;
     }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -203,11 +203,73 @@ $assert('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"></svg>' === f
 $assert(str_contains((string) file_get_contents($cliOutputRoot . '/artifact/style.css'), 'background-image:url("assets/cli-image.svg")'), 'cli-output-dir-preserves-asset-reference');
 $assert(str_contains($html, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 11 11"'), 'html-vector-blob-svg');
 $assert(str_contains($html, 'd="M 0 0 L 10 0 L 10 10 Z"'), 'html-vector-blob-path');
-$assert(str_contains($css, 'body{margin:0;overflow-x:auto}'), 'css-static-page-body-shell');
-$assert(str_contains($css, '.figma-root{position:relative;width:max-content;min-width:100%;overflow-x:visible}'), 'css-static-page-root-shell');
-$assert(! str_contains($css, 'overflow-x:hidden'), 'css-static-page-allows-horizontal-scroll');
+$assert(str_contains($css, 'body{margin:0;overflow-x:hidden}'), 'css-static-page-body-shell');
+$assert(str_contains($css, '.figma-root{position:relative;width:100%;max-width:100%;overflow-x:hidden}'), 'css-static-page-root-shell');
 $assert(! str_contains($css, 'order:'), 'css-avoids-source-order');
 $assert(! str_contains($css, 'font-family:Inter') && ! str_contains($css, 'body{margin:0;background') && ! str_contains($css, 'body{margin:0;color'), 'css-avoids-hardcoded-theme-style');
+
+$offsetPageResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'     => 'Offset Board Fixture',
+    'document' => array(
+        'id'       => 'doc:1',
+        'type'     => 'DOCUMENT',
+        'name'     => 'Document',
+        'children' => array(
+            array(
+                'id'       => 'canvas:1',
+                'type'     => 'CANVAS',
+                'name'     => 'Page 1',
+                'children' => array(
+                    array(
+                        'id'                  => 'frame:selected',
+                        'type'                => 'FRAME',
+                        'name'                => 'Selected Website Page',
+                        'absoluteBoundingBox' => array('x' => 3497, 'y' => 212, 'width' => 1440, 'height' => 900),
+                        'children'            => array(
+                            array(
+                                'id'                  => 'frame:selected-card',
+                                'type'                => 'FRAME',
+                                'name'                => 'Hero Card',
+                                'absoluteBoundingBox' => array('x' => 3537, 'y' => 252, 'width' => 320, 'height' => 160),
+                                'layoutPositioning'   => 'ABSOLUTE',
+                                'children'            => array(
+                                    array(
+                                        'id'                  => 'text:selected-title',
+                                        'type'                => 'TEXT',
+                                        'name'                => 'Hero title',
+                                        'text'                => 'Selected page content',
+                                        'fontSize'            => 32,
+                                        'absoluteBoundingBox' => array('x' => 3561, 'y' => 280, 'width' => 220, 'height' => 44),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    array(
+                        'id'                  => 'frame:off-canvas-one',
+                        'type'                => 'FRAME',
+                        'name'                => 'Off Canvas One',
+                        'absoluteBoundingBox' => array('x' => 4680, 'y' => 212, 'width' => 1440, 'height' => 900),
+                    ),
+                    array(
+                        'id'                  => 'frame:off-canvas-two',
+                        'type'                => 'FRAME',
+                        'name'                => 'Off Canvas Two',
+                        'absoluteBoundingBox' => array('x' => -2200, 'y' => 212, 'width' => 1440, 'height' => 900),
+                    ),
+                ),
+            ),
+        ),
+    ),
+), array('frame_id' => 'frame:selected'));
+$offsetPageHtml = $fileContent($offsetPageResult, 'index.html');
+$offsetPageCss = $fileContent($offsetPageResult, 'style.css');
+$assert('success' === ($offsetPageResult['status'] ?? null), 'offset-page-transform-success');
+$assert(str_contains($offsetPageHtml, 'Selected page content'), 'offset-page-selected-content-rendered');
+$assert(! str_contains($offsetPageHtml, 'Off Canvas One') && ! str_contains($offsetPageHtml, 'Off Canvas Two'), 'offset-page-off-canvas-siblings-omitted');
+$assert(str_contains($offsetPageCss, '.figma-node-frame-selected-selected-website-page{width:100%;max-width:1440px;height:900px;position:relative}'), 'offset-page-root-responsive-width');
+$assert(str_contains($offsetPageCss, '.figma-node-frame-selected-card-hero-card{width:320px;height:160px;position:absolute;left:40px;top:40px}'), 'offset-page-child-rebased-position');
+$assert(! str_contains($offsetPageCss, 'left:3497px') && ! str_contains($offsetPageCss, 'left:3537px') && ! str_contains($offsetPageCss, 'left:4680px'), 'offset-page-avoids-board-left-values');
 
 $decorativeUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Decorative Underlay Fixture',


### PR DESCRIPTION
## Summary
- Rebase explicitly selected Figma page frames to local origin during scenegraph normalization so emitted page content drops design-board offsets.
- Emit selected page roots with responsive width/max-width CSS and hide root horizontal overflow.
- Add a contract fixture for an offset selected frame with off-canvas sibling frames and assert board left values are omitted.

## Tests
- composer test (figma-transformer)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and validating the transformer normalization change, CSS emission update, focused contract fixture, and PR description.