### PR TITLE
Document php-transformer Homeboy release path

### DIFF
--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -210,12 +210,18 @@ Operator-only release checklist after the release-readiness PR merges:
 - Update downstream wrapper/product PRs from review-only constraints to tagged constraints.
 - Decide whether GitHub Releases are part of this first package publication path.
 
-Homeboy owns the local release preflight for this package through `php-transformer/homeboy.json`. The only version target is `VERSION`, currently `0.1.0`; release automation should tag from the package subtree after the upstream PRs are merged, without adding wrapper-package names to this package metadata.
+Homeboy owns the local release preflight for this package through `php-transformer/homeboy.json`. Run Homeboy with `php-transformer/` as the component path so release automation detects the monorepo path and uses `php-transformer-v*` tags, without adding wrapper-package names to this package metadata.
 
 Recommended post-merge dry-run:
 
 ```sh
 homeboy release php-transformer --dry-run --skip-publish --no-github-release
+```
+
+When running from outside the package directory, pass the package path explicitly:
+
+```sh
+homeboy release php-transformer --path /path/to/blocks-engine/php-transformer --dry-run --skip-publish --no-github-release
 ```
 
 Recommended first release command after the dry-run passes and the merge commit is ready to tag:


### PR DESCRIPTION
## Summary
- Clarifies that php-transformer releases must run Homeboy against the package directory so monorepo release detection uses `php-transformer-v*` tags.
- Adds the explicit `--path` form for operators running from outside `php-transformer/`.
- Avoids adding duplicate root Homeboy config that would make php-transformer look like a repo-root component and risk unprefixed `v*` tags.

## Testing
- `homeboy version show --path /Users/chubes/Developer/blocks-engine@fix-php-transformer-homeboy-release/php-transformer php-transformer`
- `composer install --no-interaction && composer test` from `php-transformer/`

## Notes
- Did not release or tag.
- `homeboy release php-transformer --path /Users/chubes/Developer/blocks-engine@fix-php-transformer-homeboy-release/php-transformer --dry-run --skip-publish --no-github-release --i-know-ci-creates-the-github-release` reaches release planning, then Homeboy blocks execution from this feature branch because releases must run from default branch `trunk`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspecting Homeboy config behavior, updating release-path documentation, running validation, and preparing this PR.
