### PR TITLE
Recognize inline micro-elements in HTML transformer

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2321,7 +2321,7 @@ final class HtmlTransformer
 
     private function isInlineContentElement(string $tagName): bool
     {
-        return in_array($tagName, array( 'abbr', 'b', 'cite', 'code', 'em', 'font', 'i', 'mark', 'rp', 'rt', 'ruby', 'small', 'span', 'strong', 'sub', 'sup', 'time' ), true);
+        return in_array($tagName, array( 'abbr', 'b', 'cite', 'code', 'em', 'font', 'i', 'kbd', 'mark', 'rp', 'rt', 'ruby', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'time', 'var' ), true);
     }
 
     private function hasBlockContentChildren(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-inline-micro-elements.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-micro-elements.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-micro-elements",
+  "description": "Converts generic inline micro-elements into paragraph and list content instead of treating their ancestors as unsupported fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-micro-elements.json",
+    "notes": "Synthetic coverage for kbd/samp/var/mark/time phrasing elements observed in static-site fixture 60-node-editor."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><kbd>Ctrl</kbd><p>Use <kbd>Ctrl</kbd> + <kbd>K</kbd> to open <samp>Command Palette</samp> for <var>query</var> at <time datetime=\"2026-06-27\">today</time> and <mark>highlight</mark> results.</p><section><samp>stdout</samp> stores <var>$value</var></section><ul><li>Press <kbd>Enter</kbd> after <samp>Ready</samp></li></ul></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "<kbd>Ctrl</kbd>" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Use <kbd>Ctrl</kbd> + <kbd>K</kbd> to open <samp>Command Palette</samp> for <var>query</var> at <time datetime=\"2026-06-27\">today</time> and <mark>highlight</mark> results." } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "<samp>stdout</samp> stores <var>$value</var>" } },
+    { "path": "blocks.0.innerBlocks.3", "name": "core/list" },
+    { "path": "blocks.0.innerBlocks.3.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "Press <kbd>Enter</kbd> after <samp>Ready</samp>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 4 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<kbd>Ctrl</kbd>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<samp>stdout</samp> stores <var>$value</var>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<time datetime=\"2026-06-27\">today</time>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Treat `kbd`, `samp`, and `var` as generic phrasing/inline content in the PHP HTML transformer.
- Preserve these tags as safe inline HTML inside paragraph/list RichText content instead of letting unsupported child detection force ancestor fallback.
- Add focused parity coverage for standalone, nested paragraph/container, and list-item usage alongside already-supported `mark` and `time`.

## Evidence
- Source artifact: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/8e954bd5-b29e-41e1-b77a-2d081d33a355-matrix.json
- Reported unsupported family includes `fallback_block:unsupported_html_fallback:main` with `60-node-editor` selector `main:nth-of-type(1) > div:nth-of-type(3) > kbd:nth-of-type(1)`.
- This intentionally avoids PR #201 canvas fallback work and only changes generic phrasing classification.

## Tests
- `php -l php-transformer/src/HtmlToBlocks/HtmlTransformer.php`
- Focused direct transformer assertion for `html-inline-micro-elements` fixture content: verifies status `success`, zero fallbacks, preserved serialized `kbd`/`samp`/`var`/`time`, and list-item inline content.

## Expected matrix impact
- Expected to remove the `kbd` selector from `fallback_block:unsupported_html_fallback:main` for fixture `60-node-editor`.
- Expected to reduce unsupported ancestor fallback pressure where `kbd`, `samp`, or `var` are the only unsupported descendants of otherwise text-only wrappers.
- Full fixture matrix was not rerun locally per benchmark guidance.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Scoped code change, focused fixture, local verification, and PR drafting.
