### PR TITLE
Fix residual Figma layout mismatches

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -679,14 +679,7 @@ final class StaticHtmlEmitter
      */
     private function visualNodeMap(array $nodes): array
     {
-        $map = array();
-        foreach ( $nodes as $node ) {
-            if ( is_array($node) ) {
-                $this->appendVisualNodeMap($node, $map, 0.0, 0.0, null, null, $this->identityVisualTransformMatrix());
-            }
-        }
-
-        return $map;
+        return (new VisualNodeMapBuilder($this->assetsById, $this->renderTextGlyphPaths))->build($nodes);
     }
 
     /**
@@ -1320,224 +1313,6 @@ final class StaticHtmlEmitter
 
     /**
      * @param array<string, mixed> $node
-     * @param array<int, array<string, mixed>> $map
-     */
-    private function appendVisualNodeMap(array $node, array &$map, float $x, float $y, ?array $parentNode, ?array $clipRect, array $parentTransform): void
-    {
-        if ( $this->isFullyTransparentVisualNode($node) ) {
-            return;
-        }
-
-        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
-        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
-
-        if ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
-            $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
-            $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
-        } elseif ( null !== $parentNode && ('absolute' === ($layout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($node, $parentNode)) ) {
-            $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
-            $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
-        }
-
-        $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
-        $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
-        $nodeTransform = null !== $width && null !== $height ? $this->visualTransformMatrix($parentTransform, $x, $y, $width, $height, $node) : null;
-        $nodeRect = null !== $width && null !== $height && null !== $nodeTransform ? $this->transformedVisualRect($width, $height, $nodeTransform) : null;
-        $visibleRect = null;
-        if ( null !== $nodeRect && null !== $clipRect && $this->isClippableDecorativeVisualNode($node) ) {
-            $visibleRect = $this->rectIntersection($nodeRect, $clipRect);
-            if ( null === $visibleRect ) {
-                return;
-            }
-        }
-
-        if ( null !== $width && null !== $height ) {
-            $imagePaint = $this->firstImagePaint($node);
-            $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
-            $entry = array(
-                'id' => (string) ($node['id'] ?? ''),
-                'parent_id' => null !== $parentNode ? (string) ($parentNode['id'] ?? '') : '',
-                'name' => (string) ($node['name'] ?? ''),
-                'type' => strtoupper((string) ($node['type'] ?? '')),
-                'rect' => $nodeRect,
-                'layout' => array(
-                    'display' => $layout['display'] ?? null,
-                    'flex_direction' => $layout['flex_direction'] ?? null,
-                    'positioning' => $layout['positioning'] ?? null,
-                    'coordinate_space' => $box['coordinate_space'] ?? null,
-                ),
-                'image' => null === $imagePaint ? null : $this->visualImageMetadata($imagePaint),
-                'text' => empty($text) ? null : $this->visualTextMetadata($text),
-            );
-            if ( null !== $visibleRect && $visibleRect !== $nodeRect ) {
-                $entry['visible_rect'] = $visibleRect;
-                $entry['clip'] = array('source' => 'parent_clips_content');
-            }
-            $map[] = $entry;
-        }
-
-        $children = $this->nodeList($node);
-        if ( empty($children) ) {
-            return;
-        }
-
-        $childClipRect = $clipRect;
-        if ( null !== $nodeRect && true === ($layout['clips_content'] ?? false) ) {
-            $childClipRect = null === $childClipRect ? $nodeRect : $this->rectIntersection($childClipRect, $nodeRect);
-            if ( null === $childClipRect ) {
-                return;
-            }
-        }
-
-        $padding = is_array($layout['padding'] ?? null) ? $layout['padding'] : array();
-        $paddingLeft = isset($padding['left']) && is_numeric($padding['left']) ? (float) $padding['left'] : 0.0;
-        $paddingRight = isset($padding['right']) && is_numeric($padding['right']) ? (float) $padding['right'] : 0.0;
-        $paddingTop = isset($padding['top']) && is_numeric($padding['top']) ? (float) $padding['top'] : 0.0;
-        $paddingBottom = isset($padding['bottom']) && is_numeric($padding['bottom']) ? (float) $padding['bottom'] : 0.0;
-        $childX = $paddingLeft;
-        $childY = $paddingTop;
-        $gap = isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ? (float) $layout['item_spacing'] : 0.0;
-        $isRow = 'row' === ($layout['flex_direction'] ?? null);
-        $isFlex = 'flex' === ($layout['display'] ?? null);
-        $contentWidth = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width'] - $paddingLeft - $paddingRight) : null;
-        $contentHeight = isset($box['height']) && is_numeric($box['height']) ? max(0.0, (float) $box['height'] - $paddingTop - $paddingBottom) : null;
-        $mainAxis = $isRow ? 'width' : 'height';
-        $crossAxis = $isRow ? 'height' : 'width';
-        $contentMainSize = $isRow ? $contentWidth : $contentHeight;
-        $contentCrossSize = $isRow ? $contentHeight : $contentWidth;
-        $flowChildren = array();
-
-        foreach ( $children as $child ) {
-            if ( ! is_array($child) ) {
-                continue;
-            }
-
-            if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
-                continue;
-            }
-
-            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
-            if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
-                continue;
-            }
-
-            $flowChildren[] = $child;
-        }
-
-        $flowPositions = $this->visualFlexChildPositions($flowChildren, $layout, $isFlex, $isRow, $mainAxis, $crossAxis, $contentMainSize, $contentCrossSize, $gap);
-
-        foreach ( $children as $child ) {
-            if ( ! is_array($child) ) {
-                continue;
-            }
-
-            if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
-                continue;
-            }
-
-            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
-            if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
-                $this->appendVisualNodeMap($child, $map, 0.0, 0.0, $node, $childClipRect, $nodeTransform ?? $parentTransform);
-                continue;
-            }
-
-            $nodeId = (string) ($child['id'] ?? '');
-            $position = '' !== $nodeId && isset($flowPositions[$nodeId]) ? $flowPositions[$nodeId] : array('main' => 0.0, 'cross' => 0.0);
-            if ( $isRow ) {
-                $this->appendVisualNodeMap($child, $map, $childX + $position['main'], $childY + $position['cross'], $node, $childClipRect, $nodeTransform ?? $parentTransform);
-            } else {
-                $this->appendVisualNodeMap($child, $map, $childX + $position['cross'], $childY + $position['main'], $node, $childClipRect, $nodeTransform ?? $parentTransform);
-            }
-        }
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $children
-     * @param array<string, mixed> $layout
-     * @return array<string, array{main: float, cross: float}>
-     */
-    private function visualFlexChildPositions(array $children, array $layout, bool $isFlex, bool $isRow, string $mainAxis, string $crossAxis, ?float $contentMainSize, ?float $contentCrossSize, float $gap): array
-    {
-        $positions = array();
-        if ( empty($children) ) {
-            return $positions;
-        }
-
-        $wrap = $isFlex && null !== $contentMainSize && 'wrap' === ($layout['flex_wrap'] ?? null);
-        $lines = array();
-        $currentLine = array('children' => array(), 'main_size' => 0.0, 'cross_size' => 0.0);
-        foreach ( $children as $child ) {
-            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
-            $childMainSize = isset($childBox[$mainAxis]) && is_numeric($childBox[$mainAxis]) ? (float) $childBox[$mainAxis] : 0.0;
-            $childCrossSize = isset($childBox[$crossAxis]) && is_numeric($childBox[$crossAxis]) ? (float) $childBox[$crossAxis] : 0.0;
-            $lineChildCount = count($currentLine['children']);
-            $candidateMainSize = (float) $currentLine['main_size'] + ($lineChildCount > 0 ? $gap : 0.0) + $childMainSize;
-            if ( $wrap && $lineChildCount > 0 && $candidateMainSize > $contentMainSize + 0.001 ) {
-                $lines[] = $currentLine;
-                $currentLine = array('children' => array(), 'main_size' => 0.0, 'cross_size' => 0.0);
-                $lineChildCount = 0;
-                $candidateMainSize = $childMainSize;
-            }
-
-            $currentLine['children'][] = array('node' => $child, 'main_size' => $childMainSize, 'cross_size' => $childCrossSize);
-            $currentLine['main_size'] = $candidateMainSize;
-            $currentLine['cross_size'] = max((float) $currentLine['cross_size'], $childCrossSize);
-        }
-        if ( ! empty($currentLine['children']) ) {
-            $lines[] = $currentLine;
-        }
-
-        $lineCrossOffset = 0.0;
-        foreach ( $lines as $line ) {
-            $lineChildren = is_array($line['children'] ?? null) ? $line['children'] : array();
-            $lineMainSize = (float) ($line['main_size'] ?? 0.0);
-            $lineCrossSize = (float) ($line['cross_size'] ?? 0.0);
-            $cursorMain = 0.0;
-            $visualGap = $gap;
-            if ( $isFlex && null !== $contentMainSize ) {
-                $freeMainSpace = $contentMainSize - $lineMainSize;
-                $distributedMainSpace = max(0.0, $freeMainSpace);
-                $justifyContent = (string) ($layout['justify_content'] ?? 'flex-start');
-                if ( 'flex-end' === $justifyContent ) {
-                    $cursorMain = $freeMainSpace;
-                } elseif ( 'center' === $justifyContent ) {
-                    $cursorMain = $freeMainSpace / 2.0;
-                } elseif ( 'space-between' === $justifyContent && count($lineChildren) > 1 ) {
-                    $visualGap += $distributedMainSpace / (count($lineChildren) - 1);
-                } elseif ( 'space-around' === $justifyContent ) {
-                    $visualGap += $distributedMainSpace / count($lineChildren);
-                    $cursorMain = $visualGap / 2.0;
-                } elseif ( 'space-evenly' === $justifyContent ) {
-                    $visualGap += $distributedMainSpace / (count($lineChildren) + 1);
-                    $cursorMain = $visualGap;
-                }
-            }
-
-            foreach ( $lineChildren as $lineChild ) {
-                $child = is_array($lineChild['node'] ?? null) ? $lineChild['node'] : array();
-                $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
-                $childMainSize = (float) ($lineChild['main_size'] ?? 0.0);
-                $childCrossSize = (float) ($lineChild['cross_size'] ?? 0.0);
-                $nodeId = (string) ($child['id'] ?? '');
-                if ( '' !== $nodeId ) {
-                    $positions[$nodeId] = array(
-                        'main' => $cursorMain,
-                        'cross' => $lineCrossOffset + $this->visualFlexCrossAxisOffset($layout, $childLayout, $wrap ? $lineCrossSize : $contentCrossSize, $childCrossSize),
-                    );
-                }
-
-                $cursorMain += $childMainSize + $visualGap;
-            }
-
-            $lineCrossOffset += $lineCrossSize + ($wrap ? $gap : 0.0);
-        }
-
-        return $positions;
-    }
-
-    /**
-     * @param array<string, mixed> $node
      */
     private function isClippableDecorativeVisualNode(array $node): bool
     {
@@ -1574,17 +1349,6 @@ final class StaticHtmlEmitter
     }
 
     /**
-     * @param array<string, mixed> $node
-     */
-    private function isFullyTransparentVisualNode(array $node): bool
-    {
-        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
-        $opacity = $box['opacity'] ?? $node['opacity'] ?? null;
-
-        return is_numeric($opacity) && 0.001 >= (float) $opacity;
-    }
-
-    /**
      * @param array{x: float, y: float, width: float, height: float} $rect
      * @param array{x: float, y: float, width: float, height: float} $clipRect
      * @return array{x: float, y: float, width: float, height: float}|null
@@ -1600,133 +1364,6 @@ final class StaticHtmlEmitter
         }
 
         return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
-    }
-
-    /**
-     * @return array{x: float, y: float, width: float, height: float}
-     */
-    private function transformedVisualRect(float $width, float $height, array $matrix): array
-    {
-        [$a, $b, $c, $d, $e, $f] = $matrix;
-        $points = array(
-            array(0.0, 0.0),
-            array($width, 0.0),
-            array(0.0, $height),
-            array($width, $height),
-        );
-        $xs = array();
-        $ys = array();
-        foreach ( $points as $point ) {
-            [$localX, $localY] = $point;
-            $xs[] = ($a * $localX) + ($c * $localY) + $e;
-            $ys[] = ($b * $localX) + ($d * $localY) + $f;
-        }
-
-        $left = min($xs);
-        $top = min($ys);
-        $right = max($xs);
-        $bottom = max($ys);
-
-        return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
-    }
-
-    /**
-     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}
-     */
-    private function visualTransformMatrix(array $parentTransform, float $x, float $y, float $width, float $height, array $node): array
-    {
-        return $this->multiplyVisualTransformMatrices(
-            $parentTransform,
-            $this->multiplyVisualTransformMatrices(
-                $this->translationVisualTransformMatrix($x, $y),
-                $this->nodeCssVisualTransformMatrix($node, $width, $height)
-            )
-        );
-    }
-
-    /**
-     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}
-     */
-    private function nodeCssVisualTransformMatrix(array $node, float $width, float $height): array
-    {
-        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
-        $matrix = $this->cssTransformMatrixValues(is_array($box['transform'] ?? null) ? $box['transform'] : null);
-        if ( null !== $matrix ) {
-            return $matrix;
-        }
-
-        if ( isset($box['rotation']) && is_numeric($box['rotation']) ) {
-            $radians = deg2rad((float) $box['rotation']);
-            $rotation = array(cos($radians), sin($radians), -sin($radians), cos($radians), 0.0, 0.0);
-            $originX = $width / 2.0;
-            $originY = $height / 2.0;
-
-            return $this->multiplyVisualTransformMatrices(
-                $this->translationVisualTransformMatrix($originX, $originY),
-                $this->multiplyVisualTransformMatrices($rotation, $this->translationVisualTransformMatrix(-$originX, -$originY))
-            );
-        }
-
-        return $this->identityVisualTransformMatrix();
-    }
-
-    /**
-     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}
-     */
-    private function identityVisualTransformMatrix(): array
-    {
-        return array(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
-    }
-
-    /**
-     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}
-     */
-    private function translationVisualTransformMatrix(float $x, float $y): array
-    {
-        return array(1.0, 0.0, 0.0, 1.0, $x, $y);
-    }
-
-    /**
-     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}
-     */
-    private function multiplyVisualTransformMatrices(array $left, array $right): array
-    {
-        return array(
-            $left[0] * $right[0] + $left[2] * $right[1],
-            $left[1] * $right[0] + $left[3] * $right[1],
-            $left[0] * $right[2] + $left[2] * $right[3],
-            $left[1] * $right[2] + $left[3] * $right[3],
-            $left[0] * $right[4] + $left[2] * $right[5] + $left[4],
-            $left[1] * $right[4] + $left[3] * $right[5] + $left[5],
-        );
-    }
-
-    /**
-     * @param array<string, mixed> $layout
-     * @param array<string, mixed> $childLayout
-     */
-    private function visualFlexCrossAxisOffset(array $layout, array $childLayout, ?float $contentCrossSize, float $childCrossSize): float
-    {
-        if ( null === $contentCrossSize || 'flex' !== ($layout['display'] ?? null) ) {
-            return 0.0;
-        }
-
-        $alignment = (string) ($layout['align_items'] ?? 'flex-start');
-        if ( isset($childLayout['align']) && is_scalar($childLayout['align']) ) {
-            $alignment = match ( strtoupper((string) $childLayout['align']) ) {
-                'CENTER' => 'center',
-                'MAX' => 'flex-end',
-                'STRETCH' => 'stretch',
-                default => $alignment,
-            };
-        }
-
-        $freeCrossSpace = max(0.0, $contentCrossSize - $childCrossSize);
-        return match ( $alignment ) {
-            'center' => $freeCrossSpace / 2.0,
-            'flex-end' => $freeCrossSpace,
-            default => 0.0,
-        };
     }
 
     /**
@@ -1753,7 +1390,7 @@ final class StaticHtmlEmitter
             } elseif ( 'FILL' === $sizing ) {
                 $styles[] = $dimension . ':100%';
             } elseif ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
-                $property = null === $parentNode && 'height' === $dimension && 'flex' === ($layout['display'] ?? null) ? 'min-height' : $dimension;
+                $property = $dimension;
                 $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
                 $styles[] = $property . ':' . $this->number($value) . 'px';
             }
@@ -1857,7 +1494,7 @@ final class StaticHtmlEmitter
         if ( isset($layout['padding']) && is_array($layout['padding']) ) {
             foreach ( array('top', 'right', 'bottom', 'left') as $edge ) {
                 if ( isset($layout['padding'][$edge]) && is_numeric($layout['padding'][$edge]) ) {
-                    $styles[] = 'padding-' . $edge . ':' . $this->number((float) $layout['padding'][$edge]) . 'px';
+                    $styles[] = 'padding-' . $edge . ':' . $this->number($this->cssPaddingValue($node, $edge)) . 'px';
                 }
             }
         }
@@ -1873,6 +1510,39 @@ final class StaticHtmlEmitter
         }
 
         return array_values(array_unique($styles));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function cssPaddingValue(array $node, string $edge): float
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $padding = is_array($layout['padding'] ?? null) ? $layout['padding'] : array();
+        $value = isset($padding[$edge]) && is_numeric($padding[$edge]) ? (float) $padding[$edge] : 0.0;
+        $axis = in_array($edge, array('left', 'right'), true) ? 'horizontal' : 'vertical';
+        $dimension = 'horizontal' === $axis ? 'width' : 'height';
+        $sizingKey = 'horizontal' === $axis ? 'sizing_horizontal' : 'sizing_vertical';
+        if ( in_array(strtoupper((string) ($layout[$sizingKey] ?? '')), array('HUG', 'FILL'), true) ) {
+            return $value;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        if ( ! isset($box[$dimension]) || ! is_numeric($box[$dimension]) ) {
+            return $value;
+        }
+
+        $start = 'horizontal' === $axis ? 'left' : 'top';
+        $end = 'horizontal' === $axis ? 'right' : 'bottom';
+        $startValue = isset($padding[$start]) && is_numeric($padding[$start]) ? (float) $padding[$start] : 0.0;
+        $endValue = isset($padding[$end]) && is_numeric($padding[$end]) ? (float) $padding[$end] : 0.0;
+        $sum = $startValue + $endValue;
+        $available = max(0.0, (float) $box[$dimension]);
+        if ( $sum <= 0.0 || $sum <= $available ) {
+            return $value;
+        }
+
+        return $value * ($available / $sum);
     }
 
     /**
@@ -2006,6 +1676,15 @@ final class StaticHtmlEmitter
         $childBox = is_array($children[0]['box'] ?? null) ? $children[0]['box'] : array();
         if ( ! isset($box['width'], $box['height'], $childBox['width'], $childBox['height']) || ! is_numeric($box['width']) || ! is_numeric($box['height']) || ! is_numeric($childBox['width']) || ! is_numeric($childBox['height']) ) {
             return false;
+        }
+
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        if ( ! empty($layout['display'] ?? null) ) {
+            if ( 'flex' !== ($layout['display'] ?? null) ) {
+                return false;
+            }
+            $mainAxis = 'row' === ($layout['flex_direction'] ?? null) ? 'width' : 'height';
+            return (float) $childBox[$mainAxis] > (float) $box[$mainAxis];
         }
 
         return (float) $childBox['width'] > (float) $box['width'] || (float) $childBox['height'] > (float) $box['height'];
@@ -3292,69 +2971,6 @@ final class StaticHtmlEmitter
         }
 
         return array();
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     * @return array<string, mixed>|null
-     */
-    private function firstImagePaint(array $node): ?array
-    {
-        foreach ( $this->nodeImagePaints($node) as $paint ) {
-            return $paint;
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, mixed> $paint
-     * @return array<string, mixed>
-     */
-    private function visualImageMetadata(array $paint): array
-    {
-        $transform = $this->imagePaintTransformMatrix($paint);
-        $metadata = array(
-            'scale_mode' => strtoupper((string) ($paint['imageScaleMode'] ?? $paint['scaleMode'] ?? 'FILL')),
-            'has_transform' => null !== $transform && ! $this->isIdentityImageTransform($transform),
-            'color_managed' => true === ($paint['imageShouldColorManage'] ?? false),
-        );
-
-        foreach ( array('ref', 'imageHash', 'imageName', 'originalImageWidth', 'originalImageHeight', 'scale', 'rotation') as $key ) {
-            if ( isset($paint[$key]) && is_scalar($paint[$key]) ) {
-                $metadata[$key] = $paint[$key];
-            }
-        }
-
-        return $metadata;
-    }
-
-    /**
-     * @param array<string, mixed> $text
-     * @return array<string, mixed>
-     */
-    private function visualTextMetadata(array $text): array
-    {
-        $metadata = array(
-            'character_count' => isset($text['characters']) && is_scalar($text['characters']) ? strlen((string) $text['characters']) : 0,
-            'segment_count' => is_array($text['segments'] ?? null) ? count($text['segments']) : 0,
-        );
-
-        $derivedLayout = is_array($text['derived_layout'] ?? null) ? $text['derived_layout'] : array();
-        if ( ! empty($derivedLayout) ) {
-            $metadata['derived_layout'] = $derivedLayout;
-            $metadata['has_derived_layout'] = true;
-            $metadata['baseline_count'] = $derivedLayout['baseline_count'] ?? 0;
-            $metadata['glyph_count'] = $derivedLayout['glyph_count'] ?? 0;
-            $metadata['glyph_path_count'] = is_array($derivedLayout['glyph_paths'] ?? null) ? count($derivedLayout['glyph_paths']) : 0;
-            $characters = isset($text['characters']) && is_scalar($text['characters']) ? (string) $text['characters'] : '';
-            $metadata['glyph_rendering'] = $this->renderTextGlyphPaths && ! empty($derivedLayout['glyph_paths']) && $this->textAllowsGlyphRendering($characters, $text) ? 'svg_paths' : 'dom_text';
-        } else {
-            $metadata['has_derived_layout'] = false;
-            $metadata['glyph_rendering'] = 'dom_text';
-        }
-
-        return $metadata;
     }
 
     /**

--- a/figma-transformer/src/Html/VisualNodeMapBuilder.php
+++ b/figma-transformer/src/Html/VisualNodeMapBuilder.php
@@ -1,0 +1,894 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Builds source visual boxes used by DOM-box parity diagnostics.
+ */
+final class VisualNodeMapBuilder
+{
+    /**
+     * @param array<string, array<string, mixed>> $assetsById
+     */
+    public function __construct(
+        private readonly array $assetsById = array(),
+        private readonly bool $renderTextGlyphPaths = false
+    ) {
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $nodes
+     * @return array<int, array<string, mixed>>
+     */
+    public function build(array $nodes): array
+    {
+        $map = array();
+        foreach ( $nodes as $node ) {
+            if ( is_array($node) ) {
+                $this->appendVisualNodeMap($node, $map, 0.0, 0.0, null, null, $this->identityVisualTransformMatrix());
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<int, array<string, mixed>> $map
+     */
+    private function appendVisualNodeMap(array $node, array &$map, float $x, float $y, ?array $parentNode, ?array $clipRect, array $parentTransform): void
+    {
+        if ( $this->isFullyTransparentVisualNode($node) ) {
+            return;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+
+        if ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
+            $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
+            $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
+        } elseif ( null !== $parentNode && ('absolute' === ($layout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($node, $parentNode)) ) {
+            $x += $this->positionOffset($box, $parentBox, 'x', $parentNode) ?? 0.0;
+            $y += $this->positionOffset($box, $parentBox, 'y', $parentNode) ?? 0.0;
+        }
+
+        $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
+        $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
+        $nodeTransform = null !== $width && null !== $height ? $this->visualTransformMatrix($parentTransform, $x, $y, $width, $height, $node) : null;
+        $nodeRect = null !== $width && null !== $height && null !== $nodeTransform ? $this->transformedVisualRect($width, $height, $nodeTransform) : null;
+        $visibleRect = null;
+        if ( null !== $nodeRect && null !== $clipRect && $this->isClippableDecorativeVisualNode($node) ) {
+            $visibleRect = $this->rectIntersection($nodeRect, $clipRect);
+            if ( null === $visibleRect ) {
+                return;
+            }
+        }
+
+        if ( null !== $width && null !== $height ) {
+            $imagePaint = $this->firstImagePaint($node);
+            $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+            $entry = array(
+                'id' => (string) ($node['id'] ?? ''),
+                'parent_id' => null !== $parentNode ? (string) ($parentNode['id'] ?? '') : '',
+                'name' => (string) ($node['name'] ?? ''),
+                'type' => strtoupper((string) ($node['type'] ?? '')),
+                'rect' => $nodeRect,
+                'layout' => array(
+                    'display' => $layout['display'] ?? null,
+                    'flex_direction' => $layout['flex_direction'] ?? null,
+                    'positioning' => $layout['positioning'] ?? null,
+                    'coordinate_space' => $box['coordinate_space'] ?? null,
+                ),
+                'image' => null === $imagePaint ? null : $this->visualImageMetadata($imagePaint),
+                'text' => empty($text) ? null : $this->visualTextMetadata($text),
+            );
+            if ( null !== $visibleRect && $visibleRect !== $nodeRect ) {
+                $entry['visible_rect'] = $visibleRect;
+                $entry['clip'] = array('source' => 'parent_clips_content');
+            }
+            $map[] = $entry;
+        }
+
+        $children = $this->nodeList($node);
+        if ( empty($children) ) {
+            return;
+        }
+
+        $childClipRect = $clipRect;
+        if ( null !== $nodeRect && true === ($layout['clips_content'] ?? false) ) {
+            $childClipRect = null === $childClipRect ? $nodeRect : $this->rectIntersection($childClipRect, $nodeRect);
+            if ( null === $childClipRect ) {
+                return;
+            }
+        }
+
+        $paddingLeft = $this->visualPaddingValue($node, 'left');
+        $paddingRight = $this->visualPaddingValue($node, 'right');
+        $paddingTop = $this->visualPaddingValue($node, 'top');
+        $paddingBottom = $this->visualPaddingValue($node, 'bottom');
+        $childX = $paddingLeft;
+        $childY = $paddingTop;
+        $gap = isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ? (float) $layout['item_spacing'] : 0.0;
+        $isRow = 'row' === ($layout['flex_direction'] ?? null);
+        $isFlex = 'flex' === ($layout['display'] ?? null);
+        $contentWidth = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width'] - $paddingLeft - $paddingRight) : null;
+        $contentHeight = isset($box['height']) && is_numeric($box['height']) ? max(0.0, (float) $box['height'] - $paddingTop - $paddingBottom) : null;
+        $mainAxis = $isRow ? 'width' : 'height';
+        $crossAxis = $isRow ? 'height' : 'width';
+        $contentMainSize = $isRow ? $contentWidth : $contentHeight;
+        $contentCrossSize = $isRow ? $contentHeight : $contentWidth;
+        $flowChildren = array();
+
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) || $this->isFullyClippedDecorativeChild($child, $node) ) {
+                continue;
+            }
+            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
+                continue;
+            }
+            $flowChildren[] = $child;
+        }
+
+        $flowPositions = $this->visualFlexChildPositions($flowChildren, $layout, $isFlex, $isRow, $mainAxis, $crossAxis, $contentMainSize, $contentCrossSize, $gap);
+
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) || $this->isFullyClippedDecorativeChild($child, $node) ) {
+                continue;
+            }
+            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( $this->isFreeformContainer($node) || 'absolute' === ($childLayout['positioning'] ?? null) || $this->isDecorativeFlexUnderlay($child, $node) ) {
+                $this->appendVisualNodeMap($child, $map, 0.0, 0.0, $node, $childClipRect, $nodeTransform ?? $parentTransform);
+                continue;
+            }
+
+            $nodeId = (string) ($child['id'] ?? '');
+            $position = '' !== $nodeId && isset($flowPositions[$nodeId]) ? $flowPositions[$nodeId] : array('main' => 0.0, 'cross' => 0.0);
+            if ( $isRow ) {
+                $this->appendVisualNodeMap($child, $map, $childX + $position['main'], $childY + $position['cross'], $node, $childClipRect, $nodeTransform ?? $parentTransform);
+            } else {
+                $this->appendVisualNodeMap($child, $map, $childX + $position['cross'], $childY + $position['main'], $node, $childClipRect, $nodeTransform ?? $parentTransform);
+            }
+        }
+    }
+
+    private function visualFlexChildPositions(array $children, array $layout, bool $isFlex, bool $isRow, string $mainAxis, string $crossAxis, ?float $contentMainSize, ?float $contentCrossSize, float $gap): array
+    {
+        $positions = array();
+        if ( empty($children) ) {
+            return $positions;
+        }
+
+        $wrap = $isFlex && null !== $contentMainSize && 'wrap' === ($layout['flex_wrap'] ?? null);
+        $lines = array();
+        $currentLine = array('children' => array(), 'main_size' => 0.0, 'cross_size' => 0.0);
+        foreach ( $children as $child ) {
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            $childMainSize = isset($childBox[$mainAxis]) && is_numeric($childBox[$mainAxis]) ? (float) $childBox[$mainAxis] : 0.0;
+            $childCrossSize = isset($childBox[$crossAxis]) && is_numeric($childBox[$crossAxis]) ? (float) $childBox[$crossAxis] : 0.0;
+            $lineChildCount = count($currentLine['children']);
+            $candidateMainSize = (float) $currentLine['main_size'] + ($lineChildCount > 0 ? $gap : 0.0) + $childMainSize;
+            if ( $wrap && $lineChildCount > 0 && $candidateMainSize > $contentMainSize + 0.001 ) {
+                $lines[] = $currentLine;
+                $currentLine = array('children' => array(), 'main_size' => 0.0, 'cross_size' => 0.0);
+                $lineChildCount = 0;
+                $candidateMainSize = $childMainSize;
+            }
+
+            $currentLine['children'][] = array('node' => $child, 'main_size' => $childMainSize, 'cross_size' => $childCrossSize);
+            $currentLine['main_size'] = $candidateMainSize;
+            $currentLine['cross_size'] = max((float) $currentLine['cross_size'], $childCrossSize);
+        }
+        if ( ! empty($currentLine['children']) ) {
+            $lines[] = $currentLine;
+        }
+
+        $lineCrossOffset = 0.0;
+        foreach ( $lines as $line ) {
+            $lineChildren = is_array($line['children'] ?? null) ? $line['children'] : array();
+            $lineMainSize = (float) ($line['main_size'] ?? 0.0);
+            $lineCrossSize = (float) ($line['cross_size'] ?? 0.0);
+            $cursorMain = 0.0;
+            $visualGap = $gap;
+            if ( $isFlex && null !== $contentMainSize ) {
+                $freeMainSpace = $contentMainSize - $lineMainSize;
+                $distributedMainSpace = max(0.0, $freeMainSpace);
+                $justifyContent = (string) ($layout['justify_content'] ?? 'flex-start');
+                if ( 'flex-end' === $justifyContent ) {
+                    $cursorMain = $freeMainSpace;
+                } elseif ( 'center' === $justifyContent ) {
+                    $cursorMain = $freeMainSpace / 2.0;
+                } elseif ( 'space-between' === $justifyContent && count($lineChildren) > 1 ) {
+                    $visualGap += $distributedMainSpace / (count($lineChildren) - 1);
+                } elseif ( 'space-around' === $justifyContent ) {
+                    $visualGap += $distributedMainSpace / count($lineChildren);
+                    $cursorMain = $visualGap / 2.0;
+                } elseif ( 'space-evenly' === $justifyContent ) {
+                    $visualGap += $distributedMainSpace / (count($lineChildren) + 1);
+                    $cursorMain = $visualGap;
+                }
+            }
+
+            foreach ( $lineChildren as $lineChild ) {
+                $child = is_array($lineChild['node'] ?? null) ? $lineChild['node'] : array();
+                $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+                $childMainSize = (float) ($lineChild['main_size'] ?? 0.0);
+                $childCrossSize = (float) ($lineChild['cross_size'] ?? 0.0);
+                $nodeId = (string) ($child['id'] ?? '');
+                if ( '' !== $nodeId ) {
+                    $positions[$nodeId] = array(
+                        'main' => $cursorMain,
+                        'cross' => $lineCrossOffset + $this->visualFlexCrossAxisOffset($layout, $childLayout, $wrap ? $lineCrossSize : $contentCrossSize, $childCrossSize),
+                    );
+                }
+                $cursorMain += $childMainSize + $visualGap;
+            }
+
+            $lineCrossOffset += $lineCrossSize + ($wrap ? $gap : 0.0);
+        }
+
+        return $positions;
+    }
+
+    private function visualFlexCrossAxisOffset(array $layout, array $childLayout, ?float $contentCrossSize, float $childCrossSize): float
+    {
+        if ( null === $contentCrossSize || 'flex' !== ($layout['display'] ?? null) ) {
+            return 0.0;
+        }
+        $alignment = (string) ($layout['align_items'] ?? 'flex-start');
+        if ( isset($childLayout['align']) && is_scalar($childLayout['align']) ) {
+            $alignment = match ( strtoupper((string) $childLayout['align']) ) {
+                'CENTER' => 'center',
+                'MAX' => 'flex-end',
+                'STRETCH' => 'stretch',
+                default => $alignment,
+            };
+        }
+        $freeCrossSpace = $contentCrossSize - $childCrossSize;
+        return match ( $alignment ) {
+            'center' => $freeCrossSpace / 2.0,
+            'flex-end' => $freeCrossSpace,
+            default => 0.0,
+        };
+    }
+
+    private function visualPaddingValue(array $node, string $edge): float
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $padding = is_array($layout['padding'] ?? null) ? $layout['padding'] : array();
+        $value = isset($padding[$edge]) && is_numeric($padding[$edge]) ? (float) $padding[$edge] : 0.0;
+        $axis = in_array($edge, array('left', 'right'), true) ? 'horizontal' : 'vertical';
+        $dimension = 'horizontal' === $axis ? 'width' : 'height';
+        $sizingKey = 'horizontal' === $axis ? 'sizing_horizontal' : 'sizing_vertical';
+        if ( in_array(strtoupper((string) ($layout[$sizingKey] ?? '')), array('HUG', 'FILL'), true) ) {
+            return $value;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        if ( ! isset($box[$dimension]) || ! is_numeric($box[$dimension]) ) {
+            return $value;
+        }
+
+        $start = 'horizontal' === $axis ? 'left' : 'top';
+        $end = 'horizontal' === $axis ? 'right' : 'bottom';
+        $startValue = isset($padding[$start]) && is_numeric($padding[$start]) ? (float) $padding[$start] : 0.0;
+        $endValue = isset($padding[$end]) && is_numeric($padding[$end]) ? (float) $padding[$end] : 0.0;
+        $sum = $startValue + $endValue;
+        $available = max(0.0, (float) $box[$dimension]);
+        if ( $sum <= 0.0 || $sum <= $available ) {
+            return $value;
+        }
+
+        return $value * ($available / $sum);
+    }
+
+    private function isClippableDecorativeVisualNode(array $node): bool
+    {
+        return ! $this->treeHasText($node) && ! $this->treeHasImageReference($node) && $this->treeIsVectorShapeOnly($node);
+    }
+
+    private function isFullyClippedDecorativeChild(array $node, array $parentNode): bool
+    {
+        $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        if ( true !== ($parentLayout['clips_content'] ?? false) || ! $this->isClippableDecorativeVisualNode($node) ) {
+            return false;
+        }
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        if ( ! isset($parentBox['width'], $parentBox['height'], $box['width'], $box['height']) || ! is_numeric($parentBox['width']) || ! is_numeric($parentBox['height']) || ! is_numeric($box['width']) || ! is_numeric($box['height']) ) {
+            return false;
+        }
+        $left = $this->positionOffset($box, $parentBox, 'x', $parentNode);
+        $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
+        if ( null === $left || null === $top ) {
+            return false;
+        }
+        $parentRect = array('x' => 0.0, 'y' => 0.0, 'width' => (float) $parentBox['width'], 'height' => (float) $parentBox['height']);
+        $childRect = array('x' => $left, 'y' => $top, 'width' => (float) $box['width'], 'height' => (float) $box['height']);
+        return null === $this->rectIntersection($parentRect, $childRect);
+    }
+
+    private function isFullyTransparentVisualNode(array $node): bool
+    {
+        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        $opacity = $box['opacity'] ?? $node['opacity'] ?? null;
+        return is_numeric($opacity) && 0.001 >= (float) $opacity;
+    }
+
+    private function rectIntersection(array $rect, array $clipRect): ?array
+    {
+        $left = max($rect['x'], $clipRect['x']);
+        $top = max($rect['y'], $clipRect['y']);
+        $right = min($rect['x'] + $rect['width'], $clipRect['x'] + $clipRect['width']);
+        $bottom = min($rect['y'] + $rect['height'], $clipRect['y'] + $clipRect['height']);
+        if ( $right <= $left || $bottom <= $top ) {
+            return null;
+        }
+        return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
+    }
+
+    private function transformedVisualRect(float $width, float $height, array $matrix): array
+    {
+        [$a, $b, $c, $d, $e, $f] = $matrix;
+        $points = array(array(0.0, 0.0), array($width, 0.0), array(0.0, $height), array($width, $height));
+        $xs = array();
+        $ys = array();
+        foreach ( $points as $point ) {
+            [$localX, $localY] = $point;
+            $xs[] = ($a * $localX) + ($c * $localY) + $e;
+            $ys[] = ($b * $localX) + ($d * $localY) + $f;
+        }
+        $left = min($xs);
+        $top = min($ys);
+        $right = max($xs);
+        $bottom = max($ys);
+        return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
+    }
+
+    private function visualTransformMatrix(array $parentTransform, float $x, float $y, float $width, float $height, array $node): array
+    {
+        return $this->multiplyVisualTransformMatrices(
+            $parentTransform,
+            $this->multiplyVisualTransformMatrices($this->translationVisualTransformMatrix($x, $y), $this->nodeCssVisualTransformMatrix($node, $width, $height))
+        );
+    }
+
+    private function nodeCssVisualTransformMatrix(array $node, float $width, float $height): array
+    {
+        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        $matrix = $this->cssTransformMatrixValues(is_array($box['transform'] ?? null) ? $box['transform'] : null);
+        if ( null !== $matrix ) {
+            return $matrix;
+        }
+        if ( isset($box['rotation']) && is_numeric($box['rotation']) ) {
+            $radians = deg2rad((float) $box['rotation']);
+            $rotation = array(cos($radians), sin($radians), -sin($radians), cos($radians), 0.0, 0.0);
+            $originX = $width / 2.0;
+            $originY = $height / 2.0;
+            return $this->multiplyVisualTransformMatrices(
+                $this->translationVisualTransformMatrix($originX, $originY),
+                $this->multiplyVisualTransformMatrices($rotation, $this->translationVisualTransformMatrix(-$originX, -$originY))
+            );
+        }
+        return $this->identityVisualTransformMatrix();
+    }
+
+    private function identityVisualTransformMatrix(): array
+    {
+        return array(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+    }
+
+    private function translationVisualTransformMatrix(float $x, float $y): array
+    {
+        return array(1.0, 0.0, 0.0, 1.0, $x, $y);
+    }
+
+    private function multiplyVisualTransformMatrices(array $left, array $right): array
+    {
+        return array(
+            $left[0] * $right[0] + $left[2] * $right[1],
+            $left[1] * $right[0] + $left[3] * $right[1],
+            $left[0] * $right[2] + $left[2] * $right[3],
+            $left[1] * $right[2] + $left[3] * $right[3],
+            $left[0] * $right[4] + $left[2] * $right[5] + $left[4],
+            $left[1] * $right[4] + $left[3] * $right[5] + $left[5],
+        );
+    }
+
+    private function isFreeformContainer(array $node): bool
+    {
+        if ( true === ($node['layout']['freeform'] ?? false) ) {
+            return true;
+        }
+        $children = $this->nodeList($node);
+        if ( true === ($node['figma_component']['resolved'] ?? false) && ! empty($children) && empty($node['layout']['display'] ?? null) ) {
+            return true;
+        }
+        if ( empty($node['layout']['display'] ?? null) && $this->hasPositionedSourceChild($node, $children) ) {
+            return true;
+        }
+        if ( 1 !== count($children) || ! is_array($children[0]) ) {
+            return false;
+        }
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $childBox = is_array($children[0]['box'] ?? null) ? $children[0]['box'] : array();
+        if ( ! isset($box['width'], $box['height'], $childBox['width'], $childBox['height']) || ! is_numeric($box['width']) || ! is_numeric($box['height']) || ! is_numeric($childBox['width']) || ! is_numeric($childBox['height']) ) {
+            return false;
+        }
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        if ( ! empty($layout['display'] ?? null) ) {
+            if ( 'flex' !== ($layout['display'] ?? null) ) {
+                return false;
+            }
+            $mainAxis = 'row' === ($layout['flex_direction'] ?? null) ? 'width' : 'height';
+            return (float) $childBox[$mainAxis] > (float) $box[$mainAxis];
+        }
+
+        return (float) $childBox['width'] > (float) $box['width'] || (float) $childBox['height'] > (float) $box['height'];
+    }
+
+    private function hasPositionedSourceChild(array $node, array $children): bool
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION'), true) ) {
+            return false;
+        }
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            $left = $this->positionOffset($childBox, $box, 'x', $node);
+            $top = $this->positionOffset($childBox, $box, 'y', $node);
+            if ( (null !== $left && abs($left) > 0.5) || (null !== $top && abs($top) > 0.5) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function positionOffset(array $box, array $parentBox, string $dimension, ?array $parentNode = null): ?float
+    {
+        if ( ! isset($box[$dimension]) || ! is_numeric($box[$dimension]) ) {
+            return null;
+        }
+        if ( 'local' === ($box['coordinate_space'] ?? null) ) {
+            return (float) $box[$dimension];
+        }
+        if ( null !== $parentNode && (! isset($parentBox[$dimension]) ? $this->shouldInferMissingParentOrigin($parentBox, $parentNode, $dimension) : $this->shouldInferRootCanvasOrigin($parentBox, $parentNode, $dimension)) ) {
+            $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+            if ( null !== $origin ) {
+                return (float) $box[$dimension] - $origin;
+            }
+        }
+        return $this->relativeOffset($box, $parentBox, $dimension);
+    }
+
+    private function relativeOffset(array $box, array $parentBox, string $dimension): ?float
+    {
+        if ( ! isset($box[$dimension]) || ! is_numeric($box[$dimension]) ) {
+            return null;
+        }
+        $offset = (float) $box[$dimension];
+        if ( isset($parentBox[$dimension]) && is_numeric($parentBox[$dimension]) ) {
+            $offset -= (float) $parentBox[$dimension];
+        }
+        return $offset;
+    }
+
+    private function shouldInferRootCanvasOrigin(array $parentBox, array $parentNode, string $dimension): bool
+    {
+        if ( ! isset($parentBox[$dimension]) || ! is_numeric($parentBox[$dimension]) || ! empty($parentNode['_parent_id']) ) {
+            return false;
+        }
+        $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+        if ( null === $origin ) {
+            return false;
+        }
+        $parentOrigin = (float) $parentBox[$dimension];
+        if ( 0.0 === $parentOrigin ) {
+            return $origin < 0.0 || $this->hasRootCanvasOriginMismatch($parentBox, $parentNode);
+        }
+        return ($origin < 0.0 && ($parentOrigin - $origin) >= 100.0) || $this->hasRootCanvasOriginMismatch($parentBox, $parentNode);
+    }
+
+    private function shouldInferMissingParentOrigin(array $parentBox, array $parentNode, string $dimension): bool
+    {
+        $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+        if ( null === $origin ) {
+            return false;
+        }
+        foreach ( array('x' => 'width', 'y' => 'height') as $originDimension => $sizeKey ) {
+            $origin = $this->inferredContainingBlockOrigin($parentNode, $originDimension);
+            if ( null === $origin ) {
+                continue;
+            }
+            $parentSize = isset($parentBox[$sizeKey]) && is_numeric($parentBox[$sizeKey]) ? (float) $parentBox[$sizeKey] : null;
+            if ( abs($origin) >= 1000.0 || (null !== $parentSize && $origin > $parentSize + 100.0) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function hasRootCanvasOriginMismatch(array $parentBox, array $parentNode): bool
+    {
+        foreach ( array('x', 'y') as $dimension ) {
+            $origin = $this->inferredContainingBlockOrigin($parentNode, $dimension);
+            if ( null === $origin || ! isset($parentBox[$dimension]) || ! is_numeric($parentBox[$dimension]) ) {
+                continue;
+            }
+            $parentOrigin = (float) $parentBox[$dimension];
+            $sizeKey = 'x' === $dimension ? 'width' : 'height';
+            $parentSize = isset($parentBox[$sizeKey]) && is_numeric($parentBox[$sizeKey]) ? (float) $parentBox[$sizeKey] : null;
+            if ( abs($origin - $parentOrigin) >= 1000.0 || (null !== $parentSize && $origin > $parentOrigin + $parentSize + 100.0) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function inferredContainingBlockOrigin(array $parentNode, string $dimension): ?float
+    {
+        $preferredOrigin = null;
+        $fallbackOrigin = null;
+        foreach ( $this->nodeList($parentNode) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            if ( 'local' === ($childBox['coordinate_space'] ?? null) || ! isset($childBox[$dimension]) || ! is_numeric($childBox[$dimension]) ) {
+                continue;
+            }
+            $value = (float) $childBox[$dimension];
+            $fallbackOrigin = null === $fallbackOrigin ? $value : min($fallbackOrigin, $value);
+            if ( $this->isContainingBlockOriginCandidate($child) ) {
+                $preferredOrigin = null === $preferredOrigin ? $value : min($preferredOrigin, $value);
+            }
+        }
+        return $preferredOrigin ?? $fallbackOrigin;
+    }
+
+    private function isContainingBlockOriginCandidate(array $node): bool
+    {
+        return $this->treeHasText($node) || $this->treeHasImageReference($node) || ! $this->treeIsVectorShapeOnly($node);
+    }
+
+    private function isDecorativeFlexUnderlay(array $node, array $parentNode): bool
+    {
+        $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        if ( ! in_array((string) ($parentLayout['display'] ?? ''), array('flex', 'inline-flex'), true) ) {
+            return false;
+        }
+        if ( 'absolute' === ($node['layout']['positioning'] ?? null) || $this->treeHasText($node) || $this->treeHasImageReference($node) ) {
+            return false;
+        }
+        if ( ! $this->treeIsVectorShapeOnly($node) || ! $this->parentHasTextOutsideNode($parentNode, $node) ) {
+            return false;
+        }
+        return $this->isOversizedAgainstParent($node, $parentNode);
+    }
+
+    private function parentHasTextOutsideNode(array $parentNode, array $node): bool
+    {
+        $nodeId = (string) ($node['id'] ?? '');
+        foreach ( $this->nodeList($parentNode) as $sibling ) {
+            if ( ! is_array($sibling) || (string) ($sibling['id'] ?? '') === $nodeId ) {
+                continue;
+            }
+            if ( $this->treeHasText($sibling) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function isOversizedAgainstParent(array $node, array $parentNode): bool
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        foreach ( array('width', 'height') as $dimension ) {
+            if ( ! isset($box[$dimension], $parentBox[$dimension]) || ! is_numeric($box[$dimension]) || ! is_numeric($parentBox[$dimension]) || 0.0 >= (float) $parentBox[$dimension] ) {
+                return false;
+            }
+        }
+        if ( (float) $box['width'] < 300.0 && (float) $box['height'] < 300.0 ) {
+            return false;
+        }
+        $widthRatio = (float) $box['width'] / (float) $parentBox['width'];
+        $heightRatio = (float) $box['height'] / (float) $parentBox['height'];
+        $areaRatio = ((float) $box['width'] * (float) $box['height']) / ((float) $parentBox['width'] * (float) $parentBox['height']);
+        return 0.75 <= $widthRatio || 0.75 <= $heightRatio || 0.45 <= $areaRatio;
+    }
+
+    private function treeHasText(array $node): bool
+    {
+        if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
+            return '' !== trim(strip_tags($this->textContent($node)));
+        }
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) && $this->treeHasText($child) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function treeHasImageReference(array $node): bool
+    {
+        if ( null !== $this->nodeAssetPath($node) || ! empty($this->explicitNodeAssetReferences($node)) || ! empty($this->nodeImagePaints($node)) ) {
+            return true;
+        }
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) && $this->treeHasImageReference($child) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function treeIsVectorShapeOnly(array $node): bool
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        $children = $this->nodeList($node);
+        if ( empty($children) ) {
+            return in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON', 'RECTANGLE'), true);
+        }
+        if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'BOOLEAN_OPERATION'), true) ) {
+            return false;
+        }
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) || ! $this->treeIsVectorShapeOnly($child) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function firstImagePaint(array $node): ?array
+    {
+        foreach ( $this->nodeImagePaints($node) as $paint ) {
+            return $paint;
+        }
+        return null;
+    }
+
+    private function visualImageMetadata(array $paint): array
+    {
+        $transform = $this->imagePaintTransformMatrix($paint);
+        $metadata = array(
+            'scale_mode' => strtoupper((string) ($paint['imageScaleMode'] ?? $paint['scaleMode'] ?? 'FILL')),
+            'has_transform' => null !== $transform && ! $this->isIdentityImageTransform($transform),
+            'color_managed' => true === ($paint['imageShouldColorManage'] ?? false),
+        );
+        foreach ( array('ref', 'imageHash', 'imageName', 'originalImageWidth', 'originalImageHeight', 'scale', 'rotation') as $key ) {
+            if ( isset($paint[$key]) && is_scalar($paint[$key]) ) {
+                $metadata[$key] = $paint[$key];
+            }
+        }
+        return $metadata;
+    }
+
+    private function visualTextMetadata(array $text): array
+    {
+        $metadata = array(
+            'character_count' => isset($text['characters']) && is_scalar($text['characters']) ? strlen((string) $text['characters']) : 0,
+            'segment_count' => is_array($text['segments'] ?? null) ? count($text['segments']) : 0,
+        );
+        $derivedLayout = is_array($text['derived_layout'] ?? null) ? $text['derived_layout'] : array();
+        if ( ! empty($derivedLayout) ) {
+            $metadata['derived_layout'] = $derivedLayout;
+            $metadata['has_derived_layout'] = true;
+            $metadata['baseline_count'] = $derivedLayout['baseline_count'] ?? 0;
+            $metadata['glyph_count'] = $derivedLayout['glyph_count'] ?? 0;
+            $metadata['glyph_path_count'] = is_array($derivedLayout['glyph_paths'] ?? null) ? count($derivedLayout['glyph_paths']) : 0;
+            $characters = isset($text['characters']) && is_scalar($text['characters']) ? (string) $text['characters'] : '';
+            $metadata['glyph_rendering'] = $this->renderTextGlyphPaths && ! empty($derivedLayout['glyph_paths']) && $this->textAllowsGlyphRendering($characters, $text) ? 'svg_paths' : 'dom_text';
+        } else {
+            $metadata['has_derived_layout'] = false;
+            $metadata['glyph_rendering'] = 'dom_text';
+        }
+        return $metadata;
+    }
+
+    private function nodeAssetPath(array $node): ?string
+    {
+        foreach ( $this->nodeAssetReferences($node) as $assetId ) {
+            if ( isset($this->assetsById[$assetId]) ) {
+                return (string) $this->assetsById[$assetId]['path'];
+            }
+        }
+        return null;
+    }
+
+    private function nodeAssetReferences(array $node): array
+    {
+        $references = array();
+        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref', 'id', 'name') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) ) {
+                $references[] = (string) $node[$key];
+            }
+        }
+        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+            foreach ( is_array($node[$paintKey] ?? null) ? $node[$paintKey] : array() as $paint ) {
+                if ( ! is_array($paint) ) {
+                    continue;
+                }
+                foreach ( array('imageRef', 'imageHash', 'ref', 'asset_id', 'assetId', 'image_ref') as $key ) {
+                    if ( isset($paint[$key]) && is_scalar($paint[$key]) ) {
+                        $references[] = (string) $paint[$key];
+                    }
+                }
+            }
+        }
+        return array_values(array_unique(array_filter($references, static fn (string $reference): bool => '' !== $reference)));
+    }
+
+    private function explicitNodeAssetReferences(array $node): array
+    {
+        $references = array();
+        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
+                $references[] = (string) $node[$key];
+            }
+        }
+        if ( is_array($node['image'] ?? null) ) {
+            foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+                if ( isset($node['image'][$key]) && is_scalar($node['image'][$key]) && '' !== (string) $node['image'][$key] ) {
+                    $references[] = (string) $node['image'][$key];
+                }
+            }
+        }
+        return array_values(array_unique($references));
+    }
+
+    private function nodeImagePaints(array $node): array
+    {
+        $imagePaints = array();
+        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+            $paintCollections = array();
+            if ( is_array($node[$paintKey] ?? null) ) {
+                $paintCollections[] = $node[$paintKey];
+            }
+            if ( is_array($node['figma_paints'][$paintKey] ?? null) ) {
+                $paintCollections[] = $node['figma_paints'][$paintKey];
+            }
+            foreach ( $paintCollections as $paints ) {
+                foreach ( $paints as $paint ) {
+                    if ( is_array($paint) && 'IMAGE' === strtoupper((string) ($paint['type'] ?? '')) ) {
+                        $imagePaints[] = $paint;
+                    }
+                }
+            }
+        }
+        return $imagePaints;
+    }
+
+    private function imagePaintTransformMatrix(array $paint): ?array
+    {
+        $transform = $paint['transform'] ?? null;
+        if ( ! is_array($transform) ) {
+            return null;
+        }
+        if ( isset($transform['m00'], $transform['m01'], $transform['m02'], $transform['m10'], $transform['m11'], $transform['m12']) ) {
+            $values = array('m00' => $transform['m00'], 'm01' => $transform['m01'], 'm02' => $transform['m02'], 'm10' => $transform['m10'], 'm11' => $transform['m11'], 'm12' => $transform['m12']);
+        } elseif ( is_array($transform[0] ?? null) && is_array($transform[1] ?? null) ) {
+            $values = array('m00' => $transform[0][0] ?? null, 'm01' => $transform[0][1] ?? null, 'm02' => $transform[0][2] ?? null, 'm10' => $transform[1][0] ?? null, 'm11' => $transform[1][1] ?? null, 'm12' => $transform[1][2] ?? null);
+        } else {
+            return null;
+        }
+        foreach ( $values as $value ) {
+            if ( ! is_numeric($value) ) {
+                return null;
+            }
+        }
+        return array_map(static fn (mixed $value): float => (float) $value, $values);
+    }
+
+    private function isIdentityImageTransform(array $transform): bool
+    {
+        return 0.00001 > abs((float) $transform['m00'] - 1.0)
+            && 0.00001 > abs((float) $transform['m01'])
+            && 0.00001 > abs((float) $transform['m02'])
+            && 0.00001 > abs((float) $transform['m10'])
+            && 0.00001 > abs((float) $transform['m11'] - 1.0)
+            && 0.00001 > abs((float) $transform['m12']);
+    }
+
+    private function textContent(array $node): string
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        if ( isset($text['characters']) && is_scalar($text['characters']) ) {
+            $characters = (string) $text['characters'];
+            if ( $this->isUnresolvedComponentPlaceholderText($node, $characters) ) {
+                return '';
+            }
+            return htmlspecialchars($characters, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+        $characters = (string) ($node['characters'] ?? $node['text'] ?? '');
+        if ( $this->isUnresolvedComponentPlaceholderText($node, $characters) ) {
+            return '';
+        }
+        return htmlspecialchars($characters, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    private function isUnresolvedComponentPlaceholderText(array $node, string $characters): bool
+    {
+        $placeholder = strtolower(trim($characters));
+        if ( ! in_array($placeholder, array('button label'), true) ) {
+            return false;
+        }
+        $id = (string) ($node['id'] ?? '');
+        return str_contains($id, '/') || isset($node['figma_component_source_id']);
+    }
+
+    private function textAllowsGlyphRendering(string $characters, array $text): bool
+    {
+        if ( $this->textNeedsDomSymbolFallback($characters) ) {
+            return false;
+        }
+        if ( mb_strlen($characters) > 80 ) {
+            return false;
+        }
+        if ( mb_strlen($characters) > 45 && 1 === preg_match('/[.!?。！？]$/u', trim($characters)) ) {
+            return false;
+        }
+        if ( str_contains($characters, "\n") && ! $this->textLooksLikeDisplayText($text) ) {
+            return false;
+        }
+        if ( ! empty($text['segments'] ?? array()) ) {
+            return false;
+        }
+        return true;
+    }
+
+    private function textNeedsDomSymbolFallback(string $characters): bool
+    {
+        return 1 === preg_match('/[\\x{2190}-\\x{21FF}\\x{2600}-\\x{27BF}]/u', $characters);
+    }
+
+    private function textLooksLikeDisplayText(array $text): bool
+    {
+        $style = is_array($text['style'] ?? null) ? $text['style'] : array();
+        return isset($style['font_size']) && is_numeric($style['font_size']) && (float) $style['font_size'] >= 32.0;
+    }
+
+    private function cssTransformMatrixValues(?array $transform): ?array
+    {
+        if ( null === $transform ) {
+            return null;
+        }
+        if ( isset($transform['m00'], $transform['m01'], $transform['m02'], $transform['m10'], $transform['m11'], $transform['m12']) ) {
+            if ( 0.00001 > abs((float) $transform['m00'] - 1.0) && 0.00001 > abs((float) $transform['m01']) && 0.00001 > abs((float) $transform['m10']) && 0.00001 > abs((float) $transform['m11'] - 1.0) ) {
+                return null;
+            }
+            $values = array($transform['m00'], $transform['m10'], $transform['m01'], $transform['m11'], 0, 0);
+        } elseif ( 2 === count($transform) && is_array($transform[0] ?? null) && is_array($transform[1] ?? null) ) {
+            $values = array($transform[0][0] ?? null, $transform[1][0] ?? null, $transform[0][1] ?? null, $transform[1][1] ?? null, $transform[0][2] ?? null, $transform[1][2] ?? null);
+        } else {
+            return null;
+        }
+        foreach ( $values as $value ) {
+            if ( ! is_numeric($value) ) {
+                return null;
+            }
+        }
+        return array_map(static fn (mixed $value): float => (float) $value, $values);
+    }
+
+    private function nodeList(array $container): array
+    {
+        if ( is_array($container['nodes'] ?? null) ) {
+            return array_values($container['nodes']);
+        }
+        if ( is_array($container['children'] ?? null) ) {
+            return array_values($container['children']);
+        }
+        return array();
+    }
+}

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param callable(bool, string): void $assert
+ * @param callable(array<string, mixed>, string): ?array<string, mixed> $findVisualNode
+ * @param callable(array<string, mixed>, string): string $fileContent
+ */
+function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $assert, callable $findVisualNode, callable $fileContent): void
+{
+    $visualFlexAlignmentResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Visual Flex Alignment Fixture',
+        'nodes' => array(
+            array(
+                'id'                    => 'visual-flex:row',
+                'type'                  => 'FRAME',
+                'name'                  => 'Visual flex row',
+                'width'                 => 500,
+                'height'                => 100,
+                'layoutMode'            => 'HORIZONTAL',
+                'primaryAxisAlignItems' => 'MAX',
+                'counterAxisAlignItems' => 'CENTER',
+                'itemSpacing'           => 20,
+                'children'              => array(
+                    array('id' => 'visual-flex:first', 'type' => 'RECTANGLE', 'name' => 'First child', 'width' => 100, 'height' => 20),
+                    array('id' => 'visual-flex:second', 'type' => 'RECTANGLE', 'name' => 'Second child', 'width' => 50, 'height' => 40),
+                ),
+            ),
+            array(
+                'id'                    => 'visual-flex:column',
+                'type'                  => 'FRAME',
+                'name'                  => 'Visual flex column',
+                'width'                 => 300,
+                'height'                => 200,
+                'layoutMode'            => 'VERTICAL',
+                'counterAxisAlignItems' => 'CENTER',
+                'paddingLeft'           => 20,
+                'paddingRight'          => 20,
+                'paddingTop'            => 10,
+                'children'              => array(
+                    array('id' => 'visual-flex:centered', 'type' => 'RECTANGLE', 'name' => 'Centered child', 'width' => 100, 'height' => 30),
+                ),
+            ),
+        ),
+    ));
+    $visualFlexFirst = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:first');
+    $visualFlexSecond = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:second');
+    $visualFlexCentered = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:centered');
+    $assert(330.0 === ($visualFlexFirst['rect']['x'] ?? null), 'visual-map-flex-end-first-x');
+    $assert(40.0 === ($visualFlexFirst['rect']['y'] ?? null), 'visual-map-flex-center-first-y');
+    $assert(450.0 === ($visualFlexSecond['rect']['x'] ?? null), 'visual-map-flex-end-second-x');
+    $assert(30.0 === ($visualFlexSecond['rect']['y'] ?? null), 'visual-map-flex-center-second-y');
+    $assert(100.0 === ($visualFlexCentered['rect']['x'] ?? null), 'visual-map-column-center-child-x');
+    $assert(10.0 === ($visualFlexCentered['rect']['y'] ?? null), 'visual-map-column-padding-child-y');
+
+    $visualFlexCrossOverflowMap = (new Automattic\BlocksEngine\FigmaTransformer\Html\VisualNodeMapBuilder())->build(array(
+        array(
+            'id'       => 'visual-cross:column',
+            'type'     => 'FRAME',
+            'name'     => 'Overflow centered column',
+            'box'      => array('width' => 120, 'height' => 120),
+            'layout'   => array('display' => 'flex', 'flex_direction' => 'column', 'align_items' => 'center'),
+            'children' => array(
+                array('id' => 'visual-cross:wide', 'type' => 'RECTANGLE', 'name' => 'Wide centered child', 'box' => array('width' => 200, 'height' => 30)),
+            ),
+        ),
+    ));
+    $visualFlexCrossOverflowWide = null;
+    foreach ( $visualFlexCrossOverflowMap as $visualNode ) {
+        if ( is_array($visualNode) && 'visual-cross:wide' === ($visualNode['id'] ?? null) ) {
+            $visualFlexCrossOverflowWide = $visualNode;
+            break;
+        }
+    }
+    $assert(-40.0 === ($visualFlexCrossOverflowWide['rect']['x'] ?? null), 'visual-map-column-overflow-center-child-x');
+
+    $visualFlexOverflowResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Visual Flex Overflow Alignment Fixture',
+        'nodes' => array(
+            array(
+                'id'                    => 'visual-overflow:flex-end',
+                'type'                  => 'FRAME',
+                'name'                  => 'Overflow flex end row',
+                'width'                 => 80,
+                'height'                => 40,
+                'layoutMode'            => 'HORIZONTAL',
+                'primaryAxisAlignItems' => 'MAX',
+                'counterAxisAlignItems' => 'MIN',
+                'itemSpacing'           => 8,
+                'children'              => array(
+                    array('id' => 'visual-overflow:end-first', 'type' => 'RECTANGLE', 'name' => 'End first child', 'width' => 50, 'height' => 20),
+                    array('id' => 'visual-overflow:end-second', 'type' => 'RECTANGLE', 'name' => 'End second child', 'width' => 50, 'height' => 20),
+                ),
+            ),
+            array(
+                'id'                    => 'visual-overflow:center',
+                'type'                  => 'FRAME',
+                'name'                  => 'Overflow centered row',
+                'width'                 => 80,
+                'height'                => 40,
+                'layoutMode'            => 'HORIZONTAL',
+                'primaryAxisAlignItems' => 'CENTER',
+                'counterAxisAlignItems' => 'MIN',
+                'itemSpacing'           => 8,
+                'children'              => array(
+                    array('id' => 'visual-overflow:center-first', 'type' => 'RECTANGLE', 'name' => 'Center first child', 'width' => 50, 'height' => 20),
+                    array('id' => 'visual-overflow:center-second', 'type' => 'RECTANGLE', 'name' => 'Center second child', 'width' => 50, 'height' => 20),
+                ),
+            ),
+        ),
+    ));
+    $visualOverflowEndFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-first');
+    $visualOverflowEndSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-second');
+    $visualOverflowCenterFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-first');
+    $visualOverflowCenterSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-second');
+    $assert(-28.0 === ($visualOverflowEndFirst['rect']['x'] ?? null), 'visual-map-overflow-flex-end-first-x');
+    $assert(30.0 === ($visualOverflowEndSecond['rect']['x'] ?? null), 'visual-map-overflow-flex-end-second-x');
+    $assert(-14.0 === ($visualOverflowCenterFirst['rect']['x'] ?? null), 'visual-map-overflow-center-first-x');
+    $assert(44.0 === ($visualOverflowCenterSecond['rect']['x'] ?? null), 'visual-map-overflow-center-second-x');
+
+    $visualFlexWrapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Visual Flex Wrap Fixture',
+        'nodes' => array(
+            array(
+                'id'                    => 'visual-wrap:frame',
+                'type'                  => 'FRAME',
+                'name'                  => 'Wrapped card row',
+                'width'                 => 220,
+                'height'                => 200,
+                'layoutMode'            => 'HORIZONTAL',
+                'layoutWrap'            => 'WRAP',
+                'itemSpacing'           => 10,
+                'counterAxisAlignItems' => 'MIN',
+                'children'              => array(
+                    array('id' => 'visual-wrap:first', 'type' => 'RECTANGLE', 'name' => 'First card', 'width' => 100, 'height' => 40),
+                    array('id' => 'visual-wrap:second', 'type' => 'RECTANGLE', 'name' => 'Second card', 'width' => 100, 'height' => 60),
+                    array('id' => 'visual-wrap:third', 'type' => 'RECTANGLE', 'name' => 'Third card', 'width' => 100, 'height' => 30),
+                ),
+            ),
+        ),
+    ));
+    $visualFlexWrapCss = $fileContent($visualFlexWrapResult, 'style.css');
+    $visualFlexWrapFirst = $findVisualNode($visualFlexWrapResult, 'visual-wrap:first');
+    $visualFlexWrapSecond = $findVisualNode($visualFlexWrapResult, 'visual-wrap:second');
+    $visualFlexWrapThird = $findVisualNode($visualFlexWrapResult, 'visual-wrap:third');
+    $assert(str_contains($visualFlexWrapCss, 'flex-wrap:wrap;align-content:flex-start'), 'visual-map-flex-wrap-align-content-packed');
+    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 100.0, 'height' => 40.0) === ($visualFlexWrapFirst['rect'] ?? null), 'visual-map-flex-wrap-first-line-first-card');
+    $assert(array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0) === ($visualFlexWrapSecond['rect'] ?? null), 'visual-map-flex-wrap-first-line-second-card');
+    $assert(array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0) === ($visualFlexWrapThird['rect'] ?? null), 'visual-map-flex-wrap-second-line-card');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/FixtureMatrixContract.php';
 require_once __DIR__ . '/LayoutMismatchContract.php';
 require_once __DIR__ . '/OriginInferenceContract.php';
 require_once __DIR__ . '/SyntheticFigKiwiFixtureBuilder.php';
