### PR TITLE
Introduce HTML pattern recognizer registry

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -10,6 +10,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use DOMDocument;
 use DOMElement;
@@ -27,7 +29,7 @@ final class HtmlTransformer
 
     private readonly LogoPattern $logoPattern;
 
-    private readonly NavigationPattern $navigationPattern;
+    private readonly PatternRecognizerRegistry $patternRecognizers;
 
     /**
      * @var array<string, string>
@@ -92,7 +94,9 @@ final class HtmlTransformer
         $this->buttonsPattern    = new ButtonsPattern();
         $this->detailsPattern    = new DetailsPattern();
         $this->logoPattern       = new LogoPattern();
-        $this->navigationPattern = new NavigationPattern();
+        $this->patternRecognizers = new PatternRecognizerRegistry(array(
+            new NavigationPattern(),
+        ));
     }
 
     /**
@@ -904,6 +908,16 @@ final class HtmlTransformer
         return $blocks;
     }
 
+    private function patternContext(bool $includeRuntimeDomTarget = true): PatternContext
+    {
+        return new PatternContext(
+            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement),
+            $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null
+        );
+    }
+
     /**
      * @param array<int, array<string, mixed>> $fallbacks
      * @return array<string, mixed>|null
@@ -978,13 +992,7 @@ final class HtmlTransformer
         }
 
         if ( 'ul' === $tagName || 'ol' === $tagName ) {
-            $navigation = $this->navigationPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement),
-                fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement)
-            );
+            $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
             if ( null !== $navigation ) {
                 return $navigation;
             }
@@ -1281,12 +1289,7 @@ final class HtmlTransformer
         }
 
         if ( 'nav' === $tagName ) {
-            $navigation = $this->navigationPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext(false));
             if ( null !== $navigation ) {
                 return $navigation;
             }
@@ -1315,13 +1318,7 @@ final class HtmlTransformer
             }
 
             if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
-                $navigation = $this->navigationPattern->match(
-                    $element,
-                    fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                    fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement),
-                    fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement)
-                );
+                $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
                 if ( null !== $navigation ) {
                     return $navigation;
                 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -5,19 +5,20 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
-final class NavigationPattern
+final class NavigationPattern implements PatternRecognizerInterface
 {
     private const BLOCK_LEVEL_LABEL_TAGS = 'address|article|aside|blockquote|div|dl|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|main|nav|ol|p|pre|section|table|ul';
 
     /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @param callable(DOMElement): bool|null $isRuntimeDomTarget
      * @return array<string, mixed>|null
      */
-    public function match(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null): ?array
+    public function match(DOMElement $element, PatternContext $context): ?array
     {
+        $presentationAttributes = $context->presentationAttributesCallback();
+        $innerHtml = $context->innerHtmlCallback();
+        $createBlock = $context->createBlockCallback();
+        $isRuntimeDomTarget = $context->isRuntimeDomTargetCallback();
+
         if ( 'nav' !== strtolower($element->tagName) && ! $this->hasNavigationSignal($element) && ! $this->hasDirectListNavigationSignal($element) ) {
             return null;
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+final class PatternContext
+{
+    /**
+     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $innerHtml
+     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
+     * @param callable(DOMElement): bool|null $isRuntimeDomTarget
+     */
+    public function __construct(
+        private readonly mixed $presentationAttributes,
+        private readonly mixed $innerHtml,
+        private readonly mixed $createBlock,
+        private readonly mixed $isRuntimeDomTarget = null
+    ) {
+    }
+
+    /**
+     * @return callable(DOMElement): array<string, mixed>
+     */
+    public function presentationAttributesCallback(): callable
+    {
+        return $this->presentationAttributes;
+    }
+
+    /**
+     * @return callable(DOMElement): string
+     */
+    public function innerHtmlCallback(): callable
+    {
+        return $this->innerHtml;
+    }
+
+    /**
+     * @return callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed>
+     */
+    public function createBlockCallback(): callable
+    {
+        return $this->createBlock;
+    }
+
+    /**
+     * @return callable(DOMElement): bool|null
+     */
+    public function isRuntimeDomTargetCallback(): ?callable
+    {
+        return is_callable($this->isRuntimeDomTarget) ? $this->isRuntimeDomTarget : null;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerInterface.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+interface PatternRecognizerInterface
+{
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function match(DOMElement $element, PatternContext $context): ?array;
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+final class PatternRecognizerRegistry
+{
+    /**
+     * @param array<int, PatternRecognizerInterface> $recognizers
+     */
+    public function __construct(private readonly array $recognizers)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function firstMatch(DOMElement $element, PatternContext $context): ?array
+    {
+        foreach ( $this->recognizers as $recognizer ) {
+            $block = $recognizer->match($element, $context);
+            if ( null !== $block ) {
+                return $block;
+            }
+        }
+
+        return null;
+    }
+}

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -11,6 +11,9 @@ use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatAdapterInterface;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerInterface;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationView;
@@ -192,6 +195,32 @@ $assert('' === ArtifactPath::safeRelativePath('../secrets/logo.png'), 'artifact 
 $assert('assets/logo.png' === ArtifactPath::resolveRelativePath('../assets/logo.png?version=1#hash', 'pages/home.html'), 'artifact references resolve relative paths without query or fragment');
 $assert('' === ArtifactPath::resolveRelativePath('https://example.com/logo.png', 'pages/home.html'), 'artifact references reject URL references');
 $assert('' === ArtifactPath::resolveRelativePath('../../logo.png', 'pages/home.html'), 'artifact references reject traversal above the artifact root');
+
+$registryDocument = new DOMDocument();
+$registryDocument->loadHTML('<div></div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+$registryElement = $registryDocument->getElementsByTagName('div')->item(0);
+$registry = new PatternRecognizerRegistry(array(
+    new class implements PatternRecognizerInterface {
+        public function match(DOMElement $element, PatternContext $context): ?array
+        {
+            return 'div' === strtolower($element->tagName) ? array('blockName' => 'core/group') : null;
+        }
+    },
+));
+$registryContext = new PatternContext(
+    static fn (DOMElement $element): array => array(),
+    static fn (DOMElement $element): string => '',
+    static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $innerBlocks)
+);
+$assert($registryElement instanceof DOMElement, 'pattern registry fixture element parses');
+$assert('core/group' === ($registry->firstMatch($registryElement, $registryContext)['blockName'] ?? null), 'pattern registry returns the first recognizer match');
+
+$navigationResult = ( new HtmlTransformer() )->transform('<nav class="primary"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();
+$navigationBlock = $navigationResult['blocks'][0] ?? array();
+$assert('core/navigation' === ($navigationBlock['blockName'] ?? null), 'navigation conversion still emits a navigation block');
+$assert(2 === count($navigationBlock['innerBlocks'] ?? array()), 'navigation conversion still preserves direct navigation links');
+$assert('About' === ($navigationBlock['innerBlocks'][0]['attrs']['label'] ?? null), 'navigation conversion still preserves link labels');
+$assert('/about' === ($navigationBlock['innerBlocks'][0]['attrs']['url'] ?? null), 'navigation conversion still preserves link URLs');
 
 $fixture = file_get_contents(dirname(__DIR__) . '/fixtures/simple-html.html');
 $result  = ( new HtmlTransformer() )->transform($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><canvas>Fallback</canvas>")->toArray();


### PR DESCRIPTION
## Summary
- add a minimal generic pattern recognizer registry seam for php-transformer
- migrate navigation pattern dispatch through the registry
- add contract coverage proving navigation behavior is preserved

## Testing
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general subagents
- **Used for:** architecture refactor drafting, implementation, and tests