### PR TITLE
Detect button-styled anchors/buttons generically in HTML transformer

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -152,10 +152,54 @@ final class ButtonsPattern
             return true;
         }
 
-		return $this->hasAnyToken($anchor, array( 'button', 'btn', 'cta', 'action' ))
+		return $this->hasButtonClassSignal($anchor)
+			|| $this->hasAnyToken($anchor, array( 'cta', 'action' ))
 			|| $this->hasPhrase($anchor, array( 'call-to-action', 'primary-action', 'secondary-action' ))
-			|| $this->hasActionText($anchor);
+			|| $this->hasActionText($anchor)
+			|| $this->hasButtonStyleSignal($anchor);
     }
+
+	/**
+	 * Detect button-like class/id tokens generically.
+	 *
+	 * Keys off the generic "btn"/"button" substring rather than any one specific
+	 * class string, so framework variants are all recognized: btn, btn-primary,
+	 * hero-btn, link-btn, btnPrimary, actionButton, icon-button, roundedbtn, etc.
+	 */
+	private function hasButtonClassSignal(DOMElement $element): bool
+	{
+		foreach ( array( 'class', 'id' ) as $attribute ) {
+			$value = strtolower($element->hasAttribute($attribute) ? $element->getAttribute($attribute) : '');
+			if ( str_contains($value, 'btn') || str_contains($value, 'button') ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Detect button-like inline styling.
+	 *
+	 * Treats an element as a button when it carries padding plus a button shape
+	 * signal (a filled, non-transparent background or a border radius). This lets
+	 * styled anchors with no recognizable class still be promoted to buttons,
+	 * while plain text links (no padding/fill) stay links.
+	 */
+	private function hasButtonStyleSignal(DOMElement $element): bool
+	{
+		$style = strtolower($element->hasAttribute('style') ? $element->getAttribute('style') : '');
+		if ( '' === $style || ! preg_match('/(?:^|;)\s*padding(?:-[a-z]+)?\s*:\s*[^;]+/', $style) ) {
+			return false;
+		}
+
+		if ( preg_match('/(?:^|;)\s*border[a-z-]*radius\s*:\s*[^;]+/', $style) ) {
+			return true;
+		}
+
+		return preg_match('/(?:^|;)\s*background(?:-color)?\s*:\s*[^;]+/', $style) === 1
+			&& preg_match('/(?:^|;)\s*background(?:-color)?\s*:\s*(?:transparent|none|inherit|initial|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))\s*(?:;|$)/', $style) !== 1;
+	}
 
 	private function hasContainerButtonSignal(DOMElement $element): bool
 	{

--- a/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
+++ b/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
@@ -260,7 +260,16 @@ final class ButtonMenuVisualProbe
 
     private function hasButtonSignal(DOMElement $element): bool
     {
-        return $this->hasAnyToken($element, array( 'button', 'btn' )) || str_contains(strtolower($element->hasAttribute('class') ? $element->getAttribute('class') : ''), 'wp-element-button');
+        // Generic button-token detection: any class/id containing the "btn" or
+        // "button" substring (covers btn, btn-primary, hero-btn, btnPrimary,
+        // actionButton, roundedbtn, wp-element-button, etc.). Kept consistent with
+        // the HTML transformer's button-signal heuristic.
+        $value = strtolower(
+            ( $element->hasAttribute('class') ? $element->getAttribute('class') : '' ) . ' '
+            . ( $element->hasAttribute('id') ? $element->getAttribute('id') : '' )
+        );
+
+        return str_contains($value, 'btn') || str_contains($value, 'button');
     }
 
     private function hasRegressionRiskSignal(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-button-generic-class-and-style-signal.json
+++ b/php-transformer/tests/fixtures/parity/html-button-generic-class-and-style-signal.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-generic-class-and-style-signal",
+  "description": "Recognizes button-like anchors generically: a camelCase class carrying the btn token, an inline button-shape style (padding plus fill and radius) with no recognizable class, and role=button all convert to core/buttons/core/button rather than plain links.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-generic-class-and-style-signal.json",
+    "notes": "Generic transformer boundary fixture for button-signal detection (button-fidelity diagnostic iteration)."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New generic button-signal detection has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><a class=\"btnPrimary\" href=\"/teams\">See the Teams</a><a href=\"/signup\" style=\"display:inline-block;padding:12px 24px;background:#0a66c2;color:#ffffff;border-radius:6px\">Sign up today</a><a href=\"/donate\" role=\"button\">Donate</a></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "See the Teams", "url": "/teams", "className": "btnPrimary" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Sign up today", "url": "/signup", "style": "display:inline-block;padding:12px 24px;background:#0a66c2;color:#ffffff;border-radius:6px" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/button", "attrs": { "text": "Donate", "url": "/donate" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:buttons -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button btnPrimary\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"display:inline-block;padding:12px 24px;background:#0a66c2;color:#ffffff;border-radius:6px\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:paragraph" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-plain-link-not-button-signal.json
+++ b/php-transformer/tests/fixtures/parity/html-plain-link-not-button-signal.json
@@ -1,0 +1,28 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-plain-link-not-button-signal",
+  "description": "Negative guard for button-signal detection: a plain inline text link with no button class, role, or button-shape styling stays an anchor inside a paragraph and is never promoted to core/buttons.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-plain-link-not-button-signal.json",
+    "notes": "Regression guard ensuring ordinary links are not mistaken for buttons."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Negative guard for new generic button-signal detection."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><p>Read our <a href=\"/about\">about page</a> for details.</p></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/paragraph" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/about\">about page</a>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:buttons" }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the PHP transformer's button-signal heuristic so anchors and `<button>` elements that are *visually* buttons get recognized as `core/buttons` + `core/button`, independent of a site's class-naming convention.

This is part of a diagnostic-driven transformer iteration addressing a **button-fidelity blind spot**: the static-site fixture matrix imports call-to-action buttons (styled anchors like `class="btn btn-primary"` / `btn-ghost`, plus real submit `<button>`s) that previously could lose their button structure depending on how their classes were named. Button fidelity is also not yet surfaced as a precise harness finding, so this hardens the heuristic proactively.

## What changed

- `ButtonsPattern::hasButtonSignal()` now keys off a **generic `btn`/`button` substring** in `class`/`id` rather than exact, delimiter-split tokens. Hyphenated names (`btn-primary`, `hero-btn`) already worked; this additionally catches camelCase/glued variants (`btnPrimary`, `actionButton`, `roundedbtn`, `icon-button`). The existing `role="button"`, `cta`/`action` tokens, CTA phrases, and action-text signals are preserved.
- Added an **inline button-shape style signal**: `padding` plus a filled (non-transparent) `background`/`background-color` or a `border-radius` promotes an otherwise class-less styled anchor to a button. Plain text links (no padding/fill) stay links.
- The primary vs secondary/ghost distinction is preserved as before via `className`/`style` carried through presentation attributes (e.g. ghost/outline → `is-style-outline`).
- Aligned `ButtonMenuVisualProbe::hasButtonSignal()` to the same generic substring detection so the visual-parity diagnostic classification stays consistent with the transformer.
- Added parity fixtures: a positive case (generic class token, inline button styling, and `role=button` all → `core/buttons`) and a negative guard (a plain inline link is never promoted).

Generic by design — no fixture-specific or magic class strings. `NavigationPattern` / font materialization untouched.

## Tests

- `php tests/contract/run.php` (+ runtime/bootstrap canonical scripts): pass
- `php tests/parity/run.php`: **112 fixtures pass** (110 baseline + 2 new), with the two new button fixtures and no regressions
- Real navigation links continue to convert to `core/navigation`, not buttons.

Do not merge — opening for review as part of the transformer diagnostic iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)