### PR TITLE
Improve Figma matrix diagnostics

### DIFF
--- a/figma-transformer/bin/figma-transformer
+++ b/figma-transformer/bin/figma-transformer
@@ -152,6 +152,13 @@ if ( is_string($outputDir) && '' !== $outputDir ) {
     $outputDir = rtrim($outputDir, DIRECTORY_SEPARATOR);
 }
 
+if ( isset($options['parity']['dom_boxes_path']) && is_scalar($options['parity']['dom_boxes_path']) ) {
+    $domBoxes = blocks_engine_figma_transformer_cli_read_json_file((string) $options['parity']['dom_boxes_path']);
+    if ( is_array($domBoxes) ) {
+        $options['generated_dom_boxes'] = $domBoxes;
+    }
+}
+
 $transformer = blocks_engine_figma_transformer_cli_transformer(is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null);
 if ( true === ($options['inspect_frames'] ?? false) ) {
     if ( str_ends_with(strtolower($path), '.json') ) {
@@ -336,6 +343,19 @@ function blocks_engine_figma_transformer_cli_safe_output_path(string $path): boo
     }
 
     return true;
+}
+
+/**
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_transformer_cli_read_json_file(string $path): ?array
+{
+    if ( '' === $path || ! is_readable($path) ) {
+        return null;
+    }
+
+    $decoded = json_decode((string) file_get_contents($path), true);
+    return is_array($decoded) ? $decoded : null;
 }
 
 /**

--- a/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
+++ b/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
@@ -140,6 +140,12 @@ final class LayoutMismatchReportBuilder
             }
         }
 
+        foreach ( is_array($evidence['entrypoints'] ?? null) ? $evidence['entrypoints'] : array() as $entrypoint ) {
+            if ( is_array($entrypoint) && is_array($entrypoint['elements'] ?? null) ) {
+                $nodes = array_merge($nodes, $entrypoint['elements']);
+            }
+        }
+
         if ( empty($nodes) && is_array($evidence['generated']['boxes'] ?? null) ) {
             $nodes = $evidence['generated']['boxes'];
         }
@@ -196,7 +202,7 @@ final class LayoutMismatchReportBuilder
      */
     private function boxFromNode(array $node): ?array
     {
-        foreach ( array('rect', 'box', 'bounding_client_rect', 'bounds') as $key ) {
+        foreach ( array('rect', 'box', 'bounding_client_rect', 'boundingClientRect', 'bounds') as $key ) {
             if ( is_array($node[$key] ?? null) ) {
                 $box = $this->boxFromValue($node[$key]);
                 if ( null !== $box ) {

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -631,6 +631,7 @@ final class FigmaTransformer
         $layout = is_array($transformDiagnostics['layout'] ?? null) ? $transformDiagnostics['layout'] : array();
         $layout['layout_mismatch'] = $layoutMismatch;
         $layout['layout_mismatch_count'] = (int) ($layoutMismatch['summary']['diagnostic_count'] ?? 0);
+        $layout['layout_mismatch_status'] = (string) ($layoutMismatch['status'] ?? 'not_run');
         $transformDiagnostics['layout'] = $layout;
         $transformDiagnostics['artifact_quality'] = $this->withLayoutMismatchArtifactQuality(
             is_array($transformDiagnostics['artifact_quality'] ?? null) ? $transformDiagnostics['artifact_quality'] : array(),
@@ -680,6 +681,7 @@ final class FigmaTransformer
         $artifactQuality['signals'] = $signals;
         $summary = is_array($artifactQuality['summary'] ?? null) ? $artifactQuality['summary'] : array();
         $summary['layout_mismatch_count'] = $count;
+        $summary['layout_mismatch_status'] = (string) ($layoutMismatch['status'] ?? 'not_run');
         $summary['misplaced_element_count'] = (int) ($layoutMismatch['summary']['code_counts']['misplaced_element'] ?? 0);
         $summary['element_size_mismatch_count'] = (int) ($layoutMismatch['summary']['code_counts']['element_size_mismatch'] ?? 0);
         $summary['element_outside_parent_bounds_count'] = (int) ($layoutMismatch['summary']['code_counts']['element_outside_parent_bounds'] ?? 0);
@@ -710,6 +712,7 @@ final class FigmaTransformer
             'decorative_underlays' => array('count' => 0, 'nodes' => array()),
             'image_heavy_landmark_candidates' => array(),
             'layout_mismatch_count' => 0,
+            'layout_mismatch_status' => 'not_evaluated',
             'layout_mismatches' => array(),
         );
         $fontFamilies = array();
@@ -787,6 +790,9 @@ final class FigmaTransformer
             $pageLayoutMismatch = is_array($pageLayout['layout_mismatch'] ?? null) ? $pageLayout['layout_mismatch'] : array();
             $pageLayoutMismatchDiagnostics = is_array($pageLayoutMismatch['diagnostics'] ?? null) ? $pageLayoutMismatch['diagnostics'] : array();
             $layout['layout_mismatch_count'] += (int) ($pageLayoutMismatch['summary']['diagnostic_count'] ?? count($pageLayoutMismatchDiagnostics));
+            if ( ! empty($pageLayoutMismatch) ) {
+                $layout['layout_mismatch_status'] = 'fail' === ($pageLayoutMismatch['status'] ?? null) ? 'fail' : ('not_evaluated' === $layout['layout_mismatch_status'] ? (string) ($pageLayoutMismatch['status'] ?? 'not_run') : $layout['layout_mismatch_status']);
+            }
             foreach ( $pageLayoutMismatchDiagnostics as $item ) {
                 if ( is_array($item) ) {
                     $layout['layout_mismatches'][] = array_merge($pageContext, $item);
@@ -857,10 +863,20 @@ final class FigmaTransformer
             $signals[] = array('severity' => 'warning', 'code' => 'off_canvas_left_css', 'count' => (int) $layout['large_negative_left_count']);
         }
         if ( ! empty($layout['fixed_root_width_count']) ) {
-            $signals[] = array('severity' => 'warning', 'code' => 'fixed_root_width', 'count' => (int) $layout['fixed_root_width_count']);
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'fixed_root_width',
+                'count' => (int) $layout['fixed_root_width_count'],
+                'sample_nodes' => array_slice(is_array($layout['fixed_root_width_nodes'] ?? null) ? $layout['fixed_root_width_nodes'] : array(), 0, 10),
+            );
         }
         if ( ! empty($layout['large_absolute_offset_count']) ) {
-            $signals[] = array('severity' => 'warning', 'code' => 'large_absolute_offsets', 'count' => (int) $layout['large_absolute_offset_count']);
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'large_absolute_offsets',
+                'count' => (int) $layout['large_absolute_offset_count'],
+                'sample_nodes' => array_slice(is_array($layout['large_absolute_offset_nodes'] ?? null) ? $layout['large_absolute_offset_nodes'] : array(), 0, 10),
+            );
         }
         if ( ! empty($layout['image_heavy_landmark_candidates']) ) {
             $signals[] = array('severity' => 'warning', 'code' => 'image_heavy_landmark_candidate', 'count' => count($layout['image_heavy_landmark_candidates']));
@@ -919,6 +935,7 @@ final class FigmaTransformer
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
                 'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
+                'layout_mismatch_status' => (string) ($layout['layout_mismatch_status'] ?? 'not_evaluated'),
             ),
         );
     }

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -321,7 +321,7 @@ final class StaticHtmlEmitter
         $className = 'figma-node-' . $this->slug($id . '-' . $name);
         $children = $this->nodeList($node);
         $content = $text;
-        $vectorSvg = $this->supportedVectorSvg($node, $type);
+        $vectorSvg = $this->supportedVectorSvg($node, $type, $parentNode);
         $assetPath = $this->nodeAssetPath($node);
         $hasVectorAssetFallback = $this->isUnsupportedVectorType($type) && null !== $assetPath;
 
@@ -684,6 +684,8 @@ final class StaticHtmlEmitter
                 'nodes' => array(),
             ),
             'image_heavy_landmark_candidates' => array(),
+            'layout_mismatch_count' => 0,
+            'layout_mismatch_status' => 'not_evaluated',
         );
 
         foreach ( $nodes as $node ) {
@@ -773,6 +775,7 @@ final class StaticHtmlEmitter
                 'severity' => 'warning',
                 'code' => 'fixed_root_width',
                 'count' => (int) $layout['fixed_root_width_count'],
+                'sample_nodes' => array_slice(is_array($layout['fixed_root_width_nodes'] ?? null) ? $layout['fixed_root_width_nodes'] : array(), 0, 10),
             );
         }
         if ( ! empty($layout['large_absolute_offset_count']) ) {
@@ -780,6 +783,7 @@ final class StaticHtmlEmitter
                 'severity' => 'warning',
                 'code' => 'large_absolute_offsets',
                 'count' => (int) $layout['large_absolute_offset_count'],
+                'sample_nodes' => array_slice(is_array($layout['large_absolute_offset_nodes'] ?? null) ? $layout['large_absolute_offset_nodes'] : array(), 0, 10),
             );
         }
         if ( ! empty($layout['image_heavy_landmark_candidates']) ) {
@@ -843,6 +847,8 @@ final class StaticHtmlEmitter
                 'fixed_root_width_count' => (int) ($layout['fixed_root_width_count'] ?? 0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
+                'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
+                'layout_mismatch_status' => (string) ($layout['layout_mismatch_status'] ?? 'not_evaluated'),
             ),
         );
     }
