### PR TITLE
Add Figma DOM box matrix capture

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -15,6 +15,9 @@ $maxPages = (int) ($options['max_pages'] ?? 3);
 $inspectLimit = (int) ($options['inspect_limit'] ?? 100);
 $dryRun = true === ($options['dry_run'] ?? false);
 $inspectOnly = true === ($options['inspect_only'] ?? false);
+$captureDomBoxes = true === ($options['capture_dom_boxes'] ?? false);
+$homeboyCommand = (string) ($options['homeboy_command'] ?? (getenv('HOMEBOY_COMMAND') ?: 'homeboy'));
+$domBoxProviderCommand = (string) ($options['dom_box_provider_command'] ?? (getenv('HOMEBOY_DOM_BOX_CAPTURE_COMMAND') ?: ''));
 $only = isset($options['only']) ? array_filter(array_map('trim', explode(',', (string) $options['only']))) : array();
 $adHocFixtures = matrix_list_option($options['fixture'] ?? array());
 $fontCssPassthrough = matrix_font_css_passthrough($options);
@@ -55,6 +58,9 @@ $summary = array(
     'inspect_limit' => $inspectLimit,
     'dry_run' => $dryRun,
     'inspect_only' => $inspectOnly,
+    'capture_dom_boxes' => $captureDomBoxes,
+    'homeboy_command' => $captureDomBoxes ? $homeboyCommand : null,
+    'dom_box_provider_command_configured' => $captureDomBoxes ? '' !== $domBoxProviderCommand : null,
     'font_css' => $fontCssPassthrough['summary'],
     'evidence' => $evidenceOptions['summary'],
     'fixtures' => array(),
@@ -97,6 +103,13 @@ foreach ( $fixtures as $fixture ) {
         $dryRunFrameIds = $hasDryRunFrameIds ? $fixture['frame_ids'] : array('<selected-frame-ids>');
         $dryRunEntryFrameId = (string) ($fixture['entry_frame_id'] ?? ($hasDryRunFrameIds ? ($dryRunFrameIds[0] ?? '') : '<entry-frame-id>'));
         $record['evidence'] = matrix_fixture_evidence($evidenceOptions, $fixture, matrix_dry_run_pages($dryRunFrameIds));
+        if ( $captureDomBoxes ) {
+            $record['dom_box_capture'] = array(
+                'status' => 'planned',
+                'command' => matrix_dom_box_capture_command($homeboyCommand, $domBoxProviderCommand, $fixtureOutputDir, array('<generated-html-entrypoints>'), $fixtureOutputDir . '/dom-boxes.json'),
+                'report_path' => $fixtureOutputDir . '/dom-boxes.json',
+            );
+        }
         $record['command'] = matrix_transform_command($figmaRoot, $fixturePath, $dryRunFrameIds, $dryRunEntryFrameId, $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $record['evidence']['transform_arguments'] ?? array());
         $summary['fixtures'][] = $record;
         continue;
@@ -132,14 +145,57 @@ foreach ( $fixtures as $fixture ) {
         continue;
     }
 
-    $command = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $record['evidence']['transform_arguments'] ?? array());
+    $command = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $captureDomBoxes ? array() : ($record['evidence']['transform_arguments'] ?? array()));
     $record['command'] = $command;
     passthru($command, $exitCode);
     $record['exit_code'] = $exitCode;
     $record['duration_ms'] = (int) round((microtime(true) - $startedAt) * 1000);
     $record['status'] = 0 === $exitCode ? 'completed' : 'failed';
 
