### PR TITLE
Preserve readable runtime forms as islands

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1729,8 +1729,14 @@ final class HtmlTransformer
                 'controls'        => $controls,
                 'control_count'   => count($controls),
                 'events'          => $this->eventMetadata($element),
+                'readable_blocks' => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
                 'required_scripts' => $this->requiredScriptsForElement($element),
             ));
+
+            if ( null !== $readableFormBlock ) {
+                return $readableFormBlock;
+            }
+
             $fallbacks[] = FallbackDiagnostic::build(array(
                 'type'            => 'html',
                 'reason'          => 'form_requires_runtime',
@@ -1753,7 +1759,7 @@ final class HtmlTransformer
                 'html_truncated'  => $boundedHtml['truncated'],
             ), $this->fallbackProvenance);
 
-            return $readableFormBlock;
+            return null;
         }
 
         if ( 'nav' === $tagName ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -309,25 +309,33 @@ $assert('contract-test' === ($contextual['provenance'][0]['scope'] ?? ''), 'HTML
 $formFallback = ( new HtmlTransformer() )->transform(
     '<main><form action="/contact" method="post" data-action="contact-submit"><label for="email">Email</label><input id="email" name="email" type="email" required><select name="topic"><option value="support" selected>Support</option></select><button type="submit">Send</button></form></main>'
 )->toArray();
-$formDiagnostic = $formFallback['source_reports']['conversion_report']['fallback_diagnostics'][0] ?? array();
+$formRuntimeIsland = $formFallback['source_reports']['runtime_islands'][0] ?? array();
 $formFallbackBlocks = $formFallback['blocks'][0]['innerBlocks'] ?? array();
-$assert('core/group' === ($formFallback['blocks'][0]['blockName'] ?? ''), 'form fallback materializes readable control blocks');
-$assert('core/paragraph' === ($formFallbackBlocks[0]['blockName'] ?? ''), 'form fallback exposes readable input text');
-$assert('core/group' === ($formFallbackBlocks[1]['blockName'] ?? ''), 'form fallback exposes readable select options');
-$assert('core/buttons' === ($formFallbackBlocks[2]['blockName'] ?? ''), 'form fallback exposes readable submit button');
-$assertNormalizedFallbackDiagnostic($formDiagnostic, 'html_form_fallback', 'warning', 'server_or_client_form_handler', 'form');
+$assert(array() === ($formFallback['fallbacks'] ?? array()), 'readable runtime form converts without unsupported fallback diagnostics');
+$assert(array() === ($formFallback['source_reports']['conversion_report']['fallback_diagnostics'] ?? array()), 'readable runtime form is not projected as a fallback diagnostic');
+$assert('core/group' === ($formFallback['blocks'][0]['blockName'] ?? ''), 'runtime form materializes readable control blocks');
+$assert('core/paragraph' === ($formFallbackBlocks[0]['blockName'] ?? ''), 'runtime form exposes readable input text');
+$assert('core/group' === ($formFallbackBlocks[1]['blockName'] ?? ''), 'runtime form exposes readable select options');
+$assert('core/buttons' === ($formFallbackBlocks[2]['blockName'] ?? ''), 'runtime form exposes readable submit button');
 $assert('form' === ($formFallback['source_reports']['interaction_candidates'][0]['kind'] ?? ''), 'HTML source report exposes form interaction candidate');
 $assert('form' === ($formFallback['source_reports']['conversion_report']['interaction_candidates'][0]['kind'] ?? ''), 'conversion report projects interaction candidates');
 $assert('/contact' === ($formFallback['source_reports']['interaction_candidates'][0]['target'] ?? ''), 'form interaction candidate exposes action target');
-$assert('html_form_fallback' === ($formDiagnostic['diagnostic_code'] ?? ''), 'conversion report exposes form fallback diagnostic code');
-$assert('/contact' === ($formDiagnostic['form']['action'] ?? ''), 'conversion report exposes form action metadata');
-$assert('post' === ($formDiagnostic['form']['method'] ?? ''), 'conversion report exposes normalized form method metadata');
-$assert(3 === ($formDiagnostic['control_count'] ?? null), 'conversion report exposes form control count');
-$assert('email' === ($formDiagnostic['controls'][0]['name'] ?? ''), 'conversion report exposes form control names');
-$assert('Email' === ($formDiagnostic['controls'][0]['label'] ?? ''), 'conversion report exposes form control labels');
-$assert(true === ($formDiagnostic['controls'][0]['required'] ?? null), 'conversion report exposes required form controls');
-$assert('support' === ($formDiagnostic['controls'][1]['options'][0]['value'] ?? ''), 'conversion report exposes select option values');
-$assert(is_int($formDiagnostic['html_bytes'] ?? null), 'conversion report exposes bounded fallback HTML byte size');
+$assert('form' === ($formRuntimeIsland['kind'] ?? ''), 'readable runtime form reports as a runtime island');
+$assert('form_requires_runtime' === ($formRuntimeIsland['preservation_reason'] ?? ''), 'form runtime island exposes preservation reason');
+$assert('/contact' === ($formRuntimeIsland['form']['action'] ?? ''), 'form runtime island exposes form action metadata');
+$assert('post' === ($formRuntimeIsland['form']['method'] ?? ''), 'form runtime island exposes normalized form method metadata');
+$assert(3 === ($formRuntimeIsland['control_count'] ?? null), 'form runtime island exposes form control count');
+$assert('email' === ($formRuntimeIsland['controls'][0]['name'] ?? ''), 'form runtime island exposes form control names');
+$assert('Email' === ($formRuntimeIsland['controls'][0]['label'] ?? ''), 'form runtime island exposes form control labels');
+$assert(true === ($formRuntimeIsland['controls'][0]['required'] ?? null), 'form runtime island exposes required form controls');
+$assert('support' === ($formRuntimeIsland['controls'][1]['options'][0]['value'] ?? ''), 'form runtime island exposes select option values');
+$assert(is_int($formRuntimeIsland['source_bytes'] ?? null), 'form runtime island exposes bounded source byte size');
+$assert('core/group' === ($formRuntimeIsland['readable_blocks'][0]['blockName'] ?? ''), 'form runtime island carries its readable approximation metadata');
+
+$scriptOnlyFormFallback = ( new HtmlTransformer() )->transform('<main><form action="/contact" method="post"><script>window.submitContact()</script></form></main>')->toArray();
+$scriptOnlyFormDiagnostic = $scriptOnlyFormFallback['source_reports']['conversion_report']['fallback_diagnostics'][0] ?? array();
+$assertNormalizedFallbackDiagnostic($scriptOnlyFormDiagnostic, 'html_form_fallback', 'warning', 'server_or_client_form_handler', 'form');
+$assert(array() === ($scriptOnlyFormFallback['blocks'] ?? array()), 'runtime form without readable controls still falls back only as metadata');
 
 $rangeControlResult = ( new HtmlTransformer() )->transform(
     '<main><section><label for="density">Density</label><input type="range" id="density" min="6" max="60" step="2" value="28"></section></main>'

--- a/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-expanded-gap-primitives",
-  "description": "Preserves generic HTML parity gaps for visual placeholders, media wrappers, nested lists, scoped runtime fallbacks, resized SVG images, and code-window labels.",
+  "description": "Preserves generic HTML parity gaps for visual placeholders, media wrappers, nested lists, scoped runtime islands, resized SVG images, and code-window labels.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-expanded-gap-primitives.json",
@@ -39,27 +39,33 @@
     { "path": "blocks.0.innerBlocks.6.innerBlocks.1", "name": "core/code", "attrs": { "className": "language-php", "content": "<?php add_action();" } }
   ],
   "expected_fallbacks": [
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback" },
     { "type": "html", "reason": "script_requires_runtime", "tag": "script", "diagnostic_code": "html_script_fallback" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 7 },
-    { "path": "fallbacks", "assert": "count", "count": 2 },
-    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
-    { "path": "fallbacks.0.control_count", "assert": "equals", "value": 2 },
-    { "path": "fallbacks.1.attributes.src", "assert": "equals", "value": "/widget.js" },
-    { "path": "fallbacks.1.context.parent_tag", "assert": "equals", "value": "section" },
-    { "path": "fallbacks.1.html", "assert": "equals", "value": "" },
-    { "path": "fallbacks.1.body", "assert": "equals", "value": "hydrate()" },
-    { "path": "fallbacks.1.body_truncated", "assert": "equals", "value": false },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.attributes.src", "assert": "equals", "value": "/widget.js" },
+    { "path": "fallbacks.0.context.parent_tag", "assert": "equals", "value": "section" },
+    { "path": "fallbacks.0.html", "assert": "equals", "value": "" },
+    { "path": "fallbacks.0.body", "assert": "equals", "value": "hydrate()" },
+    { "path": "fallbacks.0.body_truncated", "assert": "equals", "value": false },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 2 },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "form" },
+    { "path": "source_reports.runtime_islands.0.preservation_reason", "assert": "equals", "value": "form_requires_runtime" },
+    { "path": "source_reports.runtime_islands.0.form.action", "assert": "equals", "value": "/signup" },
+    { "path": "source_reports.runtime_islands.0.control_count", "assert": "equals", "value": 2 },
+    { "path": "source_reports.runtime_islands.0.readable_blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "source_reports.runtime_islands.1.kind", "assert": "equals", "value": "script" },
+    { "path": "source_reports.runtime_islands.1.attributes.src", "assert": "equals", "value": "/widget.js" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-image is-resized\"><img src=\"logo.svg\" alt=\"Logo\" width=\"120\" height=\"80\"/></figure>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<li>Parent<!-- wp:list -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "theme.json" },
     { "path": "serialized_blocks", "assert": "contains", "value": "functions.php" },
-    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_form_fallback" },
-    { "path": "diagnostics.2.code", "assert": "equals", "value": "html_script_fallback" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_script_fallback" },
+    { "path": "diagnostics.2.code", "assert": "equals", "value": "preserved_runtime_island" },
+    { "path": "diagnostics.2.kind", "assert": "equals", "value": "form" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
@@ -5,7 +5,7 @@
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-runtime-form-fallback-metadata.json",
-    "notes": "Simple non-search forms become readable labels and inert button blocks while action-backed submit behavior stays in fallback metadata."
+    "notes": "Simple non-search forms become readable labels and inert button blocks while action-backed submit behavior stays in runtime-island metadata."
   },
   "legacy_comparison": {
     "skip": true,
@@ -20,22 +20,24 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/group" },
     { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "newsletter" } }
   ],
-  "expected_fallbacks": [
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "control_count": 4 },
-    { "type": "html", "reason": "form_requires_runtime", "tag": "form", "diagnostic_code": "html_form_fallback", "control_count": 2 }
-  ],
+  "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 2 },
-    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
-    { "path": "fallbacks.0.control_count", "assert": "equals", "value": 4 },
-    { "path": "fallbacks.1.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
-    { "path": "fallbacks.1.control_count", "assert": "equals", "value": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 2 },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "form" },
+    { "path": "source_reports.runtime_islands.0.form.action", "assert": "equals", "value": "/contact" },
+    { "path": "source_reports.runtime_islands.0.control_count", "assert": "equals", "value": 4 },
+    { "path": "source_reports.runtime_islands.0.readable_blocks.0.innerBlocks", "assert": "count", "count": 4 },
+    { "path": "source_reports.runtime_islands.1.kind", "assert": "equals", "value": "form" },
+    { "path": "source_reports.runtime_islands.1.form.action", "assert": "equals", "value": "/newsletter" },
+    { "path": "source_reports.runtime_islands.1.control_count", "assert": "equals", "value": 2 },
+    { "path": "source_reports.runtime_islands.1.readable_blocks.0.innerBlocks", "assert": "count", "count": 2 },
     { "path": "serialized_blocks", "assert": "contains", "value": "Name (required)" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Email: you@example.com" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Subscribe" },
     { "path": "coverage.0.block_count", "assert": "equals", "value": 1 },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-runtime-form-readable-controls",
-  "description": "Keeps runtime-backed forms visible as readable blocks while preserving fallback metadata for submit behavior.",
+  "description": "Keeps runtime-backed forms visible as readable blocks while preserving runtime-island metadata for submit behavior.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-runtime-form-readable-controls.json",
@@ -23,25 +23,25 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Newsletter", "level": 2 } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/group" }
   ],
