### PR TITLE
Clarify Figma fixture matrix CLI

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -8,6 +8,11 @@ $figmaRoot = $root . '/figma-transformer';
 require_once __DIR__ . '/figma-fixture-selection.php';
 
 $options = matrix_options($argv);
+if ( true === ($options['help'] ?? false) ) {
+    matrix_print_help();
+    exit(0);
+}
+
 $fixtureDir = $options['fixture_dir'] ?? ($figmaRoot . '/fixtures');
 $defaultOutputRoot = getenv('HOMEBOY_ARTIFACT_ROOT') ?: sys_get_temp_dir();
 $outputDir = $options['output_dir'] ?? ($defaultOutputRoot . '/figma-transformer-fixture-matrix-' . gmdate('Ymd-His'));
@@ -22,12 +27,19 @@ $homeboyCommand = (string) ($options['homeboy_command'] ?? (getenv('HOMEBOY_COMM
 $domBoxProviderCommand = (string) ($options['dom_box_provider_command'] ?? (getenv('HOMEBOY_DOM_BOX_CAPTURE_COMMAND') ?: ''));
 $only = isset($options['only']) ? array_filter(array_map('trim', explode(',', (string) $options['only']))) : array();
 $adHocFixtures = matrix_list_option($options['fixture'] ?? array());
+$fixtureDiscoveryEnabled = empty($adHocFixtures) || true === ($options['include_fixture_dir'] ?? false);
 $fontCssPassthrough = matrix_font_css_passthrough($options);
 $evidenceOptions = matrix_evidence_options($options);
 $selectionLock = matrix_selection_lock_options($options);
 
-$fixtures = matrix_discover_fixtures($fixtureDir);
+$fixtures = $fixtureDiscoveryEnabled ? matrix_discover_fixtures($fixtureDir) : array();
 foreach ( $adHocFixtures as $fixturePath ) {
+    if ( ! is_file($fixturePath) || ! is_readable($fixturePath) ) {
+        fwrite(STDERR, "Explicit fixture is not readable: {$fixturePath}\n");
+        fwrite(STDERR, "Use --fixture=/absolute/path/to/file.fig, or omit --fixture to discover fixtures from --fixture-dir.\n");
+        exit(1);
+    }
+
     $fixtures[] = matrix_fixture_from_path($fixturePath, true);
 }
 
@@ -62,6 +74,7 @@ if ( ! empty($only) ) {
 
 if ( empty($fixtures) ) {
     fwrite(STDERR, "No fixtures selected.\n");
+    fwrite(STDERR, "Use --fixture=/absolute/path/to/file.fig for explicit fixture paths, or --fixture-dir=/path/to/fixtures for discovery. Run with --help for examples.\n");
     exit(1);
 }
 
@@ -271,6 +284,16 @@ function matrix_options(array $argv): array
             continue;
         }
 
+        if ( '--help' === $arg || '-h' === $arg ) {
+            $options['help'] = true;
+            continue;
+        }
+
+        if ( '--include-fixture-dir' === $arg ) {
+            $options['include_fixture_dir'] = true;
+            continue;
+        }
+
         if ( ! str_starts_with($arg, '--') || ! str_contains($arg, '=') ) {
             continue;
         }
@@ -291,6 +314,54 @@ function matrix_options(array $argv): array
     }
 
     return $options;
+}
+
+function matrix_print_help(): void
+{
+    echo <<<'HELP'
+Usage:
+  php scripts/figma-fixture-matrix.php [options]
+
+Fixture selection:
+  --fixture=/path/to/file.fig       Run one explicit fixture path. Repeat for multiple fixtures.
+                                    When provided, fixture-dir discovery is disabled by default.
+  --fixture-dir=/path/to/fixtures   Discover *.fig fixtures from this directory. Defaults to ./fixtures.
+  --include-fixture-dir             Combine --fixture paths with --fixture-dir discovery.
+  --only=id[,id]                    Filter selected fixtures by fixture id.
+  --selection-lock=/path/to.json    Reuse locked frame ids from a prior matrix summary.
+  --frame-ids=id[,id]               Force frame ids for every selected fixture.
+  --entry-frame-id=id               Force the entry frame id when using --frame-ids.
+
+Run modes:
+  --dry-run                         Print planned commands without running transforms.
+  --inspect-only                    Inspect fixtures without running transforms.
+  --capture-dom-boxes               Capture DOM boxes after transform and rerun with evidence.
+
+Output and tooling:
+  --output-dir=/path                Matrix artifact directory. Defaults under HOMEBOY_ARTIFACT_ROOT or temp.
+  --zstd-command=/path/to/zstd      zstd binary or command.
+  --max-nodes=5000                  Transform node budget per fixture.
+  --max-pages=3                     Auto-selected frame/page limit.
+  --inspect-limit=100               Inspect frame listing limit.
+  --homeboy-command=/path           Homeboy command for DOM box capture.
+  --homeboy-bin=/path               Alias for --homeboy-command.
+  --dom-box-provider-command=cmd    Provider command passed to HOMEBOY_DOM_BOX_CAPTURE_COMMAND.
+  --dom-box-command=cmd             Alias for --dom-box-provider-command.
+  --font-css=css                    Inline CSS passed through to transformer.
+  --font-css-file=/path             CSS file passed through to transformer.
+  --parity-report=/path             Evidence path template. Supports {fixture}, {id}, {frame_id}, {page}, {slug}.
+  --dom-boxes=/path                 Evidence path template for DOM boxes.
+  --layout-report=/path             Evidence path template for layout report.
+  --layout-mismatch-report=/path    Evidence path template for layout mismatch report.
+  --help, -h                        Show this help text.
+
+Examples:
+  php scripts/figma-fixture-matrix.php --help
+  php scripts/figma-fixture-matrix.php --dry-run --fixture=/tmp/patched-fixtures/home.fig
+  php scripts/figma-fixture-matrix.php --dry-run --fixture-dir=/tmp/fixture-corpus
+  php scripts/figma-fixture-matrix.php --dry-run --fixture=/tmp/home.fig --include-fixture-dir
+
+HELP;
 }
 
 /**

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -10,6 +10,7 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $matrixFixtureDir = sys_get_temp_dir() . '/figma-fixture-matrix-contract-' . getmypid() . '-' . bin2hex(random_bytes(4));
     mkdir($matrixFixtureDir, 0777, true);
     file_put_contents($matrixFixtureDir . '/alias.fig', 'placeholder fig fixture');
+    file_put_contents($matrixFixtureDir . '/explicit.fig', 'explicit fig fixture');
 
     $matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
     file_put_contents($matrixSelectionLockPath, json_encode(array(
@@ -53,6 +54,24 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
         . ' --homeboy-command=' . escapeshellarg($matrixFixtureDir . '/missing-homeboy')
         . ' 2>&1';
     exec($missingHomeboyCommand, $missingHomeboyOutput, $missingHomeboyExitCode);
+    $matrixHelpOutput = array();
+    $matrixHelpCommand = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
+        . ' --help'
+        . ' 2>&1';
+    exec($matrixHelpCommand, $matrixHelpOutput, $matrixHelpExitCode);
+    $explicitFixtureCommand = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
+        . ' --dry-run --fixture-dir=' . escapeshellarg($matrixFixtureDir)
+        . ' --fixture=' . escapeshellarg($matrixFixtureDir . '/explicit.fig');
+    $explicitFixtureOutput = shell_exec($explicitFixtureCommand);
+    $explicitFixtureSummary = is_string($explicitFixtureOutput) ? json_decode($explicitFixtureOutput, true) : null;
+    $missingExplicitFixtureOutput = array();
+    $missingExplicitFixtureCommand = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
+        . ' --dry-run --fixture=' . escapeshellarg($matrixFixtureDir . '/missing.fig')
+        . ' 2>&1';
+    exec($missingExplicitFixtureCommand, $missingExplicitFixtureOutput, $missingExplicitFixtureExitCode);
 
     $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
     $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
@@ -79,4 +98,14 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $missingHomeboyMessage = implode("\n", $missingHomeboyOutput);
     $assert(str_contains($missingHomeboyMessage, 'DOM box capture requires a runnable Homeboy command'), 'fixture-matrix-capture-preflight-missing-homeboy-message');
     $assert(str_contains($missingHomeboyMessage, 'Set --homeboy-command, --homeboy-bin, or HOMEBOY_COMMAND'), 'fixture-matrix-capture-preflight-homeboy-remediation');
+    $assert(0 === $matrixHelpExitCode, 'fixture-matrix-help-exits-zero');
+    $matrixHelpMessage = implode("\n", $matrixHelpOutput);
+    $assert(str_contains($matrixHelpMessage, 'Usage:'), 'fixture-matrix-help-usage');
+    $assert(str_contains($matrixHelpMessage, '--fixture=/path/to/file.fig'), 'fixture-matrix-help-explicit-fixture');
+    $assert(is_array($explicitFixtureSummary), 'fixture-matrix-explicit-fixture-json-summary');
+    $assert(1 === count($explicitFixtureSummary['fixtures'] ?? array()), 'fixture-matrix-explicit-fixture-disables-dir-discovery');
+    $assert($matrixFixtureDir . '/explicit.fig' === ($explicitFixtureSummary['fixtures'][0]['path'] ?? null), 'fixture-matrix-explicit-fixture-path');
+    $assert(0 !== $missingExplicitFixtureExitCode, 'fixture-matrix-missing-explicit-fixture-fails');
+    $missingExplicitFixtureMessage = implode("\n", $missingExplicitFixtureOutput);
+    $assert(str_contains($missingExplicitFixtureMessage, 'Explicit fixture is not readable'), 'fixture-matrix-missing-explicit-fixture-message');
 }


### PR DESCRIPTION
## Summary
- add first-class `--help` / `-h` output for the fixture matrix runner
- make explicit `--fixture=` paths disable implicit fixture directory discovery by default
- add `--include-fixture-dir` and clearer errors for unreadable explicit fixtures

## Testing
- `php -l figma-transformer/scripts/figma-fixture-matrix.php`
- `php -l figma-transformer/tests/contract/FixtureMatrixContract.php`
- `php tests/contract/run.php`
- `php figma-transformer/scripts/figma-fixture-matrix.php --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, plus OpenCode subagents
- **Used for:** implementation, test execution, and PR description drafting
