### PR TITLE
Add Figma matrix selection locks

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -24,6 +24,7 @@ $only = isset($options['only']) ? array_filter(array_map('trim', explode(',', (s
 $adHocFixtures = matrix_list_option($options['fixture'] ?? array());
 $fontCssPassthrough = matrix_font_css_passthrough($options);
 $evidenceOptions = matrix_evidence_options($options);
+$selectionLock = matrix_selection_lock_options($options);
 
 $fixtures = matrix_discover_fixtures($fixtureDir);
 foreach ( $adHocFixtures as $fixturePath ) {
@@ -38,6 +39,20 @@ if ( isset($options['frame_ids']) ) {
         $fixtures[$index]['mode'] = 'transform';
         $fixtures[$index]['frame_ids'] = $globalFrameIds;
         $fixtures[$index]['entry_frame_id'] = (string) ($options['entry_frame_id'] ?? ($globalFrameIds[0] ?? ''));
+        $fixtures[$index]['selection_source'] = 'manual_frame_ids';
+    }
+} elseif ( ! empty($selectionLock['records']) ) {
+    foreach ( $fixtures as $index => $fixture ) {
+        $fixtureId = (string) ($fixture['id'] ?? '');
+        if ( '' === $fixtureId || ! isset($selectionLock['records'][$fixtureId]) ) {
+            continue;
+        }
+
+        $lockRecord = $selectionLock['records'][$fixtureId];
+        $fixtures[$index]['mode'] = 'transform';
+        $fixtures[$index]['frame_ids'] = $lockRecord['frame_ids'];
+        $fixtures[$index]['entry_frame_id'] = $lockRecord['entry_frame_id'] ?? ($lockRecord['frame_ids'][0] ?? '');
+        $fixtures[$index]['selection_source'] = 'selection_lock';
     }
 }
 
@@ -65,6 +80,7 @@ $summary = array(
     'dom_box_provider_command_configured' => $captureDomBoxes ? '' !== $domBoxProviderCommand : null,
     'font_css' => $fontCssPassthrough['summary'],
     'evidence' => $evidenceOptions['summary'],
+    'selection' => $selectionLock['summary'],
     'fixtures' => array(),
 );
 
@@ -100,7 +116,7 @@ foreach ( $fixtures as $fixture ) {
 
     if ( $dryRun ) {
         $record['status'] = 'planned';
-        $record['selection'] = isset($fixture['frame_ids']) ? 'manual_frame_ids' : 'auto_from_inspection';
+        $record['selection'] = $fixture['selection_source'] ?? (isset($fixture['frame_ids']) ? 'manual_frame_ids' : 'auto_from_inspection');
         $hasDryRunFrameIds = isset($fixture['frame_ids']) && is_array($fixture['frame_ids']);
         $dryRunFrameIds = $hasDryRunFrameIds ? $fixture['frame_ids'] : array('<selected-frame-ids>');
         $dryRunEntryFrameId = (string) ($fixture['entry_frame_id'] ?? ($hasDryRunFrameIds ? ($dryRunFrameIds[0] ?? '') : '<entry-frame-id>'));
@@ -130,6 +146,7 @@ foreach ( $fixtures as $fixture ) {
     $inspection = json_decode((string) file_get_contents($inspectPath), true);
     $record['inspection'] = matrix_inspection_summary(is_array($inspection) ? $inspection : array());
     $frameIds = isset($fixture['frame_ids']) && is_array($fixture['frame_ids']) ? $fixture['frame_ids'] : matrix_select_frame_ids(is_array($inspection) ? $inspection : array(), $maxPages);
+    $record['selection'] = $fixture['selection_source'] ?? (isset($fixture['frame_ids']) ? 'manual_frame_ids' : 'auto_from_inspection');
     $record['selected_frame_ids'] = $frameIds;
     $record['selected_frames'] = matrix_selected_frame_records(is_array($inspection) ? $inspection : array(), $frameIds);
     $record['entry_frame_id'] = (string) ($fixture['entry_frame_id'] ?? ($frameIds[0] ?? ''));
@@ -287,6 +304,81 @@ function matrix_list_option(mixed $value): array
     }
 
     return array();
+}
+
+/**
+ * @param array<string, mixed> $options
+ * @return array{records: array<string, array{frame_ids: array<int, string>, entry_frame_id?: string}>, summary: array<string, mixed>}
+ */
+function matrix_selection_lock_options(array $options): array
+{
+    if ( ! isset($options['selection_lock']) || ! is_scalar($options['selection_lock']) || '' === trim((string) $options['selection_lock']) ) {
+        return array(
+            'records' => array(),
+            'summary' => array(
+                'mode' => 'auto_from_inspection',
+            ),
+        );
+    }
+
+    $path = (string) $options['selection_lock'];
+    if ( ! is_file($path) || ! is_readable($path) ) {
+        fwrite(STDERR, "Selection lock is not readable: {$path}\n");
+        exit(1);
+    }
+
+    $decoded = json_decode((string) file_get_contents($path), true);
+    if ( ! is_array($decoded) ) {
+        fwrite(STDERR, "Selection lock is not valid JSON: {$path}\n");
+        exit(1);
+    }
+
+    $records = matrix_selection_lock_records($decoded);
+    return array(
+        'records' => $records,
+        'summary' => array(
+            'mode' => 'locked_frame_ids',
+            'path' => $path,
+            'fixture_count' => count($records),
+        ),
+    );
+}
+
+/**
+ * @param array<string, mixed> $decoded
+ * @return array<string, array{frame_ids: array<int, string>, entry_frame_id?: string}>
+ */
+function matrix_selection_lock_records(array $decoded): array
+{
+    $records = array();
+    $fixtures = is_array($decoded['fixtures'] ?? null) ? $decoded['fixtures'] : $decoded;
+
+    foreach ( $fixtures as $key => $fixture ) {
+        if ( ! is_array($fixture) ) {
+            continue;
+        }
+
+        $fixtureId = isset($fixture['id']) && is_scalar($fixture['id']) ? (string) $fixture['id'] : (is_string($key) ? $key : '');
+        $frameIds = array();
+        if ( is_array($fixture['selected_frame_ids'] ?? null) ) {
+            $frameIds = $fixture['selected_frame_ids'];
+        } elseif ( is_array($fixture['frame_ids'] ?? null) ) {
+            $frameIds = $fixture['frame_ids'];
+        }
+
+        $frameIds = array_values(array_filter(array_map('strval', $frameIds), static fn (string $frameId): bool => '' !== trim($frameId)));
+        if ( '' === $fixtureId || empty($frameIds) ) {
+            continue;
+        }
+
+        $record = array('frame_ids' => $frameIds);
+        if ( isset($fixture['entry_frame_id']) && is_scalar($fixture['entry_frame_id']) && '' !== (string) $fixture['entry_frame_id'] ) {
+            $record['entry_frame_id'] = (string) $fixture['entry_frame_id'];
+        }
+        $records[$fixtureId] = $record;
+    }
+
+    return $records;
 }
 
 /**

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $assert): void
+{
+    $matrixFixtureDir = sys_get_temp_dir() . '/figma-fixture-matrix-contract-' . getmypid() . '-' . bin2hex(random_bytes(4));
+    mkdir($matrixFixtureDir, 0777, true);
+    file_put_contents($matrixFixtureDir . '/alias.fig', 'placeholder fig fixture');
+
+    $matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
+    file_put_contents($matrixSelectionLockPath, json_encode(array(
+        'schema'   => 'blocks-engine/figma-transformer/fixture-matrix/v1',
+        'fixtures' => array(
+            array(
+                'id'                 => 'alias',
+                'selected_frame_ids' => array('locked:home', 'locked:about'),
+                'entry_frame_id'     => 'locked:home',
+            ),
+        ),
+    ), JSON_THROW_ON_ERROR));
+
+    $matrixDryRun = static function (array $args) use ($matrixFixtureDir): ?array {
+        $command = escapeshellarg(PHP_BINARY)
+            . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
+            . ' --dry-run --capture-dom-boxes --fixture-dir=' . escapeshellarg($matrixFixtureDir);
+        foreach ( $args as $arg ) {
+            $command .= ' ' . escapeshellarg($arg);
+        }
+
+        $output = shell_exec($command);
+        return is_string($output) ? json_decode($output, true) : null;
+    };
+
+    $matrixAliasSummary = $matrixDryRun(array(
+        '--homeboy-bin=/opt/homeboy-alias',
+        '--dom-box-command=node dom-box-alias',
+    ));
+    $matrixCanonicalSummary = $matrixDryRun(array(
+        '--homeboy-command=/opt/homeboy-canonical',
+        '--dom-box-provider-command=node dom-box-canonical',
+    ));
+    $matrixSelectionLockSummary = $matrixDryRun(array(
+        '--selection-lock=' . $matrixSelectionLockPath,
+    ));
+
+    $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
+    $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
+    $assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');
+    $matrixAliasCaptureCommand = (string) ($matrixAliasSummary['fixtures'][0]['dom_box_capture']['command'] ?? '');
+    $assert(str_contains($matrixAliasCaptureCommand, escapeshellarg('/opt/homeboy-alias')), 'fixture-matrix-alias-capture-uses-homeboy-bin');
+    $assert(str_contains($matrixAliasCaptureCommand, 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg('node dom-box-alias')), 'fixture-matrix-alias-capture-uses-dom-box-command');
+
+    $assert(is_array($matrixCanonicalSummary), 'fixture-matrix-canonical-json-summary');
+    $assert('/opt/homeboy-canonical' === ($matrixCanonicalSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-command-canonical');
+    $assert(true === ($matrixCanonicalSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-provider-command-canonical-configured');
+    $matrixCanonicalCaptureCommand = (string) ($matrixCanonicalSummary['fixtures'][0]['dom_box_capture']['command'] ?? '');
+    $assert(str_contains($matrixCanonicalCaptureCommand, escapeshellarg('/opt/homeboy-canonical')), 'fixture-matrix-canonical-capture-uses-homeboy-command');
+    $assert(str_contains($matrixCanonicalCaptureCommand, 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg('node dom-box-canonical')), 'fixture-matrix-canonical-capture-uses-dom-box-provider-command');
+
+    $assert(is_array($matrixSelectionLockSummary), 'fixture-matrix-selection-lock-json-summary');
+    $assert('locked_frame_ids' === ($matrixSelectionLockSummary['selection']['mode'] ?? null), 'fixture-matrix-selection-lock-summary-mode');
+    $assert(1 === ($matrixSelectionLockSummary['selection']['fixture_count'] ?? null), 'fixture-matrix-selection-lock-fixture-count');
+    $assert('selection_lock' === ($matrixSelectionLockSummary['fixtures'][0]['selection'] ?? null), 'fixture-matrix-selection-lock-fixture-source');
+    $matrixSelectionLockCommand = (string) ($matrixSelectionLockSummary['fixtures'][0]['command'] ?? '');
+    $assert(str_contains($matrixSelectionLockCommand, "--frame-ids='locked:home,locked:about'"), 'fixture-matrix-selection-lock-frame-ids');
+    $assert(str_contains($matrixSelectionLockCommand, "--entry-frame-id='locked:home'"), 'fixture-matrix-selection-lock-entry-frame');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../figma-transformer.php';
 require_once __DIR__ . '/../../scripts/figma-fixture-selection.php';
+require_once __DIR__ . '/FixtureMatrixContract.php';
 require_once __DIR__ . '/SyntheticFigKiwiFixtureBuilder.php';
 
 use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCapability;
@@ -4127,61 +4128,7 @@ $assert(! str_contains($derivedSymbolInstanceHtml, '<g transform="scale'), 'deri
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-2-derived-label{width:90px;height:24px;position:absolute;left:12px;top:6px'), 'derived-symbol-instance-label-size-position');
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-3-derived-icon{width:10px;height:10px;position:absolute;left:110px;top:10px'), 'derived-symbol-instance-icon-size-position');
 
-$matrixFixtureDir = sys_get_temp_dir() . '/figma-fixture-matrix-contract-' . getmypid() . '-' . bin2hex(random_bytes(4));
-mkdir($matrixFixtureDir, 0777, true);
-file_put_contents($matrixFixtureDir . '/alias.fig', 'placeholder fig fixture');
-$matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
-file_put_contents($matrixSelectionLockPath, json_encode(array(
-    'schema'   => 'blocks-engine/figma-transformer/fixture-matrix/v1',
-    'fixtures' => array(
-        array(
-            'id'                 => 'alias',
-            'selected_frame_ids' => array('locked:home', 'locked:about'),
-            'entry_frame_id'     => 'locked:home',
-        ),
-    ),
-), JSON_THROW_ON_ERROR));
-$matrixDryRun = static function (array $args) use ($matrixFixtureDir): ?array {
-    $command = escapeshellarg(PHP_BINARY)
-        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
-        . ' --dry-run --capture-dom-boxes --fixture-dir=' . escapeshellarg($matrixFixtureDir);
-    foreach ( $args as $arg ) {
-        $command .= ' ' . escapeshellarg($arg);
-    }
-
-    $output = shell_exec($command);
-    return is_string($output) ? json_decode($output, true) : null;
-};
-$matrixAliasSummary = $matrixDryRun(array(
-    '--homeboy-bin=/opt/homeboy-alias',
-    '--dom-box-command=node dom-box-alias',
-));
-$matrixCanonicalSummary = $matrixDryRun(array(
-    '--homeboy-command=/opt/homeboy-canonical',
-    '--dom-box-provider-command=node dom-box-canonical',
-));
-$matrixSelectionLockSummary = $matrixDryRun(array(
-    '--selection-lock=' . $matrixSelectionLockPath,
-));
-$assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
-$assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
-$assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');
-$matrixAliasCaptureCommand = (string) ($matrixAliasSummary['fixtures'][0]['dom_box_capture']['command'] ?? '');
-$assert(str_contains($matrixAliasCaptureCommand, escapeshellarg('/opt/homeboy-alias')), 'fixture-matrix-alias-capture-uses-homeboy-bin');
-$assert(str_contains($matrixAliasCaptureCommand, 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg('node dom-box-alias')), 'fixture-matrix-alias-capture-uses-dom-box-command');
-$assert(is_array($matrixCanonicalSummary), 'fixture-matrix-canonical-json-summary');
-$assert('/opt/homeboy-canonical' === ($matrixCanonicalSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-command-canonical');
-$assert(true === ($matrixCanonicalSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-provider-command-canonical-configured');
-$matrixCanonicalCaptureCommand = (string) ($matrixCanonicalSummary['fixtures'][0]['dom_box_capture']['command'] ?? '');
-$assert(str_contains($matrixCanonicalCaptureCommand, escapeshellarg('/opt/homeboy-canonical')), 'fixture-matrix-canonical-capture-uses-homeboy-command');
-$assert(str_contains($matrixCanonicalCaptureCommand, 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg('node dom-box-canonical')), 'fixture-matrix-canonical-capture-uses-dom-box-provider-command');
-$assert(is_array($matrixSelectionLockSummary), 'fixture-matrix-selection-lock-json-summary');
-$assert('locked_frame_ids' === ($matrixSelectionLockSummary['selection']['mode'] ?? null), 'fixture-matrix-selection-lock-summary-mode');
-$assert(1 === ($matrixSelectionLockSummary['selection']['fixture_count'] ?? null), 'fixture-matrix-selection-lock-fixture-count');
-$assert('selection_lock' === ($matrixSelectionLockSummary['fixtures'][0]['selection'] ?? null), 'fixture-matrix-selection-lock-fixture-source');
-$matrixSelectionLockCommand = (string) ($matrixSelectionLockSummary['fixtures'][0]['command'] ?? '');
-$assert(str_contains($matrixSelectionLockCommand, "--frame-ids='locked:home,locked:about'"), 'fixture-matrix-selection-lock-frame-ids');
-$assert(str_contains($matrixSelectionLockCommand, "--entry-frame-id='locked:home'"), 'fixture-matrix-selection-lock-entry-frame');
+blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4130,6 +4130,17 @@ $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40
 $matrixFixtureDir = sys_get_temp_dir() . '/figma-fixture-matrix-contract-' . getmypid() . '-' . bin2hex(random_bytes(4));
 mkdir($matrixFixtureDir, 0777, true);
 file_put_contents($matrixFixtureDir . '/alias.fig', 'placeholder fig fixture');
+$matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
+file_put_contents($matrixSelectionLockPath, json_encode(array(
+    'schema'   => 'blocks-engine/figma-transformer/fixture-matrix/v1',
+    'fixtures' => array(
+        array(
+            'id'                 => 'alias',
+            'selected_frame_ids' => array('locked:home', 'locked:about'),
+            'entry_frame_id'     => 'locked:home',
+        ),
+    ),
+), JSON_THROW_ON_ERROR));
 $matrixDryRun = static function (array $args) use ($matrixFixtureDir): ?array {
     $command = escapeshellarg(PHP_BINARY)
         . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
@@ -4149,6 +4160,9 @@ $matrixCanonicalSummary = $matrixDryRun(array(
     '--homeboy-command=/opt/homeboy-canonical',
     '--dom-box-provider-command=node dom-box-canonical',
 ));
+$matrixSelectionLockSummary = $matrixDryRun(array(
+    '--selection-lock=' . $matrixSelectionLockPath,
+));
 $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
 $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
 $assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');
@@ -4161,6 +4175,13 @@ $assert(true === ($matrixCanonicalSummary['dom_box_provider_command_configured']
 $matrixCanonicalCaptureCommand = (string) ($matrixCanonicalSummary['fixtures'][0]['dom_box_capture']['command'] ?? '');
 $assert(str_contains($matrixCanonicalCaptureCommand, escapeshellarg('/opt/homeboy-canonical')), 'fixture-matrix-canonical-capture-uses-homeboy-command');
 $assert(str_contains($matrixCanonicalCaptureCommand, 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg('node dom-box-canonical')), 'fixture-matrix-canonical-capture-uses-dom-box-provider-command');
+$assert(is_array($matrixSelectionLockSummary), 'fixture-matrix-selection-lock-json-summary');
+$assert('locked_frame_ids' === ($matrixSelectionLockSummary['selection']['mode'] ?? null), 'fixture-matrix-selection-lock-summary-mode');
+$assert(1 === ($matrixSelectionLockSummary['selection']['fixture_count'] ?? null), 'fixture-matrix-selection-lock-fixture-count');
+$assert('selection_lock' === ($matrixSelectionLockSummary['fixtures'][0]['selection'] ?? null), 'fixture-matrix-selection-lock-fixture-source');
+$matrixSelectionLockCommand = (string) ($matrixSelectionLockSummary['fixtures'][0]['command'] ?? '');
+$assert(str_contains($matrixSelectionLockCommand, "--frame-ids='locked:home,locked:about'"), 'fixture-matrix-selection-lock-frame-ids');
+$assert(str_contains($matrixSelectionLockCommand, "--entry-frame-id='locked:home'"), 'fixture-matrix-selection-lock-entry-frame');
 
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");


### PR DESCRIPTION
## Summary
- add --selection-lock support to the Figma fixture matrix runner
- allow locks from prior matrix summaries or fixture-to-frame manifests
- report selection metadata so discovery runs and locked regression runs are explicit
- move fixture-matrix CLI contract coverage into a dedicated contract file

## Verification
- php -l figma-transformer/scripts/figma-fixture-matrix.php
- php -l figma-transformer/tests/contract/run.php
- php -l figma-transformer/tests/contract/FixtureMatrixContract.php
- php figma-transformer/tests/contract/run.php
- local dry-run with prior summary selection lock returned locked_frame_ids for 6 fixtures

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the selection-lock runner changes, adding contract coverage, splitting the new fixture-matrix tests, and running verification.