### PR TITLE
Convert static accordions to Core accordion blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -131,6 +131,25 @@ final class BlockFactory
             );
         }
 
+        if ( 'core/accordion' === $name ) {
+            return array( 'opening' => '<div' . $this->blockSupportAttrs($attrs, 'wp-block-accordion') . '>', 'closing' => '</div>' );
+        }
+
+        if ( 'core/accordion-item' === $name ) {
+            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), ! empty($attrs['openByDefault']) ? 'is-open' : '');
+            return array( 'opening' => '<div' . $this->blockSupportAttrs($attrs, 'wp-block-accordion-item') . '>', 'closing' => '</div>' );
+        }
+
+        if ( 'core/accordion-heading' === $name ) {
+            $level = (int) ($attrs['level'] ?? 3);
+            $level = max(1, min(6, $level));
+            return '<h' . $level . $this->blockSupportAttrs($attrs, 'wp-block-accordion-heading') . '><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">' . ($attrs['title'] ?? '') . '</span></button></h' . $level . '>';
+        }
+
+        if ( 'core/accordion-panel' === $name ) {
+            return array( 'opening' => '<div' . $this->blockSupportAttrs($attrs, 'wp-block-accordion-panel') . '>', 'closing' => '</div>' );
+        }
+
         if ( 'core/image' === $name ) {
             return $this->imageHtml($attrs);
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformationOptions;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\AccordionPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
@@ -139,6 +140,7 @@ final class HtmlTransformer
         $this->detailsPattern    = new DetailsPattern();
         $this->logoPattern       = new LogoPattern();
         $this->patternRecognizers = new PatternRecognizerRegistry(array(
+            new AccordionPattern(),
             new NavigationPattern(),
         ));
     }
@@ -1439,8 +1441,29 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
             fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
             fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement),
-            $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null
+            $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
+            fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
+            fn (DOMElement $sourceElement, array $excludedTags): array => $this->convertPatternChildrenWithoutTags($sourceElement, $excludedTags)
         );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function convertPatternChildren(DOMElement $element): array
