### PR TITLE
Diagnose referenced site JS that is never materialized (runtime_script_not_materialized)

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -76,7 +76,7 @@ final class ArtifactCompiler
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
         $sourceReports['materialization_plan'] = ( new MaterializationPlanBuilder() )->fromCompiledSite($sourceReports['compiled_site']);
-        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands']);
+        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references']);
         if ( array() !== $entryBlocks['runtime_islands'] ) {
             $sourceReports['runtime_islands'] = $entryBlocks['runtime_islands'];
         }

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
+use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use DOMDocument;
 use DOMElement;
 
@@ -13,9 +14,10 @@ final class RuntimeDependencyParityReport
     /**
      * @param array<int, array<string, mixed>> $files
      * @param array<int, array<string, mixed>> $runtimeIslands
+     * @param array<int, array<string, mixed>> $assetReferences
      * @return array<string, mixed>
      */
-    public function fromArtifact(array $files, string $sourceHtml, string $generatedHtml, string $sourcePath = '', array $runtimeIslands = array()): array
+    public function fromArtifact(array $files, string $sourceHtml, string $generatedHtml, string $sourcePath = '', array $runtimeIslands = array(), array $assetReferences = array()): array
     {
         $sourceTargets = $this->sourceTargets($sourceHtml, $sourcePath);
         $generatedTargets = $this->withRuntimeIslandTargets($this->htmlTargets($generatedHtml), $runtimeIslands);
@@ -87,12 +89,144 @@ final class RuntimeDependencyParityReport
             }
         }
 
+        foreach ( $this->scriptMaterializationFindings($files, $runtimeIslands, $assetReferences, $generatedHtml, $sourcePath) as $finding ) {
+            $findings[] = $finding;
+        }
+
         return array_filter(array(
             'schema'       => self::SCHEMA,
             'status'       => array() === $findings ? 'pass' : 'warning',
             'dependencies' => $this->dedupeRows($dependencies),
             'findings'     => $this->dedupeRows($findings),
         ), static fn (mixed $value): bool => array() !== $value);