-    if ( 0 === $exitCode && is_file($resultPath) ) {
+    if ( 0 === $exitCode && $captureDomBoxes ) {
+        $domBoxesPath = $fixtureOutputDir . '/dom-boxes.json';
+        $entrypoints = matrix_html_entrypoints($fixtureOutputDir);
+        $captureCommand = matrix_dom_box_capture_command($homeboyCommand, $domBoxProviderCommand, $fixtureOutputDir, $entrypoints, $domBoxesPath);
+        $record['dom_box_capture'] = array(
+            'status' => empty($entrypoints) ? 'no_html_entrypoints' : 'running',
+            'command' => $captureCommand,
+            'report_path' => $domBoxesPath,
+            'entrypoints' => $entrypoints,
+        );
+        if ( ! empty($entrypoints) ) {
+            passthru($captureCommand, $captureExitCode);
+            $record['dom_box_capture']['exit_code'] = $captureExitCode;
+            $record['dom_box_capture']['exists'] = is_file($domBoxesPath);
+            $record['dom_box_capture']['status'] = 0 === $captureExitCode && is_file($domBoxesPath) ? 'completed' : 'failed';
+            if ( 'failed' === $record['dom_box_capture']['status'] ) {
+                $record['status'] = 'dom_box_capture_failed';
+            }
+            if ( 0 === $captureExitCode && is_file($domBoxesPath) ) {
+                $capturedEvidenceOptions = matrix_merge_evidence_templates($evidenceOptions, array(
+                    'dom_boxes_path' => $domBoxesPath,
+                ));
+                $capturedEvidence = matrix_fixture_evidence($capturedEvidenceOptions, $fixture, $record['selected_frames']);
+                $rerunResultPath = $outputDir . '/' . $fixture['id'] . '-result-with-dom-boxes.json';
+                $rerunCommand = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $rerunResultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $capturedEvidence['transform_arguments'] ?? array());
+                $record['dom_box_rerun_command'] = $rerunCommand;
+                passthru($rerunCommand, $rerunExitCode);
+                $record['dom_box_rerun_exit_code'] = $rerunExitCode;
+                if ( 0 === $rerunExitCode && is_file($rerunResultPath) ) {
+                    $resultPath = $rerunResultPath;
+                    $record['result_path'] = $resultPath;
+                    $record['exit_code'] = $rerunExitCode;
+                    $record['evidence'] = $capturedEvidence;
+                    $record['status'] = 'completed';
+                } else {
+                    $record['status'] = 'dom_box_rerun_failed';
+                }
+            }
+        }
+    }
+
+    $record['duration_ms'] = (int) round((microtime(true) - $startedAt) * 1000);
+
+    if ( 'completed' === $record['status'] && is_file($resultPath) ) {
         $result = json_decode((string) file_get_contents($resultPath), true);
         if ( is_array($result) ) {
             $result = matrix_attach_evidence_to_result($result, $record['evidence']);
@@ -156,6 +212,10 @@ foreach ( $fixtures as $fixture ) {
                 $record['quality_status'] = $diagnostics['artifact_quality']['quality_status'] ?? null;
                 $record['quality_summary'] = $diagnostics['artifact_quality']['summary'] ?? null;
                 $record['transform_selection'] = $diagnostics['selection'] ?? null;
+                if ( is_array($record['parity'] ?? null) && is_array($record['quality_summary']) ) {
+                    $record['parity']['layout_mismatch_count'] = $record['quality_summary']['layout_mismatch_count'] ?? $record['parity']['layout_mismatch_count'];
+                    $record['parity']['layout_mismatch_status'] = $record['quality_summary']['layout_mismatch_status'] ?? null;
+                }
             }
         }
     }
@@ -180,6 +240,11 @@ function matrix_options(array $argv): array
 
         if ( '--inspect-only' === $arg ) {
             $options['inspect_only'] = true;
+            continue;
+        }
+
+        if ( '--capture-dom-boxes' === $arg ) {
+            $options['capture_dom_boxes'] = true;
             continue;
         }
 
@@ -281,6 +346,25 @@ function matrix_evidence_options(array $options): array
         'summary' => empty($templates) ? array('source' => 'none') : array(
             'source' => 'runner_paths',
             'templates' => $templates,
+            'template_tokens' => array('{fixture}', '{id}', '{frame_id}', '{page}', '{slug}'),
+        ),
+    );
+}
+
+/**
+ * @param array{templates: array<string, string>, summary: array<string, mixed>} $evidenceOptions
+ * @param array<string, string> $templates
+ * @return array{templates: array<string, string>, summary: array<string, mixed>}
+ */
+function matrix_merge_evidence_templates(array $evidenceOptions, array $templates): array
+{
+    $merged = array_merge($evidenceOptions['templates'], $templates);
+
+    return array(
+        'templates' => $merged,
+        'summary' => empty($merged) ? array('source' => 'none') : array(
+            'source' => 'runner_paths',
+            'templates' => $merged,
             'template_tokens' => array('{fixture}', '{id}', '{frame_id}', '{page}', '{slug}'),
         ),
     );
@@ -496,6 +580,65 @@ function matrix_evidence_transform_arguments(array $paths): array
     }
 
     return $arguments;
