### PR TITLE
Diagnostic: carried-but-inert script-target parity (#225)

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -76,7 +76,7 @@ final class ArtifactCompiler
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
         $sourceReports['materialization_plan'] = ( new MaterializationPlanBuilder() )->fromCompiledSite($sourceReports['compiled_site']);
-        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references']);
+        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references'], $entryBlocks['interaction_candidates']);
         if ( array() !== $entryBlocks['runtime_islands'] ) {
             $sourceReports['runtime_islands'] = $entryBlocks['runtime_islands'];
         }
@@ -129,7 +129,7 @@ final class ArtifactCompiler
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
      */
     private function compileEntryBlocks(string $html, string $entryPath, array $files): array
     {
@@ -142,12 +142,13 @@ final class ArtifactCompiler
             'fallbacks'         => $result['fallbacks'],
             'assets'            => $result['assets'],
             'runtime_islands'   => $result['runtime_islands'],
+            'interaction_candidates' => $result['interaction_candidates'],
         );
     }
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
      */
     private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope): array
     {
@@ -159,6 +160,7 @@ final class ArtifactCompiler
                 'fallbacks'         => array(),
                 'assets'            => array(),
                 'runtime_islands'   => array(),
+                'interaction_candidates' => array(),
             );
         }
 
@@ -170,6 +172,7 @@ final class ArtifactCompiler
                 'fallbacks'         => array(),
                 'assets'            => array(),
                 'runtime_islands'   => array(),
+                'interaction_candidates' => array(),
             );
         }
 
@@ -190,6 +193,7 @@ final class ArtifactCompiler
             'fallbacks'         => is_array($result['fallbacks'] ?? null) ? $result['fallbacks'] : array(),
             'assets'            => is_array($result['assets'] ?? null) ? $result['assets'] : array(),
             'runtime_islands'   => is_array($result['source_reports']['runtime_islands'] ?? null) ? $result['source_reports']['runtime_islands'] : array(),
+            'interaction_candidates' => is_array($result['source_reports']['interaction_candidates'] ?? null) ? $result['source_reports']['interaction_candidates'] : array(),
         );
     }
 

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -15,14 +15,16 @@ final class RuntimeDependencyParityReport
      * @param array<int, array<string, mixed>> $files
      * @param array<int, array<string, mixed>> $runtimeIslands
      * @param array<int, array<string, mixed>> $assetReferences
+     * @param array<int, array<string, mixed>> $interactionCandidates
      * @return array<string, mixed>
      */
