### PR TITLE
Improve vector network diagnostics

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -251,7 +251,7 @@ final class ScenegraphNormalizer
                     'blob_ref_seen' => array(),
                 );
 
-                foreach ( array('geometry', 'blob_ref', 'byte_length', 'signature_hex', 'network_counts') as $contextKey ) {
+                foreach ( array('geometry', 'blob_ref', 'byte_length', 'signature_hex', 'network_counts', 'single_region_loop_candidate', 'candidate_layout', 'candidate_vertex_points_sample', 'candidate_decoder_requirement') as $contextKey ) {
                     if ( array_key_exists($contextKey, $context) ) {
                         $groups[$key]['context'][$contextKey] = $context[$contextKey];
                     }
@@ -2218,9 +2218,56 @@ final class ScenegraphNormalizer
         $counts = $this->vectorNetworkCounts($bytes);
         if ( null !== $counts ) {
             $context['network_counts'] = $counts;
+            $context += $this->vectorNetworkSingleRegionCandidateContext($bytes, $counts);
         }
 
         return $context;
+    }
+
+    /**
+     * @param array{0:int,1:int,2:int} $counts
+     * @return array<string, mixed>
+     */
+    private function vectorNetworkSingleRegionCandidateContext(string $bytes, array $counts): array
+    {
+        [$vertexCount, $segmentCount, $regionCount] = $counts;
+        if ( $vertexCount < 3 || $vertexCount > 32 || $vertexCount !== $segmentCount || 1 !== $regionCount ) {
+            return array();
+        }
+
+        $expectedLength = 24 + ( $vertexCount * 44 );
+        if ( strlen($bytes) !== $expectedLength ) {
+            return array();
+        }
+
+        return array(
+            'single_region_loop_candidate' => true,
+            'candidate_layout' => array(
+                'vertex_stride' => 20,
+                'segment_stride' => 16,
+                'region_bytes'  => 12 + ( $vertexCount * 8 ),
+            ),
+            'candidate_vertex_points_sample' => $this->vectorNetworkVertexPointSample($bytes, $vertexCount),
+            'candidate_decoder_requirement' => 'Decode only after segment endpoints and region winding/order are validated as one closed non-branching loop.',
+        );
+    }
+
+    /**
+     * @return array<int, array{0: float, 1: float}>
+     */
+    private function vectorNetworkVertexPointSample(string $bytes, int $vertexCount): array
+    {
+        $points = array();
+        $limit = min($vertexCount, 8);
+        for ( $index = 0; $index < $limit; $index++ ) {
+            $point = $this->readFloatPair($bytes, 12 + ( $index * 20 ) + 4);
+            if ( null === $point || ! is_finite($point[0]) || ! is_finite($point[1]) ) {
+                return array();
+            }
+            $points[] = array($point[0], $point[1]);
+        }
+
+        return $points;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1087,6 +1087,17 @@ $assert(2 === ($vectorNetworkDiagnostic['context']['occurrence_count'] ?? null),
 $assert(2 === ($vectorNetworkDiagnostic['context']['affected_node_count'] ?? null), 'vector-network-diagnostic-affected-node-count');
 $assert(array('vector:data-malformed', 'vector:data-painted-fallback') === ($vectorNetworkDiagnostic['context']['sample_node_ids'] ?? null), 'vector-network-diagnostic-sample-nodes');
 $assert(array('1') === ($vectorNetworkDiagnostic['context']['sample_blob_refs'] ?? null), 'vector-network-diagnostic-sample-blob-refs');
+$nonRectVectorNetworkDiagnostic = null;
+foreach ( $vectorNetworkDiagnostics as $diagnostic ) {
+    if ( array(4, 4, 1) === ($diagnostic['context']['network_counts'] ?? null) ) {
+        $nonRectVectorNetworkDiagnostic = $diagnostic;
+        break;
+    }
+}
+$assert(true === ($nonRectVectorNetworkDiagnostic['context']['single_region_loop_candidate'] ?? null), 'vector-network-single-region-candidate-diagnostic');
+$assert(array('vertex_stride' => 20, 'segment_stride' => 16, 'region_bytes' => 44) === ($nonRectVectorNetworkDiagnostic['context']['candidate_layout'] ?? null), 'vector-network-candidate-layout-diagnostic');
+$assert(array(array(0.0, 0.0), array(12.0, 0.0), array(8.0, 6.0), array(0.0, 6.0)) === ($nonRectVectorNetworkDiagnostic['context']['candidate_vertex_points_sample'] ?? null), 'vector-network-candidate-point-sample');
+$assert('Decode only after segment endpoints and region winding/order are validated as one closed non-branching loop.' === ($nonRectVectorNetworkDiagnostic['context']['candidate_decoder_requirement'] ?? null), 'vector-network-candidate-requirement');
 
 $zeroHeightSeparatorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Zero Height Separator Fixture',


### PR DESCRIPTION
## Summary
- identify compact single-region vector-network candidates in unsupported diagnostics
- add bounded candidate context and decoder requirements to the diagnostic payload
- preserve unsupported behavior instead of guessing topology or rendering fake paths
- add contract coverage for the new diagnostic context

## Evidence
Latest locked DOM matrix showed wpjobmanager-com and fisiostetic still have unsupported small vectorNetworkBlob groups. Existing rect decoders do not match, and the current parser cannot safely prove segment endpoints, region winding/order, or closed non-branching topology.

## Verification
- php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagents
- **Used for:** Parallel vector investigation, diagnostic implementation, contract coverage, and verification.