### PR TITLE
Improve generated SVG asset diagnostics

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -1002,10 +1002,59 @@ final class FigmaTransformer
             'schema' => 'blocks-engine/figma-transformer/generated-svg-assets/v1',
             'count' => count($assets),
             'bytes' => array_sum(array_map(static fn (array $asset): int => (int) ($asset['bytes'] ?? 0), $assets)),
+            'gzip_bytes' => $this->sumNullableGeneratedSvgAssetMetric($assets, 'gzip_bytes'),
+            'path_element_count' => array_sum(array_map(static fn (array $asset): int => (int) ($asset['path_element_count'] ?? 0), $assets)),
+            'path_data_bytes' => array_sum(array_map(static fn (array $asset): int => (int) ($asset['path_data_bytes'] ?? 0), $assets)),
+            'largest_path_data_bytes' => empty($assets) ? 0 : max(array_map(static fn (array $asset): int => (int) ($asset['largest_path_data_bytes'] ?? 0), $assets)),
+            'unique_path_data_count' => $this->uniqueGeneratedSvgPathDataCount($assets),
+            'duplicate_path_data_count' => $this->duplicateGeneratedSvgPathDataCount($assets),
             'paths' => array_values(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $assets)),
             'largest_assets' => array_slice($assets, 0, 10),
             'assets' => $assets,
         );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     */
