### PR TITLE
Report uncapped layout mismatch summaries

### DIFF
--- a/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
+++ b/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
@@ -84,9 +84,10 @@ final class LayoutMismatchReportBuilder
             static fn (array $left, array $right): int => (($right['max_delta'] ?? 0) <=> ($left['max_delta'] ?? 0)) ?: strcmp((string) ($left['node']['id'] ?? ''), (string) ($right['node']['id'] ?? ''))
         );
 
-        $diagnostics = array_slice($diagnostics, 0, $limit);
+        $totalDiagnostics = $diagnostics;
+        $diagnostics = array_slice($totalDiagnostics, 0, $limit);
         $codeCounts = array();
-        foreach ( $diagnostics as $diagnostic ) {
+        foreach ( $totalDiagnostics as $diagnostic ) {
             $code = (string) ($diagnostic['code'] ?? '');
             if ( '' !== $code ) {
                 $codeCounts[$code] = ($codeCounts[$code] ?? 0) + 1;
@@ -105,10 +106,12 @@ final class LayoutMismatchReportBuilder
                 'generated_node_count' => count($generatedNodes),
                 'matched_node_count' => $matched,
                 'unmatched_source_node_count' => $unmatchedSource,
-                'diagnostic_count' => count($diagnostics),
+                'diagnostic_count' => count($totalDiagnostics),
+                'reported_diagnostic_count' => count($diagnostics),
+                'truncated' => count($diagnostics) < count($totalDiagnostics),
                 'code_counts' => $codeCounts,
-                'clusters' => $this->diagnosticClusters($diagnostics),
-                'suspected_causes' => $this->suspectedCauseSummary($diagnostics),
+                'clusters' => $this->diagnosticClusters($totalDiagnostics),
+                'suspected_causes' => $this->suspectedCauseSummary($totalDiagnostics),
             ),
             'diagnostics' => $diagnostics,
         );

--- a/figma-transformer/tests/contract/LayoutMismatchContract.php
+++ b/figma-transformer/tests/contract/LayoutMismatchContract.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\LayoutMismatchReportBuilder;
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_layout_mismatch_contract(callable $assert): void
+{
+    $sourceNodes = array();
+    $generatedBoxes = array();
+    for ( $index = 1; $index <= 4; $index++ ) {
+        $nodeId = 'limited:item:' . $index;
+        $sourceNodes[] = array(
+            'id'   => $nodeId,
+            'name' => 'Limited item ' . $index,
+            'type' => 'TEXT',
+            'rect' => array('x' => 0, 'y' => $index * 40, 'width' => 120, 'height' => 20),
+        );
+        $generatedBoxes[] = array(
+            'node_id' => $nodeId,
+            'rect'    => array('x' => 80, 'y' => $index * 40, 'width' => 120 + $index, 'height' => 20),
+        );
+    }
+
+    $report = ( new LayoutMismatchReportBuilder() )->build(
+        array('visual_node_map' => $sourceNodes),
+        array('boxes' => $generatedBoxes),
+        array('threshold' => 24, 'limit' => 2)
+    );
+
+    $summary = is_array($report['summary'] ?? null) ? $report['summary'] : array();
+    $assert(4 === ($summary['diagnostic_count'] ?? null), 'layout-mismatch-total-count-uncapped');
+    $assert(2 === ($summary['reported_diagnostic_count'] ?? null), 'layout-mismatch-reported-count-limited');
+    $assert(true === ($summary['truncated'] ?? null), 'layout-mismatch-summary-truncated');
+    $assert(4 === ($summary['code_counts']['misplaced_element'] ?? null), 'layout-mismatch-code-counts-uncapped');
+    $assert(4 === ($summary['clusters']['repeated_position_delta'][0]['count'] ?? null), 'layout-mismatch-clusters-uncapped');
+    $assert(2 === count($report['diagnostics'] ?? array()), 'layout-mismatch-diagnostics-limited');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../figma-transformer.php';
 require_once __DIR__ . '/../../scripts/figma-fixture-selection.php';
 require_once __DIR__ . '/FixtureMatrixContract.php';
+require_once __DIR__ . '/LayoutMismatchContract.php';
 require_once __DIR__ . '/SyntheticFigKiwiFixtureBuilder.php';
 
 use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCapability;
@@ -1413,6 +1414,7 @@ $assert(in_array('parent-visual-map-mismatch', $genericCauses, true), 'layout-mi
 $assert(in_array('zero-size-source-box', $genericCauses, true), 'layout-mismatch-zero-size-source-box-suspected-cause');
 $assert(in_array('generated-vs-source-clipping', $genericCauses, true), 'layout-mismatch-generated-vs-source-clipping-suspected-cause');
 $assert(in_array('vector-shell-wrapper-offset', $genericCauses, true), 'layout-mismatch-vector-shell-wrapper-offset-suspected-cause');
+blocks_engine_figma_transformer_run_layout_mismatch_contract($assert);
 
 $layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name' => 'Layout Mismatch Fixture',


### PR DESCRIPTION
## Summary
- compute layout mismatch summary counts, clusters, and suspected causes from the full diagnostic set
- keep the returned diagnostics list limited for readability
- expose reported_diagnostic_count and truncated so matrix artifacts show when details are capped
- add dedicated layout mismatch contract coverage without adding more bulk to the main contract file

## Verification
- php -l figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
- php -l figma-transformer/tests/contract/run.php
- php -l figma-transformer/tests/contract/LayoutMismatchContract.php
- php figma-transformer/tests/contract/run.php

## Evidence
- Fan-out artifact inspection found layout_mismatch as the dominant matrix failure cluster and large_absolute_offsets as the next renderer target.
- This fixes the reporting layer first so the next locked/discovery matrix run ranks high-volume mismatch causes from uncapped totals instead of the displayed diagnostic slice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Artifact/code inspection, implementing uncapped layout mismatch summaries, adding contract coverage, and running verification.