### PR TITLE
Preserve generic form status targets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -342,6 +342,7 @@ final class ArtifactCompiler
     {
         $selectors = array();
         $controlSelectors = $this->formControlSelectors($html);
+        $statusFeedbackSelectors = $this->formStatusFeedbackSelectors($html);
         foreach ( $this->documentScriptContents($html, $sourcePath, $files) as $script ) {
             $runtimeControlSelectors = $this->scriptControlRuntimeSelectors($script);
             foreach ( $this->scriptDomSelectors($script) as $selector ) {
@@ -352,7 +353,66 @@ final class ArtifactCompiler
             }
         }
 
+        foreach ( $this->allScriptContents($files) as $script ) {
+            foreach ( $this->scriptDomSelectors($script) as $selector ) {
+                if ( isset($statusFeedbackSelectors[$selector]) ) {
+                    $selectors[$selector] = true;
+                }
+            }
+        }
+
         return array_keys($selectors);
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function formStatusFeedbackSelectors(string $html): array
+    {
+        $selectors = array();
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if ( ! $loaded ) {
+            return array();
+        }
+
+        foreach ( $document->getElementsByTagName('*') as $element ) {
+            if ( ! $element instanceof DOMElement || ! $this->isFormStatusFeedbackElement($element) ) {
+                continue;
+            }
+
+            $id = trim($element->hasAttribute('id') ? $element->getAttribute('id') : '');
+            if ( '' !== $id ) {
+                $selectors['#' . $id] = true;
+            }
+            foreach ( preg_split('/\s+/', trim($element->hasAttribute('class') ? $element->getAttribute('class') : '')) ?: array() as $class ) {
+                if ( '' !== $class && ! $this->isBehaviorHookClassName($class) ) {
+                    $selectors['.' . $class] = true;
+                }
+            }
+        }
+
+        return $selectors;
+    }
+
+    private function isFormStatusFeedbackElement(DOMElement $element): bool
+    {
+        if ( in_array(strtolower($element->tagName), array('button', 'input', 'select', 'textarea', 'form', 'script', 'style'), true) ) {
+            return false;
+        }
+
+        $tokens = strtolower(trim(implode(' ', array(
+            $element->hasAttribute('id') ? $element->getAttribute('id') : '',
+            $element->hasAttribute('class') ? $element->getAttribute('class') : '',
+            $element->hasAttribute('role') ? $element->getAttribute('role') : '',
+            $element->hasAttribute('aria-live') ? 'aria-live' : '',
+        ))));
+
+        return (bool) preg_match('/(?:^|[^a-z0-9])(?:form|contact|newsletter|signup|subscribe|submission|submit|message|status|feedback|alert|notice|response|success|error|warning|confirmation|thanks?)(?:[^a-z0-9]|$)/', $tokens)
+            && (bool) preg_match('/(?:^|[^a-z0-9])(?:success|error|message|status|feedback|alert|notice|response|warning|confirmation|thanks?|aria-live)(?:[^a-z0-9]|$)/', $tokens);
     }
 
     /**
@@ -482,6 +542,27 @@ final class ArtifactCompiler
         }
 
         return $selectors;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, string>
+     */
+    private function allScriptContents(array $files): array
+    {
+        $scripts = array();
+        foreach ( $files as $file ) {
+            if ( $this->isMaterializedScriptAsset($file) && is_string($file['content'] ?? null) ) {
+                $scripts[] = (string) $file['content'];
+            }
+        }
+
+        return $scripts;
+    }
+
+    private function isBehaviorHookClassName(string $className): bool
+    {
+        return 1 === preg_match('/^js(?:$|[-_:]|[A-Z])/', $className);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1419,6 +1419,9 @@ final class HtmlTransformer
         if ( 'p' === $tagName ) {
             $content = $this->innerHtml($element);
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                if ( $this->isRuntimeDomTarget($element) ) {
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
+                }
                 $textBlocks = $this->convertText(trim($element->textContent ?? ''));
                 return $textBlocks[0] ?? null;
             }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1161,6 +1161,29 @@ $assert(str_contains((string) ($runtimeTargetContainerSite['serialized_blocks'] 
 $assert(str_contains((string) ($runtimeTargetContainerSite['serialized_blocks'] ?? ''), 'mobile-nav-overlay'), 'artifact block markup preserves mobile nav overlay target class after navigation dedupe');
 $assert(! str_contains((string) ($runtimeTargetContainerSite['serialized_blocks'] ?? ''), 'drawer-nav'), 'artifact block markup still removes duplicate drawer navigation links after preserving target wrapper');
 
+$externalFormStatusTargetSite = $compiler->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><form class="contact-form"><label>Email<input type="email" name="email"></label><button type="submit">Send</button></form><div class="form-success js-form-success" role="status" aria-live="polite"></div><p class="form-error"></p></main>',
+            'website/nav.js' => 'document.querySelector(".form-success"); document.querySelector(".form-error");',
+        ),
+    )
+)->toArray();
+$externalFormStatusMarkup = (string) ($externalFormStatusTargetSite['serialized_blocks'] ?? '');
+$externalFormStatusReport = $externalFormStatusTargetSite['source_reports']['runtime_dependency_parity'] ?? array();
+$externalFormStatusDependencies = array();
+foreach ( $externalFormStatusReport['dependencies'] ?? array() as $dependency ) {
+    $externalFormStatusDependencies[$dependency['selector'] ?? ''] = $dependency;
+}
+$assert('pass' === ($externalFormStatusReport['status'] ?? ''), 'runtime dependency parity passes external-script form feedback targets');
+$assert(true === ($externalFormStatusDependencies['.form-success']['generated_present'] ?? null), 'external script .form-success target remains present in generated block markup');
+$assert(true === ($externalFormStatusDependencies['.form-error']['generated_present'] ?? null), 'external script .form-error target remains present in generated block markup');
+$assert(str_contains($externalFormStatusMarkup, 'form-success'), 'generated block markup preserves form success feedback class');
+$assert(str_contains($externalFormStatusMarkup, 'form-error'), 'generated block markup preserves form error feedback class');
+$assert(! str_contains($externalFormStatusMarkup, 'js-form-success'), 'generated block markup still omits behavior-hook feedback classes');
+$assert(! str_contains($externalFormStatusMarkup, '<div class="form-success js-form-success"'), 'form feedback target is not preserved as raw HTML fallback markup');
+
 $legacyFrontPageSite = $compiler->compile(
     array(
         'entrypoint' => 'index.html',


### PR DESCRIPTION
## Summary
- Preserve generic form status/feedback DOM targets referenced by script assets, including success/error/message/status containers.
- Keep output in editable core blocks rather than raw HTML fallback markup.
- Continue filtering behavior-hook classes such as `js-*` from generated markup.

## Evidence
- Post-release SSI matrix run: https://homeboy-artifacts-tunnel.dev.chubes.net/10cc02d8-e07d-4595-8e5a-170c2ed1bab0
- Top family addressed: `runtime_target_gap:runtime_dependency_missing_dom_target:class:form-success`
- Affected fixtures from evidence: `36-church-community`, `4-course-education`, `41-generative-art-studio`, `42-immersive-product-launch`, `9-membership-community`

## Tests
- `php tests/contract/run.php`
- `composer test:canonical`

## Expected Matrix Impact
- Expected to clear the 5-count `.form-success` runtime target gap family by retaining generated block selectors for generic form success/status feedback containers.
- Also covers adjacent generic feedback selectors such as `.form-error`, `.form-message`, `.form-status`, alert/notice/response/confirmation containers when referenced by script assets.
- No local benchmark run was performed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the generic PHP transformer fix, adding focused contract coverage, and preparing this PR description.