+require_once __DIR__ . '/VisualNodeMapContract.php';
 
 use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCapability;
 use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder;
@@ -187,7 +188,7 @@ $assert(str_contains($html, '<h2 class="figma-node-1-2-hero-title"'), 'title-emi
 $assert(str_contains($html, '<div class="figma-node-1-3-cards-group"'), 'group-emits-div');
 $assert(! str_contains($html, '<FRAME') && ! str_contains($html, '<GROUP') && ! str_contains($html, '<TEXT') && ! str_contains($html, '<RECTANGLE'), 'html-avoids-custom-tags');
 $assert(! str_contains($html, 'cdn.example.com') && ! str_contains($css, 'cdn.example.com'), 'html-css-avoid-external-cdn');
-$assert(str_contains($css, '.figma-node-1-1-hero-section{width:1200px;min-height:600px;background:#ffffff;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;padding-top:40px;padding-right:32px;padding-bottom:40px;padding-left:32px;gap:24px}'), 'css-frame-layout-style');
+$assert(str_contains($css, '.figma-node-1-1-hero-section{width:1200px;height:600px;background:#ffffff;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;padding-top:40px;padding-right:32px;padding-bottom:40px;padding-left:32px;gap:24px}'), 'css-frame-layout-style');
 $assert(str_contains($css, '.figma-node-1-2-hero-title{font-size:48px;font-weight:700;color:#1a334d;flex-shrink:0}'), 'css-text-style');
 $assert(str_contains($css, '.figma-node-1-4-hero-image-rectangle{width:320px;height:180px;position:absolute;left:10px;top:20px;background:#ff0000;background-image:url("assets/hero-image.svg")'), 'css-rectangle-asset-style');
 $assert(str_contains($css, '.figma-node-1-5-nested-image-paint{') && str_contains($css, 'background-image:url("assets/fixture-photo.jpg")'), 'css-nested-image-hash-asset-style');
@@ -527,7 +528,7 @@ $decorativeUnderlayDiagnostics = $decorativeUnderlayResult['source_reports']['fi
 $decorativeUnderlayLayout = $decorativeUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
 $decorativeUnderlayArt = $findVisualNode($decorativeUnderlayResult, 'underlay:art');
 $decorativeUnderlayVector = $findVisualNode($decorativeUnderlayResult, 'underlay:vector');
-$assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-parent-flex-hero{width:1000px;min-height:600px;position:relative;display:flex;flex-direction:row}'), 'decorative-underlay-parent-relative');
+$assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-parent-flex-hero{width:1000px;height:600px;position:relative;display:flex;flex-direction:row}'), 'decorative-underlay-parent-relative');
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-art-decorative-art{width:900px;height:700px;position:absolute;left:40px;top:-50px;z-index:0;pointer-events:none}'), 'decorative-underlay-absolute');
 $assert(str_contains($decorativeUnderlayCss, '.figma-node-underlay-copy-copy-stack{width:320px;height:120px;position:relative;z-index:1;flex-shrink:0}'), 'decorative-underlay-content-stacks-above');
 $assert(array('x' => 40.0, 'y' => -50.0, 'width' => 900.0, 'height' => 700.0) === ($decorativeUnderlayArt['rect'] ?? null), 'decorative-underlay-visual-map-includes-css-offset');
@@ -1276,8 +1277,8 @@ $nearZeroContainerResult = blocks_engine_figma_transformer_transform_scenegraph(
     ),
 ));
 $nearZeroContainerCss = $fileContent($nearZeroContainerResult, 'style.css');