-    public function fromArtifact(array $files, string $sourceHtml, string $generatedHtml, string $sourcePath = '', array $runtimeIslands = array(), array $assetReferences = array()): array
+    public function fromArtifact(array $files, string $sourceHtml, string $generatedHtml, string $sourcePath = '', array $runtimeIslands = array(), array $assetReferences = array(), array $interactionCandidates = array()): array
     {
         $sourceTargets = $this->sourceTargets($sourceHtml, $sourcePath);
         $generatedTargets = $this->withRuntimeIslandTargets($this->htmlTargets($generatedHtml), $runtimeIslands);
         $dependencies = array();
         $findings = array();
+        $flaggedSelectors = array();
 
         foreach ( $files as $file ) {
             if ( ! $this->isScriptFile($file) ) {
@@ -65,6 +67,8 @@ final class RuntimeDependencyParityReport
                     continue;
                 }
 
+                $flaggedSelectors[$selector] = true;
+
                 $severity = 'telemetry' === $scriptKind ? 'info' : 'warning';
                 $repairBucket = $canvasApi ? 'runtime_canvas_target_preservation' : 'runtime_dom_target_preservation';
                 $findings[] = array_filter(array(
@@ -90,6 +94,10 @@ final class RuntimeDependencyParityReport
         }
 
         foreach ( $this->scriptMaterializationFindings($files, $runtimeIslands, $assetReferences, $generatedHtml, $sourcePath) as $finding ) {
+            $findings[] = $finding;
+        }
+
+        foreach ( $this->scriptTargetParityFindings($files, $interactionCandidates, $sourceTargets, $generatedTargets, $sourcePath, $flaggedSelectors) as $finding ) {
             $findings[] = $finding;
         }
 
@@ -173,6 +181,140 @@ final class RuntimeDependencyParityReport
         }
 
         return $findings;
+    }
+
+    /**
+     * Detect carried-but-inert client scripts: a first-party client script IS
+     * materialized in the artifact (so #218's `runtime_script_not_materialized`
+     * stays silent — the script loads/enqueues), yet an interactive DOM target
+     * the transformer authoritatively recorded for the source was transformed
+     * away (deduped, folded into a core block, or dropped) and is no longer
+     * present — verbatim — in the generated block markup or any preserved runtime
+     * island. The script therefore executes against a target that no longer
+     * exists and silently no-ops: "script enqueued" is a false parity signal.
+     *
+     * Targets come from `interaction_candidates` — the transformer's own record
+     * of interactive elements and the DOM they drive (authoritative), rather than
+     * re-deriving selectors from script source (the heuristic the main DOM-target
+     * loop already covers). Selectors already flagged by that loop are skipped to
+     * avoid duplicate findings, and native-behavior candidates (native `details`
+     * toggles, form submissions) plus form-control targets are excluded because
+     * they do not depend on a carried client script.
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @param array<int, array<string, mixed>> $interactionCandidates
+     * @param array<string, array<string, mixed>> $sourceTargets
+     * @param array{ids: array<string, bool>, classes: array<string, bool>} $generatedTargets
+     * @param array<string, bool> $flaggedSelectors
+     * @return array<int, array<string, mixed>>
+     */
+    private function scriptTargetParityFindings(array $files, array $interactionCandidates, array $sourceTargets, array $generatedTargets, string $sourcePath, array $flaggedSelectors): array
+    {
+        if ( array() === $interactionCandidates || ! $this->hasCarriedFirstPartyClientScript($files) ) {
+            return array();
+        }
+
+        // Native behaviors (the native <details> toggle, native form submission)
+        // are rebuilt by core blocks / covered by the form fallback and do not
+        // depend on a carried client script, so a missing target there is not an
+        // inert-JS parity loss this diagnostic should own.
+        $nativeRuntimeRequirements = array('native_toggle', 'form_submission');
+        $findings = array();
+        $seenSelectors = array();
+
+        foreach ( $interactionCandidates as $candidate ) {
+            if ( ! is_array($candidate) ) {
+                continue;
+            }
+
+            $runtimeRequirement = (string) ($candidate['runtime_requirement'] ?? '');
+            if ( in_array($runtimeRequirement, $nativeRuntimeRequirements, true) ) {
+                continue;
+            }
+
+            $selector = $this->normalizedTargetSelector((string) ($candidate['target'] ?? ''));
+            if ( '' === $selector ) {
+                continue;
+            }
+            if ( isset($flaggedSelectors[$selector]) || isset($seenSelectors[$selector]) ) {
+                continue;
+            }
+
+            $target = $sourceTargets[$selector] ?? array();
+            if ( $this->isFormControlTarget($target) ) {
+                continue;
+            }
+            if ( $this->targetExists(array('selector' => $selector), $generatedTargets) ) {
+                continue;
+            }
+
+            $seenSelectors[$selector] = true;
+            $interactionKind = (string) ($candidate['kind'] ?? '');
+            $materializationHint = (string) ($candidate['materialization_hint'] ?? '');
+            $findings[] = array_filter(array(
+                'code'                 => 'runtime_script_target_missing',
+                'severity'             => 'warning',
+                'source_path'          => $target['source_path'] ?? $sourcePath,
+                'selector'             => $selector,
+                'target_id'            => $target['id'] ?? ( str_starts_with($selector, '#') ? substr($selector, 1) : '' ),
+                'target_class'         => $target['class'] ?? ( str_starts_with($selector, '.') ? substr($selector, 1) : '' ),
+                'target_kind'          => $target['tag'] ?? '',
+                'interaction_kind'     => $interactionKind,
+                'interaction_selector' => (string) ($candidate['selector'] ?? ''),
+                'trigger'              => (string) ($candidate['trigger'] ?? ''),
+                'runtime_requirement'  => $runtimeRequirement,
+                'client_script_present' => true,
+                'repair_bucket'        => 'runtime_interactive_behavior_restoration',
+                'suggested_primitive'  => 'runtime_dom_target',
+                'actionability'        => 'restore_or_rebuild_the_interactive_dom_target_so_the_carried_client_script_remains_functional',
+                'materialization_hint' => '' !== $materializationHint ? $materializationHint : 'preserve_interactive_target_markup_required_by_carried_client_script',
+                'message'              => sprintf('A client script is carried for the %s interaction, but its DOM target %s was transformed away and is no longer present in the generated block markup, so the carried script no-ops.', '' !== $interactionKind ? $interactionKind : 'interactive', $selector),
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value);
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Whether the artifact carries a materialized first-party (non-telemetry)
+     * client script. Used to gate the carried-but-inert target diagnostic: only
+     * when a client script actually loads is a missing interactive target an
+     * inert-JS parity loss.
+     *
+     * @param array<int, array<string, mixed>> $files
+     */
+    private function hasCarriedFirstPartyClientScript(array $files): bool
+    {
+        foreach ( $files as $file ) {
+            if ( ! is_array($file) || ! $this->isScriptFile($file) ) {
+                continue;
+            }
+            $content = (string) ($file['content'] ?? '');
+            if ( '' === trim($content) ) {
+                continue;
+            }
+            if ( 'telemetry' !== $this->scriptKind((string) ($file['path'] ?? ''), $content) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Normalize an interaction-candidate target to a single clean id/class
+     * selector (`#id` / `.class`). Structural nth-of-type paths and other
+     * non-id/class targets return '' so they are ignored — presence is only
+     * checkable for ids/classes.
+     */
+    private function normalizedTargetSelector(string $target): string
+    {
+        $target = trim($target);
+        if ( 1 === preg_match('/^[#.][A-Za-z][A-Za-z0-9_-]*$/', $target) ) {
+            return $target;
+        }
+
+        return '';
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/artifact-runtime-script-target-missing.json
+++ b/php-transformer/tests/fixtures/parity/artifact-runtime-script-target-missing.json
@@ -1,0 +1,43 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-runtime-script-target-missing",
+  "description": "Flags a carried-but-inert client script: the script is materialized in the artifact, but an interactive DOM target the transformer recorded (a hamburger toggle's aria-controls target) was deduped away during conversion, so the carried script no-ops.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-runtime-script-target-missing.json",
+    "notes": "Generic script-target parity: a carried first-party client script whose interaction_candidates target is not present (verbatim) in the generated block markup must surface a feature-parity finding. The duplicate menu is deduplicated, so #mobile-menu is transformed away even though the control element survives."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<header><nav class=\"primary-nav\"><ul><li><a href=\"/\">Home</a></li><li><a href=\"/a\">A</a></li></ul></nav><button class=\"nav-toggle\" aria-controls=\"mobile-menu\">Menu</button></header><nav id=\"mobile-menu\"><ul><li><a href=\"/\">Home</a></li><li><a href=\"/a\">A</a></li></ul></nav><script src=\"js/nav.js\"></script>"
+        },
+        {
+          "path": "js/nav.js",
+          "kind": "js",
+          "content": "document.querySelectorAll('[aria-controls]').forEach(function (b) { b.addEventListener('click', function () { var t = document.getElementById(b.getAttribute('aria-controls')); if (t) { t.hidden = !t.hidden; } }); });"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "warning" },
+    { "path": "source_reports.runtime_dependency_parity.findings", "assert": "count", "count": 1 },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.code", "assert": "equals", "value": "runtime_script_target_missing" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.severity", "assert": "equals", "value": "warning" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.selector", "assert": "equals", "value": "#mobile-menu" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.repair_bucket", "assert": "equals", "value": "runtime_interactive_behavior_restoration" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.client_script_present", "assert": "equals", "value": true },
+    { "path": "source_reports.conversion_report.runtime_dependency_parity.findings.0.code", "assert": "equals", "value": "runtime_script_target_missing" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/artifact-runtime-script-target-preserved-no-finding.json
+++ b/php-transformer/tests/fixtures/parity/artifact-runtime-script-target-preserved-no-finding.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-runtime-script-target-preserved-no-finding",
+  "description": "A carried client script whose interactive DOM target survives conversion (the toggle's aria-controls target is preserved verbatim) emits no runtime_script_target_missing finding.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-runtime-script-target-preserved-no-finding.json",
+    "notes": "Negative coverage for script-target parity: when the interactive target referenced by a carried first-party client script remains present in the generated block markup, runtime dependency parity stays clean (no false positive)."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<header><button class=\"nav-toggle\" aria-controls=\"mobile-menu\">Menu</button></header><nav id=\"mobile-menu\"><ul><li><a href=\"/\">Home</a></li></ul></nav><script src=\"js/nav.js\"></script>"
+        },
+        {
+          "path": "js/nav.js",
+          "kind": "js",
+          "content": "document.querySelectorAll('[aria-controls]').forEach(function (b) { b.addEventListener('click', function () { var t = document.getElementById(b.getAttribute('aria-controls')); if (t) { t.hidden = !t.hidden; } }); });"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "mobile-menu" }
+  ]
+}


### PR DESCRIPTION
Closes #225

## Problem
`RuntimeDependencyParityReport` already flags scripts that were never carried (`runtime_script_not_materialized`, #218). The opposite silent failure remained: a client script IS carried/enqueued, but the DOM it targets was **transformed away** by the conversion (e.g. a hamburger toggle's `aria-controls` target gets deduped / folded into a core block). The script loads and **no-ops** — "script enqueued = fine" is a false parity signal.

## Approach (authoritative, not a heuristic)
Targets are read from the transformer's own `interaction_candidates` metadata (`kind` / `trigger` / `target` / `runtime_requirement`) — the authoritative record of interactive source elements and the DOM they drive — rather than re-deriving selectors from script source (the existing DOM-target loop already covers that heuristic). For each carried-but-inert candidate whose `target` (a clean `#id` / `.class`) is **not present verbatim** in the generated block markup or any preserved runtime island, the report emits:

- **code** `runtime_script_target_missing`
- **severity** `warning`
- **repair_bucket** `runtime_interactive_behavior_restoration` (feature-parity / restore-interactive-behavior)
- selector / target / interaction context consistent with existing findings.

`interaction_candidates` are now threaded from the entry-block compile through `ArtifactCompiler` into the report (they weren't previously available on the artifact path).

## No false positives / no #218 regression
- Fires **only** when a carried first-party (non-telemetry) client script exists. This is mutually exclusive with `runtime_script_not_materialized`, which fires only when the script is **not** carried — so the two never double-report and #218 is untouched.
- Skips native-behavior candidates (native `details` toggle, form submission) and form-control targets — these don't depend on a carried client script.
- Skips selectors already flagged by the script-source DOM-target loop (no duplicate findings).
- A target preserved verbatim (including inside a runtime island) yields **no** finding. No carried script, or no recorded targets → no finding.

## Scratch reproduction (before → after)
Source: duplicate nav where a hamburger `button[aria-controls="mobile-menu"]` targets `nav#mobile-menu`, which is **deduped away** during conversion; a generic carried `js/nav.js` wires `[aria-controls]` and never literally names `#mobile-menu`.

- **Before:** no finding (`runtime_dependency_parity.status: pass`) — the script-source heuristic can't see `#mobile-menu`, so the inert script was invisible.
- **After:** `runtime_script_target_missing` for `#mobile-menu`, `repair_bucket: runtime_interactive_behavior_restoration`, severity `warning`.
- **Negatives confirmed:** no scripts → no finding; telemetry-only script → no finding; target preserved (single nav, not deduped) → no finding.

## Limitations
- Presence is only checkable for clean `#id` / `.class` targets; structural `nth-of-type` candidate targets are ignored (can't be matched verbatim). This is conservative — it never invents authoritative detection it can't back.
- Detection inherits the transformer's `interaction_candidates` coverage (controls, modals, tabs, accordions, carousels). Behaviors the transformer doesn't record as interaction candidates aren't covered by this path; the script-source DOM-target loop remains the supplement for literally-named selectors.

## Tests
- `composer test:canonical` ✅
- `composer parity` ✅ (124 fixtures, +2)
- Added `artifact-runtime-script-target-missing.json` (positive) and `artifact-runtime-script-target-preserved-no-finding.json` (negative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)