### PR TITLE
Drop dead hamburger toggles for non-converting navs (#232)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1469,18 +1469,21 @@ final class HtmlTransformer
     }
 
     /**
-     * A JS-only hamburger menu-toggle that is redundant chrome once a nearby
-     * navigation menu converts to core/navigation.
+     * A JS-only hamburger menu-toggle that is redundant chrome whenever it is
+     * associated with a source navigation menu — whether or not that menu
+     * converts to core/navigation.
      *
      * The toggle is detected GENERICALLY by structural/semantic signals — never
      * by a specific class string — so any framework's hamburger is recognized:
      * a <button> (or <a role="button">) carrying aria-controls and/or
      * aria-expanded whose visible content is empty/decorative bars (only empty
-     * spans or an icon, no text label). It is suppressed only when it is the
-     * opener for, or sits beside, a navigation menu that becomes
-     * core/navigation — which already ships its own working responsive overlay
-     * hamburger. Real labeled buttons, and toggles with no associated nav, still
-     * convert normally.
+     * spans or an icon, no text label). It is suppressed when it opens, lives
+     * inside, or sits beside a source navigation menu. A converted menu already
+     * ships its own responsive overlay hamburger; a menu that does NOT convert
+     * still must not gain an always-visible dead hamburger the source hid behind
+     * responsive CSS/JS the importer cannot carry (the "added UI" defect). Real
+     * labeled buttons, and toggle-shaped controls with no associated navigation,
+     * still convert to core/button normally.
      */
     private function isRedundantMenuToggleControl(DOMElement $element): bool
     {
@@ -1488,7 +1491,7 @@ final class HtmlTransformer
             return false;
         }
 
-        return $this->hasNearbyConvertibleNavigation($element);
+        return $this->hasAssociatedNavigationMenu($element);
     }
 
     private function isHamburgerMenuToggleControl(DOMElement $element): bool
@@ -1521,10 +1524,14 @@ final class HtmlTransformer
     }
 
     /**
-     * Whether a navigation menu that converts to core/navigation is the toggle's
-     * aria-controls target or sits within the toggle's enclosing landmark.
+     * Whether the toggle is associated with a source navigation menu: it opens
+     * one via aria-controls, lives inside a navigation landmark, or sits beside a
+     * navigation menu within its enclosing landmark. Association does NOT require
+     * the menu to convert to core/navigation — a navbar whose links fail to
+     * convert must still drop its dead hamburger rather than emit it as an
+     * always-visible core/button.
      */