-$assert(str_contains($nearZeroContainerCss, '.figma-node-near-zero-container-decorative-zero-height-wrapper{width:600px;min-height:0px;position:relative;display:flex;flex-direction:column}'), 'near-zero-container-keeps-zero-height-layout');
-$assert(! str_contains($nearZeroContainerCss, '.figma-node-near-zero-container-decorative-zero-height-wrapper{width:600px;min-height:0px;position:relative;transform:'), 'near-zero-container-suppresses-transform-bounds-inflation');
+$assert(str_contains($nearZeroContainerCss, '.figma-node-near-zero-container-decorative-zero-height-wrapper{width:600px;height:0px;position:relative;display:flex;flex-direction:column}'), 'near-zero-container-keeps-zero-height-layout');
+$assert(! str_contains($nearZeroContainerCss, '.figma-node-near-zero-container-decorative-zero-height-wrapper{width:600px;height:0px;position:relative;transform:'), 'near-zero-container-suppresses-transform-bounds-inflation');
 $assert(str_contains($nearZeroContainerCss, '.figma-node-near-zero-child-decorative-child{width:600px;height:320px;position:absolute;flex-shrink:0}'), 'near-zero-container-keeps-child-rendering');
 
 $agenticChevronLeftPrefix = hex2bin('0600000006000000010000000000000000000041000080410000000000000000');
