### PR TITLE
Avoid canvas core/html fallback blocks

### DIFF
--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -181,10 +181,21 @@ final class RuntimeDependencyParityReport
             $selector = is_string($island['selector'] ?? null) ? trim($island['selector']) : '';
             if ( str_starts_with($selector, '#') ) {
                 $targets['ids'][substr($selector, 1)] = true;
-                continue;
             }
             if ( str_starts_with($selector, '.') ) {
                 $targets['classes'][substr($selector, 1)] = true;
+            }
+
+            $attributes = is_array($island['attributes'] ?? null) ? $island['attributes'] : array();
+            $id = is_string($attributes['id'] ?? null) ? trim($attributes['id']) : '';
+            if ( '' !== $id ) {
+                $targets['ids'][$id] = true;
+            }
+            $classList = is_string($attributes['class'] ?? null) ? trim($attributes['class']) : '';
+            foreach ( preg_split('/\s+/', $classList) ?: array() as $class ) {
+                if ( '' !== $class ) {
+                    $targets['classes'][$class] = true;
+                }
             }
         }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1516,8 +1516,7 @@ final class HtmlTransformer
             }
 
             $this->captureCanvasFallback($element, $fallbacks);
-            $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
-            return $this->createBlock('core/html', array( 'content' => $boundedHtml['html'] ), array(), $element);
+            return null;
         }
 
         if ( 'script' === $tagName ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -670,8 +670,13 @@ $assert('canvas_requires_runtime' === ($canvasDiagnostic['reason'] ?? ''), 'canv
 $assert('bonsai' === ($canvasFallback['fallbacks'][0]['attributes']['id'] ?? ''), 'canvas fallback preserves id for runtime mapping');
 $assert(str_contains((string) ($canvasFallback['fallbacks'][0]['html'] ?? ''), '<canvas id="bonsai"'), 'canvas fallback preserves bounded safe canvas markup');
 $assert(str_contains((string) ($canvasDiagnostic['script_dependency_hint'] ?? ''), '#bonsai'), 'canvas diagnostic flags id-based script dependency risk');
-$assert(str_contains((string) ($canvasFallback['serialized_blocks'] ?? ''), '<!-- wp:html'), 'runtime canvas emits bounded core/html preservation island');
-$assert(str_contains((string) ($canvasFallback['serialized_blocks'] ?? ''), '<canvas id="bonsai"'), 'runtime canvas preserves native canvas markup for script execution');
+$canvasRuntimeIslands = array_values(array_filter($canvasFallback['source_reports']['runtime_islands'] ?? array(), static fn (array $island): bool => 'canvas' === ($island['kind'] ?? '')));
+$assert(1 === count($canvasRuntimeIslands), 'runtime canvas projects as a bounded runtime island');
+$assert('#bonsai' === ($canvasRuntimeIslands[0]['selector'] ?? ''), 'runtime canvas island preserves script-addressable selector');
+$assert(str_contains((string) ($canvasRuntimeIslands[0]['source_snippet'] ?? ''), '<canvas id="bonsai"'), 'runtime canvas island preserves bounded source snippet for runtime mapping');
+$assert(1 === count($canvasRuntimeIslands[0]['required_scripts'] ?? array()), 'runtime canvas island preserves required script context');
+$assert(! str_contains((string) ($canvasFallback['serialized_blocks'] ?? ''), '<!-- wp:html'), 'runtime canvas does not emit serialized core/html fallback blocks');
+$assert(! str_contains((string) ($canvasFallback['serialized_blocks'] ?? ''), '<canvas id="bonsai"'), 'runtime canvas does not serialize raw canvas markup into block output');
 
 $runtimePreserved = ( new HtmlTransformer() )->transform(
     '<main><canvas id="stage" aria-hidden="true"></canvas><input id="amount" value="10"><div id="app-shell">Runtime shell</div></main>',
@@ -690,7 +695,7 @@ foreach ( $runtimeSelectors as $selector ) {
         $runtimeClassifications[$selector['tag'] ?? ''] = $selector['conversion_classification'] ?? '';
     }
 }
-$assert('runtime_island_preserved' === ($runtimeClassifications['canvas'] ?? ''), 'runtime-preserved canvas core/html block is classified as runtime island preservation');
+$assert('runtime_island_preserved' === ($runtimeClassifications['canvas'] ?? ''), 'runtime-preserved canvas metadata is classified as runtime island preservation');
 $assert('runtime_island_preserved' === ($runtimeClassifications['input'] ?? ''), 'runtime-preserved control metadata is classified as runtime island preservation');
 $runtimePreservedIslandKinds = array_map(static fn (array $island): string => (string) ($island['kind'] ?? ''), $runtimePreserved['source_reports']['runtime_islands'] ?? array());
 $assert(in_array('dom', $runtimePreservedIslandKinds, true), 'runtime-preserved DOM target projects as a runtime island');
@@ -974,7 +979,7 @@ $assert(true === ($canvasDependency['canvas_api'] ?? null), 'runtime dependency 
 $assert(true === ($canvasDependency['generated_present'] ?? null), 'runtime dependency parity passes preserved canvas id target');
 $assert(null !== $stageDependency, 'runtime dependency parity records canvas class querySelector dependency');
 $assert(true === ($stageDependency['generated_present'] ?? null), 'runtime dependency parity passes preserved canvas class target');
-$assert(str_contains($runtimeDependencyMarkup, '<canvas id="canvas" class="stage"></canvas>'), 'artifact compiler emits referenced canvas runtime target markup');
+$assert(! str_contains($runtimeDependencyMarkup, '<canvas id="canvas" class="stage"></canvas>'), 'artifact compiler does not emit referenced canvas runtime target markup');
 $assert(! str_contains($runtimeDependencyMarkup, 'unused-canvas'), 'artifact compiler does not preserve unreferenced canvas markup');
 $runtimeDependencyIslands = $runtimeDependencySite['source_reports']['runtime_islands'] ?? array();
 $runtimeDependencyIslandsByKind = array();
@@ -987,6 +992,7 @@ $runtimeDependencyCanvasIsland = $runtimeDependencyIslandsByKind['canvas'][0] ??
 $runtimeDependencyDomIsland = $runtimeDependencyIslandsByKind['dom'][0] ?? array();
 $assert('canvas' === ($runtimeDependencyCanvasIsland['kind'] ?? ''), 'artifact runtime island identifies canvas kind');
 $assert('#canvas' === ($runtimeDependencyCanvasIsland['selector'] ?? ''), 'artifact runtime island exposes canvas selector');
+$assert('stage' === ($runtimeDependencyCanvasIsland['attributes']['class'] ?? ''), 'artifact runtime island exposes canvas class for runtime dependency parity');
 $assert(str_contains((string) ($runtimeDependencyCanvasIsland['source_snippet'] ?? ''), '<canvas id="canvas" class="stage"></canvas>'), 'artifact runtime island exposes canvas source snippet');
 $assert(! empty($runtimeDependencyCanvasIsland['required_scripts'] ?? array()), 'artifact runtime island exposes required script metadata');
 $assert('#status-container' === ($runtimeDependencyDomIsland['selector'] ?? ''), 'artifact DOM runtime island exposes selector');
@@ -1010,12 +1016,13 @@ $decorativeCanvasSite = $compiler->compile(
 )->toArray();
 $decorativeCanvasMarkup = (string) ($decorativeCanvasSite['serialized_blocks'] ?? '');
 $decorativeCanvasFallbacks = $decorativeCanvasSite['fallbacks'] ?? array();
-$assert(str_contains($decorativeCanvasMarkup, '<canvas id="lab-canvas" class="stage" aria-label="Live pattern"></canvas>'), 'artifact compiler preserves canvas markup only for selectors with direct canvas API usage');
+$assert(! str_contains($decorativeCanvasMarkup, '<canvas id="lab-canvas" class="stage" aria-label="Live pattern"></canvas>'), 'artifact compiler omits runtime canvas markup from serialized blocks');
 $assert(! str_contains($decorativeCanvasMarkup, 'hero-canvas'), 'artifact compiler omits decorative canvas touched by script without canvas API usage');
 $assert(1 === count($decorativeCanvasFallbacks), 'artifact compiler records one runtime canvas fallback for the interactive canvas only');
 $assert('lab-canvas' === ($decorativeCanvasFallbacks[0]['attributes']['id'] ?? ''), 'runtime canvas fallback provenance points to the interactive canvas');
 $assert(1 === count($decorativeCanvasSite['source_reports']['runtime_islands'] ?? array()), 'decorative canvas is not over-reported as a runtime island');
 $assert('#lab-canvas' === ($decorativeCanvasSite['source_reports']['runtime_islands'][0]['selector'] ?? ''), 'runtime island provenance points to the interactive canvas');
+$assert(str_contains((string) ($decorativeCanvasSite['source_reports']['runtime_islands'][0]['source_snippet'] ?? ''), '<canvas id="lab-canvas" class="stage" aria-label="Live pattern"></canvas>'), 'artifact compiler preserves direct canvas API target as runtime island metadata');
 
 $runtimeTargetContainerSite = $compiler->compile(
     array(

--- a/php-transformer/tests/fixtures/parity/unsupported-fallback.json
+++ b/php-transformer/tests/fixtures/parity/unsupported-fallback.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "unsupported-html-fallback",
-  "description": "Reports runtime-targeted native canvas HTML as runtime-critical fallback metadata.",
+  "description": "Reports runtime-targeted native canvas HTML as runtime-critical fallback metadata without materializing an unsafe core/html block.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/smoke-unsupported-html-fallback-hook.php",
@@ -18,22 +18,25 @@
       "runtime_canvas_selectors": ["#runtime-canvas"]
     }
   },
-  "expected_blocks": [
-    { "path": "blocks.0", "name": "core/html", "attrs": { "content": "<canvas id=\"runtime-canvas\"><p>Fallback content</p></canvas>" } }
-  ],
+  "expected_blocks": [],
   "expected_fallbacks": [
     { "type": "html", "reason": "canvas_requires_runtime", "diagnostic_code": "html_canvas_runtime_fallback", "tag": "canvas", "selector": "canvas:nth-of-type(1)", "child_count": 1 }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/html" },
+    { "path": "blocks", "assert": "count", "count": 0 },
     { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "fallbacks.0.type", "assert": "equals", "value": "html" },
     { "path": "fallbacks.0.reason", "assert": "equals", "value": "canvas_requires_runtime" },
     { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_canvas_runtime_fallback" },
     { "path": "fallbacks.0.tag", "assert": "equals", "value": "canvas" },
     { "path": "fallbacks.0.selector", "assert": "equals", "value": "canvas:nth-of-type(1)" },
+    { "path": "source_reports.html.runtime_islands", "assert": "count", "count": 1 },
+    { "path": "source_reports.html.runtime_islands.0.kind", "assert": "equals", "value": "canvas" },
+    { "path": "source_reports.html.runtime_islands.0.selector", "assert": "equals", "value": "#runtime-canvas" },
+    { "path": "source_reports.html.runtime_islands.0.source_snippet", "assert": "contains", "value": "<canvas id=\"runtime-canvas\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<canvas" },
     { "path": "diagnostics.1.selector", "assert": "equals", "value": "canvas:nth-of-type(1)" },
     { "path": "diagnostics.0.code", "assert": "equals", "value": "html_to_blocks_core_slice" }
   ]


### PR DESCRIPTION
## Summary
- Stop materializing runtime-targeted `<canvas>` elements as serialized `core/html` blocks.
- Keep the existing bounded fallback metadata and `runtime_islands` report for canvas runtime mapping.
- Update the canvas parity fixture to assert no emitted `wp:html`/`<canvas>` markup while preserving the runtime island and fallback diagnostic.

## Evidence
- Latest SSI matrix run: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/8e954bd5-b29e-41e1-b77a-2d081d33a355-matrix.json
- Finding packets: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/a55abe62-56a5-4820-aacb-1fc573bf84fa-finding-packets.json
- Target family: `fallback_block:core_html_block:canvas`, count 17

## Tests
- `php tests/parity/run.php` from `php-transformer` passed: 113 fixture(s)

## Expected impact
- Reduces inappropriate serialized `core/html` canvas fallback blocks for fixtures where canvas behavior is runtime-owned.
- Preserves bounded canvas metadata for downstream runtime island handling instead of losing the selector/script context.
- Expected to address the `fallback_block:core_html_block:canvas` family in fixtures such as `43-interactive-space-explorer`, `51-cursed-arg-site`, `55-algorithm-visualizer`, `57-webgl-shader-gallery`, and `58-infinite-whiteboard` without fixture-specific rules.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Interpreting SSI fixture matrix evidence, implementing the transformer change, updating focused parity coverage, and drafting this PR description.
