### PR TITLE
Add typography parity diagnostic and enrich semantic-parity findings

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -199,7 +199,7 @@ final class HtmlTransformer
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
-        $semanticParityReport = $this->semanticParityReport($body, $blocks, $sourceProvenance);
+        $semanticParityReport = $this->semanticParityReport($body, $blocks, $sourceProvenance, $html, (string) ($options['static_css'] ?? ''));
         $diagnostics = array(
             array(
                 'code'    => 'html_to_blocks_core_slice',
@@ -373,13 +373,22 @@ final class HtmlTransformer
      * @param array<int, array<string, mixed>> $sourceProvenance
      * @return array<string, mixed>
      */
-    private function semanticParityReport(DOMElement $body, array $blocks, array $sourceProvenance): array
+    private function semanticParityReport(DOMElement $body, array $blocks, array $sourceProvenance, string $html = '', string $staticCss = ''): array
     {
         $sourceLandmarks = $this->sourceLandmarkReport($body);
         $blockLandmarks = $this->blockLandmarkReport($blocks, $sourceProvenance, $sourceLandmarks);
         $sourceMenus = $this->sourceNavigationMenus($body);
         $blockMenus = $this->blockNavigationMenus($blocks);
         $findings = $this->semanticParityFindings($sourceLandmarks, $blockLandmarks, $sourceMenus, $blockMenus);
+        $findings = array_merge(
+            $findings,
+            ( new TypographyParityAnalyzer() )->findings($html, $staticCss, $this->inlineHeadingFontDeclarations($body))
+        );
+
+        $findings = array_map(
+            fn (array $finding): array => $this->enrichSemanticParityFinding($finding, $body, $sourceProvenance),
+            $findings
+        );
 
         return array(
             'schema' => 'blocks-engine/php-transformer/semantic-parity/v1',
@@ -945,6 +954,178 @@ final class HtmlTransformer
         }
 
         return $findings;
+    }
+
+    /**
+     * Make a semantic-parity finding fix-ready by attaching additive context:
+     * a stable `reason_code`, the bounded `source_snippet` for its selector, and
+     * the `observed_block` output produced for that region (or an explicit
+     * "none"). Strictly additive — never alters parity pass/fail counts.
+     *
+     * @param array<string, mixed> $finding
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     * @return array<string, mixed>
+     */
+    private function enrichSemanticParityFinding(array $finding, DOMElement $body, array $sourceProvenance): array
+    {
+        if ( ! isset($finding['reason_code']) && isset($finding['code']) ) {
+            $finding['reason_code'] = (string) $finding['code'];
+        }
+
+        if ( ! isset($finding['source_snippet']) ) {
+            $finding['source_snippet'] = $this->semanticParitySourceSnippet((string) ($finding['selector'] ?? ''), $body);
+        }
+
+        if ( ! isset($finding['observed_block']) ) {
+            $finding['observed_block'] = $this->observedBlockForFinding($finding, $sourceProvenance);
+        }
+
+        return $finding;
+    }
+
+    /**
+     * Bounded source HTML for a finding selector, reusing the same bounded-HTML
+     * helper used for runtime-island findings. Returns "none" when the selector
+     * cannot be resolved back to a source element.
+     */
+    private function semanticParitySourceSnippet(string $selector, DOMElement $body): string
+    {
+        $element = $this->resolveSelectorElement($body, $selector);
+        if ( ! $element instanceof DOMElement ) {
+            return 'none';
+        }
+
+        $bounded = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
+
+        return '' === $bounded['html'] ? 'none' : $bounded['html'];
+    }
+
+    /**
+     * Resolve a `tag:nth-of-type(n) > …` selector produced by elementSelector()
+     * back to the source element, so findings can carry the offending markup.
+     */
+    private function resolveSelectorElement(DOMElement $body, string $selector): ?DOMElement
+    {
+        $selector = trim($selector);
+        if ( '' === $selector ) {
+            return null;
+        }
+
+        $current = $body;
+        foreach ( explode(' > ', $selector) as $part ) {
+            if ( ! preg_match('/^([a-z0-9]+):nth-of-type\((\d+)\)$/i', trim($part), $match) ) {
+                return null;
+            }
+
+            $tag = strtolower($match[1]);
+            $target = (int) $match[2];
+            $index = 0;
+            $found = null;
+            foreach ( $current->childNodes as $child ) {
+                if ( $child instanceof DOMElement && strtolower($child->tagName) === $tag ) {
+                    ++$index;
+                    if ( $index === $target ) {
+                        $found = $child;
+                        break;
+                    }
+                }
+            }
+
+            if ( ! $found instanceof DOMElement ) {
+                return null;
+            }
+
+            $current = $found;
+        }
+
+        return $current === $body ? null : $current;
+    }
+
+    /**
+     * Observed block output produced for a finding's region. Prefers block data
+     * already carried by the finding, then provenance lookup by selector, and
+     * falls back to an explicit "none" when nothing was generated.
+     *
+     * @param array<string, mixed> $finding
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     * @return array<string, mixed>|string
+     */
+    private function observedBlockForFinding(array $finding, array $sourceProvenance): array|string
+    {
+        if ( isset($finding['block_items']) && is_array($finding['block_items']) && array() !== $finding['block_items'] ) {
+            return array( 'block_items' => $finding['block_items'] );
+        }
+
+        if ( isset($finding['block_item']) && is_array($finding['block_item']) && array() !== $finding['block_item'] ) {
+            return array( 'block_item' => $finding['block_item'] );
+        }
+
+        $blockNames = $this->blockNamesForSelector((string) ($finding['selector'] ?? ''), $sourceProvenance);
+
+        return array() === $blockNames ? 'none' : array( 'block_names' => $blockNames );
+    }
+
+    /**
+     * Block names whose source provenance selector matches or descends from the
+     * given selector.
+     *
+     * @param array<int, array<string, mixed>> $sourceProvenance
+     * @return array<int, string>
+     */
+    private function blockNamesForSelector(string $selector, array $sourceProvenance): array
+    {
+        if ( '' === $selector ) {
+            return array();
+        }
+
+        $names = array();
+        foreach ( $sourceProvenance as $entry ) {
+            if ( ! is_array($entry) ) {
+                continue;
+            }
+
+            $blockSelector = (string) ($entry['selector'] ?? '');
+            if ( $selector === $blockSelector || str_starts_with($blockSelector, $selector . ' > ') ) {
+                $name = (string) ($entry['block_name'] ?? '');
+                if ( '' !== $name ) {
+                    $names[$name] = true;
+                }
+            }
+        }
+
+        return array_keys($names);
+    }
+
+    /**
+     * Heading-element inline `style="font-family:…"` declarations resolved from
+     * the source DOM, for the typography parity diagnostic.
+     *
+     * @return array<int, array{family: string, selector: string, source_snippet: string}>
+     */
+    private function inlineHeadingFontDeclarations(DOMElement $body): array
+    {
+        $declarations = array();
+        foreach ( array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ) as $tag ) {
+            foreach ( $body->getElementsByTagName($tag) as $heading ) {
+                if ( ! $heading instanceof DOMElement ) {
+                    continue;
+                }
+
+                $style = $this->attr($heading, 'style');
+                if ( '' === $style || ! preg_match('/font-family\s*:\s*([^;{}]+)/i', $style, $match) ) {
+                    continue;
+                }
+
+                $bounded = $this->boundedFallbackHtml($this->safeFallbackHtml($heading));
+                $declarations[] = array(
+                    'family'         => trim((string) $match[1]),
+                    'selector'       => $this->elementSelector($heading),
+                    'source_snippet' => $bounded['html'],
+                );
+            }
+        }
+
+        return $declarations;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/TypographyParityAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/TypographyParityAnalyzer.php
@@ -1,0 +1,303 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
+
+/**
+ * Detects source typefaces (linked web-font families and heading/body
+ * `font-family` declarations) and reports the ones that are not represented in
+ * the materialized output typography.
+ *
+ * "Represented" is defined by the font materialization plan the transformer can
+ * derive from the same sources (see FontMaterializationPlanBuilder), so a font
+ * that DOES materialize never produces a finding and the diagnostic stays in
+ * agreement with the materialization layer.
+ *
+ * Generic only — no provider-, fixture-, or family-specific strings.
+ */
+final class TypographyParityAnalyzer
+{
+    private const SNIPPET_BYTE_LIMIT = 2000;
+
+    /** @var array<int,string> */
+    private const WEB_SAFE_FAMILIES = array(
+        'arial', 'courier new', 'georgia', 'helvetica', 'monospace',
+        'sans-serif', 'serif', 'system-ui', 'times new roman', 'verdana',
+        'cursive', 'fantasy', 'ui-monospace', 'ui-sans-serif', 'ui-serif',
+        'inherit', 'initial', 'unset',
+    );
+
+    public function __construct(
+        private readonly FontMaterializationPlanBuilder $planBuilder = new FontMaterializationPlanBuilder()
+    ) {
+    }
+
+    /**
+     * @param array<int,array{family:string,selector:string,source_snippet:string}> $inlineHeadingDeclarations
+     *   Heading-element inline `style="font-family:…"` declarations resolved from the DOM.
+     * @return array<int,array<string,mixed>>
+     */
+    public function findings(string $html, string $css, array $inlineHeadingDeclarations = array()): array
+    {
+        $materialized = $this->materializedFamilyKeys($html, $css);
+
+        $findings = array();
+        $seen = array();
+
+        foreach ( $this->linkedWebFontFamilies($html) as $linked ) {
+            $key = 'web_font_not_materialized|' . $this->familyKey($linked['family']);
+            if ( isset($seen[$key]) || $this->isRepresented($linked['family'], $materialized) ) {
+                continue;
+            }
+            $seen[$key] = true;
+            $findings[] = array(
+                'code'           => 'web_font_not_materialized',
+                'severity'       => 'warning',
+                'font_family'    => $linked['family'],
+                'selector'       => 'head > link[href]',
+                'source_snippet' => $linked['source_snippet'],
+                'observed_block' => 'none',
+                'summary'        => 'Source linked web-font family was not materialized into output typography.',
+            );
+        }
+
+        $headingDeclarations = array_merge(
+            $this->headingFamiliesFromCss($this->styleBlockCss($html)),
+            $this->normalizeInlineHeadingDeclarations($inlineHeadingDeclarations)
+        );
+
+        foreach ( $headingDeclarations as $declaration ) {
+            $family = (string) $declaration['family'];
+            $key = 'typography_font_family_dropped|' . $this->familyKey($family);
+            if ( '' === $family || isset($seen[$key]) || $this->isRepresented($family, $materialized) ) {
+                continue;
+            }
+            $seen[$key] = true;
+            $findings[] = array(
+                'code'           => 'typography_font_family_dropped',
+                'severity'       => 'warning',
+                'font_family'    => $family,
+                'font_role'      => (string) ($declaration['role'] ?? 'heading'),
+                'selector'       => (string) ($declaration['selector'] ?? ''),
+                'source_snippet' => $this->boundSnippet((string) ($declaration['source_snippet'] ?? '')),
+                'observed_block' => 'none',
+                'summary'        => 'Source ' . ((string) ($declaration['role'] ?? 'heading')) . ' font-family was not represented in output typography.',
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Families the materialization plan derived from the same sources retains.
+     *
+     * @return array<string,true>
+     */
+    private function materializedFamilyKeys(string $html, string $css): array
+    {
+        $plan = $this->planBuilder->fromWebFontSources($html, $css);
+        $keys = array();
+        foreach ( (array) ($plan['fonts'] ?? array()) as $font ) {
+            if ( is_array($font) && '' !== (string) ($font['family'] ?? '') ) {
+                $keys[$this->familyKey((string) $font['family'])] = true;
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Parse `family=` query params out of every `<link href>` generically,
+     * regardless of provider host.
+     *
+     * @return array<int,array{family:string,source_snippet:string}>
+     */
+    private function linkedWebFontFamilies(string $html): array
+    {
+        if ( '' === trim($html) || ! preg_match_all('/<link\b[^>]*>/i', $html, $matches) ) {
+            return array();
+        }
+
+        $families = array();
+        foreach ( $matches[0] as $tag ) {
+            $href = $this->attributeValue((string) $tag, 'href');
+            if ( '' === $href ) {
+                continue;
+            }
+            $href = html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
+            $query = (string) (parse_url($href, PHP_URL_QUERY) ?: '');
+            if ( '' === $query ) {
+                continue;
+            }
+            foreach ( explode('&', $query) as $param ) {
+                if ( ! preg_match('/^family=(.*)$/i', $param, $match) ) {
+                    continue;
+                }
+                $value = urldecode((string) $match[1]);
+                foreach ( explode('|', $value) as $spec ) {
+                    $family = $this->primaryFamily(explode(':', trim($spec), 2)[0] ?? '');
+                    if ( '' === $family ) {
+                        continue;
+                    }
+                    $families[$this->familyKey($family)] = array(
+                        'family'         => $family,
+                        'source_snippet' => $this->boundSnippet(trim((string) $tag)),
+                    );
+                }
+            }
+        }
+
+        return array_values($families);
+    }
+
+    /**
+     * Heading/body `font-family` declarations from CSS rules.
+     *
+     * @return array<int,array{family:string,role:string,selector:string,source_snippet:string}>
+     */
+    private function headingFamiliesFromCss(string $css): array
+    {
+        if ( '' === trim($css) || ! preg_match_all('/([^{}]+)\{([^{}]*)\}/s', $css, $rules, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        $declarations = array();
+        foreach ( $rules as $rule ) {
+            if ( ! preg_match('/font-family\s*:\s*([^;{}]+)/i', (string) $rule[2], $declaration) ) {
+                continue;
+            }
+            $family = $this->primaryFamily((string) $declaration[1]);
+            if ( '' === $family ) {
+                continue;
+            }
+
+            foreach ( array_map('trim', explode(',', (string) $rule[1])) as $selector ) {
+                if ( '' === $selector ) {
+                    continue;
+                }
+                $role = $this->roleForSelector($selector);
+                if ( '' === $role ) {
+                    continue;
+                }
+                $declarations[] = array(
+                    'family'         => $family,
+                    'role'           => $role,
+                    'selector'       => $selector,
+                    'source_snippet' => $this->boundSnippet(trim((string) $rule[0])),
+                );
+            }
+        }
+
+        return $declarations;
+    }
+
+    private function roleForSelector(string $selector): string
+    {
+        if ( preg_match('/(^|[\s>+~])h[1-6]\b/i', $selector) ) {
+            return 'heading';
+        }
+        if ( preg_match('/(^|[\s>+~])(body|html|:root|\*)\b/i', $selector) ) {
+            return 'body';
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<int,array{family?:string,selector?:string,source_snippet?:string}> $declarations
+     * @return array<int,array{family:string,role:string,selector:string,source_snippet:string}>
+     */
+    private function normalizeInlineHeadingDeclarations(array $declarations): array
+    {
+        $normalized = array();
+        foreach ( $declarations as $declaration ) {
+            if ( ! is_array($declaration) ) {
+                continue;
+            }
+            $family = $this->primaryFamily((string) ($declaration['family'] ?? ''));
+            if ( '' === $family ) {
+                continue;
+            }
+            $normalized[] = array(
+                'family'         => $family,
+                'role'           => 'heading',
+                'selector'       => (string) ($declaration['selector'] ?? ''),
+                'source_snippet' => $this->boundSnippet((string) ($declaration['source_snippet'] ?? '')),
+            );
+        }
+
+        return $normalized;
+    }
+
+    private function styleBlockCss(string $html): string
+    {
+        if ( '' === trim($html) || ! preg_match_all('/<style\b[^>]*>(.*?)<\/style>/is', $html, $matches) ) {
+            return '';
+        }
+
+        return implode("\n", $matches[1]);
+    }
+
+    /**
+     * @param array<string,true> $materialized
+     */
+    private function isRepresented(string $family, array $materialized): bool
+    {
+        if ( $this->isWebSafeFamily($family) ) {
+            return true;
+        }
+
+        return isset($materialized[$this->familyKey($family)]);
+    }
+
+    private function primaryFamily(string $declaration): string
+    {
+        foreach ( explode(',', $declaration) as $candidate ) {
+            $family = $this->normalizeFamily($candidate);
+            if ( '' !== $family && ! $this->isWebSafeFamily($family) ) {
+                return $family;
+            }
+        }
+
+        return '';
+    }
+
+    private function attributeValue(string $tag, string $name): string
+    {
+        if ( preg_match('/(?:^|\s)' . preg_quote($name, '/') . '\s*=\s*(["\'])(.*?)\1/is', $tag, $match) ) {
+            return (string) $match[2];
+        }
+        if ( preg_match('/(?:^|\s)' . preg_quote($name, '/') . '\s*=\s*([^\s"\'>]+)/is', $tag, $match) ) {
+            return (string) $match[1];
+        }
+
+        return '';
+    }
+
+    private function normalizeFamily(string $family): string
+    {
+        return trim($family, " \t\n\r\0\x0B\"'");
+    }
+
+    private function familyKey(string $family): string
+    {
+        return strtolower($this->normalizeFamily($family));
+    }
+
+    private function isWebSafeFamily(string $family): bool
+    {
+        return in_array(strtolower($this->normalizeFamily($family)), self::WEB_SAFE_FAMILIES, true);
+    }
+
+    private function boundSnippet(string $snippet): string
+    {
+        $snippet = trim($snippet);
+        if ( strlen($snippet) > self::SNIPPET_BYTE_LIMIT ) {
+            return substr($snippet, 0, self::SNIPPET_BYTE_LIMIT) . '...';
+        }
+
+        return $snippet;
+    }
+}

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1258,6 +1258,64 @@ $webFontMaterializationPlan = ( new MaterializationPlanBuilder() )->fromCompiled
 ));
 $assert('Oswald' === ($webFontMaterializationPlan['theme']['font_materialization']['roles']['heading'] ?? null), 'materialization plan materializes heading font from web-font sources');
 
+// Typography/web-font parity diagnostic (semantic-parity finding family).
+$semanticFindings = static function (array $result): array {
+    return $result['source_reports']['semantic_parity']['findings'] ?? array();
+};
+$findingsByCode = static function (array $findings, string $code): array {
+    return array_values(array_filter($findings, static fn (array $finding): bool => ($finding['code'] ?? '') === $code));
+};
+
+// Positive: a heading web-font declared only in an inline <style> block (no link, no static css)
+// is genuinely dropped and must surface a typography parity finding.
+$droppedHeadingFontResult = ( new HtmlTransformer() )->transform(
+    '<!doctype html><html><head><style>h1,h2{font-family:"Display Custom",sans-serif}</style></head><body><main><h1>Heading</h1><p>Copy</p></main></body></html>',
+    array()
+)->toArray();
+$droppedHeadingFindings = $findingsByCode($semanticFindings($droppedHeadingFontResult), 'typography_font_family_dropped');
+$assert(array() !== $droppedHeadingFindings, 'dropped heading web-font emits typography_font_family_dropped finding');
+$assert('Display Custom' === ($droppedHeadingFindings[0]['font_family'] ?? null), 'typography finding records the dropped font family generically');
+$assert(str_contains((string) ($droppedHeadingFindings[0]['source_snippet'] ?? ''), 'Display Custom'), 'typography finding carries bounded source snippet');
+$assert('none' === ($droppedHeadingFindings[0]['observed_block'] ?? null), 'dropped typography finding records explicit none observed_block');
+$assert('typography_font_family_dropped' === ($droppedHeadingFindings[0]['reason_code'] ?? null), 'typography finding carries stable reason_code');
+
+// Positive: a web-font family linked from a non-materializing provider surfaces web_font_not_materialized.
+$nonMaterializedLinkResult = ( new HtmlTransformer() )->transform(
+    '<!doctype html><html><head><link rel="stylesheet" href="https://use.typekit.net/css?family=Brand+Face:wght@400;700"></head><body><main><h1>Heading</h1></main></body></html>',
+    array()
+)->toArray();
+$nonMaterializedFindings = $findingsByCode($semanticFindings($nonMaterializedLinkResult), 'web_font_not_materialized');
+$assert(array() !== $nonMaterializedFindings, 'non-materializing linked web-font emits web_font_not_materialized finding');
+$assert('Brand Face' === ($nonMaterializedFindings[0]['font_family'] ?? null), 'web_font_not_materialized finding records the linked family generically');
+$assert(str_contains((string) ($nonMaterializedFindings[0]['source_snippet'] ?? ''), '<link'), 'web_font_not_materialized finding carries the source link snippet');
+
+// Negative: a font that materializes (Google Fonts link + matching css) must NOT produce any typography finding.
+$materializedFontResult = ( new HtmlTransformer() )->transform(
+    '<!doctype html><html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Display+Custom:wght@400;700&display=swap"></head><body><main><h1>Heading</h1></main></body></html>',
+    array('static_css' => 'h1,h2,h3{font-family:"Display Custom",sans-serif}')
+)->toArray();
+$materializedTypographyFindings = array_filter(
+    $semanticFindings($materializedFontResult),
+    static fn (array $finding): bool => in_array($finding['code'] ?? '', array('typography_font_family_dropped', 'web_font_not_materialized'), true)
+);
+$assert(array() === $materializedTypographyFindings, 'materialized web-font produces no typography parity finding');
+
+// Enrichment: every semantic-parity finding (landmark/navigation) carries source_snippet, observed_block, and reason_code.
+$underSpecifiedResult = ( new HtmlTransformer() )->transform(
+    '<body><header><nav><span>Menu</span></nav></header><main><p>Copy</p></main></body>',
+    array()
+)->toArray();
+$semanticParityFindings = $semanticFindings($underSpecifiedResult);
+$assert(array() !== $semanticParityFindings, 'navigation/landmark drop produces semantic-parity findings');
+foreach ( $semanticParityFindings as $finding ) {
+    $assert(isset($finding['reason_code']) && '' !== (string) $finding['reason_code'], 'semantic-parity finding carries reason_code');
+    $assert(isset($finding['source_snippet']) && '' !== (string) $finding['source_snippet'], 'semantic-parity finding carries source_snippet');
+    $assert(isset($finding['observed_block']), 'semantic-parity finding carries observed_block');
+}
+$navMissingFindings = $findingsByCode($semanticParityFindings, 'navigation_menu_missing');
+$assert(array() !== $navMissingFindings, 'navigation_menu_missing finding is emitted for unrepresented nav');
+$assert(str_contains((string) ($navMissingFindings[0]['source_snippet'] ?? ''), '<nav'), 'navigation_menu_missing finding source_snippet contains the source nav markup');
+
 $fragment = $compiler->compileFragment('<main><h2>Fragment</h2><p>Copy</p></main>', 'fixture:fragment')->toArray();
 $assert('success' === $fragment['status'], 'fragment compiles successfully', (string) $fragment['status']);
 $assert('fixture:fragment' === ($fragment['provenance'][0]['source'] ?? ''), 'fragment compile exposes source provenance');


### PR DESCRIPTION
Closes #198
Closes #199

Two coupled changes to the `php-transformer/src/HtmlToBlocks/HtmlTransformer.php` semantic-parity finding layer (they share the same finding-emission path).

## #198 — Typography/web-font parity diagnostic (blind spot)
Adds a typography parity check so dropped source typefaces are no longer silent. A new generic helper `HtmlToBlocks/TypographyParityAnalyzer` detects source typefaces and emits findings in the existing `html_semantic_parity_*` family:

- `web_font_not_materialized` — a family linked via any `<link href>` (`family=` params parsed generically across providers) that is not materialized into output.
- `typography_font_family_dropped` — a heading/body `font-family` (from `<style>` blocks and inline heading `style` declarations) that is not represented in output.

"Represented" is defined by the font materialization plan derived from the same sources via `FontMaterializationPlanBuilder::fromWebFontSources()`, so the diagnostic agrees with the materialization that landed in PR #194: a font that DOES materialize (e.g. a Google Fonts `<link>` + matching CSS) never produces a finding. Findings only fire on genuine drops. Detection is generic — no provider-, fixture-, or family-specific strings.

## #199 — Enrich under-specified semantic-parity findings
The `landmark_count_mismatch` / `navigation_menu_missing` (and the new typography) findings already carried a `selector` but lacked source/observed context, so they landed in `diagnostic_blind_spots`. Each semantic-parity finding now additionally carries:

- `source_snippet` — bounded source HTML for the selector, reusing the same bounded-HTML helper used by runtime-island findings (selector is resolved back to the source element).
- `observed_block` — the block output produced for the region (block names / block items from provenance), or an explicit `"none"`.
- `reason_code` — a stable code so findings classify out of `generic_finding_family`.

Enrichment is strictly additive metadata: it does not change parity pass/fail counts.

## Tests
- Added to `tests/contract/run.php`: a typography-drop positive (`typography_font_family_dropped` from an inline `<style>` heading font), a `web_font_not_materialized` positive (non-materializing provider link), a materialized-font negative (Google Fonts link + CSS produces no typography finding), and assertions that landmark/navigation findings now carry `source_snippet` / `observed_block` / `reason_code`.
- `composer test:canonical` green; `composer parity` green (113 fixtures, no pass/fail regression); `composer test:packaging` green.

Scope limited to `php-transformer/src/HtmlToBlocks/` and tests; no changes to `src/VisualParity/` or `src/StaticSite/FontMaterialization/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)