### PR TITLE
Add Figma transform quality report

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -139,6 +139,9 @@ foreach ( $fixtures as $fixture ) {
                 $record['vector_placeholders'] = $diagnostics['vectors']['placeholders'] ?? null;
                 $record['generated_svg_assets'] = $diagnostics['generated_svg_assets'] ?? null;
                 $record['artifact_quality'] = $diagnostics['artifact_quality'] ?? null;
+                $record['quality_status'] = $diagnostics['artifact_quality']['quality_status'] ?? null;
+                $record['quality_summary'] = $diagnostics['artifact_quality']['summary'] ?? null;
+                $record['transform_selection'] = $diagnostics['selection'] ?? null;
             }
         }
     }

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -717,6 +717,7 @@ final class FigmaTransformer
         return array(
             'schema' => 'blocks-engine/figma-transformer/transform-diagnostics/v1',
             'scope' => 'multi_page',
+            'selection' => $this->multiPageSelectionDiagnostics($pageReports),
             'pages' => $pages,
             'images' => $images,
             'vectors' => $vectors,
@@ -778,11 +779,15 @@ final class FigmaTransformer
             );
         }
 
+        $failCodes = array('missing_render_assets', 'vector_placeholders');
+        $failCount = count(array_filter($signals, static fn (array $signal): bool => in_array((string) ($signal['code'] ?? ''), $failCodes, true)));
         $warningCount = count(array_filter($signals, static fn (array $signal): bool => 'warning' === ($signal['severity'] ?? null)));
