### PR TITLE
Aggregate unsupported vector network diagnostics

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -64,7 +64,7 @@ final class ScenegraphNormalizer
         $textInventory   = $this->buildTextInventory($nodeMap);
         $assetReferences = $this->buildAssetReferences($nodeMap);
         $sourceName      = $this->readSourceName($source, $renderNodes);
-        $diagnostics     = $this->compactGlyphCommandBlobDiagnostics($diagnostics);
+        $diagnostics     = $this->compactUnsupportedVectorNetworkBlobDiagnostics($this->compactGlyphCommandBlobDiagnostics($diagnostics));
 
         return array(
             'schema'              => 'blocks-engine/figma-transformer/scenegraph/v1',
@@ -207,6 +207,82 @@ final class ScenegraphNormalizer
                 'sample_glyphs'       => $sampleGlyphs,
             ),
         );
+
+        return $compacted;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    private function compactUnsupportedVectorNetworkBlobDiagnostics(array $diagnostics): array
+    {
+        $compacted = array();
+        $groups = array();
+
+        foreach ( $diagnostics as $diagnostic ) {
+            if ( ! is_array($diagnostic) || 'unsupported_vector_network_blob' !== ($diagnostic['code'] ?? null) ) {
+                $compacted[] = $diagnostic;
+                continue;
+            }
+
+            $context = is_array($diagnostic['context'] ?? null) ? $diagnostic['context'] : array();
+            $signatureHex = isset($context['signature_hex']) && is_scalar($context['signature_hex']) ? (string) $context['signature_hex'] : '';
+            $byteLength = isset($context['byte_length']) && is_numeric($context['byte_length']) ? (int) $context['byte_length'] : null;
+            $networkCounts = is_array($context['network_counts'] ?? null) ? array_values($context['network_counts']) : null;
+            $key = json_encode(array($signatureHex, $byteLength, $networkCounts), JSON_UNESCAPED_SLASHES);
+            if ( ! is_string($key) ) {
+                $key = $signatureHex . ':' . (string) $byteLength;
+            }
+
+            if ( ! isset($groups[$key]) ) {
+                $groups[$key] = array(
+                    'severity' => $diagnostic['severity'] ?? 'warning',
+                    'message'  => $diagnostic['message'] ?? 'Unsupported Figma vector network blob was omitted from SVG output.',
+                    'source'   => $diagnostic['source'] ?? 'ScenegraphNormalizer',
+                    'context'  => array(
+                        'occurrence_count' => 0,
+                        'affected_node_count' => 0,
+                        'sample_node_ids'  => array(),
+                        'sample_blob_refs' => array(),
+                    ),
+                    'node_ids' => array(),
+                    'blob_refs' => array(),
+                    'blob_ref_seen' => array(),
+                );
+
+                foreach ( array('geometry', 'blob_ref', 'byte_length', 'signature_hex', 'network_counts') as $contextKey ) {
+                    if ( array_key_exists($contextKey, $context) ) {
+                        $groups[$key]['context'][$contextKey] = $context[$contextKey];
+                    }
+                }
+            }
+
+            $groups[$key]['context']['occurrence_count']++;
+            $nodeId = isset($context['node_id']) && is_scalar($context['node_id']) ? (string) $context['node_id'] : '';
+            if ( '' !== $nodeId ) {
+                $groups[$key]['node_ids'][$nodeId] = true;
+            }
+            $blobRef = isset($context['blob_ref']) && is_scalar($context['blob_ref']) ? (string) $context['blob_ref'] : '';
+            if ( '' !== $blobRef && ! isset($groups[$key]['blob_ref_seen'][$blobRef]) ) {
+                $groups[$key]['blob_refs'][] = $blobRef;
+                $groups[$key]['blob_ref_seen'][$blobRef] = true;
+            }
+        }
+
+        foreach ( $groups as $group ) {
+            $context = $group['context'];
+            $context['affected_node_count'] = count($group['node_ids']);
+            $context['sample_node_ids'] = array_slice(array_keys($group['node_ids']), 0, 10);
+            $context['sample_blob_refs'] = array_slice($group['blob_refs'], 0, 10);
+            $compacted[] = array(
+                'severity' => $group['severity'],
+                'code'     => 'unsupported_vector_network_blob',
+                'message'  => $group['message'],
+                'source'   => $group['source'],
+                'context'  => $context,
+            );
+        }
 
         return $compacted;
     }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -725,6 +725,15 @@ $assert(str_contains($vectorDataHtml, 'd="M0 0L10 0 10 10Z"'), 'vector-data-rend
 $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-painted-fallback"') && str_contains($vectorDataHtml, '<rect x="0" y="0" width="12" height="6" fill="#0000ff"/>'), 'vector-data-painted-network-fallback-rect');
 $assert(in_array('unsupported_vector_network_blob', $vectorDataDiagnosticCodes, true), 'vector-data-malformed-network-diagnostic');
 $assert(1 === ($vectorNetworkDiagnostic['context']['byte_length'] ?? null) && 'ff' === ($vectorNetworkDiagnostic['context']['signature_hex'] ?? null), 'vector-network-diagnostic-context');
+$vectorNetworkDiagnostics = array_values(array_filter(
+    $vectorDataResult['diagnostics'] ?? array(),
+    static fn (array $diagnostic): bool => 'unsupported_vector_network_blob' === ($diagnostic['code'] ?? null)
+));
+$assert(1 === count($vectorNetworkDiagnostics), 'vector-network-repeated-diagnostics-compacted');
+$assert(2 === ($vectorNetworkDiagnostic['context']['occurrence_count'] ?? null), 'vector-network-diagnostic-occurrence-count');
+$assert(2 === ($vectorNetworkDiagnostic['context']['affected_node_count'] ?? null), 'vector-network-diagnostic-affected-node-count');
+$assert(array('vector:data-malformed', 'vector:data-painted-fallback') === ($vectorNetworkDiagnostic['context']['sample_node_ids'] ?? null), 'vector-network-diagnostic-sample-nodes');
+$assert(array('1') === ($vectorNetworkDiagnostic['context']['sample_blob_refs'] ?? null), 'vector-network-diagnostic-sample-blob-refs');
 
 $agenticChevronLeftPrefix = hex2bin('0600000006000000010000000000000000000041000080410000000000000000');
 $agenticChevronRightPrefix = hex2bin('06000000060000000100000000000000f4fdb43f0000804100000000be9f1641');


### PR DESCRIPTION
## Summary
- Aggregate repeated `unsupported_vector_network_blob` diagnostics by blob signature, byte length, and network counts.
- Preserve occurrence frequency, affected node counts, sample node IDs, and sample blob refs on the aggregated warning.
- Add contract coverage for repeated unsupported vector network blobs without changing visual output behavior.

## Verification
- `php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`

## Latest matrix evidence targeted
- Run id: `figma-transformer-matrix-homeboy-flow-20260626-1152`
- Summary artifact: `/Users/chubes/.local/share/homeboy/artifacts/figma-transformer-matrix-homeboy-flow-20260626-1152/526e79bd-8dd2-41f3-8dac-8dde7d1d94f0-53f9da09-5611-42ef-9696-5a0591b90220-summary.json`
- FSE result: `/Users/chubes/.local/share/homeboy/artifacts/figma-transformer-matrix-homeboy-flow-20260626-1152/76e8224b-d68b-4a66-946f-f8dc58fa8137-c6222707-a78e-4d14-b6d7-f29b31cff4b4-figma-transformer-matrix-homeboy-flow-20260626-1152/fse-pilot-build-theme-result.json`
- Projected FSE diagnostic delta from the existing result artifact: `unsupported_vector_network_blob` entries collapse from 906 warnings to 1 aggregated group, preserving `occurrence_count: 906`, `affected_node_count: 13`, `blob_ref: 707`, `byte_length: 172`, signature `0400000004000000000000000000000000000000000000000000000000008043`, and network counts `[4,4,0]`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing diagnostic aggregation, tests, and PR preparation.