@@ -2743,6 +2744,51 @@ $fixedFlexResult = blocks_engine_figma_transformer_transform_scenegraph(array(
 $fixedFlexCss = $fileContent($fixedFlexResult, 'style.css');
 $assert(str_contains($fixedFlexCss, '.figma-node-flex-child-a-fixed-child-a{width:70px;height:40px;flex-shrink:0}'), 'fixed-flex-child-does-not-shrink');
 
+$fixedRootFlexResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Fixed Root Flex Fixture',
+    'nodes' => array(
+        array(
+            'id'                   => 'fixed-root:flex',
+            'type'                 => 'FRAME',
+            'name'                 => 'Fixed root flex',
+            'width'                => 1280,
+            'height'               => 100,
+            'layoutMode'           => 'VERTICAL',
+            'layoutSizingVertical' => 'FIXED',
+            'children'             => array(
+                array('id' => 'fixed-root:copy', 'type' => 'TEXT', 'name' => 'Fixed root copy', 'text' => 'Root height stays fixed', 'width' => 200, 'height' => 20),
+            ),
+        ),
+    ),
+));
+$fixedRootFlexCss = $fileContent($fixedRootFlexResult, 'style.css');
+$assert(str_contains($fixedRootFlexCss, '.figma-node-fixed-root-flex-fixed-root-flex{width:1280px;height:100px;display:flex;flex-direction:column}'), 'fixed-root-flex-emits-fixed-height');
+$assert(! str_contains($fixedRootFlexCss, '.figma-node-fixed-root-flex-fixed-root-flex{width:1280px;min-height:100px'), 'fixed-root-flex-does-not-emit-min-height');
+
+$fixedPaddingClampResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Fixed Padding Clamp Fixture',
+    'nodes' => array(
+        array(
+            'id'                   => 'padding:frame',
+            'type'                 => 'FRAME',
+            'name'                 => 'Impossible fixed padding',
+            'width'                => 1280,
+            'height'               => 100,
+            'layoutMode'           => 'VERTICAL',
+            'layoutSizingVertical' => 'FIXED',
+            'paddingTop'           => 80,
+            'paddingBottom'        => 80,
+            'children'             => array(
+                array('id' => 'padding:copy', 'type' => 'TEXT', 'name' => 'Padded copy', 'text' => 'Padding is clamped', 'width' => 200, 'height' => 20),
+            ),
+        ),
+    ),
+));
+$fixedPaddingClampCss = $fileContent($fixedPaddingClampResult, 'style.css');
+$fixedPaddingClampCopy = $findVisualNode($fixedPaddingClampResult, 'padding:copy');
+$assert(str_contains($fixedPaddingClampCss, '.figma-node-padding-frame-impossible-fixed-padding{width:1280px;height:100px;display:flex;flex-direction:column;padding-top:50px;padding-bottom:50px}'), 'fixed-padding-clamped-css');
+$assert(50.0 === ($fixedPaddingClampCopy['rect']['y'] ?? null), 'fixed-padding-clamped-visual-map');
+
 $stylePaintResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Style Paint Fixture',
     'nodes' => array(
@@ -3278,7 +3324,7 @@ $layoutFidelityResult = blocks_engine_figma_transformer_transform_scenegraph(arr
 
 $layoutFidelityCss = $fileContent($layoutFidelityResult, 'style.css');
 
-$assert(str_contains($layoutFidelityCss, '.figma-node-5-1-layout-frame{width:500px;min-height:300px;overflow:hidden;position:relative;display:flex;flex-direction:row;justify-content:flex-start;align-items:stretch}'), 'layout-frame-clips-and-positions-absolute-children');
+$assert(str_contains($layoutFidelityCss, '.figma-node-5-1-layout-frame{width:500px;height:300px;overflow:hidden;position:relative;display:flex;flex-direction:row;justify-content:flex-start;align-items:stretch}'), 'layout-frame-clips-and-positions-absolute-children');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-2-fixed-card{width:100px;height:80px;opacity:0.6;transform:rotate(15deg);flex-shrink:0}'), 'layout-fixed-sizing-and-rotation');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-3-hug-label{width:fit-content;height:fit-content;font-size:12px;flex-shrink:0}'), 'layout-hug-sizing');
 $assert(str_contains($layoutFidelityCss, '.figma-node-5-4-fill-panel{width:100%;height:100%;flex-grow:1;flex-shrink:1;align-self:stretch}'), 'layout-fill-sizing-without-source-order');
