### PR TITLE
Improve painted vector network fallback

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3070,6 +3070,16 @@ final class StaticHtmlEmitter
             $path = $this->primitivePolygonPath($width, $height, $this->polygonPointCount($node));
             return array('<path d="' . $this->sanitizeAttribute($path) . '" ' . implode(' ', $paint) . '/>');
         }
+        if ( in_array($type, array('VECTOR', 'BOOLEAN_OPERATION'), true) ) {
+            if ( 'BOOLEAN_OPERATION' === $type && ! empty($this->nodeList($node)) ) {
+                return array();
+            }
+            if ( 'fill="none"' === $paint[0] && ! $this->hasSvgStroke($paint) ) {
+                return array();
+            }
+
+            return array('<rect x="0" y="0" width="' . $this->number($width) . '" height="' . $this->number($height) . '" ' . implode(' ', $paint) . '/>');
+        }
         return array();
     }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -653,6 +653,15 @@ $vectorDataResult = blocks_engine_figma_transformer_transform_scenegraph(array(
             'height'     => 10,
             'vectorData' => array('vectorNetworkBlob' => 1),
         ),
+        array(
+            'id'         => 'vector:data-painted-fallback',
+            'type'       => 'VECTOR',
+            'name'       => 'Painted Network Fallback',
+            'width'      => 12,
+            'height'     => 6,
+            'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 1))),
+            'vectorData' => array('vectorNetworkBlob' => 1),
+        ),
     ),
 ));
 $vectorDataHtml = $fileContent($vectorDataResult, 'index.html');
@@ -669,6 +678,7 @@ $vectorDataDiagnosticCodes = array_map(
 );
 $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data"') && str_contains($vectorDataHtml, 'data-figma-vector="true"'), 'vector-data-renders-svg');
 $assert(str_contains($vectorDataHtml, 'd="M 0 0 L 10 0 L 10 10 Z"'), 'vector-data-renders-command-blob-path');
+$assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-painted-fallback"') && str_contains($vectorDataHtml, '<rect x="0" y="0" width="12" height="6" fill="#0000ff"/>'), 'vector-data-painted-network-fallback-rect');
 $assert(in_array('unsupported_vector_network_blob', $vectorDataDiagnosticCodes, true), 'vector-data-malformed-network-diagnostic');
 $assert(1 === ($vectorNetworkDiagnostic['context']['byte_length'] ?? null) && 'ff' === ($vectorNetworkDiagnostic['context']['signature_hex'] ?? null), 'vector-network-diagnostic-context');
 


### PR DESCRIPTION
## Summary
- Render undecodable painted VECTOR/leaf BOOLEAN_OPERATION nodes as bounded inline SVG rectangles instead of invisible unsupported placeholders.
- Keep unsupported vector network diagnostics intact and avoid decoding vectorData.vectorNetworkBlob semantics beyond existing guarded decoders.
- Add contract coverage for a painted undecodable vectorNetworkBlob fallback.

## Verification
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting existing vector fallback behavior, implementing the focused fallback, adding contract coverage, and running verification.