-    private function hasNearbyConvertibleNavigation(DOMElement $toggle): bool
+    private function hasAssociatedNavigationMenu(DOMElement $toggle): bool
     {
         $controlledIds = preg_split('/\s+/', trim($this->attr($toggle, 'aria-controls'))) ?: array();
         foreach ( $controlledIds as $controlledId ) {
@@ -1533,23 +1540,43 @@ final class HtmlTransformer
             }
 
             $target = $this->elementWithId($toggle, $controlledId);
-            if ( $target instanceof DOMElement && ! $target->isSameNode($toggle) && $this->convertsToCoreNavigation($target) ) {
+            if ( $target instanceof DOMElement && ! $target->isSameNode($toggle) && $this->isAssociatedNavigationTarget($target) ) {
                 return true;
             }
         }
 
         $scope = $this->menuToggleScope($toggle);
+        if ( $this->isNavigationLandmark($scope) ) {
+            return true;
+        }
+
         foreach ( $scope->getElementsByTagName('*') as $candidate ) {
             if ( ! $candidate instanceof DOMElement || $candidate->isSameNode($toggle) ) {
                 continue;
             }
 
-            if ( $this->isNavigationMenuCandidate($candidate) && $this->convertsToCoreNavigation($candidate) ) {
+            if ( $this->isAssociatedNavigationTarget($candidate) ) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Whether an element is a navigation menu the toggle can be bound to: a
+     * structural/semantic navigation menu candidate (nav landmark or signaled
+     * list), or any container that converts to core/navigation (e.g. a signaled
+     * direct-anchor menu div).
+     */
+    private function isAssociatedNavigationTarget(DOMElement $element): bool
+    {
+        return $this->isNavigationMenuCandidate($element) || $this->convertsToCoreNavigation($element);
+    }
+
+    private function isNavigationLandmark(DOMElement $element): bool
+    {
+        return 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->attr($element, 'role'));
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -710,6 +710,66 @@ $assert(str_contains($labeledButtonsSerialized, '<!-- wp:button'), 'labeled/stan
 $assert(str_contains($labeledButtonsSerialized, 'Sign Up'), 'labeled button text is preserved as core/button');
 $assert(str_contains($labeledButtonsSerialized, 'aria-controls="missing"'), 'a toggle-looking control with no associated nav still converts to core/button');
 
+// Recursively counts blocks by name across the block tree (the serialized string
+// renders nested navigation/buttons without block-comment delimiters, so structural
+// counts are the reliable signal).
+$countBlockName = static function (array $blocks, string $name) use (&$countBlockName): int {
+    $count = 0;
+    foreach ( $blocks as $block ) {
+        if ( ! is_array($block) ) {
+            continue;
+        }
+        if ( $name === ( $block['blockName'] ?? '' ) ) {
+            $count++;
+        }
+        if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+            $count += $countBlockName($block['innerBlocks'], $name);
+        }
+    }
+    return $count;
+};
+
+// Regression (#232): the common "navbar" header — a brand/logo anchor + a list of
+// nav links + a hamburger toggle inside ONE <nav> — must convert the link list to
+// core/navigation, lift the brand out separately (not as a menu item), and drop the
+// dead hamburger. Generic structural markup only (no fixture-specific class names).
+$navbarHeader = ( new HtmlTransformer() )->transform(
+    '<nav class="masthead" role="navigation" aria-label="Main navigation"><a href="/" class="brand">Studio <em>Vale</em></a><ul class="primary-menu"><li><a href="/">Home</a></li><li><a href="/music">Music</a></li><li><a href="/tour">Tour</a></li></ul><button class="burger" aria-label="Toggle menu" aria-expanded="false"><span></span><span></span><span></span></button></nav>'
+)->toArray();
+$navbarBlocks = $navbarHeader['blocks'] ?? array();
+$navbarSerialized = (string) ($navbarHeader['serialized_blocks'] ?? '');
+$navbarParity = $navbarHeader['source_reports']['semantic_parity'] ?? array();
+$navbarBlockMenu = $navbarParity['navigation_menus']['blocks'][0] ?? array();
+$assert('pass' === ($navbarParity['status'] ?? ''), 'navbar (brand + ul links + toggle) preserves semantic parity');
+$assert(true === ($navbarBlockMenu['represented_as_core_navigation'] ?? null), 'navbar link list is represented as core/navigation');
+$assert(1 === $countBlockName($navbarBlocks, 'core/navigation'), 'navbar emits exactly one core/navigation block for the link list');
+$assert(3 === ($navbarBlockMenu['item_count'] ?? null), 'navbar core/navigation carries the link list while the brand is lifted out separately');
+$assert(str_contains($navbarSerialized, 'Studio'), 'navbar brand/logo is preserved (lifted out of the menu) rather than dropped');
+$assert(0 === $countBlockName($navbarBlocks, 'core/button'), 'navbar hamburger toggle is dropped instead of emitted as a dead core/button');
+$assert(! str_contains($navbarSerialized, 'burger'), 'navbar hamburger toggle chrome class is not emitted into block output');
+
+// Regression (#232): broaden #221 — a hamburger toggle associated with a nav that
+// does NOT convert to core/navigation (e.g. its list has a non-link item) must STILL
+// be dropped, never emitted as an always-visible dead core/button the source hid
+// behind responsive CSS/JS the importer cannot carry ("added UI" defect).
+$nonConvertingNavbar = ( new HtmlTransformer() )->transform(
+    '<header><a class="brand" href="/">Studio</a><nav class="primary" aria-label="Primary"><ul class="primary-menu"><li>Plain announcement copy</li><li><a href="/music">Music</a></li></ul></nav><button class="burger" aria-label="Toggle menu" aria-controls="primary-menu" aria-expanded="false"><span></span><span></span></button></header>'
+)->toArray();
+$nonConvertingBlocks = $nonConvertingNavbar['blocks'] ?? array();
+$nonConvertingSerialized = (string) ($nonConvertingNavbar['serialized_blocks'] ?? '');
+$assert(0 === $countBlockName($nonConvertingBlocks, 'core/button'), 'hamburger toggle for a non-converting nav is dropped rather than emitted as a dead core/button');
+$assert(! str_contains($nonConvertingSerialized, 'burger'), 'non-converting navbar hamburger toggle chrome class is not emitted into block output');
+$assert(str_contains($nonConvertingSerialized, 'Studio'), 'non-converting navbar preserves the brand/logo content');
+
+// Negative (#232): a labelless toggle-shaped control with no associated navigation in
+// scope must NOT be over-suppressed by the broadened rule — it still converts to
+// core/button (only navigation-associated dead hamburgers are dropped).
+$standaloneToggle = ( new HtmlTransformer() )->transform(
+    '<section class="widget"><button aria-controls="panel" aria-expanded="false"><span></span><span></span></button></section>'
+)->toArray();
+$standaloneToggleBlocks = $standaloneToggle['blocks'] ?? array();
+$assert(1 === $countBlockName($standaloneToggleBlocks, 'core/button'), 'a toggle-shaped control with no navigation in scope still converts to core/button');
+
 $runtimeTargetNavigation = ( new HtmlTransformer() )->transform(
     '<nav aria-label="Docs"><ul><li><a class="nav-link" href="/guide">Guide</a></li></ul></nav>',
     array('runtime_dom_selectors' => array('.nav-link'))

--- a/php-transformer/tests/fixtures/parity/html-nav-toggle-nonconverting-drop.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-toggle-nonconverting-drop.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-toggle-nonconverting-drop",
+  "description": "Broadens #221: a navbar whose link list does NOT convert to core/navigation (it contains a non-link list item) must still drop its dead JS hamburger menu-toggle rather than emit it as an always-visible core/button the source hid behind responsive CSS/JS. The brand/logo is lifted out as a paragraph and the menu degrades to core/list, but the spurious hamburger is gone. Detected generically (aria-controls/aria-expanded plus empty decorative bars + an associated nav landmark), never by a fixture-specific class string.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-toggle-nonconverting-drop.json",
+    "notes": "Generic navbar header where the menu list cannot be represented as core/navigation, so the toggle's nav never converts."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"masthead\"><nav class=\"primary-nav\" role=\"navigation\" aria-label=\"Primary\"><a href=\"index.html\" class=\"brand\">Northwind</a><ul class=\"nav-menu\"><li>Seasonal hours vary</li><li><a href=\"gatherings.html\">Gatherings</a></li><li><a href=\"stories.html\">Stories</a></li></ul><button class=\"hamburger\" aria-label=\"Open navigation menu\" aria-controls=\"nav-menu\" aria-expanded=\"false\"><span></span><span></span><span></span></button></nav></header>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "masthead" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "primary-nav" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "brand" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/list", "attrs": { "className": "nav-menu" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:button" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "hamburger" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Northwind" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
Closes #232

## Root cause

The "navbar" header — a brand/logo anchor + a list of nav links + a hamburger toggle inside one `<nav>` — produces two issues per #232:

1. **The nav must convert.** On current `trunk` this is already handled by intervening work (#197, #221, and the chrome/branded-header coverage): the inner link list converts to `core/navigation` and the brand/logo is lifted out into a paragraph (the nav element bails in `NavigationPattern::hasNavigationChrome` so the fallback path can lift the logo rather than swallowing it as a menu item — see the existing `html-nav-menu-flat-list` parity fixture and the `brandedHeader`/`chromeHeader` contract tests). I added a contract regression locking this navbar shape in.
2. **Never emit a dead hamburger.** This is the genuine remaining defect — a spurious "added UI" bug. #221's menu-toggle suppression only fired when a nearby menu **converted** to `core/navigation`. When the navbar's links do **not** convert (e.g. the list contains a non-link item), the JS-only hamburger toggle survived as an always-visible `core/button`. Its click JS isn't carried and the responsive CSS that hid it on desktop doesn't carry, so WordPress shows a hamburger the source never showed on desktop.

## Fix

Broadened `isRedundantMenuToggleControl` in `HtmlTransformer.php`: a hamburger-style toggle (a `button`/`role=button` carrying `aria-controls`/`aria-expanded` whose visible content is empty/decorative bars, no text label) is dropped whenever it is **associated** with a source navigation menu — it opens one via `aria-controls`, lives inside a `<nav>`/`role=navigation` landmark, or sits beside a navigation menu candidate — **regardless of whether that menu converts** to `core/navigation`.

This reuses #221's existing generic detection (`isHamburgerMenuToggleControl`, `menuToggleScope`, `isNavigationMenuCandidate`, `convertsToCoreNavigation`) — no duplicated heuristics, no fixture-specific class strings.

### Why no false positives
- A real labeled `<button>Sign Up</button>` is not a hamburger (`isHamburgerMenuToggleControl` requires an empty visible label) → still `core/button`.
- A toggle-shaped control with **no navigation in scope** (e.g. a lone `aria-controls` button in a non-nav container or header) has no associated nav → still `core/button`. Existing negative tests and a new over-suppression negative lock this in.
- **No parity-counter changes.** The source-side semantic-parity counter still counts items identically, so the parity gate stays in sync (pass/fail unchanged across all 125 fixtures).

## Scope note
`NavigationPattern.php` was intentionally not modified. The navbar already converts correctly on `trunk`; the one residual pattern-level wrinkle (a brand anchor mixed among *direct* nav anchors is counted as a menu item) currently passes semantic parity because both source and block sides count it the same way. "Fixing" it would require changing the source-side parity counter to also exclude brand/logo anchors — the exact change that desyncs the parity gate — for marginal benefit (the logo is preserved either way). The focused, parity-safe fix lives in `HtmlTransformer`.

## Tests
- `composer test:canonical` — pass (incl. new navbar + broadened-drop + over-suppression-negative contract regressions)
- `composer parity` — pass, 125 fixtures (incl. new `html-nav-toggle-nonconverting-drop.json`)
- `composer test` (canonical + parity + packaging) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)