+    }
+
+    /**
+     * Detect source-declared client-script execution dependencies (referenced
+     * external `<script src>` islands flagged `client_script_execution`) whose
+     * backing script was never materialized as an artifact file nor carried into
+     * the generated markup. When that happens, every interaction that depended on
+     * that script is silently non-functional — a feature-parity loss the existing
+     * DOM-target comparison cannot see because it only inspects scripts present in
+     * the artifact.
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @param array<int, array<string, mixed>> $runtimeIslands
+     * @param array<int, array<string, mixed>> $assetReferences
+     * @return array<int, array<string, mixed>>
+     */
+    private function scriptMaterializationFindings(array $files, array $runtimeIslands, array $assetReferences, string $generatedHtml, string $sourcePath): array
+    {
+        $materialized = $this->materializedScriptPaths($files, $assetReferences, $sourcePath);
+        $findings = array();
+
+        foreach ( $runtimeIslands as $island ) {
+            if ( ! is_array($island) ) {
+                continue;
+            }
+            if ( 'script' !== ($island['kind'] ?? '') ) {
+                continue;
+            }
+            if ( ! str_contains((string) ($island['runtime_requirement'] ?? ''), 'client_script_execution') ) {
+                continue;
+            }
+            if ( 'external' !== ($island['script_source_kind'] ?? '') ) {
+                continue;
+            }
+
+            $attributes = is_array($island['attributes'] ?? null) ? $island['attributes'] : array();
+            $src = trim((string) ($attributes['src'] ?? ''));
+            if ( '' === $src ) {
+                continue;
+            }
+
+            $islandSourcePath = (string) ($island['source_path'] ?? $sourcePath);
+            $resolved = ArtifactPath::resolveRelativePath($src, $islandSourcePath);
+            $normalizedSrc = $this->normalizeScriptPath($src);
+
+            if ( isset($materialized[$resolved]) || ('' !== $normalizedSrc && isset($materialized[$normalizedSrc])) ) {
+                continue;
+            }
+            if ( '' !== trim($generatedHtml) && str_contains($generatedHtml, $src) ) {
+                continue;
+            }
+
+            $scriptKind = $this->scriptKind($src, '');
+            $severity = 'telemetry' === $scriptKind ? 'info' : 'warning';
+            $findings[] = array_filter(array(
+                'code'              => 'runtime_script_not_materialized',
+                'severity'          => $severity,
+                'source_path'       => $islandSourcePath,
+                'script_path'       => '' !== $resolved ? $resolved : $src,
+                'script_src'        => $src,
+                'script_kind'       => $scriptKind,
+                'script_source_kind' => 'external',
+                'selector'          => (string) ($island['selector'] ?? ''),
+                'target_kind'       => (string) ($island['tag'] ?? 'script'),
+                'runtime_requirement' => 'client_script_execution',
+                'repair_bucket'     => 'runtime_script_materialization',
+                'suggested_primitive' => 'runtime_script',
+                'actionability'     => 'materialize_or_enqueue_the_referenced_client_script_so_dependent_interactions_execute',
+                'materialization_hint' => 'carry_or_enqueue_the_referenced_script_source_so_client_script_execution_is_restored',
+                'message'           => sprintf('Source references client script %s requiring client_script_execution, but it was not materialized or carried into the artifact, so the dependent interactions are non-functional.', $src),
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value);
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Set of artifact-materialized script paths, keyed by normalized path. A
+     * script is considered materialized when its content survives as a file in
+     * the artifact bundle, or when it surfaces as a resolved asset reference
+     * (which is only recorded when the referenced file was found).
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @param array<int, array<string, mixed>> $assetReferences
+     * @return array<string, bool>
+     */
+    private function materializedScriptPaths(array $files, array $assetReferences, string $sourcePath): array
+    {
+        $paths = array();
+
+        foreach ( $files as $file ) {
+            if ( ! is_array($file) || ! $this->isScriptFile($file) ) {
+                continue;
+            }
+            $path = $this->normalizeScriptPath((string) ($file['path'] ?? ''));
+            if ( '' !== $path ) {
+                $paths[$path] = true;
+            }
+        }
+
+        foreach ( $assetReferences as $reference ) {
+            if ( ! is_array($reference) ) {
+                continue;
+            }
+            if ( 'script' !== ($reference['element'] ?? '') ) {
+                continue;
+            }
+            foreach ( array('asset_path', 'resolved_path') as $key ) {
+                $path = $this->normalizeScriptPath((string) ($reference[$key] ?? ''));
+                if ( '' !== $path ) {
+                    $paths[$path] = true;
+                }
+            }
+            $url = (string) ($reference['url'] ?? '');
+            if ( '' !== $url ) {
+                $resolved = ArtifactPath::resolveRelativePath($url, (string) ($reference['source_path'] ?? $sourcePath));
+                if ( '' !== $resolved ) {
+                    $paths[$this->normalizeScriptPath($resolved)] = true;
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    private function normalizeScriptPath(string $path): string
+    {
+        return ltrim(trim($path), '/');
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/artifact-runtime-script-materialized-no-finding.json
+++ b/php-transformer/tests/fixtures/parity/artifact-runtime-script-materialized-no-finding.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-runtime-script-materialized-no-finding",
+  "description": "A referenced external client script whose JavaScript is materialized in the artifact does not emit a runtime_script_not_materialized finding.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-runtime-script-materialized-no-finding.json",
+    "notes": "Negative coverage: when the referenced <script src> backing file is carried in the artifact bundle, runtime dependency parity stays clean."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<main><div class=\"counter\"><button id=\"increment\">Add</button><span id=\"total\">0</span></div><script src=\"js/app.js\"></script></main>"
+        },
+        {
+          "path": "js/app.js",
+          "kind": "js",
+          "content": "document.getElementById('increment').addEventListener('click', function () { document.getElementById('total'); });"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/artifact-runtime-script-not-materialized.json
+++ b/php-transformer/tests/fixtures/parity/artifact-runtime-script-not-materialized.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-runtime-script-not-materialized",
+  "description": "Flags a source-declared external client script that was never materialized or carried into the artifact, so dependent interactions are non-functional.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-runtime-script-not-materialized.json",
+    "notes": "Generic runtime-dependency parity: a referenced <script src> requiring client_script_execution with no backing artifact file must surface a feature-parity finding."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<main><div class=\"counter\"><button id=\"increment\">Add</button><span id=\"total\">0</span></div><script src=\"js/app.js\"></script></main>"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "warning" },
+    { "path": "source_reports.runtime_dependency_parity.findings", "assert": "count", "count": 1 },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.code", "assert": "equals", "value": "runtime_script_not_materialized" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.severity", "assert": "equals", "value": "warning" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.repair_bucket", "assert": "equals", "value": "runtime_script_materialization" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.runtime_requirement", "assert": "equals", "value": "client_script_execution" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.script_src", "assert": "equals", "value": "js/app.js" },
+    { "path": "source_reports.conversion_report.runtime_dependency_parity.findings.0.code", "assert": "equals", "value": "runtime_script_not_materialized" }
+  ]
+}


### PR DESCRIPTION
Closes #218

## Problem
When a source page references external JS (`<script src="js/main.js">`), the transformer drops the `<script>` tag and only records the script as a `client_script_execution` runtime-island hint (plus, when the file is bundled, an asset reference). It never enqueues or rebuilds the behavior. `RuntimeDependencyParityReport` only compares DOM targets for scripts that **are** present in the artifact, so when no script is carried there is nothing to compare and the report stays **silent** — every interaction that depended on that script is dead with no parity finding.

## Change
`RuntimeDependencyParityReport::fromArtifact` now adds a generic feature-parity diagnostic. It keys off the already-captured `client_script_execution` runtime-island hints and asset references:

- Builds the set of **materialized** script paths (script files in the artifact + resolved script asset references).
- For each source-declared **external** `<script src>` island flagged `client_script_execution`, if the script was neither materialized as an artifact file nor carried into the generated markup, it emits:
  - `code: runtime_script_not_materialized`
  - `repair_bucket: runtime_script_materialization`, `suggested_primitive: runtime_script`
  - selector / source / `script_src` context consistent with the existing finding-enrichment conventions
  - `severity: warning` (`info` for telemetry-style scripts)

This flips `runtime_dependency_parity.status` to `warning` so the fixture matrix / gate can see the feature-parity loss.

## No regressions
- Pages with no external scripts → no finding.
- Pages whose scripts **are** carried (backing file present) → no finding.
- Generic only — no fixture-specific selectors or strings.
- Stays entirely within the ArtifactCompiler / runtime-dependency surface (no changes to `HtmlTransformer.php` / `NavigationPattern.php`).

## Tests
- New positive fixture `artifact-runtime-script-not-materialized` (referenced script, no backing file → finding).
- New negative fixture `artifact-runtime-script-materialized-no-finding` (backing JS present → clean).
- `composer test:canonical`, `composer parity` (120 fixtures), and `composer test` (incl. packaging) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)