+}
+
+/**
+ * @return array<int, string>
+ */
+function matrix_html_entrypoints(string $root): array
+{
+    if ( ! is_dir($root) ) {
+        return array();
+    }
+
+    $entrypoints = array();
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS));
+    foreach ( $iterator as $file ) {
+        if ( ! $file instanceof SplFileInfo || ! $file->isFile() || 'html' !== strtolower($file->getExtension()) ) {
+            continue;
+        }
+        $path = $file->getPathname();
+        $relative = ltrim(substr($path, strlen(rtrim($root, DIRECTORY_SEPARATOR)) + 1), DIRECTORY_SEPARATOR);
+        $entrypoints[] = str_replace(DIRECTORY_SEPARATOR, '/', $relative);
+    }
+
+    usort($entrypoints, static function (string $a, string $b): int {
+        if ( 'index.html' === $a ) {
+            return 'index.html' === $b ? 0 : -1;
+        }
+        if ( 'index.html' === $b ) {
+            return 1;
+        }
+        return strnatcasecmp($a, $b);
+    });
+
+    return $entrypoints;
+}
+
+/**
+ * @param array<int, string> $entrypoints
+ */
+function matrix_dom_box_capture_command(string $homeboyCommand, string $domBoxProviderCommand, string $root, array $entrypoints, string $reportPath): string
+{
+    $parts = array(
+        escapeshellarg($homeboyCommand),
+        'tunnel',
+        'artifact-origin',
+        'dom-boxes',
+        '--root=' . escapeshellarg($root),
+        '--report=' . escapeshellarg($reportPath),
+    );
+
+    foreach ( $entrypoints as $entrypoint ) {
+        $parts[] = '--entrypoint=' . escapeshellarg($entrypoint);
+    }
+
+    $command = implode(' ', $parts);
+    if ( '' === $domBoxProviderCommand ) {
+        return $command;
+    }
+
+    return 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg($domBoxProviderCommand) . ' ' . $command;
 }
 
 function matrix_slug(string $value): string

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -96,6 +96,8 @@ final class StaticHtmlEmitter
             $files[] = $assetFile;
         }
 
+        $files = $this->withInlineCssFiles($files, $css);
+
         $visualNodeMap = $this->visualNodeMap($nodes);
         $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
         $transformDiagnostics = $this->transformDiagnostics($nodes, $assetFiles, $fontFamilies, $fontCss, $css, $diagnostics);
@@ -254,6 +256,8 @@ final class StaticHtmlEmitter
             $files[] = $assetFile;
         }
 
+        $files = $this->withInlineCssFiles($files, $css);
+
         $visualNodeMap = $this->visualNodeMap($renderedNodes);
         $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
         $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $assetFiles, $fontFamilies, $fontCss, $css, $diagnostics);
