### PR TITLE
Avoid decorative large offset false positives

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1092,7 +1092,7 @@ final class StaticHtmlEmitter
     private function largeAbsoluteOffsetDiagnostic(array $node, array $parentNode): ?array
     {
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        if ( 'absolute' !== ($layout['positioning'] ?? null) && ! $this->isFreeformContainer($parentNode) && ! $this->isDecorativeFlexUnderlay($node, $parentNode) ) {
+        if ( $this->isDecorativeFlexUnderlay($node, $parentNode) || ('absolute' !== ($layout['positioning'] ?? null) && ! $this->isFreeformContainer($parentNode)) ) {
             return null;
         }
 
@@ -2008,7 +2008,8 @@ final class StaticHtmlEmitter
      */
     private function inferredContainingBlockOrigin(array $parentNode, string $dimension): ?float
     {
-        $origin = null;
+        $preferredOrigin = null;
+        $fallbackOrigin = null;
         foreach ( $this->nodeList($parentNode) as $child ) {
             if ( ! is_array($child) ) {
                 continue;
@@ -2020,10 +2021,23 @@ final class StaticHtmlEmitter
             }
 
             $value = (float) $childBox[$dimension];
-            $origin = null === $origin ? $value : min($origin, $value);
+            $fallbackOrigin = null === $fallbackOrigin ? $value : min($fallbackOrigin, $value);
+            if ( $this->isContainingBlockOriginCandidate($child) ) {
+                $preferredOrigin = null === $preferredOrigin ? $value : min($preferredOrigin, $value);
+            }
         }
 
-        return $origin;
+        return $preferredOrigin ?? $fallbackOrigin;
+    }
+
+    /**
+     * Prefer content-bearing children for canvas-origin inference so decorative vector underlays do not rebase content.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function isContainingBlockOriginCandidate(array $node): bool
+    {
+        return $this->treeHasText($node) || $this->treeHasImageReference($node) || ! $this->treeIsVectorShapeOnly($node);
     }
 
     /**

--- a/figma-transformer/tests/contract/OriginInferenceContract.php
+++ b/figma-transformer/tests/contract/OriginInferenceContract.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param callable(bool, string): void $assert
+ * @param callable(array<string, mixed>, string): string $fileContent
+ * @param callable(array<string, mixed>, string): ?array<string, mixed> $findVisualNode
+ */
+function blocks_engine_figma_transformer_run_origin_inference_contract(callable $assert, callable $fileContent, callable $findVisualNode): void
+{
+    $decorativeOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Decorative Origin Candidate Fixture',
+        'nodes' => array(
+            array(
+                'id'                  => 'origin-pref:frame',
+                'type'                => 'FRAME',
+                'name'                => 'Decorative origin frame',
+                'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 700, 'height' => 360),
+                'children'            => array(
+                    array(
+                        'id'                  => 'origin-pref:underlay',
+                        'type'                => 'FRAME',
+                        'name'                => 'Decorative glow',
+                        'absoluteBoundingBox' => array('x' => -500, 'y' => -200, 'width' => 1100, 'height' => 720),
+                        'children'            => array(
+                            array(
+                                'id'                  => 'origin-pref:vector',
+                                'type'                => 'VECTOR',
+                                'name'                => 'Glow vector',
+                                'absoluteBoundingBox' => array('x' => -500, 'y' => -200, 'width' => 1100, 'height' => 720),
+                            ),
+                        ),
+                    ),
+                    array(
+                        'id'                  => 'origin-pref:copy',
+                        'type'                => 'TEXT',
+                        'name'                => 'Headline',
+                        'characters'          => 'Content establishes the local origin',
+                        'absoluteBoundingBox' => array('x' => 100, 'y' => 80, 'width' => 320, 'height' => 48),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $decorativeOriginCss = $fileContent($decorativeOriginResult, 'style.css');
+    $decorativeOriginCopy = $findVisualNode($decorativeOriginResult, 'origin-pref:copy');
+    $assert(str_contains($decorativeOriginCss, '.figma-node-origin-pref-copy-headline{width:320px;height:48px;position:absolute;left:100px;top:80px'), 'origin-inference-ignores-decorative-outlier-css');
+    $assert(array('x' => 100.0, 'y' => 80.0, 'width' => 320.0, 'height' => 48.0) === ($decorativeOriginCopy['rect'] ?? null), 'origin-inference-ignores-decorative-outlier-visual-map');
+
+    $shapeOnlyOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Shape Only Origin Candidate Fixture',
+        'nodes' => array(
+            array(
+                'id'                  => 'shape-origin:frame',
+                'type'                => 'FRAME',
+                'name'                => 'Shape only origin frame',
+                'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 700, 'height' => 360),
+                'children'            => array(
+                    array(
+                        'id'                  => 'shape-origin:first',
+                        'type'                => 'RECTANGLE',
+                        'name'                => 'First shape',
+                        'absoluteBoundingBox' => array('x' => -500, 'y' => -200, 'width' => 200, 'height' => 160),
+                    ),
+                    array(
+                        'id'                  => 'shape-origin:second',
+                        'type'                => 'RECTANGLE',
+                        'name'                => 'Second shape',
+                        'absoluteBoundingBox' => array('x' => -300, 'y' => -120, 'width' => 200, 'height' => 160),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $shapeOnlyOriginCss = $fileContent($shapeOnlyOriginResult, 'style.css');
+    $shapeOnlyFirst = $findVisualNode($shapeOnlyOriginResult, 'shape-origin:first');
+    $assert(str_contains($shapeOnlyOriginCss, '.figma-node-shape-origin-first-first-shape{width:200px;height:160px;position:absolute;left:0px;top:0px'), 'origin-inference-shape-only-fallback-css');
+    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 200.0, 'height' => 160.0) === ($shapeOnlyFirst['rect'] ?? null), 'origin-inference-shape-only-fallback-visual-map');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../figma-transformer.php';
 require_once __DIR__ . '/../../scripts/figma-fixture-selection.php';
 require_once __DIR__ . '/FixtureMatrixContract.php';
 require_once __DIR__ . '/LayoutMismatchContract.php';
+require_once __DIR__ . '/OriginInferenceContract.php';
 require_once __DIR__ . '/SyntheticFigKiwiFixtureBuilder.php';
 
 use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCapability;
@@ -523,9 +524,11 @@ $decorativeUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph
 ));
 $decorativeUnderlayCss = $fileContent($decorativeUnderlayResult, 'style.css');
 $decorativeUnderlayDiagnostics = $decorativeUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
+$decorativeUnderlayLayout = $decorativeUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-parent-flex-hero{width:1000px;min-height:600px;position:relative;display:flex;flex-direction:row}'), 'decorative-underlay-parent-relative');
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-art-decorative-art{width:900px;height:700px;position:absolute;left:40px;top:-50px;z-index:0;pointer-events:none}'), 'decorative-underlay-absolute');
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-copy-copy-stack{width:320px;height:120px;position:relative;z-index:1;flex-shrink:0}'), 'decorative-underlay-content-stacks-above');
+$assert(0 === ($decorativeUnderlayLayout['large_absolute_offset_count'] ?? null), 'decorative-underlay-not-large-absolute-offset');
 $assert(1 === ($decorativeUnderlayDiagnostics['count'] ?? null), 'decorative-underlay-diagnostics-count');
 $assert(array(
     'node_id'       => 'underlay:art',
@@ -3523,6 +3526,7 @@ $assert(str_contains($positiveRootCanvasOriginCss, '.figma-node-positive-origin-
 $assert(str_contains($positiveRootCanvasOriginCss, '.figma-node-positive-origin-cta-cta{width:240px;height:40px;position:absolute;left:200px;top:400px'), 'positive-root-canvas-origin-normalizes-text-child');
 $positiveRootCanvasOriginDiagnostics = $positiveRootCanvasOriginResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
 $assert(0 === ($positiveRootCanvasOriginDiagnostics['layout']['large_absolute_offset_count'] ?? null), 'positive-root-canvas-origin-diagnostics-no-large-offset');
+blocks_engine_figma_transformer_run_origin_inference_contract($assert, $fileContent, $findVisualNode);
 
 $resolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Component Instance Fixture',


### PR DESCRIPTION
## Summary
- stop counting decorative flex underlays as large absolute offset failures
- keep decorative underlays rendered and reported through the existing decorative_underlays diagnostic
- prefer content/non-vector children when inferring selected-frame origins so decorative vector outliers do not rebase content
- add focused origin inference contract coverage outside the main contract monolith

## Evidence
Fan-out artifact inspection identified large_absolute_offsets as the next renderer-quality target, with WP Cloud mostly decorative/vector/background-like and Agentic mostly real freeform content.

Targeted locked transforms without DOM capture:
- agentic-commerce-wip: large_absolute_offset_count 83 -> 83, decorative_underlays 0
- wp-cloud-2: large_absolute_offset_count 12 -> 8, decorative_underlays 10

This intentionally does not clamp or suppress Agentic's content/freeform offsets.

## Verification
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/tests/contract/run.php
- php -l figma-transformer/tests/contract/OriginInferenceContract.php
- php figma-transformer/tests/contract/run.php
- locked transform: agentic-commerce-wip frames 361:4410,72:546,148:1608
- locked transform: wp-cloud-2 frames 5145:7945,5145:6474,6218:946

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Fan-out artifact/code/test investigation, implementing the renderer diagnostic fix, adding contract coverage, and running verification.