### PR TITLE
Render size-only simple vector networks

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2080,14 +2080,41 @@ final class ScenegraphNormalizer
             return null;
         }
 
-        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
-        $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : ( isset($node['width']) && is_numeric($node['width']) ? (float) $node['width'] : 0.0 );
-        $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : ( isset($node['height']) && is_numeric($node['height']) ? (float) $node['height'] : 0.0 );
+        $width = $this->rawNodeDimension($node, 'width');
+        $height = $this->rawNodeDimension($node, 'height');
         if ( $width <= 0.0 || $height <= 0.0 ) {
             return null;
         }
 
         return 'M 0 0 L ' . $this->svgNumber($width) . ' 0 L ' . $this->svgNumber($width) . ' ' . $this->svgNumber($height) . ' L 0 ' . $this->svgNumber($height) . ' Z';
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function rawNodeDimension(array $node, string $dimension): float
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        if ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
+            return (float) $box[$dimension];
+        }
+
+        if ( isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
+            return (float) $node[$dimension];
+        }
+
+        $sizeKey = 'width' === $dimension ? 'x' : 'y';
+        if ( is_array($node['size'] ?? null) && isset($node['size'][$sizeKey]) && is_numeric($node['size'][$sizeKey]) ) {
+            return (float) $node['size'][$sizeKey];
+        }
+
+        foreach ( array('absoluteBoundingBox', 'absoluteRenderBounds') as $boundsKey ) {
+            if ( is_array($node[$boundsKey] ?? null) && isset($node[$boundsKey][$dimension]) && is_numeric($node[$boundsKey][$dimension]) ) {
+                return (float) $node[$boundsKey][$dimension];
+            }
+        }
+
+        return 0.0;
     }
 
     private function looksLikeVectorNetworkBlob(string $bytes): bool

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2908,6 +2908,44 @@ $assert(3 === substr_count($instanceVectorChildrenHtml, 'data-figma-vector="true
 $assert(str_contains($instanceVectorChildrenCss, '.figma-node-icon-one-icon-vector-vector{width:10px;height:10px'), 'instance-vector-css-one');
 $assert(str_contains($instanceVectorChildrenCss, '.figma-node-icon-two-icon-vector-vector{width:10px;height:10px'), 'instance-vector-css-two');
 
+$instanceSimpleNetworkVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Instance Simple Network Vector Fixture',
+    'blobs' => array(array('bytes' => $simpleRectNetworkBlob)),
+    'nodes' => array(
+        array(
+            'id'       => 'simple-network-icon:component',
+            'type'     => 'COMPONENT',
+            'name'     => 'Simple network icon component',
+            'key'      => 'simple-network-icon-key',
+            'children' => array(
+                array(
+                    'id'         => 'simple-network-icon:vector',
+                    'type'       => 'VECTOR',
+                    'name'       => 'Vector 10',
+                    'size'       => array('x' => 12, 'y' => 6),
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0.5, 'b' => 1))),
+                    'vectorData' => array('vectorNetworkBlob' => 0),
+                ),
+            ),
+        ),
+        array(
+            'id'          => 'simple-network-icon:instance',
+            'type'        => 'INSTANCE',
+            'name'        => 'Simple network icon instance',
+            'componentId' => 'simple-network-icon-key',
+        ),
+    ),
+));
+$instanceSimpleNetworkVectorHtml = $fileContent($instanceSimpleNetworkVectorResult, 'index.html');
+$instanceSimpleNetworkVectorDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $instanceSimpleNetworkVectorResult['diagnostics'] ?? array()
+);
+$assert(str_contains($instanceSimpleNetworkVectorHtml, 'data-figma-node-id="simple-network-icon:instance/simple-network-icon:vector"'), 'instance-simple-network-vector-child-id-namespaced');
+$assert(str_contains($instanceSimpleNetworkVectorHtml, 'd="M0 0L12 0 12 6 0 6Z"') && str_contains($instanceSimpleNetworkVectorHtml, 'fill="#0080ff"'), 'instance-simple-network-vector-renders-size-derived-path');
+$assert(! in_array('unsupported_vector_node_placeholder', $instanceSimpleNetworkVectorDiagnosticCodes, true), 'instance-simple-network-vector-no-placeholder-diagnostic');
+$assert(! in_array('unsupported_vector_network_blob', $instanceSimpleNetworkVectorDiagnosticCodes, true), 'instance-simple-network-vector-no-network-diagnostic');
+
 $nestedInstanceVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Nested Instance Vector Fixture',
     'blobs' => array(array('bytes' => $vectorCommandBlob)),


### PR DESCRIPTION
## Summary
- Render guarded 4-point simple vector-network blobs when node dimensions are available through raw Figma `size` or bounds fields before normalized `box` exists.
- Keeps the existing exact signature/count/length guard; this does not broaden unknown vector-network decoding.
- Adds contract coverage for a namespaced instance child named `Vector 10` with `size`-only dimensions and the residual simple network blob shape.

## Verification
- `php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`

## Measured Delta
- Synthetic residual-path fixture: simple vector-network instance child renders as SVG path and produces no `unsupported_vector_node_placeholder` or `unsupported_vector_network_blob` diagnostic.
- Targeted FSE transform delta was not rerun locally because this checkout does not contain the private `fse-pilot-build-theme.fig` fixture; prior post-#149-#151 evidence was FSE vector placeholders `15 -> 12` and residual diagnostics `906 -> 3`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing residual FSE vector placeholders, implementing the generic fix, tests, and PR preparation.