@@ -3314,142 +3360,7 @@ $hugOverflowResult = blocks_engine_figma_transformer_transform_scenegraph(array(
 $hugOverflowCss = $fileContent($hugOverflowResult, 'style.css');
 $assert(str_contains($hugOverflowCss, '.figma-node-hug-overflow-button-hug-overflow-button{width:max-content;height:40px;display:flex;flex-direction:row;justify-content:flex-end;align-items:center;padding-right:6px;padding-left:6px;gap:8px}'), 'layout-hug-flex-main-axis-expands-to-intrinsic-span');
 
-$visualFlexAlignmentResult = blocks_engine_figma_transformer_transform_scenegraph(array(
-    'name'  => 'Visual Flex Alignment Fixture',
-    'nodes' => array(
-        array(
-            'id'                    => 'visual-flex:row',
-            'type'                  => 'FRAME',
-            'name'                  => 'Visual flex row',
-            'width'                 => 500,
-            'height'                => 100,
-            'layoutMode'            => 'HORIZONTAL',
-            'primaryAxisAlignItems' => 'MAX',
-            'counterAxisAlignItems' => 'CENTER',
-            'itemSpacing'           => 20,
-            'children'              => array(
-                array('id' => 'visual-flex:first', 'type' => 'RECTANGLE', 'name' => 'First child', 'width' => 100, 'height' => 20),
-                array('id' => 'visual-flex:second', 'type' => 'RECTANGLE', 'name' => 'Second child', 'width' => 50, 'height' => 40),
-            ),
-        ),
-        array(
-            'id'                    => 'visual-flex:column',
-            'type'                  => 'FRAME',
-            'name'                  => 'Visual flex column',
-            'width'                 => 300,
-            'height'                => 200,
-            'layoutMode'            => 'VERTICAL',
-            'counterAxisAlignItems' => 'CENTER',
-            'paddingLeft'           => 20,
-            'paddingRight'          => 20,
-            'paddingTop'            => 10,
-            'children'              => array(
-                array('id' => 'visual-flex:centered', 'type' => 'RECTANGLE', 'name' => 'Centered child', 'width' => 100, 'height' => 30),
-            ),
-        ),
-    ),
-));
-$visualFlexFirst = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:first');
-$visualFlexSecond = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:second');
-$visualFlexCentered = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:centered');
-$assert(330.0 === ($visualFlexFirst['rect']['x'] ?? null), 'visual-map-flex-end-first-x');
-$assert(40.0 === ($visualFlexFirst['rect']['y'] ?? null), 'visual-map-flex-center-first-y');
-$assert(450.0 === ($visualFlexSecond['rect']['x'] ?? null), 'visual-map-flex-end-second-x');
-$assert(30.0 === ($visualFlexSecond['rect']['y'] ?? null), 'visual-map-flex-center-second-y');
-$assert(100.0 === ($visualFlexCentered['rect']['x'] ?? null), 'visual-map-column-center-child-x');
-$assert(10.0 === ($visualFlexCentered['rect']['y'] ?? null), 'visual-map-column-padding-child-y');
-
-$visualFlexOverflowResult = blocks_engine_figma_transformer_transform_scenegraph(array(
-    'name'  => 'Visual Flex Overflow Alignment Fixture',
-    'nodes' => array(
-        array(
-            'id'                    => 'visual-overflow:flex-end',
-            'type'                  => 'FRAME',
-            'name'                  => 'Overflow flex end row',
-            'width'                 => 80,
-            'height'                => 40,
-            'layoutMode'            => 'HORIZONTAL',
-            'primaryAxisAlignItems' => 'MAX',
-            'counterAxisAlignItems' => 'MIN',
-            'itemSpacing'           => 8,
-            'children'              => array(
-                array('id' => 'visual-overflow:end-first', 'type' => 'RECTANGLE', 'name' => 'End first child', 'width' => 50, 'height' => 20),
-                array('id' => 'visual-overflow:end-second', 'type' => 'RECTANGLE', 'name' => 'End second child', 'width' => 50, 'height' => 20),
-            ),
-        ),
-        array(
-            'id'                    => 'visual-overflow:center',
-            'type'                  => 'FRAME',
-            'name'                  => 'Overflow centered row',
-            'width'                 => 80,
-            'height'                => 40,
-            'layoutMode'            => 'HORIZONTAL',
-            'primaryAxisAlignItems' => 'CENTER',
-            'counterAxisAlignItems' => 'MIN',
-            'itemSpacing'           => 8,
-            'children'              => array(
-                array('id' => 'visual-overflow:center-first', 'type' => 'RECTANGLE', 'name' => 'Center first child', 'width' => 50, 'height' => 20),
-                array('id' => 'visual-overflow:center-second', 'type' => 'RECTANGLE', 'name' => 'Center second child', 'width' => 50, 'height' => 20),
-            ),
-        ),
-    ),
-));
-$visualOverflowEndFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-first');
-$visualOverflowEndSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-second');
-$visualOverflowCenterFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-first');
-$visualOverflowCenterSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-second');
-$assert(-28.0 === ($visualOverflowEndFirst['rect']['x'] ?? null), 'visual-map-overflow-flex-end-first-x');
-$assert(30.0 === ($visualOverflowEndSecond['rect']['x'] ?? null), 'visual-map-overflow-flex-end-second-x');
-$assert(-14.0 === ($visualOverflowCenterFirst['rect']['x'] ?? null), 'visual-map-overflow-center-first-x');
-$assert(44.0 === ($visualOverflowCenterSecond['rect']['x'] ?? null), 'visual-map-overflow-center-second-x');
-
-$visualFlexWrapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
-    'name'  => 'Visual Flex Wrap Fixture',
-    'nodes' => array(
-        array(
-            'id'                    => 'visual-wrap:frame',
-            'type'                  => 'FRAME',
-            'name'                  => 'Wrapped card row',
-            'width'                 => 220,
-            'height'                => 200,
-            'layoutMode'            => 'HORIZONTAL',
-            'layoutWrap'            => 'WRAP',
-            'itemSpacing'           => 10,
-            'counterAxisAlignItems' => 'MIN',
-            'children'              => array(
-                array(
-                    'id'     => 'visual-wrap:first',
-                    'type'   => 'RECTANGLE',
-                    'name'   => 'First card',
-                    'width'  => 100,
-                    'height' => 40,
-                ),
-                array(
-                    'id'     => 'visual-wrap:second',
-                    'type'   => 'RECTANGLE',
-                    'name'   => 'Second card',
-                    'width'  => 100,
-                    'height' => 60,
-                ),
-                array(
-                    'id'     => 'visual-wrap:third',
-                    'type'   => 'RECTANGLE',
-                    'name'   => 'Third card',
-                    'width'  => 100,
-                    'height' => 30,
-                ),
-            ),
-        ),
-    ),
-));
-$visualFlexWrapCss = $fileContent($visualFlexWrapResult, 'style.css');
-$visualFlexWrapFirst = $findVisualNode($visualFlexWrapResult, 'visual-wrap:first');
-$visualFlexWrapSecond = $findVisualNode($visualFlexWrapResult, 'visual-wrap:second');
-$visualFlexWrapThird = $findVisualNode($visualFlexWrapResult, 'visual-wrap:third');
-$assert(str_contains($visualFlexWrapCss, 'flex-wrap:wrap;align-content:flex-start'), 'visual-map-flex-wrap-align-content-packed');
-$assert(array('x' => 0.0, 'y' => 0.0, 'width' => 100.0, 'height' => 40.0) === ($visualFlexWrapFirst['rect'] ?? null), 'visual-map-flex-wrap-first-line-first-card');
-$assert(array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0) === ($visualFlexWrapSecond['rect'] ?? null), 'visual-map-flex-wrap-first-line-second-card');
-$assert(array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0) === ($visualFlexWrapThird['rect'] ?? null), 'visual-map-flex-wrap-second-line-card');
+blocks_engine_figma_transformer_run_visual_node_map_contract($assert, $findVisualNode, $fileContent);
 
 $kiwiStackLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Kiwi Stack Layout Fixture',