+    private function sumNullableGeneratedSvgAssetMetric(array $assets, string $key): ?int
+    {
+        $sum = 0;
+        foreach ( $assets as $asset ) {
+            if ( ! array_key_exists($key, $asset) || null === $asset[$key] ) {
+                return null;
+            }
+            $sum += (int) $asset[$key];
+        }
+
+        return $sum;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     */
+    private function uniqueGeneratedSvgPathDataCount(array $assets): int
+    {
+        $hashes = array();
+        foreach ( $assets as $asset ) {
+            foreach ( is_array($asset['path_data_hashes'] ?? null) ? $asset['path_data_hashes'] : array() as $hash ) {
+                if ( is_scalar($hash) && '' !== (string) $hash ) {
+                    $hashes[(string) $hash] = true;
+                }
+            }
+        }
+
+        return count($hashes);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     */
+    private function duplicateGeneratedSvgPathDataCount(array $assets): int
+    {
+        $pathDataCount = array_sum(array_map(static fn (array $asset): int => (int) ($asset['path_data_count'] ?? 0), $assets));
+
+        return max(0, $pathDataCount - $this->uniqueGeneratedSvgPathDataCount($assets));
     }
 
     /**
@@ -1117,16 +1166,49 @@ final class FigmaTransformer
         $assets = array();
         foreach ( $files as $file ) {
             $content = isset($file['content']) && is_scalar($file['content']) ? (string) $file['content'] : '';
-            $assets[] = array(
+            $asset = array(
                 'id'        => (string) ($file['source_id'] ?? ''),
                 'path'      => (string) ($file['path'] ?? ''),
                 'mime_type' => (string) ($file['mime_type'] ?? 'application/octet-stream'),
                 'bytes'     => strlen($content),
                 'hash'      => hash('sha256', $content),
             );
+            if ( 'image/svg+xml' === ($file['mime_type'] ?? null) && str_starts_with((string) ($file['source_id'] ?? ''), 'generated-vector-') ) {
+                $asset += $this->svgAssetMetrics($content);
+            }
+            $assets[] = $asset;
         }
 
         return $assets;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function svgAssetMetrics(string $content): array
+    {
+        $pathElementCount = preg_match_all('/<path\b[^>]*>/i', $content, $pathMatches);
+        $pathDataValues = array();
+        foreach ( $pathMatches[0] ?? array() as $pathElement ) {
+            if ( preg_match('/\bd\s*=\s*(["\'])(.*?)\1/is', (string) $pathElement, $pathDataMatch) ) {
+                $pathDataValues[] = html_entity_decode((string) $pathDataMatch[2], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        }
+
+        $pathDataBytes = array_map(static fn (string $pathData): int => strlen($pathData), $pathDataValues);
+        $pathDataHashes = array_map(static fn (string $pathData): string => hash('sha256', $pathData), $pathDataValues);
+        $uniquePathDataHashes = array_values(array_unique($pathDataHashes));
+
+        return array(
+            'gzip_bytes' => function_exists('gzencode') ? strlen((string) gzencode($content, 9)) : null,
+            'path_element_count' => false === $pathElementCount ? 0 : $pathElementCount,
+            'path_data_count' => count($pathDataValues),
+            'path_data_bytes' => array_sum($pathDataBytes),
+            'largest_path_data_bytes' => empty($pathDataBytes) ? 0 : max($pathDataBytes),
+            'unique_path_data_count' => count($uniquePathDataHashes),
+            'duplicate_path_data_count' => max(0, count($pathDataValues) - count($uniquePathDataHashes)),
+            'path_data_hashes' => $uniquePathDataHashes,
+        );
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -968,13 +968,13 @@ final class StaticHtmlEmitter
             }
 
             $content = (string) ($file['content'] ?? '');
-            $assets[] = array(
+            $assets[] = array_merge(array(
                 'id'        => $sourceId,
                 'path'      => (string) ($file['path'] ?? ''),
                 'mime_type' => 'image/svg+xml',
                 'bytes'     => strlen($content),
                 'hash'      => hash('sha256', $content),
-            );
+            ), $this->svgAssetMetrics($content));
         }
 
         usort($assets, static fn (array $a, array $b): int => ((int) $b['bytes'] <=> (int) $a['bytes']) ?: strcmp((string) $a['path'], (string) $b['path']));
@@ -984,10 +984,59 @@ final class StaticHtmlEmitter
             'threshold_bytes' => self::EXTERNAL_VECTOR_SVG_BYTES,
             'count' => count($assets),
             'bytes' => array_sum(array_map(static fn (array $asset): int => (int) ($asset['bytes'] ?? 0), $assets)),
+            'gzip_bytes' => $this->sumNullableAssetMetric($assets, 'gzip_bytes'),
+            'path_element_count' => array_sum(array_map(static fn (array $asset): int => (int) ($asset['path_element_count'] ?? 0), $assets)),
+            'path_data_bytes' => array_sum(array_map(static fn (array $asset): int => (int) ($asset['path_data_bytes'] ?? 0), $assets)),
+            'largest_path_data_bytes' => empty($assets) ? 0 : max(array_map(static fn (array $asset): int => (int) ($asset['largest_path_data_bytes'] ?? 0), $assets)),
+            'unique_path_data_count' => $this->uniqueAssetPathDataCount($assets),
+            'duplicate_path_data_count' => $this->duplicateAssetPathDataCount($assets),
             'paths' => array_values(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $assets)),
             'largest_assets' => array_slice($assets, 0, 10),
             'assets' => $assets,
         );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     */
+    private function sumNullableAssetMetric(array $assets, string $key): ?int
+    {
+        $sum = 0;
+        foreach ( $assets as $asset ) {
+            if ( ! array_key_exists($key, $asset) || null === $asset[$key] ) {
+                return null;
+            }
+            $sum += (int) $asset[$key];
+        }
+
+        return $sum;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     */
+    private function uniqueAssetPathDataCount(array $assets): int
+    {
+        $hashes = array();
+        foreach ( $assets as $asset ) {
+            foreach ( is_array($asset['path_data_hashes'] ?? null) ? $asset['path_data_hashes'] : array() as $hash ) {
+                if ( is_scalar($hash) && '' !== (string) $hash ) {
+                    $hashes[(string) $hash] = true;
+                }
+            }
+        }
+
+        return count($hashes);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     */
+    private function duplicateAssetPathDataCount(array $assets): int
+    {
+        $pathDataCount = array_sum(array_map(static fn (array $asset): int => (int) ($asset['path_data_count'] ?? 0), $assets));
+
+        return max(0, $pathDataCount - $this->uniqueAssetPathDataCount($assets));
     }
 
     /**
@@ -3037,16 +3086,49 @@ final class StaticHtmlEmitter
         $assets = array();
         foreach ( $assetFiles as $file ) {
             $content = (string) ($file['content'] ?? '');
-            $assets[] = array(
+            $asset = array(
                 'id'        => (string) ($file['source_id'] ?? ''),
                 'path'      => (string) $file['path'],
                 'mime_type' => (string) $file['mime_type'],
                 'bytes'     => strlen($content),
                 'hash'      => hash('sha256', $content),
             );
+            if ( 'image/svg+xml' === ($file['mime_type'] ?? null) && str_starts_with((string) ($file['source_id'] ?? ''), 'generated-vector-') ) {
+                $asset += $this->svgAssetMetrics($content);
+            }
+            $assets[] = $asset;
         }
 
         return $assets;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function svgAssetMetrics(string $content): array
+    {
+        $pathElementCount = preg_match_all('/<path\b[^>]*>/i', $content, $pathMatches);
+        $pathDataValues = array();
+        foreach ( $pathMatches[0] ?? array() as $pathElement ) {
+            if ( preg_match('/\bd\s*=\s*(["\'])(.*?)\1/is', (string) $pathElement, $pathDataMatch) ) {
+                $pathDataValues[] = html_entity_decode((string) $pathDataMatch[2], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        }
+
+        $pathDataBytes = array_map(static fn (string $pathData): int => strlen($pathData), $pathDataValues);
+        $pathDataHashes = array_map(static fn (string $pathData): string => hash('sha256', $pathData), $pathDataValues);
+        $uniquePathDataHashes = array_values(array_unique($pathDataHashes));
+
+        return array(
+            'gzip_bytes' => function_exists('gzencode') ? strlen((string) gzencode($content, 9)) : null,
+            'path_element_count' => false === $pathElementCount ? 0 : $pathElementCount,
+            'path_data_count' => count($pathDataValues),
+            'path_data_bytes' => array_sum($pathDataBytes),
+            'largest_path_data_bytes' => empty($pathDataBytes) ? 0 : max($pathDataBytes),
+            'unique_path_data_count' => count($uniquePathDataHashes),
+            'duplicate_path_data_count' => max(0, count($pathDataValues) - count($uniquePathDataHashes)),
+            'path_data_hashes' => $uniquePathDataHashes,
+        );
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -926,7 +926,16 @@ $externalizedVectorDiagnostics = $externalizedVectorResult['source_reports']['fi
 $assert('blocks-engine/figma-transformer/generated-svg-assets/v1' === ($externalizedVectorDiagnostics['schema'] ?? null), 'generated-svg-assets-diagnostics-schema');
 $assert(1 === ($externalizedVectorDiagnostics['count'] ?? null), 'generated-svg-assets-diagnostics-count');
 $assert(($externalizedVectorDiagnostics['bytes'] ?? 0) > 65536, 'generated-svg-assets-diagnostics-bytes');
+$assert(($externalizedVectorDiagnostics['gzip_bytes'] ?? 0) > 0, 'generated-svg-assets-diagnostics-gzip-bytes');
+$assert(1 === ($externalizedVectorDiagnostics['path_element_count'] ?? null), 'generated-svg-assets-diagnostics-path-element-count');
+$assert(($externalizedVectorDiagnostics['path_data_bytes'] ?? 0) > 65536, 'generated-svg-assets-diagnostics-path-data-bytes');
+$assert(($externalizedVectorDiagnostics['largest_path_data_bytes'] ?? 0) > 65536, 'generated-svg-assets-diagnostics-largest-path-data-bytes');
+$assert(1 === ($externalizedVectorDiagnostics['unique_path_data_count'] ?? null), 'generated-svg-assets-diagnostics-unique-path-data-count');
+$assert(0 === ($externalizedVectorDiagnostics['duplicate_path_data_count'] ?? null), 'generated-svg-assets-diagnostics-duplicate-path-data-count');
 $assert(array((string) ($externalizedVectorAssets[0]['path'] ?? '')) === ($externalizedVectorDiagnostics['paths'] ?? null), 'generated-svg-assets-diagnostics-paths');
+$assert(1 === ($externalizedVectorDiagnostics['assets'][0]['path_element_count'] ?? null), 'generated-svg-assets-diagnostics-asset-path-element-count');
+$assert(($externalizedVectorDiagnostics['assets'][0]['path_data_bytes'] ?? 0) > 65536, 'generated-svg-assets-diagnostics-asset-path-data-bytes');
+$assert(1 === ($externalizedVectorDiagnostics['assets'][0]['unique_path_data_count'] ?? null), 'generated-svg-assets-diagnostics-asset-unique-path-data-count');
 
 $starVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Star Vector Fixture',
@@ -1608,6 +1617,7 @@ $multiPageResult = blocks_engine_figma_transformer_transform_scenegraph(array(
                     'children' => array(
                         array('id' => 'text:home', 'type' => 'TEXT', 'name' => 'Home title', 'characters' => 'Home Hero', 'fontName' => array('family' => 'Example Sans', 'style' => 'Regular'), 'fontSize' => 20),
                         array('id' => 'image:home', 'type' => 'RECTANGLE', 'name' => 'Home image', 'width' => 100, 'height' => 60, 'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'home-image'))),
+                        array('id' => 'vector:home-large', 'type' => 'VECTOR', 'name' => 'Home Large Vector', 'width' => 10, 'height' => 10, 'figma_vector_paths' => array(array('data' => $externalizedVectorPath, 'source' => 'strokeGeometry'))),
                     ),
                 ),
                 array(
@@ -1644,7 +1654,7 @@ $assert(str_contains($multiPageStyle, '.figma-node-frame-about-about'), 'multi-p
 $assert(2 === ($multiPageResult['metrics']['page_count'] ?? null), 'multi-page-page-count');
 $assert(2 === ($multiPageResult['source_reports']['compiled_site']['totals']['page_count'] ?? null), 'multi-page-compiled-site-page-count');
 $assert('about.html' === ($multiPageResult['source_reports']['compiled_site']['pages'][1]['path'] ?? null), 'multi-page-compiled-site-page-path');
-$assert(2 === ($multiPageResult['source_reports']['compiled_site']['totals']['asset_count'] ?? null), 'multi-page-compiled-site-asset-count');
+$assert(3 === ($multiPageResult['source_reports']['compiled_site']['totals']['asset_count'] ?? null), 'multi-page-compiled-site-asset-count');
 $assert(array('Example Sans') === ($multiPageResult['source_reports']['figma']['html']['font_families'] ?? null), 'multi-page-font-families-aggregated');
 $assert(array(array('family' => 'Example Sans', 'weights' => array(400, 700))) === ($multiPageResult['source_reports']['figma']['html']['font_usage'] ?? null), 'multi-page-font-usage-aggregated');
 $assert(array(array('family' => 'Example Sans', 'weights' => array(400, 700))) === ($multiPageResult['source_reports']['compiled_site']['theme']['font_usage'] ?? null), 'multi-page-compiled-site-font-usage');
@@ -1658,8 +1668,13 @@ $assert(2 === count($multiPageTransformDiagnostics['pages'] ?? array()), 'multi-
 $assert('about.html' === ($multiPageTransformDiagnostics['pages'][1]['page_path'] ?? null), 'multi-page-transform-diagnostics-page-path');
 $assert(2 === ($multiPageTransformDiagnostics['images']['paint_refs'] ?? null), 'multi-page-transform-diagnostics-image-paints');
 $assert(2 === ($multiPageTransformDiagnostics['images']['resolved_assets'] ?? null), 'multi-page-transform-diagnostics-resolved-assets');
-$assert(2 === ($multiPageTransformDiagnostics['assets']['emitted_files'] ?? null), 'multi-page-transform-diagnostics-emitted-assets');
-$assert(0 === ($multiPageTransformDiagnostics['generated_svg_assets']['count'] ?? null), 'multi-page-transform-diagnostics-generated-svg-count');
+$assert(3 === ($multiPageTransformDiagnostics['assets']['emitted_files'] ?? null), 'multi-page-transform-diagnostics-emitted-assets');
+$assert(1 === ($multiPageTransformDiagnostics['generated_svg_assets']['count'] ?? null), 'multi-page-transform-diagnostics-generated-svg-count');
+$assert(($multiPageTransformDiagnostics['generated_svg_assets']['gzip_bytes'] ?? 0) > 0, 'multi-page-transform-diagnostics-generated-svg-gzip-bytes');
+$assert(1 === ($multiPageTransformDiagnostics['generated_svg_assets']['path_element_count'] ?? null), 'multi-page-transform-diagnostics-generated-svg-path-element-count');
+$assert(($multiPageTransformDiagnostics['generated_svg_assets']['path_data_bytes'] ?? 0) > 65536, 'multi-page-transform-diagnostics-generated-svg-path-data-bytes');
+$assert(1 === ($multiPageTransformDiagnostics['generated_svg_assets']['unique_path_data_count'] ?? null), 'multi-page-transform-diagnostics-generated-svg-unique-path-data-count');
+$assert(0 === ($multiPageTransformDiagnostics['generated_svg_assets']['duplicate_path_data_count'] ?? null), 'multi-page-transform-diagnostics-generated-svg-duplicate-path-data-count');
 $assert('selected_frames' === ($multiPageTransformDiagnostics['selection']['mode'] ?? null), 'multi-page-transform-diagnostics-selection-mode');
 $assert('frame:home' === ($multiPageTransformDiagnostics['selection']['selected_frames'][0]['frame_id'] ?? null), 'multi-page-transform-diagnostics-entry-frame-selection');
 $assert('about.html' === ($multiPageTransformDiagnostics['selection']['selected_frames'][1]['path'] ?? null), 'multi-page-transform-diagnostics-about-selection-path');


### PR DESCRIPTION
## Summary
- enrich generated SVG reports with gzip size, path counts, path-data bytes, largest path-data bytes, and duplicate/unique path data counts
- aggregate the new metrics across multi-page transforms
- add contract coverage around externalized generated SVG reporting

## Evidence
Latest locked DOM matrix showed wp-cloud-2 generated_svg_bytes=3489810 across 5 valid complex SVG assets. Investigation found this is real vector complexity, not obvious duplicate output, so richer diagnostics are the safe next step before optimization.

## Verification
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/src/FigmaTransformer.php
- php -l figma-transformer/tests/contract/run.php
- php figma-transformer/tests/contract/run.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagents
- **Used for:** SVG artifact analysis, diagnostics implementation, contract coverage, and verification.