+    {
+        $fallbacks = array();
+        return $this->convertChildren($element, $fallbacks, true);
+    }
+
+    /**
+     * @param array<int, string> $excludedTags
+     * @return array<int, array<string, mixed>>
+     */
+    private function convertPatternChildrenWithoutTags(DOMElement $element, array $excludedTags): array
+    {
+        $fallbacks = array();
+        return $this->convertChildrenWithoutTags($element, $fallbacks, $excludedTags);
     }
 
     /**
@@ -1594,6 +1617,8 @@ final class HtmlTransformer
                 'attrs'       => $attrs,
                 'innerBlocks' => $innerBlocks,
             ),
+            null,
+            null,
             null
         );
     }

--- a/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
@@ -1,0 +1,215 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+final class AccordionPattern implements PatternRecognizerInterface
+{
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function match(DOMElement $element, PatternContext $context): ?array
+    {
+        $createBlock = $context->createBlockCallback();
+        $convertChildren = $context->convertChildrenCallback();
+        $convertChildrenWithoutTags = $context->convertChildrenWithoutTagsCallback();
+        $presentationAttributes = $context->presentationAttributesCallback();
+        $innerHtml = $context->innerHtmlCallback();
+
+        if ( null === $convertChildren || null === $convertChildrenWithoutTags || ! $this->hasAccordionSignal($element) || $this->hasRuntimeHeavyDescendant($element) ) {
+            return null;
+        }
+
+        $items = array();
+        foreach ( $this->directChildElements($element) as $child ) {
+            $item = $this->accordionItem($child, $innerHtml, $convertChildren, $convertChildrenWithoutTags, $createBlock, $presentationAttributes);
+            if ( null === $item ) {
+                return null;
+            }
+            $items[] = $item;
+        }
+
+        if ( count($items) < 2 ) {
+            return null;
+        }
+
+        return $createBlock('core/accordion', $presentationAttributes($element), $items, $element);
+    }
+
+    private function accordionItem(DOMElement $item, callable $innerHtml, callable $convertChildren, callable $convertChildrenWithoutTags, callable $createBlock, callable $presentationAttributes): ?array
+    {
+        if ( ! $this->isAccordionItemElement($item) || $this->hasRuntimeHeavyDescendant($item) ) {
+            return null;
+        }
+
+        $title = $this->titleElement($item);
+        if ( ! $title instanceof DOMElement ) {
+            return null;
+        }
+
+        $panel = $this->panelElement($item, $title);
+        if ( null !== $panel && $panel->isSameNode($title) ) {
+            return null;
+        }
+
+        $titleHtml = $this->titleHtml($title, $innerHtml);
+        if ( '' === trim(strip_tags($titleHtml)) ) {
+            return null;
+        }
+
+        $panelBlocks = $panel instanceof DOMElement ? $convertChildren($panel) : $convertChildrenWithoutTags($item, array( 'summary' ));
+        if ( array() === $panelBlocks ) {
+            return null;
+        }
+
+        $headingAttrs = array(
+            'title' => $titleHtml,
+            'level' => $this->headingLevel($title),
+        );
+
+        return $createBlock('core/accordion-item', array_filter(array_merge($presentationAttributes($item), array(
+            'openByDefault' => $this->isOpen($item, $title, $panel) ? true : '',
+        )), static fn ($value): bool => '' !== $value), array(
+            $createBlock('core/accordion-heading', $headingAttrs, array(), $title),
+            $createBlock('core/accordion-panel', $panel instanceof DOMElement ? $presentationAttributes($panel) : array(), $panelBlocks, $panel),
+        ), $item);
+    }
+
+    private function hasAccordionSignal(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        $class = strtolower($this->attr($element, 'class'));
+        $role = strtolower($this->attr($element, 'role'));
+
+        return str_contains($class, 'accordion')
+            || str_contains($class, 'faq')
+            || 'accordion' === $role
+            || in_array($tagName, array( 'section', 'div', 'ul', 'ol' ), true) && str_contains(strtolower($this->attr($element, 'aria-label')), 'faq');
+    }
+
+    private function isAccordionItemElement(DOMElement $element): bool
+    {
+        if ( 'details' === strtolower($element->tagName) ) {
+            return true;
+        }
+
+        $class = strtolower($this->attr($element, 'class'));
+        return str_contains($class, 'item')
+            || str_contains($class, 'accordion')
+            || str_contains($class, 'faq')
+            || str_contains($class, 'question');
+    }
+
+    private function titleElement(DOMElement $item): ?DOMElement
+    {
+        foreach ( $this->directChildElements($item) as $child ) {
+            $tagName = strtolower($child->tagName);
+            if ( 'summary' === $tagName || 'button' === $tagName || preg_match('/^h[1-6]$/', $tagName) ) {
+                return $child;
+            }
+
+            $class = strtolower($this->attr($child, 'class'));
+            if ( str_contains($class, 'title') || str_contains($class, 'heading') || str_contains($class, 'question') || str_contains($class, 'trigger') ) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+
+    private function panelElement(DOMElement $item, DOMElement $title): ?DOMElement
+    {
+        $controlledId = trim($this->attr($title, 'aria-controls'));
+        if ( '' !== $controlledId ) {
+            foreach ( $item->getElementsByTagName('*') as $candidate ) {
+                if ( $candidate instanceof DOMElement && $candidate->getAttribute('id') === $controlledId ) {
+                    return $candidate;
+                }
+            }
+        }
+
+        foreach ( $this->directChildElements($item) as $child ) {
+            if ( $child->isSameNode($title) ) {
+                continue;
+            }
+
+            $class = strtolower($this->attr($child, 'class'));
+            $role = strtolower($this->attr($child, 'role'));
+            if ( 'region' === $role || str_contains($class, 'panel') || str_contains($class, 'content') || str_contains($class, 'body') || str_contains($class, 'answer') ) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+
+    private function titleHtml(DOMElement $title, callable $innerHtml): string
+    {
+        $html = $innerHtml($title);
+        $html = preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html;
+        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>.*?<\/\1>/is', '', $html) ?? $html;
+
+        return trim($html);
+    }
+
+    private function headingLevel(DOMElement $title): int
+    {
+        return preg_match('/^h([1-6])$/', strtolower($title->tagName), $matches) ? (int) $matches[1] : 3;
+    }
+
+    private function isOpen(DOMElement $item, DOMElement $title, ?DOMElement $panel): bool
+    {
+        if ( $item->hasAttribute('open') || 'true' === strtolower($this->attr($title, 'aria-expanded')) ) {
+            return true;
+        }
+
+        foreach ( array_filter(array( $item, $title, $panel )) as $element ) {
+            if ( $element instanceof DOMElement && preg_match('/(?:^|\s)(?:active|open|is-active|is-open|expanded)(?:\s|$)/i', $this->attr($element, 'class')) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasRuntimeHeavyDescendant(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( in_array(strtolower($candidate->tagName), array( 'script', 'canvas', 'template', 'iframe', 'form' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function directChildElements(DOMElement $element): array
+    {
+        $children = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') ) {
+                return array();
+            }
+
+            if ( $child instanceof DOMElement ) {
+                $children[] = $child;
+            }
+        }
+
+        return $children;
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? trim($element->getAttribute($name)) : '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -12,12 +12,16 @@ final class PatternContext
      * @param callable(DOMElement): string $innerHtml
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @param callable(DOMElement): bool|null $isRuntimeDomTarget
+     * @param callable(DOMElement): array<int, array<string, mixed>>|null $convertChildren
+     * @param callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null $convertChildrenWithoutTags
      */
     public function __construct(
         private readonly mixed $presentationAttributes,
         private readonly mixed $innerHtml,
         private readonly mixed $createBlock,
-        private readonly mixed $isRuntimeDomTarget = null
+        private readonly mixed $isRuntimeDomTarget = null,
+        private readonly mixed $convertChildren = null,
+        private readonly mixed $convertChildrenWithoutTags = null
     ) {
     }
 
