### PR TITLE
Add typography visual-parity probe (closes #200)

### DIFF
--- a/php-transformer/src/VisualParity/TypographyVisualProbe.php
+++ b/php-transformer/src/VisualParity/TypographyVisualProbe.php
@@ -1,0 +1,405 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\VisualParity;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+
+/**
+ * Extracts normalized typography probes (heading + body roles) from rendered
+ * HTML so source and target renders can be compared for font-family,
+ * font-weight, and type-scale fidelity.
+ *
+ * Mirrors {@see ButtonMenuVisualProbe}: a generic, self-contained extractor
+ * that emits the shared visual-parity probe envelope. No fixture-specific
+ * strings or assumptions.
+ */
+final class TypographyVisualProbe
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/visual-parity-probes/v1';
+
+    /**
+     * Inheritable typography properties resolved from the nearest ancestor when
+     * the element itself does not declare them (mirrors CSS inheritance for the
+     * font shorthand family).
+     */
+    private const INHERITABLE_FIELDS = array(
+        'font-family',
+        'font-style',
+        'font-weight',
+        'letter-spacing',
+        'line-height',
+        'text-transform',
+    );
+
+    private const TYPOGRAPHY_FIELDS = array(
+        'font-family',
+        'font-size',
+        'font-style',
+        'font-weight',
+        'letter-spacing',
+        'line-height',
+        'text-decoration',
+        'text-transform',
+    );
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function extract(string $html): array
+    {
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $sourceHtml = preg_match('/<(?:!doctype|html|head|body)\b/i', $html) ? $html : '<body>' . $this->bodyHtml($html) . '</body>';
+        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?>' . $sourceHtml, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        if ( ! $loaded ) {
+            return array(
+                'schema' => self::SCHEMA,
+                'status' => 'failed',
+                'probes' => array(),
+                'summary' => array(
+                    'total' => 0,
+                    'by_role' => array(),
+                    'type_scale' => array(),
+                    'font_families' => array(),
+                ),
+                'diagnostics' => array(
+                    array(
+                        'code' => 'html_parse_failed',
+                        'message' => 'Unable to parse HTML for typography probes.',
+                    ),
+                ),
+            );
+        }
+
+        $body = $document->getElementsByTagName('body')->item(0);
+        if ( ! $body instanceof DOMElement ) {
+            return $this->result(array());
+        }
+
+        $rules = $this->styleRules($document);
+        $xpath = new DOMXPath($document);
+        $nodes = $xpath->query('//h1|//h2|//h3|//h4|//h5|//h6|//p');
+        $probes = array();
+        $seen = array();
+
+        if ( false !== $nodes ) {
+            foreach ( $nodes as $node ) {
+                if ( ! $node instanceof DOMElement || $this->isInsideStyleOrScript($node) ) {
+                    continue;
+                }
+
+                $text = $this->normalizedText($node);
+                if ( '' === $text ) {
+                    continue;
+                }
+
+                $selector = $this->selector($node);
+                if ( isset($seen[$selector]) ) {
+                    continue;
+                }
+                $seen[$selector] = true;
+
+                $tag = strtolower($node->tagName);
+                $isHeading = preg_match('/^h([1-6])$/', $tag, $match) === 1;
+
+                $probe = array(
+                    'id' => 'typography-probe-' . ( count($probes) + 1 ),
+                    'role' => $isHeading ? 'heading' : 'body',
+                    'level' => $isHeading ? (int) $match[1] : 0,
+                    'tag' => $tag,
+                    'selector' => $selector,
+                    'text' => mb_substr($text, 0, 120),
+                );
+
+                $typography = $this->computedTypography($node, $rules);
+                if ( array() !== $typography ) {
+                    $probe['typography'] = $typography;
+                }
+
+                $probes[] = $probe;
+            }
+        }
+
+        return $this->result($probes);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $probes
+     * @return array<string, mixed>
+     */
+    private function result(array $probes): array
+    {
+        $byRole = array();
+        $typeScale = array();
+        $fontFamilies = array();
+        foreach ( $probes as $probe ) {
+            $role = (string) ($probe['role'] ?? 'unknown');
+            $byRole[$role] = ($byRole[$role] ?? 0) + 1;
+
+            $typography = is_array($probe['typography'] ?? null) ? $probe['typography'] : array();
+            $tag = (string) ($probe['tag'] ?? '');
+            if ( isset($typography['font-size']) && '' !== (string) $typography['font-size'] && ! isset($typeScale[$tag]) ) {
+                $typeScale[$tag] = (string) $typography['font-size'];
+            }
+            if ( isset($typography['font-family']) && '' !== (string) $typography['font-family'] ) {
+                $fontFamilies[(string) $typography['font-family']] = true;
+            }
+        }
+        ksort($byRole);
+        ksort($typeScale);
+        $families = array_keys($fontFamilies);
+        sort($families);
+
+        return array(
+            'schema' => self::SCHEMA,
+            'status' => 'success',
+            'probes' => $probes,
+            'summary' => array(
+                'total' => count($probes),
+                'by_role' => $byRole,
+                'type_scale' => $typeScale,
+                'font_families' => $families,
+            ),
+            'diagnostics' => array(),
+        );
+    }
+
+    private function bodyHtml(string $html): string
+    {
+        if ( preg_match('/<body\b[^>]*>(.*?)<\/body>/is', $html, $match) ) {
+            return (string) $match[1];
+        }
+
+        return $html;
+    }
+
+    /**
+     * Resolves the typography style for an element, applying CSS inheritance for
+     * inheritable properties from the nearest ancestor that declares them.
+     *
+     * @param array<int, array{selector: string, declarations: array<string, string>}> $rules
+     * @return array<string, string>
+     */
+    private function computedTypography(DOMElement $element, array $rules): array
+    {
+        $style = $this->computedStyle($element, $rules);
+
+        foreach ( self::INHERITABLE_FIELDS as $field ) {
+            if ( isset($style[$field]) && '' !== trim($style[$field]) ) {
+                continue;
+            }
+            for ( $node = $element->parentNode; $node instanceof DOMElement; $node = $node->parentNode ) {
+                $ancestor = $this->computedStyle($node, $rules);
+                if ( isset($ancestor[$field]) && '' !== trim($ancestor[$field]) ) {
+                    $style[$field] = $ancestor[$field];
+                    break;
+                }
+            }
+        }
+
+        ksort($style);
+
+        return $style;
+    }
+
+    /**
+     * @param array<int, array{selector: string, declarations: array<string, string>}> $rules
+     * @return array<string, string>
+     */
+    private function computedStyle(DOMElement $element, array $rules): array
+    {
+        $style = array();
+        foreach ( $rules as $rule ) {
+            if ( $this->matchesSimpleSelector($element, $rule['selector']) ) {
+                $style = array_merge($style, $rule['declarations']);
+            }
+        }
+
+        if ( $element->hasAttribute('style') ) {
+            $style = array_merge($style, $this->declarations($element->getAttribute('style')));
+        }
+
+        $style = array_intersect_key($style, array_flip(self::TYPOGRAPHY_FIELDS));
+        ksort($style);
+
+        return $style;
+    }
+
+    /**
+     * @return array<int, array{selector: string, declarations: array<string, string>}>
+     */
+    private function styleRules(DOMDocument $document): array
+    {
+        $rules = array();
+        foreach ( $document->getElementsByTagName('style') as $style ) {
+            $css = (string) $style->textContent;
+            if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
+                continue;
+            }
+            foreach ( $matches as $match ) {
+                foreach ( explode(',', (string) $match[1]) as $selector ) {
+                    $selector = trim($selector);
+                    if ( '' === $selector ) {
+                        continue;
+                    }
+                    $rules[] = array(
+                        'selector' => $selector,
+                        'declarations' => $this->declarations((string) $match[2]),
+                    );
+                }
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function declarations(string $style): array
+    {
+        $declarations = array();
+        foreach ( explode(';', $style) as $declaration ) {
+            if ( ! str_contains($declaration, ':') ) {
+                continue;
+            }
+            [$name, $value] = array_map('trim', explode(':', $declaration, 2));
+            $name = strtolower($name);
+            if ( '' !== $name && '' !== $value ) {
+                $declarations[$name] = preg_replace('/\s+/', ' ', $value) ?? $value;
+            }
+        }
+
+        return $declarations;
+    }
+
+    private function matchesSimpleSelector(DOMElement $element, string $selector): bool
+    {
+        $selector = trim(preg_replace('/:(hover|focus|active|visited|before|after)\b.*/', '', $selector) ?? $selector);
+        if ( '' === $selector || str_contains($selector, '>') || str_contains($selector, '+') || str_contains($selector, '~') ) {
+            return false;
+        }
+
+        if ( str_contains($selector, ' ') ) {
+            return $this->matchesDescendantSelector($element, $selector);
+        }
+
+        if ( preg_match('/^#([A-Za-z0-9_-]+)$/', $selector, $match) ) {
+            return $element->hasAttribute('id') && $element->getAttribute('id') === $match[1];
+        }
+
+        if ( preg_match('/^\.([A-Za-z0-9_-]+)$/', $selector, $match) ) {
+            return in_array($match[1], $this->tokens($element->hasAttribute('class') ? $element->getAttribute('class') : ''), true);
+        }
+
+        if ( preg_match('/^([A-Za-z0-9_-]+)(\.[A-Za-z0-9_-]+)+$/', $selector) ) {
+            $parts = explode('.', $selector);
+            $tag = array_shift($parts);
+            if ( strtolower((string) $tag) !== strtolower($element->tagName) ) {
+                return false;
+            }
+            $classes = $this->tokens($element->hasAttribute('class') ? $element->getAttribute('class') : '');
+            foreach ( $parts as $class ) {
+                if ( ! in_array($class, $classes, true) ) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return strtolower($selector) === strtolower($element->tagName);
+    }
+
+    private function matchesDescendantSelector(DOMElement $element, string $selector): bool
+    {
+        $parts = preg_split('/\s+/', trim($selector)) ?: array();
+        if ( array() === $parts || ! $this->matchesSimpleSelector($element, array_pop($parts)) ) {
+            return false;
+        }
+
+        $current = $element->parentNode instanceof DOMElement ? $element->parentNode : null;
+        for ( $index = count($parts) - 1; $index >= 0; --$index ) {
+            $matched = false;
+            for ( $node = $current; $node instanceof DOMElement; $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null ) {
+                if ( $this->matchesSimpleSelector($node, $parts[$index]) ) {
+                    $matched = true;
+                    $current = $node->parentNode instanceof DOMElement ? $node->parentNode : null;
+                    break;
+                }
+            }
+            if ( ! $matched ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function selector(DOMElement $element): string
+    {
+        $segments = array();
+        for ( $node = $element; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); $node = $node->parentNode ) {
+            $segment = strtolower($node->tagName);
+            if ( $node->hasAttribute('id') && '' !== trim($node->getAttribute('id')) ) {
+                $segment .= '#' . trim($node->getAttribute('id'));
+                array_unshift($segments, $segment);
+                break;
+            }
+            $classes = $this->tokens($node->hasAttribute('class') ? $node->getAttribute('class') : '');
+            if ( array() !== $classes ) {
+                $segment .= '.' . implode('.', array_slice($classes, 0, 2));
+            }
+            $index = $this->elementIndex($node);
+            if ( $index > 1 ) {
+                $segment .= ':nth-of-type(' . $index . ')';
+            }
+            array_unshift($segments, $segment);
+        }
+
+        return implode(' > ', $segments);
+    }
+
+    private function elementIndex(DOMElement $element): int
+    {
+        $index = 1;
+        for ( $node = $element->previousSibling; $node instanceof DOMNode; $node = $node->previousSibling ) {
+            if ( $node instanceof DOMElement && strtolower($node->tagName) === strtolower($element->tagName) ) {
+                ++$index;
+            }
+        }
+
+        return $index;
+    }
+
+    private function normalizedText(DOMElement $element): string
+    {
+        return trim(preg_replace('/\s+/', ' ', html_entity_decode((string) $element->textContent, ENT_QUOTES | ENT_HTML5)) ?? '');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function tokens(string $value): array
+    {
+        return array_values(array_filter(preg_split('/\s+/', trim($value)) ?: array(), static fn (string $token): bool => '' !== $token));
+    }
+
+    private function isInsideStyleOrScript(DOMElement $element): bool
+    {
+        for ( $node = $element->parentNode; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( in_array(strtolower($node->tagName), array( 'script', 'style' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/php-transformer/src/VisualParity/TypographyVisualProbeComparator.php
+++ b/php-transformer/src/VisualParity/TypographyVisualProbeComparator.php
@@ -1,0 +1,332 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\VisualParity;
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\VisualParityReportContract;
+
+/**
+ * Compares source and target typography probe sets and emits a
+ * {@see VisualParityReportContract::REPORT_SCHEMA} report: typography matches
+ * (component kind "generic"), findings when font-family / font-weight / type
+ * scale drift between source and target, and aligned recommendations.
+ *
+ * Mirrors the additive shape of {@see ButtonMenuVisualProbeComparator} while
+ * going one step further by emitting through the shared visual-parity report
+ * contract. Generic; no fixture-specific assumptions.
+ */
+final class TypographyVisualProbeComparator
+{
+    /**
+     * Typography properties compared between matched source/target probes.
+     * Each entry maps the probe property to the report category label.
+     */
+    private const COMPARED_PROPERTIES = array(
+        'font-family' => 'family',
+        'font-weight' => 'weight',
+        'font-size' => 'scale',
+    );
+
+    /**
+     * @param array<string, mixed> $source
+     * @param array<string, mixed> $target
+     * @return array<string, mixed>
+     */
+    public function compare(array $source, array $target): array
+    {
+        $sourceProbes = $this->probes($source);
+        $targetProbes = $this->probes($target);
+        $available = array_fill_keys(array_keys($targetProbes), true);
+
+        $matches = array();
+        $findings = array();
+        $recommendations = array();
+        $unmatchedSource = array();
+
+        foreach ( $sourceProbes as $sourceProbe ) {
+            $targetIndex = $this->bestTargetIndex($sourceProbe, $targetProbes, $available);
+            if ( null === $targetIndex ) {
+                $unmatchedSource[] = $this->candidateSummary($sourceProbe);
+                $finding = $this->missingRoleFinding($sourceProbe, count($findings) + 1);
+                $recommendation = $this->recommendationFor($finding, count($recommendations) + 1);
+                $finding['recommendation_ids'] = array($recommendation['id']);
+                $findings[] = $finding;
+                $recommendations[] = $recommendation;
+                continue;
+            }
+
+            unset($available[$targetIndex]);
+            $targetProbe = $targetProbes[$targetIndex];
+
+            $deltas = $this->typographyDeltas($sourceProbe, $targetProbe);
+            $match = array(
+                'kind' => 'generic',
+                'source_selector' => $this->selector($sourceProbe),
+                'target_selector' => $this->selector($targetProbe),
+                'confidence' => $this->confidence($sourceProbe, $targetProbe),
+                'typography' => array_filter(array(
+                    'role' => (string) ($sourceProbe['role'] ?? ''),
+                    'level' => (int) ($sourceProbe['level'] ?? 0),
+                    'source' => $this->typography($sourceProbe),
+                    'target' => $this->typography($targetProbe),
+                    'deltas' => $deltas,
+                ), static fn ($value): bool => array() !== $value && '' !== $value),
+            );
+            $matches[] = $match;
+
+            foreach ( $deltas as $delta ) {
+                $finding = $this->deltaFinding($sourceProbe, $delta, count($findings) + 1);
+                $recommendation = $this->recommendationFor($finding, count($recommendations) + 1);
+                $finding['recommendation_ids'] = array($recommendation['id']);
+                $findings[] = $finding;
+                $recommendations[] = $recommendation;
+            }
+        }
+
+        $hasFindings = array() !== $findings;
+        $report = array(
+            'schema' => VisualParityReportContract::REPORT_SCHEMA,
+            'status' => $hasFindings ? 'warning' : 'pass',
+            'severity' => $hasFindings ? 'warning' : 'none',
+            'source_render' => array('kind' => 'source', 'renderer' => 'php-transformer'),
+            'target_render' => array('kind' => 'target', 'renderer' => 'php-transformer'),
+            'viewports' => array(),
+            'matches' => $matches,
+            'findings' => $findings,
+            'recommendations' => $recommendations,
+            'summary' => array(
+                'source_total' => count($sourceProbes),
+                'target_total' => count($targetProbes),
+                'matched_total' => count($matches),
+                'unmatched_source_total' => count($unmatchedSource),
+                'finding_total' => count($findings),
+            ),
+            'unmatched_source' => $unmatchedSource,
+            'diagnostics' => array(),
+        );
+
+        return $report;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     * @return array<int, array<string, mixed>>
+     */
+    private function probes(array $result): array
+    {
+        $probes = $result['probes'] ?? array();
+        return is_array($probes) ? array_values(array_filter($probes, 'is_array')) : array();
+    }
+
+    /**
+     * @param array<string, mixed> $sourceProbe
+     * @param array<int, array<string, mixed>> $targetProbes
+     * @param array<int, bool> $available
+     */
+    private function bestTargetIndex(array $sourceProbe, array $targetProbes, array $available): ?int
+    {
+        $bestIndex = null;
+        $bestScore = 0;
+        foreach ( array_keys($available) as $index ) {
+            $score = $this->matchScore($sourceProbe, $targetProbes[$index]);
+            if ( $score > $bestScore ) {
+                $bestScore = $score;
+                $bestIndex = $index;
+            }
+        }
+
+        return $bestScore >= 3 ? $bestIndex : null;
+    }
+
+    /**
+     * @param array<string, mixed> $sourceProbe
+     * @param array<string, mixed> $targetProbe
+     */
+    private function matchScore(array $sourceProbe, array $targetProbe): int
+    {
+        if ( (string) ($sourceProbe['role'] ?? '') !== (string) ($targetProbe['role'] ?? '') ) {
+            return 0;
+        }
+
+        $score = 3;
+        if ( (int) ($sourceProbe['level'] ?? 0) === (int) ($targetProbe['level'] ?? 0) ) {
+            $score += 2;
+        }
+        if ( '' !== $this->normalizedText($sourceProbe) && $this->normalizedText($sourceProbe) === $this->normalizedText($targetProbe) ) {
+            $score += 5;
+        }
+
+        return $score;
+    }
+
+    private function confidence(array $sourceProbe, array $targetProbe): float
+    {
+        $score = $this->matchScore($sourceProbe, $targetProbe);
+        return round(min(1.0, $score / 10), 2);
+    }
+
+    /**
+     * @param array<string, mixed> $sourceProbe
+     * @param array<string, mixed> $targetProbe
+     * @return array<int, array<string, string>>
+     */
+    private function typographyDeltas(array $sourceProbe, array $targetProbe): array
+    {
+        $sourceStyle = $this->typography($sourceProbe);
+        $targetStyle = $this->typography($targetProbe);
+        $deltas = array();
+
+        foreach ( self::COMPARED_PROPERTIES as $property => $group ) {
+            $sourceValue = $this->normalizeValue($property, (string) ($sourceStyle[$property] ?? ''));
+            $targetValue = $this->normalizeValue($property, (string) ($targetStyle[$property] ?? ''));
+            if ( '' === $sourceValue || $sourceValue === $targetValue ) {
+                continue;
+            }
+
+            $deltas[] = array(
+                'group' => $group,
+                'property' => $property,
+                'source' => (string) ($sourceStyle[$property] ?? ''),
+                'target' => (string) ($targetStyle[$property] ?? ''),
+            );
+        }
+
+        return $deltas;
+    }
+
+    /**
+     * @param array<string, mixed> $sourceProbe
+     * @param array<string, string> $delta
+     * @return array<string, mixed>
+     */
+    private function deltaFinding(array $sourceProbe, array $delta, int $sequence): array
+    {
+        $label = $this->roleLabel($sourceProbe);
+        $target = '' === $delta['target'] ? 'no declared value' : $delta['target'];
+
+        return array(
+            'id' => 'typography-' . $delta['group'] . '-' . $sequence,
+            'severity' => 'warning',
+            'category' => 'typography',
+            'summary' => sprintf('%s %s changed from "%s" to "%s".', $label, $delta['property'], $delta['source'], $target),
+            'kind' => 'generic',
+            'property' => $delta['property'],
+            'source_value' => $delta['source'],
+            'target_value' => $delta['target'],
+            'selector' => $this->selector($sourceProbe),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $sourceProbe
+     * @return array<string, mixed>
+     */
+    private function missingRoleFinding(array $sourceProbe, int $sequence): array
+    {
+        $label = $this->roleLabel($sourceProbe);
+
+        return array(
+            'id' => 'typography-missing-' . $sequence,
+            'severity' => 'warning',
+            'category' => 'typography',
+            'summary' => sprintf('%s present in source has no matching target element.', $label),
+            'kind' => 'generic',
+            'property' => 'presence',
+            'selector' => $this->selector($sourceProbe),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $finding
+     * @return array<string, mixed>
+     */
+    private function recommendationFor(array $finding, int $sequence): array
+    {
+        $property = (string) ($finding['property'] ?? 'typography');
+        $summary = 'presence' === $property
+            ? 'Restore the missing typographic element so source and target structure match.'
+            : sprintf('Align the target %s with the source typography treatment.', $property);
+
+        return array(
+            'id' => 'rec-typography-' . $sequence,
+            'priority' => 'medium',
+            'summary' => $summary,
+            'finding_ids' => array((string) $finding['id']),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $probe
+     * @return array<string, string>
+     */
+    private function typography(array $probe): array
+    {
+        $style = $probe['typography'] ?? array();
+        return is_array($style) ? array_filter($style, 'is_string') : array();
+    }
+
+    private function normalizeValue(string $property, string $value): string
+    {
+        $value = strtolower(trim(preg_replace('/\s+/', ' ', $value) ?? $value));
+        if ( '' === $value ) {
+            return '';
+        }
+
+        if ( 'font-family' === $property ) {
+            $value = str_replace(array('"', "'"), '', $value);
+            $value = preg_replace('/\s*,\s*/', ',', $value) ?? $value;
+            return $value;
+        }
+
+        if ( 'font-weight' === $property ) {
+            return array(
+                'normal' => '400',
+                'bold' => '700',
+                'lighter' => '300',
+                'bolder' => '700',
+            )[$value] ?? $value;
+        }
+
+        return $value;
+    }
+
+    /** @param array<string, mixed> $probe */
+    private function roleLabel(array $probe): string
+    {
+        $role = (string) ($probe['role'] ?? 'text');
+        if ( 'heading' === $role ) {
+            $level = (int) ($probe['level'] ?? 0);
+            return $level > 0 ? 'Heading level ' . $level : 'Heading';
+        }
+
+        return ucfirst($role);
+    }
+
+    /**
+     * @param array<string, mixed> $probe
+     * @return array<string, mixed>
+     */
+    private function candidateSummary(array $probe): array
+    {
+        return array_filter(array(
+            'id' => $probe['id'] ?? null,
+            'role' => $probe['role'] ?? null,
+            'level' => $probe['level'] ?? null,
+            'text' => $probe['text'] ?? null,
+            'selector' => $probe['selector'] ?? null,
+        ), static fn ($value): bool => null !== $value && '' !== $value);
+    }
+
+    /** @param array<string, mixed> $probe */
+    private function selector(array $probe): string
+    {
+        $selector = trim((string) ($probe['selector'] ?? ''));
+        return '' !== $selector ? $selector : (string) ($probe['tag'] ?? '');
+    }
+
+    /** @param array<string, mixed> $probe */
+    private function normalizedText(array $probe): string
+    {
+        return strtolower(trim(preg_replace('/\s+/', ' ', (string) ($probe['text'] ?? '')) ?? ''));
+    }
+}

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -18,6 +18,8 @@ use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationView;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\TypographyVisualProbe;
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\TypographyVisualProbeComparator;
 
 if ( ! function_exists('serialize_blocks') ) {
     /**
@@ -191,6 +193,35 @@ try {
 } catch ( \InvalidArgumentException $exception ) {
     $assert(str_contains($exception->getMessage(), 'unsupported component kind'), 'visual parity report rejects product-specific match kinds', $exception->getMessage());
 }
+
+// Typography visual probe comparator emits reports through the shared
+// VisualParityReportContract: findings when source vs target typography drifts,
+// none when they align.
+$typographyProbe = new TypographyVisualProbe();
+$typographyComparator = new TypographyVisualProbeComparator();
+$typographySource = '<style>body{font-family:"Inter",sans-serif}h1{font-family:"Playfair Display",serif;font-size:48px;font-weight:700}p{font-size:18px}</style><body><article><h1>Welcome Home</h1><p>Intro body copy here.</p></article></body>';
+$typographyTarget = '<style>body{font-family:Arial,sans-serif}h1{font-size:32px;font-weight:400}p{font-size:18px}</style><body><article><h1>Welcome Home</h1><p>Intro body copy here.</p></article></body>';
+
+$typographyMismatchReport = $typographyComparator->compare(
+    $typographyProbe->extract($typographySource),
+    $typographyProbe->extract($typographyTarget)
+);
+VisualParityReportContract::assertReport($typographyMismatchReport);
+$assert(VisualParityReportContract::REPORT_SCHEMA === ($typographyMismatchReport['schema'] ?? ''), 'typography probe emits the visual parity report contract schema');
+$assert('warning' === ($typographyMismatchReport['status'] ?? ''), 'typography probe report warns when source vs target typography differs');
+$assert(count($typographyMismatchReport['findings'] ?? array()) > 0, 'typography probe emits findings on typography drift');
+$typographyCategories = array_map(static fn (array $finding): string => (string) ($finding['category'] ?? ''), $typographyMismatchReport['findings'] ?? array());
+$assert(in_array('typography', $typographyCategories, true), 'typography probe findings use the typography category');
+$typographyMatchKinds = array_map(static fn (array $match): string => (string) ($match['kind'] ?? ''), $typographyMismatchReport['matches'] ?? array());
+$assert(array() === array_diff($typographyMatchKinds, array('generic')), 'typography probe matches use the generic component kind');
+
+$typographyMatchReport = $typographyComparator->compare(
+    $typographyProbe->extract($typographySource),
+    $typographyProbe->extract($typographySource)
+);
+VisualParityReportContract::assertReport($typographyMatchReport);
+$assert('pass' === ($typographyMatchReport['status'] ?? ''), 'typography probe report passes when source and target typography match');
+$assert(array() === ($typographyMatchReport['findings'] ?? array('non-empty')), 'typography probe emits no findings when typography matches');
 
 $assert('assets/logo.png' === ArtifactPath::safeRelativePath(' ./assets//logo.png '), 'artifact paths trim relative markers and duplicate separators');
 $assert('' === ArtifactPath::safeRelativePath('/assets/logo.png'), 'artifact paths reject root-absolute paths');

--- a/php-transformer/tests/fixtures/parity/visual-parity-typography-compare-match.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-typography-compare-match.json
@@ -1,0 +1,26 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-typography-compare-match",
+  "description": "Compares matching source and target typography probes and emits a passing contract visual-parity report with no findings when font-family, weight, and type scale align.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-typography-compare-match.json",
+    "notes": "Generic PHP-boundary typography comparison; verifies a clean pass through the visual-parity report contract."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Typography comparison output is a diagnostic contract for visual parity review."
+  },
+  "operation": "typography_parity_probe.compare",
+  "input": {
+    "source_content": "<style>body{font-family:\"Inter\",sans-serif}h1{font-family:\"Playfair Display\",serif;font-size:48px;font-weight:700}p{font-size:18px}</style><body><article><h1>Welcome Home</h1><p>Some intro body copy here.</p></article></body>",
+    "target_content": "<style>body{font-family:'Inter', sans-serif}h1{font-family:'Playfair Display', serif;font-size:48px;font-weight:bold}p{font-size:18px}</style><body><section><h1>Welcome Home</h1><p>Some intro body copy here.</p></section></body>"
+  },
+  "expect": [
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/visual-parity-report/v1" },
+    { "path": "status", "assert": "equals", "value": "pass" },
+    { "path": "severity", "assert": "equals", "value": "none" },
+    { "path": "summary.matched_total", "assert": "equals", "value": 2 },
+    { "path": "summary.finding_total", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/visual-parity-typography-compare-mismatch.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-typography-compare-mismatch.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-typography-compare-mismatch",
+  "description": "Compares source and target typography probes and emits a contract visual-parity report with findings when heading/body font-family, weight, and type scale drift.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-typography-compare-mismatch.json",
+    "notes": "Generic PHP-boundary typography comparison; emits the shared visual-parity report contract."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Typography comparison output is a diagnostic contract for visual parity review."
+  },
+  "operation": "typography_parity_probe.compare",
+  "input": {
+    "source_content": "<style>body{font-family:\"Inter\",sans-serif}h1{font-family:\"Playfair Display\",serif;font-size:48px;font-weight:700}p{font-size:18px}</style><body><article><h1>Welcome Home</h1><p>Some intro body copy here.</p></article></body>",
+    "target_content": "<style>body{font-family:Arial,sans-serif}h1{font-size:32px;font-weight:400}p{font-size:18px}</style><body><article><h1>Welcome Home</h1><p>Some intro body copy here.</p></article></body>"
+  },
+  "expect": [
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/visual-parity-report/v1" },
+    { "path": "status", "assert": "equals", "value": "warning" },
+    { "path": "severity", "assert": "equals", "value": "warning" },
+    { "path": "summary.matched_total", "assert": "equals", "value": 2 },
+    { "path": "summary.finding_total", "assert": "equals", "value": 4 },
+    { "path": "matches.0.kind", "assert": "equals", "value": "generic" },
+    { "path": "matches.0.typography.deltas.0.group", "assert": "equals", "value": "family" },
+    { "path": "matches.0.typography.deltas.1.group", "assert": "equals", "value": "weight" },
+    { "path": "matches.0.typography.deltas.2.group", "assert": "equals", "value": "scale" },
+    { "path": "findings.0.category", "assert": "equals", "value": "typography" },
+    { "path": "findings.0.property", "assert": "equals", "value": "font-family" },
+    { "path": "recommendations.0.finding_ids.0", "assert": "equals", "value": "typography-family-1" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/visual-parity-typography-extract.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-typography-extract.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "visual-parity-typography-extract",
+  "description": "Extracts normalized heading and body typography probes (font-family, font-weight, type scale) from rendered HTML, including inherited body font-family.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/visual-parity-typography-extract.json",
+    "notes": "Generic typography visual probe fixture; not coupled to any source site."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Probe output is a new upstream diagnostic surface."
+  },
+  "operation": "typography_parity_probe.extract",
+  "input": {
+    "content": "<style>body{font-family:\"Inter\",sans-serif}h1{font-family:\"Playfair Display\",serif;font-size:48px;font-weight:700;text-transform:uppercase}p{font-size:18px;line-height:1.6}</style><body><article><h1>Welcome Home</h1><p>Some intro body copy here.</p></article></body>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/visual-parity-probes/v1" },
+    { "path": "summary.total", "assert": "equals", "value": 2 },
+    { "path": "summary.by_role.heading", "assert": "equals", "value": 1 },
+    { "path": "summary.by_role.body", "assert": "equals", "value": 1 },
+    { "path": "summary.type_scale.h1", "assert": "equals", "value": "48px" },
+    { "path": "probes.0.role", "assert": "equals", "value": "heading" },
+    { "path": "probes.0.level", "assert": "equals", "value": 1 },
+    { "path": "probes.0.typography.font-family", "assert": "equals", "value": "\"Playfair Display\",serif" },
+    { "path": "probes.0.typography.font-weight", "assert": "equals", "value": "700" },
+    { "path": "probes.0.typography.text-transform", "assert": "equals", "value": "uppercase" },
+    { "path": "probes.1.role", "assert": "equals", "value": "body" },
+    { "path": "probes.1.typography.font-family", "assert": "equals", "value": "\"Inter\",sans-serif" },
+    { "path": "probes.1.typography.font-size", "assert": "equals", "value": "18px" }
+  ]
+}

--- a/php-transformer/tests/parity/run.php
+++ b/php-transformer/tests/parity/run.php
@@ -8,6 +8,8 @@ use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\VisualParity\ButtonMenuVisualProbe;
 use Automattic\BlocksEngine\PhpTransformer\VisualParity\ButtonMenuVisualProbeComparator;
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\TypographyVisualProbe;
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\TypographyVisualProbeComparator;
 
 if ( in_array('--legacy-child', $argv ?? array(), true) ) {
     runLegacyChildProcess();
@@ -308,6 +310,20 @@ function runFixture(array $fixture): array
             $probe->extract((string) ($input['source_content'] ?? '')),
             $probe->extract((string) ($input['target_content'] ?? ''))
         );
+    }
+
+    if ( 'typography_parity_probe.extract' === $fixture['operation'] ) {
+        return ( new TypographyVisualProbe() )->extract((string) ($input['content'] ?? ''));
+    }
+
+    if ( 'typography_parity_probe.compare' === $fixture['operation'] ) {
+        $probe = new TypographyVisualProbe();
+        $report = ( new TypographyVisualProbeComparator() )->compare(
+            $probe->extract((string) ($input['source_content'] ?? '')),
+            $probe->extract((string) ($input['target_content'] ?? ''))
+        );
+        \Automattic\BlocksEngine\PhpTransformer\Contract\VisualParityReportContract::assertReport($report);
+        return $report;
     }
 
     fail("Fixture {$fixture['name']} declares unsupported operation: {$fixture['operation']}");


### PR DESCRIPTION
Closes #200

## What

The visual-parity engine (`php-transformer/src/VisualParity/`) had a real, contracted engine but shipped exactly one probe (`ButtonMenuVisualProbe` + comparator), so rendered typography fidelity was unmeasured. This adds a generic typography probe and wires it through the existing `VisualParityReportContract`.

## Changes

- **`TypographyVisualProbe`** — extracts normalized heading (`h1`–`h6`) and body (`p`) typography probes: `font-family`, `font-weight`, type scale (`font-size`), plus `line-height`/`letter-spacing`/`text-transform`. Resolves CSS inheritance for inheritable properties (e.g. body `font-family`) by walking ancestors. Emits the shared `visual-parity-probes/v1` envelope with a `summary` (by_role, type_scale, font_families). Self-contained and generic, mirroring `ButtonMenuVisualProbe`.
- **`TypographyVisualProbeComparator`** — matches source vs target probes by role + level and emits a report through `VisualParityReportContract::REPORT_SCHEMA`: matches with component kind `generic`, `typography` findings (font-family / font-weight / type-scale drift, plus missing-element gaps), and aligned recommendations. Normalizes font-family quoting/spacing and weight keywords (`bold`→`700`) so equivalent declarations don't false-positive.
- Registered additively in `tests/parity/run.php` as new operations `typography_parity_probe.extract` / `.compare` (the compare branch asserts the report against the contract), exactly as `ButtonMenu` is wired, so future probes compose.

## Tests

- New parity fixtures: `visual-parity-typography-extract`, `visual-parity-typography-compare-mismatch` (emits findings), `visual-parity-typography-compare-match` (no findings).
- New `tests/contract/run.php` assertions exercise the comparator through `VisualParityReportContract::assertReport` for both the drift (warning + findings) and match (pass + no findings) cases.
- `composer test:canonical`, `composer parity`, and full `composer test` all green; existing ButtonMenu probe and tests untouched.

Scope kept inside `php-transformer/src/VisualParity/` plus tests; the contract enum was not modified (typography matches reuse the existing `generic` kind). `HtmlTransformer.php` and `StaticSite/FontMaterialization/` were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)