### PR TITLE
Fix decorative underlay visual map offsets

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1286,7 +1286,7 @@ final class StaticHtmlEmitter
         if ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
             $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
             $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
-        } elseif ( null !== $parentNode && 'absolute' === ($layout['positioning'] ?? null) ) {
+        } elseif ( null !== $parentNode && ('absolute' === ($layout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($node, $parentNode)) ) {
             $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
             $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
         }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -525,9 +525,13 @@ $decorativeUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph
 $decorativeUnderlayCss = $fileContent($decorativeUnderlayResult, 'style.css');
 $decorativeUnderlayDiagnostics = $decorativeUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
 $decorativeUnderlayLayout = $decorativeUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+$decorativeUnderlayArt = $findVisualNode($decorativeUnderlayResult, 'underlay:art');
+$decorativeUnderlayVector = $findVisualNode($decorativeUnderlayResult, 'underlay:vector');
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-parent-flex-hero{width:1000px;min-height:600px;position:relative;display:flex;flex-direction:row}'), 'decorative-underlay-parent-relative');
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-art-decorative-art{width:900px;height:700px;position:absolute;left:40px;top:-50px;z-index:0;pointer-events:none}'), 'decorative-underlay-absolute');
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-copy-copy-stack{width:320px;height:120px;position:relative;z-index:1;flex-shrink:0}'), 'decorative-underlay-content-stacks-above');
+$assert(array('x' => 40.0, 'y' => -50.0, 'width' => 900.0, 'height' => 700.0) === ($decorativeUnderlayArt['rect'] ?? null), 'decorative-underlay-visual-map-includes-css-offset');
+$assert(array('x' => 40.0, 'y' => -50.0, 'width' => 900.0, 'height' => 700.0) === ($decorativeUnderlayVector['rect'] ?? null), 'decorative-underlay-child-visual-map-inherits-css-offset');
 $assert(0 === ($decorativeUnderlayLayout['large_absolute_offset_count'] ?? null), 'decorative-underlay-not-large-absolute-offset');
 $assert(1 === ($decorativeUnderlayDiagnostics['count'] ?? null), 'decorative-underlay-diagnostics-count');
 $assert(array(


### PR DESCRIPTION
## Summary
- apply decorative flex underlay offsets in the visual node map
- align visual-node-map evidence with the CSS renderer for absolute decorative underlays
- add contract coverage for underlay child visual rects

## Evidence
Latest locked DOM matrix showed wp-cloud-2 For Agencies had 89 vector child mismatches under parent 6218:1119. The mismatch delta matched the decorative underlay parent's emitted CSS offset, making this a visual-node-map/reporting bug rather than a renderer bug.

## Verification
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php
- targeted synthetic transform confirmed underlay vector child rect includes parent offset

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagents
- **Used for:** Parallel investigation, implementation, contract coverage, and verification.