### PR TITLE
Refine Figma image-heavy artifact diagnostics

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -609,7 +609,7 @@ final class FigmaTransformer
      */
     private function mergePageTransformDiagnostics(array $pageReports, array $assetReport): array
     {
-        $images = array('paint_refs' => 0, 'node_refs' => 0, 'resolved_assets' => 0, 'image_block_count' => 0, 'image_block_nodes' => array(), 'missing_assets' => array());
+        $images = array('paint_refs' => 0, 'node_refs' => 0, 'resolved_assets' => 0, 'image_block_count' => 0, 'total_node_count' => 0, 'image_block_nodes' => array(), 'missing_assets' => array());
         $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'placeholders' => 0, 'placeholder_nodes' => array());
         $layout = array(
             'large_negative_left_count' => 0,
@@ -637,7 +637,7 @@ final class FigmaTransformer
             $pages[] = array_merge($pageContext, array('transform_diagnostics' => $diagnostics));
 
             $pageImages = is_array($diagnostics['images'] ?? null) ? $diagnostics['images'] : array();
-            foreach ( array('paint_refs', 'node_refs', 'resolved_assets', 'image_block_count') as $key ) {
+            foreach ( array('paint_refs', 'node_refs', 'resolved_assets', 'image_block_count', 'total_node_count') as $key ) {
                 $images[$key] += (int) ($pageImages[$key] ?? 0);
             }
             foreach ( is_array($pageImages['image_block_nodes'] ?? null) ? $pageImages['image_block_nodes'] : array() as $item ) {
@@ -764,8 +764,18 @@ final class FigmaTransformer
         if ( ! empty($layout['image_heavy_landmark_candidates']) ) {
             $signals[] = array('severity' => 'warning', 'code' => 'image_heavy_landmark_candidate', 'count' => count($layout['image_heavy_landmark_candidates']));
         }
-        if ( (int) ($images['image_block_count'] ?? 0) >= 12 ) {
-            $signals[] = array('severity' => 'warning', 'code' => 'excessive_image_blocks', 'count' => (int) $images['image_block_count']);
+        $imageBlockCount = (int) ($images['image_block_count'] ?? 0);
+        $totalNodeCount = max(0, (int) ($images['total_node_count'] ?? 0));
+        $imageNodeDensity = $totalNodeCount > 0 ? $imageBlockCount / $totalNodeCount : 0.0;
+        if ( $imageBlockCount >= 12 && ($imageNodeDensity >= 0.35 || ! empty($layout['image_heavy_landmark_candidates'])) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'excessive_image_blocks',
+                'count' => $imageBlockCount,
+                'threshold' => 12,
+                'image_node_density' => round($imageNodeDensity, 3),
+                'sample_nodes' => array_slice(is_array($images['image_block_nodes'] ?? null) ? $images['image_block_nodes'] : array(), 0, 10),
+            );
         }
         if ( (int) ($vectors['rendered_asset_fallbacks'] ?? 0) >= 8 ) {
             $signals[] = array('severity' => 'warning', 'code' => 'excessive_vector_image_fallbacks', 'count' => (int) $vectors['rendered_asset_fallbacks']);
@@ -794,7 +804,9 @@ final class FigmaTransformer
                 'vector_placeholders' => (int) ($vectors['placeholders'] ?? 0),
                 'missing_font_css' => count($fonts['missing_css'] ?? array()),
                 'emitted_asset_files' => (int) ($assets['emitted_files'] ?? 0),
-                'image_block_count' => (int) ($images['image_block_count'] ?? 0),
+                'image_block_count' => $imageBlockCount,
+                'image_node_density' => round($imageNodeDensity, 3),
+                'total_node_count' => $totalNodeCount,
                 'vector_image_fallbacks' => (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
                 'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -662,6 +662,7 @@ final class StaticHtmlEmitter
             'node_refs'       => 0,
             'resolved_assets' => 0,
             'image_block_count' => 0,
+            'total_node_count' => 0,
             'image_block_nodes' => array(),
             'missing_assets'  => array(),
         );
@@ -788,11 +789,17 @@ final class StaticHtmlEmitter
                 'count' => count($layout['image_heavy_landmark_candidates']),
             );
         }
-        if ( (int) ($image['image_block_count'] ?? 0) >= 12 ) {
+        $imageBlockCount = (int) ($image['image_block_count'] ?? 0);
+        $totalNodeCount = max(0, (int) ($image['total_node_count'] ?? 0));
+        $imageNodeDensity = $totalNodeCount > 0 ? $imageBlockCount / $totalNodeCount : 0.0;
+        if ( $imageBlockCount >= 12 && ($imageNodeDensity >= 0.35 || ! empty($layout['image_heavy_landmark_candidates'])) ) {
             $signals[] = array(
                 'severity' => 'warning',
                 'code' => 'excessive_image_blocks',
-                'count' => (int) $image['image_block_count'],
+                'count' => $imageBlockCount,
+                'threshold' => 12,
+                'image_node_density' => round($imageNodeDensity, 3),
+                'sample_nodes' => array_slice(is_array($image['image_block_nodes'] ?? null) ? $image['image_block_nodes'] : array(), 0, 10),
             );
         }
         if ( (int) ($vectors['rendered_asset_fallbacks'] ?? 0) >= 8 ) {
@@ -826,7 +833,9 @@ final class StaticHtmlEmitter
                 'vector_placeholders' => (int) ($vectors['placeholders'] ?? 0),
                 'missing_font_css' => count($fonts['missing_css'] ?? array()),
                 'emitted_asset_files' => (int) ($assets['emitted_files'] ?? 0),
-                'image_block_count' => (int) ($image['image_block_count'] ?? 0),
+                'image_block_count' => $imageBlockCount,
+                'image_node_density' => round($imageNodeDensity, 3),
+                'total_node_count' => $totalNodeCount,
                 'vector_image_fallbacks' => (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
                 'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
@@ -940,6 +949,8 @@ final class StaticHtmlEmitter
      */
     private function collectTransformDiagnostics(array $node, array &$image, array &$vectors, array &$layout, ?array $parentNode = null): void
     {
+        ++$image['total_node_count'];
+
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $nodeLayout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -263,8 +263,50 @@ $assert(in_array('excessive_image_blocks', $qualitySignalCodes, true), 'quality-
 $assert(in_array('excessive_vector_image_fallbacks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-vector-fallbacks');
 $assert('needs_review' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-status-needs-review');
 $assert('warn' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['quality_status'] ?? null), 'quality-diagnostics-quality-status-warn');
+$qualitySignals = $qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
+$excessiveImageSignal = null;
+foreach ( is_array($qualitySignals) ? $qualitySignals : array() as $signal ) {
+    if ( is_array($signal) && 'excessive_image_blocks' === ($signal['code'] ?? null) ) {
+        $excessiveImageSignal = $signal;
+        break;
+    }
+}
+$assert(12 === ($excessiveImageSignal['threshold'] ?? null), 'quality-diagnostics-excessive-image-threshold');
+$assert(($excessiveImageSignal['image_node_density'] ?? 0) > 0.35, 'quality-diagnostics-excessive-image-density');
+$assert(! empty($excessiveImageSignal['sample_nodes']) && count($excessiveImageSignal['sample_nodes']) <= 10, 'quality-diagnostics-excessive-image-samples');
+$assert(20 === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['summary']['image_block_count'] ?? null), 'quality-diagnostics-image-block-summary-count');
+$assert(22 === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['summary']['total_node_count'] ?? null), 'quality-diagnostics-total-node-summary-count');
 $assert('quality:root' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['selection']['selected_frames'][0]['frame_id'] ?? null), 'quality-diagnostics-selected-frame-id');
 $assert(22 === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['selection']['selected_frames'][0]['node_count'] ?? null), 'quality-diagnostics-selected-frame-node-count');
+
+$normalImageAssets = array();
+$normalImageChildren = array();
+for ( $i = 1; $i <= 12; $i++ ) {
+    $normalImageAssets['normal-image-' . $i] = array('mime_type' => 'image/png', 'content' => 'normal image ' . $i);
+    $normalImageChildren[] = array('id' => 'normal:image:' . $i, 'type' => 'RECTANGLE', 'name' => 'Gallery image ' . $i, 'width' => 120, 'height' => 90, 'asset_id' => 'normal-image-' . $i);
+}
+for ( $i = 1; $i <= 32; $i++ ) {
+    $normalImageChildren[] = array('id' => 'normal:text:' . $i, 'type' => 'TEXT', 'name' => 'Body copy ' . $i, 'characters' => 'Paragraph ' . $i, 'fontSize' => 16);
+}
+$normalImageResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'   => 'Normal Image Count Fixture',
+    'assets' => $normalImageAssets,
+    'nodes'  => array(
+        array(
+            'id'       => 'normal:root',
+            'type'     => 'FRAME',
+            'name'     => 'Editorial gallery page',
+            'width'    => 960,
+            'height'   => 1600,
+            'layoutMode' => 'VERTICAL',
+            'children' => $normalImageChildren,
+        ),
+    ),
+));
+$normalImageQuality = $normalImageResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality'] ?? array();
+$assert(! in_array('excessive_image_blocks', $artifactQualitySignalCodes($normalImageResult), true), 'quality-diagnostics-normal-image-count-no-excessive-signal');
+$assert(12 === ($normalImageQuality['summary']['image_block_count'] ?? null), 'quality-diagnostics-normal-image-count-summary');
+$assert(($normalImageQuality['summary']['image_node_density'] ?? 1) < 0.35, 'quality-diagnostics-normal-image-density-summary');
 
 $cleanQualityResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Clean Quality Fixture',


### PR DESCRIPTION
## Summary
- Refine the excessive image block artifact-quality signal so it requires both count and image-node density, or an image-heavy landmark candidate.
- Add image-node density, total node count, threshold, and sample nodes to diagnostics for easier triage.
- Cover dense image-heavy output and a normal 12-image content page in contract tests.

## Verification
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php && php -l figma-transformer/src/FigmaTransformer.php && php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, contract coverage, verification, and PR preparation.