### PR TITLE
Add 73-h44-lacrosse website fixture

### DIFF
--- a/fixtures/website-product-class-manifest.json
+++ b/fixtures/website-product-class-manifest.json
@@ -1,14 +1,14 @@
 {
   "schema": "blocks-engine/fixtures/website-product-class-manifest/v1",
   "source": "homeboy-rigs/static-site-importer-fixture-matrix/v1",
-  "source_fixture_count": 71,
+  "source_fixture_count": 72,
   "entrypoint": "index.html",
   "description": "Migration manifest for organizing fixtures/websites by Homeboy Rigs product class directories. Paths are repository-relative to fixtures/.",
   "classes": [
     { "product_class": "canvas/webgl/audio/runtime-heavy", "fixture_count": 9 },
     { "product_class": "docs/blog", "fixture_count": 5 },
     { "product_class": "ecommerce/catalog", "fixture_count": 1 },
-    { "product_class": "marketing/static", "fixture_count": 56 }
+    { "product_class": "marketing/static", "fixture_count": 57 }
   ],
   "fixtures": [
     { "id": "2-onepager-coffee", "current_path": "websites/2-onepager-coffee", "product_class": "marketing/static", "intended_path": "websites/marketing/static/2-onepager-coffee", "entrypoint": "index.html" },
@@ -81,6 +81,7 @@
     { "id": "69-markdown-editor", "current_path": "websites/69-markdown-editor", "product_class": "marketing/static", "intended_path": "websites/marketing/static/69-markdown-editor", "entrypoint": "index.html" },
     { "id": "70-typing-test", "current_path": "websites/70-typing-test", "product_class": "marketing/static", "intended_path": "websites/marketing/static/70-typing-test", "entrypoint": "index.html" },
     { "id": "71-beyond-the-block", "current_path": "websites/71-beyond-the-block", "product_class": "marketing/static", "intended_path": "websites/marketing/static/71-beyond-the-block", "entrypoint": "index.html" },
-    { "id": "72-why-wordpress", "current_path": "websites/72-why-wordpress", "product_class": "marketing/static", "intended_path": "websites/marketing/static/72-why-wordpress", "entrypoint": "index.html" }
+    { "id": "72-why-wordpress", "current_path": "websites/72-why-wordpress", "product_class": "marketing/static", "intended_path": "websites/marketing/static/72-why-wordpress", "entrypoint": "index.html" },
+    { "id": "73-h44-lacrosse", "current_path": "websites/73-h44-lacrosse", "product_class": "marketing/static", "intended_path": "websites/marketing/static/73-h44-lacrosse", "entrypoint": "index.html" }
   ]
 }