@@ -1011,7 +1017,7 @@ final class StaticHtmlEmitter
         $type = strtoupper((string) ($node['type'] ?? ''));
         if ( $this->isUnsupportedVectorType($type) ) {
             ++$vectors['nodes'];
-            if ( null !== $this->supportedVectorSvg($node, $type) ) {
+            if ( null !== $this->supportedVectorSvg($node, $type, $parentNode) ) {
                 ++$vectors['rendered_paths'];
             } elseif ( null !== $this->nodeAssetPath($node) ) {
                 ++$vectors['rendered_asset_fallbacks'];
@@ -2894,7 +2900,7 @@ final class StaticHtmlEmitter
     /**
      * @param array<string, mixed> $node
      */
-    private function supportedVectorSvg(array $node, string $type): ?string
+    private function supportedVectorSvg(array $node, string $type, ?array $parentNode = null): ?string
     {
         if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'RECTANGLE', 'STAR', 'POLYGON', 'REGULAR_POLYGON'), true) ) {
             return null;
@@ -2909,7 +2915,7 @@ final class StaticHtmlEmitter
 
         $elements = $this->vectorPathElements($node);
         if ( empty($elements) ) {
-            $elements = $this->primitiveVectorElements($node, $type, $width, $height);
+            $elements = $this->primitiveVectorElements($node, $type, $width, $height, $parentNode);
         }
         if ( empty($elements) ) {
             return null;
@@ -3085,7 +3091,7 @@ final class StaticHtmlEmitter
     /**
      * @return array<int, string>
      */
-    private function primitiveVectorElements(array $node, string $type, float $width, float $height): array
+    private function primitiveVectorElements(array $node, string $type, float $width, float $height, ?array $parentNode = null): array
     {
         $paint = $this->svgPaintAttributes($node);
         if ( 'LINE' === $type ) {
@@ -3112,12 +3118,51 @@ final class StaticHtmlEmitter
                 return array();
             }
             if ( 'fill="none"' === $paint[0] && ! $this->hasSvgStroke($paint) ) {
-                return array();
+                if ( $this->hasExplicitVectorSource($node) ) {
+                    return array();
+                }
+                $paint = $this->inheritedVectorPaintAttributes($parentNode);
+                if ( empty($paint) ) {
+                    return array();
+                }
             }
 
             return array('<rect x="0" y="0" width="' . $this->number($width) . '" height="' . $this->number($height) . '" ' . implode(' ', $paint) . '/>');
         }
         return array();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function inheritedVectorPaintAttributes(?array $parentNode): array
+    {
+        if ( null === $parentNode ) {
+            return array();
+        }
+
+        $fill = $this->backgroundColor($parentNode);
+        return null === $fill ? array() : array('fill="' . $this->sanitizeAttribute($fill) . '"');
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasExplicitVectorSource(array $node): bool
+    {
+        foreach ( array('figma_vector_paths', 'vectorPaths', 'paths', 'fillGeometry', 'strokeGeometry') as $key ) {
+            if ( ! empty($node[$key]) ) {
+                return true;
+            }
+        }
+
+        foreach ( array('pathData', 'path', 'd') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== trim((string) $node[$key]) ) {
+                return true;
+            }
+        }
+
+        return isset($node['vectorData']) && is_array($node['vectorData']) && ! empty($node['vectorData']);
     }
 
     private function primitiveStarPath(float $width, float $height): string

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -153,6 +153,16 @@ $artifactQualitySignalCodes = static function (array $result): array {
         is_array($signals) ? $signals : array()
     ));
 };
+$artifactQualitySignal = static function (array $result, string $code): ?array {
+    $signals = $result['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
+    foreach ( is_array($signals) ? $signals : array() as $signal ) {
+        if ( is_array($signal) && $code === ($signal['code'] ?? null) ) {
+            return $signal;
+        }
+    }
+
+    return null;
+};
 
 $assert('blocks-engine/figma-transformer/result/v1' === ($result['schema'] ?? null), 'result-schema');
 $assert('success' === ($result['status'] ?? null), 'scenegraph-transform-success');
@@ -262,6 +272,11 @@ $assert(in_array('large_absolute_offsets', $qualitySignalCodes, true), 'quality-
 $assert(in_array('image_heavy_landmark_candidate', $qualitySignalCodes, true), 'quality-diagnostics-image-heavy-landmark');
 $assert(in_array('excessive_image_blocks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-image-blocks');
 $assert(in_array('excessive_vector_image_fallbacks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-vector-fallbacks');
+$fixedRootWidthSignal = $artifactQualitySignal($qualityDiagnosticsResult, 'fixed_root_width');
+$largeOffsetSignal = $artifactQualitySignal($qualityDiagnosticsResult, 'large_absolute_offsets');
+$assert('quality:root' === ($fixedRootWidthSignal['sample_nodes'][0]['node_id'] ?? null), 'quality-diagnostics-fixed-root-width-sample-node');
+$assert('quality:offcanvas' === ($largeOffsetSignal['sample_nodes'][0]['node_id'] ?? null), 'quality-diagnostics-large-absolute-offset-sample-node');
+$assert('quality:root' === ($largeOffsetSignal['sample_nodes'][0]['parent_id'] ?? null), 'quality-diagnostics-large-absolute-offset-sample-parent');
 $assert('needs_review' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-status-needs-review');
 $assert('warn' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['quality_status'] ?? null), 'quality-diagnostics-quality-status-warn');
 $qualitySignals = $qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
@@ -676,6 +691,34 @@ $assert(str_contains($starVectorHtml, 'data-figma-node-id="vector:primitive-star
 $assert(str_contains($starVectorHtml, 'data-figma-node-id="vector:primitive-polygon"') && str_contains($starVectorHtml, 'data-figma-vector="true"'), 'primitive-polygon-vector-renders');
 $assert(! str_contains($starVectorHtml, 'data-figma-unsupported-vector="true"'), 'star-vector-path-not-placeholder');
 
+$geometrylessVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Geometryless Vector Fixture',
+    'nodes' => array(
+        array(
+            'id'         => 'vector:geometryless-parent',
+            'type'       => 'FRAME',
+            'name'       => 'Geometryless vector parent',
+            'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.2, 'g' => 0.4, 'b' => 0.6))),
+            'children'   => array(
+                array(
+                    'id'     => 'vector:geometryless',
+                    'type'   => 'VECTOR',
+                    'name'   => 'Geometryless vector bounds',
+                    'width'  => 16,
+                    'height' => 8,
+                ),
+            ),
+        ),
+    ),
+));
+$geometrylessVectorHtml = $fileContent($geometrylessVectorResult, 'index.html');
+$geometrylessVectorDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $geometrylessVectorResult['diagnostics'] ?? array()
+);
+$assert(str_contains($geometrylessVectorHtml, 'data-figma-node-id="vector:geometryless"') && str_contains($geometrylessVectorHtml, '<rect x="0" y="0" width="16" height="8" fill="#336699"/>'), 'geometryless-vector-renders-inherited-color-bounds');
+$assert(! in_array('unsupported_vector_node_placeholder', $geometrylessVectorDiagnosticCodes, true), 'geometryless-vector-no-placeholder-diagnostic');
+
 $simpleRectNetworkPrefix = hex2bin('0400000004000000000000000000000000000000000000000000000000008043');
 $simpleRectNetworkBlob = str_pad(false === $simpleRectNetworkPrefix ? '' : $simpleRectNetworkPrefix, 172, "\0");
 $vectorDataResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -863,6 +906,37 @@ $assert(in_array('misplaced_element', $footerLayoutMismatchCodes, true), 'layout
 $assert(in_array('element_outside_parent_bounds', $footerLayoutMismatchCodes, true), 'layout-mismatch-outside-parent');
 $assert(880.0 === ($footerLayoutMismatch['diagnostics'][0]['delta']['y'] ?? null), 'layout-mismatch-delta-y');
 
+$homeboyDomLayoutMismatch = $layoutMismatchBuilder->build(
+    array(
+        'visual_node_map' => array(
+            array('id' => 'card', 'name' => 'Card', 'type' => 'FRAME', 'rect' => array('x' => 320, 'y' => 120, 'width' => 300, 'height' => 180)),
+        ),
+    ),
+    array(
+        'schema' => 'homeboy/static-artifact-dom-boxes/v1',
+        'entrypoints' => array(
+            array(
+                'page_path' => '/index.html',
+                'elements' => array(
+                    array('node_id' => 'card', 'selector' => '[data-figma-node-id="card"]', 'boundingClientRect' => array('x' => 8, 'y' => 120, 'width' => 1424, 'height' => 180)),
+                ),
+            ),
+        ),
+    ),
+    array('threshold' => 24)
+);
+$homeboyDomLayoutMismatchCodes = array_map(static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''), $homeboyDomLayoutMismatch['diagnostics'] ?? array());
+$homeboyDomMisplaced = null;
+foreach ( $homeboyDomLayoutMismatch['diagnostics'] ?? array() as $diagnostic ) {
+    if ( is_array($diagnostic) && 'misplaced_element' === ($diagnostic['code'] ?? null) ) {
+        $homeboyDomMisplaced = $diagnostic;
+        break;
+    }
+}
+$assert('fail' === ($homeboyDomLayoutMismatch['status'] ?? null), 'layout-mismatch-homeboy-dom-status');
+$assert(in_array('element_size_mismatch', $homeboyDomLayoutMismatchCodes, true), 'layout-mismatch-homeboy-dom-size-code');
+$assert(-312.0 === ($homeboyDomMisplaced['delta']['x'] ?? null), 'layout-mismatch-homeboy-dom-x-delta');
+
 $layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name' => 'Layout Mismatch Fixture',
     'nodes' => array(
@@ -891,7 +965,18 @@ $layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scene
 $layoutMismatchTransformDiagnostics = $layoutMismatchTransformResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
 $layoutMismatchArtifactQualityCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), $layoutMismatchTransformDiagnostics['artifact_quality']['signals'] ?? array());
 $assert(0 < ($layoutMismatchTransformDiagnostics['layout']['layout_mismatch_count'] ?? 0), 'layout-mismatch-transform-count');
+$assert('fail' === ($layoutMismatchTransformDiagnostics['layout']['layout_mismatch_status'] ?? null), 'layout-mismatch-transform-status');
 $assert(in_array('layout_mismatch', $layoutMismatchArtifactQualityCodes, true), 'layout-mismatch-artifact-quality-signal');
+
+$layoutNotEvaluatedResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name' => 'Layout Not Evaluated Fixture',
+    'nodes' => array(
+        array('id' => 'layout:not-evaluated', 'type' => 'FRAME', 'name' => 'Simple Page', 'width' => 720, 'height' => 320),
+    ),
+));
+$layoutNotEvaluatedQuality = $layoutNotEvaluatedResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['summary'] ?? array();
+$assert(0 === ($layoutNotEvaluatedQuality['layout_mismatch_count'] ?? null), 'layout-not-evaluated-count-zero');
+$assert('not_evaluated' === ($layoutNotEvaluatedQuality['layout_mismatch_status'] ?? null), 'layout-not-evaluated-status');
 
 $unusedAssetResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'   => 'Unused Asset Fixture',


### PR DESCRIPTION
## Summary
- Load DOM box evidence supplied through `--parity-dom-boxes-path` into Figma layout mismatch diagnostics.
- Support Homeboy DOM-box report shapes (`entrypoints[].elements[].boundingClientRect`) in the layout mismatch builder.
- Mark layout mismatch summaries as `not_evaluated` when no browser/DOM evidence was supplied, instead of presenting an ambiguous zero.
- Add bounded sample nodes to `fixed_root_width` and `large_absolute_offsets` quality signals.
- Add a conservative fallback for bounded geometryless vector primitives that can inherit a concrete parent fill color.

## Evidence
- Matrix run: `figma-transformer-matrix-post-homeboy-provider-20260626-1717`
- Status: pass
- Directory artifact: `4cf82ed4-8067-40e3-820b-f2a0a2974e3e`
- Summary artifact: `fe7a4171-b4bf-4fb2-85a1-8ff4d14560a0`
- Targeted local rerun output: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/figma-fse-after-fanout`
- FSE still reports `vector_placeholders=12`; remaining placeholders are repeated separator/menu component vectors and are not faked by this PR.
- Quality signals now include actionable sample node context.

## Tests
- `php figma-transformer/tests/contract/run.php`
- `php -l figma-transformer/bin/figma-transformer`
- `php -l figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php`
- `php -l figma-transformer/src/FigmaTransformer.php`
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/tests/contract/run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Matrix evidence analysis, parallel subagent investigation, implementation, test updates, verification, and PR description drafting.
