### PR TITLE
Fix overflowed flex visual map alignment

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1446,19 +1446,20 @@ final class StaticHtmlEmitter
             $cursorMain = 0.0;
             $visualGap = $gap;
             if ( $isFlex && null !== $contentMainSize ) {
-                $freeMainSpace = max(0.0, $contentMainSize - $lineMainSize);
+                $freeMainSpace = $contentMainSize - $lineMainSize;
+                $distributedMainSpace = max(0.0, $freeMainSpace);
                 $justifyContent = (string) ($layout['justify_content'] ?? 'flex-start');
                 if ( 'flex-end' === $justifyContent ) {
                     $cursorMain = $freeMainSpace;
                 } elseif ( 'center' === $justifyContent ) {
                     $cursorMain = $freeMainSpace / 2.0;
                 } elseif ( 'space-between' === $justifyContent && count($lineChildren) > 1 ) {
-                    $visualGap += $freeMainSpace / (count($lineChildren) - 1);
+                    $visualGap += $distributedMainSpace / (count($lineChildren) - 1);
                 } elseif ( 'space-around' === $justifyContent ) {
-                    $visualGap += $freeMainSpace / count($lineChildren);
+                    $visualGap += $distributedMainSpace / count($lineChildren);
                     $cursorMain = $visualGap / 2.0;
                 } elseif ( 'space-evenly' === $justifyContent ) {
-                    $visualGap += $freeMainSpace / (count($lineChildren) + 1);
+                    $visualGap += $distributedMainSpace / (count($lineChildren) + 1);
                     $cursorMain = $visualGap;
                 }
             }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3235,6 +3235,50 @@ $assert(30.0 === ($visualFlexSecond['rect']['y'] ?? null), 'visual-map-flex-cent
 $assert(100.0 === ($visualFlexCentered['rect']['x'] ?? null), 'visual-map-column-center-child-x');
 $assert(10.0 === ($visualFlexCentered['rect']['y'] ?? null), 'visual-map-column-padding-child-y');
 
+$visualFlexOverflowResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Visual Flex Overflow Alignment Fixture',
+    'nodes' => array(
+        array(
+            'id'                    => 'visual-overflow:flex-end',
+            'type'                  => 'FRAME',
+            'name'                  => 'Overflow flex end row',
+            'width'                 => 80,
+            'height'                => 40,
+            'layoutMode'            => 'HORIZONTAL',
+            'primaryAxisAlignItems' => 'MAX',
+            'counterAxisAlignItems' => 'MIN',
+            'itemSpacing'           => 8,
+            'children'              => array(
+                array('id' => 'visual-overflow:end-first', 'type' => 'RECTANGLE', 'name' => 'End first child', 'width' => 50, 'height' => 20),
+                array('id' => 'visual-overflow:end-second', 'type' => 'RECTANGLE', 'name' => 'End second child', 'width' => 50, 'height' => 20),
+            ),
+        ),
+        array(
+            'id'                    => 'visual-overflow:center',
+            'type'                  => 'FRAME',
+            'name'                  => 'Overflow centered row',
+            'width'                 => 80,
+            'height'                => 40,
+            'layoutMode'            => 'HORIZONTAL',
+            'primaryAxisAlignItems' => 'CENTER',
+            'counterAxisAlignItems' => 'MIN',
+            'itemSpacing'           => 8,
+            'children'              => array(
+                array('id' => 'visual-overflow:center-first', 'type' => 'RECTANGLE', 'name' => 'Center first child', 'width' => 50, 'height' => 20),
+                array('id' => 'visual-overflow:center-second', 'type' => 'RECTANGLE', 'name' => 'Center second child', 'width' => 50, 'height' => 20),
+            ),
+        ),
+    ),
+));
+$visualOverflowEndFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-first');
+$visualOverflowEndSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-second');
+$visualOverflowCenterFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-first');
+$visualOverflowCenterSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-second');
+$assert(-28.0 === ($visualOverflowEndFirst['rect']['x'] ?? null), 'visual-map-overflow-flex-end-first-x');
+$assert(30.0 === ($visualOverflowEndSecond['rect']['x'] ?? null), 'visual-map-overflow-flex-end-second-x');
+$assert(-14.0 === ($visualOverflowCenterFirst['rect']['x'] ?? null), 'visual-map-overflow-center-first-x');
+$assert(44.0 === ($visualOverflowCenterSecond['rect']['x'] ?? null), 'visual-map-overflow-center-second-x');
+
 $visualFlexWrapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Visual Flex Wrap Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- model signed negative free space in visual flex positioning for overflowing rows
- align visual-node-map output with browser flex behavior for centered and flex-end overflow
- keep distributed space handling conservative for space-between/around/evenly
- add contract coverage for overflowed flex-end and centered rows

## Evidence
Latest locked DOM matrix at /home/chubes/Developer/_matrix_outputs/figma-after-pr186-wave-20260627/matrix showed agentic-commerce-wip layout=131. Investigation found dominant menu/button clusters where browser flex alignment uses negative free space while the visual map clamped free space to zero.

## Verification
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagents
- **Used for:** Matrix evidence analysis, implementation, contract coverage, and verification.