### PR TITLE
Decode validated Figma vector network loops

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2018,6 +2018,11 @@ final class ScenegraphNormalizer
             return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob', 'windingRule' => 'NONZERO');
         }
 
+        $path = $this->decodeSingleClosedLoopVectorNetworkBlob($bytes);
+        if ( null !== $path ) {
+            return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob.singleClosedLoop', 'windingRule' => 'NONZERO');
+        }
+
         $path = $this->decodeSimpleRectVectorNetworkBlob($bytes, $node);
         if ( null !== $path ) {
             return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob.simpleRectFallback', 'windingRule' => 'NONZERO');
@@ -2128,6 +2133,118 @@ final class ScenegraphNormalizer
             . ' L ' . $this->svgNumber($maxX) . ' ' . $this->svgNumber($maxY)
             . ' L ' . $this->svgNumber($minX) . ' ' . $this->svgNumber($maxY)
             . ' Z';
+    }
+
+    private function decodeSingleClosedLoopVectorNetworkBlob(string $bytes): ?string
+    {
+        $counts = $this->vectorNetworkCounts($bytes);
+        if ( null === $counts ) {
+            return null;
+        }
+
+        [$vertexCount, $segmentCount, $regionCount] = $counts;
+        if ( $vertexCount < 3 || $vertexCount > 32 || $vertexCount !== $segmentCount || 1 !== $regionCount ) {
+            return null;
+        }
+
+        if ( strlen($bytes) !== 24 + ( $vertexCount * 44 ) ) {
+            return null;
+        }
+
+        $vertices = array();
+        for ( $index = 0; $index < $vertexCount; $index++ ) {
+            $vertexOffset = 12 + ( $index * 20 );
+            if ( ! $this->bytesAreZero($bytes, $vertexOffset, 4) || ! $this->bytesAreZero($bytes, $vertexOffset + 12, 8) ) {
+                return null;
+            }
+
+            $point = $this->readFloatPair($bytes, $vertexOffset + 4);
+            if ( null === $point || ! is_finite($point[0]) || ! is_finite($point[1]) ) {
+                return null;
+            }
+            $vertices[] = $point;
+        }
+
+        $segments = array();
+        $degree = array_fill(0, $vertexCount, 0);
+        $segmentOffset = 12 + ( $vertexCount * 20 );
+        for ( $index = 0; $index < $segmentCount; $index++ ) {
+            $currentSegmentOffset = $segmentOffset + ( $index * 16 );
+            if ( ! $this->bytesAreZero($bytes, $currentSegmentOffset + 8, 8) ) {
+                return null;
+            }
+
+            $start = $this->readUint32($bytes, $currentSegmentOffset);
+            $end = $this->readUint32($bytes, $currentSegmentOffset + 4);
+            if ( null === $start || null === $end || $start < 0 || $start >= $vertexCount || $end < 0 || $end >= $vertexCount || $start === $end ) {
+                return null;
+            }
+            $segments[] = array($start, $end);
+            $degree[$start]++;
+            $degree[$end]++;
+        }
+
+        foreach ( $degree as $vertexDegree ) {
+            if ( 2 !== $vertexDegree ) {
+                return null;
+            }
+        }
+
+        $regionOffset = $segmentOffset + ( $segmentCount * 16 );
+        $regionSegmentCount = $this->readUint32($bytes, $regionOffset);
+        if ( $segmentCount !== $regionSegmentCount || ! $this->bytesAreZero($bytes, $regionOffset + 4, 8) ) {
+            return null;
+        }
+
+        $orderedVertexIndexes = array();
+        $usedSegments = array();
+        for ( $index = 0; $index < $segmentCount; $index++ ) {
+            $entryOffset = $regionOffset + 12 + ( $index * 8 );
+            $segmentIndex = $this->readUint32($bytes, $entryOffset);
+            $direction = $this->readUint32($bytes, $entryOffset + 4);
+            if ( null === $segmentIndex || null === $direction || $segmentIndex < 0 || $segmentIndex >= $segmentCount || isset($usedSegments[$segmentIndex]) || ( 0 !== $direction && 1 !== $direction ) ) {
+                return null;
+            }
+
+            $usedSegments[$segmentIndex] = true;
+            [$start, $end] = $segments[$segmentIndex];
+            if ( 1 === $direction ) {
+                [$start, $end] = array($end, $start);
+            }
+
+            if ( 0 === $index ) {
+                $orderedVertexIndexes[] = $start;
+                $orderedVertexIndexes[] = $end;
+                continue;
+            }
+
+            if ( $orderedVertexIndexes[count($orderedVertexIndexes) - 1] !== $start ) {
+                return null;
+            }
+            $orderedVertexIndexes[] = $end;
+        }
+
+        if ( count($orderedVertexIndexes) !== $vertexCount + 1 || $orderedVertexIndexes[0] !== $orderedVertexIndexes[count($orderedVertexIndexes) - 1] || count(array_unique(array_slice($orderedVertexIndexes, 0, -1))) !== $vertexCount ) {
+            return null;
+        }
+
+        $windingArea = 0.0;
+        for ( $index = 0; $index < $vertexCount; $index++ ) {
+            $current = $vertices[$orderedVertexIndexes[$index]];
+            $next = $vertices[$orderedVertexIndexes[$index + 1]];
+            $windingArea += ( $current[0] * $next[1] ) - ( $next[0] * $current[1] );
+        }
+        if ( abs($windingArea) < 0.000001 ) {
+            return null;
+        }
+
+        $parts = array();
+        foreach ( array_slice($orderedVertexIndexes, 0, -1) as $index => $vertexIndex ) {
+            $point = $vertices[$vertexIndex];
+            $parts[] = ( 0 === $index ? 'M ' : 'L ' ) . $this->svgNumber($point[0]) . ' ' . $this->svgNumber($point[1]);
+        }
+
+        return implode(' ', $parts) . ' Z';
     }
 
     /**
@@ -2374,6 +2491,25 @@ final class ScenegraphNormalizer
         }
 
         return array((float) $x[1], (float) $y[1]);
+    }
+
+    private function bytesAreZero(string $bytes, int $offset, int $length): bool
+    {
+        if ( strlen($bytes) < $offset + $length ) {
+            return false;
+        }
+
+        return str_repeat("\0", $length) === substr($bytes, $offset, $length);
+    }
+
+    private function readUint32(string $bytes, int $offset): ?int
+    {
+        if ( strlen($bytes) < $offset + 4 ) {
+            return null;
+        }
+
+        $value = unpack('V', substr($bytes, $offset, 4));
+        return false === $value ? null : (int) $value[1];
     }
 
     private function svgNumber(float $value): string

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -993,6 +993,27 @@ $assert(! in_array('unsupported_vector_node_placeholder', $geometrylessVectorDia
 
 $simpleRectNetworkPrefix = hex2bin('0400000004000000000000000000000000000000000000000000000000008043');
 $simpleRectNetworkBlob = str_pad(false === $simpleRectNetworkPrefix ? '' : $simpleRectNetworkPrefix, 172, "\0");
+$singleLoopNetworkBlob = static function (array $points, array $segments, array $regionEntries, ?int $regionSegmentCount = null): string {
+    $vertexCount = count($points);
+    $segmentCount = count($segments);
+    $blob = pack('V3', $vertexCount, $segmentCount, 1) . str_repeat("\0", ( $vertexCount * 20 ) + ( $segmentCount * 16 ) + 12 + ( $vertexCount * 8 ));
+    foreach ( $points as $index => $point ) {
+        $blob = substr_replace($blob, pack('g', $point[0]) . pack('g', $point[1]), 12 + ( $index * 20 ) + 4, 8);
+    }
+
+    $segmentOffset = 12 + ( $vertexCount * 20 );
+    foreach ( $segments as $index => $segment ) {
+        $blob = substr_replace($blob, pack('V2', $segment[0], $segment[1]), $segmentOffset + ( $index * 16 ), 8);
+    }
+
+    $regionOffset = $segmentOffset + ( $segmentCount * 16 );
+    $blob = substr_replace($blob, pack('V3', $regionSegmentCount ?? count($regionEntries), 0, 0), $regionOffset, 12);
+    foreach ( $regionEntries as $index => $entry ) {
+        $blob = substr_replace($blob, pack('V2', $entry[0], $entry[1]), $regionOffset + 12 + ( $index * 8 ), 8);
+    }
+
+    return $blob;
+};
 $closedRectNetworkBlob = pack('V3', 4, 4, 1) . str_repeat("\0", 188);
 foreach ( array(array(0.0, 0.0), array(12.0, 0.0), array(12.0, 6.0), array(0.0, 6.0)) as $index => $point ) {
     $offset = 12 + ( $index * 20 ) + 4;
@@ -1102,6 +1123,49 @@ $assert(true === ($nonRectVectorNetworkDiagnostic['context']['single_region_loop
 $assert(array('vertex_stride' => 20, 'segment_stride' => 16, 'region_bytes' => 44) === ($nonRectVectorNetworkDiagnostic['context']['candidate_layout'] ?? null), 'vector-network-candidate-layout-diagnostic');
 $assert(array(array(0.0, 0.0), array(12.0, 0.0), array(8.0, 6.0), array(0.0, 6.0)) === ($nonRectVectorNetworkDiagnostic['context']['candidate_vertex_points_sample'] ?? null), 'vector-network-candidate-point-sample');
 $assert('Decode only after segment endpoints and region winding/order are validated as one closed non-branching loop.' === ($nonRectVectorNetworkDiagnostic['context']['candidate_decoder_requirement'] ?? null), 'vector-network-candidate-requirement');
+
+$loopDecoderResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Vector Network Loop Decoder Fixture',
+    'blobs' => array(
+        array('bytes' => $singleLoopNetworkBlob(
+            array(array(0.0, 0.0), array(12.0, 0.0), array(8.0, 6.0), array(0.0, 6.0)),
+            array(array(0, 1), array(1, 2), array(2, 3), array(3, 0)),
+            array(array(0, 0), array(1, 0), array(2, 0), array(3, 0))
+        )),
+        array('bytes' => $singleLoopNetworkBlob(
+            array(array(0.0, 0.0), array(12.0, 0.0), array(8.0, 6.0), array(0.0, 6.0)),
+            array(array(0, 1), array(1, 2), array(1, 3), array(3, 0)),
+            array(array(0, 0), array(1, 0), array(2, 0), array(3, 0))
+        )),
+        array('bytes' => $singleLoopNetworkBlob(
+            array(array(0.0, 0.0), array(12.0, 0.0), array(8.0, 6.0), array(0.0, 6.0)),
+            array(array(0, 1), array(1, 2), array(2, 3), array(3, 0)),
+            array(array(0, 0), array(1, 0), array(2, 0), array(3, 1))
+        )),
+        array('bytes' => $singleLoopNetworkBlob(
+            array(array(0.0, 0.0), array(12.0, 0.0), array(8.0, 6.0), array(0.0, 6.0)),
+            array(array(0, 1), array(1, 2), array(2, 3), array(3, 0)),
+            array(array(0, 0), array(1, 0), array(2, 0), array(3, 0)),
+            3
+        )),
+    ),
+    'nodes' => array(
+        array('id' => 'vector:loop-supported', 'type' => 'VECTOR', 'name' => 'Supported Loop', 'width' => 12, 'height' => 6, 'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.1, 'g' => 0.2, 'b' => 0.3))), 'vectorData' => array('vectorNetworkBlob' => 0)),
+        array('id' => 'vector:loop-branch', 'type' => 'VECTOR', 'name' => 'Branched Loop', 'width' => 12, 'height' => 6, 'vectorData' => array('vectorNetworkBlob' => 1)),
+        array('id' => 'vector:loop-open-order', 'type' => 'VECTOR', 'name' => 'Open Region Order', 'width' => 12, 'height' => 6, 'vectorData' => array('vectorNetworkBlob' => 2)),
+        array('id' => 'vector:loop-malformed-region', 'type' => 'VECTOR', 'name' => 'Malformed Region', 'width' => 12, 'height' => 6, 'vectorData' => array('vectorNetworkBlob' => 3)),
+    ),
+));
+$loopDecoderHtml = $fileContent($loopDecoderResult, 'index.html');
+$loopDecoderDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $loopDecoderResult['diagnostics'] ?? array()
+);
+$assert(str_contains($loopDecoderHtml, 'data-figma-node-id="vector:loop-supported"') && str_contains($loopDecoderHtml, 'd="M0 0L12 0 8 6 0 6Z"') && str_contains($loopDecoderHtml, 'fill="#1a334d"'), 'vector-network-single-loop-renders-path');
+$assert(str_contains($loopDecoderHtml, 'data-figma-node-id="vector:loop-branch"') && str_contains($loopDecoderHtml, 'data-figma-unsupported-vector="true"'), 'vector-network-branch-keeps-placeholder');
+$assert(str_contains($loopDecoderHtml, 'data-figma-node-id="vector:loop-open-order"') && str_contains($loopDecoderHtml, 'data-figma-unsupported-vector="true"'), 'vector-network-open-order-keeps-placeholder');
+$assert(str_contains($loopDecoderHtml, 'data-figma-node-id="vector:loop-malformed-region"') && str_contains($loopDecoderHtml, 'data-figma-unsupported-vector="true"'), 'vector-network-malformed-region-keeps-placeholder');
+$assert(in_array('unsupported_vector_network_blob', $loopDecoderDiagnosticCodes, true), 'vector-network-unsupported-loop-topology-diagnostic');
 
 $zeroHeightSeparatorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Zero Height Separator Fixture',


### PR DESCRIPTION
## Summary
- add guarded decoder for validated single closed-loop vectorNetworkBlob payloads
- require finite vertices, valid endpoint topology, degree-2 closed loop, ordered region entries, and non-zero winding area
- reject richer/curved or ambiguous topology instead of flattening unsafely
- add synthetic coverage for valid closed loops and invalid branch/open/malformed cases

## Evidence
Latest locked DOM matrix still showed wpjobmanager-com placeholders=15 and fisiostetic placeholders=2. Prior diagnostics identified single_region_loop_candidate payloads with vertex_stride=20 and segment_stride=16, requiring endpoint and region validation before rendering.

## Verification
- php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagents
- **Used for:** Vector-network evidence analysis, decoder implementation, contract coverage, and verification.