### PR TITLE
Render closed rect vector networks

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2023,6 +2023,11 @@ final class ScenegraphNormalizer
             return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob.simpleRectFallback', 'windingRule' => 'NONZERO');
         }
 
+        $path = $this->decodeClosedRectVectorNetworkBlob($bytes);
+        if ( null !== $path ) {
+            return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob.closedRectFallback', 'windingRule' => 'NONZERO');
+        }
+
         if ( ! $this->looksLikeVectorNetworkBlob($bytes) ) {
             $path = $this->decodeVectorCommandBlob($bytes);
             if ( null !== $path ) {
@@ -2087,6 +2092,60 @@ final class ScenegraphNormalizer
         }
 
         return 'M 0 0 L ' . $this->svgNumber($width) . ' 0 L ' . $this->svgNumber($width) . ' ' . $this->svgNumber($height) . ' L 0 ' . $this->svgNumber($height) . ' Z';
+    }
+
+    private function decodeClosedRectVectorNetworkBlob(string $bytes): ?string
+    {
+        if ( 200 !== strlen($bytes) ) {
+            return null;
+        }
+
+        if ( array(4, 4, 1) !== $this->vectorNetworkCounts($bytes) ) {
+            return null;
+        }
+
+        $points = $this->closedRectVectorNetworkPoints($bytes);
+        if ( null === $points ) {
+            return null;
+        }
+
+        $xs = array_values(array_unique(array_map(static fn (array $point): string => sprintf('%.6F', $point[0]), $points)));
+        $ys = array_values(array_unique(array_map(static fn (array $point): string => sprintf('%.6F', $point[1]), $points)));
+        if ( 2 !== count($xs) || 2 !== count($ys) ) {
+            return null;
+        }
+
+        $minX = min(array_map('floatval', $xs));
+        $maxX = max(array_map('floatval', $xs));
+        $minY = min(array_map('floatval', $ys));
+        $maxY = max(array_map('floatval', $ys));
+        if ( $maxX <= $minX || $maxY <= $minY ) {
+            return null;
+        }
+
+        return 'M ' . $this->svgNumber($minX) . ' ' . $this->svgNumber($minY)
+            . ' L ' . $this->svgNumber($maxX) . ' ' . $this->svgNumber($minY)
+            . ' L ' . $this->svgNumber($maxX) . ' ' . $this->svgNumber($maxY)
+            . ' L ' . $this->svgNumber($minX) . ' ' . $this->svgNumber($maxY)
+            . ' Z';
+    }
+
+    /**
+     * @return array<int, array{0: float, 1: float}>|null
+     */
+    private function closedRectVectorNetworkPoints(string $bytes): ?array
+    {
+        $points = array();
+        for ( $index = 0; $index < 4; $index++ ) {
+            $offset = 12 + ( $index * 20 );
+            $point = $this->readFloatPair($bytes, $offset + 4);
+            if ( null === $point || ! is_finite($point[0]) || ! is_finite($point[1]) ) {
+                return null;
+            }
+            $points[] = $point;
+        }
+
+        return $points;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -910,9 +910,19 @@ $assert(! in_array('unsupported_vector_node_placeholder', $geometrylessVectorDia
 
 $simpleRectNetworkPrefix = hex2bin('0400000004000000000000000000000000000000000000000000000000008043');
 $simpleRectNetworkBlob = str_pad(false === $simpleRectNetworkPrefix ? '' : $simpleRectNetworkPrefix, 172, "\0");
+$closedRectNetworkBlob = pack('V3', 4, 4, 1) . str_repeat("\0", 188);
+foreach ( array(array(0.0, 0.0), array(12.0, 0.0), array(12.0, 6.0), array(0.0, 6.0)) as $index => $point ) {
+    $offset = 12 + ( $index * 20 ) + 4;
+    $closedRectNetworkBlob = substr_replace($closedRectNetworkBlob, pack('g', $point[0]) . pack('g', $point[1]), $offset, 8);
+}
+$nonRectNetworkBlob = pack('V3', 4, 4, 1) . str_repeat("\0", 188);
+foreach ( array(array(0.0, 0.0), array(12.0, 0.0), array(8.0, 6.0), array(0.0, 6.0)) as $index => $point ) {
+    $offset = 12 + ( $index * 20 ) + 4;
+    $nonRectNetworkBlob = substr_replace($nonRectNetworkBlob, pack('g', $point[0]) . pack('g', $point[1]), $offset, 8);
+}
 $vectorDataResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Vector Data Fixture',
-    'blobs' => array(array('bytes' => $vectorCommandBlob), array('bytes' => "\xff"), array('bytes' => $simpleRectNetworkBlob)),
+    'blobs' => array(array('bytes' => $vectorCommandBlob), array('bytes' => "\xff"), array('bytes' => $simpleRectNetworkBlob), array('bytes' => $closedRectNetworkBlob), array('bytes' => $nonRectNetworkBlob)),
     'nodes' => array(
         array(
             'id'         => 'vector:data',
@@ -949,6 +959,24 @@ $vectorDataResult = blocks_engine_figma_transformer_transform_scenegraph(array(
             'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0.5, 'b' => 1))),
             'vectorData' => array('vectorNetworkBlob' => 2),
         ),
+        array(
+            'id'         => 'vector:data-closed-rect-network',
+            'type'       => 'VECTOR',
+            'name'       => 'Closed Rect Network',
+            'width'      => 12,
+            'height'     => 6,
+            'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.2, 'g' => 0.4, 'b' => 0.6))),
+            'vectorData' => array('vectorNetworkBlob' => 3),
+        ),
+        array(
+            'id'         => 'vector:data-non-rect-network',
+            'type'       => 'VECTOR',
+            'name'       => 'Non Rect Network',
+            'width'      => 12,
+            'height'     => 6,
+            'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.6, 'g' => 0.4, 'b' => 0.2))),
+            'vectorData' => array('vectorNetworkBlob' => 4),
+        ),
     ),
 ));
 $vectorDataHtml = $fileContent($vectorDataResult, 'index.html');
@@ -967,13 +995,15 @@ $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data"') && str
 $assert(str_contains($vectorDataHtml, 'd="M0 0L10 0 10 10Z"'), 'vector-data-renders-command-blob-path');
 $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-painted-fallback"') && str_contains($vectorDataHtml, '<rect x="0" y="0" width="12" height="6" fill="#0000ff"/>'), 'vector-data-painted-network-fallback-rect');
 $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-simple-rect-network"') && str_contains($vectorDataHtml, 'd="M0 0L12 0 12 6 0 6Z"') && str_contains($vectorDataHtml, 'fill="#0080ff"'), 'vector-data-simple-rect-network-renders-bounded-path');
+$assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-closed-rect-network"') && str_contains($vectorDataHtml, 'd="M0 0L12 0 12 6 0 6Z"') && str_contains($vectorDataHtml, 'fill="#336699"'), 'vector-data-closed-rect-network-renders-bounded-path');
+$assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-non-rect-network"') && str_contains($vectorDataHtml, 'data-figma-unsupported-vector="true"'), 'vector-data-non-rect-network-keeps-placeholder');
 $assert(in_array('unsupported_vector_network_blob', $vectorDataDiagnosticCodes, true), 'vector-data-malformed-network-diagnostic');
 $assert(1 === ($vectorNetworkDiagnostic['context']['byte_length'] ?? null) && 'ff' === ($vectorNetworkDiagnostic['context']['signature_hex'] ?? null), 'vector-network-diagnostic-context');
 $vectorNetworkDiagnostics = array_values(array_filter(
     $vectorDataResult['diagnostics'] ?? array(),
     static fn (array $diagnostic): bool => 'unsupported_vector_network_blob' === ($diagnostic['code'] ?? null)
 ));
-$assert(1 === count($vectorNetworkDiagnostics), 'vector-network-repeated-diagnostics-compacted');
+$assert(2 === count($vectorNetworkDiagnostics), 'vector-network-repeated-diagnostics-compacted');
 $assert(2 === ($vectorNetworkDiagnostic['context']['occurrence_count'] ?? null), 'vector-network-diagnostic-occurrence-count');
 $assert(2 === ($vectorNetworkDiagnostic['context']['affected_node_count'] ?? null), 'vector-network-diagnostic-affected-node-count');
 $assert(array('vector:data-malformed', 'vector:data-painted-fallback') === ($vectorNetworkDiagnostic['context']['sample_node_ids'] ?? null), 'vector-network-diagnostic-sample-nodes');


### PR DESCRIPTION
## Summary
- Decode guarded closed `[4,4,1]` four-point vector-network blobs as SVG rectangle paths.
- Keep non-rect `[4,4,1]` networks on the unsupported diagnostic path.
- Add contract coverage for closed-rect rendering and non-rect rejection.

## Verification
- `php figma-transformer/tests/contract/run.php`
- `php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php`
- `php -l figma-transformer/tests/contract/run.php`

## Fixture evidence
Baseline artifact anchor: `figma-six-fixture-refreshed-20260627`. Persisted artifacts show unsupported `[4,4,1]` vector-network blobs in impacted fixtures:
- `wpjobmanager-com`: 2 of 5 placeholder/unsupported nodes have `[4,4,1]`, byte length 200, so expected placeholders `5 -> 3` and unsupported vector-network groups `5 -> 3` after this fallback.
- `games-hotline-blog-updates`: 1 of 4 unsupported vector-network groups has `[4,4,1]`, byte length 200, so expected unsupported groups `4 -> 2` across result + DOM rerun records.
- `fisiostetic`: unsupported groups are `[17,17,1]` and `[11,11,1]`; expected unchanged `2 placeholders / 2 unsupported`.

Private `.fig` fixtures are not present in this checkout or the persisted local artifact mirror, so I could not rerun the targeted matrix locally from source. The fallback is covered by a synthetic contract fixture matching the `[4,4,1]`, 200-byte closed-rect shape observed in the persisted matrix diagnostics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating fixture diagnostics, implementing the guarded vector-network fallback, adding contract coverage, and drafting this PR description.
