### PR TITLE
Classify static script metadata generically

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3638,6 +3638,9 @@ final class HtmlTransformer
 
         $scriptRole = $this->scriptRole($element);
         if ( 'data' !== $scriptRole ) {
+            $scriptRole = $this->staticScriptMetadataRole($element);
+        }
+        if ( null === $scriptRole ) {
             return false;
         }
 
@@ -3676,6 +3679,45 @@ final class HtmlTransformer
         }
 
         return 'runtime';
+    }
+
+    private function staticScriptMetadataRole(DOMElement $element): ?string
+    {
+        $body = trim($element->textContent ?? '');
+        if ( '' === $body || $this->scriptBodyHasExecutableRuntimeSignals($body) ) {
+            return null;
+        }
+
+        $type = strtolower(trim($this->attr($element, 'type')));
+        if ( 'module' === $type && $this->scriptBodyContainsOnlyStaticImports($body) ) {
+            return 'static_import';
+        }
+
+        if ( $this->scriptBodyContainsOnlyStaticConfig($body) ) {
+            return 'static_config';
+        }
+
+        return null;
+    }
+
+    private function scriptBodyHasExecutableRuntimeSignals(string $body): bool
+    {
+        return 1 === preg_match('/\b(?:document|location|navigator|history|customElements)\b|\b(?:addEventListener|removeEventListener|querySelector|getElementById|appendChild|insertBefore|replaceChild|removeChild|classList|innerHTML|outerHTML|fetch|XMLHttpRequest|setTimeout|setInterval|requestAnimationFrame|import\s*\()\b|\b(?:function|class|new)\b|=>/', $body);
+    }
+
+    private function scriptBodyContainsOnlyStaticImports(string $body): bool
+    {
+        $withoutImports = preg_replace('/^\s*import\s+(?:(?:[\s\S]*?\s+from\s+)?[\'\"][^\'\"]+[\'\"]|[\'\"][^\'\"]+[\'\"])\s*;?\s*/m', '', $body);
+
+        return is_string($withoutImports) && '' === trim($withoutImports);
+    }
+
+    private function scriptBodyContainsOnlyStaticConfig(string $body): bool
+    {
+        $statementPattern = '(?:const|let|var)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*=\s*(?:\{[\s\S]*?\}|\[[\s\S]*?\]|[\'\"][\s\S]*?[\'\"]|[0-9.]+|true|false|null)\s*;?';
+        $globalConfigPattern = '(?:window|globalThis)\.[A-Za-z_$][A-Za-z0-9_$.]*(?:CONFIG|Config|config|SETTINGS|Settings|settings|DATA|Data|data|PROPS|Props|props)[A-Za-z0-9_$.]*\s*=\s*(?:\{[\s\S]*?\}|\[[\s\S]*?\]|[\'\"][\s\S]*?[\'\"]|[0-9.]+|true|false|null)\s*;?';
+
+        return 1 === preg_match('/^\s*(?:' . $statementPattern . '|' . $globalConfigPattern . ')+\s*$/', $body);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-static-script-metadata-no-fallback.json
+++ b/php-transformer/tests/fixtures/parity/html-static-script-metadata-no-fallback.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-static-script-metadata-no-fallback",
-  "description": "Preserves non-executable inline script data as metadata while keeping executable scripts as runtime fallbacks.",
+  "description": "Preserves structured data, static config, import maps, and import-only module scripts as metadata while keeping executable scripts as runtime fallbacks.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-static-script-metadata-no-fallback.json",
-    "notes": "JSON-LD script tags are structured data, not client runtime behavior; executable inline scripts still require runtime fallback diagnostics."
+    "notes": "Static script data and import-only module scripts are bounded metadata; executable inline scripts still require runtime fallback diagnostics."
   },
   "legacy_comparison": {
     "skip": true,
@@ -13,7 +13,7 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<main><h1>Bakery</h1><script type=\"application/ld+json\">{\"@context\":\"https://schema.org\",\"@type\":\"Bakery\",\"name\":\"Loaf Lab\"}</script><script type=\"text/javascript\">window.loafLab.init();</script><p>Fresh bread daily.</p></main>"
+    "content": "<main><h1>Bakery</h1><script type=\"application/ld+json\">{\"@context\":\"https://schema.org\",\"@type\":\"Bakery\",\"name\":\"Loaf Lab\"}</script><script type=\"application/json\" id=\"site-data\">{\"theme\":\"warm\",\"featured\":true}</script><script type=\"importmap\">{\"imports\":{\"loaf\":\"./assets/loaf.js\"}}</script><script>window.__LOAF_CONFIG__ = {\"currency\":\"USD\",\"featured\":true};</script><script type=\"module\">import \"./assets/config.js\";\nimport settings from \"./assets/settings.js\";</script><script type=\"text/javascript\">document.querySelector(\"main\").classList.add(\"hydrated\");</script><p>Fresh bread daily.</p></main>"
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group" },
@@ -26,7 +26,7 @@
       "diagnostic_code": "html_script_fallback",
       "script_role": "runtime",
       "script_source_kind": "inline",
-      "body": "window.loafLab.init();"
+      "body": "document.querySelector(\"main\").classList.add(\"hydrated\");"
     }
   ],
   "expect": [
@@ -34,10 +34,18 @@
     { "path": "fallbacks", "assert": "count", "count": 1 },
     { "path": "diagnostics.1.code", "assert": "equals", "value": "html_static_script_metadata" },
     { "path": "diagnostics.1.reason", "assert": "equals", "value": "script_static_metadata" },
-    { "path": "source_reports.html.script_metadata", "assert": "count", "count": 1 },
+    { "path": "source_reports.html.script_metadata", "assert": "count", "count": 5 },
     { "path": "source_reports.html.script_metadata.0.script_role", "assert": "equals", "value": "data" },
     { "path": "source_reports.html.script_metadata.0.attributes.type", "assert": "equals", "value": "application/ld+json" },
     { "path": "source_reports.html.script_metadata.0.body", "assert": "contains", "value": "schema.org" },
+    { "path": "source_reports.html.script_metadata.1.attributes.type", "assert": "equals", "value": "application/json" },
+    { "path": "source_reports.html.script_metadata.2.attributes.type", "assert": "equals", "value": "importmap" },
+    { "path": "source_reports.html.script_metadata.3.script_role", "assert": "equals", "value": "static_config" },
+    { "path": "source_reports.html.script_metadata.3.body", "assert": "contains", "value": "__LOAF_CONFIG__" },
+    { "path": "source_reports.html.script_metadata.4.script_role", "assert": "equals", "value": "static_import" },
+    { "path": "source_reports.html.script_metadata.4.body", "assert": "contains", "value": "./assets/settings.js" },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 1 },
+    { "path": "source_reports.runtime_islands.0.script_role", "assert": "equals", "value": "runtime" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
   ]
 }


