### PR TITLE
Emit generic behavior-loss diagnostic for interactive controls

### DIFF
--- a/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
+++ b/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
@@ -158,6 +158,19 @@ final class FallbackDiagnostic
                 'suggested_primitive'   => 'core/html',
                 'materialization_hint'  => 'preserve_sanitized_markup_until_a_specific_block_mapping_exists',
             ),
+            'interactive_control_behavior_lost' => array(
+                'severity'              => 'warning',
+                'conversion_classification' => 'behavior_loss',
+                'loss_class'            => 'interactive_behavior_loss',
+                'diagnostic_class'      => 'interactive_behavior_loss',
+                'preservation_strategy' => 'none_behavior_dropped',
+                'runtime_requirement'   => 'client_event_handler',
+                'recoverability'        => 'recoverable_with_interactive_block_or_script_runtime',
+                'actionability'         => 'rebuild_control_behavior_as_interactive_block_or_enqueue_handler_script',
+                'suggested_repair_class' => 'restore_interactive_behavior',
+                'suggested_primitive'   => 'interactive_control',
+                'materialization_hint'  => 'rebuild_as_interactive_block_or_preserve_handler_via_script_runtime',
+            ),
             default => array(
                 'severity'              => 'warning',
                 'conversion_classification' => 'unsupported_loss',
@@ -186,6 +199,7 @@ final class FallbackDiagnostic
         return match ( $code ) {
             'html_form_fallback' => 'interactive_form',
             'html_script_fallback' => 'runtime_script',
+            'interactive_control_behavior_lost' => 'interactive_control',
             'html_iframe_embed_fallback' => 'external_embed',
             'html_canvas_runtime_fallback' => 'runtime_canvas',
             'html_template_metadata' => 'inert_template_metadata',

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -196,6 +196,7 @@ final class HtmlTransformer
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
         $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));
+        $this->appendInteractiveControlBehaviorLossFallbacks($body, $fallbacks);
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
@@ -3276,6 +3277,188 @@ final class HtmlTransformer
         }
 
         return $candidates;
