### PR TITLE
Recognize safe iframe embeds generically

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -5275,7 +5275,7 @@ final class HtmlTransformer
         $host = strtolower((string) parse_url($url, PHP_URL_HOST));
         $path = (string) parse_url($url, PHP_URL_PATH);
 
-        if ( str_ends_with($host, 'youtube.com') && preg_match('~^/embed/([^/?#]+)~', $path, $matches) ) {
+        if ( ( str_ends_with($host, 'youtube.com') || str_ends_with($host, 'youtube-nocookie.com') ) && preg_match('~^/embed/([^/?#]+)~', $path, $matches) ) {
             return 'https://www.youtube.com/watch?v=' . $matches[1];
         }
 
@@ -5293,7 +5293,7 @@ final class HtmlTransformer
     private function embedProviderSlug(string $url): string
     {
         $host = strtolower((string) parse_url($url, PHP_URL_HOST));
-        if ( str_ends_with($host, 'youtube.com') || 'youtu.be' === $host ) {
+        if ( str_ends_with($host, 'youtube.com') || str_ends_with($host, 'youtube-nocookie.com') || 'youtu.be' === $host ) {
             return 'youtube';
         }
         if ( str_ends_with($host, 'vimeo.com') ) {
@@ -5326,15 +5326,20 @@ final class HtmlTransformer
     private function convertIframeElement(DOMElement $iframe, array &$fallbacks): ?array
     {
         $url = $this->safeEmbedUrl($this->attr($iframe, 'src'));
-        if ( '' !== $url ) {
+        $providerNameSlug = '' === $url ? '' : $this->embedProviderSlug($url);
+        if ( '' !== $providerNameSlug ) {
             return $this->createBlock('core/embed', array_filter(array_merge($this->presentationAttributes($iframe), array(
                 'url'              => $this->canonicalEmbedUrl($url),
                 'type'             => 'video',
-                'providerNameSlug' => $this->embedProviderSlug($url),
+                'providerNameSlug' => $providerNameSlug,
             )), static fn ($value): bool => '' !== $value), array(), $iframe);
         }
 
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($iframe));
+        $this->recordRuntimeIsland($iframe, 'iframe', 'iframe_requires_embed_runtime', 'third_party_embed_runtime', array(
+            'preservation_strategy' => 'sanitized_embed_markup',
+            'attributes'            => $this->safeEmbedAttributes($iframe),
+        ));
         $fallbacks[] = FallbackDiagnostic::build(array(
             'type'            => 'html',
             'reason'          => 'iframe_embed_fallback',

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -722,6 +722,33 @@ $assertNormalizedFallbackDiagnostic($diagnosticsByCode['html_iframe_embed_fallba
 $assert(! isset($diagnosticsByCode['html_inline_svg_fallback']), 'safe inline SVGs convert to image blocks instead of fallback diagnostics');
 $assert(! isset($diagnosticsByCode['html_canvas_runtime_fallback']), 'non-runtime canvas does not emit runtime canvas fallback diagnostics');
 
+$safeProviderIframe = ( new HtmlTransformer() )->transform(
+    '<main><iframe title="Demo" src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="560" height="315"></iframe></main>'
+)->toArray();
+$safeProviderBlock = $safeProviderIframe['blocks'][0] ?? array();
+$assert('core/embed' === ($safeProviderBlock['blockName'] ?? ''), 'safe provider iframe converts to core/embed');
+$assert('https://www.youtube.com/watch?v=dQw4w9WgXcQ' === ($safeProviderBlock['attrs']['url'] ?? ''), 'safe provider iframe canonicalizes embed URL');
+$assert('youtube' === ($safeProviderBlock['attrs']['providerNameSlug'] ?? ''), 'safe provider iframe records provider slug');
+$assert(array() === ($safeProviderIframe['fallbacks'] ?? array()), 'safe provider iframe does not emit fallback metadata');
+
+$unknownIframe = ( new HtmlTransformer() )->transform(
+    '<main><section><h2>Playground</h2><p>Before embed.</p><iframe title="Interactive demo" src="https://example.test/playground" width="640" height="360" allow="fullscreen"></iframe><p>After embed.</p></section></main>'
+)->toArray();
+$unknownDiagnostics = $unknownIframe['source_reports']['conversion_report']['fallback_diagnostics'] ?? array();
+$unknownIframeDiagnostics = array_values(array_filter($unknownDiagnostics, static fn (array $diagnostic): bool => 'html_iframe_embed_fallback' === ($diagnostic['diagnostic_code'] ?? '')));
+$assert(1 === count($unknownIframeDiagnostics), 'unknown iframe emits one iframe fallback diagnostic');
+$assert('runtime_island_preserved' === ($unknownIframeDiagnostics[0]['conversion_classification'] ?? ''), 'unknown iframe fallback is classified as runtime island preservation');
+$assert('https://example.test/playground' === ($unknownIframe['fallbacks'][0]['attributes']['src'] ?? ''), 'unknown iframe fallback preserves bounded safe src metadata');
+$unknownIframeIslands = array_values(array_filter($unknownIframe['source_reports']['runtime_islands'] ?? array(), static fn (array $island): bool => 'iframe' === ($island['kind'] ?? '')));
+$assert(1 === count($unknownIframeIslands), 'unknown iframe projects as a runtime island');
+$assert('iframe_requires_embed_runtime' === ($unknownIframeIslands[0]['preservation_reason'] ?? ''), 'unknown iframe runtime island exposes preservation reason');
+$unknownSerialized = (string) ($unknownIframe['serialized_blocks'] ?? '');
+$assert(! str_contains($unknownSerialized, '<!-- wp:embed'), 'unknown iframe does not become a provider embed block');
+$assert(! str_contains($unknownSerialized, '<!-- wp:html'), 'unknown iframe does not force raw HTML fallback materialization');
+$assert(str_contains($unknownSerialized, 'Playground'), 'ancestor content around unknown iframe still converts heading content');
+$assert(str_contains($unknownSerialized, 'Before embed.'), 'ancestor content before unknown iframe still converts');
+$assert(str_contains($unknownSerialized, 'After embed.'), 'ancestor content after unknown iframe still converts');
+
 $canvasFallback = ( new HtmlTransformer() )->transform(
     '<main><canvas id="bonsai" class="stage" width="640" height="360">Fallback</canvas><script src="/js/script.js"></script></main>',
     array('runtime_canvas_selectors' => array('#bonsai'))


### PR DESCRIPTION
## Summary
- Convert iframe URLs from recognized safe providers to `core/embed` instead of treating every `http(s)` iframe as embeddable.
- Preserve unknown iframe markup as bounded fallback/runtime-island metadata scoped to the iframe.
- Keep ancestor and sibling content converting normally when an iframe needs runtime preservation.

## Evidence
- Source evidence envelope: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-post-196-homeboy-bench.json`
- Matrix artifact: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/8e954bd5-b29e-41e1-b77a-2d081d33a355-matrix.json
- Finding packets: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/a55abe62-56a5-4820-aacb-1fc573bf84fa-finding-packets.json
- Target family: `fallback_block:unsupported_html_fallback:main`, including fixture `56-code-playground` selector `main:nth-of-type(1) > section:nth-of-type(2) > div:nth-of-type(1) > iframe:nth-of-type(1)`.

## Tests
- `php tests/contract/run.php` from `php-transformer`

## Expected impact
- Supported YouTube/Vimeo iframe embeds materialize as editable `core/embed` blocks with canonical provider URLs.
- Unknown iframe embeds no longer force broad ancestor fallback materialization; they are preserved as iframe-scoped runtime islands/fallback metadata.
- Expected to reduce remaining `fallback_block:unsupported_html_fallback:main` cases where a nested iframe is the unsupported child, including `56-code-playground`, without duplicating the canvas-only work in #201.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Interpreting SSI matrix evidence, implementing the generic PHP transformer iframe/embed recognition, adding focused contract coverage, and drafting this PR description.
