### PR TITLE
Improve Figma layout drift diagnostics

### DIFF
--- a/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
+++ b/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
@@ -104,9 +104,160 @@ final class LayoutMismatchReportBuilder
                 'unmatched_source_node_count' => $unmatchedSource,
                 'diagnostic_count' => count($diagnostics),
                 'code_counts' => $codeCounts,
+                'clusters' => $this->diagnosticClusters($diagnostics),
             ),
             'diagnostics' => $diagnostics,
         );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function diagnosticClusters(array $diagnostics): array
+    {
+        return array(
+            'parent_delta' => $this->parentDeltaClusters($diagnostics),
+            'repeated_position_delta' => $this->repeatedPositionDeltaClusters($diagnostics),
+            'node_pattern' => $this->nodePatternClusters($diagnostics),
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    private function parentDeltaClusters(array $diagnostics): array
+    {
+        $groups = array();
+        foreach ( $diagnostics as $diagnostic ) {
+            $node = is_array($diagnostic['node'] ?? null) ? $diagnostic['node'] : array();
+            $parentId = isset($node['parent_id']) && is_scalar($node['parent_id']) && '' !== (string) $node['parent_id'] ? (string) $node['parent_id'] : '(root)';
+            $this->addClusterDiagnostic($groups, $parentId, $diagnostic, array('parent_id' => $parentId));
+        }
+
+        return $this->clusterValues($groups);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    private function repeatedPositionDeltaClusters(array $diagnostics): array
+    {
+        $groups = array();
+        foreach ( $diagnostics as $diagnostic ) {
+            $delta = is_array($diagnostic['delta'] ?? null) ? $diagnostic['delta'] : array();
+            if ( ! is_numeric($delta['x'] ?? null) || ! is_numeric($delta['y'] ?? null) ) {
+                continue;
+            }
+
+            $x = (int) round((float) $delta['x']);
+            $y = (int) round((float) $delta['y']);
+            $key = 'x:' . $x . '|y:' . $y;
+            $this->addClusterDiagnostic($groups, $key, $diagnostic, array('delta' => array('x' => $x, 'y' => $y)));
+        }
+
+        return array_values(array_filter(
+            $this->clusterValues($groups),
+            static fn (array $cluster): bool => 1 < (int) ($cluster['count'] ?? 0)
+        ));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    private function nodePatternClusters(array $diagnostics): array
+    {
+        $groups = array();
+        foreach ( $diagnostics as $diagnostic ) {
+            $node = is_array($diagnostic['node'] ?? null) ? $diagnostic['node'] : array();
+            $type = isset($node['type']) && is_scalar($node['type']) && '' !== (string) $node['type'] ? (string) $node['type'] : '(unknown)';
+            $namePattern = $this->namePattern(isset($node['name']) && is_scalar($node['name']) ? (string) $node['name'] : '');
+            $key = $type . '|' . $namePattern;
+            $this->addClusterDiagnostic($groups, $key, $diagnostic, array('type' => $type, 'name_pattern' => $namePattern));
+        }
+
+        return $this->clusterValues($groups);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $groups
+     * @param array<string, mixed> $diagnostic
+     * @param array<string, mixed> $fields
+     */
+    private function addClusterDiagnostic(array &$groups, string $key, array $diagnostic, array $fields): void
+    {
+        if ( ! isset($groups[$key]) ) {
+            $groups[$key] = array_merge($fields, array(
+                'count' => 0,
+                'max_delta' => 0.0,
+                'average_delta' => array('x' => 0.0, 'y' => 0.0),
+                'code_counts' => array(),
+                'sample_nodes' => array(),
+                '_delta_x_total' => 0.0,
+                '_delta_y_total' => 0.0,
+            ));
+        }
+
+        $delta = is_array($diagnostic['delta'] ?? null) ? $diagnostic['delta'] : array();
+        $deltaX = is_numeric($delta['x'] ?? null) ? (float) $delta['x'] : 0.0;
+        $deltaY = is_numeric($delta['y'] ?? null) ? (float) $delta['y'] : 0.0;
+        $groups[$key]['count']++;
+        $groups[$key]['_delta_x_total'] += $deltaX;
+        $groups[$key]['_delta_y_total'] += $deltaY;
+        $groups[$key]['max_delta'] = max((float) $groups[$key]['max_delta'], is_numeric($diagnostic['max_delta'] ?? null) ? (float) $diagnostic['max_delta'] : 0.0);
+
+        $code = isset($diagnostic['code']) && is_scalar($diagnostic['code']) ? (string) $diagnostic['code'] : '';
+        if ( '' !== $code ) {
+            $groups[$key]['code_counts'][$code] = ($groups[$key]['code_counts'][$code] ?? 0) + 1;
+        }
+
+        $node = is_array($diagnostic['node'] ?? null) ? $diagnostic['node'] : array();
+        if ( count($groups[$key]['sample_nodes']) < 3 ) {
+            $groups[$key]['sample_nodes'][] = array_filter(array(
+                'id' => isset($node['id']) && is_scalar($node['id']) ? (string) $node['id'] : null,
+                'name' => isset($node['name']) && is_scalar($node['name']) ? (string) $node['name'] : null,
+                'type' => isset($node['type']) && is_scalar($node['type']) ? (string) $node['type'] : null,
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+        }
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $groups
+     * @return array<int, array<string, mixed>>
+     */
+    private function clusterValues(array $groups): array
+    {
+        $clusters = array_values(array_map(
+            static function (array $cluster): array {
+                $count = max(1, (int) $cluster['count']);
+                $cluster['average_delta'] = array(
+                    'x' => round((float) $cluster['_delta_x_total'] / $count, 2),
+                    'y' => round((float) $cluster['_delta_y_total'] / $count, 2),
+                );
+                ksort($cluster['code_counts']);
+                unset($cluster['_delta_x_total'], $cluster['_delta_y_total']);
+                return $cluster;
+            },
+            $groups
+        ));
+
+        usort(
+            $clusters,
+            static fn (array $left, array $right): int => ((int) ($right['count'] ?? 0) <=> (int) ($left['count'] ?? 0)) ?: ((float) ($right['max_delta'] ?? 0.0) <=> (float) ($left['max_delta'] ?? 0.0))
+        );
+
+        return array_slice($clusters, 0, 10);
+    }
+
+    private function namePattern(string $name): string
+    {
+        $pattern = strtolower(trim(preg_replace('/\s+/', ' ', preg_replace('/\d+/', '#', $name) ?? '') ?? ''));
+        $pattern = trim(preg_replace('/[^a-z#]+/', ' ', $pattern) ?? '');
+
+        return '' === $pattern ? '(unnamed)' : $pattern;
     }
 
     /**

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -714,6 +714,7 @@ final class FigmaTransformer
             'layout_mismatch_count' => 0,
             'layout_mismatch_status' => 'not_evaluated',
             'layout_mismatches' => array(),
+            'layout_mismatch_clusters' => array(),
         );
         $fontFamilies = array();
         $missingCss = array();
@@ -796,6 +797,20 @@ final class FigmaTransformer
             foreach ( $pageLayoutMismatchDiagnostics as $item ) {
                 if ( is_array($item) ) {
                     $layout['layout_mismatches'][] = array_merge($pageContext, $item);
+                }
+            }
+            $pageLayoutMismatchClusters = is_array($pageLayoutMismatch['summary']['clusters'] ?? null) ? $pageLayoutMismatch['summary']['clusters'] : array();
+            foreach ( $pageLayoutMismatchClusters as $clusterType => $clusters ) {
+                if ( ! is_array($clusters) ) {
+                    continue;
+                }
+                if ( ! isset($layout['layout_mismatch_clusters'][$clusterType]) ) {
+                    $layout['layout_mismatch_clusters'][$clusterType] = array();
+                }
+                foreach ( $clusters as $cluster ) {
+                    if ( is_array($cluster) ) {
+                        $layout['layout_mismatch_clusters'][$clusterType][] = array_merge($pageContext, $cluster);
+                    }
                 }
             }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1314,12 +1314,62 @@ final class StaticHtmlEmitter
         }
 
         $padding = is_array($layout['padding'] ?? null) ? $layout['padding'] : array();
-        $childX = $x + ( isset($padding['left']) && is_numeric($padding['left']) ? (float) $padding['left'] : 0.0 );
-        $childY = $y + ( isset($padding['top']) && is_numeric($padding['top']) ? (float) $padding['top'] : 0.0 );
+        $paddingLeft = isset($padding['left']) && is_numeric($padding['left']) ? (float) $padding['left'] : 0.0;
+        $paddingRight = isset($padding['right']) && is_numeric($padding['right']) ? (float) $padding['right'] : 0.0;
+        $paddingTop = isset($padding['top']) && is_numeric($padding['top']) ? (float) $padding['top'] : 0.0;
+        $paddingBottom = isset($padding['bottom']) && is_numeric($padding['bottom']) ? (float) $padding['bottom'] : 0.0;
+        $childX = $x + $paddingLeft;
+        $childY = $y + $paddingTop;
         $gap = isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ? (float) $layout['item_spacing'] : 0.0;
-        $cursorX = $childX;
-        $cursorY = $childY;
         $isRow = 'row' === ($layout['flex_direction'] ?? null);
+        $isFlex = 'flex' === ($layout['display'] ?? null);
+        $contentWidth = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width'] - $paddingLeft - $paddingRight) : null;
+        $contentHeight = isset($box['height']) && is_numeric($box['height']) ? max(0.0, (float) $box['height'] - $paddingTop - $paddingBottom) : null;
+        $mainAxis = $isRow ? 'width' : 'height';
+        $crossAxis = $isRow ? 'height' : 'width';
+        $contentMainSize = $isRow ? $contentWidth : $contentHeight;
+        $contentCrossSize = $isRow ? $contentHeight : $contentWidth;
+        $flowChildren = array();
+
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
+                continue;
+            }
+
+            $flowChildren[] = $child;
+        }
+
+        $cursorMain = 0.0;
+        $visualGap = $gap;
+        if ( $isFlex && null !== $contentMainSize && ! empty($flowChildren) ) {
+            $totalMainSize = 0.0;
+            foreach ( $flowChildren as $child ) {
+                $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+                $totalMainSize += isset($childBox[$mainAxis]) && is_numeric($childBox[$mainAxis]) ? (float) $childBox[$mainAxis] : 0.0;
+            }
+
+            $totalMainSize += $gap * max(0, count($flowChildren) - 1);
+            $freeMainSpace = max(0.0, $contentMainSize - $totalMainSize);
+            $justifyContent = (string) ($layout['justify_content'] ?? 'flex-start');
+            if ( 'flex-end' === $justifyContent ) {
+                $cursorMain = $freeMainSpace;
+            } elseif ( 'center' === $justifyContent ) {
+                $cursorMain = $freeMainSpace / 2.0;
+            } elseif ( 'space-between' === $justifyContent && count($flowChildren) > 1 ) {
+                $visualGap += $freeMainSpace / (count($flowChildren) - 1);
+            } elseif ( 'space-around' === $justifyContent ) {
+                $visualGap += $freeMainSpace / count($flowChildren);
+                $cursorMain = $visualGap / 2.0;
+            } elseif ( 'space-evenly' === $justifyContent ) {
+                $visualGap += $freeMainSpace / (count($flowChildren) + 1);
+                $cursorMain = $visualGap;
+            }
+        }
 
         foreach ( $children as $child ) {
             if ( ! is_array($child) ) {
@@ -1333,13 +1383,44 @@ final class StaticHtmlEmitter
                 continue;
             }
 
-            $this->appendVisualNodeMap($child, $map, $cursorX, $cursorY, $node);
+            $childMainSize = isset($childBox[$mainAxis]) && is_numeric($childBox[$mainAxis]) ? (float) $childBox[$mainAxis] : 0.0;
+            $childCrossSize = isset($childBox[$crossAxis]) && is_numeric($childBox[$crossAxis]) ? (float) $childBox[$crossAxis] : 0.0;
+            $crossOffset = $this->visualFlexCrossAxisOffset($layout, $childLayout, $contentCrossSize, $childCrossSize);
             if ( $isRow ) {
-                $cursorX += ( isset($childBox['width']) && is_numeric($childBox['width']) ? (float) $childBox['width'] : 0.0 ) + $gap;
+                $this->appendVisualNodeMap($child, $map, $childX + $cursorMain, $childY + $crossOffset, $node);
             } else {
-                $cursorY += ( isset($childBox['height']) && is_numeric($childBox['height']) ? (float) $childBox['height'] : 0.0 ) + $gap;
+                $this->appendVisualNodeMap($child, $map, $childX + $crossOffset, $childY + $cursorMain, $node);
             }
+            $cursorMain += $childMainSize + $visualGap;
         }
+    }
+
+    /**
+     * @param array<string, mixed> $layout
+     * @param array<string, mixed> $childLayout
+     */
+    private function visualFlexCrossAxisOffset(array $layout, array $childLayout, ?float $contentCrossSize, float $childCrossSize): float
+    {
+        if ( null === $contentCrossSize || 'flex' !== ($layout['display'] ?? null) ) {
+            return 0.0;
+        }
+
+        $alignment = (string) ($layout['align_items'] ?? 'flex-start');
+        if ( isset($childLayout['align']) && is_scalar($childLayout['align']) ) {
+            $alignment = match ( strtoupper((string) $childLayout['align']) ) {
+                'CENTER' => 'center',
+                'MAX' => 'flex-end',
+                'STRETCH' => 'stretch',
+                default => $alignment,
+            };
+        }
+
+        $freeCrossSpace = max(0.0, $contentCrossSize - $childCrossSize);
+        return match ( $alignment ) {
+            'center' => $freeCrossSpace / 2.0,
+            'flex-end' => $freeCrossSpace,
+            default => 0.0,
+        };
     }
 
     /**
@@ -1419,7 +1500,7 @@ final class StaticHtmlEmitter
             $styles[] = 'opacity:' . $this->number((float) $box['opacity']);
         }
 
-        $transform = $this->transformStyle($box);
+        $transform = $this->isNearZeroHeightContainer($node, $type) ? null : $this->transformStyle($box);
         if ( null !== $transform ) {
             $styles[] = 'transform:' . $transform;
             if ( $this->hasExplicitTransformMatrix($box) ) {
@@ -1557,6 +1638,19 @@ final class StaticHtmlEmitter
         }
 
         return (float) $childBox['width'] > (float) $box['width'] || (float) $childBox['height'] > (float) $box['height'];
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isNearZeroHeightContainer(array $node, string $type): bool
+    {
+        if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE'), true) || empty($this->nodeList($node)) ) {
+            return false;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        return isset($box['height']) && is_numeric($box['height']) && 0.5 >= abs((float) $box['height']);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -139,6 +139,15 @@ $fileContent = static function (array $result, string $path): string {
 
     return '';
 };
+$findVisualNode = static function (array $result, string $id): ?array {
+    foreach ( $result['source_reports']['figma']['html']['visual_node_map'] ?? array() as $node ) {
+        if ( is_array($node) && $id === ($node['id'] ?? null) ) {
+            return $node;
+        }
+    }
+
+    return null;
+};
 
 $html = $fileContent($result, 'index.html');
 $css = $fileContent($result, 'style.css');
@@ -818,6 +827,37 @@ $assert(! str_contains($zeroHeightSeparatorHtml, 'data-figma-unsupported-vector=
 $assert(str_contains($zeroHeightSeparatorCss, '.figma-node-vector-zero-height-separator-wide-zero-height-separator{width:1004px;height:4px'), 'zero-height-separator-css-bounded-height');
 $assert(in_array('unsupported_vector_network_blob', $zeroHeightSeparatorDiagnosticCodes, true), 'zero-height-separator-keeps-network-diagnostic');
 
+$nearZeroContainerResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Near Zero Container Fixture',
+    'nodes' => array(
+        array(
+            'id'                => 'near-zero:container',
+            'type'              => 'FRAME',
+            'name'              => 'Decorative zero-height wrapper',
+            'width'             => 600,
+            'height'            => 0.0002,
+            'layoutMode'        => 'VERTICAL',
+            'relativeTransform' => array(
+                array(0.8, -0.6, 0),
+                array(0.6, 0.8, 0),
+            ),
+            'children'          => array(
+                array(
+                    'id'     => 'near-zero:child',
+                    'type'   => 'RECTANGLE',
+                    'name'   => 'Decorative child',
+                    'width'  => 600,
+                    'height' => 320,
+                ),
+            ),
+        ),
+    ),
+));
+$nearZeroContainerCss = $fileContent($nearZeroContainerResult, 'style.css');
+$assert(str_contains($nearZeroContainerCss, '.figma-node-near-zero-container-decorative-zero-height-wrapper{width:600px;min-height:0px;position:relative;display:flex;flex-direction:column}'), 'near-zero-container-keeps-zero-height-layout');
+$assert(! str_contains($nearZeroContainerCss, '.figma-node-near-zero-container-decorative-zero-height-wrapper{width:600px;min-height:0px;position:relative;transform:'), 'near-zero-container-suppresses-transform-bounds-inflation');
+$assert(str_contains($nearZeroContainerCss, '.figma-node-near-zero-child-decorative-child{width:600px;height:320px;position:absolute;flex-shrink:0}'), 'near-zero-container-keeps-child-rendering');
+
 $agenticChevronLeftPrefix = hex2bin('0600000006000000010000000000000000000041000080410000000000000000');
 $agenticChevronRightPrefix = hex2bin('06000000060000000100000000000000f4fdb43f0000804100000000be9f1641');
 $agenticChevronWrongCountsPrefix = hex2bin('0600000005000000010000000000000000000041000080410000000000000000');
@@ -965,6 +1005,30 @@ $assert('fail' === ($homeboyDomLayoutMismatch['status'] ?? null), 'layout-mismat
 $assert(in_array('element_size_mismatch', $homeboyDomLayoutMismatchCodes, true), 'layout-mismatch-homeboy-dom-size-code');
 $assert(-312.0 === ($homeboyDomMisplaced['delta']['x'] ?? null), 'layout-mismatch-homeboy-dom-x-delta');
 
+$clusteredLayoutMismatch = $layoutMismatchBuilder->build(
+    array(
+        'visual_node_map' => array(
+            array('id' => 'cluster:root', 'name' => 'Cluster Root', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 0, 'width' => 400, 'height' => 300)),
+            array('id' => 'cluster:item:1', 'parent_id' => 'cluster:root', 'name' => 'Item 1', 'type' => 'TEXT', 'rect' => array('x' => 20, 'y' => 40, 'width' => 120, 'height' => 20)),
+            array('id' => 'cluster:item:2', 'parent_id' => 'cluster:root', 'name' => 'Item 2', 'type' => 'TEXT', 'rect' => array('x' => 20, 'y' => 80, 'width' => 120, 'height' => 20)),
+        ),
+    ),
+    array(
+        'boxes' => array(
+            array('node_id' => 'cluster:root', 'rect' => array('x' => 0, 'y' => 0, 'width' => 400, 'height' => 300)),
+            array('node_id' => 'cluster:item:1', 'rect' => array('x' => 52, 'y' => 88, 'width' => 120, 'height' => 20)),
+            array('node_id' => 'cluster:item:2', 'rect' => array('x' => 52, 'y' => 128, 'width' => 120, 'height' => 20)),
+        ),
+    ),
+    array('threshold' => 24)
+);
+$clusterSummary = $clusteredLayoutMismatch['summary']['clusters'] ?? array();
+$assert(2 === ($clusterSummary['parent_delta'][0]['count'] ?? null), 'layout-mismatch-parent-delta-cluster-count');
+$assert('cluster:root' === ($clusterSummary['parent_delta'][0]['parent_id'] ?? null), 'layout-mismatch-parent-delta-cluster-parent');
+$assert(2 === ($clusterSummary['repeated_position_delta'][0]['count'] ?? null), 'layout-mismatch-repeated-delta-cluster-count');
+$assert(array('x' => 32, 'y' => 48) === ($clusterSummary['repeated_position_delta'][0]['delta'] ?? null), 'layout-mismatch-repeated-delta-cluster-values');
+$assert('item #' === ($clusterSummary['node_pattern'][0]['name_pattern'] ?? null), 'layout-mismatch-node-pattern-normalized-name');
+
 $layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name' => 'Layout Mismatch Fixture',
     'nodes' => array(
@@ -995,6 +1059,7 @@ $layoutMismatchArtifactQualityCodes = array_map(static fn (array $signal): strin
 $assert(0 < ($layoutMismatchTransformDiagnostics['layout']['layout_mismatch_count'] ?? 0), 'layout-mismatch-transform-count');
 $assert('fail' === ($layoutMismatchTransformDiagnostics['layout']['layout_mismatch_status'] ?? null), 'layout-mismatch-transform-status');
 $assert(in_array('layout_mismatch', $layoutMismatchArtifactQualityCodes, true), 'layout-mismatch-artifact-quality-signal');
+$assert(! empty($layoutMismatchTransformDiagnostics['layout']['layout_mismatch']['summary']['clusters']['parent_delta']), 'layout-mismatch-transform-parent-clusters');
 
 $layoutNotEvaluatedResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name' => 'Layout Not Evaluated Fixture',
@@ -2647,6 +2712,51 @@ $assert(str_contains($layoutFidelityCss, '.figma-node-5-4-fill-panel{width:100%;
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-5-absolute-badge{width:50px;height:20px;position:absolute;left:20px;right:430px;top:20px;bottom:260px;background:#000000;flex-shrink:0}'), 'layout-absolute-constraints-without-source-z-index');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-6-matrix-transform{width:30px;height:30px;transform:matrix(0,1,-1,0,40,60);transform-origin:0 0;flex-shrink:0}'), 'layout-relative-transform-matrix');
 $assert(! str_contains($layoutFidelityCss, 'font-family:Inter') && ! str_contains($layoutFidelityCss, 'body{margin:0;background') && ! str_contains($layoutFidelityCss, 'body{margin:0;color'), 'layout-css-avoids-theme-defaults');
+
+$visualFlexAlignmentResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Visual Flex Alignment Fixture',
+    'nodes' => array(
+        array(
+            'id'                    => 'visual-flex:row',
+            'type'                  => 'FRAME',
+            'name'                  => 'Visual flex row',
+            'width'                 => 500,
+            'height'                => 100,
+            'layoutMode'            => 'HORIZONTAL',
+            'primaryAxisAlignItems' => 'MAX',
+            'counterAxisAlignItems' => 'CENTER',
+            'itemSpacing'           => 20,
+            'children'              => array(
+                array('id' => 'visual-flex:first', 'type' => 'RECTANGLE', 'name' => 'First child', 'width' => 100, 'height' => 20),
+                array('id' => 'visual-flex:second', 'type' => 'RECTANGLE', 'name' => 'Second child', 'width' => 50, 'height' => 40),
+            ),
+        ),
+        array(
+            'id'                    => 'visual-flex:column',
+            'type'                  => 'FRAME',
+            'name'                  => 'Visual flex column',
+            'width'                 => 300,
+            'height'                => 200,
+            'layoutMode'            => 'VERTICAL',
+            'counterAxisAlignItems' => 'CENTER',
+            'paddingLeft'           => 20,
+            'paddingRight'          => 20,
+            'paddingTop'            => 10,
+            'children'              => array(
+                array('id' => 'visual-flex:centered', 'type' => 'RECTANGLE', 'name' => 'Centered child', 'width' => 100, 'height' => 30),
+            ),
+        ),
+    ),
+));
+$visualFlexFirst = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:first');
+$visualFlexSecond = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:second');
+$visualFlexCentered = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:centered');
+$assert(330.0 === ($visualFlexFirst['rect']['x'] ?? null), 'visual-map-flex-end-first-x');
+$assert(40.0 === ($visualFlexFirst['rect']['y'] ?? null), 'visual-map-flex-center-first-y');
+$assert(450.0 === ($visualFlexSecond['rect']['x'] ?? null), 'visual-map-flex-end-second-x');
+$assert(30.0 === ($visualFlexSecond['rect']['y'] ?? null), 'visual-map-flex-center-second-y');
+$assert(100.0 === ($visualFlexCentered['rect']['x'] ?? null), 'visual-map-column-center-child-x');
+$assert(10.0 === ($visualFlexCentered['rect']['y'] ?? null), 'visual-map-column-padding-child-y');
 
 $kiwiStackLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Kiwi Stack Layout Fixture',


### PR DESCRIPTION
## Summary
- model flex alignment, padding, gaps, and distributed spacing in the Figma visual node map used by layout mismatch diagnostics
- suppress transform bounds inflation for near-zero-height container wrappers with children
- cluster layout mismatches by parent delta, repeated position delta, and node pattern so the next generic fixes are easier to identify

## Verification
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php`
- `php -l figma-transformer/src/FigmaTransformer.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`
- targeted private FSE DOM matrix: layout mismatches dropped from 100 to 55, vector placeholders stayed 0, quality status stayed warn

## Notes
- Full Lab DOM matrix is still blocked until the Lab Homeboy binary includes `tunnel artifact-origin dom-boxes`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, subagent exploration, verification, targeted matrix evidence, and PR preparation