+    }
+
+    /**
+     * Emit a generic behavior-loss diagnostic for interactive controls that
+     * convert to static, non-interactive blocks without their behavior being
+     * preserved or rebuilt.
+     *
+     * Detection is structural/semantic — handler attributes (on*), declarative
+     * JS hooks (data-action/toggle/target/...), ARIA control state
+     * (aria-controls/aria-expanded/aria-haspopup), or a button role on a
+     * non-button, non-link element — never a fixture-specific class string.
+     *
+     * Controls whose behavior survives conversion are intentionally excluded so
+     * ordinary content stays silent: forms (covered by html_form_fallback),
+     * script DOM targets (covered by the runtime dependency parity report),
+     * elements preserved as runtime islands, hamburger toggles folded into
+     * core/navigation, controls consumed by a menu that becomes core/navigation,
+     * and plain links/buttons with no interaction signals.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    private function appendInteractiveControlBehaviorLossFallbacks(DOMElement $body, array &$fallbacks): void
+    {
+        $emitted = 0;
+        $seen = array();
+        foreach ( $body->getElementsByTagName('*') as $element ) {
+            if ( ! $element instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( $emitted >= self::MAX_INTERACTION_CANDIDATES ) {
+                return;
+            }
+
+            $signals = $this->interactionSignalEvidence($element);
+            if ( array() === $signals || ! $this->isInteractiveControlBehaviorLoss($element) ) {
+                continue;
+            }
+
+            $key = strtolower($element->tagName) . '|' . $this->elementSelector($element);
+            if ( isset($seen[$key]) ) {
+                continue;
+            }
+            $seen[$key] = true;
+
+            $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
+            $fallbacks[] = FallbackDiagnostic::build(array_filter(array(
+                'type'                => 'html',
+                'reason'              => 'interactive_control_behavior_lost',
+                'diagnostic_code'     => 'interactive_control_behavior_lost',
+                'message'             => 'An interactive control was converted to a static block, so its source behavior is no longer wired to any runtime.',
+                'source_format'       => 'html',
+                'tag'                 => strtolower($element->tagName),
+                'selector'            => $this->elementSelector($element),
+                'attributes'          => $this->htmlAttributes($element),
+                'context'             => $this->sourceContext($element),
+                'events'              => $this->eventMetadata($element),
+                'interaction_signals' => $signals,
+                'controlled_target'   => $this->controlledTarget($element),
+                'html'                => $boundedHtml['html'],
+                'html_bytes'          => $boundedHtml['bytes'],
+                'html_truncated'      => $boundedHtml['truncated'],
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->fallbackProvenance);
+            ++$emitted;
+        }
+    }
+
+    /**
+     * Whether an element carries structural interaction signals AND converts to
+     * a static block with its behavior dropped (not preserved or rebuilt).
+     */
+    private function isInteractiveControlBehaviorLoss(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+
+        // Elements with a dedicated preservation or diagnostic path. SVG (and
+        // its subtree) is sanitized/diagnosed by the inline-SVG fallback paths,
+        // which already account for any scriptable content.
+        if ( in_array($tagName, array( 'form', 'input', 'select', 'textarea', 'details', 'summary', 'script', 'svg' ), true) ) {
+            return false;
+        }
+
+        if ( $this->hasAncestorTag($element, array( 'svg' )) ) {
+            return false;
+        }
+
+        if ( array() === $this->interactionSignalEvidence($element) ) {
+            return false;
+        }
+
+        // Behavior is preserved or rebuilt elsewhere — not lost.
+        if ( $this->isRedundantMenuToggleControl($element) ) {
+            return false;
+        }
+
+        if ( $this->isFoldedIntoCoreNavigation($element) ) {
+            return false;
+        }
+
+        if ( $this->isRuntimeDomTarget($element) ) {
+            return false;
+        }
+
+        if ( $this->isPreservedRuntimeIslandElement($element) ) {
+            return false;
+        }
+
+        if ( $this->hasAncestorTag($element, array( 'form' )) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Structural/semantic interaction signals on an element, as generic evidence
+     * tokens. Never matches class-name strings.
+     *
+     * @return array<int, string>
+     */
+    private function interactionSignalEvidence(DOMElement $element): array
+    {
+        $tagName = strtolower($element->tagName);
+        $evidence = array();
+
+        foreach ( $this->eventMetadata($element) as $event ) {
+            $attribute = (string) ($event['attribute'] ?? '');
+            if ( '' !== $attribute ) {
+                $evidence[] = $attribute;
+            }
+        }
+
+        foreach ( array( 'aria-controls', 'aria-expanded', 'aria-haspopup' ) as $ariaAttribute ) {
+            if ( '' !== trim($this->attr($element, $ariaAttribute)) ) {
+                $evidence[] = $ariaAttribute;
+            }
+        }
+
+        // Only data-* attributes that unambiguously BIND behavior count as a
+        // signal — never data-* that merely carries a value (e.g. data-target as
+        // a counter goal). data-action/on/event also surface via eventMetadata.
+        foreach ( array_keys($this->safeDataAttributes($element)) as $dataName ) {
+            if ( preg_match('/^data-(?:action|on|event|toggle)$/i', (string) $dataName) ) {
+                $evidence[] = strtolower((string) $dataName);
+            }
+        }
+
+        if ( 'button' === strtolower($this->attr($element, 'role')) && 'button' !== $tagName ) {
+            $href = 'a' === $tagName ? $this->safeLinkUrl($this->attr($element, 'href')) : '';
+            if ( '' === $href ) {
+                $evidence[] = 'role=button';
+            }
+        }
+
+        return array_values(array_unique($evidence));
+    }
+
+    /**
+     * Whether the element (or an ancestor) is a navigation menu that converts to
+     * core/navigation, which rebuilds its toggle/submenu behavior natively.
+     */
+    private function isFoldedIntoCoreNavigation(DOMElement $element): bool
+    {
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $this->isNavigationMenuCandidate($node) && $this->convertsToCoreNavigation($node) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPreservedRuntimeIslandElement(DOMElement $element): bool
+    {
+        $selector = $this->runtimeIslandSelector($element);
+        foreach ( $this->runtimeIslands as $island ) {
+            if ( is_array($island) && ($island['selector'] ?? null) === $selector ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -945,6 +945,54 @@ $emptyRuntimeControl = ( new HtmlTransformer() )->transform(
 $assert(str_contains((string) ($emptyRuntimeControl['serialized_blocks'] ?? ''), 'nav-toggle'), 'empty runtime control button class is preserved for scripts');
 $assert(str_contains((string) ($emptyRuntimeControl['serialized_blocks'] ?? ''), 'aria-expanded="false"'), 'empty runtime control button ARIA state is preserved');
 
+// Behavior-loss diagnostic: an interactive control converted to a static block
+// without its behavior must surface a generic, severity-warning finding so the
+// loss is no longer silent. Detection is structural (handler attributes, ARIA
+// control state, declarative JS hooks, button role on a non-button), never a
+// fixture-specific class string.
+$behaviorLossCollect = static function (array $result): array {
+    $codes = array();
+    foreach ( $result['fallbacks'] ?? array() as $fallback ) {
+        if ( 'interactive_control_behavior_lost' === ($fallback['diagnostic_code'] ?? '') ) {
+            $codes[] = $fallback;
+        }
+    }
+    return $codes;
+};
+
+$handlerControl = ( new HtmlTransformer() )->transform('<main><button onclick="doThing()">Act</button></main>')->toArray();
+$handlerFindings = $behaviorLossCollect($handlerControl);
+$assert(1 === count($handlerFindings), 'a button with an onclick handler that becomes a static block emits one behavior-loss finding');
+$assert(in_array('onclick', $handlerFindings[0]['interaction_signals'] ?? array(), true), 'behavior-loss finding records the structural interaction signal');
+$assert('warning' === ($handlerFindings[0]['severity'] ?? ''), 'behavior-loss finding is a warning');
+$assert('behavior_loss' === ($handlerFindings[0]['conversion_classification'] ?? ''), 'behavior-loss finding is classified as behavior loss');
+$assert('restore_interactive_behavior' === ($handlerFindings[0]['suggested_repair_class'] ?? ''), 'behavior-loss finding routes to the feature-parity repair bucket');
+$assert('interactive_control' === ($handlerFindings[0]['pattern_family'] ?? ''), 'behavior-loss finding exposes the generic interactive control pattern family');
+$handlerLossDiagnostic = array_values(array_filter($handlerControl['diagnostics'] ?? array(), static fn (array $diagnostic): bool => 'interactive_control_behavior_lost' === ($diagnostic['code'] ?? '')));
+$assert(1 === count($handlerLossDiagnostic), 'behavior-loss finding is projected into the diagnostics stream');
+
+$ariaToggleNoNav = ( new HtmlTransformer() )->transform('<main><header><button aria-controls="missing" aria-expanded="false"><span></span></button></header></main>')->toArray();
+$assert(1 === count($behaviorLossCollect($ariaToggleNoNav)), 'an aria-controls toggle with no associated navigation that becomes a dead core/button emits a behavior-loss finding');
+
+$roleButtonControl = ( new HtmlTransformer() )->transform('<main><div role="button" data-action="open">Open</div></main>')->toArray();
+$assert(1 === count($behaviorLossCollect($roleButtonControl)), 'a non-button element with role=button plus a declarative handler emits a behavior-loss finding');
+
+// Negatives: ordinary content must stay silent.
+$plainButton = ( new HtmlTransformer() )->transform('<main><button type="submit">Sign Up</button></main>')->toArray();
+$assert(array() === $behaviorLossCollect($plainButton), 'a plain button with no interaction signals does not emit a behavior-loss finding');
+
+$plainLink = ( new HtmlTransformer() )->transform('<main><a href="/about">About</a></main>')->toArray();
+$assert(array() === $behaviorLossCollect($plainLink), 'a plain link does not emit a behavior-loss finding');
+
+$roleButtonLink = ( new HtmlTransformer() )->transform('<main><a role="button" href="/buy">Buy</a></main>')->toArray();
+$assert(array() === $behaviorLossCollect($roleButtonLink), 'a real link styled with role=button preserves navigation and does not emit a behavior-loss finding');
+
+$valueDataAttribute = ( new HtmlTransformer() )->transform('<main><span data-target="47200">0</span></main>')->toArray();
+$assert(array() === $behaviorLossCollect($valueDataAttribute), 'a data-* attribute that carries a value rather than binding behavior does not emit a behavior-loss finding');
+
+$foldedNavToggle = ( new HtmlTransformer() )->transform('<header><div class="header-inner"><a class="brand" href="/">Logo</a><nav class="nav-links"><a href="/">Home</a><a href="/about">About</a></nav><button class="nav-toggle" aria-label="Open navigation menu" aria-controls="mobile-nav" aria-expanded="false"><span></span><span></span><span></span></button></div></header><nav class="mobile-nav" id="mobile-nav"><a href="/">Home</a><a href="/about">About</a></nav>')->toArray();
+$assert(array() === $behaviorLossCollect($foldedNavToggle), 'a hamburger toggle folded into core/navigation does not emit a behavior-loss finding');
+
 $assetMetadataOptions = array(
     'context' => array(
         'asset_metadata' => array(

--- a/php-transformer/tests/fixtures/parity/html-context-syntax-card-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-context-syntax-card-grid.json
@@ -24,13 +24,14 @@
     { "path": "blocks.1", "name": "core/quote", "attrs": { "className": "testimonial", "citation": "<cite>Casey</cite> Engineer" } }
   ],
   "expected_fallbacks": [
-    { "type": "unsupported_element", "reason": "unsupported_element", "diagnostic_code": "html_unsupported_element", "tag": "x-widget" }
+    { "type": "unsupported_element", "reason": "unsupported_element", "diagnostic_code": "html_unsupported_element", "tag": "x-widget" },
+    { "type": "html", "reason": "interactive_control_behavior_lost", "diagnostic_code": "interactive_control_behavior_lost", "severity": "warning", "conversion_classification": "behavior_loss", "suggested_repair_class": "restore_interactive_behavior", "pattern_family": "interactive_control", "tag": "x-widget" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 2 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 4 },
-    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 2 },
     { "path": "fallbacks.0.context.parent_tag", "assert": "equals", "value": "section" },
     { "path": "fallbacks.0.context.nearest_heading", "assert": "equals", "value": "Features" },
     { "path": "fallbacks.0.context.data_attributes.data-action", "assert": "equals", "value": "open" },

--- a/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
+++ b/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
@@ -24,12 +24,13 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Only child", "level": 2 } }
   ],
   "expected_fallbacks": [
-    { "type": "inline_svg", "reason": "unsafe_inline_svg", "tag": "svg", "diagnostic_code": "html_unsafe_inline_svg", "selector": "svg:nth-of-type(1)", "source": "fixture:html-provenance-wrapper-safety", "scope": "parity" }
+    { "type": "inline_svg", "reason": "unsafe_inline_svg", "tag": "svg", "diagnostic_code": "html_unsafe_inline_svg", "selector": "svg:nth-of-type(1)", "source": "fixture:html-provenance-wrapper-safety", "scope": "parity" },
+    { "type": "html", "reason": "interactive_control_behavior_lost", "diagnostic_code": "interactive_control_behavior_lost", "severity": "warning", "conversion_classification": "behavior_loss", "tag": "section", "selector": "section:nth-of-type(1)" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 2 },
     { "path": "fallbacks.0.html", "assert": "contains", "value": "<svg class=\"badge\">" },
     { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script>" },
     { "path": "fallbacks.0.html", "assert": "not_contains", "value": "alert(1)" },
@@ -55,14 +56,14 @@
     { "path": "source_reports.conversion_report.source_format", "assert": "equals", "value": "html" },
     { "path": "source_reports.conversion_report.source", "assert": "equals", "value": "fixture:html-provenance-wrapper-safety" },
     { "path": "source_reports.conversion_report.source_summary.block_count", "assert": "equals", "value": 2 },
-    { "path": "source_reports.conversion_report.source_summary.fallback_count", "assert": "equals", "value": 1 },
-    { "path": "source_reports.conversion_report.selector_summary.selectors", "assert": "count", "count": 3 },
+    { "path": "source_reports.conversion_report.source_summary.fallback_count", "assert": "equals", "value": 2 },
+    { "path": "source_reports.conversion_report.selector_summary.selectors", "assert": "count", "count": 4 },
     { "path": "source_reports.conversion_report.fallback_diagnostics.0.diagnostic_code", "assert": "equals", "value": "html_unsafe_inline_svg" },
     { "path": "source_reports.conversion_report.fallback_diagnostics.0.selector", "assert": "equals", "value": "svg:nth-of-type(1)" },
     { "path": "source_reports.conversion_report.presentation_gaps.0.type", "assert": "equals", "value": "source_presentation_signal" },
     { "path": "source_reports.conversion_report.presentation_gaps.0.signals.layout.type", "assert": "equals", "value": "constrained" },
     { "path": "diagnostics.1.selector", "assert": "equals", "value": "svg:nth-of-type(1)" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 },
     { "path": "coverage.0.source_provenance_count", "assert": "equals", "value": 2 }
   ]
 }


### PR DESCRIPTION
Closes #219

## Problem
When an element carrying interaction signals converts to a **static, non-interactive block** without preserving/rebuilding its behavior, no diagnostic was emitted — the lost interactivity was silent. Forms at least fired `html_form_fallback`; other controls (a `<button onclick=...>`/`<button aria-controls=...>` that became a dead `core/button`, a `<div role=button data-action>`, a `<section onclick>` flattened to a `core/group`) lost their behavior with zero signal. PR #221 already suppresses nav menu-toggles folded into `core/navigation`; this covers the general remaining case.

## What this does
Adds a generic behavior-loss finding emitted through the existing `FallbackDiagnostic` mechanism:

- **Code:** `interactive_control_behavior_lost`, severity `warning`
- **Classification:** `behavior_loss` / `interactive_behavior_loss`
- **Repair bucket (feature parity):** `suggested_repair_class = restore_interactive_behavior`, `pattern_family = interactive_control`
- Carries the same enriched, generic finding metadata as existing fallbacks (selector, source context, specificity, parent/ancestor reason), plus the structural `interaction_signals` evidence and the bounded sanitized source HTML.

### Detection (structural/semantic only — never class strings)
An element is flagged when it has at least one of:
- an `on*` handler attribute,
- a declarative JS hook `data-action` / `data-on` / `data-event` / `data-toggle`,
- ARIA control state `aria-controls` / `aria-expanded` / `aria-haspopup`,
- `role="button"` on a non-`<button>`, non-link element.

### Why it won't false-positive
Controls whose behavior survives conversion are excluded, so ordinary content stays silent:
- `<form>`/`<input>`/`<select>`/`<textarea>` and form descendants — covered by `html_form_fallback`;
- script DOM targets — covered by the runtime dependency parity report;
- elements preserved as runtime islands;
- hamburger toggles folded into `core/navigation` (and any control consumed by a menu that becomes `core/navigation`);
- `<svg>` and its subtree — sanitized/diagnosed by the inline-SVG fallback paths;
- plain links/buttons and `role="button"` anchors that still navigate (real `href`);
- ambiguous value-carrying `data-*` (e.g. a counter's `data-target`) — only behavior-binding hooks count.

## Tests
- New positive + negative coverage in `tests/contract/run.php` (handler control → finding; aria toggle with no nav → finding; `role=button`+`data-action` → finding; plain button/link, `role=button` link, value `data-*`, folded nav toggle → no finding).
- Updated two parity fixtures that contain genuine interaction-signal elements (`<x-widget onclick data-action>`, `<section onclick>`) to expect the intended new finding.
- `composer test:canonical` and `composer parity` (120 fixtures) pass. Stayed entirely out of `src/ArtifactCompiler/RuntimeDependencyParityReport.php` (PR #218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)