@@ -303,6 +307,42 @@ final class StaticHtmlEmitter
     private function htmlDocument(string $title, string $stylesheetHref, string $body): string
     {
         return "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>" . $title . "</title>\n<link rel=\"stylesheet\" href=\"" . $this->sanitizeAttribute($stylesheetHref) . "\">\n</head>\n<body>\n<main class=\"figma-root\" data-figma-root=\"true\">\n" . $body . "</main>\n</body>\n</html>\n";
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, array<string, mixed>>
+     */
+    private function withInlineCssFiles(array $files, string $css): array
+    {
+        if ( '' === $css ) {
+            return $files;
+        }
+
+        foreach ( $files as $index => $file ) {
+            if ( ! is_array($file) || 'text/html' !== ($file['mime_type'] ?? null) || ! isset($file['content']) || ! is_scalar($file['content']) ) {
+                continue;
+            }
+
+            $file['content'] = $this->withInlineCss((string) $file['content'], $css);
+            $files[$index] = $file;
+        }
+
+        return $files;
+    }
+
+    private function withInlineCss(string $html, string $css): string
+    {
+        if ( '' === $css || str_contains($html, '<style data-figma-transformer-css="true">') ) {
+            return $html;
+        }
+
+        $style = '<style data-figma-transformer-css="true">' . str_replace('</style', '<\/style', $css) . '</style>';
+        if ( str_contains($html, '</head>') ) {
+            return str_replace('</head>', $style . "\n</head>", $html);
+        }
+
+        return $style . "\n" . $html;
     }
 
     /**
@@ -1312,6 +1352,7 @@ final class StaticHtmlEmitter
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $zeroHeightVectorFallbackHeight = $this->zeroHeightVectorFallbackHeight($node, $type);
         foreach ( array('width', 'height') as $dimension ) {
             $sizingKey = 'width' === $dimension ? 'sizing_horizontal' : 'sizing_vertical';
             $sizing = strtoupper((string) ($layout[$sizingKey] ?? ''));
@@ -1327,7 +1368,8 @@ final class StaticHtmlEmitter
                 }
 
                 $property = null === $parentNode && 'height' === $dimension && 'flex' === ($layout['display'] ?? null) ? 'min-height' : $dimension;
-                $styles[] = $property . ':' . $this->number((float) $box[$dimension]) . 'px';
+                $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
+                $styles[] = $property . ':' . $this->number($value) . 'px';
             }
         }
 
@@ -2909,19 +2951,24 @@ final class StaticHtmlEmitter
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $width = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width']) : 0.0;
         $height = isset($box['height']) && is_numeric($box['height']) ? max(0.0, (float) $box['height']) : 0.0;
-        if ( $width <= 0 || $height <= 0 ) {
+        $zeroHeightVectorFallbackHeight = $this->zeroHeightVectorFallbackHeight($node, $type);
+        if ( $width <= 0 || ( $height <= 0 && null === $zeroHeightVectorFallbackHeight ) ) {
             return null;
         }
+        $renderHeight = $height <= 0 && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : $height;
 
         $elements = $this->vectorPathElements($node);
+        if ( empty($elements) && $height <= 0 && null !== $zeroHeightVectorFallbackHeight ) {
+            $elements = $this->zeroHeightVectorElements($node, $type, $width, $renderHeight);
+        }
         if ( empty($elements) ) {
-            $elements = $this->primitiveVectorElements($node, $type, $width, $height, $parentNode);
+            $elements = $this->primitiveVectorElements($node, $type, $width, $renderHeight, $parentNode);
         }
         if ( empty($elements) ) {
             return null;
         }
 
-        $viewBox = array('x' => 0.0, 'y' => 0.0, 'width' => $width, 'height' => $height);
+        $viewBox = array('x' => 0.0, 'y' => 0.0, 'width' => $width, 'height' => $renderHeight);
         $pathBounds = $this->vectorPathBounds($node);
         if ( null !== $pathBounds && ( $pathBounds['width'] > $width + 0.001 || $pathBounds['height'] > $height + 0.001 || $pathBounds['x'] < -0.001 || $pathBounds['y'] < -0.001 ) ) {
             $viewBox = $pathBounds;
@@ -3133,6 +3180,56 @@ final class StaticHtmlEmitter
     }
 
     /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function zeroHeightVectorElements(array $node, string $type, float $width, float $height): array
+    {
+        $paint = $this->svgPaintAttributes($node);
+        if ( $this->hasSvgStroke($paint) ) {
+            $paint = array_values(array_filter($paint, static fn (string $attribute): bool => ! str_starts_with($attribute, 'fill=')));
+            return array('<line x1="0" y1="' . $this->number($height / 2) . '" x2="' . $this->number($width) . '" y2="' . $this->number($height / 2) . '" ' . implode(' ', $paint) . '/>');
+        }
+
+        if ( 'LINE' === $type ) {
+            return array('<line x1="0" y1="' . $this->number($height / 2) . '" x2="' . $this->number($width) . '" y2="' . $this->number($height / 2) . '" fill="none" stroke="currentColor" stroke-width="' . $this->number($height) . '"/>');
+        }
+
+        if ( $this->hasSvgFill($paint) ) {
+            return array('<rect x="0" y="0" width="' . $this->number($width) . '" height="' . $this->number($height) . '" ' . implode(' ', $paint) . '/>');
+        }
+
+        return array();
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function zeroHeightVectorFallbackHeight(array $node, string $type): ?float
+    {
+        if ( ! in_array($type, array('LINE', 'VECTOR'), true) ) {
+            return null;
+        }
+        if ( 'VECTOR' === $type && ! $this->hasExplicitVectorSource($node) ) {
+            return null;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : 0.0;
+        $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : 0.0;
+        if ( $width <= 0.0 || $height > 0.0 ) {
+            return null;
+        }
+
+        $paint = $this->svgPaintAttributes($node);
+        if ( 'LINE' === $type || $this->hasSvgStroke($paint) || $this->hasSvgFill($paint) ) {
+            return max(1.0, $this->strokeWeight($node));
+        }
+
+        return null;
+    }
+
+    /**
      * @return array<int, string>
      */
     private function inheritedVectorPaintAttributes(?array $parentNode): array
@@ -3304,6 +3401,20 @@ final class StaticHtmlEmitter
     {
         foreach ( $attributes as $attribute ) {
             if ( str_starts_with($attribute, 'stroke=') ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, string> $attributes
+     */
+    private function hasSvgFill(array $attributes): bool
+    {
+        foreach ( $attributes as $attribute ) {
+            if ( str_starts_with($attribute, 'fill=') && 'fill="none"' !== $attribute ) {
                 return true;
             }
         }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -790,6 +790,34 @@ $assert(2 === ($vectorNetworkDiagnostic['context']['affected_node_count'] ?? nul
 $assert(array('vector:data-malformed', 'vector:data-painted-fallback') === ($vectorNetworkDiagnostic['context']['sample_node_ids'] ?? null), 'vector-network-diagnostic-sample-nodes');
 $assert(array('1') === ($vectorNetworkDiagnostic['context']['sample_blob_refs'] ?? null), 'vector-network-diagnostic-sample-blob-refs');
 
+$zeroHeightSeparatorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Zero Height Separator Fixture',
+    'blobs' => array(array('bytes' => "\xff")),
+    'nodes' => array(
+        array(
+            'id'           => 'vector:zero-height-separator',
+            'type'         => 'VECTOR',
+            'name'         => 'Wide Zero Height Separator',
+            'width'        => 1004,
+            'height'       => 0,
+            'strokeWeight' => 4,
+            'strokePaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.75, 'g' => 0.75, 'b' => 0.75))),
+            'vectorData'   => array('vectorNetworkBlob' => 0),
+        ),
+    ),
+));
+$zeroHeightSeparatorHtml = $fileContent($zeroHeightSeparatorResult, 'index.html');
+$zeroHeightSeparatorCss = $fileContent($zeroHeightSeparatorResult, 'style.css');
+$zeroHeightSeparatorDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $zeroHeightSeparatorResult['diagnostics'] ?? array()
+);
+$assert(str_contains($zeroHeightSeparatorHtml, 'data-figma-node-id="vector:zero-height-separator"') && str_contains($zeroHeightSeparatorHtml, 'data-figma-vector="true"'), 'zero-height-separator-renders-vector');
+$assert(str_contains($zeroHeightSeparatorHtml, '<line x1="0" y1="2" x2="1004" y2="2" stroke="#bfbfbf" stroke-width="4"/>'), 'zero-height-separator-renders-line');
+$assert(! str_contains($zeroHeightSeparatorHtml, 'data-figma-unsupported-vector="true"'), 'zero-height-separator-not-placeholder');
+$assert(str_contains($zeroHeightSeparatorCss, '.figma-node-vector-zero-height-separator-wide-zero-height-separator{width:1004px;height:4px'), 'zero-height-separator-css-bounded-height');
+$assert(in_array('unsupported_vector_network_blob', $zeroHeightSeparatorDiagnosticCodes, true), 'zero-height-separator-keeps-network-diagnostic');
+
 $agenticChevronLeftPrefix = hex2bin('0600000006000000010000000000000000000041000080410000000000000000');
 $agenticChevronRightPrefix = hex2bin('06000000060000000100000000000000f4fdb43f0000804100000000be9f1641');
 $agenticChevronWrongCountsPrefix = hex2bin('0600000005000000010000000000000000000041000080410000000000000000');
@@ -1113,6 +1141,7 @@ $assert('success' === ($multiPageResult['status'] ?? null), 'multi-page-transfor
 $assert(str_contains($multiPageIndex, 'Home Hero'), 'multi-page-index-renders-entry-frame');
 $assert(! str_contains($multiPageIndex, 'About Hero'), 'multi-page-index-omits-other-frame');
 $assert(str_contains($multiPageAbout, 'About Hero'), 'multi-page-about-renders-second-frame');
+$assert(str_contains($multiPageIndex, '<style data-figma-transformer-css="true">') && str_contains($multiPageIndex, '.figma-node-frame-home-home'), 'multi-page-index-inlines-page-css');
 $assert(str_contains($multiPageStyle, '.figma-node-frame-home-home'), 'multi-page-shared-css-home');
 $assert(str_contains($multiPageStyle, '.figma-node-frame-about-about'), 'multi-page-shared-css-about');
 $assert(2 === ($multiPageResult['metrics']['page_count'] ?? null), 'multi-page-page-count');

--- a/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
+++ b/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import { chromium } from 'playwright';
+
+const DEFAULT_VIEWPORT = { width: 1440, height: 900, device_scale_factor: 1 };
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});
+
+async function main() {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    printHelp();
+    return;
+  }
+
+  const baseUrl = requiredEnv('HOMEBOY_DOM_BOX_BASE_URL').replace(/\/+$/, '');
+  const pagePaths = parsePagePaths(requiredEnv('HOMEBOY_DOM_BOX_PAGE_PATHS_JSON'));
+  const textSampleLimit = parseTextSampleLimit(process.env.HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT ?? '160');
+
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({
+      viewport: { width: DEFAULT_VIEWPORT.width, height: DEFAULT_VIEWPORT.height },
+      deviceScaleFactor: DEFAULT_VIEWPORT.device_scale_factor,
+    });
+    const entrypoints = [];
+
+    for (const pagePath of pagePaths) {
+      const page = await context.newPage();
+      const pageUrl = `${baseUrl}${String(pagePath).startsWith('/') ? pagePath : `/${pagePath}`}`;
+      await page.goto(pageUrl, { waitUntil: 'load' });
+      entrypoints.push({
+        page_path: pagePath,
+        page_url: page.url(),
+        viewport: DEFAULT_VIEWPORT,
+        elements: await extractElements(page, textSampleLimit),
+      });
+      await page.close();
+    }
+
+    process.stdout.write(`${JSON.stringify({ entrypoints }, null, 2)}\n`);
+  } finally {
+    await browser.close();
+  }
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function parsePagePaths(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`HOMEBOY_DOM_BOX_PAGE_PATHS_JSON must be valid JSON: ${error.message}`);
+  }
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string' || item.trim() === '')) {
+    throw new Error('HOMEBOY_DOM_BOX_PAGE_PATHS_JSON must be a JSON array of paths.');
+  }
+  return parsed;
+}
+
+function parseTextSampleLimit(raw) {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error('HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT must be a positive integer.');
+  }
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`Capture DOM boxes for Homeboy artifact-origin dom-boxes.\n\nEnvironment:\n  HOMEBOY_DOM_BOX_BASE_URL             Static artifact origin base URL.\n  HOMEBOY_DOM_BOX_PAGE_PATHS_JSON      JSON array of page paths to capture.\n  HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT    Optional positive integer, default 160.\n\nOutput:\n  JSON browser payload on stdout for Homeboy to shape as homeboy/static-artifact-dom-boxes/v1.\n`);
+}
+
+async function extractElements(page, textSampleLimit) {
+  return page.evaluate((limit) => {
+    function normalizeText(value) {
+      return String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, limit);
+    }
+
+    function selectorFor(element, nodeId) {
+      const tag = element.tagName.toLowerCase();
+      return `${tag}[data-figma-node-id="${String(nodeId).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`;
+    }
+
+    return Array.from(document.querySelectorAll('[data-figma-node-id]')).map((element) => {
+      const rect = element.getBoundingClientRect();
+      const nodeId = element.getAttribute('data-figma-node-id') || '';
+      const nodeName = element.getAttribute('data-figma-node-name') || element.getAttribute('data-figma-name') || element.getAttribute('aria-label') || null;
+      return {
+        node_id: nodeId,
+        node_name: nodeName,
+        selector: selectorFor(element, nodeId),
+        tag: element.tagName.toLowerCase(),
+        text_sample: normalizeText(element.textContent),
+        boundingClientRect: {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+          top: rect.top,
+          right: rect.right,
+          bottom: rect.bottom,
+          left: rect.left,
+        },
+      };
+    });
+  }, textSampleLimit);
+}

