### PR TITLE
Account for transformed Figma vector boxes

### DIFF
--- a/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
+++ b/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
@@ -36,8 +36,8 @@ final class LayoutMismatchReportBuilder
                 continue;
             }
 
-            $sourceBox = $this->boxFromNode($sourceNode);
             $generatedBox = $this->boxFromNode($generatedNode);
+            $sourceBox = null === $generatedBox ? $this->boxFromNode($sourceNode) : $this->sourceBoxForGeneratedBox($sourceNode, $generatedBox);
             if ( null === $sourceBox || null === $generatedBox ) {
                 continue;
             }
@@ -491,6 +491,40 @@ final class LayoutMismatchReportBuilder
         }
 
         return $this->boxFromValue($node);
+    }
+
+    /**
+     * @param array<string, mixed> $sourceNode
+     * @param array{x: float, y: float, width: float, height: float} $generatedBox
+     * @return array{x: float, y: float, width: float, height: float}|null
+     */
+    private function sourceBoxForGeneratedBox(array $sourceNode, array $generatedBox): ?array
+    {
+        $sourceBox = $this->boxFromNode($sourceNode);
+        if ( ! is_array($sourceNode['visible_rect'] ?? null) ) {
+            return $sourceBox;
+        }
+
+        $visibleBox = $this->boxFromValue($sourceNode['visible_rect']);
+        if ( null === $sourceBox || null === $visibleBox ) {
+            return $sourceBox ?? $visibleBox;
+        }
+
+        return $this->boxDistance($visibleBox, $generatedBox) < $this->boxDistance($sourceBox, $generatedBox) ? $visibleBox : $sourceBox;
+    }
+
+    /**
+     * @param array{x: float, y: float, width: float, height: float} $left
+     * @param array{x: float, y: float, width: float, height: float} $right
+     */
+    private function boxDistance(array $left, array $right): float
+    {
+        return max(
+            abs($right['x'] - $left['x']),
+            abs($right['y'] - $left['y']),
+            abs($right['width'] - $left['width']),
+            abs($right['height'] - $left['height'])
+        );
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1293,11 +1293,11 @@ final class StaticHtmlEmitter
 
         $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
         $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
-        $nodeRect = null !== $width && null !== $height ? array('x' => $x, 'y' => $y, 'width' => $width, 'height' => $height) : null;
-        $mapRect = $nodeRect;
+        $nodeRect = null !== $width && null !== $height ? $this->transformedVisualRect(array('x' => $x, 'y' => $y, 'width' => $width, 'height' => $height), $node) : null;
+        $visibleRect = null;
         if ( null !== $nodeRect && null !== $clipRect && $this->isClippableDecorativeVisualNode($node) ) {
-            $mapRect = $this->rectIntersection($nodeRect, $clipRect);
-            if ( null === $mapRect ) {
+            $visibleRect = $this->rectIntersection($nodeRect, $clipRect);
+            if ( null === $visibleRect ) {
                 return;
             }
         }
@@ -1305,12 +1305,12 @@ final class StaticHtmlEmitter
         if ( null !== $width && null !== $height ) {
             $imagePaint = $this->firstImagePaint($node);
             $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
-            $map[] = array(
+            $entry = array(
                 'id' => (string) ($node['id'] ?? ''),
                 'parent_id' => null !== $parentNode ? (string) ($parentNode['id'] ?? '') : '',
                 'name' => (string) ($node['name'] ?? ''),
                 'type' => strtoupper((string) ($node['type'] ?? '')),
-                'rect' => $mapRect,
+                'rect' => $nodeRect,
                 'layout' => array(
                     'display' => $layout['display'] ?? null,
                     'flex_direction' => $layout['flex_direction'] ?? null,
@@ -1320,6 +1320,11 @@ final class StaticHtmlEmitter
                 'image' => null === $imagePaint ? null : $this->visualImageMetadata($imagePaint),
                 'text' => empty($text) ? null : $this->visualTextMetadata($text),
             );
+            if ( null !== $visibleRect && $visibleRect !== $nodeRect ) {
+                $entry['visible_rect'] = $visibleRect;
+                $entry['clip'] = array('source' => 'parent_clips_content');
+            }
+            $map[] = $entry;
         }
 
         $children = $this->nodeList($node);
@@ -1542,6 +1547,41 @@ final class StaticHtmlEmitter
         if ( $right <= $left || $bottom <= $top ) {
             return null;
         }
+
+        return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
+    }
+
+    /**
+     * @param array{x: float, y: float, width: float, height: float} $rect
+     * @return array{x: float, y: float, width: float, height: float}
+     */
+    private function transformedVisualRect(array $rect, array $node): array
+    {
+        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        $matrix = $this->cssTransformMatrixValues(is_array($box['transform'] ?? null) ? $box['transform'] : null);
+        if ( null === $matrix ) {
+            return $rect;
+        }
+
+        [$a, $b, $c, $d, $e, $f] = $matrix;
+        $points = array(
+            array(0.0, 0.0),
+            array($rect['width'], 0.0),
+            array(0.0, $rect['height']),
+            array($rect['width'], $rect['height']),
+        );
+        $xs = array();
+        $ys = array();
+        foreach ( $points as $point ) {
+            [$localX, $localY] = $point;
+            $xs[] = $rect['x'] + ($a * $localX) + ($c * $localY) + $e;
+            $ys[] = $rect['y'] + ($b * $localX) + ($d * $localY) + $f;
+        }
+
+        $left = min($xs);
+        $top = min($ys);
+        $right = max($xs);
+        $bottom = max($ys);
 
         return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
     }
@@ -2172,6 +2212,24 @@ final class StaticHtmlEmitter
      */
     private function cssMatrix(array $transform): ?string
     {
+        $values = $this->cssTransformMatrixValues($transform);
+        if ( null === $values ) {
+            return null;
+        }
+
+        return 'matrix(' . implode(',', array_map(fn (mixed $value): string => $this->number((float) $value), $values)) . ')';
+    }
+
+    /**
+     * @param array<int|string, mixed>|null $transform
+     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}|null
+     */
+    private function cssTransformMatrixValues(?array $transform): ?array
+    {
+        if ( null === $transform ) {
+            return null;
+        }
+
         if ( isset($transform['m00'], $transform['m01'], $transform['m02'], $transform['m10'], $transform['m11'], $transform['m12']) ) {
             if ( 0.00001 > abs((float) $transform['m00'] - 1.0) && 0.00001 > abs((float) $transform['m01']) && 0.00001 > abs((float) $transform['m10']) && 0.00001 > abs((float) $transform['m11'] - 1.0) ) {
                 return null;
@@ -2189,7 +2247,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        return 'matrix(' . implode(',', array_map(fn (mixed $value): string => $this->number((float) $value), $values)) . ')';
+        return array_map(static fn (mixed $value): float => (float) $value, $values);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -641,7 +641,8 @@ $clippedVisibleCopy = $findVisualNode($clippedDecorativeResult, 'clip:copy');
 $assert(str_contains($clippedDecorativeCss, '.figma-node-clip-parent-clipped-parent{width:200px;height:100px;overflow:hidden;position:relative}'), 'clipped-decorative-parent-overflow-hidden');
 $assert(! str_contains($clippedDecorativeHtml, 'Off canvas decorative group') && ! str_contains($clippedDecorativeCss, 'figma-node-clip-hidden-group'), 'fully-clipped-decorative-node-not-emitted');
 $assert(null === $clippedHiddenGroup && null === $clippedHiddenVector, 'fully-clipped-decorative-nodes-omitted-from-visual-map');
-$assert(array('x' => 0.0, 'y' => 20.0, 'width' => 40.0, 'height' => 30.0) === ($clippedPartialVector['rect'] ?? null), 'partly-clipped-decorative-node-visual-map-intersection');
+$assert(array('x' => -20.0, 'y' => 20.0, 'width' => 60.0, 'height' => 30.0) === ($clippedPartialVector['rect'] ?? null), 'partly-clipped-decorative-node-keeps-source-rect');
+$assert(array('x' => 0.0, 'y' => 20.0, 'width' => 40.0, 'height' => 30.0) === ($clippedPartialVector['visible_rect'] ?? null), 'partly-clipped-decorative-node-visible-rect-intersection');
 $assert(array('x' => -10.0, 'y' => 70.0, 'width' => 140.0, 'height' => 20.0) === ($clippedVisibleCopy['rect'] ?? null), 'clipped-content-node-keeps-source-rect');
 $assert(0 === ($clippedDecorativeDiagnostics['large_absolute_offset_count'] ?? null), 'fully-clipped-decorative-node-not-counted-as-large-offset');
 
@@ -694,9 +695,53 @@ $gamesControlLayoutResult = blocks_engine_figma_transformer_transform_scenegraph
 ));
 $gamesControlDiagnostics = $gamesControlLayoutResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
 $gamesControlIcon = $findVisualNode($gamesControlLayoutResult, 'games:icon');
-$assert(array('x' => 0.0, 'y' => 8.0, 'width' => 16.0, 'height' => 24.0) === ($gamesControlIcon['rect'] ?? null), 'games-control-clipped-icon-visual-map-intersection');
+$assert(array('x' => -8.0, 'y' => 8.0, 'width' => 24.0, 'height' => 24.0) === ($gamesControlIcon['rect'] ?? null), 'games-control-clipped-icon-source-rect');
+$assert(array('x' => 0.0, 'y' => 8.0, 'width' => 16.0, 'height' => 24.0) === ($gamesControlIcon['visible_rect'] ?? null), 'games-control-clipped-icon-visible-rect-intersection');
 $assert(0 === ($gamesControlDiagnostics['layout_mismatch_count'] ?? null), 'games-control-layout-mismatch-count-zero');
 $assert('pass' === ($gamesControlDiagnostics['layout_mismatch_status'] ?? null), 'games-control-layout-mismatch-pass');
+
+$flippedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Flipped Vector Layout Guard Fixture',
+    'blobs' => array(array('bytes' => $vectorCommandBlob)),
+    'nodes' => array(
+        array(
+            'id'       => 'flip:parent',
+            'type'     => 'FRAME',
+            'name'     => 'Flip parent',
+            'width'    => 120,
+            'height'   => 80,
+            'children' => array(
+                array(
+                    'id'           => 'flip:vector',
+                    'type'         => 'VECTOR',
+                    'name'         => 'Flipped vector',
+                    'x'            => 20,
+                    'y'            => 10,
+                    'width'        => 60,
+                    'height'       => 30,
+                    'transform'    => array('m00' => -1, 'm01' => 0, 'm02' => 0, 'm10' => 0, 'm11' => 1, 'm12' => 0),
+                    'fillGeometry' => array(array('commandsBlob' => 0)),
+                ),
+            ),
+        ),
+    ),
+), array(
+    'generated_dom_boxes' => array(
+        'schema' => 'homeboy/static-artifact-dom-boxes/v1',
+        'boxes'  => array(
+            array('node_id' => 'flip:parent', 'rect' => array('x' => 0, 'y' => 0, 'width' => 120, 'height' => 80)),
+            array('node_id' => 'flip:vector', 'rect' => array('x' => -40, 'y' => 10, 'width' => 60, 'height' => 30)),
+        ),
+    ),
+    'layout_mismatch_threshold'      => 1,
+    'layout_mismatch_size_threshold' => 1,
+));
+$flippedVectorDiagnostics = $flippedVectorResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+$flippedVectorNode = $findVisualNode($flippedVectorResult, 'flip:vector');
+$assert(str_contains($fileContent($flippedVectorResult, 'style.css'), 'transform:matrix(-1,0,0,1,0,0);transform-origin:0 0'), 'flipped-vector-css-transform-matrix');
+$assert(array('x' => -40.0, 'y' => 10.0, 'width' => 60.0, 'height' => 30.0) === ($flippedVectorNode['rect'] ?? null), 'flipped-vector-visual-map-applies-matrix');
+$assert(0 === ($flippedVectorDiagnostics['layout_mismatch_count'] ?? null), 'flipped-vector-layout-mismatch-count-zero');
+$assert('pass' === ($flippedVectorDiagnostics['layout_mismatch_status'] ?? null), 'flipped-vector-layout-mismatch-pass');
 
 $transparentVisualMapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Transparent Visual Map Fixture',


### PR DESCRIPTION
## Summary

- Apply emitted CSS transform matrices to Figma visual-node layout rects so flipped/vector-shell nodes compare against browser DOM boxes correctly.
- Preserve both full source `rect` and clipped `visible_rect` for clipped decorative vector nodes, letting layout diagnostics choose the generated-box match without dropping visible content.
- Add contract guards for clipped decorative vectors, Games-style clipped icons, and flipped vector matrix layout parity.

## Verification

- `php figma-transformer/tests/contract/run.php`
- WP.Cloud targeted rerun using Homeboy run `figma-six-fixture-refreshed-20260627` DOM boxes:
  - command shape: `php -d memory_limit=1536M figma-transformer/bin/figma-transformer ~/Downloads/WP.Cloud\ 2.0\ \(1\).fig --multi-page --frame-ids=5145:7945,5145:6474,6218:946 --entry-frame-id=5145:7945 --max-nodes=5000 --parity-dom-boxes-path=<homeboy artifact wp-cloud-2/dom-boxes.json>`

## Count deltas

- WP.Cloud layout mismatches: `217 -> 212`.
- WP.Cloud `off_canvas_left_css`: `6 -> 6`.
- WP.Cloud `large_absolute_offsets`: `12 -> 12`.
- WP.Cloud generated SVG assets: `5 -> 5`.
- Games regression guard: contract synthetic clipped-icon layout mismatch stays `0`.

## Notes

- The Agentic and Games private `.fig` fixtures were not present in the local worktree or Downloads, so real-fixture matrix reruns for those were not available locally.
- Local matrix DOM capture currently fails because `figma-fixture-matrix.php` calls `homeboy tunnel artifact-origin dom-boxes`, but the current local Homeboy exposes `serve`, `status`, and `inspect` under `artifact-origin`, not `dom-boxes`. I did not change that separate workflow in this PR.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code investigation, implementation, contract test updates, and verification summarization.