+        $qualityStatus = $failCount > 0 ? 'fail' : (empty($signals) ? 'pass' : 'warn');
 
         return array(
             'schema' => 'blocks-engine/figma-transformer/artifact-quality/v1',
             'status' => $warningCount > 0 ? 'needs_review' : (empty($signals) ? 'clean' : 'info'),
+            'quality_status' => $qualityStatus,
             'signals' => $signals,
             'summary' => array(
                 'missing_asset_nodes' => count($images['missing_assets'] ?? array()),
@@ -798,6 +803,37 @@ final class FigmaTransformer
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
             ),
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $pageReports
+     * @return array<string, mixed>
+     */
+    private function multiPageSelectionDiagnostics(array $pageReports): array
+    {
+        $frames = array();
+        foreach ( $pageReports as $page ) {
+            if ( ! is_array($page) ) {
+                continue;
+            }
+
+            $frames[] = array_filter(array(
+                'frame_id' => (string) ($page['frame_id'] ?? ''),
+                'name' => (string) ($page['name'] ?? ''),
+                'path' => (string) ($page['path'] ?? ''),
+                'entrypoint' => true === ($page['entrypoint'] ?? false),
+                'node_count' => (int) ($page['node_count'] ?? 0),
+                'text_node_count' => (int) ($page['text_node_count'] ?? 0),
+                'asset_reference_count' => (int) ($page['asset_reference_count'] ?? 0),
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+        }
+
+        return array(
+            'schema' => 'blocks-engine/figma-transformer/selection/v1',
+            'mode' => 'selected_frames',
+            'page_count' => count($frames),
+            'selected_frames' => $frames,
         );
     }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -713,6 +713,7 @@ final class StaticHtmlEmitter
 
         return array(
             'schema' => 'blocks-engine/figma-transformer/transform-diagnostics/v1',
+            'selection' => $this->selectionDiagnostics($nodes),
             'images' => $image,
             'vectors' => $vectors,
             'fonts' => $fonts,
@@ -809,11 +810,15 @@ final class StaticHtmlEmitter
             );
         }
 
+        $failCodes = array('missing_render_assets', 'vector_placeholders');
+        $failCount = count(array_filter($signals, static fn (array $signal): bool => in_array((string) ($signal['code'] ?? ''), $failCodes, true)));
         $warningCount = count(array_filter($signals, static fn (array $signal): bool => 'warning' === ($signal['severity'] ?? null)));
+        $qualityStatus = $failCount > 0 ? 'fail' : (empty($signals) ? 'pass' : 'warn');
 
         return array(
             'schema' => 'blocks-engine/figma-transformer/artifact-quality/v1',
             'status' => $warningCount > 0 ? 'needs_review' : (empty($signals) ? 'clean' : 'info'),
+            'quality_status' => $qualityStatus,
             'signals' => $signals,
             'summary' => array(
                 'missing_asset_nodes' => count($image['missing_assets'] ?? array()),
@@ -830,6 +835,64 @@ final class StaticHtmlEmitter
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
             ),
         );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $nodes
+     * @return array<string, mixed>
+     */
+    private function selectionDiagnostics(array $nodes): array
+    {
+        $frames = array();
+        foreach ( $nodes as $node ) {
+            if ( is_array($node) ) {
+                $frames[] = $this->selectedFrameDiagnostic($node, 'index.html', true);
+            }
+        }
+
+        return array(
+            'schema' => 'blocks-engine/figma-transformer/selection/v1',
+            'mode' => count($frames) > 1 ? 'root_nodes' : 'single_root',
+            'page_count' => count($frames),
+            'selected_frames' => $frames,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function selectedFrameDiagnostic(array $node, string $path, bool $entrypoint): array
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $assetReferences = $this->countAssetReferences($node);
+
+        return array_filter(array(
+            'frame_id' => isset($node['id']) && is_scalar($node['id']) ? (string) $node['id'] : '',
+            'name' => isset($node['name']) && is_scalar($node['name']) ? (string) $node['name'] : '',
+            'type' => strtoupper((string) ($node['type'] ?? '')),
+            'path' => $path,
+            'entrypoint' => $entrypoint,
+            'width' => $this->reportNumericValue($box['width'] ?? null),
+            'height' => $this->reportNumericValue($box['height'] ?? null),
+            'node_count' => $this->countNodes(array($node)),
+            'asset_reference_count' => $assetReferences,
+        ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function countAssetReferences(array $node): int
+    {
+        $count = (! empty($this->explicitNodeAssetReferences($node)) || ! empty($this->nodeImagePaints($node))) ? 1 : 0;
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $count += $this->countAssetReferences($child);
+            }
+        }
+
+        return $count;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -262,6 +262,9 @@ $assert(in_array('image_heavy_landmark_candidate', $qualitySignalCodes, true), '
 $assert(in_array('excessive_image_blocks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-image-blocks');
 $assert(in_array('excessive_vector_image_fallbacks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-vector-fallbacks');
 $assert('needs_review' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-status-needs-review');
+$assert('warn' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['quality_status'] ?? null), 'quality-diagnostics-quality-status-warn');
+$assert('quality:root' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['selection']['selected_frames'][0]['frame_id'] ?? null), 'quality-diagnostics-selected-frame-id');
+$assert(22 === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['selection']['selected_frames'][0]['node_count'] ?? null), 'quality-diagnostics-selected-frame-node-count');
 
 $cleanQualityResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Clean Quality Fixture',
@@ -282,6 +285,28 @@ $cleanQualityResult = blocks_engine_figma_transformer_transform_scenegraph(array
 ));
 $assert(array() === $artifactQualitySignalCodes($cleanQualityResult), 'quality-diagnostics-clean-page-no-signals');
 $assert('clean' === ($cleanQualityResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-clean-page-status');
+$assert('pass' === ($cleanQualityResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['quality_status'] ?? null), 'quality-diagnostics-clean-page-quality-status-pass');
+
+$incompleteQualityResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Incomplete Quality Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'incomplete:root',
+            'type'     => 'FRAME',
+            'name'     => 'Incomplete page',
+            'width'    => 720,
+            'height'   => 320,
+            'children' => array(
+                array('id' => 'incomplete:image', 'type' => 'RECTANGLE', 'name' => 'Missing hero asset', 'width' => 320, 'height' => 180, 'asset_id' => 'missing-hero'),
+                array('id' => 'incomplete:vector', 'type' => 'VECTOR', 'name' => 'Unsupported logo mark'),
+            ),
+        ),
+    ),
+));
+$incompleteQuality = $incompleteQualityResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality'] ?? array();
+$assert('fail' === ($incompleteQuality['quality_status'] ?? null), 'quality-diagnostics-incomplete-quality-status-fail');
+$assert(1 === ($incompleteQuality['summary']['missing_asset_nodes'] ?? null), 'quality-diagnostics-incomplete-missing-asset-count');
+$assert(1 === ($incompleteQuality['summary']['vector_placeholders'] ?? null), 'quality-diagnostics-incomplete-vector-placeholder-count');
 
 $offsetPageResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'     => 'Offset Board Fixture',
@@ -855,6 +880,10 @@ $assert(2 === ($multiPageTransformDiagnostics['images']['paint_refs'] ?? null), 
 $assert(2 === ($multiPageTransformDiagnostics['images']['resolved_assets'] ?? null), 'multi-page-transform-diagnostics-resolved-assets');
 $assert(2 === ($multiPageTransformDiagnostics['assets']['emitted_files'] ?? null), 'multi-page-transform-diagnostics-emitted-assets');
 $assert(0 === ($multiPageTransformDiagnostics['generated_svg_assets']['count'] ?? null), 'multi-page-transform-diagnostics-generated-svg-count');
+$assert('selected_frames' === ($multiPageTransformDiagnostics['selection']['mode'] ?? null), 'multi-page-transform-diagnostics-selection-mode');
+$assert('frame:home' === ($multiPageTransformDiagnostics['selection']['selected_frames'][0]['frame_id'] ?? null), 'multi-page-transform-diagnostics-entry-frame-selection');
+$assert('about.html' === ($multiPageTransformDiagnostics['selection']['selected_frames'][1]['path'] ?? null), 'multi-page-transform-diagnostics-about-selection-path');
+$assert('warn' === ($multiPageTransformDiagnostics['artifact_quality']['quality_status'] ?? null), 'multi-page-transform-diagnostics-quality-status-warn');
 
 $imageScaleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'   => 'Image Scale Fixture',


### PR DESCRIPTION
## Summary
- Adds selected-frame/page diagnostics to Figma transform diagnostics.
- Adds an aggregate `artifact_quality.quality_status` of `pass`, `warn`, or `fail` while preserving the existing quality status field.
- Surfaces the quality status, summary, and selection diagnostics in the repo-local Figma fixture matrix output.
- Expands contract coverage for clean, warning, failing, single-root, and multi-page diagnostics.

## Testing
- `php figma-transformer/tests/contract/run.php`
- `php figma-transformer/scripts/figma-fixture-matrix.php --dry-run --fixture-dir="/Users/chubes/Developer/blocks-engine@cook-figma-transformer-large-fig/figma-transformer/fixtures"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Figma transformer diagnostics flow, implementing the diagnostic report fields, updating matrix output, adding contract coverage, and running verification.
