### PR TITLE
Wire Figma matrix parity evidence

### DIFF
--- a/figma-transformer/bin/figma-transformer
+++ b/figma-transformer/bin/figma-transformer
@@ -12,7 +12,7 @@ if ( is_readable($autoload) ) {
 
 $path = $argv[1] ?? '';
 if ( '' === $path || '--help' === $path || '-h' === $path ) {
-    fwrite(STDERR, "Usage: figma-transformer <path-to-fig-or-scenegraph-json> [--inspect-frames[=<limit>]] [--multi-page] [--frame-ids=<id,id>] [--entry-frame-id=<id>] [--max-pages=<count>] [--output-dir=<dir>] [--omit-asset-content] [--max-nodes=<count>] [--max-kiwi-message-decode-bytes=<bytes>] [--zstd-command=<path>] [--frame-id=<id>] [--font-css=<css>] [--font-css-file=<path>] [--render-text-glyph-paths] [--parity-status=<status>] [--parity-source-screenshot-url=<url>] [--parity-source-screenshot-path=<path>] [--parity-generated-screenshot-artifact=<artifact>] [--parity-diff-image-artifact=<artifact>] [--parity-pixel-mismatch-count=<count>] [--parity-pixel-mismatch-ratio=<ratio>] [--parity-threshold=<ratio>] [--parity-viewport=<width>x<height>]\n");
+    fwrite(STDERR, "Usage: figma-transformer <path-to-fig-or-scenegraph-json> [--inspect-frames[=<limit>]] [--multi-page] [--frame-ids=<id,id>] [--entry-frame-id=<id>] [--max-pages=<count>] [--output-dir=<dir>] [--omit-asset-content] [--max-nodes=<count>] [--max-kiwi-message-decode-bytes=<bytes>] [--zstd-command=<path>] [--frame-id=<id>] [--font-css=<css>] [--font-css-file=<path>] [--render-text-glyph-paths] [--parity-status=<status>] [--parity-report-path=<path>] [--parity-source-screenshot-url=<url>] [--parity-source-screenshot-path=<path>] [--parity-generated-screenshot-artifact=<artifact>] [--parity-diff-image-artifact=<artifact>] [--parity-pixel-mismatch-count=<count>] [--parity-pixel-mismatch-ratio=<ratio>] [--parity-threshold=<ratio>] [--parity-viewport=<width>x<height>] [--parity-dom-boxes-path=<path>] [--parity-layout-report-path=<path>] [--parity-layout-mismatch-count=<count>]\n");
     exit(1);
 }
 
@@ -123,6 +123,8 @@ foreach ( array_slice($argv, 2) as $argument ) {
     $parityMap = array(
         'parity-status' => 'status',
         'parity-reason' => 'reason',
+        'parity-report-path' => 'report_path',
+        'parity-report-artifact' => 'report_artifact',
         'parity-source-screenshot-url' => 'source_screenshot_url',
         'parity-source-screenshot-path' => 'source_screenshot_path',
         'parity-source-screenshot-artifact' => 'source_screenshot_artifact',
@@ -135,6 +137,10 @@ foreach ( array_slice($argv, 2) as $argument ) {
         'parity-pixel-mismatch-count' => 'pixel_mismatch_count',
         'parity-pixel-mismatch-ratio' => 'pixel_mismatch_ratio',
         'parity-threshold' => 'threshold',
+        'parity-dom-boxes-path' => 'dom_boxes_path',
+        'parity-layout-report-path' => 'layout_report_path',
+        'parity-layout-mismatch-report-path' => 'layout_mismatch_report_path',
+        'parity-layout-mismatch-count' => 'layout_mismatch_count',
     );
 
     if ( isset($parityMap[$name]) ) {

--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -18,6 +18,7 @@ $inspectOnly = true === ($options['inspect_only'] ?? false);
 $only = isset($options['only']) ? array_filter(array_map('trim', explode(',', (string) $options['only']))) : array();
 $adHocFixtures = matrix_list_option($options['fixture'] ?? array());
 $fontCssPassthrough = matrix_font_css_passthrough($options);
+$evidenceOptions = matrix_evidence_options($options);
 
 $fixtures = matrix_discover_fixtures($fixtureDir);
 foreach ( $adHocFixtures as $fixturePath ) {
@@ -55,6 +56,7 @@ $summary = array(
     'dry_run' => $dryRun,
     'inspect_only' => $inspectOnly,
     'font_css' => $fontCssPassthrough['summary'],
+    'evidence' => $evidenceOptions['summary'],
     'fixtures' => array(),
 );
 
@@ -86,6 +88,7 @@ foreach ( $fixtures as $fixture ) {
     $record['inspect_path'] = $inspectPath;
     $record['result_path'] = $resultPath;
     $record['artifact_dir'] = $fixtureOutputDir;
+    $record['evidence'] = matrix_fixture_evidence($evidenceOptions, $fixture, array());
 
     if ( $dryRun ) {
         $record['status'] = 'planned';
@@ -93,7 +96,8 @@ foreach ( $fixtures as $fixture ) {
         $hasDryRunFrameIds = isset($fixture['frame_ids']) && is_array($fixture['frame_ids']);
         $dryRunFrameIds = $hasDryRunFrameIds ? $fixture['frame_ids'] : array('<selected-frame-ids>');
         $dryRunEntryFrameId = (string) ($fixture['entry_frame_id'] ?? ($hasDryRunFrameIds ? ($dryRunFrameIds[0] ?? '') : '<entry-frame-id>'));
-        $record['command'] = matrix_transform_command($figmaRoot, $fixturePath, $dryRunFrameIds, $dryRunEntryFrameId, $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments']);
+        $record['evidence'] = matrix_fixture_evidence($evidenceOptions, $fixture, matrix_dry_run_pages($dryRunFrameIds));
+        $record['command'] = matrix_transform_command($figmaRoot, $fixturePath, $dryRunFrameIds, $dryRunEntryFrameId, $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $record['evidence']['transform_arguments'] ?? array());
         $summary['fixtures'][] = $record;
         continue;
     }
@@ -114,6 +118,7 @@ foreach ( $fixtures as $fixture ) {
     $record['selected_frame_ids'] = $frameIds;
     $record['selected_frames'] = matrix_selected_frame_records(is_array($inspection) ? $inspection : array(), $frameIds);
     $record['entry_frame_id'] = (string) ($fixture['entry_frame_id'] ?? ($frameIds[0] ?? ''));
+    $record['evidence'] = matrix_fixture_evidence($evidenceOptions, $fixture, $record['selected_frames']);
 
     if ( $inspectOnly ) {
         $record['status'] = 'inspected';
@@ -127,7 +132,7 @@ foreach ( $fixtures as $fixture ) {
         continue;
     }
 
-    $command = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments']);
+    $command = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $record['evidence']['transform_arguments'] ?? array());
     $record['command'] = $command;
     passthru($command, $exitCode);
     $record['exit_code'] = $exitCode;
@@ -137,7 +142,10 @@ foreach ( $fixtures as $fixture ) {
     if ( 0 === $exitCode && is_file($resultPath) ) {
         $result = json_decode((string) file_get_contents($resultPath), true);
         if ( is_array($result) ) {
+            $result = matrix_attach_evidence_to_result($result, $record['evidence']);
+            file_put_contents($resultPath, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
             $record['result_status'] = $result['status'] ?? null;
+            $record['parity'] = matrix_parity_summary(is_array($result['parity'] ?? null) ? $result['parity'] : array());
             $record['metrics'] = $result['metrics'] ?? array();
             $diagnostics = $result['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
             if ( is_array($diagnostics) ) {
@@ -246,6 +254,39 @@ function matrix_font_css_passthrough(array $options): array
 }
 
 /**
+ * @param array<string, mixed> $options
+ * @return array{templates: array<string, string>, summary: array<string, mixed>}
+ */
+function matrix_evidence_options(array $options): array
+{
+    $map = array(
+        'parity_report' => 'parity_report_path',
+        'parity_report_path' => 'parity_report_path',
+        'dom_boxes' => 'dom_boxes_path',
+        'dom_boxes_path' => 'dom_boxes_path',
+        'layout_report' => 'layout_report_path',
+        'layout_report_path' => 'layout_report_path',
+        'layout_mismatch_report' => 'layout_mismatch_report_path',
+        'layout_mismatch_report_path' => 'layout_mismatch_report_path',
+    );
+    $templates = array();
+    foreach ( $map as $optionKey => $templateKey ) {
+        if ( isset($options[$optionKey]) && is_scalar($options[$optionKey]) && '' !== (string) $options[$optionKey] ) {
+            $templates[$templateKey] = (string) $options[$optionKey];
+        }
+    }
+
+    return array(
+        'templates' => $templates,
+        'summary' => empty($templates) ? array('source' => 'none') : array(
+            'source' => 'runner_paths',
+            'templates' => $templates,
+            'template_tokens' => array('{fixture}', '{id}', '{frame_id}', '{page}', '{slug}'),
+        ),
+    );
+}
+
+/**
  * @return array<int, array<string, mixed>>
  */
 function matrix_discover_fixtures(string $fixtureDir): array
@@ -326,8 +367,9 @@ function matrix_inspect_command(string $figmaRoot, string $fixturePath, string $
 /**
  * @param array<int, string> $frameIds
  * @param array<int, string> $fontCssArguments
+ * @param array<int, string> $evidenceArguments
  */
-function matrix_transform_command(string $figmaRoot, string $fixturePath, array $frameIds, string $entryFrameId, string $fixtureOutputDir, string $resultPath, string $zstdCommand, int $maxNodes, array $fontCssArguments = array()): string
+function matrix_transform_command(string $figmaRoot, string $fixturePath, array $frameIds, string $entryFrameId, string $fixtureOutputDir, string $resultPath, string $zstdCommand, int $maxNodes, array $fontCssArguments = array(), array $evidenceArguments = array()): string
 {
     $parts = array(
         escapeshellarg(PHP_BINARY),
@@ -344,8 +386,122 @@ function matrix_transform_command(string $figmaRoot, string $fixturePath, array 
     );
 
     array_push($parts, ...$fontCssArguments);
+    array_push($parts, ...$evidenceArguments);
 
     return implode(' ', $parts) . ' > ' . escapeshellarg($resultPath);
+}
+
+/**
+ * @param array{templates: array<string, string>, summary: array<string, mixed>} $evidenceOptions
+ * @param array<string, mixed> $fixture
+ * @param array<int, array<string, mixed>> $pages
+ * @return array<string, mixed>
+ */
+function matrix_fixture_evidence(array $evidenceOptions, array $fixture, array $pages): array
+{
+    $templates = $evidenceOptions['templates'];
+    if ( empty($templates) ) {
+        return array('source' => 'none', 'transform_arguments' => array());
+    }
+
+    $fixturePaths = array();
+    foreach ( $templates as $key => $template ) {
+        $fixturePaths[$key] = matrix_resolve_evidence_template($template, $fixture, array());
+    }
+
+    $pageRecords = array();
+    foreach ( $pages as $page ) {
+        $pagePaths = array();
+        foreach ( $templates as $key => $template ) {
+            $pagePaths[$key] = matrix_resolve_evidence_template($template, $fixture, $page);
+        }
+        $pageRecords[] = array(
+            'frame_id' => (string) ($page['id'] ?? $page['frame_id'] ?? ''),
+            'name' => (string) ($page['name'] ?? ''),
+            'slug' => (string) ($page['slug'] ?? ''),
+            'paths' => matrix_evidence_path_records($pagePaths),
+        );
+    }
+
+    return array(
+        'source' => 'runner_paths',
+        'paths' => matrix_evidence_path_records($fixturePaths),
+        'pages' => $pageRecords,
+        'transform_arguments' => matrix_evidence_transform_arguments($fixturePaths),
+    );
+}
+
+/**
+ * @param array<int, string> $frameIds
+ * @return array<int, array<string, mixed>>
+ */
+function matrix_dry_run_pages(array $frameIds): array
+{
+    return array_map(static fn (string $frameId): array => array('id' => $frameId, 'name' => $frameId, 'slug' => matrix_slug($frameId)), $frameIds);
+}
+
+/**
+ * @param array<string, mixed> $fixture
+ * @param array<string, mixed> $page
+ */
+function matrix_resolve_evidence_template(string $template, array $fixture, array $page): string
+{
+    $frameId = (string) ($page['frame_id'] ?? $page['id'] ?? '');
+    $tokens = array(
+        '{fixture}' => (string) ($fixture['id'] ?? ''),
+        '{id}' => (string) ($fixture['id'] ?? ''),
+        '{frame_id}' => '' !== $frameId ? $frameId : (string) ($fixture['entry_frame_id'] ?? ''),
+        '{page}' => (string) ($page['name'] ?? ''),
+        '{slug}' => (string) ($page['slug'] ?? ('' !== $frameId ? matrix_slug($frameId) : (string) ($fixture['id'] ?? ''))),
+    );
+
+    return strtr($template, $tokens);
+}
+
+/**
+ * @param array<string, string> $paths
+ * @return array<string, array<string, mixed>>
+ */
+function matrix_evidence_path_records(array $paths): array
+{
+    $records = array();
+    foreach ( $paths as $key => $path ) {
+        $records[$key] = array(
+            'path' => $path,
+            'exists' => is_file($path),
+            'readable' => is_readable($path),
+        );
+    }
+
+    return $records;
+}
+
+/**
+ * @param array<string, string> $paths
+ * @return array<int, string>
+ */
+function matrix_evidence_transform_arguments(array $paths): array
+{
+    $map = array(
+        'parity_report_path' => '--parity-report-path=',
+        'dom_boxes_path' => '--parity-dom-boxes-path=',
+        'layout_report_path' => '--parity-layout-report-path=',
+        'layout_mismatch_report_path' => '--parity-layout-mismatch-report-path=',
+    );
+    $arguments = array();
+    foreach ( $map as $key => $argument ) {
+        if ( isset($paths[$key]) && '' !== $paths[$key] ) {
+            $arguments[] = $argument . escapeshellarg($paths[$key]);
+        }
+    }
+
+    return $arguments;
+}
+
+function matrix_slug(string $value): string
+{
+    $slug = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '-', $value));
+    return trim($slug, '-') ?: 'page';
 }
 
 /**
@@ -359,6 +515,160 @@ function matrix_inspection_summary(array $inspection): array
         'node_count' => $inspection['node_count'] ?? null,
         'candidate_count' => $inspection['candidate_count'] ?? null,
         'returned_count' => $inspection['returned_count'] ?? null,
+    );
+}
+
+/**
+ * @param array<string, mixed> $result
+ * @param array<string, mixed> $evidence
+ * @return array<string, mixed>
+ */
+function matrix_attach_evidence_to_result(array $result, array $evidence): array
+{
+    if ( 'runner_paths' !== ($evidence['source'] ?? null) ) {
+        return $result;
+    }
+
+    $parity = is_array($result['parity'] ?? null) ? $result['parity'] : array();
+    $parity['artifacts'] = is_array($parity['artifacts'] ?? null) ? $parity['artifacts'] : array();
+    $parity['layout_diagnostics'] = is_array($parity['layout_diagnostics'] ?? null) ? $parity['layout_diagnostics'] : array();
+    $paths = is_array($evidence['paths'] ?? null) ? $evidence['paths'] : array();
+
+    foreach ( array(
+        'parity_report_path' => 'report_path',
+        'dom_boxes_path' => 'dom_boxes_path',
+        'layout_report_path' => 'layout_report_path',
+        'layout_mismatch_report_path' => 'layout_mismatch_report_path',
+    ) as $pathKey => $artifactKey ) {
+        $path = matrix_evidence_record_path($paths[$pathKey] ?? null);
+        if ( '' !== $path ) {
+            $parity['artifacts'][$artifactKey] = $path;
+        }
+    }
+
+    $parityReport = matrix_read_json_evidence($paths['parity_report_path'] ?? null);
+    if ( is_array($parityReport) ) {
+        $parity = matrix_merge_parity_report($parity, $parityReport);
+    } elseif ( 'not_run' === ($parity['status'] ?? 'not_run') && '' !== matrix_evidence_record_path($paths['parity_report_path'] ?? null) ) {
+        $parity['status'] = 'pending';
+        $parity['reason'] = 'parity_report_path_supplied';
+    }
+
+    $layoutReport = matrix_read_json_evidence($paths['layout_report_path'] ?? null);
+    if ( ! is_array($layoutReport) ) {
+        $layoutReport = matrix_read_json_evidence($paths['layout_mismatch_report_path'] ?? null);
+    }
+    if ( is_array($layoutReport) ) {
+        $parity['layout_diagnostics'] = array_merge($parity['layout_diagnostics'], matrix_layout_summary($layoutReport));
+    }
+
+    $result['parity'] = $parity;
+    return $result;
+}
+
+/**
+ * @param mixed $record
+ */
+function matrix_evidence_record_path(mixed $record): string
+{
+    if ( is_array($record) && isset($record['path']) && is_scalar($record['path']) ) {
+        return (string) $record['path'];
+    }
+
+    return '';
+}
+
+/**
+ * @param mixed $record
+ * @return array<string, mixed>|null
+ */
+function matrix_read_json_evidence(mixed $record): ?array
+{
+    $path = matrix_evidence_record_path($record);
+    if ( '' === $path || ! is_readable($path) ) {
+        return null;
+    }
+
+    $data = json_decode((string) file_get_contents($path), true);
+    return is_array($data) ? $data : null;
+}
+
+/**
+ * @param array<string, mixed> $parity
+ * @param array<string, mixed> $report
+ * @return array<string, mixed>
+ */
+function matrix_merge_parity_report(array $parity, array $report): array
+{
+    foreach ( array('status', 'reason', 'viewport') as $key ) {
+        if ( isset($report[$key]) ) {
+            $parity[$key] = $report[$key];
+        }
+    }
+
+    foreach ( array('source', 'generated', 'diff', 'diff_summary', 'metrics') as $key ) {
+        if ( isset($report[$key]) && is_array($report[$key]) ) {
+            $parity[$key] = array_merge(is_array($parity[$key] ?? null) ? $parity[$key] : array(), $report[$key]);
+        }
+    }
+
+    foreach ( array('pixel_mismatch_count', 'pixel_mismatch_ratio') as $key ) {
+        if ( isset($report[$key]) && is_numeric($report[$key]) ) {
+            $parity['metrics'][$key] = str_contains((string) $report[$key], '.') ? (float) $report[$key] : (int) $report[$key];
+            $parity['diff_summary'][$key] = $parity['metrics'][$key];
+        }
+    }
+
+    return $parity;
+}
+
+/**
+ * @param array<string, mixed> $report
+ * @return array<string, mixed>
+ */
+function matrix_layout_summary(array $report): array
+{
+    $mismatches = is_array($report['mismatches'] ?? null) ? array_values($report['mismatches']) : array();
+    $topNodes = $report['top_nodes'] ?? $report['top_mismatches'] ?? array_slice($mismatches, 0, 5);
+
+    return array(
+        'status' => $report['status'] ?? null,
+        'mismatch_count' => matrix_first_numeric($report, array('layout_mismatch_count', 'mismatch_count', 'count')) ?? count($mismatches),
+        'top_nodes' => is_array($topNodes) ? array_slice(array_values($topNodes), 0, 5) : array(),
+    );
+}
+
+/**
+ * @param array<string, mixed> $values
+ * @param array<int, string> $keys
+ */
+function matrix_first_numeric(array $values, array $keys): int|float|null
+{
+    foreach ( $keys as $key ) {
+        if ( isset($values[$key]) && is_numeric($values[$key]) ) {
+            return str_contains((string) $values[$key], '.') ? (float) $values[$key] : (int) $values[$key];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @param array<string, mixed> $parity
+ * @return array<string, mixed>
+ */
+function matrix_parity_summary(array $parity): array
+{
+    $metrics = is_array($parity['metrics'] ?? null) ? $parity['metrics'] : array();
+    $diffSummary = is_array($parity['diff_summary'] ?? null) ? $parity['diff_summary'] : array();
+    $layout = is_array($parity['layout_diagnostics'] ?? null) ? $parity['layout_diagnostics'] : array();
+
+    return array(
+        'status' => $parity['status'] ?? 'not_run',
+        'pixel_mismatch_count' => $metrics['pixel_mismatch_count'] ?? $diffSummary['pixel_mismatch_count'] ?? null,
+        'pixel_mismatch_ratio' => $metrics['pixel_mismatch_ratio'] ?? $diffSummary['pixel_mismatch_ratio'] ?? null,
+        'layout_mismatch_count' => $layout['mismatch_count'] ?? null,
+        'layout_top_nodes' => is_array($layout['top_nodes'] ?? null) ? array_slice($layout['top_nodes'], 0, 5) : array(),
     );
 }
 

--- a/figma-transformer/src/Parity/ParityReportBuilder.php
+++ b/figma-transformer/src/Parity/ParityReportBuilder.php
@@ -26,6 +26,7 @@ final class ParityReportBuilder
         }
 
         $artifacts = $this->arrayValue($evidence, 'artifacts');
+        $layoutDiagnostics = $this->arrayValue($evidence, 'layout_diagnostics');
         $source = $this->arrayValue($evidence, 'source');
         $generated = $this->arrayValue($evidence, 'generated');
         $diff = $this->nullableArrayValue($evidence, 'diff');
@@ -42,6 +43,11 @@ final class ParityReportBuilder
         $this->copyScalar($evidence, 'diff_image_path', $diff, 'image_path');
         $this->copyScalar($evidence, 'diff_image_url', $diff, 'image_url');
         $this->copyScalar($evidence, 'diff_image_artifact', $diff, 'image_artifact');
+        $this->copyScalar($evidence, 'report_path', $artifacts, 'report_path');
+        $this->copyScalar($evidence, 'report_artifact', $artifacts, 'report_artifact');
+        $this->copyScalar($evidence, 'dom_boxes_path', $artifacts, 'dom_boxes_path');
+        $this->copyScalar($evidence, 'layout_report_path', $artifacts, 'layout_report_path');
+        $this->copyScalar($evidence, 'layout_mismatch_report_path', $artifacts, 'layout_mismatch_report_path');
         $this->copyScalar($evidence, 'frame_id', $source, 'frame_id');
         $this->copyScalar($evidence, 'frame_id', $generated, 'frame_id');
         $this->copyNumeric($evidence, 'pixel_mismatch_count', $diffSummary, 'pixel_mismatch_count');
@@ -49,6 +55,11 @@ final class ParityReportBuilder
         $this->copyNumeric($evidence, 'pixel_mismatch_ratio', $diffSummary, 'pixel_mismatch_ratio');
         $this->copyNumeric($evidence, 'pixel_mismatch_ratio', $metrics, 'pixel_mismatch_ratio');
         $this->copyNumeric($evidence, 'threshold', $diffSummary, 'threshold');
+        $this->copyNumeric($evidence, 'layout_mismatch_count', $layoutDiagnostics, 'mismatch_count');
+
+        if ( isset($evidence['layout_top_nodes']) && is_array($evidence['layout_top_nodes']) ) {
+            $layoutDiagnostics['top_nodes'] = array_values($evidence['layout_top_nodes']);
+        }
 
         if ( array_key_exists('threshold', $diffSummary) && array_key_exists('pixel_mismatch_ratio', $diffSummary) ) {
             $diffSummary['passed'] = (float) $diffSummary['pixel_mismatch_ratio'] <= (float) $diffSummary['threshold'];
@@ -64,6 +75,7 @@ final class ParityReportBuilder
             'side_by_side' => $evidence['side_by_side'] ?? null,
             'diff'         => empty($diff) ? null : $diff,
             'diff_summary' => $diffSummary,
+            'layout_diagnostics' => $layoutDiagnostics,
             'metrics'      => $metrics,
             'viewport'     => $viewport,
         );

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1432,6 +1432,12 @@ $pendingParity = $parityBuilder->build(array(
     'artifacts' => array(
         'report_path' => 'artifacts/parity-report.json',
     ),
+    'dom_boxes_path' => 'artifacts/dom-boxes.json',
+    'layout_report_path' => 'artifacts/layout-report.json',
+    'layout_mismatch_count' => 3,
+    'layout_top_nodes' => array(
+        array('id' => '1:2', 'name' => 'Hero title'),
+    ),
 ));
 $comparedParity = $parityBuilder->build(array(
     'status'    => 'compared',
@@ -1476,6 +1482,10 @@ $unknownParity = $parityBuilder->build(array(
 ));
 $assert('pending' === ($pendingParity['status'] ?? null), 'parity-pending-status');
 $assert('artifacts/parity-report.json' === ($pendingParity['artifacts']['report_path'] ?? null), 'parity-pending-artifact-path');
+$assert('artifacts/dom-boxes.json' === ($pendingParity['artifacts']['dom_boxes_path'] ?? null), 'parity-dom-boxes-artifact-path');
+$assert('artifacts/layout-report.json' === ($pendingParity['artifacts']['layout_report_path'] ?? null), 'parity-layout-report-artifact-path');
+$assert(3 === ($pendingParity['layout_diagnostics']['mismatch_count'] ?? null), 'parity-layout-mismatch-count');
+$assert('1:2' === ($pendingParity['layout_diagnostics']['top_nodes'][0]['id'] ?? null), 'parity-layout-top-node');
 $assert('compared' === ($comparedParity['status'] ?? null), 'parity-compared-status');
 $assert('artifacts/source.png' === ($comparedParity['source']['screenshot_path'] ?? null), 'parity-source-screenshot-path');
 $assert('artifacts/generated.png' === ($comparedParity['generated']['screenshot_path'] ?? null), 'parity-generated-screenshot-path');


### PR DESCRIPTION
## Summary
- Add Figma transformer CLI parity metadata flags for report, DOM boxes, and layout mismatch evidence paths.
- Add matrix evidence path/template options and dry-run command output for runner-produced parity/layout artifacts.
- Attach readable parity/layout reports to transform result JSON and surface parity status, pixel mismatch metrics, and layout mismatch top-node summaries in matrix output.

## Verification
- `php -l figma-transformer/scripts/figma-fixture-matrix.php`
- `php -l figma-transformer/bin/figma-transformer`
- `php -l figma-transformer/src/Parity/ParityReportBuilder.php`
- `php figma-transformer/tests/contract/run.php`
- Matrix dry-run with fake parity/dom/layout evidence path templates.
- Matrix non-browser run with synthetic JSON scenegraph and fake parity/layout reports outside the repo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing matrix parity/layout evidence wiring, tests, and PR preparation.