### PR TITLE
feat(artifact-compiler): emit companion_plugin_payload producer seam (#491 slice 2)

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -76,6 +76,10 @@ final class ArtifactCompiler
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
         $sourceReports['materialization_plan'] = ( new MaterializationPlanBuilder() )->fromCompiledSite($sourceReports['compiled_site']);
+        $companionPluginPayload = ( new CompanionPluginPayload() )->fromBlockTypes($blockTypes, $normalized['files'], $artifact);
+        if ( array() !== $companionPluginPayload ) {
+            $sourceReports['companion_plugin_payload'] = $companionPluginPayload;
+        }
         $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references'], $entryBlocks['interaction_candidates']);
         if ( array() !== $entryBlocks['runtime_islands'] ) {
             $sourceReports['runtime_islands'] = $entryBlocks['runtime_islands'];

--- a/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
+++ b/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
@@ -1,0 +1,315 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
+
+/**
+ * Producer for the companion-plugin payload consumed by Static Site Importer.
+ *
+ * This is the producer half of the companion-plugin / plugin-materialization
+ * keystone (issue #491). Slice 1 (SSI #492) built the consumer:
+ * Static_Site_Importer_Companion_Plugin::scaffold() turns a payload into an
+ * installable, theme-independent plugin that houses generated custom blocks
+ * (registered from their own block.json) and preserved island JS. This class is
+ * the producer seam: it packages the generated block definitions the artifact
+ * already carries (block.json + render + view JS + assets) into a payload whose
+ * shape exactly matches what scaffold() consumes.
+ *
+ * Contract (consumed by scaffold(), keys it reads):
+ *   - site_slug   (string)  per-site naming; SSI may override at install time.
+ *   - site_name   (string)  optional human-readable name; defaults to slug.
+ *   - mu_plugin   (bool)    optional; emit as a must-use loader.
+ *   - blocks[]    (array)   each: name, block_json, render, view_js, assets{}.
+ *   - preserved_js[] (array) each: content, handle, src, block. Slot for the
+ *                            JS->plugin wire-up (SSI #488); empty for now.
+ *
+ * When the artifact carries no generated custom blocks (the common case today,
+ * since mapping still prefers core/Automattic blocks with a core/html
+ * fallback), the payload is empty and the compiler omits it. This class does
+ * not decide what becomes a custom block; it only packages blocks the artifact
+ * already declares via block.json.
+ */
+final class CompanionPluginPayload
+{
+    /**
+     * Shared contract identifier. Mirrors the consumer schema declared by
+     * Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA so SSI can assert
+     * conformance. scaffold() does not require it, but stamping it makes the
+     * producer<->consumer contract explicit and greppable across repos.
+     */
+    public const SCHEMA = 'static-site-importer/companion-plugin/v1';
+
+    /**
+     * Build the companion-plugin payload from detected generated blocks.
+     *
+     * @param array<int, array<string, mixed>> $blockTypes Block-type artifacts from detectBlockTypes().
+     * @param array<int, array<string, mixed>> $files      Normalized artifact files (carry content).
+     * @param array<string, mixed>             $artifact   Raw artifact envelope (for site identity).
+     * @return array<string, mixed> Empty array when there are no generated blocks.
+     */
+    public function fromBlockTypes(array $blockTypes, array $files, array $artifact): array
+    {
+        $blocks = array();
+        foreach ( $blockTypes as $blockType ) {
+            if ( ! is_array($blockType) ) {
+                continue;
+            }
+            $block = $this->buildBlock($blockType, $files);
+            if ( array() !== $block ) {
+                $blocks[] = $block;
+            }
+        }
+
+        if ( array() === $blocks ) {
+            // No generated custom blocks: the payload is absent. SSI keeps the
+            // existing required-plugin path and the core/html fallback applies.
+            return array();
+        }
+
+        $payload = array(
+            'schema' => self::SCHEMA,
+            'blocks' => $blocks,
+            // Slot for preserved island JS. Populated by the JS->plugin wire-up
+            // (SSI #488); empty here so the producer seam exists today.
+            'preserved_js' => array(),
+        );
+
+        $siteSlug = $this->siteSlug($artifact);
+        if ( '' !== $siteSlug ) {
+            $payload['site_slug'] = $siteSlug;
+        }
+        $siteName = $this->siteName($artifact);
+        if ( '' !== $siteName ) {
+            $payload['site_name'] = $siteName;
+        }
+        if ( $this->muPlugin($artifact) ) {
+            $payload['mu_plugin'] = true;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Build one block entry conforming to scaffold()'s per-block contract.
+     *
+     * @param array<string, mixed>             $blockType One detectBlockTypes() entry.
+     * @param array<int, array<string, mixed>> $files     Normalized artifact files.
+     * @return array<string, mixed> Empty array when the block cannot be packaged.
+     */
+    private function buildBlock(array $blockType, array $files): array
+    {
+        $name = is_scalar($blockType['slug'] ?? null) ? (string) $blockType['slug'] : '';
+        if ( '' === $name ) {
+            $fqn = is_scalar($blockType['name'] ?? null) ? (string) $blockType['name'] : '';
+            $name = '' === $fqn ? '' : (string) substr(strrchr('/' . $fqn, '/') ?: '', 1);
+        }
+        if ( '' === $name ) {
+            return array();
+        }
+
+        $blockJson = is_array($blockType['block_json'] ?? null) ? $blockType['block_json'] : array();
+        if ( array() === $blockJson ) {
+            return array();
+        }
+
+        $directory = is_scalar($blockType['directory'] ?? null) ? (string) $blockType['directory'] : '';
+        $contents = $this->blockFileContents($files, $directory);
+
+        $blockJsonPath = is_scalar($blockType['block_json_path'] ?? null) ? (string) $blockType['block_json_path'] : '';
+        $blockJsonRel = $this->relativePath($blockJsonPath, $directory);
+
+        $renderPath = $this->firstReferencedFilePath($blockType, 'render');
+        $renderRel = $this->relativePath($renderPath, $directory);
+        $viewJsPath = $this->firstReferencedFilePath($blockType, 'view_script');
+        $viewJsRel = $this->relativePath($viewJsPath, $directory);
+
+        // Paths handled by dedicated keys are excluded from the generic assets
+        // map so scaffold() does not write them twice.
+        $handled = array_filter(array($blockJsonRel, $renderRel, $viewJsRel), static fn (string $p): bool => '' !== $p);
+
+        $block = array(
+            'name'       => $name,
+            'block_json' => $blockJson,
+        );
+
+        if ( '' !== $renderRel && array_key_exists($renderRel, $contents) ) {
+            $block['render'] = $contents[$renderRel];
+        }
+        if ( '' !== $viewJsRel && array_key_exists($viewJsRel, $contents) ) {
+            $block['view_js'] = $contents[$viewJsRel];
+        }
+
+        $assets = array();
+        foreach ( $contents as $relative => $content ) {
+            if ( in_array($relative, $handled, true) ) {
+                continue;
+            }
+            $assets[$relative] = $content;
+        }
+        if ( array() !== $assets ) {
+            ksort($assets);
+            $block['assets'] = $assets;
+        }
+
+        return $block;
+    }
+
+    /**
+     * Collect block-directory file contents keyed by path relative to the block.
+     *
+     * @param array<int, array<string, mixed>> $files     Normalized artifact files.
+     * @param string                           $directory Block source directory.
+     * @return array<string, string>
+     */
+    private function blockFileContents(array $files, string $directory): array
+    {
+        $prefix = '' === $directory ? '' : rtrim($directory, '/') . '/';
+        $contents = array();
+        foreach ( $files as $file ) {
+            $path = is_scalar($file['path'] ?? null) ? (string) $file['path'] : '';
+            if ( '' === $path ) {
+                continue;
+            }
+            if ( '' !== $prefix && ! str_starts_with($path, $prefix) ) {
+                continue;
+            }
+            $relative = $this->relativePath($path, $directory);
+            if ( '' === $relative ) {
+                continue;
+            }
+            $contents[$relative] = $this->fileContent($file);
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Decode a normalized file's content, base64-decoding binary payloads.
+     *
+     * @param array<string, mixed> $file Normalized file record.
+     */
+    private function fileContent(array $file): string
+    {
+        if ( ! empty($file['binary']) && is_scalar($file['content_base64'] ?? null) ) {
+            $decoded = base64_decode((string) $file['content_base64'], true);
+            if ( false !== $decoded ) {
+                return $decoded;
+            }
+        }
+
+        return is_scalar($file['content'] ?? null) ? (string) $file['content'] : '';
+    }
+
+    /**
+     * Resolve the first resolved file path for a block asset contract field.
+     *
+     * @param array<string, mixed> $blockType detectBlockTypes() entry.
+     * @param string               $field     Asset contract field, e.g. render.
+     */
+    private function firstReferencedFilePath(array $blockType, string $field): string
+    {
+        $references = $blockType['assets'][$field] ?? null;
+        if ( ! is_array($references) ) {
+            return '';
+        }
+        foreach ( $references as $reference ) {
+            if ( is_array($reference) && 'file' === ($reference['type'] ?? '') && is_scalar($reference['path'] ?? null) ) {
+                return (string) $reference['path'];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Reduce an artifact-absolute path to a block-directory-relative path.
+     */
+    private function relativePath(string $path, string $directory): string
+    {
+        $path = trim($path);
+        if ( '' === $path ) {
+            return '';
+        }
+        $prefix = '' === $directory ? '' : rtrim($directory, '/') . '/';
+        if ( '' !== $prefix && str_starts_with($path, $prefix) ) {
+            return substr($path, strlen($prefix));
+        }
+
+        return '' === $prefix ? $path : '';
+    }
+
+    /**
+     * Sanitized per-site slug from the raw artifact, when carried.
+     *
+     * @param array<string, mixed> $artifact Raw artifact envelope.
+     */
+    private function siteSlug(array $artifact): string
+    {
+        $candidates = array(
+            $artifact['site_slug'] ?? null,
+            is_array($artifact['site'] ?? null) ? ($artifact['site']['slug'] ?? null) : null,
+            is_array($artifact['site'] ?? null) ? ($artifact['site']['name'] ?? null) : null,
+            $artifact['name'] ?? null,
+        );
+        foreach ( $candidates as $candidate ) {
+            if ( ! is_scalar($candidate) ) {
+                continue;
+            }
+            $slug = $this->sanitizeSlug((string) $candidate);
+            if ( '' !== $slug ) {
+                return $slug;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Human-readable site name from the raw artifact, when carried.
+     *
+     * @param array<string, mixed> $artifact Raw artifact envelope.
+     */
+    private function siteName(array $artifact): string
+    {
+        $candidates = array(
+            $artifact['site_name'] ?? null,
+            is_array($artifact['site'] ?? null) ? ($artifact['site']['name'] ?? null) : null,
+            is_array($artifact['site'] ?? null) ? ($artifact['site']['title'] ?? null) : null,
+        );
+        foreach ( $candidates as $candidate ) {
+            if ( is_scalar($candidate) && '' !== trim((string) $candidate) ) {
+                return trim((string) $candidate);
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Whether the artifact requests a must-use companion plugin.
+     *
+     * @param array<string, mixed> $artifact Raw artifact envelope.
+     */
+    private function muPlugin(array $artifact): bool
+    {
+        if ( ! empty($artifact['mu_plugin']) ) {
+            return true;
+        }
+        if ( is_array($artifact['site'] ?? null) && ! empty($artifact['site']['mu_plugin']) ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Lowercase, hyphen-delimited slug; portable since WP is not loaded here.
+     */
+    private function sanitizeSlug(string $value): string
+    {
+        $value = strtolower(trim($value));
+        $value = preg_replace('/[^a-z0-9]+/', '-', $value);
+
+        return trim((string) $value, '-');
+    }
+}

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1767,6 +1767,69 @@ $unnamedBlock = $compiler->compile(
 $assert('generated/fallback' === ($unnamedBlock['block_types'][0]['name'] ?? ''), 'unnamed block.json receives stable generated name');
 $assert(in_array('block_json_missing_name', array_column($unnamedBlock['diagnostics'], 'code'), true), 'unnamed block.json emits a diagnostic');
 
+// Companion-plugin payload producer (issue #491 slice 2): generated blocks are
+// packaged into a payload whose shape matches the SSI #492 scaffold() consumer.
+$companion = $compiler->compile(
+    array(
+        'site'  => array( 'name' => 'Acme Co', 'slug' => 'acme' ),
+        'files' => array(
+            'index.html'             => '<main><section class="hero"><h1>Hi</h1></section></main>',
+            'blocks/hero/block.json' => json_encode(
+                array(
+                    'apiVersion'   => 3,
+                    'name'         => 'acme/hero',
+                    'title'        => 'Hero',
+                    'category'     => 'design',
+                    'render'       => 'file:./render.php',
+                    'viewScript'   => 'file:./view.js',
+                    'style'        => 'file:./style.css',
+                    'editorScript' => 'file:./index.js',
+                ),
+                JSON_UNESCAPED_SLASHES
+            ),
+            'blocks/hero/render.php' => '<?php echo "<div>hero</div>";',
+            'blocks/hero/view.js'    => 'console.log("hero island");',
+            'blocks/hero/style.css'  => '.wp-block-acme-hero{padding:2rem}',
+            'blocks/hero/index.js'   => 'import metadata from "./block.json";',
+        ),
+    )
+)->toArray();
+$companionPayload = $companion['source_reports']['companion_plugin_payload'] ?? null;
+$assert(is_array($companionPayload), 'companion_plugin_payload is emitted when a generated block is present');
+$assert('static-site-importer/companion-plugin/v1' === ($companionPayload['schema'] ?? ''), 'companion payload stamps the shared consumer schema');
+$assert('acme' === ($companionPayload['site_slug'] ?? ''), 'companion payload derives site_slug from the artifact');
+$assert('Acme Co' === ($companionPayload['site_name'] ?? ''), 'companion payload derives site_name from the artifact');
+$assert(array() === ($companionPayload['preserved_js'] ?? null), 'companion payload exposes an empty preserved_js slot');
+$assert(1 === count($companionPayload['blocks'] ?? array()), 'companion payload carries one block');
+$companionBlock = $companionPayload['blocks'][0] ?? array();
+$assert('hero' === ($companionBlock['name'] ?? ''), 'companion block name is the local slug for SSI namespacing');
+$assert('acme/hero' === ($companionBlock['block_json']['name'] ?? ''), 'companion block carries the decoded block.json');
+$assert(str_contains((string) ($companionBlock['render'] ?? ''), '<div>hero</div>'), 'companion block carries render content');
+$assert(str_contains((string) ($companionBlock['view_js'] ?? ''), 'hero island'), 'companion block carries view JS content');
+$assert(str_contains((string) ($companionBlock['assets']['style.css'] ?? ''), 'padding'), 'companion block carries non-render/view assets');
+$assert(isset($companionBlock['assets']['index.js']), 'companion block carries editor script asset');
+$assert(! isset($companionBlock['assets']['render.php']), 'render is not duplicated into the assets map');
+$assert(! isset($companionBlock['assets']['view.js']), 'view JS is not duplicated into the assets map');
+$assert(! isset($companionBlock['assets']['block.json']), 'block.json is not duplicated into the assets map');
+
+$companionNoSite = $compiler->compile(
+    array(
+        'files' => array(
+            'index.html'             => '<main></main>',
+            'blocks/card/block.json' => json_encode(array( 'apiVersion' => 3, 'name' => 'x/card', 'render' => 'file:./render.php' )),
+            'blocks/card/render.php' => '<?php echo "card";',
+        ),
+    )
+)->toArray();
+$companionNoSitePayload = $companionNoSite['source_reports']['companion_plugin_payload'] ?? null;
+$assert(is_array($companionNoSitePayload), 'companion payload is emitted even without site identity');
+$assert(! isset($companionNoSitePayload['site_slug']), 'companion payload omits site_slug when the artifact carries none (SSI fills it)');
+
+$companionAbsent = $compiler->compile(
+    array( 'files' => array( 'index.html' => '<main><h1>Plain</h1><p>No blocks</p></main>' ) )
+)->toArray();
+$assert(! array_key_exists('companion_plugin_payload', $companionAbsent['source_reports']), 'companion_plugin_payload is absent when no generated blocks exist');
+
 $normalized = $compiler->compile(
     array(
         'entry'   => 'public/index.html',


### PR DESCRIPTION
## Summary

Refs #491 (slice 2 of N). Slice 1 is **SSI #492** (merged), which built the *consumer*: `Static_Site_Importer_Companion_Plugin::scaffold()` turns a "companion plugin payload" into an installable, theme-independent plugin that houses generated custom blocks (registered from their own `block.json`) plus preserved island JS. This PR is the **producer**: it extends the blocks-engine `ArtifactCompiler` to emit a `companion_plugin_payload` whose shape **exactly matches** what slice-1's `scaffold()` consumes.

This is purely the packaging seam. It does **not** change mapping/routing — `core/html` stays the safe fallback, and there is no "generate a custom block instead of core/html" path here (that is a later wire-up / recognizer hook). The producer only packages generated blocks the artifact *already* declares via `block.json` (the compiler already detects/validates these — see `invalid_block_json` / `block_json_missing_name`).

## Payload shape -> slice-1 contract

`source_reports.companion_plugin_payload`:

- `schema` — stamps `static-site-importer/companion-plugin/v1` (mirrors SSI's `PAYLOAD_SCHEMA`) so the consumer can assert conformance.
- `blocks[]` — one per detected generated block: `name` (local slug; SSI namespaces it to `ssi-<site>/<name>`), `block_json` (decoded array), `render` (render.php content), `view_js` (viewScript content), `assets{}` (remaining block-dir files keyed by block-relative path). Render / view JS / block.json are excluded from `assets` so the consumer doesn't write them twice.
- `preserved_js[]` — empty slot today; reserved for the JS->plugin wire-up (SSI #488).
- `site_slug` / `site_name` / `mu_plugin` — derived from the artifact envelope when carried; omitted otherwise (SSI supplies site identity at install time).

## Producer behavior

- Emitted only when at least one generated block exists; **absent** when there are none (the common case today). Existing block.json detection/validation is unchanged.
- All packaging lives in a new `src/ArtifactCompiler/CompanionPluginPayload.php` builder wired into `ArtifactCompiler::compile()`. `HtmlTransformer.php` / `ButtonsPattern.php` are untouched (avoiding the #233 button-styling work).

## Proven end-to-end

A scratch harness ran the emitted payload through slice-1's **real** `scaffold()` (fetched from `origin/main`): it materializes a complete `ssi-acme/...` plugin file set (main plugin file, `blocks/hero/block.json` rewritten to `ssi-acme/hero`, `render.php`, `view.js`, `style.css`, `index.js`). Confirms the shape conforms to slice-1 with no slice-1 change required.

## Tests

- `composer test:canonical` — pass (added contract assertions: payload present with a synthetic block, present without site identity, absent without blocks; render/view/block.json not duplicated into assets).
- `composer parity` — pass (125 fixtures).
- `composer test` (incl. packaging install-proof) — pass.

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)