### PR TITLE
Improve Figma matrix DOM capture preflight

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -65,6 +65,10 @@ if ( empty($fixtures) ) {
     exit(1);
 }
 
+if ( $captureDomBoxes && ! $dryRun ) {
+    matrix_preflight_homeboy_command($homeboyCommand);
+}
+
 $summary = array(
     'schema' => 'blocks-engine/figma-transformer/fixture-matrix/v1',
     'fixture_dir' => $fixtureDir,
@@ -528,6 +532,32 @@ function matrix_default_zstd_command(): string
 
     $path = trim((string) shell_exec('command -v zstd 2>/dev/null'));
     return '' !== $path ? $path : 'zstd';
+}
+
+function matrix_preflight_homeboy_command(string $homeboyCommand): void
+{
+    $homeboyCommand = trim($homeboyCommand);
+    if ( '' === $homeboyCommand ) {
+        fwrite(STDERR, "DOM box capture requires a Homeboy command. Set --homeboy-command, --homeboy-bin, or HOMEBOY_COMMAND to a runnable homeboy binary.\n");
+        exit(1);
+    }
+
+    if ( str_contains($homeboyCommand, DIRECTORY_SEPARATOR) ) {
+        if ( is_file($homeboyCommand) && is_executable($homeboyCommand) ) {
+            return;
+        }
+
+        fwrite(STDERR, "DOM box capture requires a runnable Homeboy command, but configured path is not executable: {$homeboyCommand}\nSet --homeboy-command, --homeboy-bin, or HOMEBOY_COMMAND to the active homeboy binary before rerunning.\n");
+        exit(1);
+    }
+
+    $resolved = trim((string) shell_exec('command -v ' . escapeshellarg($homeboyCommand) . ' 2>/dev/null'));
+    if ( '' !== $resolved ) {
+        return;
+    }
+
+    fwrite(STDERR, "DOM box capture requires a runnable Homeboy command, but '{$homeboyCommand}' was not found on PATH.\nSet --homeboy-command, --homeboy-bin, or HOMEBOY_COMMAND to the active homeboy binary before rerunning.\n");
+    exit(1);
 }
 
 function matrix_inspect_command(string $figmaRoot, string $fixturePath, string $resultPath, string $zstdCommand, int $inspectLimit): string

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -46,6 +46,13 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $matrixSelectionLockSummary = $matrixDryRun(array(
         '--selection-lock=' . $matrixSelectionLockPath,
     ));
+    $missingHomeboyOutput = array();
+    $missingHomeboyCommand = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
+        . ' --capture-dom-boxes --fixture-dir=' . escapeshellarg($matrixFixtureDir)
+        . ' --homeboy-command=' . escapeshellarg($matrixFixtureDir . '/missing-homeboy')
+        . ' 2>&1';
+    exec($missingHomeboyCommand, $missingHomeboyOutput, $missingHomeboyExitCode);
 
     $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
     $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
@@ -68,4 +75,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $matrixSelectionLockCommand = (string) ($matrixSelectionLockSummary['fixtures'][0]['command'] ?? '');
     $assert(str_contains($matrixSelectionLockCommand, "--frame-ids='locked:home,locked:about'"), 'fixture-matrix-selection-lock-frame-ids');
     $assert(str_contains($matrixSelectionLockCommand, "--entry-frame-id='locked:home'"), 'fixture-matrix-selection-lock-entry-frame');
+    $assert(0 !== $missingHomeboyExitCode, 'fixture-matrix-capture-preflight-missing-homeboy-fails');
+    $missingHomeboyMessage = implode("\n", $missingHomeboyOutput);
+    $assert(str_contains($missingHomeboyMessage, 'DOM box capture requires a runnable Homeboy command'), 'fixture-matrix-capture-preflight-missing-homeboy-message');
+    $assert(str_contains($missingHomeboyMessage, 'Set --homeboy-command, --homeboy-bin, or HOMEBOY_COMMAND'), 'fixture-matrix-capture-preflight-homeboy-remediation');
 }

--- a/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
+++ b/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { chromium } from 'playwright';
 
 const DEFAULT_VIEWPORT = { width: 1440, height: 900, device_scale_factor: 1 };
