### PR TITLE
Redesign 73-h44-lacrosse fixture — coastal/hibiscus identity

### DIFF
--- a/fixtures/websites/73-h44-lacrosse/about.html
+++ b/fixtures/websites/73-h44-lacrosse/about.html
@@ -7,7 +7,7 @@
   <meta name="description" content="The story behind H44 Lacrosse — founded by Jonathan Huber, a Division I lacrosse player at Stony Brook and St. John's who wore number 44 and built a club to bring elite, Long Island–style coaching to Jacksonville.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -16,10 +16,17 @@
     <div class="container header-inner">
       <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
         <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
-          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
-          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
-          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+          <circle cx="21" cy="21" r="20" fill="#13314f" stroke="#d9c4a3" stroke-width="2"/>
+          <path d="M7 31 C12 28, 16 34, 21 31 C26 28, 30 34, 35 31" stroke="#7fb8cf" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.6"/>
+          <g transform="translate(30.5 11.5) scale(0.4)" fill="#d8674e">
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(72)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(144)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(216)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(288)"/>
+            <circle cx="0" cy="0" r="2.2" fill="#f2b134"/>
+          </g>
+          <text x="21" y="26.5" text-anchor="middle" fill="#ffffff" font-family="Poppins, Arial, sans-serif" font-size="16" font-weight="700">44</text>
         </svg>
         <span class="brand-text">
           <span class="brand-name">H44</span>

--- a/fixtures/websites/73-h44-lacrosse/coaches.html
+++ b/fixtures/websites/73-h44-lacrosse/coaches.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Meet the H44 Lacrosse coaching staff across our 12U, 14U, and High School teams. Experienced coaches focused on development, sportsmanship, and the game.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -16,10 +16,17 @@
     <div class="container header-inner">
       <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
         <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
-          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
-          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
-          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+          <circle cx="21" cy="21" r="20" fill="#13314f" stroke="#d9c4a3" stroke-width="2"/>
+          <path d="M7 31 C12 28, 16 34, 21 31 C26 28, 30 34, 35 31" stroke="#7fb8cf" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.6"/>
+          <g transform="translate(30.5 11.5) scale(0.4)" fill="#d8674e">
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(72)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(144)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(216)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(288)"/>
+            <circle cx="0" cy="0" r="2.2" fill="#f2b134"/>
+          </g>
+          <text x="21" y="26.5" text-anchor="middle" fill="#ffffff" font-family="Poppins, Arial, sans-serif" font-size="16" font-weight="700">44</text>
         </svg>
         <span class="brand-text">
           <span class="brand-name">H44</span>

--- a/fixtures/websites/73-h44-lacrosse/contact.html
+++ b/fixtures/websites/73-h44-lacrosse/contact.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Contact H44 Lacrosse in Jacksonville, FL. Reach out about tryouts, clinics, and joining our 12U, 14U, or High School teams.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -16,10 +16,17 @@
     <div class="container header-inner">
       <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
         <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
-          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
-          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
-          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+          <circle cx="21" cy="21" r="20" fill="#13314f" stroke="#d9c4a3" stroke-width="2"/>
+          <path d="M7 31 C12 28, 16 34, 21 31 C26 28, 30 34, 35 31" stroke="#7fb8cf" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.6"/>
+          <g transform="translate(30.5 11.5) scale(0.4)" fill="#d8674e">
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(72)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(144)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(216)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(288)"/>
+            <circle cx="0" cy="0" r="2.2" fill="#f2b134"/>
+          </g>
+          <text x="21" y="26.5" text-anchor="middle" fill="#ffffff" font-family="Poppins, Arial, sans-serif" font-size="16" font-weight="700">44</text>
         </svg>
         <span class="brand-text">
           <span class="brand-name">H44</span>
@@ -66,8 +73,8 @@
 
           <!-- Contact info -->
           <div>
-            <span class="eyebrow" style="color:var(--lime-2);font-family:'Oswald',sans-serif;text-transform:uppercase;letter-spacing:3px;font-size:0.8rem;">Reach Us</span>
-            <h2 style="color:var(--navy);font-size:clamp(1.7rem,3.5vw,2.3rem);margin-top:8px;">H44 Lacrosse Club</h2>
+            <span class="eyebrow" style="color:var(--coral);font-family:'Poppins',sans-serif;letter-spacing:0.5px;font-size:0.82rem;font-weight:600;">Reach Us</span>
+            <h2 style="color:var(--blue);font-size:clamp(1.7rem,3.5vw,2.3rem);margin-top:8px;">H44 Lacrosse Club</h2>
             <ul class="info-list">
               <li>
                 <span class="info-icon" aria-hidden="true">@</span>