### PR DESCRIPTION
## Summary
- Classify inline static script data beyond MIME-only JSON-LD, including application/json, import maps, literal config assignments, and import-only module declarations.
- Keep executable/runtime scripts as bounded runtime-island fallback metadata when they contain DOM/runtime behavior signals.
- Expand the script parity fixture so static metadata and DOM-mutating executable scripts are covered together.

## Evidence
- Latest SSI matrix run artifact: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/8e954bd5-b29e-41e1-b77a-2d081d33a355-matrix.json
- Finding packets: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/a55abe62-56a5-4820-aacb-1fc573bf84fa-finding-packets.json
- Target family: `fallback_block:unsupported_html_fallback:script`, count 9, including `11-nonprofit-campaign`, `12-portfolio`, `14-restaurant`, `15-saas`, and `2-onepager-coffee`.
- Avoids PR #201 canvas scope: https://github.com/Automattic/blocks-engine/pull/201

## Tests
- `php -l src/HtmlToBlocks/HtmlTransformer.php`
- `php tests/parity/run.php`
- `php tests/contract/run.php`

## Expected impact
- Structured/static script data should become `html_static_script_metadata` diagnostics and `source_reports.html.script_metadata`, avoiding unsupported script fallback blocks for bounded data/config/import declarations.
- DOM-mutating and otherwise runtime-dependent scripts still produce `html_script_fallback` plus `runtime_islands`, preserving executable behavior loss instead of hiding it.
- Expected to reduce the `fallback_block:unsupported_html_fallback:script` family where the fixture script is static/config/import-shaped, while leaving true client runtime scripts in the matrix for downstream runtime-island handling.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Interpreting SSI fixture matrix evidence, implementing the generic PHP transformer script classifier, expanding focused parity coverage, running focused checks, and drafting this PR description.