--- a/php-transformer/tools/visual-parity/package-lock.json
+++ b/php-transformer/tools/visual-parity/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@automattic/blocks-engine-visual-parity",
       "version": "0.0.0",
       "bin": {
+        "blocks-engine-dom-box-provider": "bin/dom-box-provider.mjs",
         "blocks-engine-visual-parity": "bin/visual-parity.mjs"
       },
       "devDependencies": {

--- a/php-transformer/tools/visual-parity/package.json
+++ b/php-transformer/tools/visual-parity/package.json
@@ -5,7 +5,8 @@
   "description": "Generic visual parity probe extractor for static HTML and materialized output fixtures.",
   "type": "module",
   "bin": {
-    "blocks-engine-visual-parity": "bin/visual-parity.mjs"
+    "blocks-engine-visual-parity": "bin/visual-parity.mjs",
+    "blocks-engine-dom-box-provider": "bin/dom-box-provider.mjs"
   },
   "scripts": {
     "test": "node tests/smoke.mjs"

--- a/php-transformer/tools/visual-parity/tests/smoke.mjs
+++ b/php-transformer/tools/visual-parity/tests/smoke.mjs
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rm } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
@@ -6,6 +7,7 @@ import { spawn } from 'node:child_process';
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const outputDir = path.join(root, 'tmp');
 const output = path.join(outputDir, 'visual-parity-smoke.json');
+const domFixture = path.join(outputDir, 'dom-box.html');
 
 await mkdir(outputDir, { recursive: true });
 
@@ -27,7 +29,38 @@ assert(report.source.snapshots[0].probes[0].matches[0].display === 'inline-block
 assert(report.source.snapshots[0].probes[0].matches[0].padding.top === '10px', 'extracts computed padding');
 assert(report.comparison[0].probes[0].count_delta === 0, 'compares source and target counts');
 
+await writeFile(domFixture, '<!doctype html><html><body><main data-figma-node-id="12:34" data-figma-node-name="Hero">Hello world</main></body></html>');
+const server = createServer(async (request, response) => {
+  if (request.url === '/dom-box.html') {
+    response.writeHead(200, { 'content-type': 'text/html' });
+    response.end(await readFile(domFixture));
+    return;
+  }
+  response.writeHead(404, { 'content-type': 'application/json' });
+  response.end('{"error":"not_found"}');
+});
+await new Promise((resolve, reject) => {
+  server.on('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+try {
+  const address = server.address();
+  const domReport = await runJson(process.execPath, [path.join(root, 'bin/dom-box-provider.mjs')], root, {
+    ...process.env,
+    HOMEBOY_DOM_BOX_BASE_URL: `http://127.0.0.1:${address.port}`,
+    HOMEBOY_DOM_BOX_PAGE_PATHS_JSON: JSON.stringify(['/dom-box.html']),
+    HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT: '20',
+  });
+  assert(domReport.entrypoints.length === 1, 'DOM provider captures one entrypoint');
+  assert(domReport.entrypoints[0].elements[0].node_id === '12:34', 'DOM provider captures node id');
+  assert(domReport.entrypoints[0].elements[0].node_name === 'Hero', 'DOM provider captures node name');
+  assert(domReport.entrypoints[0].elements[0].text_sample === 'Hello world', 'DOM provider captures text sample');
+} finally {
+  await new Promise((resolve) => server.close(resolve));
+}
+
 await rm(output, { force: true });
+await rm(domFixture, { force: true });
 console.log('Visual parity smoke test passed.');
 
 function run(command, args, cwd) {
@@ -40,6 +73,28 @@ function run(command, args, cwd) {
         return;
       }
       reject(new Error(`${command} exited with ${code}`));
+    });
+  });
+}
+
+function runJson(command, args, cwd, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env, stdio: ['ignore', 'pipe', 'inherit'] });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${command} exited with ${code}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- add an opt-in two-pass Figma fixture matrix mode that captures Homeboy DOM boxes and reruns transforms with layout evidence
- add a generic visual-parity DOM box provider command for Homeboy's provider boundary
- inline emitted CSS in generated static HTML so artifact captures are self-styling
- render source-backed zero-height stroked vector separators as bounded SVG lines instead of placeholders

## Verification
- `php -l figma-transformer/scripts/figma-fixture-matrix.php`
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php figma-transformer/tests/contract/run.php`
- `npm test` in `php-transformer/tools/visual-parity`
- targeted private FSE matrix with DOM capture: DOM capture completed, rerun completed, vector placeholders dropped from 4 to 0, layout mismatch remained evaluated at 100

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, test updates, fixture-matrix verification, and PR preparation
