### PR TITLE
Avoid double-transforming absolute Figma bounds

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1649,7 +1649,7 @@ final class StaticHtmlEmitter
             $styles[] = 'opacity:' . $this->number((float) $box['opacity']);
         }
 
-        $transform = $this->isNearZeroHeightContainer($node, $type) ? null : $this->transformStyle($box);
+        $transform = $this->isNearZeroHeightContainer($node, $type) || $this->hasAbsoluteVisualBounds($node) ? null : $this->transformStyle($box);
         if ( null !== $transform ) {
             $styles[] = 'transform:' . $transform;
             if ( $this->hasExplicitTransformMatrix($box) ) {
@@ -2157,6 +2157,15 @@ final class StaticHtmlEmitter
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasAbsoluteVisualBounds(array $node): bool
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        return 'absolute' === ($box['coordinate_space'] ?? null);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -235,6 +235,34 @@ $assert(! str_contains($css, 'overflow-x:hidden'), 'css-preserves-horizontal-scr
 $assert(! str_contains($css, 'order:'), 'css-avoids-source-order');
 $assert(! str_contains($css, 'font-family:Inter') && ! str_contains($css, 'body{margin:0;background') && ! str_contains($css, 'body{margin:0;color'), 'css-avoids-hardcoded-theme-style');
 
+$absoluteTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name' => 'Absolute Transform Fixture',
+    'nodes' => array(
+        array(
+            'id' => 'absolute:root',
+            'type' => 'FRAME',
+            'name' => 'Root',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 200),
+            'children' => array(
+                array(
+                    'id' => 'absolute:child',
+                    'type' => 'RECTANGLE',
+                    'name' => 'Rotated child',
+                    'absoluteBoundingBox' => array('x' => 40, 'y' => 50, 'width' => 80, 'height' => 60),
+                    'layoutPositioning' => 'ABSOLUTE',
+                    'relativeTransform' => array(
+                        array(0, -1, 40),
+                        array(1, 0, 50),
+                    ),
+                    'fill' => array('r' => 1, 'g' => 0, 'b' => 0),
+                ),
+            ),
+        ),
+    ),
+));
+$absoluteTransformCss = $fileContent($absoluteTransformResult, 'style.css');
+$assert(str_contains($absoluteTransformCss, '.figma-node-absolute-child-rotated-child{width:80px;height:60px;position:absolute;left:40px;top:50px;background:#ff0000}'), 'absolute-visual-bounds-skip-css-transform');
+
 $qualityAssets = array();
 for ( $i = 1; $i <= 20; $i++ ) {
     $qualityAssets['quality-image-' . $i] = array('mime_type' => 'image/png', 'content' => 'image ' . $i);


### PR DESCRIPTION
## Summary
- Preserve absolute visual-bounds geometry as emitted left/top/width/height instead of applying a second CSS transform matrix.
- Add contract coverage for an absolute node with a relative transform matrix to ensure it emits fixed geometry without CSS transform.

## Evidence
- Homeboy baseline run: figma-six-fixture-refreshed-20260627.
- Baseline top mismatch evidence included Agentic transformed shape drift, e.g. node 375:6765 source box 1436x1547 at 2081,173 vs generated DOM box 1225x2684 at 857,-1311 while CSS emitted the visual-bound size plus transform:matrix(...).

## Verification
- php tests/contract/run.php

## Matrix verification
- Targeted Agentic/WP.Cloud matrix rerun was not feasible in this clean worktree because private .fig fixtures are not present and the matrix script exits with "No fixtures selected."
- No private .fig fixtures were added or committed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating layout mismatch artifacts, implementing the emitter fix, adding contract coverage, and drafting this PR description.
