### PR TITLE
Add Figma layout mismatch diagnostics

### DIFF
--- a/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
+++ b/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Diagnostics;
+
+/**
+ * Compares source Figma visual boxes with runner-supplied generated DOM boxes.
+ */
+final class LayoutMismatchReportBuilder
+{
+    public const SCHEMA = 'blocks-engine/figma-transformer/layout-mismatch-report/v1';
+    public const DOM_BOXES_SCHEMA = 'homeboy/static-artifact-dom-boxes/v1';
+
+    /**
+     * @param array<string, mixed> $htmlSourceReport
+     * @param array<string, mixed> $evidence
+     * @param array<string, mixed> $options
+     * @return array<string, mixed>
+     */
+    public function build(array $htmlSourceReport, array $evidence = array(), array $options = array()): array
+    {
+        $threshold = $this->numericOption($options, 'threshold', 24.0);
+        $sizeThreshold = $this->numericOption($options, 'size_threshold', $threshold);
+        $limit = max(1, (int) $this->numericOption($options, 'limit', 100.0));
+        $sourceNodes = $this->sourceNodesById($htmlSourceReport);
+        $generatedNodes = $this->generatedNodesById($evidence);
+        $diagnostics = array();
+        $matched = 0;
+        $unmatchedSource = 0;
+
+        foreach ( $sourceNodes as $nodeId => $sourceNode ) {
+            $generatedNode = $generatedNodes[$nodeId] ?? null;
+            if ( null === $generatedNode ) {
+                $unmatchedSource++;
+                continue;
+            }
+
+            $sourceBox = $this->boxFromNode($sourceNode);
+            $generatedBox = $this->boxFromNode($generatedNode);
+            if ( null === $sourceBox || null === $generatedBox ) {
+                continue;
+            }
+
+            $matched++;
+            $delta = $this->delta($sourceBox, $generatedBox);
+            $positionMismatch = abs($delta['x']) > $threshold || abs($delta['y']) > $threshold;
+            $sizeMismatch = abs($delta['width']) > $sizeThreshold || abs($delta['height']) > $sizeThreshold;
+            $outsideParent = $this->outsideGeneratedParent($sourceNode, $generatedNode, $generatedNodes, $threshold);
+            if ( ! $positionMismatch && ! $sizeMismatch && null === $outsideParent ) {
+                continue;
+            }
+
+            if ( $positionMismatch || $sizeMismatch ) {
+                $diagnostics[] = $this->diagnostic(
+                    $positionMismatch ? 'misplaced_element' : 'element_size_mismatch',
+                    $sourceNode,
+                    $generatedNode,
+                    $sourceBox,
+                    $generatedBox,
+                    $delta,
+                    $threshold,
+                    $sizeThreshold
+                );
+            }
+
+            if ( $positionMismatch && $sizeMismatch ) {
+                $diagnostics[] = $this->diagnostic('element_size_mismatch', $sourceNode, $generatedNode, $sourceBox, $generatedBox, $delta, $threshold, $sizeThreshold);
+            }
+
+            if ( null !== $outsideParent ) {
+                $diagnostics[] = array_merge(
+                    $this->diagnostic('element_outside_parent_bounds', $sourceNode, $generatedNode, $sourceBox, $generatedBox, $delta, $threshold, $sizeThreshold),
+                    array('parent' => $outsideParent)
+                );
+            }
+        }
+
+        usort(
+            $diagnostics,
+            static fn (array $left, array $right): int => (($right['max_delta'] ?? 0) <=> ($left['max_delta'] ?? 0)) ?: strcmp((string) ($left['node']['id'] ?? ''), (string) ($right['node']['id'] ?? ''))
+        );
+
+        $diagnostics = array_slice($diagnostics, 0, $limit);
+        $codeCounts = array();
+        foreach ( $diagnostics as $diagnostic ) {
+            $code = (string) ($diagnostic['code'] ?? '');
+            if ( '' !== $code ) {
+                $codeCounts[$code] = ($codeCounts[$code] ?? 0) + 1;
+            }
+        }
+        ksort($codeCounts);
+
+        return array(
+            'schema' => self::SCHEMA,
+            'input_schema' => isset($evidence['schema']) && is_scalar($evidence['schema']) ? (string) $evidence['schema'] : self::DOM_BOXES_SCHEMA,
+            'status' => empty($generatedNodes) ? 'not_run' : (empty($diagnostics) ? 'pass' : 'fail'),
+            'threshold' => $threshold,
+            'size_threshold' => $sizeThreshold,
+            'summary' => array(
+                'source_node_count' => count($sourceNodes),
+                'generated_node_count' => count($generatedNodes),
+                'matched_node_count' => $matched,
+                'unmatched_source_node_count' => $unmatchedSource,
+                'diagnostic_count' => count($diagnostics),
+                'code_counts' => $codeCounts,
+            ),
+            'diagnostics' => $diagnostics,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function numericOption(array $values, string $key, float $default): float
+    {
+        return isset($values[$key]) && is_numeric($values[$key]) ? max(0.0, (float) $values[$key]) : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $htmlSourceReport
+     * @return array<string, array<string, mixed>>
+     */
+    private function sourceNodesById(array $htmlSourceReport): array
+    {
+        $nodes = is_array($htmlSourceReport['visual_node_map'] ?? null) ? $htmlSourceReport['visual_node_map'] : array();
+        return $this->nodesById($nodes);
+    }
+
+    /**
+     * @param array<string, mixed> $evidence
+     * @return array<string, array<string, mixed>>
+     */
+    private function generatedNodesById(array $evidence): array
+    {
+        $nodes = array();
+        foreach ( array('boxes', 'nodes', 'dom_boxes', 'elements') as $key ) {
+            if ( is_array($evidence[$key] ?? null) ) {
+                $nodes = array_merge($nodes, $evidence[$key]);
+            }
+        }
+
+        if ( empty($nodes) && is_array($evidence['generated']['boxes'] ?? null) ) {
+            $nodes = $evidence['generated']['boxes'];
+        }
+
+        return $this->nodesById($nodes);
+    }
+
+    /**
+     * @param array<int, mixed> $nodes
+     * @return array<string, array<string, mixed>>
+     */
+    private function nodesById(array $nodes): array
+    {
+        $byId = array();
+        foreach ( $nodes as $node ) {
+            if ( ! is_array($node) ) {
+                continue;
+            }
+
+            $id = $this->nodeId($node);
+            if ( '' === $id ) {
+                continue;
+            }
+
+            $node['id'] = $id;
+            $byId[$id] = $node;
+        }
+
+        ksort($byId);
+        return $byId;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeId(array $node): string
+    {
+        foreach ( array('id', 'node_id', 'figma_node_id', 'data_figma_node_id', 'data-figma-node-id') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
+                return (string) $node[$key];
+            }
+        }
+
+        if ( isset($node['attributes']['data-figma-node-id']) && is_scalar($node['attributes']['data-figma-node-id']) ) {
+            return (string) $node['attributes']['data-figma-node-id'];
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array{x: float, y: float, width: float, height: float}|null
+     */
+    private function boxFromNode(array $node): ?array
+    {
+        foreach ( array('rect', 'box', 'bounding_client_rect', 'bounds') as $key ) {
+            if ( is_array($node[$key] ?? null) ) {
+                $box = $this->boxFromValue($node[$key]);
+                if ( null !== $box ) {
+                    return $box;
+                }
+            }
+        }
+
+        return $this->boxFromValue($node);
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     * @return array{x: float, y: float, width: float, height: float}|null
+     */
+    private function boxFromValue(array $value): ?array
+    {
+        $x = $value['x'] ?? $value['left'] ?? null;
+        $y = $value['y'] ?? $value['top'] ?? null;
+        $width = $value['width'] ?? null;
+        $height = $value['height'] ?? null;
+        if ( null === $width && isset($value['right']) && is_numeric($value['right']) && is_numeric($x) ) {
+            $width = (float) $value['right'] - (float) $x;
+        }
+        if ( null === $height && isset($value['bottom']) && is_numeric($value['bottom']) && is_numeric($y) ) {
+            $height = (float) $value['bottom'] - (float) $y;
+        }
+
+        foreach ( array($x, $y, $width, $height) as $part ) {
+            if ( ! is_numeric($part) ) {
+                return null;
+            }
+        }
+
+        return array('x' => (float) $x, 'y' => (float) $y, 'width' => (float) $width, 'height' => (float) $height);
+    }
+
+    /**
+     * @param array{x: float, y: float, width: float, height: float} $sourceBox
+     * @param array{x: float, y: float, width: float, height: float} $generatedBox
+     * @return array{x: float, y: float, width: float, height: float}
+     */
+    private function delta(array $sourceBox, array $generatedBox): array
+    {
+        return array(
+            'x' => $generatedBox['x'] - $sourceBox['x'],
+            'y' => $generatedBox['y'] - $sourceBox['y'],
+            'width' => $generatedBox['width'] - $sourceBox['width'],
+            'height' => $generatedBox['height'] - $sourceBox['height'],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $sourceNode
+     * @param array<string, mixed> $generatedNode
+     * @param array<string, array<string, mixed>> $generatedNodes
+     * @return array<string, mixed>|null
+     */
+    private function outsideGeneratedParent(array $sourceNode, array $generatedNode, array $generatedNodes, float $threshold): ?array
+    {
+        $parentId = isset($sourceNode['parent_id']) && is_scalar($sourceNode['parent_id']) ? (string) $sourceNode['parent_id'] : '';
+        if ( '' === $parentId || ! isset($generatedNodes[$parentId]) ) {
+            return null;
+        }
+
+        $parentBox = $this->boxFromNode($generatedNodes[$parentId]);
+        $childBox = $this->boxFromNode($generatedNode);
+        if ( null === $parentBox || null === $childBox ) {
+            return null;
+        }
+
+        $overflow = array(
+            'left' => max(0.0, $parentBox['x'] - $childBox['x']),
+            'top' => max(0.0, $parentBox['y'] - $childBox['y']),
+            'right' => max(0.0, ($childBox['x'] + $childBox['width']) - ($parentBox['x'] + $parentBox['width'])),
+            'bottom' => max(0.0, ($childBox['y'] + $childBox['height']) - ($parentBox['y'] + $parentBox['height'])),
+        );
+        $maxOverflow = max($overflow);
+        if ( $maxOverflow <= $threshold ) {
+            return null;
+        }
+
+        return array(
+            'id' => $parentId,
+            'generated_box' => $parentBox,
+            'overflow' => $overflow,
+            'max_overflow' => $maxOverflow,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $sourceNode
+     * @param array<string, mixed> $generatedNode
+     * @param array{x: float, y: float, width: float, height: float} $sourceBox
+     * @param array{x: float, y: float, width: float, height: float} $generatedBox
+     * @param array{x: float, y: float, width: float, height: float} $delta
+     * @return array<string, mixed>
+     */
+    private function diagnostic(string $code, array $sourceNode, array $generatedNode, array $sourceBox, array $generatedBox, array $delta, float $threshold, float $sizeThreshold): array
+    {
+        return array_filter(array(
+            'severity' => 'warning',
+            'code' => $code,
+            'node' => array(
+                'id' => (string) ($sourceNode['id'] ?? ''),
+                'name' => (string) ($sourceNode['name'] ?? ''),
+                'type' => (string) ($sourceNode['type'] ?? ''),
+                'parent_id' => (string) ($sourceNode['parent_id'] ?? ''),
+            ),
+            'source_box' => $sourceBox,
+            'generated_box' => $generatedBox,
+            'delta' => $delta,
+            'max_delta' => max(abs($delta['x']), abs($delta['y']), abs($delta['width']), abs($delta['height'])),
+            'threshold' => $threshold,
+            'size_threshold' => $sizeThreshold,
+            'page_path' => isset($generatedNode['page_path']) && is_scalar($generatedNode['page_path']) ? (string) $generatedNode['page_path'] : null,
+            'frame_id' => isset($generatedNode['frame_id']) && is_scalar($generatedNode['frame_id']) ? (string) $generatedNode['frame_id'] : null,
+            'selector' => isset($generatedNode['selector']) && is_scalar($generatedNode['selector']) ? (string) $generatedNode['selector'] : null,
+        ), static fn (mixed $value): bool => null !== $value);
+    }
+}

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\FigmaTransformer;
 
 use Automattic\BlocksEngine\FigmaTransformer\Contract\FigmaTransformResult;
+use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\LayoutMismatchReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader;
 use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\ParityReportBuilder;
@@ -21,6 +22,7 @@ final class FigmaTransformer
         private readonly FigArchiveReader $archiveReader = new FigArchiveReader(),
         private readonly StaticHtmlEmitter $htmlEmitter = new StaticHtmlEmitter(),
         private readonly ParityReportBuilder $parityReportBuilder = new ParityReportBuilder(),
+        private readonly LayoutMismatchReportBuilder $layoutMismatchReportBuilder = new LayoutMismatchReportBuilder(),
         private readonly ScenegraphNormalizer $scenegraphNormalizer = new ScenegraphNormalizer(),
         private readonly ScenegraphFrameInspector $frameInspector = new ScenegraphFrameInspector(),
         private readonly ScenegraphPagePlanner $pagePlanner = new ScenegraphPagePlanner()
@@ -399,6 +401,7 @@ final class FigmaTransformer
         $startedAt = microtime(true);
         $normalized = $this->scenegraphNormalizer->normalize($scenegraph, $options);
         $artifact    = $this->htmlEmitter->emit($normalized, $options);
+        $artifact    = $this->withLayoutMismatchReport($artifact, $options);
         $diagnostics = array_merge($normalized['diagnostics'] ?? array(), $artifact['diagnostics']);
         $parity      = $this->parityReportBuilder->build($options['parity'] ?? array());
 
@@ -603,6 +606,93 @@ final class FigmaTransformer
     }
 
     /**
+     * @param array<string, mixed> $artifact
+     * @param array<string, mixed> $options
+     * @return array<string, mixed>
+     */
+    private function withLayoutMismatchReport(array $artifact, array $options): array
+    {
+        $evidence = $this->layoutMismatchEvidenceFromOptions($options);
+        if ( empty($evidence) ) {
+            return $artifact;
+        }
+
+        $sourceReport = is_array($artifact['source_report'] ?? null) ? $artifact['source_report'] : array();
+        $reportOptions = is_array($options['layout_mismatch_options'] ?? null) ? $options['layout_mismatch_options'] : array();
+        if ( isset($options['layout_mismatch_threshold']) ) {
+            $reportOptions['threshold'] = $options['layout_mismatch_threshold'];
+        }
+        if ( isset($options['layout_mismatch_size_threshold']) ) {
+            $reportOptions['size_threshold'] = $options['layout_mismatch_size_threshold'];
+        }
+
+        $layoutMismatch = $this->layoutMismatchReportBuilder->build($sourceReport, $evidence, $reportOptions);
+        $transformDiagnostics = is_array($sourceReport['transform_diagnostics'] ?? null) ? $sourceReport['transform_diagnostics'] : array();
+        $layout = is_array($transformDiagnostics['layout'] ?? null) ? $transformDiagnostics['layout'] : array();
+        $layout['layout_mismatch'] = $layoutMismatch;
+        $layout['layout_mismatch_count'] = (int) ($layoutMismatch['summary']['diagnostic_count'] ?? 0);
+        $transformDiagnostics['layout'] = $layout;
+        $transformDiagnostics['artifact_quality'] = $this->withLayoutMismatchArtifactQuality(
+            is_array($transformDiagnostics['artifact_quality'] ?? null) ? $transformDiagnostics['artifact_quality'] : array(),
+            $layoutMismatch
+        );
+        $sourceReport['transform_diagnostics'] = $transformDiagnostics;
+        $artifact['source_report'] = $sourceReport;
+
+        return $artifact;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, mixed>
+     */
+    private function layoutMismatchEvidenceFromOptions(array $options): array
+    {
+        foreach ( array('layout_mismatch', 'layout_mismatch_evidence', 'generated_dom_boxes', 'dom_boxes') as $key ) {
+            if ( is_array($options[$key] ?? null) ) {
+                return $options[$key];
+            }
+        }
+
+        if ( is_array($options['metadata']['generated_dom_boxes'] ?? null) ) {
+            return $options['metadata']['generated_dom_boxes'];
+        }
+        if ( is_array($options['metadata']['dom_boxes'] ?? null) ) {
+            return $options['metadata']['dom_boxes'];
+        }
+
+        return array();
+    }
+
+    /**
+     * @param array<string, mixed> $artifactQuality
+     * @param array<string, mixed> $layoutMismatch
+     * @return array<string, mixed>
+     */
+    private function withLayoutMismatchArtifactQuality(array $artifactQuality, array $layoutMismatch): array
+    {
+        $count = (int) ($layoutMismatch['summary']['diagnostic_count'] ?? 0);
+        $artifactQuality['schema'] = $artifactQuality['schema'] ?? 'blocks-engine/figma-transformer/artifact-quality/v1';
+        $signals = is_array($artifactQuality['signals'] ?? null) ? $artifactQuality['signals'] : array();
+        if ( $count > 0 ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'layout_mismatch', 'count' => $count);
+        }
+        $artifactQuality['signals'] = $signals;
+        $summary = is_array($artifactQuality['summary'] ?? null) ? $artifactQuality['summary'] : array();
+        $summary['layout_mismatch_count'] = $count;
+        $summary['misplaced_element_count'] = (int) ($layoutMismatch['summary']['code_counts']['misplaced_element'] ?? 0);
+        $summary['element_size_mismatch_count'] = (int) ($layoutMismatch['summary']['code_counts']['element_size_mismatch'] ?? 0);
+        $summary['element_outside_parent_bounds_count'] = (int) ($layoutMismatch['summary']['code_counts']['element_outside_parent_bounds'] ?? 0);
+        $artifactQuality['summary'] = $summary;
+        if ( $count > 0 ) {
+            $artifactQuality['status'] = 'needs_review';
+            $artifactQuality['quality_status'] = 'warn';
+        }
+
+        return $artifactQuality;
+    }
+
+    /**
      * @param array<int, array<string, mixed>> $pageReports
      * @param array<int, array<string, mixed>> $assetReport
      * @return array<string, mixed>
@@ -619,6 +709,8 @@ final class FigmaTransformer
             'large_absolute_offset_nodes' => array(),
             'decorative_underlays' => array('count' => 0, 'nodes' => array()),
             'image_heavy_landmark_candidates' => array(),
+            'layout_mismatch_count' => 0,
+            'layout_mismatches' => array(),
         );
         $fontFamilies = array();
         $missingCss = array();
@@ -692,6 +784,14 @@ final class FigmaTransformer
                     $layout['image_heavy_landmark_candidates'][] = array_merge($pageContext, $item);
                 }
             }
+            $pageLayoutMismatch = is_array($pageLayout['layout_mismatch'] ?? null) ? $pageLayout['layout_mismatch'] : array();
+            $pageLayoutMismatchDiagnostics = is_array($pageLayoutMismatch['diagnostics'] ?? null) ? $pageLayoutMismatch['diagnostics'] : array();
+            $layout['layout_mismatch_count'] += (int) ($pageLayoutMismatch['summary']['diagnostic_count'] ?? count($pageLayoutMismatchDiagnostics));
+            foreach ( $pageLayoutMismatchDiagnostics as $item ) {
+                if ( is_array($item) ) {
+                    $layout['layout_mismatches'][] = array_merge($pageContext, $item);
+                }
+            }
 
             $pageDiagnosticCodes = is_array($page['diagnostic_codes'] ?? null) ? $page['diagnostic_codes'] : (is_array($diagnostics['diagnostic_codes'] ?? null) ? $diagnostics['diagnostic_codes'] : array());
             foreach ( $pageDiagnosticCodes as $code => $count ) {
@@ -700,6 +800,7 @@ final class FigmaTransformer
         }
 
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
+        $layout['layout_mismatches'] = array_values($layout['layout_mismatches']);
         ksort($diagnosticCodes);
         $fonts = array(
             'families' => $fontFamilies,
@@ -764,6 +865,9 @@ final class FigmaTransformer
         if ( ! empty($layout['image_heavy_landmark_candidates']) ) {
             $signals[] = array('severity' => 'warning', 'code' => 'image_heavy_landmark_candidate', 'count' => count($layout['image_heavy_landmark_candidates']));
         }
+        if ( ! empty($layout['layout_mismatch_count']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'layout_mismatch', 'count' => (int) $layout['layout_mismatch_count']);
+        }
         $imageBlockCount = (int) ($images['image_block_count'] ?? 0);
         $totalNodeCount = max(0, (int) ($images['total_node_count'] ?? 0));
         $imageNodeDensity = $totalNodeCount > 0 ? $imageBlockCount / $totalNodeCount : 0.0;
@@ -814,6 +918,7 @@ final class FigmaTransformer
                 'fixed_root_width_count' => (int) ($layout['fixed_root_width_count'] ?? 0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
+                'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
             ),
         );
     }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -838,6 +838,61 @@ $assert(($result['files'] ?? array()) === ($sameResult['files'] ?? array()), 'de
 $assert('blocks-engine/figma-transformer/parity-report/v1' === ($result['parity']['schema'] ?? null), 'parity-schema');
 $assert('not_run' === ($result['parity']['status'] ?? null), 'parity-default-not-run');
 
+$layoutMismatchBuilder = new \Automattic\BlocksEngine\FigmaTransformer\Diagnostics\LayoutMismatchReportBuilder();
+$footerLayoutMismatch = $layoutMismatchBuilder->build(
+    array(
+        'visual_node_map' => array(
+            array('id' => 'footer', 'name' => 'Footer', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 880, 'width' => 1200, 'height' => 120)),
+            array('id' => 'footer:text', 'parent_id' => 'footer', 'name' => 'Footer legal text', 'type' => 'TEXT', 'rect' => array('x' => 40, 'y' => 920, 'width' => 220, 'height' => 24)),
+        ),
+    ),
+    array(
+        'schema' => 'homeboy/static-artifact-dom-boxes/v1',
+        'boxes' => array(
+            array('node_id' => 'footer', 'rect' => array('x' => 0, 'y' => 880, 'width' => 1200, 'height' => 120)),
+            array('node_id' => 'footer:text', 'selector' => '[data-figma-node-id="footer:text"]', 'rect' => array('x' => 40, 'y' => 1800, 'width' => 220, 'height' => 24)),
+        ),
+    ),
+    array('threshold' => 24)
+);
+$footerLayoutMismatchCodes = array_map(static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''), $footerLayoutMismatch['diagnostics'] ?? array());
+$assert('blocks-engine/figma-transformer/layout-mismatch-report/v1' === ($footerLayoutMismatch['schema'] ?? null), 'layout-mismatch-schema');
+$assert('homeboy/static-artifact-dom-boxes/v1' === ($footerLayoutMismatch['input_schema'] ?? null), 'layout-mismatch-input-schema');
+$assert('fail' === ($footerLayoutMismatch['status'] ?? null), 'layout-mismatch-fail-status');
+$assert(in_array('misplaced_element', $footerLayoutMismatchCodes, true), 'layout-mismatch-misplaced-element');
+$assert(in_array('element_outside_parent_bounds', $footerLayoutMismatchCodes, true), 'layout-mismatch-outside-parent');
+$assert(880.0 === ($footerLayoutMismatch['diagnostics'][0]['delta']['y'] ?? null), 'layout-mismatch-delta-y');
+
+$layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name' => 'Layout Mismatch Fixture',
+    'nodes' => array(
+        array(
+            'id' => 'frame:layout-mismatch',
+            'type' => 'FRAME',
+            'name' => 'Layout Mismatch Page',
+            'width' => 1200,
+            'height' => 1000,
+            'children' => array(
+                array('id' => 'footer', 'type' => 'FRAME', 'name' => 'Footer', 'width' => 1200, 'height' => 120, 'transform' => array('m02' => 0, 'm12' => 880)),
+                array('id' => 'footer:text', 'type' => 'TEXT', 'name' => 'Footer legal text', 'characters' => 'Privacy and terms', 'width' => 220, 'height' => 24, 'transform' => array('m02' => 40, 'm12' => 920)),
+            ),
+        ),
+    ),
+), array(
+    'generated_dom_boxes' => array(
+        'schema' => 'homeboy/static-artifact-dom-boxes/v1',
+        'boxes' => array(
+            array('node_id' => 'footer', 'rect' => array('x' => 0, 'y' => 880, 'width' => 1200, 'height' => 120)),
+            array('node_id' => 'footer:text', 'rect' => array('x' => 40, 'y' => 1800, 'width' => 220, 'height' => 24)),
+        ),
+    ),
+    'layout_mismatch_threshold' => 24,
+));
+$layoutMismatchTransformDiagnostics = $layoutMismatchTransformResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$layoutMismatchArtifactQualityCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), $layoutMismatchTransformDiagnostics['artifact_quality']['signals'] ?? array());
+$assert(0 < ($layoutMismatchTransformDiagnostics['layout']['layout_mismatch_count'] ?? 0), 'layout-mismatch-transform-count');
+$assert(in_array('layout_mismatch', $layoutMismatchArtifactQualityCodes, true), 'layout-mismatch-artifact-quality-signal');
+
 $unusedAssetResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'   => 'Unused Asset Fixture',
     'assets' => array(


### PR DESCRIPTION
## Summary
- Adds a stable `blocks-engine/figma-transformer/layout-mismatch-report/v1` report builder that consumes runner-supplied DOM box evidence such as `homeboy/static-artifact-dom-boxes/v1`.
- Compares generated DOM boxes against `visual_node_map` source boxes by normalized Figma node id and emits deterministic `misplaced_element`, `element_size_mismatch`, and `element_outside_parent_bounds` diagnostics with source/generated boxes, deltas, thresholds, and page/frame context when available.
- Wires supplied evidence into `transform_diagnostics.layout` and `artifact_quality` summaries via transform options/metadata without adding matrix runner wiring.
- Adds synthetic contract coverage for a footer-like misplaced text case.

## Verification
- `php -l figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php`
- `php -l figma-transformer/src/FigmaTransformer.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing deterministic layout mismatch diagnostics, tests, and PR preparation.