+const PLAYWRIGHT_SETUP_HELP = 'Install DOM capture dependencies with: npm ci --prefix php-transformer/tools/visual-parity && npm --prefix php-transformer/tools/visual-parity run install:browsers';
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -17,8 +17,14 @@ async function main() {
   const baseUrl = requiredEnv('HOMEBOY_DOM_BOX_BASE_URL').replace(/\/+$/, '');
   const pagePaths = parsePagePaths(requiredEnv('HOMEBOY_DOM_BOX_PAGE_PATHS_JSON'));
   const textSampleLimit = parseTextSampleLimit(process.env.HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT ?? '160');
+  const { chromium } = await loadPlaywright();
 
-  const browser = await chromium.launch();
+  let browser;
+  try {
+    browser = await chromium.launch();
+  } catch (error) {
+    throw withPlaywrightSetupHelp(error);
+  }
   try {
     const context = await browser.newContext({
       viewport: { width: DEFAULT_VIEWPORT.width, height: DEFAULT_VIEWPORT.height },
@@ -43,6 +49,29 @@ async function main() {
   } finally {
     await browser.close();
   }
+}
+
+async function loadPlaywright() {
+  try {
+    return await import('playwright');
+  } catch (error) {
+    if (isMissingPlaywrightModule(error)) {
+      throw new Error(`Playwright is required for DOM box capture but is not installed. ${PLAYWRIGHT_SETUP_HELP}`);
+    }
+    throw error;
+  }
+}
+
+function isMissingPlaywrightModule(error) {
+  return error?.code === 'ERR_MODULE_NOT_FOUND' && String(error?.message ?? '').includes("'playwright'");
+}
+
+function withPlaywrightSetupHelp(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('Executable doesn\'t exist') || message.includes('playwright install')) {
+    return new Error(`${message}\n${PLAYWRIGHT_SETUP_HELP}`);
+  }
+  return error;
 }
 
 function requiredEnv(name) {

--- a/php-transformer/tools/visual-parity/package.json
+++ b/php-transformer/tools/visual-parity/package.json
@@ -9,6 +9,7 @@
     "blocks-engine-dom-box-provider": "bin/dom-box-provider.mjs"
   },
   "scripts": {
+    "install:browsers": "playwright install chromium",
     "test": "node tests/smoke.mjs"
   },
   "devDependencies": {

--- a/php-transformer/tools/visual-parity/tests/smoke.mjs
+++ b/php-transformer/tools/visual-parity/tests/smoke.mjs
@@ -1,5 +1,6 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
@@ -8,8 +9,11 @@ const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const outputDir = path.join(root, 'tmp');
 const output = path.join(outputDir, 'visual-parity-smoke.json');
 const domFixture = path.join(outputDir, 'dom-box.html');
+const missingPlaywrightDir = path.join(tmpdir(), `blocks-engine-dom-provider-missing-playwright-${process.pid}`);
+const missingPlaywrightProvider = path.join(missingPlaywrightDir, 'dom-box-provider.mjs');
 
 await mkdir(outputDir, { recursive: true });
+await mkdir(missingPlaywrightDir, { recursive: true });
 
 await run(process.execPath, [
   path.join(root, 'bin/visual-parity.mjs'),
@@ -59,8 +63,19 @@ try {
   await new Promise((resolve) => server.close(resolve));
 }
 
+await copyFile(path.join(root, 'bin/dom-box-provider.mjs'), missingPlaywrightProvider);
+const missingPlaywright = await runFailure(process.execPath, [missingPlaywrightProvider], missingPlaywrightDir, {
+  ...process.env,
+  HOMEBOY_DOM_BOX_BASE_URL: 'http://127.0.0.1:9',
+  HOMEBOY_DOM_BOX_PAGE_PATHS_JSON: JSON.stringify(['/dom-box.html']),
+});
+assert(missingPlaywright.stderr.includes('Playwright is required for DOM box capture but is not installed.'), 'DOM provider explains missing Playwright dependency');
+assert(missingPlaywright.stderr.includes('npm ci --prefix php-transformer/tools/visual-parity'), 'DOM provider suggests npm ci');
+assert(missingPlaywright.stderr.includes('install:browsers'), 'DOM provider suggests browser install script');
+
 await rm(output, { force: true });
 await rm(domFixture, { force: true });
+await rm(missingPlaywrightDir, { recursive: true, force: true });
 console.log('Visual parity smoke test passed.');
 
 function run(command, args, cwd) {
@@ -73,6 +88,28 @@ function run(command, args, cwd) {
         return;
       }
       reject(new Error(`${command} exited with ${code}`));
+    });
+  });
+}
+
+function runFailure(command, args, cwd, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        reject(new Error(`${command} unexpectedly exited with 0`));
+        return;
+      }
+      resolve({ code, stdout, stderr });
     });
   });
 }


### PR DESCRIPTION
## Summary
- preflight Homeboy command availability before non-dry-run DOM capture matrices
- fail early with actionable --homeboy-command / HOMEBOY_COMMAND guidance
- make the DOM box provider report friendly Playwright/Chromium setup guidance
- add visual-parity browser install script and coverage

## Evidence
The post-#182 matrix rerun exposed two tooling failures before the successful runner-side run: missing visual-parity Playwright deps and a stale Homeboy binary path. This PR makes those failures actionable and earlier.

## Verification
- php -l figma-transformer/scripts/figma-fixture-matrix.php
- php figma-transformer/tests/contract/run.php
- npm test initially confirmed missing-dependency behavior
- npm ci && npm run install:browsers && npm test passed in php-transformer/tools/visual-parity

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagents
- **Used for:** Parallel tooling investigation, implementation, contract/smoke coverage, and verification.