### PR TITLE
Convert icon and math primitives to Core blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -97,6 +97,20 @@ final class BlockFactory
             return '<pre class="wp-block-code"><code>' . $content . '</code></pre>';
         }
 
+        if ( 'core/math' === $name ) {
+            return '<div' . $this->blockSupportAttrs($attrs, 'wp-block-math') . '>' . ($attrs['content'] ?? '') . '</div>';
+        }
+
+        if ( 'core/icon' === $name ) {
+            $iconAttrs = array(
+                'class'       => $this->mergeClassNames('wp-block-icon', (string) ($attrs['className'] ?? '')),
+                'style'       => (string) ($attrs['style'] ?? ''),
+                'aria-label'  => (string) ($attrs['label'] ?? ''),
+                'aria-hidden' => ! empty($attrs['ariaHidden']) ? 'true' : '',
+            );
+            return '<div' . $this->htmlAttrs($iconAttrs) . '>' . ($attrs['svg'] ?? '') . '</div>';
+        }
+
         if ( 'core/preformatted' === $name ) {
             return '<pre' . $this->blockSupportAttrs($attrs, 'wp-block-preformatted') . '>' . ($attrs['content'] ?? '') . '</pre>';
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -37,9 +37,11 @@ final class HtmlTransformer
         'core/gallery',
         'core/group',
         'core/heading',
+        'core/icon',
         'core/image',
         'core/list',
         'core/list-item',
+        'core/math',
         'core/navigation',
         'core/navigation-link',
         'core/paragraph',
@@ -1610,6 +1612,11 @@ final class HtmlTransformer
             return null;
         }
 
