### PR TITLE
Preserve generic inline token selectors

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1831,6 +1831,11 @@ final class HtmlTransformer
                 return $namePriceRow;
             }
 
+            $inlineTokenGroup = $this->inlineTokenGroupBlockFromElement($element, $fallbacks);
+            if ( null !== $inlineTokenGroup ) {
+                return $inlineTokenGroup;
+            }
+
             $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
             if ( null !== $inlineContent ) {
                 return $inlineContent;
@@ -2575,6 +2580,96 @@ final class HtmlTransformer
         }
 
         return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+    }
+
+    private function inlineTokenGroupBlockFromElement(DOMElement $element, array &$fallbacks): ?array
+    {
+        if ( ! in_array(strtolower($element->tagName), array( 'div', 'footer', 'header', 'main', 'nav', 'section' ), true) ) {
+            return null;
+        }
+
+        if ( ! $this->hasInlineTokenGroupSignal($element) ) {
+            return null;
+        }
+
+        $children = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                if ( '' !== trim($child->textContent ?? '') ) {
+                    return null;
+                }
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( ! $this->isInlineTokenItemElement($child) ) {
+                return null;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( in_array($tagName, array( 'a', 'button' ), true) ) {
+                $block = $this->convertElement($child, $fallbacks, true);
+                if ( null === $block ) {
+                    return null;
+                }
+                $children[] = $block;
+                continue;
+            }
+
+            $content = $this->innerHtml($child);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+            $children[] = $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($child), array( 'content' => $content )), array(), $child);
+        }
+
+        if ( count($children) < 2 ) {
+            return null;
+        }
+
+        return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+    }
+
+    private function hasInlineTokenGroupSignal(DOMElement $element): bool
+    {
+        if ( $this->hasInlineTokenSignal($element) ) {
+            return true;
+        }
+
+        $tokenChildren = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && $this->isInlineTokenItemElement($child) ) {
+                ++$tokenChildren;
+            }
+        }
+
+        return 1 < $tokenChildren;
+    }
+
+    private function isInlineTokenItemElement(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( ! in_array($tagName, array( 'a', 'button' ), true) && ! $this->isInlineContentElement($tagName) ) {
+            return false;
+        }
+
+        return $this->hasInlineTokenSignal($element);
+    }
+
+    private function hasInlineTokenSignal(DOMElement $element): bool
+    {
+        $tokens = strtolower(trim(implode(' ', array(
+            $this->attr($element, 'class'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'role'),
+            $this->attr($element, 'data-filter'),
+            $this->attr($element, 'data-tag'),
+        ))));
+
+        return 1 === preg_match('/(?:^|[^a-z0-9])(?:chips?|pills?|badges?|tags?|filters?|facets?)(?:[^a-z0-9]|$)/', $tokens);
     }
 
     private function paragraphBlockFromInlineContentWrapper(DOMElement $element): ?array

--- a/php-transformer/tests/fixtures/parity/artifact-inline-token-runtime-target-parity.json
+++ b/php-transformer/tests/fixtures/parity/artifact-inline-token-runtime-target-parity.json
@@ -1,0 +1,47 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-inline-token-runtime-target-parity",
+  "description": "Keeps generated block markup addressable for first-party scripts targeting generic chip, pill, badge, tag, and filter token selectors.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-inline-token-runtime-target-parity.json",
+    "notes": "Covers the post-release SSI matrix runtime-target gap for token-like inline selectors without fixture-specific class names."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<main><section class=\"filter-chip-group js-filter-chip-group\"><span class=\"chip js-chip\" data-filter=\"all\">All</span><span class=\"pill js-pill\">Vegetarian</span><span class=\"badge jsBadge\">New</span><span class=\"tag js_tag\">Quick</span></section><script src=\"site.js\"></script></main>"
+        },
+        {
+          "path": "site.js",
+          "kind": "js",
+          "content": "document.querySelectorAll('.chip').forEach(function (chip) { chip.addEventListener('click', function () {}); }); document.querySelector('.pill'); document.querySelector('.badge'); document.querySelector('.tag'); document.querySelector('.filter-chip-group');"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" },
+    { "path": "source_reports.runtime_dependency_parity.dependencies", "assert": "count", "count": 5 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "filter-chip-group" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"chip\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"pill\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"badge\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"tag\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-filter-chip-group" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-chip" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-pill" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "jsBadge" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js_tag" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-inline-token-selector-preservation.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-token-selector-preservation.json
@@ -1,0 +1,43 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-token-selector-preservation",
+  "description": "Preserves stable source classes for generic chip, pill, badge, tag, and filter-like inline groups while filtering JavaScript hook classes.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-token-selector-preservation.json",
+    "notes": "Product-neutral coverage for source selector parity on inline token groups used by runtime scripts."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"filter-chip-group js-filter-chip-group\"><span class=\"chip js-chip\" data-filter=\"all\">All</span><span class=\"pill js-pill\">Vegetarian</span><span class=\"badge jsBadge\">New</span><span class=\"tag js_tag\">Quick</span></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "filter-chip-group" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "chip", "content": "All" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "pill", "content": "Vegetarian" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "className": "badge", "content": "New" } },
+    { "path": "blocks.0.innerBlocks.3", "name": "core/paragraph", "attrs": { "className": "tag", "content": "Quick" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 4 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "filter-chip-group" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"chip\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"pill\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"badge\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"tag\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-filter-chip-group" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-chip" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js-pill" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "jsBadge" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "js_tag" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Recognize generic chip/pill/badge/tag/filter-like inline token groups before collapsing phrasing-only wrappers into a single paragraph.
- Emit a `core/group` with per-token block children so stable source classes remain present in generated markup for runtime scripts.
- Continue filtering JavaScript hook classes such as `js-chip`, `jsBadge`, and `js_tag` from block output.

## Evidence
- Post-release SSI matrix run: https://homeboy-artifacts-tunnel.dev.chubes.net/10cc02d8-e07d-4595-8e5a-170c2ed1bab0
- Finding packets: https://homeboy-artifacts-tunnel.dev.chubes.net/10cc02d8-e07d-4595-8e5a-170c2ed1bab0/588cb6ca-71b3-4fea-a8da-7bde577b6445-finding-packets.json
- Top family addressed: `runtime_target_gap:runtime_dependency_missing_dom_target:class:chip`
- Affected fixtures from evidence: `23-recipe-blog`, `25-real-estate`, `26-government-municipal`, `27-university-department`, `28-enterprise-b2b`

## Tests
- `composer test:parity`
- `composer test:canonical`

## Expected matrix impact
- Should remove the generic `.chip` runtime DOM target gaps where chip-like inline groups were flattened without stable per-token block selectors.
- Expected direct reduction: up to 7 unacceptable findings in the top Blocks Engine family from the supplied post-release evidence, with likely adjacent coverage for `.pill`, `.badge`, `.tag`, and filter/facet token groups.
- Not benchmarked locally per operator rule.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigating the SSI matrix evidence, implementing the PHP transformer selector-preservation primitive, adding parity/contract fixtures, and drafting this PR description.
