### PR TITLE
Accept intuitive Figma matrix DOM provider aliases

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -254,6 +254,10 @@ function matrix_options(array $argv): array
 
         [$name, $value] = explode('=', substr($arg, 2), 2);
         $key = str_replace('-', '_', $name);
+        $key = array(
+            'dom_box_command' => 'dom_box_provider_command',
+            'homeboy_bin'     => 'homeboy_command',
+        )[$key] ?? $key;
         if ( 'fixture' === $key ) {
             $options[$key] ??= array();
             $options[$key][] = $value;

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3996,6 +3996,41 @@ $assert(! str_contains($derivedSymbolInstanceHtml, '<g transform="scale'), 'deri
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-2-derived-label{width:90px;height:24px;position:absolute;left:12px;top:6px'), 'derived-symbol-instance-label-size-position');
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-3-derived-icon{width:10px;height:10px;position:absolute;left:110px;top:10px'), 'derived-symbol-instance-icon-size-position');
 
+$matrixFixtureDir = sys_get_temp_dir() . '/figma-fixture-matrix-contract-' . getmypid() . '-' . bin2hex(random_bytes(4));
+mkdir($matrixFixtureDir, 0777, true);
+file_put_contents($matrixFixtureDir . '/alias.fig', 'placeholder fig fixture');
+$matrixDryRun = static function (array $args) use ($matrixFixtureDir): ?array {
+    $command = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
+        . ' --dry-run --capture-dom-boxes --fixture-dir=' . escapeshellarg($matrixFixtureDir);
+    foreach ( $args as $arg ) {
+        $command .= ' ' . escapeshellarg($arg);
+    }
+
+    $output = shell_exec($command);
+    return is_string($output) ? json_decode($output, true) : null;
+};
+$matrixAliasSummary = $matrixDryRun(array(
+    '--homeboy-bin=/opt/homeboy-alias',
+    '--dom-box-command=node dom-box-alias',
+));
+$matrixCanonicalSummary = $matrixDryRun(array(
+    '--homeboy-command=/opt/homeboy-canonical',
+    '--dom-box-provider-command=node dom-box-canonical',
+));
+$assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
+$assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
+$assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');
+$matrixAliasCaptureCommand = (string) ($matrixAliasSummary['fixtures'][0]['dom_box_capture']['command'] ?? '');
+$assert(str_contains($matrixAliasCaptureCommand, escapeshellarg('/opt/homeboy-alias')), 'fixture-matrix-alias-capture-uses-homeboy-bin');
+$assert(str_contains($matrixAliasCaptureCommand, 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg('node dom-box-alias')), 'fixture-matrix-alias-capture-uses-dom-box-command');
+$assert(is_array($matrixCanonicalSummary), 'fixture-matrix-canonical-json-summary');
+$assert('/opt/homeboy-canonical' === ($matrixCanonicalSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-command-canonical');
+$assert(true === ($matrixCanonicalSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-provider-command-canonical-configured');
+$matrixCanonicalCaptureCommand = (string) ($matrixCanonicalSummary['fixtures'][0]['dom_box_capture']['command'] ?? '');
+$assert(str_contains($matrixCanonicalCaptureCommand, escapeshellarg('/opt/homeboy-canonical')), 'fixture-matrix-canonical-capture-uses-homeboy-command');
+$assert(str_contains($matrixCanonicalCaptureCommand, 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg('node dom-box-canonical')), 'fixture-matrix-canonical-capture-uses-dom-box-provider-command');
+
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");
     exit(1);


### PR DESCRIPTION
## Summary
- Maps `--homeboy-bin` to the existing `homeboy_command` option.
- Maps `--dom-box-command` to the existing `dom_box_provider_command` option.
- Adds contract coverage that dry-runs the fixture matrix through both alias and canonical option forms.

Fixes #159.

## Verification
- `composer test` from `figma-transformer`: Figma Transformer contract tests passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the CLI option alias mapping, adding contract coverage, and running verification.