+        $mathBlock = $this->mathBlockFromElement($element);
+        if ( null !== $mathBlock ) {
+            return $mathBlock;
+        }
+
         if ( preg_match('/^h([1-6])$/', $tagName, $matches) ) {
             $content = $this->innerHtml($element);
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
@@ -1650,7 +1657,7 @@ final class HtmlTransformer
         }
 
         if ( $this->isInlineContentElement($tagName) ) {
-            if ( $this->isRuntimeDomTarget($element) || ( '' === trim($element->textContent ?? '') && $this->hasIconLikeContext($element) ) ) {
+            if ( $this->isRuntimeDomTarget($element) ) {
                 return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
             }
 
@@ -1895,6 +1902,11 @@ final class HtmlTransformer
         }
 
         if ( 'svg' === $tagName ) {
+            $iconBlock = $this->iconBlockFromSvgElement($element);
+            if ( null !== $iconBlock ) {
+                return $iconBlock;
+            }
+
             if ( $this->isSafeDecorativeSvgElement($element) ) {
                 if ( $this->hasIconLikeContext($element) ) {
                     return $this->inlineSvgBlockFromElement($element);
@@ -3978,6 +3990,93 @@ final class HtmlTransformer
         return $this->createBlock('core/image', $attrs, array(), $element);
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function iconBlockFromSvgElement(DOMElement $element): ?array
+    {
+        if ( ! $this->isSafeSvgContent($this->outerHtml($element)) || ! $this->isPassiveSvgMarkup($element) || ! $this->isIconSvgElement($element) ) {
+            return null;
+        }
+
+        $html = $this->safeFallbackHtml($element);
+        if ( ! $this->isSafeSvgContent($html) ) {
+            return null;
+        }
+
+        $label = $this->inlineSvgAltText($element);
+        $attrs = array_filter(array_merge($this->presentationAttributes($element), array(
+            'svg'        => $html,
+            'label'      => $label,
+            'ariaHidden' => '' === $label && ( 'true' === strtolower($this->attr($element, 'aria-hidden')) || in_array(strtolower($this->attr($element, 'role')), array( 'presentation', 'none' ), true) ),
+        )), static fn (mixed $value): bool => is_bool($value) ? $value : '' !== $value);
+
+        return $this->createBlock('core/icon', $attrs, array(), $element);
+    }
+
+    private function isIconSvgElement(DOMElement $element): bool
+    {
+        if ( $this->hasLogoLikeContext($element) || $this->hasImageLikeContext($element) || ! $this->hasSimpleSvgShape($element) ) {
+            return false;
+        }
+
+        $role = strtolower(trim($this->attr($element, 'role')));
+        if ( 'true' === strtolower(trim($this->attr($element, 'aria-hidden'))) || in_array($role, array( 'presentation', 'none' ), true) || $this->hasAriaHiddenAncestor($element) ) {
+            return $this->hasIconLikeContext($element);
+        }
+
+        return 'img' === $role && '' !== $this->inlineSvgAltText($element);
+    }
+
+    private function hasAriaHiddenAncestor(DOMElement $element): bool
+    {
+        for ( $parent = $element->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode instanceof DOMElement ? $parent->parentNode : null ) {
+            if ( 'true' === strtolower(trim($this->attr($parent, 'aria-hidden'))) ) {
+                return true;
+            }
+            if ( in_array(strtolower($parent->tagName), array( 'body', 'main', 'article', 'section' ), true) ) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasSimpleSvgShape(DOMElement $element): bool
+    {
+        $shapeCount = 0;
+        foreach ( $element->getElementsByTagName('*') as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            if ( in_array(strtolower($child->tagName), array( 'circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect' ), true) ) {
+                ++$shapeCount;
+            }
+        }
+
+        return 0 < $shapeCount && $shapeCount <= 8 && $this->hasSmallSvgViewport($element);
+    }
+
+    private function hasSmallSvgViewport(DOMElement $element): bool
+    {
+        $viewBox = trim($this->attr($element, 'viewBox'));
+        if ( '' === $viewBox ) {
+            $viewBox = trim($this->attr($element, 'viewbox'));
+        }
+        if ( preg_match('/^-?\d+(?:\.\d+)?\s+-?\d+(?:\.\d+)?\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)/', $viewBox, $matches) ) {
+            return (float) $matches[1] <= 128 && (float) $matches[2] <= 128;
+        }
+
+        $width = $this->numericSvgLength($this->attr($element, 'width'));
+        $height = $this->numericSvgLength($this->attr($element, 'height'));
+        return null !== $width && null !== $height && $width <= 128 && $height <= 128;
+    }
+
+    private function numericSvgLength(string $value): ?float
+    {
+        return preg_match('/^\s*(\d+(?:\.\d+)?)(?:px)?\s*$/i', $value, $matches) ? (float) $matches[1] : null;
+    }
+
     private function materializeInlineSvgAsset(string $html, DOMElement $element): string
     {
         $hash = hash('sha256', $html);
@@ -4636,10 +4735,111 @@ final class HtmlTransformer
         return false;
     }
 
+    private function hasLogoLikeContext(DOMElement $element): bool
+    {
+        for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null ) {
+            $context = strtolower(trim(implode(' ', array(
+                $this->attr($current, 'class'),
+                $this->attr($current, 'id'),
+                $this->attr($current, 'aria-label'),
+                $this->attr($current, 'title'),
+            ))));
+
+            if ( preg_match('/(?:^|[\s_-])(?:brand|diagram|illustration|logo|logomark|wordmark)(?:$|[\s_-])/', $context) ) {
+                return true;
+            }
+
+            if ( in_array(strtolower($current->tagName), array( 'body', 'main', 'article', 'section' ), true) ) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasImageLikeContext(DOMElement $element): bool
+    {
+        $context = strtolower(trim(implode(' ', array(
+            $this->attr($element, 'class'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'aria-label'),
+            $this->attr($element, 'title'),
+        ))));
+
+        return (bool) preg_match('/(?:^|[\s_-])(?:image|photo|picture)(?:$|[\s_-])/', $context);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function mathBlockFromElement(DOMElement $element): ?array
+    {
+        if ( ! $this->isMathElement($element) ) {
+            return null;
+        }
+
+        $tagName = strtolower($element->tagName);
+        $content = 'math' === $tagName ? $this->safeFallbackHtml($element) : $this->mathExpressionContent($element);
+        if ( '' === trim($content) ) {
+            return null;
+        }
+
+        return $this->createBlock('core/math', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+    }
+
+    private function isMathElement(DOMElement $element): bool
+    {
+        if ( 'math' === strtolower($element->tagName) ) {
+            return true;
+        }
+
+        if ( $this->hasMathSignal($element) ) {
+            return true;
+        }
+
+        return in_array(strtolower($element->tagName), array( 'div', 'p', 'span' ), true) && $this->isTeXDelimitedText(trim($element->textContent ?? ''));
+    }
+
+    private function hasMathSignal(DOMElement $element): bool
+    {
+        $signals = strtolower(trim(implode(' ', array(
+            $this->attr($element, 'class'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'data-math'),
+            $this->attr($element, 'data-latex'),
+            $this->attr($element, 'data-tex'),
+        ))));
+
+        return (bool) preg_match('/(?:^|[\s_-])(?:math|latex|tex|katex|mathjax)(?:$|[\s_-])/', $signals);
+    }
+
+    private function mathExpressionContent(DOMElement $element): string
+    {
+        $html = $this->innerHtml($element);
+        if ( '' !== trim($html) && ! preg_match('/<(?:script|style)\b/i', $html) ) {
+            return $html;
+        }
+
+        return $this->runtime->escapeHtml(trim($element->textContent ?? ''));
+    }
+
+    private function isTeXDelimitedText(string $text): bool
+    {
+        if ( str_starts_with($text, '$$') && str_ends_with($text, '$$') && 4 < strlen($text) ) {
+            return true;
+        }
+        if ( str_starts_with($text, '$') && str_ends_with($text, '$') && 2 < strlen($text) && ! str_starts_with($text, '$$') ) {
+            return true;
+        }
+
+        return ( str_starts_with($text, '\\(') && str_ends_with($text, '\\)') && 4 < strlen($text) )
+            || ( str_starts_with($text, '\\[') && str_ends_with($text, '\\]') && 4 < strlen($text) );
+    }
+
     private function isPassiveSvgMarkup(DOMElement $element): bool
     {
         $allowedTags = array_flip(array( 'circle', 'clippath', 'defs', 'desc', 'ellipse', 'g', 'line', 'lineargradient', 'mask', 'path', 'polygon', 'polyline', 'radialgradient', 'rect', 'stop', 'svg', 'title' ));
-        $allowedAttributes = array_flip(array( 'aria-hidden', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd', 'fill', 'fill-opacity', 'fill-rule', 'gradienttransform', 'gradientunits', 'height', 'id', 'offset', 'opacity', 'points', 'preserveaspectratio', 'r', 'role', 'rx', 'ry', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'style', 'transform', 'viewbox', 'width', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2' ));
+        $allowedAttributes = array_flip(array( 'aria-hidden', 'aria-label', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd', 'fill', 'fill-opacity', 'fill-rule', 'gradienttransform', 'gradientunits', 'height', 'id', 'offset', 'opacity', 'points', 'preserveaspectratio', 'r', 'role', 'rx', 'ry', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'style', 'transform', 'viewbox', 'width', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2' ));
 
         foreach ( $element->getElementsByTagName('*') as $child ) {
             if ( ! $child instanceof DOMElement || ! $this->isPassiveSvgElement($child, $allowedTags, $allowedAttributes) ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -509,18 +509,35 @@ $safeInlineSvgSerialized = (string) ($safeInlineSvg['serialized_blocks'] ?? '');
 $assert('success' === ($safeInlineSvg['status'] ?? ''), 'safe inline SVG does not trip strict fallback gates', (string) ($safeInlineSvg['status'] ?? ''));
 $assert(array() === ($safeInlineSvg['fallbacks'] ?? array()), 'safe decorative inline SVG is consumed instead of recorded as fallback metadata');
 $assert('core/group' === ($safeInlineSvg['blocks'][0]['blockName'] ?? ''), 'decorative inline SVG preserves its CSS-addressable wrapper when present');
+$assert('core/icon' === ($safeInlineSvg['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? ''), 'icon-context decorative SVG converts to a core icon block');
 $assert(! str_contains($safeInlineSvgSerialized, '<!-- wp:html'), 'safe inline SVG conversion avoids raw HTML blocks');
 $assert(! str_contains($safeInlineSvgSerialized, 'data:image/svg+xml,'), 'decorative inline SVG avoids image data URI noise');
-$assert(! str_contains(rawurldecode($safeInlineSvgSerialized), '<svg'), 'decorative inline SVG markup is omitted from serialized blocks');
+$assert(str_contains(rawurldecode($safeInlineSvgSerialized), '<svg'), 'decorative icon SVG markup is preserved in the core icon block');
 
 $safeInlineSvgAsset = ( new HtmlTransformer() )->transform(
     '<svg role="img" aria-label="Status badge" viewBox="0 0 10 10"><title>Status badge</title><circle cx="5" cy="5" r="4"></circle></svg>'
 )->toArray();
-$safeInlineSvgAssetPath = (string) ($safeInlineSvgAsset['blocks'][0]['attrs']['url'] ?? '');
-$assert(str_starts_with($safeInlineSvgAssetPath, 'assets/inline-svg-'), 'safe accessible inline SVG image references a generated SVG asset');
-$assert('image/svg+xml' === ($safeInlineSvgAsset['assets'][0]['mime_type'] ?? ''), 'safe accessible inline SVG exposes a materializable SVG asset');
-$assert(str_contains((string) ($safeInlineSvgAsset['assets'][0]['content'] ?? ''), 'aria-label="Status badge"'), 'safe accessible inline SVG asset preserves accessible label');
+$assert('core/icon' === ($safeInlineSvgAsset['blocks'][0]['blockName'] ?? ''), 'simple accessible inline SVG converts to a core icon block');
+$assert('Status badge' === ($safeInlineSvgAsset['blocks'][0]['attrs']['label'] ?? ''), 'safe accessible inline SVG icon preserves accessible label');
+$assert(array() === ($safeInlineSvgAsset['assets'] ?? array()), 'safe accessible inline SVG icon does not generate an image asset');
 $assert(! str_contains((string) ($safeInlineSvgAsset['serialized_blocks'] ?? ''), 'data:image/svg+xml,'), 'safe accessible inline SVG avoids data URI serialization');
+
+$complexSvgAsset = ( new HtmlTransformer() )->transform(
+    '<svg role="img" aria-label="Site illustration" viewBox="0 0 400 200"><title>Site illustration</title><path d="M0 0h400v200H0z"></path></svg>'
+)->toArray();
+$assert('core/image' === ($complexSvgAsset['blocks'][0]['blockName'] ?? ''), 'large accessible inline SVG stays on the existing image asset path');
+
+$mathMlResult = ( new HtmlTransformer() )->transform('<main><math><mi>x</mi><mo>=</mo><mn>2</mn></math></main>')->toArray();
+$mathMlBlock = $mathMlResult['blocks'][0] ?? array();
+$assert('core/math' === ($mathMlBlock['blockName'] ?? ''), 'MathML converts to a core math block');
+$assert(str_contains((string) ($mathMlBlock['attrs']['content'] ?? ''), '<math>'), 'MathML core math block preserves the expression markup');
+
+$texClassResult = ( new HtmlTransformer() )->transform('<main><span class="katex">E = mc^2</span><p>\(a^2 + b^2 = c^2\)</p></main>')->toArray();
+$texClassBlocks = $texClassResult['blocks'][0]['innerBlocks'] ?? array();
+$assert('core/math' === ($texClassBlocks[0]['blockName'] ?? ''), 'math-like class wrapper converts to a core math block');
+$assert('E = mc^2' === ($texClassBlocks[0]['attrs']['content'] ?? ''), 'math-like class wrapper preserves expression text');
+$assert('core/math' === ($texClassBlocks[1]['blockName'] ?? ''), 'TeX-delimited text wrapper converts to a core math block');
+$assert(str_contains((string) ($texClassBlocks[1]['attrs']['content'] ?? ''), 'a^2 + b^2 = c^2'), 'TeX-delimited math preserves expression content');
 
 $unsafeInlineSvg = ( new HtmlTransformer() )->transform('<main><svg onload="alert(1)"><path d="M0 0h1v1z"></path></svg></main>')->toArray();
 $assert('html_unsafe_inline_svg' === ($unsafeInlineSvg['fallbacks'][0]['diagnostic_code'] ?? ''), 'unsafe inline SVG remains a fallback diagnostic');
@@ -1086,10 +1103,9 @@ $artifactNonEntryInlineSvg = $compiler->compile(
     )
 )->toArray();
 $artifactNonEntryInlineSvgPage = $artifactNonEntryInlineSvg['source_reports']['materialization_plan']['pages'][1] ?? array();
-$artifactNonEntryInlineSvgAsset = $artifactNonEntryInlineSvg['source_reports']['materialization_plan']['assets'][0] ?? array();
-$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), 'assets/inline-svg-'), 'non-entry artifact page references generated inline SVG asset');
-$assert('image/svg+xml' === ($artifactNonEntryInlineSvgAsset['mime_type'] ?? ''), 'non-entry artifact generated inline SVG asset is materialized');
-$assert(str_contains((string) ($artifactNonEntryInlineSvgAsset['content'] ?? ''), 'aria-label="About icon"'), 'non-entry artifact generated inline SVG asset preserves safe SVG content');
+$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), '<!-- wp:icon'), 'non-entry artifact simple icon SVG converts to a core icon block');
+$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), 'About icon'), 'non-entry artifact core icon preserves safe SVG accessible label');
+$assert(array() === ($artifactNonEntryInlineSvg['source_reports']['materialization_plan']['assets'] ?? array()), 'non-entry artifact simple icon SVG does not materialize a generated image asset');
 $assert(1 === ($simple['source_reports']['materialization_plan']['totals']['pages'] ?? null), 'materialization plan counts pages');
 $assert('index' === ($simple['source_reports']['materialization_plan']['pages'][0]['slug'] ?? ''), 'materialization plan exposes page slug');
 $assert('blocks' === ($simple['source_reports']['materialization_plan']['pages'][0]['body_format'] ?? ''), 'materialization plan exposes converted block body format');

--- a/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
+++ b/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-background-icon-media-patterns",
-  "description": "Converts generic background-image heroes and icon-like SVG card media into core media blocks without fallbacks.",
+  "description": "Converts generic background-image heroes and icon-like SVG card media into core media/icon blocks without fallbacks.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-background-icon-media-patterns.json",
@@ -21,7 +21,7 @@
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Care that meets you", "level": 1 } },
     { "path": "blocks.1", "name": "core/group", "attrs": { "className": "feature-card" } },
     { "path": "blocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature-icon" } },
-    { "path": "blocks.1.innerBlocks.0.innerBlocks.0", "name": "core/image" },
+    { "path": "blocks.1.innerBlocks.0.innerBlocks.0", "name": "core/icon" },
     { "path": "blocks.1.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Fast booking", "level": 3 } }
   ],
   "expected_fallbacks": [],
@@ -30,7 +30,7 @@
     { "path": "blocks", "assert": "count", "count": 2 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "assets/inline-svg-" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:icon" },
     { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-decorative",
-  "description": "Consumes safe decorative inline SVG separators and icons without fallback noise while preserving meaningful accessible SVGs as image blocks.",
+  "description": "Consumes safe decorative inline SVG separators and converts simple accessible icon SVGs without fallback noise.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-decorative.json",
-    "notes": "Product-neutral fixture for decorative wave separators and accessible logo/icon SVG handling."
+    "notes": "Product-neutral fixture for decorative wave separators and accessible icon SVG handling."
   },
   "legacy_comparison": {
     "skip": true,
@@ -18,15 +18,14 @@
   "expected_blocks": [
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Before", "level": 2 } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "After" } },
-    { "path": "blocks.0.innerBlocks.2", "name": "core/image", "attrs": { "alt": "Acme integration", "title": "Acme integration" } }
+    { "path": "blocks.0.innerBlocks.2", "name": "core/icon", "attrs": { "label": "Acme integration" } }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
-    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": "assets/inline-svg-" },
-    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": ".svg" },
-    { "path": "assets.0.content", "assert": "contains", "value": "aria-label=\"Acme integration\"" },
+    { "path": "blocks.0.innerBlocks.2.attrs.svg", "assert": "contains", "value": "aria-label=\"Acme integration\"" },
+    { "path": "assets", "assert": "count", "count": 0 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-fallback",
-  "description": "Represents safe inline SVG as a bounded image block while preserving supported siblings.",
+  "description": "Represents simple accessible inline SVG as a core icon block while preserving supported siblings.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-fallback.json",
-    "notes": "Product-neutral fixture for generic safe inline SVG image handling."
+    "notes": "Product-neutral fixture for generic safe inline SVG icon handling."
   },
   "legacy_comparison": {
     "skip": true,
@@ -17,16 +17,14 @@
   },
   "expected_blocks": [
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Icon row", "level": 2 } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/image", "attrs": { "alt": "Status", "title": "Status" } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/icon", "attrs": { "label": "Status" } }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "blocks.0.innerBlocks.1.attrs.url", "assert": "contains", "value": "assets/inline-svg-" },
-    { "path": "blocks.0.innerBlocks.1.attrs.url", "assert": "contains", "value": ".svg" },
-    { "path": "assets.0.mime_type", "assert": "equals", "value": "image/svg+xml" },
-    { "path": "assets.0.content", "assert": "contains", "value": "aria-label=\"Status\"" },
+    { "path": "blocks.0.innerBlocks.1.attrs.svg", "assert": "contains", "value": "aria-label=\"Status\"" },
+    { "path": "assets", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-spacer-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-spacer-primitives.json
@@ -32,6 +32,6 @@
     { "path": "blocks.0.innerBlocks.1.innerHTML", "assert": "contains", "value": "style=\"height:48px\"" },
     { "path": "blocks.0.innerBlocks.1.innerHTML", "assert": "contains", "value": "aria-hidden=\"true\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "coverage.0.supported_blocks.23", "assert": "equals", "value": "core/spacer" }
+    { "path": "coverage.0.supported_blocks.25", "assert": "equals", "value": "core/spacer" }
   ]
 }


### PR DESCRIPTION
## Summary
- Convert safe icon-like inline SVG markup to core/icon while leaving complex SVG/logo/image-like markup on existing paths.
- Convert clear MathML/TeX/math wrapper content to core/math.
- Add serializer support and parity/contract coverage for the new native Core targets.

## Testing
- composer test
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Fanout implementation, rebase conflict resolution with registry metadata, and verification.