--- a/fixtures/websites/73-h44-lacrosse/css/main.css
+++ b/fixtures/websites/73-h44-lacrosse/css/main.css
@@ -1,24 +1,37 @@
 /* ─────────────────────────────────────────────────────────
    H44 Lacrosse — shared stylesheet
-   Picture-forward youth lacrosse club site. Photos are
-   represented as self-contained gradient + SVG placeholders
-   so the fixture has no external network dependencies.
+   Laid-back coastal identity for a Jacksonville beach-town
+   club: deep ocean blue, warm sand, off-white paper, and a
+   coral hibiscus pop. Photos are self-contained gradient +
+   SVG placeholders, and the hibiscus motif is an inline
+   (data-URI) SVG, so the fixture has no external network
+   dependencies beyond the Google Fonts link.
    ───────────────────────────────────────────────────────── */
 
 :root {
-  --navy:    #0d2240;
-  --navy-2:  #163a63;
-  --steel:   #2f5d8a;
-  --lime:    #b6e62e;
-  --lime-2:  #8fc41c;
-  --ink:     #11161d;
-  --muted:   #5a6675;
-  --paper:   #f5f7fa;
-  --white:   #ffffff;
-  --line:    #dde3ea;
-  --radius:  14px;
-  --shadow:  0 10px 30px rgba(13, 34, 64, 0.10);
-  --container: 1160px;
+  --blue:        #13314f;  /* primary dark / dark sections */
+  --blue-2:      #1f4b73;  /* mid blue */
+  --ocean:       #2f7a96;  /* ocean accent */
+  --ocean-light: #7fb8cf;  /* shallow water */
+  --sand:        #d9c4a3;  /* sand tan */
+  --sand-soft:   #e8dcc6;  /* pale sand */
+  --paper:       #faf7f1;  /* off-white background / paper */
+  --white:       #ffffff;
+  --coral:       #d8674e;  /* hibiscus coral — the pop */
+  --coral-2:     #c0543c;  /* darker coral — hovers */
+  --coral-light: #ec9d88;  /* coral on dark backgrounds */
+  --gold:        #f2b134;  /* hibiscus stamen */
+  --ink:         #1f2a33;  /* body text */
+  --muted:       #6b7680;  /* secondary text */
+  --line:        #ece3d4;  /* soft sandy hairline */
+  --radius:      18px;
+  --radius-sm:   12px;
+  --shadow:      0 14px 34px rgba(19, 49, 79, 0.10);
+  --shadow-sm:   0 6px 18px rgba(19, 49, 79, 0.08);
+  --container:   1160px;
+
+  /* Reusable coral hibiscus — 5 petals + golden stamen, inline SVG. */
+  --hibiscus: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='%23d8674e'%3E%3Cellipse cx='12' cy='5.6' rx='2.7' ry='4.6'/%3E%3Cellipse cx='12' cy='5.6' rx='2.7' ry='4.6' transform='rotate(72 12 12)'/%3E%3Cellipse cx='12' cy='5.6' rx='2.7' ry='4.6' transform='rotate(144 12 12)'/%3E%3Cellipse cx='12' cy='5.6' rx='2.7' ry='4.6' transform='rotate(216 12 12)'/%3E%3Cellipse cx='12' cy='5.6' rx='2.7' ry='4.6' transform='rotate(288 12 12)'/%3E%3C/g%3E%3Ccircle cx='12' cy='12' r='2.3' fill='%23f2b134'/%3E%3C/svg%3E");
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -30,21 +43,20 @@ body {
   font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   color: var(--ink);
   background: var(--paper);
-  line-height: 1.6;
+  line-height: 1.65;
   -webkit-font-smoothing: antialiased;
 }
 
 h1, h2, h3 {
-  font-family: "Oswald", "Inter", system-ui, sans-serif;
-  font-weight: 700;
-  letter-spacing: 0.5px;
-  line-height: 1.1;
+  font-family: "Poppins", "Inter", system-ui, sans-serif;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.18;
   margin: 0 0 0.5em;
-  text-transform: uppercase;
 }
 
-a { color: var(--steel); text-decoration: none; }
-a:hover { color: var(--navy); }
+a { color: var(--coral); text-decoration: none; }
+a:hover { color: var(--coral-2); }
 
 img { max-width: 100%; display: block; }
 
@@ -55,13 +67,32 @@ img { max-width: 100%; display: block; }
   padding: 0 22px;
 }
 
