### PR TITLE
Add deterministic figure + long-tail static-tag coverage

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1806,6 +1806,61 @@ final class HtmlTransformer
             if ( $blockquote instanceof DOMElement ) {
                 return $this->convertFigureBlockquote($element, $blockquote, $fallbacks);
             }
+
+            return $this->convertFigureGeneric($element, $fallbacks);
+        }
+
+        if ( 'figcaption' === $tagName ) {
+            $content = $this->innerHtml($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        }
+
+        if ( 'noscript' === $tagName ) {
+            $children = $this->convertChildren($element, $fallbacks, true);
+            if ( array() === $children ) {
+                $content = $this->innerHtml($element);
+                if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                    return null;
+                }
+
+                return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+            }
+
+            if ( 1 === count($children) && array() === $this->presentationAttributes($element) ) {
+                return $children[0];
+            }
+
+            return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+        }
+
+        if ( 'marquee' === $tagName || 'blink' === $tagName ) {
+            if ( $this->hasBlockContentChildren($element) ) {
+                $children = $this->convertChildren($element, $fallbacks, true);
+                if ( array() === $children ) {
+                    return null;
+                }
+
+                if ( 1 === count($children) && array() === $this->presentationAttributes($element) ) {
+                    return $children[0];
+                }
+
+                return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+            }
+
+            $content = $this->innerHtml($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        }
+
+        if ( 'label' === $tagName ) {
+            return $this->readableFormControlBlockFromElement($element);
         }
 
         if ( 'pre' === $tagName ) {
@@ -3743,6 +3798,41 @@ final class HtmlTransformer
         }
 
         return '';
+    }
+
+    /**
+     * Convert a figure that wraps non-media content (table, code, multiple
+     * elements, or text) into the closest faithful native block(s).
+     *
+     * The figcaption is consumed as a trailing caption paragraph so it is never
+     * emitted as a separate orphan fallback. A figure with a single child and no
+     * caption unwraps to that child; otherwise the children plus caption are
+     * preserved inside a core/group that carries the figure's presentation.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertFigureGeneric(DOMElement $figure, array &$fallbacks): ?array
+    {
+        $children = $this->convertChildrenWithoutTags($figure, $fallbacks, array( 'figcaption' ));
+
+        $caption = $this->firstChildElement($figure, 'figcaption');
+        if ( $caption instanceof DOMElement ) {
+            $captionHtml = $this->innerHtml($caption);
+            if ( '' !== trim($this->runtime->stripAllTags($captionHtml)) ) {
+                $children[] = $this->createBlock('core/paragraph', array( 'content' => $captionHtml ), array(), $caption);
+            }
+        }
+
+        if ( array() === $children ) {
+            return null;
+        }
+
+        if ( 1 === count($children) && array() === $this->presentationAttributes($figure) ) {
+            return $children[0];
+        }
+
+        return $this->createBlock('core/group', $this->presentationAttributes($figure), $children, $figure);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-deprecated-static-tags.json
+++ b/php-transformer/tests/fixtures/parity/html-deprecated-static-tags.json
@@ -1,0 +1,39 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-deprecated-static-tags",
+  "description": "Converts long-tail static tags (noscript, marquee, blink, orphan figcaption, standalone label) to faithful native blocks preserving visible content, with zero fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-deprecated-static-tags.json",
+    "notes": "Product-neutral coverage for deprecated/static long-tail tag conversion, reducing unsupported_noscript, unsupported_marquee, unsupported_blink, unsupported_figcaption, and unsupported_label fallbacks."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<noscript><p>JavaScript is disabled. Enable it for the full experience.</p></noscript><marquee>Breaking news ticker</marquee><blink>Sale ends soon</blink><figcaption>Orphan caption text</figcaption><label>Subscribe to updates</label>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/paragraph", "attrs": { "content": "JavaScript is disabled. Enable it for the full experience." } },
+    { "path": "blocks.1", "name": "core/paragraph", "attrs": { "content": "Breaking news ticker" } },
+    { "path": "blocks.2", "name": "core/paragraph", "attrs": { "content": "Sale ends soon" } },
+    { "path": "blocks.3", "name": "core/paragraph", "attrs": { "content": "Orphan caption text" } },
+    { "path": "blocks.4", "name": "core/paragraph", "attrs": { "content": "Subscribe to updates" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 5 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph {\"content\":\"JavaScript is disabled. Enable it for the full experience.\"} --><p>JavaScript is disabled. Enable it for the full experience.</p><!-- /wp:paragraph -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph {\"content\":\"Breaking news ticker\"} --><p>Breaking news ticker</p><!-- /wp:paragraph -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph {\"content\":\"Sale ends soon\"} --><p>Sale ends soon</p><!-- /wp:paragraph -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph {\"content\":\"Orphan caption text\"} --><p>Orphan caption text</p><!-- /wp:paragraph -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph {\"content\":\"Subscribe to updates\"} --><p>Subscribe to updates</p><!-- /wp:paragraph -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<marquee" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<blink" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-figure-generic-content.json
+++ b/php-transformer/tests/fixtures/parity/html-figure-generic-content.json
@@ -1,0 +1,43 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-figure-generic-content",
+  "description": "Converts figures that wrap non-media content (table, multiple elements, or text) into faithful core/group blocks with the figcaption consumed as a trailing caption paragraph, with zero fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-figure-generic-content.json",
+    "notes": "Product-neutral coverage for generic non-media figure deterministic conversion, reducing unsupported_figure fallbacks."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<figure class=\"data-figure\"><table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Ada</td></tr></tbody></table><figcaption>Team <em>roster</em></figcaption></figure><figure><p>First line.</p><p>Second line.</p><figcaption>Combined notes</figcaption></figure><figure>Plain figure text<figcaption>Short caption</figcaption></figure>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "data-figure" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/table" },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Team <em>roster</em>" } },
+    { "path": "blocks.1", "name": "core/group" },
+    { "path": "blocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "First line." } },
+    { "path": "blocks.1.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Second line." } },
+    { "path": "blocks.1.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Combined notes" } },
+    { "path": "blocks.2", "name": "core/group" },
+    { "path": "blocks.2.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Plain figure text" } },
+    { "path": "blocks.2.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Short caption" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"data-figure\"} --><div class=\"wp-block-group data-figure\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-table\"><table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Ada</td></tr></tbody></table></figure>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph {\"content\":\"Team <em>roster</em>\"} --><p>Team <em>roster</em></p><!-- /wp:paragraph --></div><!-- /wp:group -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group --><div class=\"wp-block-group\"><!-- wp:paragraph {\"content\":\"First line.\"} --><p>First line.</p><!-- /wp:paragraph -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph {\"content\":\"Plain figure text\"} --><p>Plain figure text</p><!-- /wp:paragraph --><!-- wp:paragraph {\"content\":\"Short caption\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## What
Adds deterministic coverage for `<figure>`/`<figcaption>` and the static long-tail tags (`<noscript>`, `<marquee>`, `<blink>`, standalone `<label>`/`<figcaption>`) so they convert to native blocks instead of emitting `html_unsupported_element` fallbacks.

Driven by an empirical fallback survey over the full website fixture corpus (72 fixtures / 343 pages): `unsupported_figure` was the single largest deterministic loss family (39 occ / 5 fixtures), and these long-tail tags were trivially convertible.

## Changes (`src/HtmlToBlocks/HtmlTransformer.php`)
- **`<figure>` (non-media):** new `convertFigureGeneric()` fallthrough — children convert via the normal path, `<figcaption>` is consumed as a trailing caption paragraph; single child unwraps, otherwise children + caption preserved in a `core/group` carrying the figure's classes/style. Existing image/picture/gallery/code-window/blockquote figure paths are untouched.
- **`<noscript>`:** inner content converts via the child path (unwrap single / group multiple / drop empty).
- **`<marquee>` / `<blink>`:** deprecated wrappers unwrap to paragraph (inline) or group (block), preserving text/markup.
- **standalone `<label>` / orphan `<figcaption>`:** routed to readable paragraph (empty labels drop silently).
- `<input>`/`<form>`/`<script>` deliberately left as runtime islands (out of scope).

## Verification
- `composer test` + `composer parity` → **green, 126 fixtures** (124 baseline + 2 new: `html-figure-generic-content.json`, `html-deprecated-static-tags.json`).
- Corpus re-run: `html_unsupported_element` dropped **53 occ / 16 fixtures → 6 occ** (only `unsupported_input` remains); fully-clean pages rose 17 → 19.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Drafting the implementation, fixtures, and corpus verification under human review.
