### PR TITLE
Add guarded fallback for simple Figma vector networks

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1873,7 +1873,7 @@ final class ScenegraphNormalizer
         }
 
         if ( empty($paths) && isset($node['vectorData']['vectorNetworkBlob']) ) {
-            $normalized = $this->normalizeVectorNetworkBlob($node['vectorData']['vectorNetworkBlob'], $blobs, $nodeId, $diagnostics);
+            $normalized = $this->normalizeVectorNetworkBlob($node['vectorData']['vectorNetworkBlob'], $node, $blobs, $nodeId, $diagnostics);
             if ( null !== $normalized ) {
                 $paths[] = $normalized;
             }
@@ -1924,7 +1924,7 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>|null
      */
-    private function normalizeVectorNetworkBlob(mixed $blobReference, array $blobs, string $nodeId, array &$diagnostics): ?array
+    private function normalizeVectorNetworkBlob(mixed $blobReference, array $node, array $blobs, string $nodeId, array &$diagnostics): ?array
     {
         $bytes = $this->readCommandBlobBytes($blobReference, $blobs);
         if ( null === $bytes ) {
@@ -1940,6 +1940,11 @@ final class ScenegraphNormalizer
         $path = $this->decodeSimpleChevronVectorNetworkBlob($bytes);
         if ( null !== $path ) {
             return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob', 'windingRule' => 'NONZERO');
+        }
+
+        $path = $this->decodeSimpleRectVectorNetworkBlob($bytes, $node);
+        if ( null !== $path ) {
+            return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob.simpleRectFallback', 'windingRule' => 'NONZERO');
         }
 
         if ( ! $this->looksLikeVectorNetworkBlob($bytes) ) {
@@ -1975,6 +1980,38 @@ final class ScenegraphNormalizer
             '06000000060000000100000000000000f4fdb43f0000804100000000be9f1641' => 'M 1.414 16 L 9.414 8 L 1.414 0 L 0 1.414 L 6.586 8 L 0 14.586 L 1.414 16 Z',
             default => null,
         };
+    }
+
+    /**
+     * Small icon vectors can arrive as a 4-vertex, 4-segment network
+     * without decodable command geometry. Keep this guard exact until the broader
+     * vector-network format is understood.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function decodeSimpleRectVectorNetworkBlob(string $bytes, array $node): ?string
+    {
+        if ( 172 !== strlen($bytes) ) {
+            return null;
+        }
+
+        if ( array(4, 4, 0) !== $this->vectorNetworkCounts($bytes) ) {
+            return null;
+        }
+
+        $signature = bin2hex(substr($bytes, 0, 32));
+        if ( '0400000004000000000000000000000000000000000000000000000000008043' !== $signature ) {
+            return null;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : ( isset($node['width']) && is_numeric($node['width']) ? (float) $node['width'] : 0.0 );
+        $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : ( isset($node['height']) && is_numeric($node['height']) ? (float) $node['height'] : 0.0 );
+        if ( $width <= 0.0 || $height <= 0.0 ) {
+            return null;
+        }
+
+        return 'M 0 0 L ' . $this->svgNumber($width) . ' 0 L ' . $this->svgNumber($width) . ' ' . $this->svgNumber($height) . ' L 0 ' . $this->svgNumber($height) . ' Z';
     }
 
     private function looksLikeVectorNetworkBlob(string $bytes): bool

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -676,9 +676,11 @@ $assert(str_contains($starVectorHtml, 'data-figma-node-id="vector:primitive-star
 $assert(str_contains($starVectorHtml, 'data-figma-node-id="vector:primitive-polygon"') && str_contains($starVectorHtml, 'data-figma-vector="true"'), 'primitive-polygon-vector-renders');
 $assert(! str_contains($starVectorHtml, 'data-figma-unsupported-vector="true"'), 'star-vector-path-not-placeholder');
 
+$simpleRectNetworkPrefix = hex2bin('0400000004000000000000000000000000000000000000000000000000008043');
+$simpleRectNetworkBlob = str_pad(false === $simpleRectNetworkPrefix ? '' : $simpleRectNetworkPrefix, 172, "\0");
 $vectorDataResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Vector Data Fixture',
-    'blobs' => array(array('bytes' => $vectorCommandBlob), array('bytes' => "\xff")),
+    'blobs' => array(array('bytes' => $vectorCommandBlob), array('bytes' => "\xff"), array('bytes' => $simpleRectNetworkBlob)),
     'nodes' => array(
         array(
             'id'         => 'vector:data',
@@ -706,6 +708,15 @@ $vectorDataResult = blocks_engine_figma_transformer_transform_scenegraph(array(
             'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 1))),
             'vectorData' => array('vectorNetworkBlob' => 1),
         ),
+        array(
+            'id'         => 'vector:data-simple-rect-network',
+            'type'       => 'VECTOR',
+            'name'       => 'Simple Rect Network',
+            'width'      => 12,
+            'height'     => 6,
+            'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0.5, 'b' => 1))),
+            'vectorData' => array('vectorNetworkBlob' => 2),
+        ),
     ),
 ));
 $vectorDataHtml = $fileContent($vectorDataResult, 'index.html');
@@ -723,6 +734,7 @@ $vectorDataDiagnosticCodes = array_map(
 $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data"') && str_contains($vectorDataHtml, 'data-figma-vector="true"'), 'vector-data-renders-svg');
 $assert(str_contains($vectorDataHtml, 'd="M0 0L10 0 10 10Z"'), 'vector-data-renders-command-blob-path');
 $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-painted-fallback"') && str_contains($vectorDataHtml, '<rect x="0" y="0" width="12" height="6" fill="#0000ff"/>'), 'vector-data-painted-network-fallback-rect');
+$assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-simple-rect-network"') && str_contains($vectorDataHtml, 'd="M0 0L12 0 12 6 0 6Z"') && str_contains($vectorDataHtml, 'fill="#0080ff"'), 'vector-data-simple-rect-network-renders-bounded-path');
 $assert(in_array('unsupported_vector_network_blob', $vectorDataDiagnosticCodes, true), 'vector-data-malformed-network-diagnostic');
 $assert(1 === ($vectorNetworkDiagnostic['context']['byte_length'] ?? null) && 'ff' === ($vectorNetworkDiagnostic['context']['signature_hex'] ?? null), 'vector-network-diagnostic-context');
 


### PR DESCRIPTION
## Summary
- Add a guarded fallback for the verified simple 4-point Figma vector-network blob shape: 172 bytes, counts `[4,4,0]`, and signature prefix `0400000004000000000000000000000000000000000000000000000000008043`.
- Render that narrow case as a bounded SVG rectangle path using node dimensions instead of producing unsupported vector placeholders.
- Add synthetic contract coverage for the simple network fallback while keeping malformed/unknown network diagnostics intact.

## Verification
- `php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`

## Matrix evidence targeted
- Homeboy run id: `figma-transformer-matrix-homeboy-flow-20260626-1152`
- Summary artifact: `/Users/chubes/.local/share/homeboy/artifacts/figma-transformer-matrix-homeboy-flow-20260626-1152/526e79bd-8dd2-41f3-8dac-8dde7d1d94f0-53f9da09-5611-42ef-9696-5a0591b90220-summary.json`
- FSE result artifact: `/Users/chubes/.local/share/homeboy/artifacts/figma-transformer-matrix-homeboy-flow-20260626-1152/76e8224b-d68b-4a66-946f-f8dc58fa8137-c6222707-a78e-4d14-b6d7-f29b31cff4b4-figma-transformer-matrix-homeboy-flow-20260626-1152/fse-pilot-build-theme-result.json`
- Targeted diagnostics: repeated `unsupported_vector_network_blob` entries for 172-byte vector-network blobs with `network_counts: [4,4,0]` and the signature prefix above, associated with the FSE vector placeholder wave.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the vector fallback, tests, and PR preparation.