### PR TITLE
Preserve semantic selectors while filtering JS hooks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2192,9 +2192,14 @@ final class HtmlTransformer
     private function presentationClassName(string $className): string
     {
         $classes = preg_split('/\s+/', trim($className)) ?: array();
-        $classes = array_filter($classes, static fn (string $class): bool => '' !== $class && ! str_starts_with($class, 'js-'));
+        $classes = array_filter($classes, static fn (string $class): bool => '' !== $class && ! self::isBehaviorHookClassName($class));
 
         return implode(' ', array_values(array_unique($classes)));
+    }
+
+    private static function isBehaviorHookClassName(string $className): bool
+    {
+        return 1 === preg_match('/^js(?:$|[-_:]|[A-Z])/', $className);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-semantic-selector-preservation.json
+++ b/php-transformer/tests/fixtures/parity/html-semantic-selector-preservation.json
@@ -1,0 +1,46 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-semantic-selector-preservation",
+  "description": "Preserves generic semantic header, navigation, and section selectors on generated block wrappers while filtering JavaScript behavior hooks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-semantic-selector-preservation.json",
+    "notes": "Product-neutral coverage for stable semantic selector preservation in generated block markup."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header id=\"site-header\" class=\"site-header js js-site-header jsHeader\"><nav id=\"mobile-nav\" class=\"site-nav js-site-nav js_nav\" aria-label=\"Primary\"><ul><li><a href=\"/\">Home</a></li><li><a href=\"/services\">Services</a></li></ul></nav></header><section id=\"feature-section\" class=\"feature-section reveal js-reveal\"><h2>Featured</h2><p>Stable source selectors remain available.</p></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "anchor": "site-header", "className": "site-header" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation", "attrs": { "anchor": "mobile-nav", "className": "site-nav" } },
+    { "path": "blocks.1", "name": "core/group", "attrs": { "anchor": "feature-section", "className": "feature-section reveal" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"anchor\":\"site-header\",\"className\":\"site-header\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"anchor\":\"mobile-nav\",\"className\":\"site-nav\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"anchor\":\"feature-section\",\"className\":\"feature-section reveal\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-site-header" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "jsHeader" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-site-nav" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js_nav" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-reveal" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "class=\"js\"" },
+    { "path": "source_reports.html.source_provenance.0.selector", "assert": "equals", "value": "header:nth-of-type(1)" },
+    { "path": "source_reports.html.source_provenance.0.source_attributes.id", "assert": "equals", "value": "site-header" },
+    { "path": "source_reports.html.source_provenance.0.source_attributes.class", "assert": "equals", "value": "site-header js js-site-header jsHeader" },
+    { "path": "source_reports.html.source_provenance.1.selector", "assert": "equals", "value": "header:nth-of-type(1) > nav:nth-of-type(1)" },
+    { "path": "source_reports.html.source_provenance.1.source_attributes.id", "assert": "equals", "value": "mobile-nav" },
+    { "path": "source_reports.html.source_provenance.4.selector", "assert": "equals", "value": "section:nth-of-type(1)" },
+    { "path": "source_reports.html.source_provenance.4.source_attributes.id", "assert": "equals", "value": "feature-section" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve stable semantic source selectors on generated block wrappers for generic header/nav/section conversion paths.
- Keep presentation class preservation generic while filtering JavaScript behavior-hook classes beyond only `js-*` (`js`, `js-*`, `js_*`, `js:*`, and camel-case `jsHook`).
- Add a product-neutral PHP transformer parity fixture proving header/nav/section source IDs/classes survive conversion, behavior hooks stay out of serialized blocks, no raw HTML fallback is emitted, and block serialization remains valid.

## Evidence
- Latest SSI fixture matrix run: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/8e954bd5-b29e-41e1-b77a-2d081d33a355-matrix.json
- Finding packets: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/a55abe62-56a5-4820-aacb-1fc573bf84fa-finding-packets.json
- Runtime/materialization target families called out from the latest matrix include `.site-header` count 24, `.site-nav` count 16, `.reveal` count 13, and `#mobile-nav` count 10.
- Open PR #201 is canvas-specific and not touched here.
- Merged PR #196 form selector work is not duplicated here.

## Tests
- `composer test:parity` from `php-transformer/` passed: 117 fixture(s)

## Expected matrix impact
- Reduces runtime/materialization target gaps where source scripts or CSS expect stable semantic header/nav/section IDs/classes to exist on generated block markup.
- Keeps behavior-only hooks out of serialized blocks so generated markup exposes semantic targets like `.site-header`, `.site-nav`, `.reveal`, and `#mobile-nav` without carrying JavaScript-only hooks.
- Does not attempt a local matrix rerun; fixture matrix benchmarks must run through Homeboy/lab.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Matrix evidence inspection, targeted transformer implementation, focused parity fixture coverage, test execution, and PR drafting.