--- a/fixtures/websites/73-h44-lacrosse/about.html
+++ b/fixtures/websites/73-h44-lacrosse/about.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About — H44 Lacrosse · The Jonathan Huber Story</title>
+  <meta name="description" content="The story behind H44 Lacrosse — founded by Jonathan Huber, a Division I lacrosse player at Stony Brook and St. John's who wore number 44 and built a club to bring elite, Long Island–style coaching to Jacksonville.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
+        <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
+          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
+          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
+          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+        </svg>
+        <span class="brand-text">
+          <span class="brand-name">H44</span>
+          <span class="brand-tag">Lacrosse Club</span>
+        </span>
+      </a>
+
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="index.html">Home</a>
+        <a href="about.html" aria-current="page">About</a>
+        <a href="teams.html">Teams</a>
+        <a href="coaches.html">Coaches</a>
+        <a href="events.html">Events</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+
+      <button class="nav-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-nav">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+    <a href="index.html">Home</a>
+    <a href="about.html" aria-current="page">About</a>
+    <a href="teams.html">Teams</a>
+    <a href="coaches.html">Coaches</a>
+    <a href="events.html">Events</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <main>
+
+    <section class="page-banner">
+      <div class="container">
+        <h1>The H44 Story</h1>
+        <p>How a Long Island lacrosse upbringing and a Division I career became Jacksonville's home for elite club lacrosse.</p>
+      </div>
+    </section>
+
+    <!-- Founder hero split -->
+    <section class="section">
+      <div class="container split">
+        <div class="photo v4" role="img" aria-label="Founder Jonathan Huber wearing number 44">
+          <span class="photo-tag">#44</span>
+          <span class="photo-label">Jonathan Huber · Founder</span>
+        </div>
+        <div>
+          <span class="eyebrow">Meet The Founder</span>
+          <h2>Jonathan Huber</h2>
+          <p>Jonathan Huber didn't just play lacrosse — he scored. A Division I athlete at both Stony Brook University and St. John's University, he wore number 44 and earned a reputation as a relentless goal scorer. That number became the name: <strong>Huber, 44 — H44</strong>.</p>
+          <a href="contact.html" class="btn btn-primary">Get In Touch</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Stat row -->
+    <section class="section alt">
+      <div class="container">
+        <div class="stat-row">
+          <div class="stat"><strong>2</strong><span>D1 Programs Played</span></div>
+          <div class="stat"><strong>44</strong><span>His Number</span></div>
+          <div class="stat"><strong>1st</strong><span>Tournament Title</span></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- The story -->
+    <section class="section">
+      <div class="container">
+        <div class="prose">
+          <p class="lead">H44 was built on a simple idea: bring the level of coaching and competition Jonathan grew up with to the families of Jacksonville, Florida.</p>
+
+          <h2>From Long Island To Division I</h2>
+          <p>Jonathan came up in the kind of lacrosse environment that produces college players — fast, physical, and demanding. He carried that game to the Division I level, suiting up at Stony Brook University and St. John's University, where his scoring touch made him a player opponents had to game-plan around.</p>
+
+          <div class="pull-quote">
+            <p>“If you want to get good at lax and earn college looks, H44 is the place.”</p>
+          </div>
+
+          <h2>Why Jacksonville</h2>
+          <p>When Jonathan looked at the youth lacrosse scene in Florida, he saw talent and passion — but not the structured, high-level pipeline he'd grown up inside. So he started one. The vision is often described in one line: <strong>the Long Island Express of Florida</strong> — that same caliber of coaching, development, and recruiting exposure, built right here in Jacksonville.</p>
+
+          <h2>One Team Per Age Group</h2>
+          <p>H44 keeps it focused: a single team at 12U, 14U, and High School. That means real coaching attention at every level — fundamentals and a love of the game for the youngest players, full-field competition for the middle group, and a genuine college-recruiting push for the varsity squad.</p>
+
+          <h2>Champions, Already</h2>
+          <p>The approach is already paying off. In the club's first season, H44 won its first-ever tournament — proof that elite coaching and the right environment translate to wins on the field, fast.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="cta">
+      <div class="container">
+        <h2>Be Part Of The Story</h2>
+        <p>Tryouts and clinics run all season. Meet the coaches, find your team, and reach out to get started.</p>
+        <div class="hero-actions" style="justify-content:center">
+          <a href="contact.html" class="btn btn-primary">Contact H44</a>
+          <a href="teams.html" class="btn btn-ghost">See the Teams</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="brand-text">
+          <span class="brand-name">H44 LACROSSE</span>
+          <span class="brand-tag">Jacksonville, FL · 12U · 14U · HS</span>
+        </div>
+        <nav class="footer-links" aria-label="Footer navigation">
+          <a href="index.html">Home</a>
+          <a href="about.html">About</a>
+          <a href="teams.html">Teams</a>
+          <a href="coaches.html">Coaches</a>
+          <a href="events.html">Events</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+      <div class="footer-bottom">© 2026 H44 Lacrosse Club. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/fixtures/websites/73-h44-lacrosse/coaches.html
+++ b/fixtures/websites/73-h44-lacrosse/coaches.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coaches — H44 Lacrosse</title>
+  <meta name="description" content="Meet the H44 Lacrosse coaching staff across our 12U, 14U, and High School teams. Experienced coaches focused on development, sportsmanship, and the game.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
+        <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
+          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
+          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
+          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+        </svg>
+        <span class="brand-text">
+          <span class="brand-name">H44</span>
+          <span class="brand-tag">Lacrosse Club</span>
+        </span>
+      </a>
+
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="teams.html">Teams</a>
+        <a href="coaches.html" aria-current="page">Coaches</a>
+        <a href="events.html">Events</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+
+      <button class="nav-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-nav">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="teams.html">Teams</a>
+    <a href="coaches.html" aria-current="page">Coaches</a>
+    <a href="events.html">Events</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <main>
+
+    <section class="page-banner">
+      <div class="container">
+        <h1>Coaching Staff</h1>
+        <p>Led by a Division I athlete, our staff brings real college-level coaching to Jacksonville — one staff per age group, all focused on development and getting players seen.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="gallery">
+
+          <div class="card coach">
+            <div class="photo v4" role="img" aria-label="Portrait of founder Jonathan Huber, number 44">
+              <span class="photo-tag">#44</span>
+              <span class="photo-label">Jonathan Huber · Founder</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Founder &amp; Director</span>
+              <h3>Jonathan Huber</h3>
+              <p>Division I lacrosse player at Stony Brook University and St. John's University, where he wore number 44 — the namesake of H44 — and was known for scoring a ton of goals. Founded the club to bring elite, Long Island–style coaching and a real college-recruiting pipeline to Jacksonville.</p>
+            </div>
+          </div>
+
+          <div class="card coach">
+            <div class="photo v3" role="img" aria-label="Portrait of Coach Mike Donnelly">
+              <span class="photo-tag">12U</span>
+              <span class="photo-label">Mike Donnelly</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Head Coach · 12U Stingers</span>
+              <h3>Mike Donnelly</h3>
+              <p>Former collegiate midfielder focused on fundamentals and making the game fun for first-time players.</p>
+            </div>
+          </div>
+
+          <div class="card coach">
+            <div class="photo v2" role="img" aria-label="Portrait of Coach Sarah Lin">
+              <span class="photo-tag">12U</span>
+              <span class="photo-label">Sarah Lin</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Assistant Coach · 12U Stingers</span>
+              <h3>Sarah Lin</h3>
+              <p>USA Lacrosse certified, leading stick-skills clinics and goalie development.</p>
+            </div>
+          </div>
+
+          <div class="card coach">
+            <div class="photo v5" role="img" aria-label="Portrait of Coach Tony Ramos">
+              <span class="photo-tag">14U</span>
+              <span class="photo-label">Tony Ramos</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Head Coach · 14U Hornets</span>
+              <h3>Tony Ramos</h3>
+              <p>Builds disciplined, fast-break offenses and teaches the full-field transition game.</p>
+            </div>
+          </div>
+
+          <div class="card coach">
+            <div class="photo v1" role="img" aria-label="Portrait of Coach Dave Whitman">
+              <span class="photo-tag">14U</span>
+              <span class="photo-label">Dave Whitman</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Assistant Coach · 14U Hornets</span>
+              <h3>Dave Whitman</h3>
+              <p>Defense and faceoff specialist with a decade of youth coaching experience.</p>
+            </div>
+          </div>
+
+          <div class="card coach">
+            <div class="photo v4" role="img" aria-label="Portrait of Coach Greg Halloran">
+              <span class="photo-tag">HS</span>
+              <span class="photo-label">Greg Halloran</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Head Coach · High School Varsity</span>
+              <h3>Greg Halloran</h3>
+              <p>Leads the varsity program and the college-recruiting pipeline for our older players.</p>
+            </div>
+          </div>
+
+          <div class="card coach">
+            <div class="photo v6" role="img" aria-label="Portrait of Coach Erin Brooks">
+              <span class="photo-tag">HS</span>
+              <span class="photo-label">Erin Brooks</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Assistant Coach · High School Varsity</span>
+              <h3>Erin Brooks</h3>
+              <p>Strength, conditioning, and game-film analysis for the varsity squad.</p>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <h2>Questions For The Staff?</h2>
+        <p>Coaches are at every practice and game. Catch the schedule on the events page to find a session near you.</p>
+        <div class="hero-actions" style="justify-content:center">
+          <a href="events.html" class="btn btn-primary">View Events</a>
+          <a href="teams.html" class="btn btn-ghost">See the Teams</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="brand-text">
+          <span class="brand-name">H44 LACROSSE</span>
+          <span class="brand-tag">Jacksonville, FL · 12U · 14U · HS</span>
+        </div>
+        <nav class="footer-links" aria-label="Footer navigation">
+          <a href="index.html">Home</a>
+          <a href="about.html">About</a>
+          <a href="teams.html">Teams</a>
+          <a href="coaches.html">Coaches</a>
+          <a href="events.html">Events</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+      <div class="footer-bottom">© 2026 H44 Lacrosse Club. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/fixtures/websites/73-h44-lacrosse/contact.html
+++ b/fixtures/websites/73-h44-lacrosse/contact.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact — H44 Lacrosse · Jacksonville, FL</title>
+  <meta name="description" content="Contact H44 Lacrosse in Jacksonville, FL. Reach out about tryouts, clinics, and joining our 12U, 14U, or High School teams.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
+        <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
+          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
+          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
+          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+        </svg>
+        <span class="brand-text">
+          <span class="brand-name">H44</span>
+          <span class="brand-tag">Lacrosse Club</span>
+        </span>
+      </a>
+
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="teams.html">Teams</a>
+        <a href="coaches.html">Coaches</a>
+        <a href="events.html">Events</a>
+        <a href="contact.html" aria-current="page">Contact</a>
+      </nav>
+
+      <button class="nav-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-nav">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="teams.html">Teams</a>
+    <a href="coaches.html">Coaches</a>
+    <a href="events.html">Events</a>
+    <a href="contact.html" aria-current="page">Contact</a>
+  </nav>
+
+  <main>
+
+    <section class="page-banner">
+      <div class="container">
+        <h1>Get In Touch</h1>
+        <p>Questions about tryouts, clinics, or joining a team? Reach out — we'd love to get your player on the field.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="contact-layout">
+
+          <!-- Contact info -->
+          <div>
+            <span class="eyebrow" style="color:var(--lime-2);font-family:'Oswald',sans-serif;text-transform:uppercase;letter-spacing:3px;font-size:0.8rem;">Reach Us</span>
+            <h2 style="color:var(--navy);font-size:clamp(1.7rem,3.5vw,2.3rem);margin-top:8px;">H44 Lacrosse Club</h2>
+            <ul class="info-list">
+              <li>
+                <span class="info-icon" aria-hidden="true">@</span>
+                <span>
+                  <span class="info-label">Email</span>
+                  <a class="info-value" href="mailto:info@h44lacrosse.com">info@h44lacrosse.com</a>
+                </span>
+              </li>
+              <li>
+                <span class="info-icon" aria-hidden="true">☎</span>
+                <span>
+                  <span class="info-label">Phone</span>
+                  <a class="info-value" href="tel:+19045550144">(904) 555-0144</a>
+                </span>
+              </li>
+              <li>
+                <span class="info-icon" aria-hidden="true">◎</span>
+                <span>
+                  <span class="info-label">Where We Play</span>
+                  <span class="info-value">Jacksonville, Florida</span>
+                </span>
+              </li>
+              <li>
+                <span class="info-icon" aria-hidden="true">▶</span>
+                <span>
+                  <span class="info-label">Follow</span>
+                  <span class="info-value">@h44lacrosse on Instagram</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Contact form -->
+          <form class="form" action="#" method="post" aria-label="Contact H44 Lacrosse">
+            <div class="row-2">
+              <div class="field">
+                <label for="parent-name">Your Name</label>
+                <input type="text" id="parent-name" name="parent-name" autocomplete="name" required>
+              </div>
+              <div class="field">
+                <label for="player-name">Player Name</label>
+                <input type="text" id="player-name" name="player-name">
+              </div>
+            </div>
+
+            <div class="row-2">
+              <div class="field">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" autocomplete="email" required>
+              </div>
+              <div class="field">
+                <label for="phone">Phone</label>
+                <input type="tel" id="phone" name="phone" autocomplete="tel">
+              </div>
+            </div>
+
+            <div class="field">
+              <label for="age-group">Age Group</label>
+              <select id="age-group" name="age-group">
+                <option value="">Select one…</option>
+                <option value="12u">12U (Ages 11–12)</option>
+                <option value="14u">14U (Ages 13–14)</option>
+                <option value="hs">High School (Grades 9–12)</option>
+                <option value="unsure">Not sure yet</option>
+              </select>
+            </div>
+
+            <div class="field">
+              <label for="message">Message</label>
+              <textarea id="message" name="message" placeholder="Tell us about your player and what you're looking for…"></textarea>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Send Message</button>
+            <p class="form-note">We'll get back to you within a couple of days. New players are always welcome.</p>
+          </form>
+
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <h2>Prefer To Just Show Up?</h2>
+        <p>Clinics and tryouts run all season — check the calendar and come meet the coaches in person.</p>
+        <div class="hero-actions" style="justify-content:center">
+          <a href="events.html" class="btn btn-primary">View Events</a>
+          <a href="coaches.html" class="btn btn-ghost">Meet the Coaches</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="brand-text">
+          <span class="brand-name">H44 LACROSSE</span>
+          <span class="brand-tag">Jacksonville, FL · 12U · 14U · HS</span>
+        </div>
+        <nav class="footer-links" aria-label="Footer navigation">
+          <a href="index.html">Home</a>
+          <a href="about.html">About</a>
+          <a href="teams.html">Teams</a>
+          <a href="coaches.html">Coaches</a>
+          <a href="events.html">Events</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+      <div class="footer-bottom">© 2026 H44 Lacrosse Club. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/fixtures/websites/73-h44-lacrosse/css/main.css
+++ b/fixtures/websites/73-h44-lacrosse/css/main.css
@@ -1,0 +1,594 @@
+/* ─────────────────────────────────────────────────────────
+   H44 Lacrosse — shared stylesheet
+   Picture-forward youth lacrosse club site. Photos are
+   represented as self-contained gradient + SVG placeholders
+   so the fixture has no external network dependencies.
+   ───────────────────────────────────────────────────────── */
+
+:root {
+  --navy:    #0d2240;
+  --navy-2:  #163a63;
+  --steel:   #2f5d8a;
+  --lime:    #b6e62e;
+  --lime-2:  #8fc41c;
+  --ink:     #11161d;
+  --muted:   #5a6675;
+  --paper:   #f5f7fa;
+  --white:   #ffffff;
+  --line:    #dde3ea;
+  --radius:  14px;
+  --shadow:  0 10px 30px rgba(13, 34, 64, 0.10);
+  --container: 1160px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3 {
+  font-family: "Oswald", "Inter", system-ui, sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  line-height: 1.1;
+  margin: 0 0 0.5em;
+  text-transform: uppercase;
+}
+
+a { color: var(--steel); text-decoration: none; }
+a:hover { color: var(--navy); }
+
+img { max-width: 100%; display: block; }
+
+.container {
+  width: 100%;
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 22px;
+}
+
+/* ── Header / nav ───────────────────────────────────────── */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--navy);
+  border-bottom: 3px solid var(--lime);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 68px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--white);
+}
+.brand:hover { color: var(--white); }
+
+.brand-mark {
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
+}
+
+.brand-text { display: flex; flex-direction: column; line-height: 1; }
+.brand-name {
+  font-family: "Oswald", sans-serif;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: 2px;
+}
+.brand-tag {
+  font-size: 0.66rem;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--lime);
+  margin-top: 3px;
+}
+
+.nav-links { display: flex; gap: 6px; }
+.nav-links a {
+  color: rgba(255, 255, 255, 0.82);
+  font-family: "Oswald", sans-serif;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  font-size: 0.92rem;
+  padding: 9px 16px;
+  border-radius: 8px;
+  transition: background 0.15s, color 0.15s;
+}
+.nav-links a:hover { background: var(--navy-2); color: var(--white); }
+.nav-links a[aria-current="page"] {
+  color: var(--navy);
+  background: var(--lime);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 8px;
+}
+.nav-toggle span {
+  width: 26px;
+  height: 3px;
+  background: var(--lime);
+  border-radius: 2px;
+  transition: transform 0.2s, opacity 0.2s;
+}
+
+.mobile-nav { display: none; background: var(--navy-2); }
+.mobile-nav.open { display: block; }
+.mobile-nav a {
+  display: block;
+  color: var(--white);
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  padding: 14px 22px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.mobile-nav a[aria-current="page"] { color: var(--lime); }
+
+/* ── Buttons ────────────────────────────────────────────── */
+.btn {
+  display: inline-block;
+  font-family: "Oswald", sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  font-size: 0.9rem;
+  padding: 13px 26px;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: transform 0.12s, background 0.15s;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary { background: var(--lime); color: var(--navy); }
+.btn-primary:hover { background: var(--lime-2); color: var(--navy); }
+.btn-ghost { background: transparent; color: var(--white); border-color: rgba(255,255,255,0.45); }
+.btn-ghost:hover { background: rgba(255,255,255,0.12); color: var(--white); }
+
+/* ── Photo placeholders (self-contained "pictures") ─────── */
+.photo {
+  position: relative;
+  border-radius: var(--radius);
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  background: linear-gradient(135deg, var(--navy) 0%, var(--steel) 100%);
+  box-shadow: var(--shadow);
+}
+.photo::before {
+  /* lacrosse stick + ball motif, drawn with CSS only */
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 78% 26%, rgba(182, 230, 46, 0.9) 0 9px, transparent 10px),
+    repeating-linear-gradient(115deg, rgba(255,255,255,0.06) 0 14px, transparent 14px 28px);
+  opacity: 0.85;
+}
+.photo::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 45%, rgba(13, 34, 64, 0.78) 100%);
+}
+.photo .photo-label {
+  position: absolute;
+  left: 16px;
+  bottom: 14px;
+  right: 16px;
+  z-index: 2;
+  color: var(--white);
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 600;
+  font-size: 1.02rem;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.5);
+}
+.photo .photo-tag {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  z-index: 2;
+  background: var(--lime);
+  color: var(--navy);
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+  font-size: 0.72rem;
+  padding: 4px 10px;
+  border-radius: 6px;
+}
+
+/* gradient variants so the gallery reads like distinct photos */
+.photo.v1 { background: linear-gradient(135deg, #0d2240, #2f5d8a); }
+.photo.v2 { background: linear-gradient(135deg, #163a63, #6aa0c9); }
+.photo.v3 { background: linear-gradient(135deg, #11304f, #8fc41c); }
+.photo.v4 { background: linear-gradient(135deg, #0d2240, #1f7a4d); }
+.photo.v5 { background: linear-gradient(135deg, #20405f, #b6e62e); }
+.photo.v6 { background: linear-gradient(135deg, #14283f, #3f76a7); }
+
+/* ── Split feature (founder / about) ────────────────────── */
+.split {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 44px;
+  align-items: center;
+}
+.split .photo { aspect-ratio: 4 / 5; }
+.split .eyebrow {
+  color: var(--lime-2);
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  font-size: 0.8rem;
+}
+.split h2 { color: var(--navy); font-size: clamp(1.9rem, 4vw, 2.8rem); margin-top: 8px; }
+.split p { color: var(--muted); font-size: 1.06rem; }
+.split .btn { margin-top: 8px; }
+@media (max-width: 820px) {
+  .split { grid-template-columns: 1fr; gap: 28px; }
+  .split .photo { max-width: 360px; }
+}
+
+/* ── Hero ───────────────────────────────────────────────── */
+.hero {
+  position: relative;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-2) 55%, var(--steel) 100%);
+  overflow: hidden;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(115deg, rgba(182,230,46,0.05) 0 18px, transparent 18px 36px);
+  pointer-events: none;
+}
+.hero-inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 40px;
+  align-items: center;
+  padding: 72px 22px 80px;
+}
+.hero-kicker {
+  display: inline-block;
+  color: var(--lime);
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 0.8rem;
+  margin-bottom: 14px;
+}
+.hero h1 { font-size: clamp(2.6rem, 6vw, 4.6rem); }
+.hero p { font-size: 1.15rem; color: rgba(255,255,255,0.86); max-width: 46ch; }
+.hero-actions { margin-top: 26px; display: flex; gap: 14px; flex-wrap: wrap; }
+.hero-art {
+  aspect-ratio: 1 / 1;
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+/* ── Sections ───────────────────────────────────────────── */
+.section { padding: 72px 0; }
+.section.alt { background: var(--white); }
+.section-head { max-width: 620px; margin: 0 auto 44px; text-align: center; }
+.section-head .eyebrow {
+  color: var(--lime-2);
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  font-size: 0.8rem;
+}
+.section-head h2 { font-size: clamp(1.9rem, 4vw, 2.8rem); color: var(--navy); margin-top: 8px; }
+.section-head p { color: var(--muted); font-size: 1.06rem; }
+
+.page-banner {
+  background: var(--navy);
+  color: var(--white);
+  border-bottom: 3px solid var(--lime);
+  text-align: center;
+  padding: 56px 22px;
+}
+.page-banner h1 { font-size: clamp(2.2rem, 5vw, 3.4rem); }
+.page-banner p { color: rgba(255,255,255,0.8); max-width: 60ch; margin: 0 auto; }
+
+/* ── Grids ──────────────────────────────────────────────── */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 22px;
+}
+.gallery.cols-2 { grid-template-columns: repeat(2, 1fr); }
+
+.card {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+}
+.card .photo { border-radius: 0; box-shadow: none; }
+.card-body { padding: 20px 22px 24px; }
+.card-body h3 { color: var(--navy); font-size: 1.3rem; }
+.card-body .meta {
+  color: var(--lime-2);
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 0.78rem;
+  margin-bottom: 6px;
+}
+.card-body p { color: var(--muted); margin: 0 0 14px; }
+.card-stats {
+  display: flex;
+  gap: 18px;
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+  margin-top: auto;
+}
+.card-stats div { display: flex; flex-direction: column; }
+.card-stats strong { font-family: "Oswald", sans-serif; font-size: 1.3rem; color: var(--navy); }
+.card-stats span { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); }
+
+/* coach cards: square portrait */
+.coach .photo { aspect-ratio: 1 / 1; }
+
+/* ── Events list ────────────────────────────────────────── */
+.events { display: flex; flex-direction: column; gap: 16px; max-width: 860px; margin: 0 auto; }
+.event {
+  display: grid;
+  grid-template-columns: 96px 1fr auto;
+  gap: 22px;
+  align-items: center;
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-left: 5px solid var(--lime);
+  border-radius: var(--radius);
+  padding: 18px 22px;
+  box-shadow: var(--shadow);
+}
+.event-date {
+  text-align: center;
+  background: var(--navy);
+  color: var(--white);
+  border-radius: 10px;
+  padding: 10px 6px;
+}
+.event-date .mon { font-family: "Oswald", sans-serif; text-transform: uppercase; letter-spacing: 2px; color: var(--lime); font-size: 0.78rem; }
+.event-date .day { font-family: "Oswald", sans-serif; font-size: 1.7rem; font-weight: 700; line-height: 1; }
+.event-info h3 { color: var(--navy); margin: 0 0 4px; font-size: 1.18rem; }
+.event-info p { margin: 0; color: var(--muted); font-size: 0.95rem; }
+.event-pill {
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+.event-pill.home { background: #e8f6cf; color: #4a6b00; }
+.event-pill.away { background: #e6eef6; color: var(--steel); }
+.event-pill.tourney { background: #fce8d6; color: #a85a18; }
+
+/* ── Prose (about story) ────────────────────────────────── */
+.prose { max-width: 720px; margin: 0 auto; }
+.prose h2 { color: var(--navy); font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin-top: 1.4em; }
+.prose p { color: var(--ink); font-size: 1.08rem; margin: 0 0 1.1em; }
+.prose .lead { font-size: 1.22rem; color: var(--muted); }
+.pull-quote {
+  border-left: 5px solid var(--lime);
+  background: var(--white);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  padding: 22px 26px;
+  margin: 1.6em 0;
+  box-shadow: var(--shadow);
+}
+.pull-quote p {
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 1.25rem;
+  color: var(--navy);
+  margin: 0;
+  line-height: 1.3;
+}
+
+/* career stat row */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  max-width: 720px;
+  margin: 0 auto 8px;
+}
+.stat-row .stat {
+  background: var(--navy);
+  color: var(--white);
+  border-radius: var(--radius);
+  padding: 24px 18px;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+.stat-row .stat strong {
+  display: block;
+  font-family: "Oswald", sans-serif;
+  font-size: 2.2rem;
+  line-height: 1;
+  color: var(--lime);
+}
+.stat-row .stat span {
+  display: block;
+  margin-top: 8px;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: rgba(255,255,255,0.78);
+}
+
+/* ── Contact ────────────────────────────────────────────── */
+.contact-layout {
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 44px;
+  align-items: start;
+}
+.info-list { list-style: none; margin: 0; padding: 0; }
+.info-list li {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--line);
+}
+.info-list li:last-child { border-bottom: 0; }
+.info-list .info-icon {
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  background: var(--lime);
+  color: var(--navy);
+  border-radius: 10px;
+  font-family: "Oswald", sans-serif;
+  font-weight: 700;
+}
+.info-list .info-label {
+  display: block;
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 0.72rem;
+  color: var(--lime-2);
+}
+.info-list .info-value { color: var(--ink); font-size: 1.04rem; }
+
+.form {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 28px;
+  box-shadow: var(--shadow);
+}
+.form .field { margin-bottom: 18px; }
+.form .row-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.form label {
+  display: block;
+  font-family: "Oswald", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  font-size: 0.76rem;
+  color: var(--navy);
+  margin-bottom: 6px;
+}
+.form input,
+.form select,
+.form textarea {
+  width: 100%;
+  font-family: inherit;
+  font-size: 1rem;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+.form input:focus,
+.form select:focus,
+.form textarea:focus {
+  outline: none;
+  border-color: var(--steel);
+  box-shadow: 0 0 0 3px rgba(47, 93, 138, 0.15);
+}
+.form textarea { resize: vertical; min-height: 120px; }
+.form .btn { width: 100%; border: 0; }
+.form-note { color: var(--muted); font-size: 0.82rem; margin: 14px 0 0; text-align: center; }
+
+@media (max-width: 820px) {
+  .contact-layout { grid-template-columns: 1fr; gap: 30px; }
+}
+@media (max-width: 520px) {
+  .stat-row { grid-template-columns: 1fr; }
+  .form .row-2 { grid-template-columns: 1fr; }
+}
+
+/* ── Strip / CTA ────────────────────────────────────────── */
+.cta {
+  background: linear-gradient(135deg, var(--navy), var(--steel));
+  color: var(--white);
+  text-align: center;
+  padding: 64px 22px;
+}
+.cta h2 { font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.cta p { color: rgba(255,255,255,0.85); max-width: 50ch; margin: 0 auto 24px; }
+
+/* ── Footer ─────────────────────────────────────────────── */
+.site-footer {
+  background: var(--ink);
+  color: rgba(255,255,255,0.7);
+  padding: 48px 0 30px;
+}
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  gap: 30px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+.footer-inner .brand-name { color: var(--white); }
+.footer-links { display: flex; gap: 28px; flex-wrap: wrap; }
+.footer-links a { color: rgba(255,255,255,0.7); font-size: 0.95rem; }
+.footer-links a:hover { color: var(--lime); }
+.footer-bottom {
+  border-top: 1px solid rgba(255,255,255,0.1);
+  margin-top: 34px;
+  padding-top: 20px;
+  font-size: 0.82rem;
+  color: rgba(255,255,255,0.5);
+}
+
+/* ── Responsive ─────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .nav-links { display: none; }
+  .nav-toggle { display: flex; }
+  .hero-inner { grid-template-columns: 1fr; padding: 52px 22px 60px; }
+  .hero-art { max-width: 360px; }
+  .gallery, .gallery.cols-2 { grid-template-columns: repeat(2, 1fr); }
+  .event { grid-template-columns: 72px 1fr; }
+  .event-pill { grid-column: 2; justify-self: start; }
+}
+@media (max-width: 520px) {
+  .gallery, .gallery.cols-2 { grid-template-columns: 1fr; }
+}

--- a/fixtures/websites/73-h44-lacrosse/events.html
+++ b/fixtures/websites/73-h44-lacrosse/events.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Events — H44 Lacrosse · Games, Tryouts &amp; Clinics</title>
+  <meta name="description" content="Upcoming H44 Lacrosse events in Jacksonville, FL — games, tryouts, clinics, and tournaments across our 12U, 14U, and High School teams.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
+        <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
+          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
+          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
+          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+        </svg>
+        <span class="brand-text">
+          <span class="brand-name">H44</span>
+          <span class="brand-tag">Lacrosse Club</span>
+        </span>
+      </a>
+
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="teams.html">Teams</a>
+        <a href="coaches.html">Coaches</a>
+        <a href="events.html" aria-current="page">Events</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+
+      <button class="nav-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-nav">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="teams.html">Teams</a>
+    <a href="coaches.html">Coaches</a>
+    <a href="events.html" aria-current="page">Events</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <main>
+
+    <section class="page-banner">
+      <div class="container">
+        <h1>Upcoming Events</h1>
+        <p>Games, tryouts, clinics, and tournaments — everything on the H44 calendar in one place.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="events">
+
+          <div class="event">
+            <div class="event-date"><span class="mon">Apr</span><span class="day">04</span></div>
+            <div class="event-info">
+              <h3>12U Stingers vs. Riverside Rapids</h3>
+              <p>Saturday · 10:00 AM · Memorial Field #2</p>
+            </div>
+            <span class="event-pill home">Home</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">Apr</span><span class="day">04</span></div>
+            <div class="event-info">
+              <h3>14U Hornets vs. Summit Storm</h3>
+              <p>Saturday · 12:30 PM · Memorial Field #1</p>
+            </div>
+            <span class="event-pill home">Home</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">Apr</span><span class="day">11</span></div>
+            <div class="event-info">
+              <h3>High School Varsity @ Northgate Knights</h3>
+              <p>Saturday · 2:00 PM · Northgate Stadium</p>
+            </div>
+            <span class="event-pill away">Away</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">Apr</span><span class="day">18</span></div>
+            <div class="event-info">
+              <h3>Spring Skills Clinic — All Ages</h3>
+              <p>Saturday · 9:00 AM – 12:00 PM · H44 Practice Complex</p>
+            </div>
+            <span class="event-pill home">Clinic</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">Apr</span><span class="day">25</span></div>
+            <div class="event-info">
+              <h3>14U Hornets vs. Lakeside Lancers</h3>
+              <p>Saturday · 11:00 AM · Memorial Field #1</p>
+            </div>
+            <span class="event-pill home">Home</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">May</span><span class="day">02</span></div>
+            <div class="event-info">
+              <h3>12U Stingers @ Harborview Hawks</h3>
+              <p>Saturday · 10:30 AM · Harborview Park</p>
+            </div>
+            <span class="event-pill away">Away</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">May</span><span class="day">09</span></div>
+            <div class="event-info">
+              <h3>Spring Tryouts — 2026–27 Season</h3>
+              <p>Saturday · 9:00 AM · H44 Practice Complex · All age groups</p>
+            </div>
+            <span class="event-pill home">Tryouts</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">May</span><span class="day">16</span></div>
+            <div class="event-info">
+              <h3>H44 Spring Shootout Tournament</h3>
+              <p>Sat–Sun · All day · Regional Sports Complex · 12U / 14U / HS</p>
+            </div>
+            <span class="event-pill tourney">Tourney</span>
+          </div>
+
+          <div class="event">
+            <div class="event-date"><span class="mon">May</span><span class="day">23</span></div>
+            <div class="event-info">
+              <h3>High School Varsity vs. Eastvale Eagles</h3>
+              <p>Saturday · 1:00 PM · Memorial Field #1 · Senior Day</p>
+            </div>
+            <span class="event-pill home">Home</span>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- Event photos -->
+    <section class="section alt">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">From the Sideline</span>
+          <h2>Past Event Highlights</h2>
+          <p>A few snapshots from recent games, clinics, and tournaments — including our first-ever tournament title.</p>
+        </div>
+        <div class="gallery">
+          <div class="photo v5" role="img" aria-label="H44 players celebrating their first tournament championship">
+            <span class="photo-tag">Champions</span>
+            <span class="photo-label">First-ever tournament win</span>
+          </div>
+          <div class="photo v2" role="img" aria-label="Coaches running a skills clinic">
+            <span class="photo-tag">Clinic</span>
+            <span class="photo-label">Skills clinic morning</span>
+          </div>
+          <div class="photo v4" role="img" aria-label="Senior day celebration on the field">
+            <span class="photo-tag">Senior Day</span>
+            <span class="photo-label">Honoring the seniors</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <h2>See You On The Field</h2>
+        <p>New players welcome at every clinic and tryout. Meet the coaches and find your team to get started.</p>
+        <div class="hero-actions" style="justify-content:center">
+          <a href="teams.html" class="btn btn-primary">See the Teams</a>
+          <a href="coaches.html" class="btn btn-ghost">Meet the Coaches</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="brand-text">
+          <span class="brand-name">H44 LACROSSE</span>
+          <span class="brand-tag">Jacksonville, FL · 12U · 14U · HS</span>
+        </div>
+        <nav class="footer-links" aria-label="Footer navigation">
+          <a href="index.html">Home</a>
+          <a href="about.html">About</a>
+          <a href="teams.html">Teams</a>
+          <a href="coaches.html">Coaches</a>
+          <a href="events.html">Events</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+      <div class="footer-bottom">© 2026 H44 Lacrosse Club. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/fixtures/websites/73-h44-lacrosse/index.html
+++ b/fixtures/websites/73-h44-lacrosse/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>H44 Lacrosse — Jacksonville, FL Club Lacrosse · 12U · 14U · High School</title>
+  <meta name="description" content="H44 Lacrosse is a Jacksonville, Florida club fielding one team per age group — 12U, 14U, and High School. Founded by D1 athlete Jonathan Huber. Elite coaching and college looks — the Long Island Express of Florida.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
+        <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
+          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
+          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
+          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+        </svg>
+        <span class="brand-text">
+          <span class="brand-name">H44</span>
+          <span class="brand-tag">Lacrosse Club</span>
+        </span>
+      </a>
+
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="index.html" aria-current="page">Home</a>
+        <a href="about.html">About</a>
+        <a href="teams.html">Teams</a>
+        <a href="coaches.html">Coaches</a>
+        <a href="events.html">Events</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+
+      <button class="nav-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-nav">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+    <a href="index.html" aria-current="page">Home</a>
+    <a href="about.html">About</a>
+    <a href="teams.html">Teams</a>
+    <a href="coaches.html">Coaches</a>
+    <a href="events.html">Events</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <main>
+
+    <!-- Hero -->
+    <section class="hero" aria-label="Welcome">
+      <div class="container hero-inner">
+        <div>
+          <span class="hero-kicker">Jacksonville, Florida · Club Lacrosse</span>
+          <h1>H44 Lacrosse</h1>
+          <p>The Long Island Express of Florida. If you want to get good at lax and earn college looks, H44 is the place — D1-caliber coaching for 12U, 14U, and High School.</p>
+          <div class="hero-actions">
+            <a href="teams.html" class="btn btn-primary">See the Teams</a>
+            <a href="events.html" class="btn btn-ghost">Upcoming Events</a>
+          </div>
+        </div>
+        <div class="hero-art photo v3" role="img" aria-label="H44 Lacrosse team celebrating on the field">
+          <span class="photo-tag">Game Day</span>
+          <span class="photo-label">H44 takes the field</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Photo highlights -->
+    <section class="section">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">The Club</span>
+          <h2>Moments From The Season</h2>
+          <p>A look at our teams, coaches, and game days across the year.</p>
+        </div>
+        <div class="gallery">
+          <div class="photo v1" role="img" aria-label="12U team huddle before a game">
+            <span class="photo-tag">12U</span>
+            <span class="photo-label">Pre-game huddle</span>
+          </div>
+          <div class="photo v2" role="img" aria-label="14U attacker driving to the goal">
+            <span class="photo-tag">14U</span>
+            <span class="photo-label">Driving the cage</span>
+          </div>
+          <div class="photo v4" role="img" aria-label="High School defense clearing the ball">
+            <span class="photo-tag">HS</span>
+            <span class="photo-label">Clearing it out</span>
+          </div>
+          <div class="photo v5" role="img" aria-label="Coach running a faceoff drill at practice">
+            <span class="photo-tag">Practice</span>
+            <span class="photo-label">Faceoff reps</span>
+          </div>
+          <div class="photo v6" role="img" aria-label="Team celebrating a goal">
+            <span class="photo-tag">Game Day</span>
+            <span class="photo-label">Celebrating a goal</span>
+          </div>
+          <div class="photo v3" role="img" aria-label="Sideline parents and players cheering">
+            <span class="photo-tag">Sideline</span>
+            <span class="photo-label">Crowd on their feet</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Founder / why H44 -->
+    <section class="section alt">
+      <div class="container split">
+        <div class="photo v4" role="img" aria-label="Founder Jonathan Huber wearing number 44">
+          <span class="photo-tag">#44</span>
+          <span class="photo-label">Jonathan Huber · Founder</span>
+        </div>
+        <div>
+          <span class="eyebrow">Why H44</span>
+          <h2>Built By A D1 Athlete</h2>
+          <p>H44 was founded by Jonathan Huber — a Division I lacrosse player at Stony Brook University and St. John's University, where he wore number 44 and built a reputation as a prolific goal scorer. The name says it all: Huber, 44. He started the club to bring that level of coaching to Jacksonville — think Long Island Express, in Florida.</p>
+          <p>In our very first season we won our first-ever tournament. If you want to get good at lacrosse and earn college looks, H44 is the place.</p>
+          <a href="coaches.html" class="btn btn-primary">Meet the Coaches</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Quick access to teams -->
+    <section class="section">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">Easy Access</span>
+          <h2>Jump To Your Team</h2>
+          <p>One team per age group. Find yours and see the roster, coaches, and schedule.</p>
+        </div>
+        <div class="gallery">
+          <a class="card" href="teams.html#u12">
+            <div class="photo v1" role="img" aria-label="H44 12U team photo">
+              <span class="photo-tag">12U</span>
+              <span class="photo-label">H44 12U</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Ages 11–12</span>
+              <h3>12U Stingers</h3>
+              <p>Where it all starts — fundamentals, fun, and first faceoffs.</p>
+            </div>
+          </a>
+          <a class="card" href="teams.html#u14">
+            <div class="photo v2" role="img" aria-label="H44 14U team photo">
+              <span class="photo-tag">14U</span>
+              <span class="photo-label">H44 14U</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Ages 13–14</span>
+              <h3>14U Hornets</h3>
+              <p>Faster game, bigger field, and the run to playoffs.</p>
+            </div>
+          </a>
+          <a class="card" href="teams.html#hs">
+            <div class="photo v4" role="img" aria-label="H44 High School team photo">
+              <span class="photo-tag">HS</span>
+              <span class="photo-label">H44 High School</span>
+            </div>
+            <div class="card-body">
+              <span class="meta">Grades 9–12</span>
+              <h3>High School Varsity</h3>
+              <p>Top-level club lacrosse and college-recruiting reps.</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="cta">
+      <div class="container">
+        <h2>Come Play With H44</h2>
+        <p>Tryouts and clinics run all season. Meet the coaches and check the calendar to get started.</p>
+        <div class="hero-actions" style="justify-content:center">
+          <a href="coaches.html" class="btn btn-primary">Meet the Coaches</a>
+          <a href="events.html" class="btn btn-ghost">View Events</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="brand-text">
+          <span class="brand-name">H44 LACROSSE</span>
+          <span class="brand-tag">Jacksonville, FL · 12U · 14U · HS</span>
+        </div>
+        <nav class="footer-links" aria-label="Footer navigation">
+          <a href="index.html">Home</a>
+          <a href="about.html">About</a>
+          <a href="teams.html">Teams</a>
+          <a href="coaches.html">Coaches</a>
+          <a href="events.html">Events</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+      <div class="footer-bottom">© 2026 H44 Lacrosse Club. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/fixtures/websites/73-h44-lacrosse/js/main.js
+++ b/fixtures/websites/73-h44-lacrosse/js/main.js
@@ -1,0 +1,19 @@
+// H44 Lacrosse — mobile navigation toggle
+(function () {
+  var toggle = document.querySelector('.nav-toggle');
+  var menu = document.getElementById('mobile-nav');
+  if (!toggle || !menu) return;
+
+  toggle.addEventListener('click', function () {
+    var open = menu.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  });
+
+  // Close the mobile menu after tapping a link.
+  menu.addEventListener('click', function (e) {
+    if (e.target.tagName === 'A') {
+      menu.classList.remove('open');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+})();

--- a/fixtures/websites/73-h44-lacrosse/teams.html
+++ b/fixtures/websites/73-h44-lacrosse/teams.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Teams — H44 Lacrosse · 12U · 14U · High School</title>
+  <meta name="description" content="Meet the H44 Lacrosse teams — one squad per age group: 12U Stingers, 14U Hornets, and High School Varsity. Rosters, coaches, and team photos.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+
+  <header class="site-header" role="banner">
+    <div class="container header-inner">
+      <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
+        <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
+          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
+          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
+          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+        </svg>
+        <span class="brand-text">
+          <span class="brand-name">H44</span>
+          <span class="brand-tag">Lacrosse Club</span>
+        </span>
+      </a>
+
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="teams.html" aria-current="page">Teams</a>
+        <a href="coaches.html">Coaches</a>
+        <a href="events.html">Events</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+
+      <button class="nav-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-nav">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="teams.html" aria-current="page">Teams</a>
+    <a href="coaches.html">Coaches</a>
+    <a href="events.html">Events</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <main>
+
+    <section class="page-banner">
+      <div class="container">
+        <h1>Our Teams</h1>
+        <p>One team per age group — easy to find, easy to follow. Tap a team for its photos and roster.</p>
+      </div>
+    </section>
+
+    <!-- 12U -->
+    <section class="section" id="u12">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">Ages 11–12</span>
+          <h2>12U Stingers</h2>
+          <p>Our entry team — building stick skills, field IQ, and a love for the game.</p>
+        </div>
+        <div class="gallery cols-2">
+          <div class="photo v1" role="img" aria-label="12U Stingers full team photo">
+            <span class="photo-tag">Team Photo</span>
+            <span class="photo-label">12U Stingers — 2026 Roster</span>
+          </div>
+          <div class="photo v6" role="img" aria-label="12U player cradling up the field">
+            <span class="photo-tag">In Action</span>
+            <span class="photo-label">Cradling up the field</span>
+          </div>
+          <div class="photo v3" role="img" aria-label="12U goalie making a save">
+            <span class="photo-tag">Between the Pipes</span>
+            <span class="photo-label">Big save</span>
+          </div>
+          <div class="photo v2" role="img" aria-label="12U team huddle with coach">
+            <span class="photo-tag">Huddle</span>
+            <span class="photo-label">Bring it in</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 14U -->
+    <section class="section alt" id="u14">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">Ages 13–14</span>
+          <h2>14U Hornets</h2>
+          <p>Full-field lacrosse, real competition, and the push toward playoffs.</p>
+        </div>
+        <div class="gallery cols-2">
+          <div class="photo v2" role="img" aria-label="14U Hornets full team photo">
+            <span class="photo-tag">Team Photo</span>
+            <span class="photo-label">14U Hornets — 2026 Roster</span>
+          </div>
+          <div class="photo v5" role="img" aria-label="14U attacker shooting on goal">
+            <span class="photo-tag">In Action</span>
+            <span class="photo-label">Top-shelf finish</span>
+          </div>
+          <div class="photo v4" role="img" aria-label="14U defense double-teaming">
+            <span class="photo-tag">Defense</span>
+            <span class="photo-label">Locking it down</span>
+          </div>
+          <div class="photo v1" role="img" aria-label="14U faceoff specialist winning the clamp">
+            <span class="photo-tag">Faceoff</span>
+            <span class="photo-label">Winning the clamp</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- HS -->
+    <section class="section" id="hs">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">Grades 9–12</span>
+          <h2>High School Varsity</h2>
+          <p>Top-level club lacrosse, recruiting exposure, and tournament travel.</p>
+        </div>
+        <div class="gallery cols-2">
+          <div class="photo v4" role="img" aria-label="High School Varsity full team photo">
+            <span class="photo-tag">Team Photo</span>
+            <span class="photo-label">H44 Varsity — 2026 Roster</span>
+          </div>
+          <div class="photo v3" role="img" aria-label="High School midfielder on a fast break">
+            <span class="photo-tag">In Action</span>
+            <span class="photo-label">Pushing transition</span>
+          </div>
+          <div class="photo v6" role="img" aria-label="High School team at a tournament">
+            <span class="photo-tag">Tournament</span>
+            <span class="photo-label">Summer showcase</span>
+          </div>
+          <div class="photo v5" role="img" aria-label="High School captains with the trophy">
+            <span class="photo-tag">Champions</span>
+            <span class="photo-label">Captains lift the cup</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <h2>Want To Join A Team?</h2>
+        <p>Reach out to the coaching staff and check the events calendar for tryout dates.</p>
+        <div class="hero-actions" style="justify-content:center">
+          <a href="coaches.html" class="btn btn-primary">Meet the Coaches</a>
+          <a href="events.html" class="btn btn-ghost">View Events</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="brand-text">
+          <span class="brand-name">H44 LACROSSE</span>
+          <span class="brand-tag">Jacksonville, FL · 12U · 14U · HS</span>
+        </div>
+        <nav class="footer-links" aria-label="Footer navigation">
+          <a href="index.html">Home</a>
+          <a href="about.html">About</a>
+          <a href="teams.html">Teams</a>
+          <a href="coaches.html">Coaches</a>
+          <a href="events.html">Events</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+      <div class="footer-bottom">© 2026 H44 Lacrosse Club. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a new website fixture: **`73-h44-lacrosse`** — a multi-page static marketing site for H44 Lacrosse, a Jacksonville, FL youth club fielding one team per age group (12U / 14U / High School).

Six pages share `css/main.css` + `js/main.js`:

- `index.html` — home (hero, season gallery, founder section, team jump-links, CTA)
- `about.html` — founder story (Jonathan Huber, D1 at Stony Brook & St. John's, #44 → H44)
- `teams.html` — anchored sections for 12U / 14U / HS photo galleries
- `coaches.html` — staff cards
- `events.html` — schedule list + past-highlights gallery
- `contact.html` — info column + inquiry form (front-end only placeholder)

## Conventions

- Self-contained: photos are CSS gradient + SVG placeholders, no external network/image deps.
- Responsive (CSS grid, mobile hamburger nav, `aria-current` active tab).
- Registered in `fixtures/website-product-class-manifest.json` under `marketing/static`; counts bumped and `php fixtures/validate-website-product-class-manifest.php` passes (72 entries across 4 classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)