### PR TITLE
Expose available Core block targets

### DIFF
--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -34,6 +34,8 @@ final class ConversionReportProjection
             'runtime_islands'      => self::runtimeIslands($sourceReports),
             'interaction_candidates' => self::interactionCandidates($sourceReports),
             'presentation_gaps'     => self::presentationGaps($sourceReports),
+            'native_target_blocks'  => self::stringList($sourceReports, 'native_target_blocks'),
+            'available_core_blocks' => self::stringList($sourceReports, 'available_core_blocks'),
             'metrics'               => $metrics,
         );
 
@@ -417,6 +419,19 @@ final class ConversionReportProjection
         }
 
         return '';
+    }
+
+    /**
+     * @param array<string, mixed> $sourceReports
+     * @return array<int, string>
+     */
+    private static function stringList(array $sourceReports, string $key): array
+    {
+        if ( ! is_array($sourceReports[$key] ?? null) ) {
+            return array();
+        }
+
+        return array_values(array_filter($sourceReports[$key], static fn (mixed $value): bool => is_string($value) && '' !== $value));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -21,6 +21,40 @@ final class HtmlTransformer
 {
     private const MAX_INTERACTION_CANDIDATES = 100;
 
+    /**
+     * @var array<int, string>
+     */
+    private const SUPPORTED_BLOCKS = array(
+        'core/audio',
+        'core/button',
+        'core/buttons',
+        'core/code',
+        'core/column',
+        'core/columns',
+        'core/details',
+        'core/embed',
+        'core/file',
+        'core/gallery',
+        'core/group',
+        'core/heading',
+        'core/image',
+        'core/list',
+        'core/list-item',
+        'core/navigation',
+        'core/navigation-link',
+        'core/paragraph',
+        'core/preformatted',
+        'core/pullquote',
+        'core/quote',
+        'core/separator',
+        'core/shortcode',
+        'core/spacer',
+        'core/navigation-submenu',
+        'core/table',
+        'core/video',
+        'core/search',
+    );
+
     private readonly BlockFactory $blockFactory;
 
     private readonly ButtonsPattern $buttonsPattern;
@@ -307,7 +341,10 @@ final class HtmlTransformer
         }
 
         $metrics = $this->metrics($html, $blocks, $serializedBlocks, $fallbacks, $diagnostics, $startedAt);
+        $nativeTargetBlocks = $this->runtime->availableCoreBlockNames();
         $sourceReports = array(
+            'native_target_blocks' => $nativeTargetBlocks,
+            'available_core_blocks' => $nativeTargetBlocks,
             'runtime_islands' => $this->runtimeIslands,
             'interaction_candidates' => $interactionCandidates,
             'wp_block_validity' => $blockValidityReport,
@@ -333,9 +370,11 @@ final class HtmlTransformer
             sourceReports: $sourceReports,
             coverage: array(
                 array(
-                    'supported_blocks' => array( 'core/audio', 'core/button', 'core/buttons', 'core/code', 'core/column', 'core/columns', 'core/details', 'core/embed', 'core/file', 'core/gallery', 'core/group', 'core/heading', 'core/image', 'core/list', 'core/list-item', 'core/navigation', 'core/navigation-link', 'core/paragraph', 'core/preformatted', 'core/pullquote', 'core/quote', 'core/separator', 'core/shortcode', 'core/spacer', 'core/navigation-submenu', 'core/table', 'core/video', 'core/search' ),
-                    'block_count'      => count($blocks),
-                    'fallback_count'   => count($fallbacks),
+                    'supported_blocks'      => self::SUPPORTED_BLOCKS,
+                    'native_target_blocks'  => $nativeTargetBlocks,
+                    'available_core_blocks' => $nativeTargetBlocks,
+                    'block_count'           => count($blocks),
+                    'fallback_count'        => count($fallbacks),
                     'source_provenance_count' => count($sourceProvenance),
                 ),
             ),

--- a/php-transformer/src/WordPress/Runtime.php
+++ b/php-transformer/src/WordPress/Runtime.php
@@ -6,6 +6,50 @@ namespace Automattic\BlocksEngine\PhpTransformer\WordPress;
 final class Runtime
 {
     /**
+     * @var array<int, string>
+     */
+    private const FALLBACK_CORE_BLOCK_NAMES = array(
+        'core/accordion',
+        'core/audio',
+        'core/breadcrumbs',
+        'core/button',
+        'core/buttons',
+        'core/categories',
+        'core/code',
+        'core/column',
+        'core/columns',
+        'core/details',
+        'core/embed',
+        'core/file',
+        'core/footnotes',
+        'core/gallery',
+        'core/group',
+        'core/heading',
+        'core/icon',
+        'core/image',
+        'core/list',
+        'core/list-item',
+        'core/math',
+        'core/navigation',
+        'core/navigation-link',
+        'core/navigation-submenu',
+        'core/paragraph',
+        'core/post-terms',
+        'core/preformatted',
+        'core/pullquote',
+        'core/query-total',
+        'core/quote',
+        'core/search',
+        'core/separator',
+        'core/shortcode',
+        'core/spacer',
+        'core/table',
+        'core/tag-cloud',
+        'core/term-description',
+        'core/video',
+    );
+
+    /**
      * @var array<int, array<string, mixed>>
      */
     private array $diagnostics = array();
@@ -60,6 +104,53 @@ final class Runtime
     public function canEscapeAttribute(): bool
     {
         return function_exists('esc_attr');
+    }
+
+    /**
+     * Native core block names available as potential WordPress targets.
+     *
+     * @return array<int, string>
+     */
+    public function availableCoreBlockNames(): array
+    {
+        $registered = $this->registeredCoreBlockNames();
+        if ( array() !== $registered ) {
+            return $registered;
+        }
+
+        return self::FALLBACK_CORE_BLOCK_NAMES;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function registeredCoreBlockNames(): array
+    {
+        if ( ! class_exists('WP_Block_Type_Registry') || ! method_exists('WP_Block_Type_Registry', 'get_instance') ) {
+            return array();
+        }
+
+        $registry = \WP_Block_Type_Registry::get_instance();
+        if ( ! is_object($registry) || ! method_exists($registry, 'get_all_registered') ) {
+            return array();
+        }
+
+        $names = array();
+        foreach ( $registry->get_all_registered() as $key => $blockType ) {
+            $name = is_string($key) ? $key : '';
+            if ( '' === $name && is_object($blockType) && isset($blockType->name) && is_string($blockType->name) ) {
+                $name = $blockType->name;
+            }
+
+            if ( str_starts_with($name, 'core/') ) {
+                $names[] = $name;
+            }
+        }
+
+        $names = array_values(array_unique($names));
+        sort($names);
+
+        return $names;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -270,6 +270,18 @@ $assert(! array_key_exists('legacy_mapping', $result), 'canonical result omits c
 $assertInvalidCanonicalEnvelope(array_merge($result, array('legacy_mapping' => array())), 'legacy_mapping', 'canonical validation rejects legacy mapping aliases');
 $assertInvalidCanonicalEnvelope(array_merge($result, array('conversion_report' => $result['source_reports']['conversion_report'])), 'only under source_reports', 'canonical validation rejects top-level conversion report aliases');
 $assertInvalidCanonicalEnvelope(array_merge($result, array('materialization_plan' => array())), 'only under source_reports', 'canonical validation rejects top-level materialization plan aliases');
+$coverage = $result['coverage'][0] ?? array();
+$supportedBlocks = $coverage['supported_blocks'] ?? array();
+$nativeTargetBlocks = $coverage['native_target_blocks'] ?? array();
+$availableCoreBlocks = $coverage['available_core_blocks'] ?? array();
+$conversionReportNativeTargetBlocks = $result['source_reports']['conversion_report']['native_target_blocks'] ?? array();
+$assert(in_array('core/paragraph', $supportedBlocks, true), 'coverage preserves existing supported block metadata');
+$assert(in_array('core/accordion', $nativeTargetBlocks, true), 'coverage exposes core/accordion as an available native target');
+$assert(in_array('core/icon', $nativeTargetBlocks, true), 'coverage exposes core/icon as an available native target');
+$assert(in_array('core/math', $nativeTargetBlocks, true), 'coverage exposes core/math as an available native target');
+$assert($nativeTargetBlocks === $availableCoreBlocks, 'coverage aliases available core blocks to native target blocks');
+$assert($nativeTargetBlocks === $conversionReportNativeTargetBlocks, 'conversion report exposes native target block metadata');
+$assert(! in_array('core/accordion', $supportedBlocks, true), 'coverage does not claim unsupported native targets as converted support');
 $runtimeCanvasResult = ( new HtmlTransformer() )->transform('<main><canvas id="fixture-canvas">Fallback</canvas></main>', array('runtime_canvas_selectors' => array('#fixture-canvas')))->toArray();
 $assert('canvas' === ($runtimeCanvasResult['source_reports']['runtime_islands'][0]['kind'] ?? ''), 'HTML transform reports runtime-targeted canvas fallback as a runtime island');
 $assert('canvas_requires_runtime' === ($runtimeCanvasResult['source_reports']['runtime_islands'][0]['preservation_reason'] ?? ''), 'runtime island exposes canvas preservation reason');

--- a/php-transformer/tests/contract/runtime-no-wordpress.php
+++ b/php-transformer/tests/contract/runtime-no-wordpress.php
@@ -8,6 +8,10 @@ use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 $runtime = new Runtime();
 
 assertSame(false, $runtime->hasWordPress(), 'No WordPress runtime should be detected in the standalone PHP test process.');
+$availableCoreBlocks = $runtime->availableCoreBlockNames();
+assertSame(true, in_array('core/accordion', $availableCoreBlocks, true), 'Fallback native target metadata should include core/accordion.');
+assertSame(true, in_array('core/icon', $availableCoreBlocks, true), 'Fallback native target metadata should include core/icon.');
+assertSame(true, in_array('core/math', $availableCoreBlocks, true), 'Fallback native target metadata should include core/math.');
 
 $blocks = $runtime->parseBlocks('<!-- wp:paragraph {"content":"Hello"} --><p>Hello</p><!-- /wp:paragraph -->');
 assertSame('core/paragraph', $blocks[0]['blockName'] ?? null, 'Fallback parser should parse serialized block comments.');

--- a/php-transformer/tests/contract/runtime-wordpress-stubs.php
+++ b/php-transformer/tests/contract/runtime-wordpress-stubs.php
@@ -81,6 +81,29 @@ if ( ! function_exists('esc_attr') ) {
     }
 }
 
+if ( ! class_exists('WP_Block_Type_Registry') ) {
+    final class WP_Block_Type_Registry
+    {
+        public static function get_instance(): self
+        {
+            return new self();
+        }
+
+        /**
+         * @return array<string|int, object>
+         */
+        public function get_all_registered(): array
+        {
+            return array(
+                'core/icon' => (object) array('name' => 'core/icon'),
+                'plugin/card' => (object) array('name' => 'plugin/card'),
+                (object) array('name' => 'core/math'),
+                'core/accordion' => (object) array('name' => 'core/accordion'),
+            );
+        }
+    }
+}
+
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
@@ -97,6 +120,7 @@ assertSame(array('stub' => 'ids="1,2"'), $runtime->parseShortcodeAttributes('ids
 assertSame('{"stub":{"path":"/demo"}}', $runtime->encodeJson(array('path' => '/demo')), 'Runtime should delegate JSON encoding to wp_json_encode().');
 assertSame('stub html <tag>', $runtime->escapeHtml('<tag>'), 'Runtime should delegate HTML escaping to esc_html().');
 assertSame('stub attr "value"', $runtime->escapeAttribute('"value"'), 'Runtime should delegate attribute escaping to esc_attr().');
+assertSame(array('core/accordion', 'core/icon', 'core/math'), $runtime->availableCoreBlockNames(), 'Runtime should expose registered core block names as native targets.');
 
 fwrite(STDOUT, "WordPress runtime stub contract passed.\n");
 


### PR DESCRIPTION
## Summary
- Add runtime-aware Core block target discovery via WP_Block_Type_Registry when WordPress is loaded.
- Keep supported_blocks as the transformer’s actual emitted block set.
- Add native_target_blocks / available_core_blocks to coverage and conversion reports so future conversion work can target current Core blocks without stale assumptions.

## Testing
- composer test
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the transformer metadata path, drafting the registry-aware implementation, and running verification.