@@ -3489,7 +3400,7 @@ $kiwiStackLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(ar
     ),
 ));
 $kiwiStackLayoutCss = $fileContent($kiwiStackLayoutResult, 'style.css');
-$assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-frame-kiwi-stack-frame{width:300px;min-height:200px;overflow:hidden;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;flex-wrap:wrap;align-content:flex-start;padding-top:8px;padding-right:20px;padding-bottom:30px;padding-left:8px;gap:24px}'), 'kiwi-stack-layout-emits-flex-padding-gap');
+$assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-frame-kiwi-stack-frame{width:300px;height:200px;overflow:hidden;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;flex-wrap:wrap;align-content:flex-start;padding-top:8px;padding-right:20px;padding-bottom:30px;padding-left:8px;gap:24px}'), 'kiwi-stack-layout-emits-flex-padding-gap');
 $assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-child-a-child-a{width:50px;height:40px;flex-shrink:0}'), 'kiwi-stack-child-not-absolute');
 
 $plainFrameLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary
- Extract visual node map projection into a dedicated builder so DOM-box source geometry is easier to test and maintain.
- Preserve fixed Figma frame heights for flex roots instead of expanding them with min-height.
- Clamp impossible fixed-axis padding so emitted CSS and source visual-map geometry stay within fixed frame bounds.
- Add focused contract coverage for flex overflow alignment, fixed root height, and fixed padding clamping.

## Evidence
- Locked six-fixture matrix layout mismatches improved from 9 to 0.
- Previously failing fixtures now pass layout parity: fse-pilot-build-theme, wp-cloud-2, and wpjobmanager-com.

## Verification
- composer test:contract from figma-transformer/
- php -l figma-transformer/src/Html/StaticHtmlEmitter.php
- php -l figma-transformer/src/Html/VisualNodeMapBuilder.php
- php -l figma-transformer/tests/contract/VisualNodeMapContract.php
- php -l figma-transformer/tests/contract/run.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the residual layout fixes, extracting visual-map code, adding contract coverage, and running verification.