-  "expected_fallbacks": [
-    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback", "tag": "form", "control_count": 2 }
-  ],
+  "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0.blockName", "assert": "equals", "value": "core/paragraph" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
-    { "path": "fallbacks.0.events.0.type", "assert": "equals", "value": "submit" },
-    { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.blockName", "assert": "equals", "value": "core/group" },
-    { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/paragraph" },
-    { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
-    { "path": "source_reports.conversion_report.fallback_diagnostics.0.readable_blocks.0.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 2 },
+    { "path": "source_reports.runtime_islands.1.kind", "assert": "equals", "value": "form" },
+    { "path": "source_reports.runtime_islands.1.events.0.type", "assert": "equals", "value": "submit" },
+    { "path": "source_reports.conversion_report.runtime_islands.1.readable_blocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "source_reports.conversion_report.runtime_islands.1.readable_blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/paragraph" },
+    { "path": "source_reports.conversion_report.runtime_islands.1.readable_blocks.0.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
+    { "path": "source_reports.conversion_report.runtime_islands.1.readable_blocks.0.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
     { "path": "source_reports.html.runtime_islands.0.kind", "assert": "equals", "value": "control" },
     { "path": "source_reports.html.runtime_islands.0.selector", "assert": "equals", "value": "#signup-email" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<input id=\"signup-email\"" },
-    { "path": "source_reports.conversion_report.fallback_diagnostics.0.reason", "assert": "equals", "value": "form_requires_runtime" }
+    { "path": "source_reports.conversion_report.runtime_islands.1.preservation_reason", "assert": "equals", "value": "form_requires_runtime" }
   ]
 }


### PR DESCRIPTION
## Summary
- Preserve runtime-dependent forms with readable static approximations as runtime-island metadata instead of fallback diagnostics.
- Keep surrounding content and readable form controls as native blocks while carrying bounded source markup, form metadata, controls, and readable approximation data on the runtime island.
- Continue emitting `html_form_fallback` only when a runtime form cannot produce a readable approximation.

## Expected matrix impact
- Should reduce `fallback_block:unsupported_html_fallback:main` findings where `reason=form_requires_runtime` for forms nested under large ancestors.
- Targeted local fixture checks against `3-artist-music` and `40-job-board` now produce `form_fallbacks=0` with form runtime islands preserved. The other listed index fixtures had no `form_requires_runtime` fallbacks in the PHP transformer path checked locally.
- Does not address unrelated fallback families such as script, iframe, kbd, or canvas.

## Conflict / overlap notes
- PR #201 (`fix/ssi-canvas-fallback-islands`) is open and touches the same transformer file, but only changes canvas handling and a canvas parity fixture. This PR does not duplicate that work.

## Tests
- `composer test:canonical`
- Targeted PHP transformer fixture check for `3-artist-music`, `40-job-board`, `56-code-playground`, `58-infinite-whiteboard`, and `60-node-editor`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** PHP transformer implementation, focused contract tests, fixture-impact verification, and PR drafting.