### PR TITLE
Improve Figma layout matrix fidelity

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -771,14 +771,41 @@ function matrix_merge_parity_report(array $parity, array $report): array
  */
 function matrix_layout_summary(array $report): array
 {
-    $mismatches = is_array($report['mismatches'] ?? null) ? array_values($report['mismatches']) : array();
-    $topNodes = $report['top_nodes'] ?? $report['top_mismatches'] ?? array_slice($mismatches, 0, 5);
+    $mismatches = is_array($report['mismatches'] ?? null) ? array_values($report['mismatches']) : (is_array($report['diagnostics'] ?? null) ? array_values($report['diagnostics']) : array());
+    $topNodes = $report['top_nodes'] ?? $report['top_mismatches'] ?? matrix_layout_top_nodes($mismatches);
+    $summary = is_array($report['summary'] ?? null) ? $report['summary'] : array();
+    $suspectedCauses = $summary['suspected_causes'] ?? $report['suspected_causes'] ?? array();
 
     return array(
         'status' => $report['status'] ?? null,
-        'mismatch_count' => matrix_first_numeric($report, array('layout_mismatch_count', 'mismatch_count', 'count')) ?? count($mismatches),
+        'mismatch_count' => matrix_first_numeric($summary, array('diagnostic_count', 'layout_mismatch_count', 'mismatch_count', 'count')) ?? matrix_first_numeric($report, array('layout_mismatch_count', 'mismatch_count', 'count')) ?? count($mismatches),
         'top_nodes' => is_array($topNodes) ? array_slice(array_values($topNodes), 0, 5) : array(),
+        'suspected_causes' => is_array($suspectedCauses) ? array_slice(array_values($suspectedCauses), 0, 5) : array(),
     );
+}
+
+/**
+ * @param array<int, mixed> $mismatches
+ * @return array<int, array<string, mixed>>
+ */
+function matrix_layout_top_nodes(array $mismatches): array
+{
+    $nodes = array();
+    foreach ( array_slice($mismatches, 0, 5) as $mismatch ) {
+        if ( ! is_array($mismatch) ) {
+            continue;
+        }
+        $node = is_array($mismatch['node'] ?? null) ? $mismatch['node'] : $mismatch;
+        $nodes[] = array_filter(array(
+            'id' => isset($node['id']) && is_scalar($node['id']) ? (string) $node['id'] : null,
+            'name' => isset($node['name']) && is_scalar($node['name']) ? (string) $node['name'] : null,
+            'type' => isset($node['type']) && is_scalar($node['type']) ? (string) $node['type'] : null,
+            'code' => isset($mismatch['code']) && is_scalar($mismatch['code']) ? (string) $mismatch['code'] : null,
+            'max_delta' => isset($mismatch['max_delta']) && is_numeric($mismatch['max_delta']) ? (float) $mismatch['max_delta'] : null,
+        ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+    }
+
+    return $nodes;
 }
 
 /**
@@ -812,6 +839,7 @@ function matrix_parity_summary(array $parity): array
         'pixel_mismatch_ratio' => $metrics['pixel_mismatch_ratio'] ?? $diffSummary['pixel_mismatch_ratio'] ?? null,
         'layout_mismatch_count' => $layout['mismatch_count'] ?? null,
         'layout_top_nodes' => is_array($layout['top_nodes'] ?? null) ? array_slice($layout['top_nodes'], 0, 5) : array(),
+        'layout_suspected_causes' => is_array($layout['suspected_causes'] ?? null) ? array_slice($layout['suspected_causes'], 0, 5) : array(),
     );
 }
 

--- a/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
+++ b/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
@@ -46,10 +46,12 @@ final class LayoutMismatchReportBuilder
             $delta = $this->delta($sourceBox, $generatedBox);
             $positionMismatch = abs($delta['x']) > $threshold || abs($delta['y']) > $threshold;
             $sizeMismatch = abs($delta['width']) > $sizeThreshold || abs($delta['height']) > $sizeThreshold;
-            $outsideParent = $this->outsideGeneratedParent($sourceNode, $generatedNode, $generatedNodes, $threshold);
+            $outsideParent = $this->outsideGeneratedParent($sourceNode, $generatedNode, $sourceNodes, $generatedNodes, $threshold);
             if ( ! $positionMismatch && ! $sizeMismatch && null === $outsideParent ) {
                 continue;
             }
+
+            $context = $this->diagnosticContext($sourceNode, $generatedNode, $sourceNodes, $generatedNodes);
 
             if ( $positionMismatch || $sizeMismatch ) {
                 $diagnostics[] = $this->diagnostic(
@@ -60,17 +62,18 @@ final class LayoutMismatchReportBuilder
                     $generatedBox,
                     $delta,
                     $threshold,
-                    $sizeThreshold
+                    $sizeThreshold,
+                    $context
                 );
             }
 
             if ( $positionMismatch && $sizeMismatch ) {
-                $diagnostics[] = $this->diagnostic('element_size_mismatch', $sourceNode, $generatedNode, $sourceBox, $generatedBox, $delta, $threshold, $sizeThreshold);
+                $diagnostics[] = $this->diagnostic('element_size_mismatch', $sourceNode, $generatedNode, $sourceBox, $generatedBox, $delta, $threshold, $sizeThreshold, $context);
             }
 
             if ( null !== $outsideParent ) {
                 $diagnostics[] = array_merge(
-                    $this->diagnostic('element_outside_parent_bounds', $sourceNode, $generatedNode, $sourceBox, $generatedBox, $delta, $threshold, $sizeThreshold),
+                    $this->diagnostic('element_outside_parent_bounds', $sourceNode, $generatedNode, $sourceBox, $generatedBox, $delta, $threshold, $sizeThreshold, $context),
                     array('parent' => $outsideParent)
                 );
             }
@@ -105,6 +108,7 @@ final class LayoutMismatchReportBuilder
                 'diagnostic_count' => count($diagnostics),
                 'code_counts' => $codeCounts,
                 'clusters' => $this->diagnosticClusters($diagnostics),
+                'suspected_causes' => $this->suspectedCauseSummary($diagnostics),
             ),
             'diagnostics' => $diagnostics,
         );
@@ -180,6 +184,130 @@ final class LayoutMismatchReportBuilder
         }
 
         return $this->clusterValues($groups);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    private function suspectedCauseSummary(array $diagnostics): array
+    {
+        $groups = array();
+        foreach ( $diagnostics as $diagnostic ) {
+            foreach ( $this->suspectedCausesForDiagnostic($diagnostic) as $cause ) {
+                $this->addClusterDiagnostic($groups, $cause, $diagnostic, array('cause' => $cause));
+            }
+        }
+
+        $causes = $this->clusterValues($groups);
+        usort(
+            $causes,
+            fn (array $left, array $right): int => $this->suspectedCausePriority((string) ($left['cause'] ?? '')) <=> $this->suspectedCausePriority((string) ($right['cause'] ?? ''))
+                ?: ((int) ($right['count'] ?? 0) <=> (int) ($left['count'] ?? 0))
+                ?: ((float) ($right['max_delta'] ?? 0.0) <=> (float) ($left['max_delta'] ?? 0.0))
+        );
+
+        return $causes;
+    }
+
+    private function suspectedCausePriority(string $cause): int
+    {
+        return match ( $cause ) {
+            'source-overflow', 'generated-vs-source-clipping', 'clipping' => 0,
+            'parent-visual-map-mismatch' => 1,
+            'same-size-position-shift', 'absolute-offset' => 2,
+            'zero-size-source-box' => 3,
+            'root-fill' => 4,
+            'text-height' => 5,
+            'vector-shell-wrapper-offset' => 6,
+            'icon/vector-bounds' => 7,
+            default => 99,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $diagnostic
+     * @return array<int, string>
+     */
+    private function suspectedCausesForDiagnostic(array $diagnostic): array
+    {
+        $causes = array();
+        $code = isset($diagnostic['code']) && is_scalar($diagnostic['code']) ? (string) $diagnostic['code'] : '';
+        $node = is_array($diagnostic['node'] ?? null) ? $diagnostic['node'] : array();
+        $type = strtoupper(isset($node['type']) && is_scalar($node['type']) ? (string) $node['type'] : '');
+        $name = strtolower(isset($node['name']) && is_scalar($node['name']) ? (string) $node['name'] : '');
+        $delta = is_array($diagnostic['delta'] ?? null) ? $diagnostic['delta'] : array();
+        $threshold = is_numeric($diagnostic['threshold'] ?? null) ? (float) $diagnostic['threshold'] : 0.0;
+        $sizeThreshold = is_numeric($diagnostic['size_threshold'] ?? null) ? (float) $diagnostic['size_threshold'] : $threshold;
+        $deltaX = is_numeric($delta['x'] ?? null) ? (float) $delta['x'] : 0.0;
+        $deltaY = is_numeric($delta['y'] ?? null) ? (float) $delta['y'] : 0.0;
+        $deltaWidth = is_numeric($delta['width'] ?? null) ? (float) $delta['width'] : 0.0;
+        $deltaHeight = is_numeric($delta['height'] ?? null) ? (float) $delta['height'] : 0.0;
+        $sourceBox = is_array($diagnostic['source_box'] ?? null) ? $diagnostic['source_box'] : array();
+        $parentDelta = is_array($diagnostic['parent_delta'] ?? null) ? $diagnostic['parent_delta'] : array();
+        $positionShift = max(abs($deltaX), abs($deltaY));
+        $sizeShift = max(abs($deltaWidth), abs($deltaHeight));
+
+        if ( 'element_outside_parent_bounds' === $code ) {
+            $parent = is_array($diagnostic['parent'] ?? null) ? $diagnostic['parent'] : array();
+            $sourceOverflow = is_array($parent['source_overflow'] ?? null) ? $parent['source_overflow'] : array();
+            $sourceOverflowMax = max(array_map(static fn (mixed $value): float => is_numeric($value) ? (float) $value : 0.0, $sourceOverflow) ?: array(0.0));
+            if ( 0.0 < $sourceOverflowMax ) {
+                $causes[] = 'source-overflow';
+            } else {
+                $causes[] = 'generated-vs-source-clipping';
+                $causes[] = 'clipping';
+            }
+        }
+
+        if ( 'misplaced_element' === $code && $positionShift > $threshold && $sizeShift <= $sizeThreshold ) {
+            $causes[] = 'same-size-position-shift';
+        }
+
+        if ( 'misplaced_element' === $code && $positionShift > max($threshold, $sizeShift) ) {
+            $causes[] = 'absolute-offset';
+        }
+
+        if ( is_numeric($parentDelta['x'] ?? null) && is_numeric($parentDelta['y'] ?? null) && $positionShift > $threshold ) {
+            $parentDeltaX = (float) $parentDelta['x'];
+            $parentDeltaY = (float) $parentDelta['y'];
+            if ( max(abs($parentDeltaX), abs($parentDeltaY)) > $threshold && abs($deltaX - $parentDeltaX) <= 2.0 && abs($deltaY - $parentDeltaY) <= 2.0 ) {
+                $causes[] = 'parent-visual-map-mismatch';
+            }
+        }
+
+        if ( $this->isNearZeroBox($sourceBox) && ($positionShift > $threshold || $sizeShift > $sizeThreshold) ) {
+            $causes[] = 'zero-size-source-box';
+        }
+
+        if ( 'TEXT' === $type && abs($deltaHeight) > $sizeThreshold ) {
+            $causes[] = 'text-height';
+        }
+
+        if ( '' === (string) ($node['parent_id'] ?? '') && (abs($deltaWidth) > $sizeThreshold || abs($deltaHeight) > $sizeThreshold) ) {
+            $causes[] = 'root-fill';
+        }
+
+        if ( ('VECTOR' === $type || str_contains($name, 'icon')) && (abs($deltaWidth) > $sizeThreshold || abs($deltaHeight) > $sizeThreshold) ) {
+            $causes[] = 'icon/vector-bounds';
+        }
+
+        if ( ('VECTOR' === $type || 'BOOLEAN_OPERATION' === $type) && 'misplaced_element' === $code && $positionShift > $threshold && $sizeShift <= $sizeThreshold ) {
+            $causes[] = 'vector-shell-wrapper-offset';
+        }
+
+        return array_values(array_unique($causes));
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     */
+    private function isNearZeroBox(array $box): bool
+    {
+        $width = is_numeric($box['width'] ?? null) ? abs((float) $box['width']) : null;
+        $height = is_numeric($box['height'] ?? null) ? abs((float) $box['height']) : null;
+
+        return null !== $width && null !== $height && ($width <= 1.0 || $height <= 1.0);
     }
 
     /**
@@ -409,10 +537,11 @@ final class LayoutMismatchReportBuilder
     /**
      * @param array<string, mixed> $sourceNode
      * @param array<string, mixed> $generatedNode
+     * @param array<string, array<string, mixed>> $sourceNodes
      * @param array<string, array<string, mixed>> $generatedNodes
      * @return array<string, mixed>|null
      */
-    private function outsideGeneratedParent(array $sourceNode, array $generatedNode, array $generatedNodes, float $threshold): ?array
+    private function outsideGeneratedParent(array $sourceNode, array $generatedNode, array $sourceNodes, array $generatedNodes, float $threshold): ?array
     {
         $parentId = isset($sourceNode['parent_id']) && is_scalar($sourceNode['parent_id']) ? (string) $sourceNode['parent_id'] : '';
         if ( '' === $parentId || ! isset($generatedNodes[$parentId]) ) {
@@ -425,22 +554,68 @@ final class LayoutMismatchReportBuilder
             return null;
         }
 
-        $overflow = array(
-            'left' => max(0.0, $parentBox['x'] - $childBox['x']),
-            'top' => max(0.0, $parentBox['y'] - $childBox['y']),
-            'right' => max(0.0, ($childBox['x'] + $childBox['width']) - ($parentBox['x'] + $parentBox['width'])),
-            'bottom' => max(0.0, ($childBox['y'] + $childBox['height']) - ($parentBox['y'] + $parentBox['height'])),
-        );
+        $overflow = $this->parentOverflow($parentBox, $childBox);
         $maxOverflow = max($overflow);
         if ( $maxOverflow <= $threshold ) {
             return null;
         }
 
-        return array(
+        $sourceParentBox = isset($sourceNodes[$parentId]) ? $this->boxFromNode($sourceNodes[$parentId]) : null;
+        $sourceChildBox = $this->boxFromNode($sourceNode);
+        $sourceOverflow = null;
+        if ( null !== $sourceParentBox && null !== $sourceChildBox ) {
+            $sourceOverflow = $this->parentOverflow($sourceParentBox, $sourceChildBox);
+            if ( $maxOverflow <= max($sourceOverflow) + $threshold ) {
+                return null;
+            }
+        }
+
+        return array_filter(array(
             'id' => $parentId,
             'generated_box' => $parentBox,
             'overflow' => $overflow,
             'max_overflow' => $maxOverflow,
+            'source_overflow' => $sourceOverflow,
+        ), static fn (mixed $value): bool => null !== $value);
+    }
+
+    /**
+     * @param array{x: float, y: float, width: float, height: float} $parentBox
+     * @param array{x: float, y: float, width: float, height: float} $childBox
+     * @return array{left: float, top: float, right: float, bottom: float}
+     */
+    private function parentOverflow(array $parentBox, array $childBox): array
+    {
+        return array(
+            'left' => max(0.0, $parentBox['x'] - $childBox['x']),
+            'top' => max(0.0, $parentBox['y'] - $childBox['y']),
+            'right' => max(0.0, ($childBox['x'] + $childBox['width']) - ($parentBox['x'] + $parentBox['width'])),
+            'bottom' => max(0.0, ($childBox['y'] + $childBox['height']) - ($parentBox['y'] + $parentBox['height'])),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $sourceNode
+     * @param array<string, mixed> $generatedNode
+     * @param array<string, array<string, mixed>> $sourceNodes
+     * @param array<string, array<string, mixed>> $generatedNodes
+     * @return array<string, mixed>
+     */
+    private function diagnosticContext(array $sourceNode, array $generatedNode, array $sourceNodes, array $generatedNodes): array
+    {
+        $parentId = isset($sourceNode['parent_id']) && is_scalar($sourceNode['parent_id']) ? (string) $sourceNode['parent_id'] : '';
+        if ( '' === $parentId || ! isset($sourceNodes[$parentId], $generatedNodes[$parentId]) ) {
+            return array();
+        }
+
+        $sourceParentBox = $this->boxFromNode($sourceNodes[$parentId]);
+        $generatedParentBox = $this->boxFromNode($generatedNodes[$parentId]);
+        if ( null === $sourceParentBox || null === $generatedParentBox ) {
+            return array();
+        }
+
+        return array(
+            'parent_delta' => $this->delta($sourceParentBox, $generatedParentBox),
         );
     }
 
@@ -450,11 +625,12 @@ final class LayoutMismatchReportBuilder
      * @param array{x: float, y: float, width: float, height: float} $sourceBox
      * @param array{x: float, y: float, width: float, height: float} $generatedBox
      * @param array{x: float, y: float, width: float, height: float} $delta
+     * @param array<string, mixed> $context
      * @return array<string, mixed>
      */
-    private function diagnostic(string $code, array $sourceNode, array $generatedNode, array $sourceBox, array $generatedBox, array $delta, float $threshold, float $sizeThreshold): array
+    private function diagnostic(string $code, array $sourceNode, array $generatedNode, array $sourceBox, array $generatedBox, array $delta, float $threshold, float $sizeThreshold, array $context = array()): array
     {
-        return array_filter(array(
+        return array_filter(array_merge(array(
             'severity' => 'warning',
             'code' => $code,
             'node' => array(
@@ -472,6 +648,6 @@ final class LayoutMismatchReportBuilder
             'page_path' => isset($generatedNode['page_path']) && is_scalar($generatedNode['page_path']) ? (string) $generatedNode['page_path'] : null,
             'frame_id' => isset($generatedNode['frame_id']) && is_scalar($generatedNode['frame_id']) ? (string) $generatedNode['frame_id'] : null,
             'selector' => isset($generatedNode['selector']) && is_scalar($generatedNode['selector']) ? (string) $generatedNode['selector'] : null,
-        ), static fn (mixed $value): bool => null !== $value);
+        ), $context), static fn (mixed $value): bool => null !== $value);
     }
 }

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -57,7 +57,7 @@ final class StaticHtmlEmitter
             'html{box-sizing:border-box}',
             '*,*::before,*::after{box-sizing:inherit}',
             'body{margin:0}',
-            '.figma-root{position:relative;width:100%;max-width:100%}',
+            '.figma-root{position:relative;min-width:100%;width:max-content}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -164,7 +164,7 @@ final class StaticHtmlEmitter
             'html{box-sizing:border-box}',
             '*,*::before,*::after{box-sizing:inherit}',
             'body{margin:0}',
-            '.figma-root{position:relative;width:100%;max-width:100%}',
+            '.figma-root{position:relative;min-width:100%;width:max-content}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -368,6 +368,9 @@ final class StaticHtmlEmitter
         if ( ! ( 'BOOLEAN_OPERATION' === $type && null !== $vectorSvg ) ) {
             foreach ( $children as $child ) {
                 if ( is_array($child) ) {
+                    if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
+                        continue;
+                    }
                     $content .= $this->emitNode($child, $cssRules, $diagnostics, $nodeStyleDiagnostics, $depth + 1, $node);
                 }
             }
@@ -679,7 +682,7 @@ final class StaticHtmlEmitter
         $map = array();
         foreach ( $nodes as $node ) {
             if ( is_array($node) ) {
-                $this->appendVisualNodeMap($node, $map, 0.0, 0.0, null);
+                $this->appendVisualNodeMap($node, $map, 0.0, 0.0, null, null);
             }
         }
 
@@ -1073,6 +1076,9 @@ final class StaticHtmlEmitter
 
         foreach ( $this->nodeList($node) as $child ) {
             if ( is_array($child) ) {
+                if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
+                    continue;
+                }
                 $this->collectTransformDiagnostics($child, $image, $vectors, $layout, $node);
             }
         }
@@ -1267,8 +1273,12 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $node
      * @param array<int, array<string, mixed>> $map
      */
-    private function appendVisualNodeMap(array $node, array &$map, float $x, float $y, ?array $parentNode): void
+    private function appendVisualNodeMap(array $node, array &$map, float $x, float $y, ?array $parentNode, ?array $clipRect): void
     {
+        if ( $this->isFullyTransparentVisualNode($node) ) {
+            return;
+        }
+
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
         $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
@@ -1283,6 +1293,15 @@ final class StaticHtmlEmitter
 
         $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
         $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
+        $nodeRect = null !== $width && null !== $height ? array('x' => $x, 'y' => $y, 'width' => $width, 'height' => $height) : null;
+        $mapRect = $nodeRect;
+        if ( null !== $nodeRect && null !== $clipRect && $this->isClippableDecorativeVisualNode($node) ) {
+            $mapRect = $this->rectIntersection($nodeRect, $clipRect);
+            if ( null === $mapRect ) {
+                return;
+            }
+        }
+
         if ( null !== $width && null !== $height ) {
             $imagePaint = $this->firstImagePaint($node);
             $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
@@ -1291,12 +1310,7 @@ final class StaticHtmlEmitter
                 'parent_id' => null !== $parentNode ? (string) ($parentNode['id'] ?? '') : '',
                 'name' => (string) ($node['name'] ?? ''),
                 'type' => strtoupper((string) ($node['type'] ?? '')),
-                'rect' => array(
-                    'x' => $x,
-                    'y' => $y,
-                    'width' => $width,
-                    'height' => $height,
-                ),
+                'rect' => $mapRect,
                 'layout' => array(
                     'display' => $layout['display'] ?? null,
                     'flex_direction' => $layout['flex_direction'] ?? null,
@@ -1311,6 +1325,14 @@ final class StaticHtmlEmitter
         $children = $this->nodeList($node);
         if ( empty($children) ) {
             return;
+        }
+
+        $childClipRect = $clipRect;
+        if ( null !== $nodeRect && true === ($layout['clips_content'] ?? false) ) {
+            $childClipRect = null === $childClipRect ? $nodeRect : $this->rectIntersection($childClipRect, $nodeRect);
+            if ( null === $childClipRect ) {
+                return;
+            }
         }
 
         $padding = is_array($layout['padding'] ?? null) ? $layout['padding'] : array();
@@ -1336,6 +1358,10 @@ final class StaticHtmlEmitter
                 continue;
             }
 
+            if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
+                continue;
+            }
+
             $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
             if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
                 continue;
@@ -1344,55 +1370,180 @@ final class StaticHtmlEmitter
             $flowChildren[] = $child;
         }
 
-        $cursorMain = 0.0;
-        $visualGap = $gap;
-        if ( $isFlex && null !== $contentMainSize && ! empty($flowChildren) ) {
-            $totalMainSize = 0.0;
-            foreach ( $flowChildren as $child ) {
-                $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
-                $totalMainSize += isset($childBox[$mainAxis]) && is_numeric($childBox[$mainAxis]) ? (float) $childBox[$mainAxis] : 0.0;
-            }
-
-            $totalMainSize += $gap * max(0, count($flowChildren) - 1);
-            $freeMainSpace = max(0.0, $contentMainSize - $totalMainSize);
-            $justifyContent = (string) ($layout['justify_content'] ?? 'flex-start');
-            if ( 'flex-end' === $justifyContent ) {
-                $cursorMain = $freeMainSpace;
-            } elseif ( 'center' === $justifyContent ) {
-                $cursorMain = $freeMainSpace / 2.0;
-            } elseif ( 'space-between' === $justifyContent && count($flowChildren) > 1 ) {
-                $visualGap += $freeMainSpace / (count($flowChildren) - 1);
-            } elseif ( 'space-around' === $justifyContent ) {
-                $visualGap += $freeMainSpace / count($flowChildren);
-                $cursorMain = $visualGap / 2.0;
-            } elseif ( 'space-evenly' === $justifyContent ) {
-                $visualGap += $freeMainSpace / (count($flowChildren) + 1);
-                $cursorMain = $visualGap;
-            }
-        }
+        $flowPositions = $this->visualFlexChildPositions($flowChildren, $layout, $isFlex, $isRow, $mainAxis, $crossAxis, $contentMainSize, $contentCrossSize, $gap);
 
         foreach ( $children as $child ) {
             if ( ! is_array($child) ) {
                 continue;
             }
 
-            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
-            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
-            if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
-                $this->appendVisualNodeMap($child, $map, $x, $y, $node);
+            if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
                 continue;
             }
 
+            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
+                $this->appendVisualNodeMap($child, $map, $x, $y, $node, $childClipRect);
+                continue;
+            }
+
+            $nodeId = (string) ($child['id'] ?? '');
+            $position = '' !== $nodeId && isset($flowPositions[$nodeId]) ? $flowPositions[$nodeId] : array('main' => 0.0, 'cross' => 0.0);
+            if ( $isRow ) {
+                $this->appendVisualNodeMap($child, $map, $childX + $position['main'], $childY + $position['cross'], $node, $childClipRect);
+            } else {
+                $this->appendVisualNodeMap($child, $map, $childX + $position['cross'], $childY + $position['main'], $node, $childClipRect);
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $children
+     * @param array<string, mixed> $layout
+     * @return array<string, array{main: float, cross: float}>
+     */
+    private function visualFlexChildPositions(array $children, array $layout, bool $isFlex, bool $isRow, string $mainAxis, string $crossAxis, ?float $contentMainSize, ?float $contentCrossSize, float $gap): array
+    {
+        $positions = array();
+        if ( empty($children) ) {
+            return $positions;
+        }
+
+        $wrap = $isFlex && null !== $contentMainSize && 'wrap' === ($layout['flex_wrap'] ?? null);
+        $lines = array();
+        $currentLine = array('children' => array(), 'main_size' => 0.0, 'cross_size' => 0.0);
+        foreach ( $children as $child ) {
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
             $childMainSize = isset($childBox[$mainAxis]) && is_numeric($childBox[$mainAxis]) ? (float) $childBox[$mainAxis] : 0.0;
             $childCrossSize = isset($childBox[$crossAxis]) && is_numeric($childBox[$crossAxis]) ? (float) $childBox[$crossAxis] : 0.0;
-            $crossOffset = $this->visualFlexCrossAxisOffset($layout, $childLayout, $contentCrossSize, $childCrossSize);
-            if ( $isRow ) {
-                $this->appendVisualNodeMap($child, $map, $childX + $cursorMain, $childY + $crossOffset, $node);
-            } else {
-                $this->appendVisualNodeMap($child, $map, $childX + $crossOffset, $childY + $cursorMain, $node);
+            $lineChildCount = count($currentLine['children']);
+            $candidateMainSize = (float) $currentLine['main_size'] + ($lineChildCount > 0 ? $gap : 0.0) + $childMainSize;
+            if ( $wrap && $lineChildCount > 0 && $candidateMainSize > $contentMainSize + 0.001 ) {
+                $lines[] = $currentLine;
+                $currentLine = array('children' => array(), 'main_size' => 0.0, 'cross_size' => 0.0);
+                $lineChildCount = 0;
+                $candidateMainSize = $childMainSize;
             }
-            $cursorMain += $childMainSize + $visualGap;
+
+            $currentLine['children'][] = array('node' => $child, 'main_size' => $childMainSize, 'cross_size' => $childCrossSize);
+            $currentLine['main_size'] = $candidateMainSize;
+            $currentLine['cross_size'] = max((float) $currentLine['cross_size'], $childCrossSize);
         }
+        if ( ! empty($currentLine['children']) ) {
+            $lines[] = $currentLine;
+        }
+
+        $lineCrossOffset = 0.0;
+        foreach ( $lines as $line ) {
+            $lineChildren = is_array($line['children'] ?? null) ? $line['children'] : array();
+            $lineMainSize = (float) ($line['main_size'] ?? 0.0);
+            $lineCrossSize = (float) ($line['cross_size'] ?? 0.0);
+            $cursorMain = 0.0;
+            $visualGap = $gap;
+            if ( $isFlex && null !== $contentMainSize ) {
+                $freeMainSpace = max(0.0, $contentMainSize - $lineMainSize);
+                $justifyContent = (string) ($layout['justify_content'] ?? 'flex-start');
+                if ( 'flex-end' === $justifyContent ) {
+                    $cursorMain = $freeMainSpace;
+                } elseif ( 'center' === $justifyContent ) {
+                    $cursorMain = $freeMainSpace / 2.0;
+                } elseif ( 'space-between' === $justifyContent && count($lineChildren) > 1 ) {
+                    $visualGap += $freeMainSpace / (count($lineChildren) - 1);
+                } elseif ( 'space-around' === $justifyContent ) {
+                    $visualGap += $freeMainSpace / count($lineChildren);
+                    $cursorMain = $visualGap / 2.0;
+                } elseif ( 'space-evenly' === $justifyContent ) {
+                    $visualGap += $freeMainSpace / (count($lineChildren) + 1);
+                    $cursorMain = $visualGap;
+                }
+            }
+
+            foreach ( $lineChildren as $lineChild ) {
+                $child = is_array($lineChild['node'] ?? null) ? $lineChild['node'] : array();
+                $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+                $childMainSize = (float) ($lineChild['main_size'] ?? 0.0);
+                $childCrossSize = (float) ($lineChild['cross_size'] ?? 0.0);
+                $nodeId = (string) ($child['id'] ?? '');
+                if ( '' !== $nodeId ) {
+                    $positions[$nodeId] = array(
+                        'main' => $cursorMain,
+                        'cross' => $lineCrossOffset + $this->visualFlexCrossAxisOffset($layout, $childLayout, $wrap ? $lineCrossSize : $contentCrossSize, $childCrossSize),
+                    );
+                }
+
+                $cursorMain += $childMainSize + $visualGap;
+            }
+
+            $lineCrossOffset += $lineCrossSize + ($wrap ? $gap : 0.0);
+        }
+
+        return $positions;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isClippableDecorativeVisualNode(array $node): bool
+    {
+        return ! $this->treeHasText($node) && ! $this->treeHasImageReference($node) && $this->treeIsVectorShapeOnly($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $parentNode
+     */
+    private function isFullyClippedDecorativeChild(array $node, array $parentNode): bool
+    {
+        $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        if ( true !== ($parentLayout['clips_content'] ?? false) || ! $this->isClippableDecorativeVisualNode($node) ) {
+            return false;
+        }
+
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        if ( ! isset($parentBox['width'], $parentBox['height'], $box['width'], $box['height']) || ! is_numeric($parentBox['width']) || ! is_numeric($parentBox['height']) || ! is_numeric($box['width']) || ! is_numeric($box['height']) ) {
+            return false;
+        }
+
+        $left = $this->positionOffset($box, $parentBox, 'x', $parentNode);
+        $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
+        if ( null === $left || null === $top ) {
+            return false;
+        }
+
+        $parentRect = array('x' => 0.0, 'y' => 0.0, 'width' => (float) $parentBox['width'], 'height' => (float) $parentBox['height']);
+        $childRect = array('x' => $left, 'y' => $top, 'width' => (float) $box['width'], 'height' => (float) $box['height']);
+
+        return null === $this->rectIntersection($parentRect, $childRect);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isFullyTransparentVisualNode(array $node): bool
+    {
+        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        $opacity = $box['opacity'] ?? $node['opacity'] ?? null;
+
+        return is_numeric($opacity) && 0.001 >= (float) $opacity;
+    }
+
+    /**
+     * @param array{x: float, y: float, width: float, height: float} $rect
+     * @param array{x: float, y: float, width: float, height: float} $clipRect
+     * @return array{x: float, y: float, width: float, height: float}|null
+     */
+    private function rectIntersection(array $rect, array $clipRect): ?array
+    {
+        $left = max($rect['x'], $clipRect['x']);
+        $top = max($rect['y'], $clipRect['y']);
+        $right = min($rect['x'] + $rect['width'], $clipRect['x'] + $clipRect['width']);
+        $bottom = min($rect['y'] + $rect['height'], $clipRect['y'] + $clipRect['height']);
+        if ( $right <= $left || $bottom <= $top ) {
+            return null;
+        }
+
+        return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
     }
 
     /**
@@ -1438,16 +1589,14 @@ final class StaticHtmlEmitter
             $sizingKey = 'width' === $dimension ? 'sizing_horizontal' : 'sizing_vertical';
             $sizing = strtoupper((string) ($layout[$sizingKey] ?? ''));
             if ( 'HUG' === $sizing ) {
-                $styles[] = $dimension . ':fit-content';
+                if ( 'flex' === ($layout['display'] ?? null) && isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
+                    $styles[] = $dimension . ':' . $this->number((float) $box[$dimension]) . 'px';
+                } else {
+                    $styles[] = $dimension . ':fit-content';
+                }
             } elseif ( 'FILL' === $sizing ) {
                 $styles[] = $dimension . ':100%';
             } elseif ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
-                if ( true === ($node['_selected_frame_root'] ?? false) && null === $parentNode && 'width' === $dimension ) {
-                    $styles[] = 'width:100%';
-                    $styles[] = 'max-width:' . $this->number((float) $box[$dimension]) . 'px';
-                    continue;
-                }
-
                 $property = null === $parentNode && 'height' === $dimension && 'flex' === ($layout['display'] ?? null) ? 'min-height' : $dimension;
                 $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
                 $styles[] = $property . ':' . $this->number($value) . 'px';
@@ -1545,6 +1694,9 @@ final class StaticHtmlEmitter
                 $styles[] = $property . ':' . (string) $layout[$source];
             }
         }
+        if ( 'wrap' === ($layout['flex_wrap'] ?? null) ) {
+            $styles[] = 'align-content:flex-start';
+        }
 
         if ( isset($layout['padding']) && is_array($layout['padding']) ) {
             foreach ( array('top', 'right', 'bottom', 'left') as $edge ) {
@@ -1627,6 +1779,10 @@ final class StaticHtmlEmitter
             return true;
         }
 
+        if ( empty($node['layout']['display'] ?? null) && $this->hasPositionedSourceChild($node, $children) ) {
+            return true;
+        }
+
         if ( 1 !== count($children) || ! is_array($children[0]) ) {
             return false;
         }
@@ -1638,6 +1794,34 @@ final class StaticHtmlEmitter
         }
 
         return (float) $childBox['width'] > (float) $box['width'] || (float) $childBox['height'] > (float) $box['height'];
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<int, mixed> $children
+     */
+    private function hasPositionedSourceChild(array $node, array $children): bool
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION'), true) ) {
+            return false;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            $left = $this->positionOffset($childBox, $box, 'x', $node);
+            $top = $this->positionOffset($childBox, $box, 'y', $node);
+            if ( (null !== $left && abs($left) > 0.5) || (null !== $top && abs($top) > 0.5) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -1685,7 +1869,7 @@ final class StaticHtmlEmitter
             return (float) $box[$dimension];
         }
 
-        if ( null !== $parentNode && (! isset($parentBox[$dimension]) || $this->shouldInferRootCanvasOrigin($parentBox, $parentNode, $dimension)) ) {
+        if ( null !== $parentNode && (! isset($parentBox[$dimension]) ? $this->shouldInferMissingParentOrigin($parentBox, $parentNode, $dimension) : $this->shouldInferRootCanvasOrigin($parentBox, $parentNode, $dimension)) ) {
             $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
             if ( null !== $origin ) {
                 return (float) $box[$dimension] - $origin;
@@ -1724,6 +1908,32 @@ final class StaticHtmlEmitter
 
         return ($origin < 0.0 && ($parentOrigin - $origin) >= 100.0)
             || $this->hasRootCanvasOriginMismatch($parentBox, $parentNode);
+    }
+
+    /**
+     * @param array<string, mixed> $parentBox
+     * @param array<string, mixed> $parentNode
+     */
+    private function shouldInferMissingParentOrigin(array $parentBox, array $parentNode, string $dimension): bool
+    {
+        $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+        if ( null === $origin ) {
+            return false;
+        }
+
+        foreach ( array('x' => 'width', 'y' => 'height') as $originDimension => $sizeKey ) {
+            $origin = $this->inferredContainingBlockOrigin($parentNode, $originDimension);
+            if ( null === $origin ) {
+                continue;
+            }
+
+            $parentSize = isset($parentBox[$sizeKey]) && is_numeric($parentBox[$sizeKey]) ? (float) $parentBox[$sizeKey] : null;
+            if ( abs($origin) >= 1000.0 || (null !== $parentSize && $origin > $parentSize + 100.0) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -3066,7 +3276,7 @@ final class StaticHtmlEmitter
         $pathBounds = $this->vectorPathBounds($node);
         if ( null !== $pathBounds && ( $pathBounds['width'] > $width + 0.001 || $pathBounds['height'] > $height + 0.001 || $pathBounds['x'] < -0.001 || $pathBounds['y'] < -0.001 ) ) {
             $viewBox = $pathBounds;
-        } elseif ( null !== $pathBounds && $this->vectorPathTouchesViewBoxEdge($pathBounds, $viewBox) ) {
+        } elseif ( null !== $pathBounds && $this->vectorMayClipStrokeAtViewBoxEdge($node) && $this->vectorPathTouchesViewBoxEdge($pathBounds, $viewBox) ) {
             $padding = 0.5;
             $viewBox = array(
                 'x' => $viewBox['x'] - $padding,
@@ -3135,6 +3345,14 @@ final class StaticHtmlEmitter
             || abs($pathBounds['y'] - $viewBox['y']) <= $epsilon
             || abs(($pathBounds['x'] + $pathBounds['width']) - ($viewBox['x'] + $viewBox['width'])) <= $epsilon
             || abs(($pathBounds['y'] + $pathBounds['height']) - ($viewBox['y'] + $viewBox['height'])) <= $epsilon;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function vectorMayClipStrokeAtViewBoxEdge(array $node): bool
+    {
+        return $this->hasSvgStroke($this->svgPaintAttributes($node));
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -227,10 +227,10 @@ $assert(is_file($cliOutputRoot . '/artifact/index.html'), 'cli-output-dir-writes
 $assert(is_file($cliOutputRoot . '/artifact/style.css'), 'cli-output-dir-writes-style');
 $assert('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"></svg>' === file_get_contents($cliOutputRoot . '/artifact/assets/cli-image.svg'), 'cli-output-dir-preserves-asset-content');
 $assert(str_contains((string) file_get_contents($cliOutputRoot . '/artifact/style.css'), 'background-image:url("assets/cli-image.svg")'), 'cli-output-dir-preserves-asset-reference');
-$assert(str_contains($html, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 11 11"'), 'html-vector-blob-svg');
+$assert(str_contains($html, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"'), 'html-vector-blob-svg');
 $assert(str_contains($html, 'd="M0 0L10 0 10 10Z"'), 'html-vector-blob-path');
 $assert(str_contains($css, 'body{margin:0}'), 'css-static-page-body-shell');
-$assert(str_contains($css, '.figma-root{position:relative;width:100%;max-width:100%}'), 'css-static-page-root-shell');
+$assert(str_contains($css, '.figma-root{position:relative;min-width:100%;width:max-content}'), 'css-static-page-root-shell');
 $assert(! str_contains($css, 'overflow-x:hidden'), 'css-preserves-horizontal-scroll');
 $assert(! str_contains($css, 'order:'), 'css-avoids-source-order');
 $assert(! str_contains($css, 'font-family:Inter') && ! str_contains($css, 'body{margin:0;background') && ! str_contains($css, 'body{margin:0;color'), 'css-avoids-hardcoded-theme-style');
@@ -434,7 +434,8 @@ $offsetPageCss = $fileContent($offsetPageResult, 'style.css');
 $assert('success' === ($offsetPageResult['status'] ?? null), 'offset-page-transform-success');
 $assert(str_contains($offsetPageHtml, 'Selected page content'), 'offset-page-selected-content-rendered');
 $assert(! str_contains($offsetPageHtml, 'Off Canvas One') && ! str_contains($offsetPageHtml, 'Off Canvas Two'), 'offset-page-off-canvas-siblings-omitted');
-$assert(str_contains($offsetPageCss, '.figma-node-frame-selected-selected-website-page{width:100%;max-width:1440px;height:900px;position:relative}'), 'offset-page-root-responsive-width');
+$assert(str_contains($offsetPageCss, '.figma-root{position:relative;min-width:100%;width:max-content}'), 'offset-page-root-expands-to-frame-width');
+$assert(str_contains($offsetPageCss, '.figma-node-frame-selected-selected-website-page{width:1440px;height:900px;position:relative}'), 'offset-page-root-keeps-frame-width');
 $assert(str_contains($offsetPageCss, '.figma-node-frame-selected-card-hero-card{width:320px;height:160px;position:absolute;left:40px;top:40px}'), 'offset-page-child-rebased-position');
 $assert(! str_contains($offsetPageCss, 'left:3497px') && ! str_contains($offsetPageCss, 'left:3537px') && ! str_contains($offsetPageCss, 'left:4680px'), 'offset-page-avoids-board-left-values');
 
@@ -572,6 +573,167 @@ $imageUnderlayGuardCss = $fileContent($imageUnderlayGuardResult, 'style.css');
 $imageUnderlayGuardUnderlays = $imageUnderlayGuardResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
 $assert(str_contains($imageUnderlayGuardCss, '.figma-node-imageguard-photo-large-photo{width:900px;height:520px;background-image:url("assets/guard-image.svg");background-size:cover;background-position:center;flex-shrink:0}'), 'image-backed-child-remains-flex-child');
 $assert(0 === ($imageUnderlayGuardUnderlays['count'] ?? null), 'image-backed-child-not-decorative-underlay-diagnostic');
+
+$clippedDecorativeResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Clipped Decorative Fixture',
+    'blobs' => array(array('bytes' => $vectorCommandBlob)),
+    'nodes' => array(
+        array(
+            'id'           => 'clip:parent',
+            'type'         => 'FRAME',
+            'name'         => 'Clipped Parent',
+            'width'        => 200,
+            'height'       => 100,
+            'clipsContent' => true,
+            'children'     => array(
+                array(
+                    'id'       => 'clip:hidden-group',
+                    'type'     => 'GROUP',
+                    'name'     => 'Off canvas decorative group',
+                    'x'        => -260,
+                    'y'        => 10,
+                    'width'    => 120,
+                    'height'   => 60,
+                    'children' => array(
+                        array(
+                            'id'           => 'clip:hidden-vector',
+                            'type'         => 'VECTOR',
+                            'name'         => 'Hidden vector flourish',
+                            'x'            => 0,
+                            'y'            => 0,
+                            'width'        => 120,
+                            'height'       => 60,
+                            'fillGeometry' => array(array('commandsBlob' => 0)),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'           => 'clip:partial-vector',
+                    'type'         => 'VECTOR',
+                    'name'         => 'Partly clipped vector flourish',
+                    'x'            => -20,
+                    'y'            => 20,
+                    'width'        => 60,
+                    'height'       => 30,
+                    'fillGeometry' => array(array('commandsBlob' => 0)),
+                ),
+                array(
+                    'id'     => 'clip:copy',
+                    'type'   => 'TEXT',
+                    'name'   => 'Visible copy',
+                    'text'   => 'Real content remains mapped',
+                    'x'      => -10,
+                    'y'      => 70,
+                    'width'  => 140,
+                    'height' => 20,
+                ),
+            ),
+        ),
+    ),
+));
+$clippedDecorativeCss = $fileContent($clippedDecorativeResult, 'style.css');
+$clippedDecorativeHtml = $fileContent($clippedDecorativeResult, 'index.html');
+$clippedDecorativeDiagnostics = $clippedDecorativeResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+$clippedHiddenGroup = $findVisualNode($clippedDecorativeResult, 'clip:hidden-group');
+$clippedHiddenVector = $findVisualNode($clippedDecorativeResult, 'clip:hidden-vector');
+$clippedPartialVector = $findVisualNode($clippedDecorativeResult, 'clip:partial-vector');
+$clippedVisibleCopy = $findVisualNode($clippedDecorativeResult, 'clip:copy');
+$assert(str_contains($clippedDecorativeCss, '.figma-node-clip-parent-clipped-parent{width:200px;height:100px;overflow:hidden;position:relative}'), 'clipped-decorative-parent-overflow-hidden');
+$assert(! str_contains($clippedDecorativeHtml, 'Off canvas decorative group') && ! str_contains($clippedDecorativeCss, 'figma-node-clip-hidden-group'), 'fully-clipped-decorative-node-not-emitted');
+$assert(null === $clippedHiddenGroup && null === $clippedHiddenVector, 'fully-clipped-decorative-nodes-omitted-from-visual-map');
+$assert(array('x' => 0.0, 'y' => 20.0, 'width' => 40.0, 'height' => 30.0) === ($clippedPartialVector['rect'] ?? null), 'partly-clipped-decorative-node-visual-map-intersection');
+$assert(array('x' => -10.0, 'y' => 70.0, 'width' => 140.0, 'height' => 20.0) === ($clippedVisibleCopy['rect'] ?? null), 'clipped-content-node-keeps-source-rect');
+$assert(0 === ($clippedDecorativeDiagnostics['large_absolute_offset_count'] ?? null), 'fully-clipped-decorative-node-not-counted-as-large-offset');
+
+$gamesControlLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Games Control Layout Guard Fixture',
+    'blobs' => array(array('bytes' => $vectorCommandBlob)),
+    'nodes' => array(
+        array(
+            'id'           => 'games:control',
+            'type'         => 'FRAME',
+            'name'         => 'Games control',
+            'width'        => 120,
+            'height'       => 40,
+            'clipsContent' => true,
+            'children'     => array(
+                array(
+                    'id'           => 'games:icon',
+                    'type'         => 'VECTOR',
+                    'name'         => 'Games icon',
+                    'x'            => -8,
+                    'y'            => 8,
+                    'width'        => 24,
+                    'height'       => 24,
+                    'fillGeometry' => array(array('commandsBlob' => 0)),
+                ),
+                array(
+                    'id'     => 'games:label',
+                    'type'   => 'TEXT',
+                    'name'   => 'Games label',
+                    'text'   => 'Games',
+                    'x'      => 24,
+                    'y'      => 10,
+                    'width'  => 60,
+                    'height' => 20,
+                ),
+            ),
+        ),
+    ),
+), array(
+    'generated_dom_boxes' => array(
+        'schema' => 'homeboy/static-artifact-dom-boxes/v1',
+        'boxes'  => array(
+            array('node_id' => 'games:control', 'rect' => array('x' => 0, 'y' => 0, 'width' => 120, 'height' => 40)),
+            array('node_id' => 'games:icon', 'rect' => array('x' => 0, 'y' => 8, 'width' => 16, 'height' => 24)),
+            array('node_id' => 'games:label', 'rect' => array('x' => 24, 'y' => 10, 'width' => 60, 'height' => 20)),
+        ),
+    ),
+    'layout_mismatch_threshold'      => 1,
+    'layout_mismatch_size_threshold' => 1,
+));
+$gamesControlDiagnostics = $gamesControlLayoutResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+$gamesControlIcon = $findVisualNode($gamesControlLayoutResult, 'games:icon');
+$assert(array('x' => 0.0, 'y' => 8.0, 'width' => 16.0, 'height' => 24.0) === ($gamesControlIcon['rect'] ?? null), 'games-control-clipped-icon-visual-map-intersection');
+$assert(0 === ($gamesControlDiagnostics['layout_mismatch_count'] ?? null), 'games-control-layout-mismatch-count-zero');
+$assert('pass' === ($gamesControlDiagnostics['layout_mismatch_status'] ?? null), 'games-control-layout-mismatch-pass');
+
+$transparentVisualMapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Transparent Visual Map Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'transparent:parent',
+            'type'     => 'FRAME',
+            'name'     => 'Invisible transformed shell',
+            'width'    => 200,
+            'height'   => 0,
+            'opacity'  => 0,
+            'rotation' => -30,
+            'children' => array(
+                array(
+                    'id'     => 'transparent:child',
+                    'type'   => 'RECTANGLE',
+                    'name'   => 'Inherited invisible child',
+                    'width'  => 200,
+                    'height' => 80,
+                    'fill'   => array('r' => 1, 'g' => 1, 'b' => 1),
+                ),
+            ),
+        ),
+        array(
+            'id'     => 'transparent:sibling',
+            'type'   => 'RECTANGLE',
+            'name'   => 'Visible sibling',
+            'y'      => 100,
+            'width'  => 40,
+            'height' => 20,
+        ),
+    ),
+));
+$assert(null === $findVisualNode($transparentVisualMapResult, 'transparent:parent'), 'transparent-parent-omitted-from-visual-map');
+$assert(null === $findVisualNode($transparentVisualMapResult, 'transparent:child'), 'transparent-child-omitted-from-visual-map');
+$assert(null !== $findVisualNode($transparentVisualMapResult, 'transparent:sibling'), 'transparent-sibling-remains-in-visual-map');
+
 $oversizedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Oversized Vector Bounds Fixture',
     'blobs' => array(array('bytes' => $vectorCommandBlob)),
@@ -590,6 +752,24 @@ $oversizedVectorHtml = $fileContent($oversizedVectorResult, 'index.html');
 $oversizedVectorCss = $fileContent($oversizedVectorResult, 'style.css');
 $assert(str_contains($oversizedVectorHtml, 'viewBox="0 0 10 10"'), 'oversized-vector-viewbox-uses-path-bounds');
 $assert(str_contains($oversizedVectorCss, '.figma-node-vector-oversized-bounds-oversized-bounds{width:5px;height:5px'), 'oversized-vector-css-keeps-node-size');
+
+$edgeAlignedFilledVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Edge Aligned Filled Vector Fixture',
+    'nodes' => array(
+        array(
+            'id'                 => 'vector:edge-aligned-fill',
+            'type'               => 'VECTOR',
+            'name'               => 'Edge Aligned Fill',
+            'width'              => 10,
+            'height'             => 10,
+            'fillPaints'         => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0))),
+            'figma_vector_paths' => array(array('data' => 'M0 0L10 0L10 10L0 10Z')),
+        ),
+    ),
+));
+$edgeAlignedFilledVectorHtml = $fileContent($edgeAlignedFilledVectorResult, 'index.html');
+$assert(str_contains($edgeAlignedFilledVectorHtml, 'viewBox="0 0 10 10"'), 'edge-aligned-filled-vector-viewbox-keeps-intrinsic-bounds');
+$assert(! str_contains($edgeAlignedFilledVectorHtml, 'viewBox="-0.5 -0.5 11 11"'), 'edge-aligned-filled-vector-no-stroke-padding');
 
 $largeDecodedPath = 'M 0 0' . str_repeat(' L 10 10', 3000) . ' Z';
 $largeDecodedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -1005,6 +1185,52 @@ $assert('fail' === ($homeboyDomLayoutMismatch['status'] ?? null), 'layout-mismat
 $assert(in_array('element_size_mismatch', $homeboyDomLayoutMismatchCodes, true), 'layout-mismatch-homeboy-dom-size-code');
 $assert(-312.0 === ($homeboyDomMisplaced['delta']['x'] ?? null), 'layout-mismatch-homeboy-dom-x-delta');
 
+$sourceAuthoredOverflowLayoutMismatch = $layoutMismatchBuilder->build(
+    array(
+        'visual_node_map' => array(
+            array('id' => 'overflow:parent', 'name' => 'Overflow Parent', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 120)),
+            array('id' => 'overflow:text', 'parent_id' => 'overflow:parent', 'name' => 'Long text', 'type' => 'TEXT', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 180)),
+        ),
+    ),
+    array(
+        'boxes' => array(
+            array('node_id' => 'overflow:parent', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 120)),
+            array('node_id' => 'overflow:text', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 180)),
+        ),
+    ),
+    array('threshold' => 24)
+);
+$assert('pass' === ($sourceAuthoredOverflowLayoutMismatch['status'] ?? null), 'layout-mismatch-source-authored-overflow-pass');
+
+$worsenedOverflowLayoutMismatch = $layoutMismatchBuilder->build(
+    array(
+        'visual_node_map' => array(
+            array('id' => 'overflow:worse:parent', 'name' => 'Overflow Parent', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 120)),
+            array('id' => 'overflow:worse:text', 'parent_id' => 'overflow:worse:parent', 'name' => 'Long text', 'type' => 'TEXT', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 180)),
+        ),
+    ),
+    array(
+        'boxes' => array(
+            array('node_id' => 'overflow:worse:parent', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 120)),
+            array('node_id' => 'overflow:worse:text', 'rect' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 220)),
+        ),
+    ),
+    array('threshold' => 24)
+);
+$worsenedOverflowCodes = array_map(static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''), $worsenedOverflowLayoutMismatch['diagnostics'] ?? array());
+$worsenedOutsideParent = null;
+foreach ( $worsenedOverflowLayoutMismatch['diagnostics'] ?? array() as $diagnostic ) {
+    if ( is_array($diagnostic) && 'element_outside_parent_bounds' === ($diagnostic['code'] ?? null) ) {
+        $worsenedOutsideParent = $diagnostic;
+        break;
+    }
+}
+$assert('fail' === ($worsenedOverflowLayoutMismatch['status'] ?? null), 'layout-mismatch-worsened-overflow-fail');
+$assert(in_array('element_outside_parent_bounds', $worsenedOverflowCodes, true), 'layout-mismatch-worsened-overflow-code');
+$assert(60.0 === ($worsenedOutsideParent['parent']['source_overflow']['bottom'] ?? null), 'layout-mismatch-worsened-source-overflow');
+$worsenedOverflowCauses = array_map(static fn (array $cause): string => (string) ($cause['cause'] ?? ''), $worsenedOverflowLayoutMismatch['summary']['suspected_causes'] ?? array());
+$assert(in_array('source-overflow', $worsenedOverflowCauses, true), 'layout-mismatch-source-overflow-suspected-cause');
+
 $clusteredLayoutMismatch = $layoutMismatchBuilder->build(
     array(
         'visual_node_map' => array(
@@ -1028,6 +1254,60 @@ $assert('cluster:root' === ($clusterSummary['parent_delta'][0]['parent_id'] ?? n
 $assert(2 === ($clusterSummary['repeated_position_delta'][0]['count'] ?? null), 'layout-mismatch-repeated-delta-cluster-count');
 $assert(array('x' => 32, 'y' => 48) === ($clusterSummary['repeated_position_delta'][0]['delta'] ?? null), 'layout-mismatch-repeated-delta-cluster-values');
 $assert('item #' === ($clusterSummary['node_pattern'][0]['name_pattern'] ?? null), 'layout-mismatch-node-pattern-normalized-name');
+$clusteredCauses = array_map(static fn (array $cause): string => (string) ($cause['cause'] ?? ''), $clusteredLayoutMismatch['summary']['suspected_causes'] ?? array());
+$assert(in_array('absolute-offset', $clusteredCauses, true), 'layout-mismatch-absolute-offset-suspected-cause');
+
+$typedLayoutMismatch = $layoutMismatchBuilder->build(
+    array(
+        'visual_node_map' => array(
+            array('id' => 'typed:root', 'name' => 'Full bleed root', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 0, 'width' => 640, 'height' => 400)),
+            array('id' => 'typed:text', 'parent_id' => 'typed:root', 'name' => 'Title', 'type' => 'TEXT', 'rect' => array('x' => 20, 'y' => 20, 'width' => 200, 'height' => 24)),
+            array('id' => 'typed:icon', 'parent_id' => 'typed:root', 'name' => 'Chevron icon', 'type' => 'VECTOR', 'rect' => array('x' => 20, 'y' => 70, 'width' => 16, 'height' => 16)),
+        ),
+    ),
+    array(
+        'boxes' => array(
+            array('node_id' => 'typed:root', 'rect' => array('x' => 0, 'y' => 0, 'width' => 800, 'height' => 500)),
+            array('node_id' => 'typed:text', 'rect' => array('x' => 20, 'y' => 20, 'width' => 200, 'height' => 70)),
+            array('node_id' => 'typed:icon', 'rect' => array('x' => 20, 'y' => 70, 'width' => 48, 'height' => 48)),
+        ),
+    ),
+    array('threshold' => 24)
+);
+$typedCauses = array_map(static fn (array $cause): string => (string) ($cause['cause'] ?? ''), $typedLayoutMismatch['summary']['suspected_causes'] ?? array());
+$assert(in_array('root-fill', $typedCauses, true), 'layout-mismatch-root-fill-suspected-cause');
+$assert(in_array('text-height', $typedCauses, true), 'layout-mismatch-text-height-suspected-cause');
+$assert(in_array('icon/vector-bounds', $typedCauses, true), 'layout-mismatch-vector-bounds-suspected-cause');
+
+$genericCauseLayoutMismatch = $layoutMismatchBuilder->build(
+    array(
+        'visual_node_map' => array(
+            array('id' => 'generic:parent', 'name' => 'Shifted parent', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 0, 'width' => 120, 'height' => 80)),
+            array('id' => 'generic:child', 'parent_id' => 'generic:parent', 'name' => 'Shifted child', 'type' => 'RECTANGLE', 'rect' => array('x' => 10, 'y' => 10, 'width' => 30, 'height' => 20)),
+            array('id' => 'generic:zero', 'name' => 'Zero width shell', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 100, 'width' => 0, 'height' => 80)),
+            array('id' => 'generic:clip-parent', 'name' => 'Clip parent', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 220, 'width' => 100, 'height' => 80)),
+            array('id' => 'generic:clip-child', 'parent_id' => 'generic:clip-parent', 'name' => 'Generated clipped child', 'type' => 'RECTANGLE', 'rect' => array('x' => 10, 'y' => 230, 'width' => 20, 'height' => 20)),
+            array('id' => 'generic:vector', 'name' => 'Decorative vector', 'type' => 'VECTOR', 'rect' => array('x' => 0, 'y' => 340, 'width' => 24, 'height' => 24)),
+        ),
+    ),
+    array(
+        'boxes' => array(
+            array('node_id' => 'generic:parent', 'rect' => array('x' => 40, 'y' => 60, 'width' => 120, 'height' => 80)),
+            array('node_id' => 'generic:child', 'rect' => array('x' => 50, 'y' => 70, 'width' => 30, 'height' => 20)),
+            array('node_id' => 'generic:zero', 'rect' => array('x' => 0, 'y' => 100, 'width' => 40, 'height' => 80)),
+            array('node_id' => 'generic:clip-parent', 'rect' => array('x' => 0, 'y' => 220, 'width' => 100, 'height' => 80)),
+            array('node_id' => 'generic:clip-child', 'rect' => array('x' => 150, 'y' => 230, 'width' => 20, 'height' => 20)),
+            array('node_id' => 'generic:vector', 'rect' => array('x' => 48, 'y' => 340, 'width' => 24, 'height' => 24)),
+        ),
+    ),
+    array('threshold' => 24)
+);
+$genericCauses = array_map(static fn (array $cause): string => (string) ($cause['cause'] ?? ''), $genericCauseLayoutMismatch['summary']['suspected_causes'] ?? array());
+$assert(in_array('same-size-position-shift', $genericCauses, true), 'layout-mismatch-same-size-position-shift-suspected-cause');
+$assert(in_array('parent-visual-map-mismatch', $genericCauses, true), 'layout-mismatch-parent-visual-map-suspected-cause');
+$assert(in_array('zero-size-source-box', $genericCauses, true), 'layout-mismatch-zero-size-source-box-suspected-cause');
+$assert(in_array('generated-vs-source-clipping', $genericCauses, true), 'layout-mismatch-generated-vs-source-clipping-suspected-cause');
+$assert(in_array('vector-shell-wrapper-offset', $genericCauses, true), 'layout-mismatch-vector-shell-wrapper-offset-suspected-cause');
 
 $layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name' => 'Layout Mismatch Fixture',
@@ -2131,7 +2411,7 @@ $objectTransformResult = blocks_engine_figma_transformer_transform_scenegraph(ar
     ),
 ));
 $objectTransformCss = $fileContent($objectTransformResult, 'style.css');
-$assert(str_contains($objectTransformCss, 'transform:matrix(-1,0,0,1,0,0)'), 'decoded-object-transform-emits-css-matrix');
+$assert(str_contains($objectTransformCss, 'transform:matrix(-1,0,0,1,0,0)'), 'decoded-object-transform-suppresses-position-translation');
 
 $localTransformPositionResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Local Transform Position Fixture',
@@ -2679,6 +2959,23 @@ $layoutFidelityResult = blocks_engine_figma_transformer_transform_scenegraph(arr
                     'layoutAlign'            => 'STRETCH',
                 ),
                 array(
+                    'id'                     => '5:7',
+                    'type'                   => 'FRAME',
+                    'name'                   => 'Hug flex button',
+                    'width'                  => 160,
+                    'height'                 => 40,
+                    'layoutMode'             => 'HORIZONTAL',
+                    'primaryAxisAlignItems'  => 'MAX',
+                    'counterAxisAlignItems'  => 'CENTER',
+                    'layoutSizingHorizontal' => 'HUG',
+                    'layoutSizingVertical'   => 'HUG',
+                    'itemSpacing'            => 8,
+                    'children'               => array(
+                        array('id' => '5:8', 'type' => 'RECTANGLE', 'name' => 'Button icon', 'width' => 16, 'height' => 16),
+                        array('id' => '5:9', 'type' => 'TEXT', 'name' => 'Button label', 'characters' => 'Buy now', 'fontSize' => 14),
+                    ),
+                ),
+                array(
                     'id'                  => '5:5',
                     'type'                => 'RECTANGLE',
                     'name'                => 'Absolute badge',
@@ -2709,6 +3006,7 @@ $assert(str_contains($layoutFidelityCss, '.figma-node-5-1-layout-frame{width:500
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-2-fixed-card{width:100px;height:80px;opacity:0.6;transform:rotate(15deg);flex-shrink:0}'), 'layout-fixed-sizing-and-rotation');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-3-hug-label{width:fit-content;height:fit-content;font-size:12px;flex-shrink:0}'), 'layout-hug-sizing');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-4-fill-panel{width:100%;height:100%;flex-grow:1;flex-shrink:1;align-self:stretch}'), 'layout-fill-sizing-without-source-order');
+$assert(str_contains($layoutFidelityCss, '.figma-node-5-7-hug-flex-button{width:160px;height:40px;display:flex;flex-direction:row;justify-content:flex-end;align-items:center;gap:8px;flex-shrink:0}'), 'layout-hug-flex-container-preserves-measured-box');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-5-absolute-badge{width:50px;height:20px;position:absolute;left:20px;right:430px;top:20px;bottom:260px;background:#000000;flex-shrink:0}'), 'layout-absolute-constraints-without-source-z-index');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-6-matrix-transform{width:30px;height:30px;transform:matrix(0,1,-1,0,40,60);transform-origin:0 0;flex-shrink:0}'), 'layout-relative-transform-matrix');
 $assert(! str_contains($layoutFidelityCss, 'font-family:Inter') && ! str_contains($layoutFidelityCss, 'body{margin:0;background') && ! str_contains($layoutFidelityCss, 'body{margin:0;color'), 'layout-css-avoids-theme-defaults');
@@ -2758,6 +3056,54 @@ $assert(30.0 === ($visualFlexSecond['rect']['y'] ?? null), 'visual-map-flex-cent
 $assert(100.0 === ($visualFlexCentered['rect']['x'] ?? null), 'visual-map-column-center-child-x');
 $assert(10.0 === ($visualFlexCentered['rect']['y'] ?? null), 'visual-map-column-padding-child-y');
 
+$visualFlexWrapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Visual Flex Wrap Fixture',
+    'nodes' => array(
+        array(
+            'id'                    => 'visual-wrap:frame',
+            'type'                  => 'FRAME',
+            'name'                  => 'Wrapped card row',
+            'width'                 => 220,
+            'height'                => 200,
+            'layoutMode'            => 'HORIZONTAL',
+            'layoutWrap'            => 'WRAP',
+            'itemSpacing'           => 10,
+            'counterAxisAlignItems' => 'MIN',
+            'children'              => array(
+                array(
+                    'id'     => 'visual-wrap:first',
+                    'type'   => 'RECTANGLE',
+                    'name'   => 'First card',
+                    'width'  => 100,
+                    'height' => 40,
+                ),
+                array(
+                    'id'     => 'visual-wrap:second',
+                    'type'   => 'RECTANGLE',
+                    'name'   => 'Second card',
+                    'width'  => 100,
+                    'height' => 60,
+                ),
+                array(
+                    'id'     => 'visual-wrap:third',
+                    'type'   => 'RECTANGLE',
+                    'name'   => 'Third card',
+                    'width'  => 100,
+                    'height' => 30,
+                ),
+            ),
+        ),
+    ),
+));
+$visualFlexWrapCss = $fileContent($visualFlexWrapResult, 'style.css');
+$visualFlexWrapFirst = $findVisualNode($visualFlexWrapResult, 'visual-wrap:first');
+$visualFlexWrapSecond = $findVisualNode($visualFlexWrapResult, 'visual-wrap:second');
+$visualFlexWrapThird = $findVisualNode($visualFlexWrapResult, 'visual-wrap:third');
+$assert(str_contains($visualFlexWrapCss, 'flex-wrap:wrap;align-content:flex-start'), 'visual-map-flex-wrap-align-content-packed');
+$assert(array('x' => 0.0, 'y' => 0.0, 'width' => 100.0, 'height' => 40.0) === ($visualFlexWrapFirst['rect'] ?? null), 'visual-map-flex-wrap-first-line-first-card');
+$assert(array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0) === ($visualFlexWrapSecond['rect'] ?? null), 'visual-map-flex-wrap-first-line-second-card');
+$assert(array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0) === ($visualFlexWrapThird['rect'] ?? null), 'visual-map-flex-wrap-second-line-card');
+
 $kiwiStackLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Kiwi Stack Layout Fixture',
     'nodes' => array(
@@ -2796,7 +3142,7 @@ $kiwiStackLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(ar
     ),
 ));
 $kiwiStackLayoutCss = $fileContent($kiwiStackLayoutResult, 'style.css');
-$assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-frame-kiwi-stack-frame{width:300px;min-height:200px;overflow:hidden;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;flex-wrap:wrap;padding-top:8px;padding-right:20px;padding-bottom:30px;padding-left:8px;gap:24px}'), 'kiwi-stack-layout-emits-flex-padding-gap');
+$assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-frame-kiwi-stack-frame{width:300px;min-height:200px;overflow:hidden;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;flex-wrap:wrap;align-content:flex-start;padding-top:8px;padding-right:20px;padding-bottom:30px;padding-left:8px;gap:24px}'), 'kiwi-stack-layout-emits-flex-padding-gap');
 $assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-child-a-child-a{width:50px;height:40px;flex-shrink:0}'), 'kiwi-stack-child-not-absolute');
 
 $plainFrameLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -2829,6 +3175,87 @@ $plainFrameLayoutCss = $fileContent($plainFrameLayoutResult, 'style.css');
 $assert(str_contains($plainFrameLayoutCss, '.figma-node-plain-frame-plain-layout-frame{width:400px;height:300px;position:relative}'), 'plain-frame-becomes-freeform-positioned-canvas');
 $assert(str_contains($plainFrameLayoutCss, '.figma-node-plain-first-first-positioned-layer{width:90px;height:40px;position:absolute;left:20px;top:20px'), 'plain-frame-first-child-positioned-relative-to-parent');
 $assert(str_contains($plainFrameLayoutCss, '.figma-node-plain-second-second-positioned-text{width:120px;height:32px;position:absolute;left:200px;top:150px'), 'plain-frame-text-child-positioned-relative-to-parent');
+
+$singleChildOffsetResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Single Child Offset Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'single-offset:frame',
+            'type'                => 'FRAME',
+            'name'                => 'Single offset frame',
+            'absoluteBoundingBox' => array('x' => 100, 'y' => 50, 'width' => 400, 'height' => 300),
+            'children'            => array(
+                array(
+                    'id'                  => 'single-offset:child',
+                    'type'                => 'RECTANGLE',
+                    'name'                => 'Offset child',
+                    'absoluteBoundingBox' => array('x' => 160, 'y' => 125, 'width' => 90, 'height' => 40),
+                ),
+            ),
+        ),
+    ),
+));
+$singleChildOffsetCss = $fileContent($singleChildOffsetResult, 'style.css');
+$singleChildOffsetVisualNode = $findVisualNode($singleChildOffsetResult, 'single-offset:child');
+$assert(str_contains($singleChildOffsetCss, '.figma-node-single-offset-frame-single-offset-frame{width:400px;height:300px;position:relative}'), 'single-child-offset-frame-becomes-freeform');
+$assert(str_contains($singleChildOffsetCss, '.figma-node-single-offset-child-offset-child{width:90px;height:40px;position:absolute;left:60px;top:75px'), 'single-child-offset-child-positioned-relative-to-parent');
+$assert(array('x' => 60.0, 'y' => 75.0, 'width' => 90.0, 'height' => 40.0) === ($singleChildOffsetVisualNode['rect'] ?? null), 'single-child-offset-visual-node-keeps-source-offset');
+
+$nestedMissingOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Nested Missing Origin Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'missing-origin:button-shell',
+            'type'     => 'GROUP',
+            'name'     => 'Button shell',
+            'width'    => 220,
+            'height'   => 64,
+            'children' => array(
+                array(
+                    'id'     => 'missing-origin:label',
+                    'type'   => 'TEXT',
+                    'name'   => 'Button label',
+                    'text'   => 'Read more',
+                    'x'      => 34,
+                    'y'      => 21,
+                    'width'  => 96,
+                    'height' => 22,
+                ),
+                array(
+                    'id'                 => 'missing-origin:icon',
+                    'type'               => 'VECTOR',
+                    'name'               => 'Button icon',
+                    'x'                  => 34,
+                    'y'                  => 8,
+                    'width'              => 16,
+                    'height'             => 16,
+                    'figma_vector_paths' => array(array('data' => 'M0 0L16 8L0 16Z')),
+                ),
+                array(
+                    'id'           => 'missing-origin:rounded',
+                    'type'         => 'RECTANGLE',
+                    'name'         => 'Decorative rounded plate',
+                    'x'            => 0,
+                    'y'            => -80,
+                    'width'        => 220,
+                    'height'       => 64,
+                    'cornerRadius' => 18,
+                ),
+            ),
+        ),
+    ),
+));
+$nestedMissingOriginCss = $fileContent($nestedMissingOriginResult, 'style.css');
+$nestedMissingOriginLabel = $findVisualNode($nestedMissingOriginResult, 'missing-origin:label');
+$nestedMissingOriginIcon = $findVisualNode($nestedMissingOriginResult, 'missing-origin:icon');
+$nestedMissingOriginRounded = $findVisualNode($nestedMissingOriginResult, 'missing-origin:rounded');
+$assert(str_contains($nestedMissingOriginCss, '.figma-node-missing-origin-button-shell-button-shell{width:220px;height:64px;position:relative}'), 'nested-missing-origin-parent-becomes-freeform');
+$assert(str_contains($nestedMissingOriginCss, '.figma-node-missing-origin-label-button-label{width:96px;height:22px;position:absolute;left:34px;top:21px'), 'nested-missing-origin-text-keeps-authored-x');
+$assert(str_contains($nestedMissingOriginCss, '.figma-node-missing-origin-icon-button-icon{width:16px;height:16px;position:absolute;left:34px;top:8px'), 'nested-missing-origin-icon-keeps-authored-x');
+$assert(str_contains($nestedMissingOriginCss, '.figma-node-missing-origin-rounded-decorative-rounded-plate{width:220px;height:64px;position:absolute;left:0px;top:-80px'), 'nested-missing-origin-rounded-keeps-negative-y');
+$assert(array('x' => 34.0, 'y' => 21.0, 'width' => 96.0, 'height' => 22.0) === ($nestedMissingOriginLabel['rect'] ?? null), 'nested-missing-origin-text-visual-map-keeps-authored-x');
+$assert(array('x' => 34.0, 'y' => 8.0, 'width' => 16.0, 'height' => 16.0) === ($nestedMissingOriginIcon['rect'] ?? null), 'nested-missing-origin-icon-visual-map-keeps-authored-x');
+$assert(array('x' => 0.0, 'y' => -80.0, 'width' => 220.0, 'height' => 64.0) === ($nestedMissingOriginRounded['rect'] ?? null), 'nested-missing-origin-rounded-visual-map-keeps-negative-y');
 
 $selectedFrameOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Selected Frame Origin Fixture',


### PR DESCRIPTION
## Summary
- refine static Figma HTML emission for desktop fidelity, including intrinsic root width, clipped decorative vectors, wrap-aware visual maps, measured HUG flex containers, and safer object transform handling
- expand layout mismatch diagnostics with parent-delta context, suspected-cause summaries, and source-authored overflow handling
- add contract coverage for Games-style clipped icons, missing-origin offsets, transparent visual-map omissions, vector viewBox handling, and matrix regression guards

## Verification
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/tests/contract/run.php`
- `php figma-transformer/tests/contract/run.php`
- `git diff --check`
- Full Lab DOM matrix: `figma-layout-iteration-5-transform-fix-20260627`
  - Agentic Commerce WIP: `168` layout mismatches, `0` vector placeholders
  - FSE Pilot Build Theme: `39` layout mismatches, `0` vector placeholders
  - Games Hotline Blog Updates: `0/pass` layout mismatches, `0` vector placeholders
  - WP.Cloud 2.0: `217` layout mismatches, `0` vector placeholders

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, diagnostics, contract tests, and Lab matrix verification