### PR TITLE
Improve generic media pattern recognition

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1124,6 +1124,9 @@ final class HtmlTransformer
 
         if ( 'svg' === $tagName ) {
             if ( $this->isSafeDecorativeSvgElement($element) ) {
+                if ( $this->hasIconLikeContext($element) ) {
+                    return $this->inlineSvgBlockFromElement($element);
+                }
                 if ( $this->isVisualLayerElement($element) ) {
                     return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
                 }
@@ -1290,6 +1293,10 @@ final class HtmlTransformer
             }
 
             $children = $this->convertChildren($element, $fallbacks, true);
+            $backgroundImage = $this->backgroundImageBlockFromElement($element);
+            if ( null !== $backgroundImage && ! $this->hasDirectMediaChild($element) ) {
+                array_unshift($children, $backgroundImage);
+            }
             if ( 1 === count($children) ) {
                 if ( $this->shouldPreserveWrapper($element) ) {
                     return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
@@ -1810,7 +1817,7 @@ final class HtmlTransformer
     private function hasGridLikeClass(DOMElement $element): bool
     {
         $className = strtolower($this->attr($element, 'class'));
-        return (bool) preg_match('/(?:^|[\s_-])(?:cards|grid|tiles|collection|gallery)(?:$|[\s_-])/', $className);
+        return (bool) preg_match('/(?:^|[\s_-])(?:cards|features|services|providers|testimonials|resources|posts|projects|stats|badges|grid|grid-[0-9]+|tiles|collection|gallery)(?:$|[\s_-])/', $className);
     }
 
     /**
@@ -2184,11 +2191,14 @@ final class HtmlTransformer
         $style = strtolower(trim($this->attr($element, 'style') . ';' . (string) ($attrs['style'] ?? '')));
         $signals = array();
 
-        if ( preg_match('/(?:^|[\s_-])(?:card|tile|panel|item)(?:$|[\s_-])/', $className) || 'article' === strtolower($element->tagName) ) {
+        if ( preg_match('/(?:^|[\s_-])(?:card|feature|service|provider|resource|post|project|stat|badge|tile|panel|item)(?:$|[\s_-])/', $className) || 'article' === strtolower($element->tagName) ) {
             $signals['card_like'] = true;
         }
-        if ( preg_match('/(?:^|[\s_-])(?:cards|grid|tiles|columns|collection|gallery)(?:$|[\s_-])/', $className) || preg_match('/(?:^|;)\s*(?:display\s*:\s*grid|grid-template-columns\s*:)/', $style) ) {
+        if ( preg_match('/(?:^|[\s_-])(?:cards|features|services|providers|testimonials|resources|posts|projects|stats|badges|grid|grid-[0-9]+|tiles|columns|collection|gallery)(?:$|[\s_-])/', $className) || preg_match('/(?:^|;)\s*(?:display\s*:\s*grid|grid-template-columns\s*:)/', $style) ) {
             $signals['grid_like'] = true;
+        }
+        if ( preg_match('/(?:^|[\s_-])(?:hero|masthead|intro|banner|container|wrap|wrapper|inner|shell)(?:$|[\s_-])/', $className) ) {
+            $signals['section_container_like'] = true;
         }
         if ( $this->isVisualLayerElement($element) ) {
             $signals['visual_layer'] = true;
@@ -2229,7 +2239,7 @@ final class HtmlTransformer
     private function isCardLikeElement(DOMElement $element): bool
     {
         $className = strtolower($this->attr($element, 'class'));
-        return 'article' === strtolower($element->tagName) || (bool) preg_match('/(?:^|[\s_-])(?:card|tile|panel|item)(?:$|[\s_-])/', $className);
+        return 'article' === strtolower($element->tagName) || (bool) preg_match('/(?:^|[\s_-])(?:card|feature|service|provider|resource|post|project|stat|badge|tile|panel|item)(?:$|[\s_-])/', $className);
     }
 
     private function isVisualLayerElement(DOMElement $element): bool
@@ -3901,6 +3911,60 @@ final class HtmlTransformer
     }
 
     /**
+     * @return array<string, mixed>|null
+     */
+    private function backgroundImageBlockFromElement(DOMElement $element): ?array
+    {
+        $url = $this->backgroundImageUrlFromStyle($this->attr($element, 'style'));
+        if ( '' === $url ) {
+            return null;
+        }
+
+        return $this->createBlock('core/image', array_filter(array(
+            'url'       => $url,
+            'alt'       => $this->backgroundImageAlt($element),
+            'className' => 'blocks-engine-background-image',
+        ), static fn (string $value): bool => '' !== $value), array(), $element);
+    }
+
+    private function backgroundImageUrlFromStyle(string $style): string
+    {
+        if ( ! preg_match('/(?:^|;)\s*background(?:-image)?\s*:\s*[^;]*url\(\s*(["\']?)([^"\')]+)\1\s*\)/i', $style, $matches) ) {
+            return '';
+        }
+
+        $url = trim(html_entity_decode((string) $matches[2], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
+            return '';
+        }
+
+        return $url;
+    }
+
+    private function backgroundImageAlt(DOMElement $element): string
+    {
+        foreach ( array( 'aria-label', 'title' ) as $attribute ) {
+            $value = trim($this->attr($element, $attribute));
+            if ( '' !== $value ) {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    private function hasDirectMediaChild(DOMElement $element): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'img', 'picture', 'svg', 'video', 'audio' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param array<int, array<string, mixed>> $fallbacks
      * @return array<string, mixed>|null
      */
@@ -4047,8 +4111,28 @@ final class HtmlTransformer
         }
 
         return (bool) preg_match('/(?:^|[\s_-])columns?(?:$|[\s_-])/', $className)
+            || ( $this->looksLikeSplitLayout($element) && 1 < $this->directElementChildCount($element) )
             || ( $this->looksLikeDocumentationLayout($element) && $this->hasSidebarAndContentChildren($element) )
             || preg_match('/(?:^|;)\s*(?:display\s*:\s*(?:inline-)?flex|grid-template-columns\s*:)/', $style);
+    }
+
+    private function looksLikeSplitLayout(DOMElement $element): bool
+    {
+        $name = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id')));
+
+        return (bool) preg_match('/(?:^|[\s_-])(?:split|two[\s_-]?col|media[\s_-]?text|text[\s_-]?media|feature[\s_-]?row|hero[\s_-]?(?:inner|grid|content|layout)|content[\s_-]?grid)(?:$|[\s_-])/', $name);
+    }
+
+    private function directElementChildCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+
+        return $count;
     }
 
     private function looksLikeDocumentationLayout(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
+++ b/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-background-icon-media-patterns",
+  "description": "Converts generic background-image heroes and icon-like SVG card media into core media blocks without fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-background-icon-media-patterns.json",
+    "notes": "Product-neutral coverage from SSI fixture matrix media/icon/background parity gaps."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"hero media-hero\" aria-label=\"Mountain clinic exterior\" style=\"background-image:url('/assets/clinic-hero.jpg');background-size:cover\"><div class=\"hero-copy\"><h1>Care that meets you</h1><p>Evidence-based care in a calm space.</p></div></section><div class=\"feature-card\"><div class=\"feature-icon\" aria-hidden=\"true\"><svg viewBox=\"0 0 24 24\" width=\"24\" height=\"24\" fill=\"none\" stroke=\"currentColor\"><path d=\"M4 12h16\"/><path d=\"M12 4v16\"/></svg></div><h3>Fast booking</h3><p>Choose the right visit online.</p></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero media-hero", "style": "background-image:url('/assets/clinic-hero.jpg');background-size:cover" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "url": "/assets/clinic-hero.jpg", "alt": "Mountain clinic exterior", "className": "blocks-engine-background-image" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Care that meets you", "level": 1 } },
+    { "path": "blocks.1", "name": "core/group", "attrs": { "className": "feature-card" } },
+    { "path": "blocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature-icon" } },
+    { "path": "blocks.1.innerBlocks.0.innerBlocks.0", "name": "core/image" },
+    { "path": "blocks.1.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Fast booking", "level": 3 } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "assets/inline-svg-" },
+    { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-generic-section-layout-hierarchy.json
+++ b/php-transformer/tests/fixtures/parity/html-generic-section-layout-hierarchy.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-generic-section-layout-hierarchy",
+  "description": "Recognizes generic hero split layouts, inner containers, repeated feature grids, and card-like children from neutral structural class tokens.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-generic-section-layout-hierarchy.json",
+    "notes": "Derived from SSI fixture matrix patterns such as hero-inner/hero-grid, wrap/container, grid-3/grid-4, feature/service/provider cards, and stat/trust-badge rows."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><section class=\"hero\"><div class=\"wrap hero-inner\"><div class=\"hero-text\"><p class=\"eyebrow\">Open source</p><h1>Launch faster</h1><p>Reusable sections with clean hierarchy.</p><div class=\"hero-actions\"><a class=\"btn btn-primary\" href=\"/start\">Start</a><a class=\"btn btn-ghost\" href=\"/demo\">Demo</a></div></div><div class=\"hero-panel\"><div class=\"stat\"><strong>43%</strong><p>faster publishing</p></div></div></div></section><section class=\"section\"><div class=\"wrap\"><div class=\"section-head\"><p class=\"kicker\">Why it works</p><h2>Feature sections stay grouped</h2></div><div class=\"features\"><div class=\"feature\"><h3>Blocks</h3><p>Composable editing.</p></div><div class=\"feature\"><h3>Ownership</h3><p>Your content stays yours.</p></div><div class=\"feature\"><h3>Ecosystem</h3><p>Thousands of extensions.</p></div></div></div></section></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "hero" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/columns", "attrs": { "className": "wrap hero-inner" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/column", "attrs": { "className": "hero-text" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/column", "attrs": { "className": "hero-panel" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "section" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "wrap" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "features", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/group", "attrs": { "className": "feature" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.1.innerBlocks.2", "name": "core/group", "attrs": { "className": "feature" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"wrap hero-inner\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"features\",\"layout\":{\"type\":\"grid\"}} -->" },
+    { "path": "source_reports.html.structure_signals.1.signals.section_container_like", "assert": "equals", "value": true },
+    { "path": "source_reports.html.structure_signals.9.signals.repeated_card_children", "assert": "equals", "value": 3 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve icon-like decorative SVGs as generated core/image assets instead of dropping them when they appear in icon/logo contexts.
- Extract safe inline CSS background images into core/image children for generic hero/section/card wrappers while preserving source wrapper layout/style.
- Broaden generic card/grid/split-layout class recognition for media-text and section hierarchy patterns surfaced by the SSI fixture matrix.
- Add parity fixtures for background/icon media patterns and generic section layout hierarchy.

## Evidence
- SSI matrix run: d8f80380-5220-4d18-8ccc-0ee2cacd1680
- Matrix summary: 71 fixtures, 71 failed, 1126 findings; runtime_target_gap 806, static_site_import_quality 320.

## Local tests
- php php-transformer/tests/parity/run.php
- cd php-transformer && composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspecting transformer/media fixture evidence, implementing generic php-transformer recognition improvements, adding parity fixtures, and running local verification.