### PR TITLE
Improve generic SSI matrix pattern recognition

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -491,7 +491,7 @@ final class HtmlTransformer
             $items = array();
             foreach ( $element->getElementsByTagName('a') as $anchor ) {
                 if ( $anchor instanceof DOMElement ) {
-                    $label = $this->normalizedNavigationLabel($anchor->textContent ?? '');
+                    $label = $this->sourceNavigationAnchorLabel($anchor);
                     if ( '' !== $label ) {
                         $items[] = array(
                             'label' => $label,
@@ -583,6 +583,28 @@ final class HtmlTransformer
     private function normalizedNavigationLabel(string $label): string
     {
         return trim(preg_replace('/\s+/', ' ', html_entity_decode($this->runtime->stripAllTags($label), ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? $label);
+    }
+
+    private function sourceNavigationAnchorLabel(DOMElement $anchor): string
+    {
+        $label = $this->normalizedNavigationLabel($anchor->textContent ?? '');
+        if ( '' !== $label ) {
+            return $label;
+        }
+
+        foreach ( array( 'aria-label', 'title' ) as $attribute ) {
+            $label = $this->normalizedNavigationLabel($this->attr($anchor, $attribute));
+            if ( '' !== $label ) {
+                return $label;
+            }
+        }
+
+        $image = $anchor->getElementsByTagName('img')->item(0);
+        if ( $image instanceof DOMElement ) {
+            return $this->normalizedNavigationLabel($this->attr($image, 'alt'));
+        }
+
+        return '';
     }
 
     /**
@@ -688,7 +710,7 @@ final class HtmlTransformer
 
             if ( 'core/navigation' === ($block['blockName'] ?? '') ) {
                 $signature = $this->navigationBlockSignature($block);
-                if ( '' !== $signature && isset($seen[$signature]) ) {
+                if ( '' !== $signature && isset($seen[$signature]) && $this->isMobileDuplicateNavigationBlock($block) ) {
                     continue;
                 }
                 if ( '' !== $signature ) {
@@ -700,6 +722,26 @@ final class HtmlTransformer
         }
 
         return $deduplicated;
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     */
+    private function isMobileDuplicateNavigationBlock(array $block): bool
+    {
+        $provenanceId = $block['_source_provenance_id'] ?? null;
+        $source = is_int($provenanceId) ? ( $this->sourceProvenance[$provenanceId] ?? array() ) : array();
+        $attributes = is_array($source['source_attributes'] ?? null) ? $source['source_attributes'] : array();
+        $context = is_array($source['context'] ?? null) ? $source['context'] : array();
+        $classNames = is_array($context['class_names'] ?? null) ? implode(' ', $context['class_names']) : '';
+
+        $haystack = strtolower(trim(implode(' ', array(
+            (string) ($attributes['class'] ?? ''),
+            (string) ($attributes['id'] ?? ''),
+            $classNames,
+        ))));
+
+        return (bool) preg_match('/(?:^|[^a-z0-9])(?:mobile|drawer|offcanvas|overlay|hamburger|menu-panel|nav-panel)(?:[^a-z0-9]|$)/', $haystack);
     }
 
     /**
@@ -889,6 +931,10 @@ final class HtmlTransformer
         }
 
         if ( $this->isInlineContentElement($tagName) ) {
+            if ( $this->isRuntimeDomTarget($element) || ( '' === trim($element->textContent ?? '') && $this->hasIconLikeContext($element) ) ) {
+                return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
+            }
+
             $dynamicText = $this->dynamicTextContent($element);
             if ( null !== $dynamicText ) {
                 return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $this->runtime->escapeHtml($dynamicText) )), array(), $element);
@@ -986,6 +1032,19 @@ final class HtmlTransformer
             $codeWindow = $this->codeWindowBlockFromElement($element, $fallbacks);
             if ( null !== $codeWindow ) {
                 return $codeWindow;
+            }
+
+            $linkedMedia = $this->figureLinkedMediaAnchor($element);
+            if ( $linkedMedia instanceof DOMElement ) {
+                $linkedPicture = $this->firstChildElement($linkedMedia, 'picture');
+                if ( $linkedPicture instanceof DOMElement ) {
+                    return $this->convertPictureElement($linkedPicture, $element, $linkedMedia);
+                }
+
+                $linkedImage = $this->firstChildElement($linkedMedia, 'img');
+                if ( $linkedImage instanceof DOMElement ) {
+                    return $this->convertImageElement($linkedImage, $element, null, $linkedMedia);
+                }
             }
 
             $image = $this->figureMediaElement($element, 'img');
@@ -1518,7 +1577,7 @@ final class HtmlTransformer
             $this->attr($element, 'role'),
         ))));
 
-        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|cards?|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap)(?:[^a-z0-9]|$)/', $tokens) ) {
+        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|cards?|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap|hero|masthead|banner|media|image|photo|gallery)(?:[^a-z0-9]|$)/', $tokens) ) {
             return true;
         }
 
@@ -1582,6 +1641,7 @@ final class HtmlTransformer
         $safe = array_flip(array(
             'background',
             'background-color',
+            'background-image',
             'border',
             'border-color',
             'border-radius',
@@ -1633,7 +1693,8 @@ final class HtmlTransformer
             [$name, $value] = array_map('trim', explode(':', $declaration, 2));
             $name = strtolower($name);
             $value = preg_replace('/\s+/', ' ', $value) ?? $value;
-            if ( '' !== $name && '' !== $value && ! preg_match('/(?:expression\s*\(|javascript\s*:|url\s*\()/i', $value) ) {
+            $allowsImageUrl = in_array($name, array( 'background', 'background-image' ), true) && ! preg_match('/(?:expression\s*\(|javascript\s*:)/i', $value);
+            if ( '' !== $name && '' !== $value && ( $allowsImageUrl || ! preg_match('/(?:expression\s*\(|javascript\s*:|url\s*\()/i', $value) ) ) {
                 $declarations[$name] = $value;
             }
         }
@@ -2530,6 +2591,28 @@ final class HtmlTransformer
         return $this->onlyChildElement($wrapper, $tagName);
     }
 
+    private function figureLinkedMediaAnchor(DOMElement $figure): ?DOMElement
+    {
+        $anchor = null;
+        foreach ( $figure->childNodes as $child ) {
+            if ( $child instanceof DOMElement && 'figcaption' === strtolower($child->tagName) ) {
+                continue;
+            }
+
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement || 'a' !== strtolower($child->tagName) || null !== $anchor ) {
+                return null;
+            }
+
+            $anchor = $child;
+        }
+
+        return $anchor instanceof DOMElement && $this->isImageOnlyAnchor($anchor) ? $anchor : null;
+    }
+
     private function onlyChildElement(DOMElement $element, string $tagName): ?DOMElement
     {
         $match = null;
@@ -3419,11 +3502,6 @@ final class HtmlTransformer
                 return null;
             }
 
-            if ( $this->isRuntimeDomTarget($control) ) {
-                $contentBlocks[] = $this->createBlock('core/html', array( 'content' => $this->safeFallbackHtml($control) ), array(), $control);
-                continue;
-            }
-
             if ( 'submit' === $this->formControlType($control) ) {
                 $buttonBlocks[] = $this->createBlock('core/button', array_merge($this->presentationAttributes($control), array(
                     'text' => $this->runtime->escapeHtml($this->readableSubmitText($control)),
@@ -3431,9 +3509,15 @@ final class HtmlTransformer
                 continue;
             }
 
+            if ( $this->isRuntimeDomTarget($control) ) {
+                $contentBlocks[] = $this->createBlock('core/html', array( 'content' => $this->safeFallbackHtml($control) ), array(), $control);
+                continue;
+            }
+
             $summary = $this->readableFormControlText($control);
             if ( '' !== $summary ) {
-                $contentBlocks[] = $this->createBlock('core/paragraph', array( 'content' => $summary ), array(), $control);
+                $attrs = $this->isRuntimeDomTarget($control) ? $this->presentationAttributes($control) : array();
+                $contentBlocks[] = $this->createBlock('core/paragraph', array_merge($attrs, array( 'content' => $summary )), array(), $control);
             }
         }
 
@@ -3461,11 +3545,6 @@ final class HtmlTransformer
                 foreach ( $controls as $control ) {
                     if ( ! $this->isReadableFormControl($control) || array() !== $this->eventMetadata($control) ) {
                         return null;
-                    }
-
-                    if ( $this->isRuntimeDomTarget($control) ) {
-                        $blocks[] = $this->createBlock('core/html', array( 'content' => $this->safeFallbackHtml($control) ), array(), $control);
-                        continue;
                     }
 
                     $summary = $this->readableFormControlText($control);
@@ -3514,13 +3593,16 @@ final class HtmlTransformer
             return $this->createBlock('core/search', $attrs, array(), $element);
         }
 
+        if ( $this->isRuntimeDomTarget($element) ) {
+            return $this->createBlock('core/html', array( 'content' => $this->safeFallbackHtml($element) ), array(), $element);
+        }
+
         $summary = $this->readableFormControlText($element);
         if ( '' === $summary ) {
             return null;
         }
 
-        $attrs = $this->isRuntimeDomTarget($element) ? $this->presentationAttributes($element) : array();
-        return $this->createBlock('core/paragraph', array_merge($attrs, array( 'content' => $summary )), array(), $element);
+        return $this->createBlock('core/paragraph', array( 'content' => $summary ), array(), $element);
     }
 
     /**
@@ -3870,6 +3952,21 @@ final class HtmlTransformer
             }
 
             if ( 'figure' === $tagName ) {
+                $linkedMedia = $this->figureLinkedMediaAnchor($child);
+                if ( $linkedMedia instanceof DOMElement ) {
+                    $linkedPicture = $this->firstChildElement($linkedMedia, 'picture');
+                    if ( $linkedPicture instanceof DOMElement ) {
+                        $images[] = $this->convertPictureElement($linkedPicture, $child, $linkedMedia);
+                        continue;
+                    }
+
+                    $linkedImage = $this->firstChildElement($linkedMedia, 'img');
+                    if ( $linkedImage instanceof DOMElement ) {
+                        $images[] = $this->convertImageElement($linkedImage, $child, null, $linkedMedia);
+                        continue;
+                    }
+                }
+
                 $image = $this->firstChildElement($child, 'img');
                 if ( $image instanceof DOMElement ) {
                     $images[] = $this->convertImageElement($image, $child);
@@ -3915,13 +4012,13 @@ final class HtmlTransformer
      */
     private function backgroundImageBlockFromElement(DOMElement $element): ?array
     {
-        $url = $this->backgroundImageUrlFromStyle($this->attr($element, 'style'));
+        $url = $this->backgroundImageUrlFromStyle($this->mergedPresentationStyle($element));
         if ( '' === $url ) {
             return null;
         }
 
         return $this->createBlock('core/image', array_filter(array(
-            'url'       => $url,
+            'url'       => $this->resolvedAssetImageUrl($url),
             'alt'       => $this->backgroundImageAlt($element),
             'className' => 'blocks-engine-background-image',
         ), static fn (string $value): bool => '' !== $value), array(), $element);
@@ -4443,14 +4540,14 @@ final class HtmlTransformer
         return in_array($extension, array( 'doc', 'docx', 'odp', 'ods', 'odt', 'pdf', 'ppt', 'pptx', 'rtf', 'txt', 'xls', 'xlsx', 'zip' ), true) ? $url : '';
     }
 
-    private function convertPictureElement(DOMElement $picture, ?DOMElement $figure = null): ?array
+    private function convertPictureElement(DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array
     {
         $image = $this->firstChildElement($picture, 'img');
         if ( ! $image instanceof DOMElement ) {
             return null;
         }
 
-        return $this->convertImageElement($image, $figure ?? $picture, $picture);
+        return $this->convertImageElement($image, $figure ?? $picture, $picture, $link);
     }
 
     private function imageBlockFromAnchor(DOMElement $anchor): ?array

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -61,7 +61,11 @@ final class NavigationPattern
                 continue;
             }
 
-            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') ) {
+            if ( $child instanceof DOMElement && $this->isSectionLabelElement($child) ) {
+                continue;
+            }
+
+            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== $this->anchorLabel($child, $innerHtml) ) {
                 if ( ! $allowsDirectItems ) {
                     return array();
                 }
@@ -132,7 +136,7 @@ final class NavigationPattern
     private function navigationBlockFromItem(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null): ?array
     {
         $anchor = $this->primaryNavigationAnchor($element);
-        if ( ! $anchor instanceof DOMElement || '' === trim($anchor->textContent ?? '') ) {
+        if ( ! $anchor instanceof DOMElement || '' === $this->anchorLabel($anchor, $innerHtml) ) {
             return null;
         }
 
@@ -145,7 +149,7 @@ final class NavigationPattern
 
         if ( array() !== $submenuBlocks ) {
             $submenuAttrs = array(
-                'label' => $this->navigationLabel($innerHtml($anchor)),
+                'label' => $this->anchorLabel($anchor, $innerHtml),
                 'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
                 'kind'  => 'custom',
             );
@@ -163,10 +167,35 @@ final class NavigationPattern
     private function navigationLinkBlock(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?DOMElement $item = null): array
     {
         return $createBlock('core/navigation-link', $this->navigationItemAttributes($item ?? $anchor, $anchor, null, array(
-            'label' => $this->navigationLabel($innerHtml($anchor)),
+            'label' => $this->anchorLabel($anchor, $innerHtml),
             'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
             'kind'  => 'custom',
         ), $presentationAttributes), array(), $anchor);
+    }
+
+    private function anchorLabel(DOMElement $anchor, callable $innerHtml): string
+    {
+        $label = $this->navigationLabel($innerHtml($anchor));
+        if ( '' !== $label ) {
+            return $label;
+        }
+
+        foreach ( array( 'aria-label', 'title' ) as $attribute ) {
+            $fallback = trim($this->attr($anchor, $attribute));
+            if ( '' !== $fallback ) {
+                return htmlspecialchars($fallback, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            }
+        }
+
+        $image = $anchor->getElementsByTagName('img')->item(0);
+        if ( $image instanceof DOMElement ) {
+            $alt = trim($this->attr($image, 'alt'));
+            if ( '' !== $alt ) {
+                return htmlspecialchars($alt, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            }
+        }
+
+        return '';
     }
 
     private function navigationLabel(string $html): string
@@ -273,6 +302,21 @@ final class NavigationPattern
         }
 
         return false;
+    }
+
+    private function isSectionLabelElement(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( preg_match('/^h[1-6]$/', $tagName) ) {
+            return true;
+        }
+
+        if ( ! in_array($tagName, array( 'span', 'p', 'strong', 'b' ), true) ) {
+            return false;
+        }
+
+        $tokens = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'id'));
+        return (bool) preg_match('/(?:^|[^a-z0-9])(?:label|heading|title)(?:[^a-z0-9]|$)/', $tokens);
     }
 
     private function hasNavigationChrome(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -420,6 +420,31 @@ $assert(! str_contains((string) ($navigationLabelResult['serialized_blocks'] ?? 
 $assert(! str_contains((string) ($navigationLabelResult['serialized_blocks'] ?? ''), '<div>Guides</div>'), 'navigation serialization avoids div markup inside submenu link text');
 $assert('pass' === ($navigationLabelResult['source_reports']['wp_block_validity']['status'] ?? ''), 'navigation labels with block-level source markup pass WordPress block validity');
 
+$footerNavigationSections = ( new HtmlTransformer() )->transform(
+    '<footer><div class="footer-grid"><nav aria-label="Product"><h3>Product</h3><ul><li><a class="footer-link" href="/features">Features</a></li><li><a class="footer-link" href="/pricing">Pricing</a></li></ul></nav><nav aria-label="Company"><p class="nav-title">Company</p><a class="footer-link" href="/about">About</a><a class="footer-link" href="/contact">Contact</a></nav><nav class="social-links" aria-label="Social"><a class="social-link" href="https://example.com/mastodon" aria-label="Mastodon"><svg aria-hidden="true"><path d="M0 0h1v1z"></path></svg></a><a class="social-link" href="https://example.com/github" title="GitHub"><span aria-hidden="true"></span></a></nav></div></footer>'
+)->toArray();
+$footerNavigationParity = $footerNavigationSections['source_reports']['semantic_parity'] ?? array();
+$footerNavigationMenus = $footerNavigationParity['navigation_menus']['blocks'] ?? array();
+$footerNavigationSerialized = (string) ($footerNavigationSections['serialized_blocks'] ?? '');
+$assert('pass' === ($footerNavigationParity['status'] ?? ''), 'footer navigation sections with headings and social labels pass semantic parity');
+$assert(3 === count($footerNavigationMenus), 'footer navigation sections emit one core/navigation block per source nav landmark');
+$assert(2 === ($footerNavigationMenus[0]['item_count'] ?? null), 'footer heading nav preserves list link count');
+$assert('Mastodon' === ($footerNavigationMenus[2]['items'][0]['label'] ?? ''), 'icon-only social links use aria-label as navigation label');
+$assert('GitHub' === ($footerNavigationMenus[2]['items'][1]['label'] ?? ''), 'icon-only social links use title as navigation label');
+$assert(str_contains($footerNavigationSerialized, 'footer-link'), 'footer navigation preserves link classes for styling and script targets');
+$assert(str_contains($footerNavigationSerialized, 'social-link'), 'social navigation preserves social link classes for styling and script targets');
+
+$headerCluster = ( new HtmlTransformer() )->transform(
+    '<header class="site-header"><a class="site-logo" href="/">Acme Lab</a><nav class="primary-nav" aria-label="Primary"><a class="nav-link" href="/work">Work</a><a class="nav-link" href="/docs"><span>Docs</span></a></nav><form class="site-search" role="search" action="/search"><label for="q">Search</label><input id="q" type="search" name="q" placeholder="Search docs"><button type="submit">Search</button></form><div class="header-actions"><a class="cta" href="/start">Get started</a></div></header>'
+)->toArray();
+$headerClusterSerialized = (string) ($headerCluster['serialized_blocks'] ?? '');
+$headerClusterParity = $headerCluster['source_reports']['semantic_parity'] ?? array();
+$assert('pass' === ($headerClusterParity['status'] ?? ''), 'header logo/nav/search/CTA clusters preserve source navigation semantic parity');
+$assert(str_contains($headerClusterSerialized, 'site-logo'), 'header cluster preserves logo link wrapper');
+$assert(str_contains($headerClusterSerialized, 'nav-link'), 'header cluster preserves nav link class target');
+$assert(str_contains($headerClusterSerialized, '<!-- wp:search'), 'header cluster converts search form to core/search');
+$assert(str_contains($headerClusterSerialized, '<!-- wp:buttons'), 'header cluster converts CTA action to buttons');
+
 $unmappedNavigation = ( new HtmlTransformer() )->transform(
     '<main><nav aria-label="Main navigation"><ul><li><a href="/">Home</a></li></ul><p>Unexpected helper copy</p></nav></main>'
 )->toArray();

--- a/php-transformer/tests/fixtures/parity/html-linked-media-background-runtime-targets.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-media-background-runtime-targets.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-linked-media-background-runtime-targets",
+  "description": "Converts linked figure/gallery media, CSS background image heroes, and empty runtime icon targets without losing generic DOM targets.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-linked-media-background-runtime-targets.json",
+    "notes": "Product-neutral coverage for SSI matrix media/card/gallery/hero parity gaps."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"hero-media\" aria-label=\"Lakeside retreat\"><h1>Retreats</h1></section><figure class=\"featured-card\"><a class=\"media-link\" href=\"/retreats\"><img class=\"card-image\" src=\"/assets/retreat.jpg\" alt=\"Retreat house\"></a><figcaption>Explore the retreat</figcaption></figure><div id=\"pattern-gallery\" class=\"gallery-cards\"><figure><a href=\"/one\"><picture><source srcset=\"/assets/one-large.jpg 900w\"><img src=\"/assets/one.jpg\" alt=\"One\"></picture></a><figcaption>One caption</figcaption></figure><figure><a href=\"/two\"><img src=\"/assets/two.jpg\" alt=\"Two\"></a><figcaption>Two caption</figcaption></figure></div><span class=\"dicon\" aria-hidden=\"true\"></span>",
+    "options": {
+      "static_css": ".hero-media{background-image:url('/assets/hero-bg.jpg');background-size:cover}",
+      "runtime_dom_selectors": ["#pattern-gallery", ".dicon"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-media", "style": "background-image:url('/assets/hero-bg.jpg')" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "url": "/assets/hero-bg.jpg", "alt": "Lakeside retreat", "className": "blocks-engine-background-image" } },
+    { "path": "blocks.1", "name": "core/image", "attrs": { "url": "/assets/retreat.jpg", "alt": "Retreat house", "caption": "Explore the retreat", "href": "/retreats", "linkDestination": "custom", "linkClass": "media-link", "className": "featured-card card-image" } },
+    { "path": "blocks.2", "name": "core/gallery", "attrs": { "anchor": "pattern-gallery", "className": "gallery-cards" } },
+    { "path": "blocks.2.innerBlocks.0", "name": "core/image", "attrs": { "url": "/assets/one.jpg", "alt": "One", "caption": "One caption", "href": "/one", "linkDestination": "custom", "srcset": "/assets/one-large.jpg 900w" } },
+    { "path": "blocks.2.innerBlocks.1", "name": "core/image", "attrs": { "url": "/assets/two.jpg", "alt": "Two", "caption": "Two caption", "href": "/two", "linkDestination": "custom" } },
+    { "path": "blocks.3", "name": "core/group", "attrs": { "className": "dicon" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "blocks-engine-background-image" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "href=\"/retreats\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "id=\"pattern-gallery\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "dicon" },
+    { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-repeated-footer-nav-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-repeated-footer-nav-preserved.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-repeated-footer-nav-preserved",
+  "description": "Preserves repeated non-mobile navigation menus instead of globally deduplicating by identical link signature.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-repeated-footer-nav-preserved.json",
+    "notes": "Covers SSI matrix footer/header semantic parity where footer menus intentionally repeat primary links."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header><nav class=\"primary-nav\"><a href=\"/\">Home</a><a href=\"/about\">About</a></nav></header><footer><nav class=\"footer-nav\"><a href=\"/\">Home</a><a href=\"/about\">About</a></nav></footer>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
+    { "path": "blocks.1", "name": "core/navigation", "attrs": { "className": "footer-nav" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.1.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "source_reports.semantic_parity.navigation_menus.source", "assert": "count", "count": 2 },
+    { "path": "source_reports.semantic_parity.navigation_menus.blocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "primary-nav" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "footer-nav" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
@@ -13,7 +13,10 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<section><h2>Newsletter</h2><form class=\"signup\" onsubmit=\"return subscribe(event)\"><input type=\"email\" required placeholder=\"you@example.com\" aria-label=\"Email address\"><button class=\"btn\">Subscribe</button></form></section>"
+    "content": "<section><h2>Newsletter</h2><form class=\"signup\" onsubmit=\"return subscribe(event)\"><input id=\"signup-email\" class=\"form-input\" type=\"email\" required placeholder=\"you@example.com\" aria-label=\"Email address\"><button class=\"btn\">Subscribe</button></form></section>",
+    "options": {
+      "runtime_dom_selectors": ["#signup-email"]
+    }
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group" },
@@ -27,12 +30,16 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 1 },
-    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.blockName", "assert": "equals", "value": "core/html" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.attrs.content", "assert": "contains", "value": "<input id=\"signup-email\"" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
     { "path": "fallbacks.0.events.0.type", "assert": "equals", "value": "submit" },
     { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.blockName", "assert": "equals", "value": "core/group" },
-    { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
+    { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/html" },
+    { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<input id=\"signup-email\"" },
     { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:html" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<input id=\"signup-email\"" },
     { "path": "source_reports.conversion_report.fallback_diagnostics.0.reason", "assert": "equals", "value": "form_requires_runtime" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-runtime-target-input-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-target-input-preserved.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-runtime-target-input-preserved",
+  "description": "Preserves non-search standalone input DOM targets when scripts reference them.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-runtime-target-input-preserved.json",
+    "notes": "Covers runtime dependency target preservation for input controls used by first-party scripts."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<input id=\"grid-size\" class=\"grid-size\" type=\"range\" min=\"2\" max=\"12\" value=\"6\">",
+    "options": {
+      "runtime_dom_selectors": ["#grid-size"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/html", "attrs": { "content": "<input id=\"grid-size\" class=\"grid-size\" type=\"range\" min=\"2\" max=\"12\" value=\"6\">" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<input id=\"grid-size\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:html" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-standalone-input-controls-readable.json
+++ b/php-transformer/tests/fixtures/parity/html-standalone-input-controls-readable.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-standalone-input-controls-readable",
+  "description": "Converts placeholder-only standalone text, email, and number inputs to readable paragraphs without raw HTML fallback.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-standalone-input-controls-readable.json",
+    "notes": "Mirrors r10 nonprofit donation/volunteer standalone input fallbacks."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<input type=\"number\" id=\"d-custom\" name=\"custom-amount\" class=\"form-input\" placeholder=\"Enter amount\" min=\"1\" aria-label=\"Custom donation amount\"><input type=\"text\" id=\"d-name\" name=\"name\" class=\"form-input\" placeholder=\"Your name\" required autocomplete=\"name\"><input type=\"email\" id=\"d-email\" name=\"email\" class=\"form-input\" placeholder=\"you@example.com\" required autocomplete=\"email\">"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/paragraph", "attrs": { "content": "Custom donation amount: Enter amount" } },
+    { "path": "blocks.1", "name": "core/paragraph", "attrs": { "content": "Your name: Your name (required)" } },
+    { "path": "blocks.2", "name": "core/paragraph", "attrs": { "content": "you@example.com: you@example.com (required)" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:html" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Custom donation amount: Enter amount" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- improve generic HTML-to-block recognition for r10 SSI matrix gaps across forms, media, navigation, and repeated footer menus
- preserve runtime-target controls when scripts need native DOM nodes while converting non-runtime controls to readable blocks
- add parity/contract coverage for linked media, background images, runtime inputs, and repeated navigation

## Testing
- php php-transformer/tests/parity/run.php
- php php-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general subagents
- **Used for:** r10 matrix diagnostic analysis, transformer patch drafting, and test fixture updates