@@ -51,5 +55,21 @@ final class PatternContext
     public function isRuntimeDomTargetCallback(): ?callable
     {
         return is_callable($this->isRuntimeDomTarget) ? $this->isRuntimeDomTarget : null;
+    }
+
+    /**
+     * @return callable(DOMElement): array<int, array<string, mixed>>|null
+     */
+    public function convertChildrenCallback(): ?callable
+    {
+        return is_callable($this->convertChildren) ? $this->convertChildren : null;
+    }
+
+    /**
+     * @return callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null
+     */
+    public function convertChildrenWithoutTagsCallback(): ?callable
+    {
+        return is_callable($this->convertChildrenWithoutTags) ? $this->convertChildrenWithoutTags : null;
     }
 }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -257,6 +257,28 @@ $assert(2 === count($navigationBlock['innerBlocks'] ?? array()), 'navigation con
 $assert('About' === ($navigationBlock['innerBlocks'][0]['attrs']['label'] ?? null), 'navigation conversion still preserves link labels');
 $assert('/about' === ($navigationBlock['innerBlocks'][0]['attrs']['url'] ?? null), 'navigation conversion still preserves link URLs');
 
+$accordionResult = ( new HtmlTransformer() )->transform('<section class="faq"><div class="faq-item active"><button class="faq-question" aria-expanded="true" aria-controls="answer-a">What is covered?</button><div id="answer-a" class="faq-answer"><p>Assessment and treatment planning.</p></div></div><div class="faq-item"><button class="faq-question" aria-expanded="false" aria-controls="answer-b">How long is a visit?</button><div id="answer-b" class="faq-answer"><p>Most visits take 45 minutes.</p></div></div></section>')->toArray();
+$accordionBlock = $accordionResult['blocks'][0] ?? array();
+$accordionItems = $accordionBlock['innerBlocks'] ?? array();
+$assert('core/accordion' === ($accordionBlock['blockName'] ?? null), 'clean FAQ containers convert to core accordion');
+$assert(2 === count($accordionItems), 'accordion conversion preserves repeated items');
+$assert('core/accordion-item' === ($accordionItems[0]['blockName'] ?? null), 'accordion conversion emits core accordion items');
+$assert(true === ($accordionItems[0]['attrs']['openByDefault'] ?? null), 'accordion conversion maps obvious expanded state');
+$assert('What is covered?' === ($accordionItems[0]['innerBlocks'][0]['attrs']['title'] ?? null), 'accordion conversion preserves item heading text');
+$assert('core/accordion-panel' === ($accordionItems[0]['innerBlocks'][1]['blockName'] ?? null), 'accordion conversion emits core accordion panels');
+$assert('Assessment and treatment planning.' === ($accordionItems[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? null), 'accordion conversion preserves panel text');
+$assert(str_contains((string) ($accordionResult['serialized_blocks'] ?? ''), '<!-- wp:accordion '), 'accordion conversion serializes native accordion block comments');
+
+$complexAccordionResult = ( new HtmlTransformer() )->transform('<section class="faq"><div class="faq-item"><button aria-controls="a">Question A</button><div id="a"><script src="accordion.js"></script><p>Answer A</p></div></div><div class="faq-item"><button aria-controls="b">Question B</button><div id="b"><p>Answer B</p></div></div></section>')->toArray();
+$assert('core/accordion' !== (($complexAccordionResult['blocks'][0] ?? array())['blockName'] ?? null), 'runtime-heavy accordion markup is not forced into native accordion');
+
+$detailsAccordionResult = ( new HtmlTransformer() )->transform('<div class="accordion"><details open><summary>Can I reschedule?</summary><p>Yes, with notice.</p></details><details><summary>Do you take cards?</summary><p>Yes.</p></details></div>')->toArray();
+$detailsAccordionItems = $detailsAccordionResult['blocks'][0]['innerBlocks'] ?? array();
+$assert('core/accordion' === (($detailsAccordionResult['blocks'][0] ?? array())['blockName'] ?? null), 'repeated details inside accordion wrappers convert to core accordion');
+$assert(true === ($detailsAccordionItems[0]['attrs']['openByDefault'] ?? null), 'details open state maps to accordion item open state');
+$assert('Can I reschedule?' === ($detailsAccordionItems[0]['innerBlocks'][0]['attrs']['title'] ?? null), 'details summary text maps to accordion heading');
+$assert('Yes, with notice.' === ($detailsAccordionItems[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? null), 'details body text maps to accordion panel');
+
 $fixture = file_get_contents(dirname(__DIR__) . '/fixtures/simple-html.html');
 $result  = ( new HtmlTransformer() )->transform($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><canvas>Fallback</canvas>")->toArray();
 


### PR DESCRIPTION
## Summary
- Detect clean static FAQ/accordion structures and emit native Core accordion blocks.
- Serialize core/accordion, core/accordion-item, core/accordion-heading, and core/accordion-panel block markup.
- Preserve expanded/open state when represented by open, aria-expanded=true, or open/active classes, while leaving runtime-heavy widgets on existing paths.

## Testing
- composer test
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Fanout implementation, rebase, conflict checks, and verification.