### PR TITLE
Improve Figma fidelity diagnostics and typography

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -1178,6 +1178,9 @@ function matrix_selected_frame_records(array $inspection, array $frameIds): arra
             'score' => $candidate['score'] ?? null,
             'rank' => matrix_candidate_rank($candidate),
             'bucket' => matrix_candidate_bucket($candidate),
+            'device_hint' => $candidate['device_hint'] ?? null,
+            'sibling_group_key' => $candidate['sibling_group_key'] ?? null,
+            'responsive_siblings' => is_array($candidate['responsive_siblings'] ?? null) ? $candidate['responsive_siblings'] : array(),
             'selection_reasons' => matrix_candidate_selection_reasons($candidate),
         );
     }

--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -354,6 +354,9 @@ Output and tooling:
   --layout-report=/path             Evidence path template for layout report.
   --layout-mismatch-report=/path    Evidence path template for layout mismatch report.
   --render-evidence=/path           Evidence path template for no-screenshot render/style evidence.
+  --source-screenshot=/path         Source screenshot path template for later pixel parity.
+  --generated-screenshot=/path      Generated screenshot path template for later pixel parity.
+  --diff-image=/path                Diff image path template for later pixel parity.
   --help, -h                        Show this help text.
 
 Examples:
@@ -524,6 +527,12 @@ function matrix_evidence_option_keys(): array
         'layout_mismatch_report_path' => 'layout_mismatch_report_path',
         'render_evidence' => 'render_evidence_path',
         'render_evidence_path' => 'render_evidence_path',
+        'source_screenshot' => 'source_screenshot_path',
+        'source_screenshot_path' => 'source_screenshot_path',
+        'generated_screenshot' => 'generated_screenshot_path',
+        'generated_screenshot_path' => 'generated_screenshot_path',
+        'diff_image' => 'diff_image_path',
+        'diff_image_path' => 'diff_image_path',
     );
 }
 
@@ -804,6 +813,9 @@ function matrix_evidence_transform_argument_prefixes(): array
         'layout_report_path' => '--parity-layout-report-path=',
         'layout_mismatch_report_path' => '--parity-layout-mismatch-report-path=',
         'render_evidence_path' => '--parity-render-evidence-path=',
+        'source_screenshot_path' => '--parity-source-screenshot-path=',
+        'generated_screenshot_path' => '--parity-generated-screenshot-path=',
+        'diff_image_path' => '--parity-diff-image-path=',
     );
 }
 
@@ -909,6 +921,10 @@ function matrix_attach_evidence_to_result(array $result, array $evidence): array
         }
     }
 
+    matrix_attach_screenshot_candidate($parity, $paths, 'source_screenshot_path', 'source', 'screenshot');
+    matrix_attach_screenshot_candidate($parity, $paths, 'generated_screenshot_path', 'generated', 'screenshot');
+    matrix_attach_screenshot_candidate($parity, $paths, 'diff_image_path', 'diff', 'image');
+
     $parityReport = matrix_read_json_evidence($paths['parity_report_path'] ?? null);
     if ( is_array($parityReport) ) {
         $parity = matrix_merge_parity_report($parity, $parityReport);
@@ -948,6 +964,33 @@ function matrix_evidence_artifact_keys(): array
         'layout_mismatch_report_path' => 'layout_mismatch_report_path',
         'render_evidence_path' => 'render_evidence_path',
     );
+}
+
+/**
+ * @param array<string, mixed> $parity
+ * @param array<string, mixed> $paths
+ */
+function matrix_attach_screenshot_candidate(array &$parity, array $paths, string $pathKey, string $section, string $prefix): void
+{
+    $record = is_array($paths[$pathKey] ?? null) ? $paths[$pathKey] : null;
+    $path = matrix_evidence_record_path($record);
+    if ( '' === $path || ! is_array($record) ) {
+        return;
+    }
+
+    $parity[$section] = is_array($parity[$section] ?? null) ? $parity[$section] : array();
+    $parity[$section][$prefix . '_path'] = $path;
+    $parity[$section][$prefix . '_exists'] = true === ($record['exists'] ?? false);
+    $parity[$section][$prefix . '_readable'] = true === ($record['readable'] ?? false);
+
+    if ( false === $parity[$section][$prefix . '_exists'] && 'not_run' === ($parity['status'] ?? 'not_run') ) {
+        $parity['status'] = 'pending';
+        $parity['reason'] = $parity['reason'] ?? 'screenshot_evidence_configured';
+    }
+
+    if ( ! isset($parity['visual_pixel_status']) ) {
+        $parity['visual_pixel_status'] = 'not_run';
+    }
 }
 
 /**

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -792,7 +792,7 @@ final class FigmaTransformer
     private function mergePageTransformDiagnostics(array $pageReports, array $assetReport): array
     {
         $images = array('paint_refs' => 0, 'node_refs' => 0, 'resolved_assets' => 0, 'image_block_count' => 0, 'total_node_count' => 0, 'image_block_nodes' => array(), 'missing_assets' => array());
-        $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'placeholders' => 0, 'placeholder_nodes' => array());
+        $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'placeholders' => 0, 'placeholder_nodes' => array(), 'placeholder_reasons' => array());
         $layout = array(
             'large_negative_left_count' => 0,
             'fixed_root_width_count' => 0,
@@ -871,6 +871,9 @@ final class FigmaTransformer
                 if ( is_array($item) ) {
                     $vectors['placeholder_nodes'][] = array_merge($pageContext, $item);
                 }
+            }
+            foreach ( is_array($pageVectors['placeholder_reasons'] ?? null) ? $pageVectors['placeholder_reasons'] : array() as $reason => $count ) {
+                $vectors['placeholder_reasons'][(string) $reason] = (int) ($vectors['placeholder_reasons'][(string) $reason] ?? 0) + (int) $count;
             }
 
             $pageFonts = is_array($diagnostics['fonts'] ?? null) ? $diagnostics['fonts'] : array();

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -543,17 +543,7 @@ final class StaticHtmlEmitter
      */
     private function expectedTextStyleData(array $node): array
     {
-        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
-        $style = is_array($text['style'] ?? null) ? $text['style'] : array();
-        if ( ! isset($style['color']) ) {
-            $paints = is_array($node['figma_paints']['fills'] ?? null) ? $node['figma_paints']['fills'] : array();
-            $color = $this->firstSolidPaint($paints);
-            if ( null !== $color ) {
-                $style['css_color'] = $color;
-            }
-        }
-
-        $declarations = $this->styleDeclarationMap($this->textStyleDeclarations($style));
+        $declarations = $this->styleDeclarationMap($this->textStyles($node));
         return array(
             'text_color'  => $declarations['color'] ?? null,
             'font_family' => $declarations['font-family'] ?? null,
@@ -2539,6 +2529,17 @@ final class StaticHtmlEmitter
         $baselines = is_array($derivedLayout['baselines'] ?? null) ? $derivedLayout['baselines'] : array();
         if ( 2 > count($baselines) ) {
             return null;
+        }
+
+        $lineHeights = array();
+        foreach ( $baselines as $baseline ) {
+            if ( is_array($baseline) && isset($baseline['lineHeight']) && is_numeric($baseline['lineHeight']) && 0.0 < (float) $baseline['lineHeight'] ) {
+                $lineHeights[] = (float) $baseline['lineHeight'];
+            }
+        }
+        if ( ! empty($lineHeights) ) {
+            sort($lineHeights);
+            return $lineHeights[(int) floor(( count($lineHeights) - 1 ) / 2)];
         }
 
         $positions = array();

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -388,9 +388,7 @@ final class StaticHtmlEmitter
                 'severity' => 'warning',
                 'code'     => 'unsupported_vector_node_placeholder',
                 'message'  => 'Unsupported vector-like Figma node emitted as a static placeholder.',
-                'node_id'  => (string) ($node['id'] ?? ''),
-                'type'     => $type,
-            );
+            ) + $this->vectorPlaceholderDiagnostic($node, $type, $parentNode);
 
             $content = '';
         }
