### PR TITLE
Lock in nav-in-chrome semantic parity (diagnostic-driven transformer iteration)

### DIFF
--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -550,6 +550,39 @@ $assert('pass' === ($dropdownHeaderParity['status'] ?? ''), 'dropdown header nav
 $assert(5 === ($dropdownHeaderBlockMenu['item_count'] ?? null), 'dropdown header nav counts parent and submenu items consistently');
 $assert('Day Hike' === ($dropdownHeaderBlockMenu['items'][2]['label'] ?? ''), 'dropdown header nav preserves submenu item labels');
 
+// Regression: a <nav> that sits as a SIBLING of a brand/logo and a menu-toggle
+// inside header/footer "chrome" container divs (direct-anchor menus, no <ul>)
+// must still be represented as core/navigation. This locks in the diagnostic
+// findings html_semantic_parity_landmark_count_mismatch (header nav) and
+// html_semantic_parity_navigation_menu_missing (footer nav) reported against an
+// earlier deployed transformer for shared-chrome static sites. Markup is generic
+// (structural signals only — no fixture-specific class names).
+$chromeHeaderNavigation = ( new HtmlTransformer() )->transform(
+    '<header class="masthead" role="banner"><div class="bar inner"><a class="logo" href="/" aria-label="Brand home"><svg viewBox="0 0 10 10" aria-hidden="true"><path d="M0 0h1v1z"></path></svg><span>Brand</span></a><nav class="primary" aria-label="Primary navigation"><a href="/">Home</a><a href="/about">About</a><a href="/teams">Teams</a><a href="/contact">Contact</a></nav><button class="burger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="drawer"><span></span><span></span><span></span></button></div></header><nav class="drawer" id="drawer" aria-label="Mobile navigation"><a href="/">Home</a><a href="/about">About</a><a href="/teams">Teams</a><a href="/contact">Contact</a></nav>'
+)->toArray();
+$chromeHeaderParity = $chromeHeaderNavigation['source_reports']['semantic_parity'] ?? array();
+$chromeHeaderBlockMenu = $chromeHeaderParity['navigation_menus']['blocks'][0] ?? array();
+$chromeHeaderFindingCodes = array_map(static fn ($f): string => (string) ($f['code'] ?? ''), $chromeHeaderParity['findings'] ?? array());
+$assert('pass' === ($chromeHeaderParity['status'] ?? ''), 'header chrome sibling nav (brand + nav + toggle) preserves semantic parity');
+$assert(! in_array('landmark_count_mismatch', $chromeHeaderFindingCodes, true), 'header chrome sibling nav avoids landmark_count_mismatch loss');
+$assert(($chromeHeaderParity['landmarks']['source']['nav'] ?? -1) === ($chromeHeaderParity['landmarks']['blocks']['nav'] ?? -2), 'header chrome sibling nav generates one core navigation landmark per source nav landmark');
+$assert(1 === count($chromeHeaderParity['navigation_menus']['blocks'] ?? array()), 'header chrome sibling nav dedupes the mobile drawer duplicate menu');
+$assert(true === ($chromeHeaderBlockMenu['represented_as_core_navigation'] ?? null), 'header chrome sibling nav is represented as core/navigation');
+$assert(4 === ($chromeHeaderBlockMenu['item_count'] ?? null), 'header chrome sibling nav preserves all direct-anchor menu items');
+$assert('Home' === ($chromeHeaderBlockMenu['items'][0]['label'] ?? ''), 'header chrome sibling nav preserves menu item labels');
+
+$chromeFooterNavigation = ( new HtmlTransformer() )->transform(
+    '<footer class="colophon"><div class="wrap"><div class="cols"><div class="about"><span>Brand Org</span></div><nav class="secondary" aria-label="Footer navigation"><a href="/">Home</a><a href="/about">About</a><a href="/teams">Teams</a><a href="/contact">Contact</a></nav></div><div class="legal">(c) 2026 Brand.</div></div></footer>'
+)->toArray();
+$chromeFooterParity = $chromeFooterNavigation['source_reports']['semantic_parity'] ?? array();
+$chromeFooterBlockMenu = $chromeFooterParity['navigation_menus']['blocks'][0] ?? array();
+$chromeFooterFindingCodes = array_map(static fn ($f): string => (string) ($f['code'] ?? ''), $chromeFooterParity['findings'] ?? array());
+$assert('pass' === ($chromeFooterParity['status'] ?? ''), 'footer chrome nested-div sibling nav preserves semantic parity');
+$assert(! in_array('navigation_menu_missing', $chromeFooterFindingCodes, true), 'footer chrome nested-div sibling nav avoids navigation_menu_missing loss');
+$assert(true === ($chromeFooterBlockMenu['represented_as_core_navigation'] ?? null), 'footer chrome nested-div nav is represented as core/navigation');
+$assert(4 === ($chromeFooterBlockMenu['item_count'] ?? null), 'footer chrome nested-div nav preserves all direct-anchor menu items');
+$assert('Contact' === ($chromeFooterBlockMenu['items'][3]['label'] ?? ''), 'footer chrome nested-div nav preserves last menu item label');
+
 $runtimeTargetNavigation = ( new HtmlTransformer() )->transform(
     '<nav aria-label="Docs"><ul><li><a class="nav-link" href="/guide">Guide</a></li></ul></nav>',
     array('runtime_dom_selectors' => array('.nav-link'))


### PR DESCRIPTION
## Summary

Part of a diagnostic-driven transformer iteration. The static-site-importer fixture matrix (new fixture `73-h44-lacrosse`, a 6-page shared-chrome youth-lacrosse site sharing `css/main.css` + `js/main.js`) failed the quality gate with two navigation/landmark semantic-parity losses (`unsupported_loss` / semantic parity) produced by the HTML->blocks transformer:

1. `html_semantic_parity_landmark_count_mismatch` — selector `header:nth-of-type(1) > div:nth-of-type(1) > nav:nth-of-type(1)` — "Source nav landmarks exceed generated core block representation."
2. `html_semantic_parity_navigation_menu_missing` — selector `footer:nth-of-type(1) > div:nth-of-type(1) > div:nth-of-type(1) > nav:nth-of-type(1)` — "Source navigation menu was not represented as a core/navigation block."

In WordPress this showed up as a "corrupted" header and a lost footer nav.

## Root cause

These findings reproduce **only against the older deployed transformer** — verified by running the exact fixture through the version vendored into static-site-importer, which predates the `PatternContext` rewrite, the `hasNavigationChrome` guard, and the `isNavigationWrapperElement` wrapper traversal. That version emitted `src nav=3, block nav=1` and produced both findings verbatim.

Current `trunk` already converts these shapes correctly. A `<nav>` that sits as a **sibling** of a brand/logo and a menu-toggle inside header/footer "chrome" container divs (direct-anchor menus, no `<ul>`) is still emitted as `core/navigation`, the menu-toggle stays a separate control, the brand/logo is not swallowed, and the mobile drawer duplicate is deduped. All six fixture pages now report `parity=pass` with zero nav findings.

Because the conversion is already correct on `trunk`, and the source-side parity counter lives in `HtmlTransformer.php` (outside the agreed `Patterns/` edit scope), no production change to `NavigationPattern.php` was warranted — any block-only adjustment would desync source/block item counts and make the gate worse. The right deliverable is locking the resolved behavior in so it cannot silently regress.

## Change

Adds generic, **structural** regression coverage (no fixture-specific class names) to `php-transformer/tests/contract/run.php` mirroring the exact diagnostic shapes:

- **Header chrome:** brand anchor + sibling `<nav>` (direct anchors) + menu-toggle button, plus a deduped mobile `<nav>`. Asserts `parity=pass`, no `landmark_count_mismatch`, one core nav landmark per source nav landmark, single deduped menu, and preserved item labels.
- **Footer chrome:** brand block + sibling `<nav>` (direct anchors) nested in container divs. Asserts `parity=pass`, no `navigation_menu_missing`, `represented_as_core_navigation`, and preserved items.

## Tests

- `composer test:canonical` — pass (no-WP runtime, WP-stub runtime, plugin bootstrap, HTML-to-blocks contract, format bridge scaffold).
- `composer parity` — pass, 110 fixtures.

Do not merge without review.