+/* ── Eyebrow (with hibiscus accent) ─────────────────────── */
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--coral);
+  font-family: "Poppins", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  font-size: 0.82rem;
+}
+.eyebrow::before {
+  content: "";
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  background: var(--hibiscus) center / contain no-repeat;
+}
+
 /* ── Header / nav ───────────────────────────────────────── */
 .site-header {
   position: sticky;
   top: 0;
   z-index: 50;
-  background: var(--navy);
-  border-bottom: 3px solid var(--lime);
+  background: var(--blue);
+  border-bottom: 3px solid var(--coral);
 }
 
 .header-inner {
@@ -80,42 +111,40 @@ img { max-width: 100%; display: block; }
 .brand:hover { color: var(--white); }
 
 .brand-mark {
-  width: 42px;
-  height: 42px;
-  flex: 0 0 42px;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
 }
 
 .brand-text { display: flex; flex-direction: column; line-height: 1; }
 .brand-name {
-  font-family: "Oswald", sans-serif;
+  font-family: "Poppins", sans-serif;
   font-weight: 700;
   font-size: 1.35rem;
-  letter-spacing: 2px;
+  letter-spacing: 0.5px;
 }
 .brand-tag {
-  font-size: 0.66rem;
-  letter-spacing: 3px;
-  text-transform: uppercase;
-  color: var(--lime);
-  margin-top: 3px;
+  font-size: 0.68rem;
+  letter-spacing: 1.5px;
+  color: var(--sand);
+  margin-top: 4px;
 }
 
 .nav-links { display: flex; gap: 6px; }
 .nav-links a {
   color: rgba(255, 255, 255, 0.82);
-  font-family: "Oswald", sans-serif;
+  font-family: "Poppins", sans-serif;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  font-size: 0.92rem;
+  letter-spacing: 0.2px;
+  font-size: 0.94rem;
   padding: 9px 16px;
-  border-radius: 8px;
+  border-radius: 10px;
   transition: background 0.15s, color 0.15s;
 }
-.nav-links a:hover { background: var(--navy-2); color: var(--white); }
+.nav-links a:hover { background: var(--blue-2); color: var(--white); }
 .nav-links a[aria-current="page"] {
-  color: var(--navy);
-  background: var(--lime);
+  color: var(--white);
+  background: var(--coral);
 }
 
 .nav-toggle {
@@ -130,43 +159,45 @@ img { max-width: 100%; display: block; }
 .nav-toggle span {
   width: 26px;
   height: 3px;
-  background: var(--lime);
+  background: var(--sand);
   border-radius: 2px;
   transition: transform 0.2s, opacity 0.2s;
 }
 
-.mobile-nav { display: none; background: var(--navy-2); }
+.mobile-nav { display: none; background: var(--blue-2); }
 .mobile-nav.open { display: block; }
 .mobile-nav a {
   display: block;
   color: var(--white);
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
+  font-family: "Poppins", sans-serif;
+  letter-spacing: 0.2px;
   padding: 14px 22px;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
-.mobile-nav a[aria-current="page"] { color: var(--lime); }
+.mobile-nav a[aria-current="page"] { color: var(--coral-light); }
 
 /* ── Buttons ────────────────────────────────────────────── */
 .btn {
   display: inline-block;
-  font-family: "Oswald", sans-serif;
+  font-family: "Poppins", sans-serif;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  font-size: 0.9rem;
-  padding: 13px 26px;
-  border-radius: 10px;
+  letter-spacing: 0.2px;
+  font-size: 0.95rem;
+  padding: 13px 28px;
+  border-radius: 999px;
   cursor: pointer;
   border: 2px solid transparent;
-  transition: transform 0.12s, background 0.15s;
+  transition: transform 0.12s, background 0.15s, box-shadow 0.15s;
 }
 .btn:active { transform: translateY(1px); }
-.btn-primary { background: var(--lime); color: var(--navy); }
-.btn-primary:hover { background: var(--lime-2); color: var(--navy); }
-.btn-ghost { background: transparent; color: var(--white); border-color: rgba(255,255,255,0.45); }
-.btn-ghost:hover { background: rgba(255,255,255,0.12); color: var(--white); }
+.btn-primary {
+  background: var(--coral);
+  color: var(--white);
+  box-shadow: 0 8px 20px rgba(216, 103, 78, 0.28);
+}
+.btn-primary:hover { background: var(--coral-2); color: var(--white); }
+.btn-ghost { background: transparent; color: var(--white); border-color: rgba(255,255,255,0.5); }
+.btn-ghost:hover { background: rgba(255,255,255,0.14); color: var(--white); }
 
 /* ── Photo placeholders (self-contained "pictures") ─────── */
 .photo {
@@ -174,24 +205,24 @@ img { max-width: 100%; display: block; }
   border-radius: var(--radius);
   overflow: hidden;
   aspect-ratio: 4 / 3;
-  background: linear-gradient(135deg, var(--navy) 0%, var(--steel) 100%);
+  background: linear-gradient(135deg, var(--blue) 0%, var(--ocean) 100%);
   box-shadow: var(--shadow);
 }
 .photo::before {
-  /* lacrosse stick + ball motif, drawn with CSS only */
+  /* coastal sun + gentle ripple motif, drawn with CSS only */
   content: "";
   position: absolute;
   inset: 0;
   background-image:
-    radial-gradient(circle at 78% 26%, rgba(182, 230, 46, 0.9) 0 9px, transparent 10px),
-    repeating-linear-gradient(115deg, rgba(255,255,255,0.06) 0 14px, transparent 14px 28px);
+    radial-gradient(circle at 78% 24%, rgba(242, 177, 52, 0.85) 0 10px, transparent 11px),
+    repeating-linear-gradient(115deg, rgba(255,255,255,0.06) 0 16px, transparent 16px 32px);
   opacity: 0.85;
 }
 .photo::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, transparent 45%, rgba(13, 34, 64, 0.78) 100%);
+  background: linear-gradient(180deg, transparent 45%, rgba(19, 49, 79, 0.78) 100%);
 }
 .photo .photo-label {
   position: absolute;
@@ -200,9 +231,8 @@ img { max-width: 100%; display: block; }
   right: 16px;
   z-index: 2;
   color: var(--white);
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+  font-family: "Poppins", sans-serif;
+  letter-spacing: 0.2px;
   font-weight: 600;
   font-size: 1.02rem;
   text-shadow: 0 1px 6px rgba(0,0,0,0.5);
@@ -212,24 +242,23 @@ img { max-width: 100%; display: block; }
   top: 14px;
   left: 14px;
   z-index: 2;
-  background: var(--lime);
-  color: var(--navy);
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  font-weight: 700;
-  font-size: 0.72rem;
-  padding: 4px 10px;
-  border-radius: 6px;
+  background: var(--coral);
+  color: var(--white);
+  font-family: "Poppins", sans-serif;
+  letter-spacing: 0.3px;
+  font-weight: 600;
+  font-size: 0.74rem;
+  padding: 4px 11px;
+  border-radius: 999px;
 }
 
 /* gradient variants so the gallery reads like distinct photos */
-.photo.v1 { background: linear-gradient(135deg, #0d2240, #2f5d8a); }
-.photo.v2 { background: linear-gradient(135deg, #163a63, #6aa0c9); }
-.photo.v3 { background: linear-gradient(135deg, #11304f, #8fc41c); }
-.photo.v4 { background: linear-gradient(135deg, #0d2240, #1f7a4d); }
-.photo.v5 { background: linear-gradient(135deg, #20405f, #b6e62e); }
-.photo.v6 { background: linear-gradient(135deg, #14283f, #3f76a7); }
+.photo.v1 { background: linear-gradient(135deg, #13314f, #2f7a96); }
+.photo.v2 { background: linear-gradient(135deg, #1f4b73, #7fb8cf); }
+.photo.v3 { background: linear-gradient(135deg, #13314f, #d8674e); }
+.photo.v4 { background: linear-gradient(135deg, #1d6b7a, #d9c4a3); }
+.photo.v5 { background: linear-gradient(135deg, #1f4b73, #ec9d88); }
+.photo.v6 { background: linear-gradient(135deg, #13314f, #4f93b0); }
 
 /* ── Split feature (founder / about) ────────────────────── */
 .split {
@@ -239,14 +268,7 @@ img { max-width: 100%; display: block; }
   align-items: center;
 }
 .split .photo { aspect-ratio: 4 / 5; }
-.split .eyebrow {
-  color: var(--lime-2);
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 3px;
-  font-size: 0.8rem;
-}
-.split h2 { color: var(--navy); font-size: clamp(1.9rem, 4vw, 2.8rem); margin-top: 8px; }
+.split h2 { color: var(--blue); font-size: clamp(1.9rem, 4vw, 2.8rem); margin-top: 10px; }
 .split p { color: var(--muted); font-size: 1.06rem; }
 .split .btn { margin-top: 8px; }
 @media (max-width: 820px) {
@@ -258,14 +280,19 @@ img { max-width: 100%; display: block; }
 .hero {
   position: relative;
   color: var(--white);
-  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-2) 55%, var(--steel) 100%);
+  background: linear-gradient(135deg, var(--blue) 0%, var(--blue-2) 55%, var(--ocean) 100%);
   overflow: hidden;
 }
 .hero::after {
+  /* soft hibiscus blooms drifting in the corners */
   content: "";
   position: absolute;
   inset: 0;
-  background-image: repeating-linear-gradient(115deg, rgba(182,230,46,0.05) 0 18px, transparent 18px 36px);
+  background-image: var(--hibiscus), var(--hibiscus);
+  background-repeat: no-repeat, no-repeat;
+  background-position: right -60px top -60px, left -40px bottom -70px;
+  background-size: 320px, 190px;
+  opacity: 0.12;
   pointer-events: none;
 }
 .hero-inner {
@@ -278,47 +305,63 @@ img { max-width: 100%; display: block; }
   padding: 72px 22px 80px;
 }
 .hero-kicker {
-  display: inline-block;
-  color: var(--lime);
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--coral-light);
+  font-family: "Poppins", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  font-size: 0.82rem;
   margin-bottom: 14px;
 }
-.hero h1 { font-size: clamp(2.6rem, 6vw, 4.6rem); }
-.hero p { font-size: 1.15rem; color: rgba(255,255,255,0.86); max-width: 46ch; }
+.hero-kicker::before {
+  content: "";
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  background: var(--hibiscus) center / contain no-repeat;
+}
+.hero h1 { font-size: clamp(2.6rem, 6vw, 4.4rem); }
+.hero p { font-size: 1.15rem; color: rgba(255,255,255,0.88); max-width: 46ch; }
 .hero-actions { margin-top: 26px; display: flex; gap: 14px; flex-wrap: wrap; }
 .hero-art {
   aspect-ratio: 1 / 1;
-  border-radius: 20px;
+  border-radius: 22px;
   box-shadow: var(--shadow);
   overflow: hidden;
 }
 
 /* ── Sections ───────────────────────────────────────────── */
-.section { padding: 72px 0; }
+.section { padding: 76px 0; }
 .section.alt { background: var(--white); }
-.section-head { max-width: 620px; margin: 0 auto 44px; text-align: center; }
-.section-head .eyebrow {
-  color: var(--lime-2);
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 3px;
-  font-size: 0.8rem;
-}
-.section-head h2 { font-size: clamp(1.9rem, 4vw, 2.8rem); color: var(--navy); margin-top: 8px; }
+.section-head { max-width: 620px; margin: 0 auto 46px; text-align: center; }
+.section-head .eyebrow { justify-content: center; }
+.section-head h2 { font-size: clamp(1.9rem, 4vw, 2.8rem); color: var(--blue); margin-top: 10px; }
 .section-head p { color: var(--muted); font-size: 1.06rem; }
 
 .page-banner {
-  background: var(--navy);
+  position: relative;
+  background: linear-gradient(135deg, var(--blue) 0%, var(--blue-2) 70%, var(--ocean) 100%);
   color: var(--white);
-  border-bottom: 3px solid var(--lime);
+  border-bottom: 3px solid var(--coral);
   text-align: center;
-  padding: 56px 22px;
+  padding: 58px 22px;
+  overflow: hidden;
 }
-.page-banner h1 { font-size: clamp(2.2rem, 5vw, 3.4rem); }
-.page-banner p { color: rgba(255,255,255,0.8); max-width: 60ch; margin: 0 auto; }
+.page-banner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: var(--hibiscus);
+  background-repeat: no-repeat;
+  background-position: right -50px top -50px;
+  background-size: 220px;
+  opacity: 0.12;
+  pointer-events: none;
+}
+.page-banner h1 { position: relative; z-index: 1; font-size: clamp(2.2rem, 5vw, 3.4rem); }
+.page-banner p { position: relative; z-index: 1; color: rgba(255,255,255,0.85); max-width: 60ch; margin: 0 auto; }
 
 /* ── Grids ──────────────────────────────────────────────── */
 .gallery {
@@ -333,19 +376,21 @@ img { max-width: 100%; display: block; }
   border: 1px solid var(--line);
   border-radius: var(--radius);
   overflow: hidden;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
+.card:hover { transform: translateY(-3px); box-shadow: var(--shadow); }
 .card .photo { border-radius: 0; box-shadow: none; }
 .card-body { padding: 20px 22px 24px; }
-.card-body h3 { color: var(--navy); font-size: 1.3rem; }
+.card-body h3 { color: var(--blue); font-size: 1.3rem; }
 .card-body .meta {
-  color: var(--lime-2);
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 0.78rem;
+  color: var(--coral);
+  font-family: "Poppins", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  font-size: 0.8rem;
   margin-bottom: 6px;
 }
 .card-body p { color: var(--muted); margin: 0 0 14px; }
@@ -357,8 +402,8 @@ img { max-width: 100%; display: block; }
   margin-top: auto;
 }
 .card-stats div { display: flex; flex-direction: column; }
-.card-stats strong { font-family: "Oswald", sans-serif; font-size: 1.3rem; color: var(--navy); }
-.card-stats span { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); }
+.card-stats strong { font-family: "Poppins", sans-serif; font-size: 1.3rem; color: var(--blue); }
+.card-stats span { font-size: 0.74rem; letter-spacing: 0.3px; color: var(--muted); }
 
 /* coach cards: square portrait */
 .coach .photo { aspect-ratio: 1 / 1; }
@@ -372,57 +417,56 @@ img { max-width: 100%; display: block; }
   align-items: center;
   background: var(--white);
   border: 1px solid var(--line);
-  border-left: 5px solid var(--lime);
+  border-left: 5px solid var(--coral);
   border-radius: var(--radius);
   padding: 18px 22px;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
 }
 .event-date {
   text-align: center;
-  background: var(--navy);
+  background: var(--blue);
   color: var(--white);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   padding: 10px 6px;
 }
-.event-date .mon { font-family: "Oswald", sans-serif; text-transform: uppercase; letter-spacing: 2px; color: var(--lime); font-size: 0.78rem; }
-.event-date .day { font-family: "Oswald", sans-serif; font-size: 1.7rem; font-weight: 700; line-height: 1; }
-.event-info h3 { color: var(--navy); margin: 0 0 4px; font-size: 1.18rem; }
+.event-date .mon { font-family: "Poppins", sans-serif; letter-spacing: 1px; color: var(--sand); font-size: 0.78rem; }
+.event-date .day { font-family: "Poppins", sans-serif; font-size: 1.7rem; font-weight: 700; line-height: 1; }
+.event-info h3 { color: var(--blue); margin: 0 0 4px; font-size: 1.18rem; }
 .event-info p { margin: 0; color: var(--muted); font-size: 0.95rem; }
 .event-pill {
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  font-size: 0.72rem;
+  font-family: "Poppins", sans-serif;
+  letter-spacing: 0.3px;
+  font-size: 0.74rem;
   font-weight: 600;
-  padding: 6px 12px;
-  border-radius: 20px;
+  padding: 6px 14px;
+  border-radius: 999px;
   white-space: nowrap;
 }
-.event-pill.home { background: #e8f6cf; color: #4a6b00; }
-.event-pill.away { background: #e6eef6; color: var(--steel); }
-.event-pill.tourney { background: #fce8d6; color: #a85a18; }
+.event-pill.home { background: #dcebf2; color: var(--blue-2); }
+.event-pill.away { background: var(--sand-soft); color: #8a6f44; }
+.event-pill.tourney { background: #fbe1d9; color: var(--coral-2); }
 
 /* ── Prose (about story) ────────────────────────────────── */
 .prose { max-width: 720px; margin: 0 auto; }
-.prose h2 { color: var(--navy); font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin-top: 1.4em; }
+.prose h2 { color: var(--blue); font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin-top: 1.4em; }
 .prose p { color: var(--ink); font-size: 1.08rem; margin: 0 0 1.1em; }
 .prose .lead { font-size: 1.22rem; color: var(--muted); }
 .pull-quote {
-  border-left: 5px solid var(--lime);
+  border-left: 5px solid var(--coral);
   background: var(--white);
   border-radius: 0 var(--radius) var(--radius) 0;
   padding: 22px 26px;
   margin: 1.6em 0;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
 }
 .pull-quote p {
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+  font-family: "Poppins", sans-serif;
+  letter-spacing: 0;
   font-size: 1.25rem;
-  color: var(--navy);
+  font-weight: 500;
+  color: var(--blue);
   margin: 0;
-  line-height: 1.3;
+  line-height: 1.4;
 }
 
 /* career stat row */
@@ -434,27 +478,26 @@ img { max-width: 100%; display: block; }
   margin: 0 auto 8px;
 }
 .stat-row .stat {
-  background: var(--navy);
+  background: var(--blue);
   color: var(--white);
   border-radius: var(--radius);
   padding: 24px 18px;
   text-align: center;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
 }
 .stat-row .stat strong {
   display: block;
-  font-family: "Oswald", sans-serif;
+  font-family: "Poppins", sans-serif;
   font-size: 2.2rem;
   line-height: 1;
-  color: var(--lime);
+  color: var(--coral-light);
 }
 .stat-row .stat span {
   display: block;
   margin-top: 8px;
   font-size: 0.74rem;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  color: rgba(255,255,255,0.78);
+  letter-spacing: 1px;
+  color: rgba(255,255,255,0.8);
 }
 
 /* ── Contact ────────────────────────────────────────────── */
@@ -479,19 +522,19 @@ img { max-width: 100%; display: block; }
   height: 40px;
   display: grid;
   place-items: center;
-  background: var(--lime);
-  color: var(--navy);
-  border-radius: 10px;
-  font-family: "Oswald", sans-serif;
+  background: var(--coral);
+  color: var(--white);
+  border-radius: 12px;
+  font-family: "Poppins", sans-serif;
   font-weight: 700;
 }
 .info-list .info-label {
   display: block;
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 0.72rem;
-  color: var(--lime-2);
+  font-family: "Poppins", sans-serif;
+  letter-spacing: 0.5px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--coral);
 }
 .info-list .info-value { color: var(--ink); font-size: 1.04rem; }
 
@@ -500,17 +543,17 @@ img { max-width: 100%; display: block; }
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 28px;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
 }
 .form .field { margin-bottom: 18px; }
 .form .row-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
 .form label {
   display: block;
-  font-family: "Oswald", sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  font-size: 0.76rem;
-  color: var(--navy);
+  font-family: "Poppins", sans-serif;
+  letter-spacing: 0.3px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--blue);
   margin-bottom: 6px;
 }
 .form input,
@@ -522,15 +565,15 @@ img { max-width: 100%; display: block; }
   color: var(--ink);
   background: var(--paper);
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   padding: 12px 14px;
 }
 .form input:focus,
 .form select:focus,
 .form textarea:focus {
   outline: none;
-  border-color: var(--steel);
-  box-shadow: 0 0 0 3px rgba(47, 93, 138, 0.15);
+  border-color: var(--coral);
+  box-shadow: 0 0 0 3px rgba(216, 103, 78, 0.15);
 }
 .form textarea { resize: vertical; min-height: 120px; }
 .form .btn { width: 100%; border: 0; }
@@ -546,21 +589,50 @@ img { max-width: 100%; display: block; }
 
 /* ── Strip / CTA ────────────────────────────────────────── */
 .cta {
-  background: linear-gradient(135deg, var(--navy), var(--steel));
+  position: relative;
+  background: linear-gradient(135deg, var(--blue), var(--ocean));
   color: var(--white);
   text-align: center;
-  padding: 64px 22px;
+  padding: 66px 22px;
+  overflow: hidden;
 }
-.cta h2 { font-size: clamp(1.8rem, 4vw, 2.6rem); }
-.cta p { color: rgba(255,255,255,0.85); max-width: 50ch; margin: 0 auto 24px; }
+.cta::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: var(--hibiscus), var(--hibiscus);
+  background-repeat: no-repeat, no-repeat;
+  background-position: left -40px top -50px, right -50px bottom -60px;
+  background-size: 170px, 240px;
+  opacity: 0.12;
+  pointer-events: none;
+}
+.cta h2 { position: relative; z-index: 1; font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.cta p { position: relative; z-index: 1; color: rgba(255,255,255,0.88); max-width: 50ch; margin: 0 auto 24px; }
+.cta .hero-actions { position: relative; z-index: 1; }
 
 /* ── Footer ─────────────────────────────────────────────── */
 .site-footer {
-  background: var(--ink);
-  color: rgba(255,255,255,0.7);
+  position: relative;
+  background: var(--blue);
+  color: rgba(255,255,255,0.72);
   padding: 48px 0 30px;
+  overflow: hidden;
+}
+.site-footer::after {
+  content: "";
+  position: absolute;
+  right: -34px;
+  bottom: -34px;
+  width: 170px;
+  height: 170px;
+  background: var(--hibiscus) center / contain no-repeat;
+  opacity: 0.08;
+  pointer-events: none;
 }
 .footer-inner {
+  position: relative;
+  z-index: 1;
   display: flex;
   justify-content: space-between;
   gap: 30px;
@@ -568,15 +640,18 @@ img { max-width: 100%; display: block; }
   align-items: flex-start;
 }
 .footer-inner .brand-name { color: var(--white); }
+.footer-inner .brand-tag { color: var(--sand); }
 .footer-links { display: flex; gap: 28px; flex-wrap: wrap; }
-.footer-links a { color: rgba(255,255,255,0.7); font-size: 0.95rem; }
-.footer-links a:hover { color: var(--lime); }
+.footer-links a { color: rgba(255,255,255,0.72); font-size: 0.95rem; }
+.footer-links a:hover { color: var(--coral-light); }
 .footer-bottom {
-  border-top: 1px solid rgba(255,255,255,0.1);
+  position: relative;
+  z-index: 1;
+  border-top: 1px solid rgba(255,255,255,0.12);
   margin-top: 34px;
   padding-top: 20px;
   font-size: 0.82rem;
-  color: rgba(255,255,255,0.5);
+  color: rgba(255,255,255,0.55);
 }
 
 /* ── Responsive ─────────────────────────────────────────── */

--- a/fixtures/websites/73-h44-lacrosse/events.html
+++ b/fixtures/websites/73-h44-lacrosse/events.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Upcoming H44 Lacrosse events in Jacksonville, FL — games, tryouts, clinics, and tournaments across our 12U, 14U, and High School teams.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -16,10 +16,17 @@
     <div class="container header-inner">
       <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
         <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
-          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
-          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
-          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+          <circle cx="21" cy="21" r="20" fill="#13314f" stroke="#d9c4a3" stroke-width="2"/>
+          <path d="M7 31 C12 28, 16 34, 21 31 C26 28, 30 34, 35 31" stroke="#7fb8cf" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.6"/>
+          <g transform="translate(30.5 11.5) scale(0.4)" fill="#d8674e">
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(72)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(144)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(216)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(288)"/>
+            <circle cx="0" cy="0" r="2.2" fill="#f2b134"/>
+          </g>
+          <text x="21" y="26.5" text-anchor="middle" fill="#ffffff" font-family="Poppins, Arial, sans-serif" font-size="16" font-weight="700">44</text>
         </svg>
         <span class="brand-text">
           <span class="brand-name">H44</span>

--- a/fixtures/websites/73-h44-lacrosse/index.html
+++ b/fixtures/websites/73-h44-lacrosse/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="H44 Lacrosse is a Jacksonville, Florida club fielding one team per age group — 12U, 14U, and High School. Founded by D1 athlete Jonathan Huber. Elite coaching and college looks — the Long Island Express of Florida.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -16,10 +16,17 @@
     <div class="container header-inner">
       <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
         <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
-          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
-          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
-          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+          <circle cx="21" cy="21" r="20" fill="#13314f" stroke="#d9c4a3" stroke-width="2"/>
+          <path d="M7 31 C12 28, 16 34, 21 31 C26 28, 30 34, 35 31" stroke="#7fb8cf" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.6"/>
+          <g transform="translate(30.5 11.5) scale(0.4)" fill="#d8674e">
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(72)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(144)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(216)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(288)"/>
+            <circle cx="0" cy="0" r="2.2" fill="#f2b134"/>
+          </g>
+          <text x="21" y="26.5" text-anchor="middle" fill="#ffffff" font-family="Poppins, Arial, sans-serif" font-size="16" font-weight="700">44</text>
         </svg>
         <span class="brand-text">
           <span class="brand-name">H44</span>

--- a/fixtures/websites/73-h44-lacrosse/teams.html
+++ b/fixtures/websites/73-h44-lacrosse/teams.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Meet the H44 Lacrosse teams — one squad per age group: 12U Stingers, 14U Hornets, and High School Varsity. Rosters, coaches, and team photos.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -16,10 +16,17 @@
     <div class="container header-inner">
       <a href="index.html" class="brand" aria-label="H44 Lacrosse — Home">
         <svg class="brand-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <circle cx="21" cy="21" r="20" fill="#163a63" stroke="#b6e62e" stroke-width="2"/>
-          <path d="M21 5 C12.5 5, 6 11.5, 6 20" stroke="#b6e62e" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.75"/>
-          <path d="M21 37 C29.5 37, 36 30.5, 36 22" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" opacity="0.5"/>
-          <text x="21" y="28" text-anchor="middle" fill="#fff" font-family="Oswald, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="0.5">44</text>
+          <circle cx="21" cy="21" r="20" fill="#13314f" stroke="#d9c4a3" stroke-width="2"/>
+          <path d="M7 31 C12 28, 16 34, 21 31 C26 28, 30 34, 35 31" stroke="#7fb8cf" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.6"/>
+          <g transform="translate(30.5 11.5) scale(0.4)" fill="#d8674e">
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(72)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(144)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(216)"/>
+            <ellipse cx="0" cy="-6.5" rx="2.7" ry="4.6" transform="rotate(288)"/>
+            <circle cx="0" cy="0" r="2.2" fill="#f2b134"/>
+          </g>
+          <text x="21" y="26.5" text-anchor="middle" fill="#ffffff" font-family="Poppins, Arial, sans-serif" font-size="16" font-weight="700">44</text>
         </svg>
         <span class="brand-text">
           <span class="brand-name">H44</span>


### PR DESCRIPTION
Visual/identity redesign of the existing `fixtures/websites/73-h44-lacrosse` static site (H44 Lacrosse, a Jacksonville, FL youth club). This is a **look-and-feel redesign only** — all copy, page structure, and the 6-page layout are unchanged.

## What changed
Pivots from the aggressive-athletic look (deep navy + electric lime, hard uppercase Oswald) to a **laid-back coastal vibe with a hibiscus pop**.

- **Palette (CSS variables):** deep ocean blue `#13314f`, sand tan `#d9c4a3`, off-white paper `#faf7f1`, white cards, and a **coral hibiscus accent `#d8674e`** (hover `#c0543c`) as the pop, plus supporting ocean/teal tones. All lime (`--lime` / `#b6e62e` / `#8fc41c`) removed.
- **Typography:** headings → **Poppins**, body → **Inter** (was Oswald+Inter). Google Fonts `<link>` updated in all 6 pages and every CSS `font-family`. Shouty all-caps + wide letter-spacing softened to relaxed, title-case styling.
- **Hibiscus motif:** a reusable inline (data-URI) SVG hibiscus — 5 coral petals + golden stamen — used as a restrained accent in eyebrows and as soft decoration in the hero, page banners, CTA, and footer. No external image/network deps.
- **Brand mark:** the inline "44" crest in all 6 headers restyled to a deep-blue disc with sand ring, ocean wave, a folded-in coral hibiscus petal, and a clean Poppins "44".
- **Photo placeholders:** `.photo` `.v1`–`.v6` gradients retuned from navy/lime to coastal tones (deep blue ↔ ocean ↔ sand ↔ soft coral); kept the gradient + SVG approach. Softer rounded corners and gentler shadows throughout.

## Notes
- Fixture stays self-contained — the only external reference is the existing Google Fonts `<link>`.
- Responsive breakpoints and the mobile nav are preserved.
- Preview locally: open `fixtures/websites/73-h44-lacrosse/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)