@@ -739,6 +737,7 @@ final class StaticHtmlEmitter
             'rendered_paths'           => 0,
             'rendered_asset_fallbacks' => 0,
             'placeholders'             => 0,
+            'placeholder_reasons'      => array(),
             'placeholder_nodes'        => array(),
         );
         $layout = array(
@@ -1156,11 +1155,10 @@ final class StaticHtmlEmitter
                 ++$vectors['rendered_asset_fallbacks'];
             } else {
                 ++$vectors['placeholders'];
-                $vectors['placeholder_nodes'][] = array(
-                    'node_id' => (string) ($node['id'] ?? ''),
-                    'name'    => (string) ($node['name'] ?? ''),
-                    'type'    => $type,
-                );
+                $placeholder = $this->vectorPlaceholderDiagnostic($node, $type, $parentNode);
+                $reason = (string) ($placeholder['reason'] ?? 'unknown');
+                $vectors['placeholder_reasons'][$reason] = (int) ($vectors['placeholder_reasons'][$reason] ?? 0) + 1;
+                $vectors['placeholder_nodes'][] = $placeholder;
             }
         }
 
@@ -3536,6 +3534,158 @@ final class StaticHtmlEmitter
         }
 
         return isset($node['vectorData']) && is_array($node['vectorData']) && ! empty($node['vectorData']);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function vectorPlaceholderDiagnostic(array $node, string $type, ?array $parentNode = null): array
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $width = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width']) : 0.0;
+        $height = isset($box['height']) && is_numeric($box['height']) ? max(0.0, (float) $box['height']) : 0.0;
+        $sourceFields = $this->vectorSourceFieldNames($node);
+        $rejectedPathSources = $this->rejectedVectorPathSourceDiagnostics($node);
+        $missingFields = array();
+        $reason = 'missing_vector_geometry';
+
+        if ( $width <= 0.0 || ( $height <= 0.0 && null === $this->zeroHeightVectorFallbackHeight($node, $type) ) ) {
+            $reason = 'missing_dimensions';
+            if ( $width <= 0.0 ) {
+                $missingFields[] = 'box.width';
+            }
+            if ( $height <= 0.0 ) {
+                $missingFields[] = 'box.height';
+            }
+        } elseif ( ! empty($rejectedPathSources) ) {
+            $reason = $this->hasOversizedRejectedVectorPath($rejectedPathSources) ? 'oversized_path_data' : 'unsupported_path_data';
+        } elseif ( 'BOOLEAN_OPERATION' === $type && ! empty($this->nodeList($node)) ) {
+            $reason = 'unsupported_boolean_operation_children';
+        } elseif ( isset($node['vectorData']) && is_array($node['vectorData']) && array_key_exists('vectorNetworkBlob', $node['vectorData']) ) {
+            $reason = 'unsupported_vector_network_blob';
+        } elseif ( ! empty($this->explicitNodeAssetReferences($node)) || ! empty($this->nodeImagePaints($node)) ) {
+            $reason = 'unresolved_asset_fallback';
+        } elseif ( ! empty($sourceFields) ) {
+            $reason = 'unsupported_vector_geometry';
+        } else {
+            $missingFields[] = 'figma_vector_paths';
+            $missingFields[] = 'vectorPaths';
+            $missingFields[] = 'paths';
+            $missingFields[] = 'pathData';
+            $missingFields[] = 'vectorData.vectorNetworkBlob';
+        }
+
+        $diagnostic = array(
+            'node_id' => (string) ($node['id'] ?? ''),
+            'name' => (string) ($node['name'] ?? ''),
+            'type' => $type,
+            'reason' => $reason,
+            'source_fields' => $sourceFields,
+            'missing_fields' => array_values(array_unique($missingFields)),
+        );
+
+        if ( ! empty($rejectedPathSources) ) {
+            $diagnostic['rejected_path_sources'] = $rejectedPathSources;
+        }
+        if ( null !== $parentNode && empty($sourceFields) && ! empty($this->inheritedVectorPaintAttributes($parentNode)) ) {
+            $diagnostic['inherited_paint_available'] = true;
+        }
+
+        return $diagnostic;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function vectorSourceFieldNames(array $node): array
+    {
+        $fields = array();
+        foreach ( array('figma_vector_paths', 'vectorPaths', 'paths', 'fillGeometry', 'strokeGeometry') as $key ) {
+            if ( ! empty($node[$key]) ) {
+                $fields[] = $key;
+            }
+        }
+        foreach ( array('pathData', 'path', 'd') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== trim((string) $node[$key]) ) {
+                $fields[] = $key;
+            }
+        }
+        if ( isset($node['vectorData']) && is_array($node['vectorData']) && ! empty($node['vectorData']) ) {
+            foreach ( array_keys($node['vectorData']) as $key ) {
+                if ( is_scalar($key) ) {
+                    $fields[] = 'vectorData.' . (string) $key;
+                }
+            }
+        }
+
+        return array_values(array_unique($fields));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, array<string, mixed>>
+     */
+    private function rejectedVectorPathSourceDiagnostics(array $node): array
+    {
+        $rawPaths = array();
+        if ( is_array($node['figma_vector_paths'] ?? null) ) {
+            foreach ( $node['figma_vector_paths'] as $rawPath ) {
+                $rawPaths[] = array('field' => 'figma_vector_paths', 'value' => $rawPath);
+            }
+        }
+        foreach ( array('vectorPaths', 'paths') as $key ) {
+            if ( is_array($node[$key] ?? null) ) {
+                foreach ( $node[$key] as $rawPath ) {
+                    $rawPaths[] = array('field' => $key, 'value' => $rawPath);
+                }
+            }
+        }
+        foreach ( array('pathData', 'path', 'd') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) ) {
+                $rawPaths[] = array('field' => $key, 'value' => array('data' => (string) $node[$key]));
+            }
+        }
+
+        $rejected = array();
+        foreach ( $rawPaths as $rawPath ) {
+            $value = $rawPath['value'];
+            $path = is_array($value) ? (string) ($value['data'] ?? $value['pathData'] ?? $value['path'] ?? $value['d'] ?? '') : (string) $value;
+            if ( '' === trim($path) ) {
+                continue;
+            }
+            $limit = $this->svgPathDataByteLimit($value);
+            if ( null !== $this->safeSvgPathData($path, $limit) ) {
+                continue;
+            }
+
+            $reason = strlen($path) > $limit ? 'oversized_path_data' : 'unsupported_path_data';
+            $source = is_array($value) && isset($value['source']) && is_scalar($value['source']) ? (string) $value['source'] : (string) $rawPath['field'];
+            $rejected[] = array(
+                'field' => (string) $rawPath['field'],
+                'source' => $source,
+                'reason' => $reason,
+                'bytes' => strlen($path),
+                'limit_bytes' => $limit,
+            );
+        }
+
+        return $rejected;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rejectedPathSources
+     */
+    private function hasOversizedRejectedVectorPath(array $rejectedPathSources): bool
+    {
+        foreach ( $rejectedPathSources as $source ) {
+            if ( 'oversized_path_data' === ($source['reason'] ?? null) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function primitiveStarPath(float $width, float $height): string

--- a/figma-transformer/src/Parity/ParityReportBuilder.php
+++ b/figma-transformer/src/Parity/ParityReportBuilder.php
@@ -24,6 +24,7 @@ final class ParityReportBuilder
         if ( ! in_array($status, self::KNOWN_STATUSES, true) ) {
             $status = 'pending';
         }
+        $reason = (string) ($overrides['reason'] ?? $evidence['reason'] ?? '');
 
         $artifacts = $this->arrayValue($evidence, 'artifacts');
         $layoutDiagnostics = $this->arrayValue($evidence, 'layout_diagnostics');
@@ -39,12 +40,18 @@ final class ParityReportBuilder
         $this->copyScalar($evidence, 'source_screenshot_path', $source, 'screenshot_path');
         $this->copyScalar($evidence, 'source_screenshot_url', $source, 'screenshot_url');
         $this->copyScalar($evidence, 'source_screenshot_artifact', $source, 'screenshot_artifact');
+        $this->copyBool($evidence, 'source_screenshot_exists', $source, 'screenshot_exists');
+        $this->copyBool($evidence, 'source_screenshot_readable', $source, 'screenshot_readable');
         $this->copyScalar($evidence, 'generated_screenshot_path', $generated, 'screenshot_path');
         $this->copyScalar($evidence, 'generated_screenshot_url', $generated, 'screenshot_url');
         $this->copyScalar($evidence, 'generated_screenshot_artifact', $generated, 'screenshot_artifact');
+        $this->copyBool($evidence, 'generated_screenshot_exists', $generated, 'screenshot_exists');
+        $this->copyBool($evidence, 'generated_screenshot_readable', $generated, 'screenshot_readable');
         $this->copyScalar($evidence, 'diff_image_path', $diff, 'image_path');
         $this->copyScalar($evidence, 'diff_image_url', $diff, 'image_url');
         $this->copyScalar($evidence, 'diff_image_artifact', $diff, 'image_artifact');
+        $this->copyBool($evidence, 'diff_image_exists', $diff, 'image_exists');
+        $this->copyBool($evidence, 'diff_image_readable', $diff, 'image_readable');
         $this->copyScalar($evidence, 'report_path', $artifacts, 'report_path');
         $this->copyScalar($evidence, 'report_artifact', $artifacts, 'report_artifact');
         $this->copyScalar($evidence, 'dom_boxes_path', $artifacts, 'dom_boxes_path');
@@ -90,14 +97,18 @@ final class ParityReportBuilder
         $hasPixelEvidence = array_key_exists('pixel_mismatch_count', $metrics)
             || array_key_exists('pixel_mismatch_ratio', $metrics)
             || array_key_exists('pixel_mismatch_count', $diffSummary)
-            || array_key_exists('pixel_mismatch_ratio', $diffSummary)
-            || ! empty($diff);
+            || array_key_exists('pixel_mismatch_ratio', $diffSummary);
+        $hasScreenshotCandidates = ! empty($source) || ! empty($generated);
+        if ( ! $hasPixelEvidence && $hasScreenshotCandidates && 'not_run' === $status ) {
+            $status = 'pending';
+            $reason = '' !== $reason ? $reason : 'screenshot_evidence_configured';
+        }
         $visualPixelStatus = $hasPixelEvidence ? $status : 'not_run';
 
         return array(
             'schema'       => self::SCHEMA,
             'status'       => $status,
-            'reason'       => (string) ($overrides['reason'] ?? $evidence['reason'] ?? ''),
+            'reason'       => $reason,
             'artifacts'    => $artifacts,
             'source'       => $source,
             'generated'    => $generated,
@@ -139,6 +150,17 @@ final class ParityReportBuilder
     {
         if ( isset($source[$sourceKey]) && is_scalar($source[$sourceKey]) ) {
             $target[$targetKey] = (string) $source[$sourceKey];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     * @param array<string, mixed> $target
+     */
+    private function copyBool(array $source, string $sourceKey, array &$target, string $targetKey): void
+    {
+        if ( isset($source[$sourceKey]) && is_bool($source[$sourceKey]) ) {
+            $target[$targetKey] = $source[$sourceKey];
         }
     }
 

--- a/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
@@ -43,7 +43,7 @@ final class ScenegraphFrameInspector
 
             $stats = $this->subtreeStats($id, $nodes, $childrenIndex, $statsMemo);
             $dimensions = $this->dimensions($node);
-            $candidates[] = array_filter(
+            $candidates[$id] = array_filter(
                 array(
                     'id'                    => $id,
                     'name'                  => (string) ($node['name'] ?? ''),
@@ -58,10 +58,18 @@ final class ScenegraphFrameInspector
                     'text_count'            => $stats['texts'],
                     'asset_reference_count' => $stats['assets'],
                     'score'                 => $this->score($type, $dimensions, $stats),
+                    'device_hint'           => $this->deviceHint((string) ($node['name'] ?? ''), $dimensions),
+                    'sibling_group_key'     => $this->siblingGroupKey($id, $node, $nodes, $parentIndex),
                 ),
                 static fn (mixed $value): bool => null !== $value
             );
         }
+
+        foreach ( $candidates as $id => $candidate ) {
+            $candidates[$id]['responsive_siblings'] = $this->responsiveSiblings($id, $candidate, $candidates);
+        }
+
+        $candidates = array_values($candidates);
 
         usort(
             $candidates,
@@ -231,6 +239,126 @@ final class ScenegraphFrameInspector
             + ($area > 300000 ? 80 : 0)
             - (($dimensions['height'] ?? 0) > 0 && ($dimensions['height'] ?? 0) < 1500 && $stats['nodes'] > 200 ? 160 : 0)
             - ($area > 0 && $area < 10000 ? 60 : 0);
+    }
+
+    /**
+     * @param array{width: float|null, height: float|null} $dimensions
+     */
+    private function deviceHint(string $name, array $dimensions): string
+    {
+        $normalized = strtolower($name);
+        $width = isset($dimensions['width']) && is_numeric($dimensions['width']) ? (float) $dimensions['width'] : 0.0;
+
+        if ( 1 === preg_match('/\b(mobile|phone|iphone|android)\b/', $normalized) || ($width > 0 && $width < 700) ) {
+            return 'mobile';
+        }
+        if ( 1 === preg_match('/\b(tablet|ipad)\b/', $normalized) || ($width >= 700 && $width < 1100) ) {
+            return 'tablet';
+        }
+        if ( 1 === preg_match('/\b(desktop|web|1440|1512|1728|1920)\b/', $normalized) || $width >= 1100 ) {
+            return 'desktop';
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * @param array<string, mixed>                 $node
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, string>               $parentIndex
+     */
+    private function siblingGroupKey(string $id, array $node, array $nodes, array $parentIndex): string
+    {
+        $page = $this->nearestAncestor($id, array('CANVAS'), $nodes, $parentIndex);
+        $section = $this->nearestAncestor($id, array('SECTION'), $nodes, $parentIndex);
+        $scope = (string) (($section['id'] ?? null) ?: ($page['id'] ?? 'root'));
+
+        return $scope . ':' . $this->normalizedPageName((string) ($node['name'] ?? ''));
+    }
+
+    /**
+     * @param array<string, mixed>                $candidate
+     * @param array<string, array<string, mixed>> $candidates
+     * @return array<int, array<string, mixed>>
+     */
+    private function responsiveSiblings(string $id, array $candidate, array $candidates): array
+    {
+        $siblings = array();
+        $groupKey = (string) ($candidate['sibling_group_key'] ?? '');
+        $deviceHint = (string) ($candidate['device_hint'] ?? 'unknown');
+        $pageId = (string) ($candidate['page']['id'] ?? '');
+        $sectionId = (string) ($candidate['section']['id'] ?? '');
+        $parentId = (string) ($candidate['parent']['id'] ?? '');
+
+        foreach ( $candidates as $siblingId => $sibling ) {
+            if ( $siblingId === $id || ! is_array($sibling) ) {
+                continue;
+            }
+
+            $sameScope = '' !== $groupKey && $groupKey === (string) ($sibling['sibling_group_key'] ?? '');
+            $sameContainer = ('' !== $sectionId && $sectionId === (string) ($sibling['section']['id'] ?? ''))
+                || ('' !== $parentId && $parentId === (string) ($sibling['parent']['id'] ?? ''))
+                || ('' !== $pageId && $pageId === (string) ($sibling['page']['id'] ?? ''));
+            $nameSimilarity = $this->nameSimilarity((string) ($candidate['name'] ?? ''), (string) ($sibling['name'] ?? ''));
+            $siblingDeviceHint = (string) ($sibling['device_hint'] ?? 'unknown');
+
+            if ( ! $sameScope && ( ! $sameContainer || $nameSimilarity < 70 ) ) {
+                continue;
+            }
+
+            $confidence = ($sameScope ? 55 : 0)
+                + ($sameContainer ? 20 : 0)
+                + min(25, max(0, $nameSimilarity - 60))
+                + ('unknown' !== $deviceHint && 'unknown' !== $siblingDeviceHint && $deviceHint !== $siblingDeviceHint ? 15 : 0);
+
+            $siblings[] = array_filter(
+                array(
+                    'id' => (string) ($sibling['id'] ?? $siblingId),
+                    'name' => (string) ($sibling['name'] ?? ''),
+                    'device_hint' => $siblingDeviceHint,
+                    'width' => $sibling['width'] ?? null,
+                    'height' => $sibling['height'] ?? null,
+                    'name_similarity' => $nameSimilarity,
+                    'confidence' => min(100, $confidence),
+                ),
+                static fn (mixed $value): bool => null !== $value
+            );
+        }
+
+        usort(
+            $siblings,
+            static fn (array $left, array $right): int => ((int) ($right['confidence'] ?? 0) <=> (int) ($left['confidence'] ?? 0))
+                ?: strcmp((string) ($left['id'] ?? ''), (string) ($right['id'] ?? ''))
+        );
+
+        return array_slice($siblings, 0, 5);
+    }
+
+    private function normalizedPageName(string $name): string
+    {
+        $normalized = strtolower($name);
+        $normalized = (string) preg_replace('/\b(desktop|mobile|tablet|phone|web|copy|variant|version|v\d+|i\d+)\b/', ' ', $normalized);
+        $normalized = (string) preg_replace('/\b\d{3,4}\s*x\s*\d{3,5}\b/', ' ', $normalized);
+        $normalized = (string) preg_replace('/\b(320|375|390|393|414|428|768|834|1024|1280|1366|1440|1512|1728|1920)\b/', ' ', $normalized);
+        $normalized = trim((string) preg_replace('/[^a-z0-9]+/', '-', $normalized), '-');
+
+        return '' === $normalized ? 'frame' : $normalized;
+    }
+
+    private function nameSimilarity(string $left, string $right): int
+    {
+        $leftName = $this->normalizedPageName($left);
+        $rightName = $this->normalizedPageName($right);
+        if ( $leftName === $rightName ) {
+            return 100;
+        }
+
+        $max = max(strlen($leftName), strlen($rightName));
+        if ( 0 === $max ) {
+            return 0;
+        }
+
+        return (int) round((1 - (levenshtein($leftName, $rightName) / $max)) * 100);
     }
 
     /**

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -51,6 +51,12 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
         '--frame-ids=render:home',
         '--render-evidence=' . $matrixFixtureDir . '/{fixture}/render-evidence.json',
     ));
+    $matrixScreenshotSummary = $matrixDryRun(array(
+        '--frame-ids=render:home',
+        '--source-screenshot=' . $matrixFixtureDir . '/screenshots/{fixture}/{slug}-source.png',
+        '--generated-screenshot=' . $matrixFixtureDir . '/screenshots/{fixture}/{slug}-generated.png',
+        '--diff-image=' . $matrixFixtureDir . '/screenshots/{fixture}/{slug}-diff.png',
+    ));
     $missingHomeboyOutput = array();
     $missingHomeboyCommand = escapeshellarg(PHP_BINARY)
         . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-fixture-matrix.php')
@@ -102,6 +108,14 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert($matrixFixtureDir . '/{fixture}/render-evidence.json' === ($matrixEvidenceSummary['evidence']['templates']['render_evidence_path'] ?? null), 'fixture-matrix-render-evidence-template-summary');
     $matrixEvidenceCommand = (string) ($matrixEvidenceSummary['fixtures'][0]['command'] ?? '');
     $assert(str_contains($matrixEvidenceCommand, '--parity-render-evidence-path=' . escapeshellarg($matrixFixtureDir . '/alias/render-evidence.json')), 'fixture-matrix-render-evidence-transform-argument');
+    $assert(is_array($matrixScreenshotSummary), 'fixture-matrix-screenshot-json-summary');
+    $assert($matrixFixtureDir . '/screenshots/{fixture}/{slug}-source.png' === ($matrixScreenshotSummary['evidence']['templates']['source_screenshot_path'] ?? null), 'fixture-matrix-source-screenshot-template-summary');
+    $matrixScreenshotPaths = $matrixScreenshotSummary['fixtures'][0]['evidence']['pages'][0]['paths'] ?? array();
+    $assert(false === ($matrixScreenshotPaths['source_screenshot_path']['exists'] ?? null), 'fixture-matrix-source-screenshot-missing-recorded');
+    $matrixScreenshotCommand = (string) ($matrixScreenshotSummary['fixtures'][0]['command'] ?? '');
+    $assert(str_contains($matrixScreenshotCommand, '--parity-source-screenshot-path=' . escapeshellarg($matrixFixtureDir . '/screenshots/alias/alias-source.png')), 'fixture-matrix-source-screenshot-transform-argument');
+    $assert(str_contains($matrixScreenshotCommand, '--parity-generated-screenshot-path=' . escapeshellarg($matrixFixtureDir . '/screenshots/alias/alias-generated.png')), 'fixture-matrix-generated-screenshot-transform-argument');
+    $assert(str_contains($matrixScreenshotCommand, '--parity-diff-image-path=' . escapeshellarg($matrixFixtureDir . '/screenshots/alias/alias-diff.png')), 'fixture-matrix-diff-image-transform-argument');
     $assert(0 !== $missingHomeboyExitCode, 'fixture-matrix-capture-preflight-missing-homeboy-fails');
     $missingHomeboyMessage = implode("\n", $missingHomeboyOutput);
     $assert(str_contains($missingHomeboyMessage, 'DOM box capture requires a runnable Homeboy command'), 'fixture-matrix-capture-preflight-missing-homeboy-message');

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1682,12 +1682,22 @@ $frameInspection = blocks_engine_figma_transformer_inspect_frames_scenegraph(arr
                                 array('id' => 'image:hero', 'type' => 'RECTANGLE', 'name' => 'Hero image', 'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'hero'))),
                             ),
                         ),
+                        array(
+                            'id' => 'frame:home-mobile',
+                            'type' => 'FRAME',
+                            'name' => 'Home Page Mobile',
+                            'width' => 390,
+                            'height' => 1200,
+                            'children' => array(
+                                array('id' => 'text:hero-mobile', 'type' => 'TEXT', 'name' => 'Hero Mobile', 'characters' => 'Hello'),
+                            ),
+                        ),
                     ),
                 ),
             ),
         ),
     ),
-), array('frame_inspection_limit' => 2));
+), array('frame_inspection_limit' => 3));
 $frameInspectionHome = null;
 foreach ( $frameInspection['candidates'] ?? array() as $candidate ) {
     if ( is_array($candidate) && 'frame:home' === ($candidate['id'] ?? null) ) {
@@ -1696,11 +1706,14 @@ foreach ( $frameInspection['candidates'] ?? array() as $candidate ) {
     }
 }
 $assert('blocks-engine/figma-transformer/frame-inspection/v1' === ($frameInspection['schema'] ?? null), 'frame-inspection-schema');
-$assert(2 === ($frameInspection['returned_count'] ?? null), 'frame-inspection-limit');
+$assert(3 === ($frameInspection['returned_count'] ?? null), 'frame-inspection-limit');
 $assert('Page One' === ($frameInspectionHome['page']['name'] ?? null), 'frame-inspection-page-ancestor');
 $assert('Marketing Pages' === ($frameInspectionHome['section']['name'] ?? null), 'frame-inspection-section-ancestor');
 $assert(1 === ($frameInspectionHome['text_count'] ?? null), 'frame-inspection-text-count');
 $assert(1 === ($frameInspectionHome['asset_reference_count'] ?? null), 'frame-inspection-asset-count');
+$assert('desktop' === ($frameInspectionHome['device_hint'] ?? null), 'frame-inspection-desktop-device-hint');
+$assert('frame:home-mobile' === ($frameInspectionHome['responsive_siblings'][0]['id'] ?? null), 'frame-inspection-responsive-sibling-id');
+$assert('mobile' === ($frameInspectionHome['responsive_siblings'][0]['device_hint'] ?? null), 'frame-inspection-responsive-sibling-device-hint');
 
 $matrixWebsiteCandidate = array(
     'id'         => 'matrix:site:home',

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2318,6 +2318,14 @@ $layoutOnlyParity = $parityBuilder->build(array(
     'dom_boxes_path' => 'artifacts/dom-boxes.json',
     'layout_mismatch_count' => 0,
 ));
+$screenshotCandidateParity = $parityBuilder->build(array(
+    'source_screenshot_path' => 'artifacts/source-candidate.png',
+    'source_screenshot_exists' => false,
+    'source_screenshot_readable' => false,
+    'generated_screenshot_path' => 'artifacts/generated-candidate.png',
+    'generated_screenshot_exists' => false,
+    'generated_screenshot_readable' => false,
+));
 $comparedParity = $parityBuilder->build(array(
     'status'    => 'compared',
     'artifacts' => array(
@@ -2374,6 +2382,12 @@ $assert(0 === ($layoutOnlyParity['layout_evidence']['mismatch_count'] ?? null), 
 $assert(! array_key_exists('pixel_mismatch_count', $layoutOnlyParity['metrics'] ?? array()), 'parity-layout-only-no-pixel-count');
 $assert('not_run' === ($layoutOnlyParity['visual_pixel_status'] ?? null), 'parity-layout-only-visual-pixel-not-run');
 $assert('not_run' === ($layoutOnlyParity['render_style_evidence']['status'] ?? null), 'parity-layout-only-render-style-not-run');
+$assert('pending' === ($screenshotCandidateParity['status'] ?? null), 'parity-screenshot-candidate-pending');
+$assert('screenshot_evidence_configured' === ($screenshotCandidateParity['reason'] ?? null), 'parity-screenshot-candidate-reason');
+$assert('not_run' === ($screenshotCandidateParity['visual_pixel_status'] ?? null), 'parity-screenshot-candidate-visual-not-run');
+$assert('artifacts/source-candidate.png' === ($screenshotCandidateParity['source']['screenshot_path'] ?? null), 'parity-screenshot-candidate-source-path');
+$assert(false === ($screenshotCandidateParity['source']['screenshot_exists'] ?? null), 'parity-screenshot-candidate-source-exists-false');
+$assert(false === ($screenshotCandidateParity['generated']['screenshot_readable'] ?? null), 'parity-screenshot-candidate-generated-readable-false');
 $assert('compared' === ($comparedParity['status'] ?? null), 'parity-compared-status');
 $assert('artifacts/source.png' === ($comparedParity['source']['screenshot_path'] ?? null), 'parity-source-screenshot-path');
 $assert('artifacts/generated.png' === ($comparedParity['generated']['screenshot_path'] ?? null), 'parity-generated-screenshot-path');

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -928,9 +928,20 @@ $largeDecodedVectorDiagnosticCodes = array_map(
     static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
     $largeDecodedVectorResult['diagnostics'] ?? array()
 );
+$largeDecodedVectorDiagnostics = $largeDecodedVectorResult['source_reports']['figma']['html']['transform_diagnostics']['vectors'] ?? array();
+$largeRawPlaceholder = null;
+foreach ( $largeDecodedVectorDiagnostics['placeholder_nodes'] ?? array() as $placeholderNode ) {
+    if ( is_array($placeholderNode) && 'vector:large-raw' === ($placeholderNode['node_id'] ?? null) ) {
+        $largeRawPlaceholder = $placeholderNode;
+        break;
+    }
+}
 $assert(str_contains($largeDecodedVectorHtml, 'data-figma-node-id="vector:large-decoded"') && str_contains($largeDecodedVectorHtml, 'data-figma-vector="true"'), 'large-decoded-vector-path-renders');
 $assert(str_contains($largeDecodedVectorHtml, 'data-figma-node-id="vector:large-raw"') && str_contains($largeDecodedVectorHtml, 'data-figma-unsupported-vector="true"'), 'large-raw-vector-path-remains-capped');
 $assert(in_array('unsupported_vector_node_placeholder', $largeDecodedVectorDiagnosticCodes, true), 'large-raw-vector-placeholder-diagnostic');
+$assert('oversized_path_data' === ($largeRawPlaceholder['reason'] ?? null), 'large-raw-vector-placeholder-reason');
+$assert(array('pathData') === ($largeRawPlaceholder['source_fields'] ?? null), 'large-raw-vector-placeholder-source-field');
+$assert(1 === ($largeDecodedVectorDiagnostics['placeholder_reasons']['oversized_path_data'] ?? null), 'large-raw-vector-placeholder-reason-count');
 
 $externalizedVectorPath = 'M 0.0000 0.0000' . str_repeat(' L 10.000001 10.000001', 12000) . ' Z';
 $externalizedEquivalentVectorPath = 'M0,0' . str_repeat('L10,10', 12000) . 'Z';
@@ -1159,6 +1170,17 @@ $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-closed-re
 $assert(str_contains($vectorDataHtml, 'data-figma-node-id="vector:data-non-rect-network"') && str_contains($vectorDataHtml, 'data-figma-unsupported-vector="true"'), 'vector-data-non-rect-network-keeps-placeholder');
 $assert(in_array('unsupported_vector_network_blob', $vectorDataDiagnosticCodes, true), 'vector-data-malformed-network-diagnostic');
 $assert(1 === ($vectorNetworkDiagnostic['context']['byte_length'] ?? null) && 'ff' === ($vectorNetworkDiagnostic['context']['signature_hex'] ?? null), 'vector-network-diagnostic-context');
+$vectorDataPlaceholderDiagnostics = $vectorDataResult['source_reports']['figma']['html']['transform_diagnostics']['vectors'] ?? array();
+$malformedNetworkPlaceholder = null;
+foreach ( $vectorDataPlaceholderDiagnostics['placeholder_nodes'] ?? array() as $placeholderNode ) {
+    if ( is_array($placeholderNode) && 'vector:data-malformed' === ($placeholderNode['node_id'] ?? null) ) {
+        $malformedNetworkPlaceholder = $placeholderNode;
+        break;
+    }
+}
+$assert('unsupported_vector_network_blob' === ($malformedNetworkPlaceholder['reason'] ?? null), 'vector-network-placeholder-reason');
+$assert(array('vectorData.vectorNetworkBlob') === ($malformedNetworkPlaceholder['source_fields'] ?? null), 'vector-network-placeholder-source-field');
+$assert(1 === ($vectorDataPlaceholderDiagnostics['placeholder_reasons']['unsupported_vector_network_blob'] ?? null), 'vector-network-placeholder-reason-count');
 $vectorNetworkDiagnostics = array_values(array_filter(
     $vectorDataResult['diagnostics'] ?? array(),
     static fn (array $diagnostic): bool => 'unsupported_vector_network_blob' === ($diagnostic['code'] ?? null)

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1190,6 +1190,30 @@ $assert(2 === ($vectorNetworkDiagnostic['context']['occurrence_count'] ?? null),
 $assert(2 === ($vectorNetworkDiagnostic['context']['affected_node_count'] ?? null), 'vector-network-diagnostic-affected-node-count');
 $assert(array('vector:data-malformed', 'vector:data-painted-fallback') === ($vectorNetworkDiagnostic['context']['sample_node_ids'] ?? null), 'vector-network-diagnostic-sample-nodes');
 $assert(array('1') === ($vectorNetworkDiagnostic['context']['sample_blob_refs'] ?? null), 'vector-network-diagnostic-sample-blob-refs');
+
+$multiPageVectorPlaceholderResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Multi Page Vector Placeholder Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'page:vector-placeholder',
+            'type'     => 'CANVAS',
+            'name'     => 'Vector Placeholder Pages',
+            'children' => array(
+                array('id' => 'frame:vector-home', 'type' => 'FRAME', 'name' => 'Vector Home', 'width' => 320, 'height' => 240, 'children' => array()),
+                array('id' => 'frame:vector-about', 'type' => 'FRAME', 'name' => 'Vector About', 'width' => 320, 'height' => 240, 'children' => array(
+                    array('id' => 'vector:multi-page-placeholder', 'type' => 'VECTOR', 'name' => 'Multi Page Placeholder', 'width' => 16, 'height' => 16, 'pathData' => 'M 0 0' . str_repeat(' L 1 1', 4000) . ' Z'),
+                )),
+            ),
+        ),
+    ),
+), array(
+    'multi_page' => true,
+    'frame_ids' => array('frame:vector-home', 'frame:vector-about'),
+    'entry_frame_id' => 'frame:vector-home',
+));
+$multiPageVectorPlaceholderDiagnostics = $multiPageVectorPlaceholderResult['source_reports']['figma']['html']['transform_diagnostics']['vectors'] ?? array();
+$assert(1 === ($multiPageVectorPlaceholderDiagnostics['placeholder_reasons']['oversized_path_data'] ?? null), 'multi-page-vector-placeholder-reason-aggregated');
+
 $nonRectVectorNetworkDiagnostic = null;
 foreach ( $vectorNetworkDiagnostics as $diagnostic ) {
     if ( array(4, 4, 1) === ($diagnostic['context']['network_counts'] ?? null) ) {

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2242,6 +2242,40 @@ $assert(str_contains($derivedLineBreakHtml, "First line\nSecond line"), 'derived
 $assert(str_contains($derivedLineBreakCss, '.figma-node-text-derived-lines-measured-lines{width:120px;height:44px;line-height:22px;white-space:pre-line}'), 'derived-baselines-enable-pre-line');
 $assert(! str_contains($derivedLineBreakCss, 'line-height:40px;line-height:22px'), 'derived-baselines-replace-source-line-height');
 
+$derivedMeasuredLineHeightResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Derived Measured Line Height Fixture',
+    'nodes' => array(
+        array(
+            'id'              => 'text:derived-measured-line-height',
+            'type'            => 'TEXT',
+            'name'            => 'Measured Line Height',
+            'characters'      => 'First line Second line',
+            'width'           => 120,
+            'height'          => 40,
+            'lineHeightPx'    => 28,
+            'derivedTextData' => array(
+                'layoutSize' => array('x' => 120, 'y' => 40),
+                'baselines'  => array(
+                    array('firstCharacter' => 0, 'endCharacter' => 10, 'lineHeight' => 20, 'position' => array('x' => 0, 'y' => 15)),
+                    array('firstCharacter' => 11, 'endCharacter' => 22, 'lineHeight' => 20, 'position' => array('x' => 0, 'y' => 38)),
+                ),
+            ),
+        ),
+    ),
+));
+$derivedMeasuredLineHeightCss = $fileContent($derivedMeasuredLineHeightResult, 'style.css');
+$derivedMeasuredLineHeightDiagnostics = $derivedMeasuredLineHeightResult['source_reports']['figma']['html']['node_style_diagnostics'] ?? array();
+$derivedMeasuredLineHeightDiagnostic = null;
+foreach ( is_array($derivedMeasuredLineHeightDiagnostics) ? $derivedMeasuredLineHeightDiagnostics : array() as $styleDiagnostic ) {
+    if ( 'text:derived-measured-line-height' === ($styleDiagnostic['node']['id'] ?? null) ) {
+        $derivedMeasuredLineHeightDiagnostic = $styleDiagnostic;
+    }
+}
+$assert(str_contains($derivedMeasuredLineHeightCss, '.figma-node-text-derived-measured-line-height-measured-line-height{width:120px;height:40px;line-height:20px;white-space:pre-line}'), 'derived-baselines-prefer-measured-line-height');
+$assert('20px' === ($derivedMeasuredLineHeightDiagnostic['expected']['line_height'] ?? null), 'derived-baselines-measured-line-height-expected-diagnostic');
+$assert('20px' === ($derivedMeasuredLineHeightDiagnostic['emitted']['line_height'] ?? null), 'derived-baselines-measured-line-height-emitted-diagnostic');
+$assert(array() === ($derivedMeasuredLineHeightDiagnostic['mismatches'] ?? null), 'derived-baselines-measured-line-height-no-diagnostic-mismatch');
+
 $parityBuilder = new ParityReportBuilder();
 $pendingParity = $parityBuilder->build(array(
     'status'    => 'pending',


### PR DESCRIPTION
## Summary

- Improve Figma text metric fidelity by emitting derived/measured line-height values when available.
- Classify vector placeholders with generic reason/source-field diagnostics and aggregate those reasons across multi-page outputs.
- Add optional screenshot path inputs to the fixture matrix so callers can wire source/generated/diff screenshots without claiming pixel parity when screenshots are absent.
- Add responsive frame diagnostics for discovery mode: `device_hint`, `sibling_group_key`, and ranked `responsive_siblings`.

## Evidence

- `composer test:contract` from `figma-transformer/`: passed.
- PHP lint on changed PHP files: passed.
- `npm test` from `php-transformer/tools/visual-parity`: passed.
- `git diff --check origin/trunk...HEAD`: passed.
- Locked six-fixture render-evidence matrix on Homeboy lab completed with DOM layout still passing across all six fixtures.

Locked matrix summary after this wave:

| Fixture | DOM layout | Render style | Vector placeholders | Artifact quality |
| --- | --- | --- | --- | --- |
| `agentic-commerce-wip` | `0 pass` | `7 fail` | `0` | `warn` |
| `fisiostetic` | `0 pass` | `20 fail` | `2` | `fail` |
| `fse-pilot-build-theme` | `0 pass` | `0 pass` | `0` | `warn` |
| `games-hotline-blog-updates` | `0 pass` | `0 pass` | `0` | `warn` |
| `wp-cloud-2` | `0 pass` | `16 fail` | `0` | `warn` |
| `wpjobmanager-com` | `0 pass` | `13 fail` | `15` | `fail` |

Notable deltas from the prior matrix:

- `fse-pilot-build-theme` render-style failures dropped from `26 fail` to `0 pass`.
- `fisiostetic` render-style failures dropped from `43 fail` to `20 fail`.
- `wpjobmanager-com` now exposes top-level vector placeholder reasons: `unsupported_vector_network_blob: 15`.
- FSE discovery-mode selected desktop frames now include mobile responsive siblings with high confidence.

Pixel parity note:

- Pixel parity still remains `not_run` unless source/generated screenshots are supplied by a caller.
- This PR only adds clean optional screenshot path inputs and pending-status semantics.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Parallel implementation/refactoring of Figma typography fidelity, vector diagnostics, screenshot parity input semantics, responsive selection diagnostics, and verification.
