### PR TITLE
Refactor (slice 1, #242): extract diagnostics projection into DiagnosticsCollector

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
+
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+
+/**
+ * Projects already-computed conversion signals (fallbacks, runtime islands,
+ * static script metadata, block-validity findings, and semantic-parity
+ * findings) into the flat diagnostics array carried by TransformerResult.
+ *
+ * This is a behavior-preserving extraction of the inline projection that
+ * previously lived in HtmlTransformer::transform(). It performs no DOM work and
+ * no logic decisions — it only reshapes data the transformer already produced —
+ * so the diagnostics output is byte-identical to the inline implementation.
+ */
+final class DiagnosticsCollector
+{
+    /**
+     * Build the success-path diagnostics array from the transformer's computed
+     * signals.
+     *
+     * @param string                            $transformerSource    Source attribution for transformer-owned diagnostics (HtmlTransformer::class).
+     * @param array<int, array<string, mixed>>  $scriptMetadata       Static script metadata preserved as bounded data.
+     * @param array<int, array<string, mixed>>  $fallbacks            Fallback diagnostics emitted during conversion.
+     * @param array<int, array<string, mixed>>  $runtimeIslands       Preserved runtime islands.
+     * @param array<string, mixed>              $blockValidityReport  Block serialization validity report.
+     * @param array<string, mixed>              $semanticParityReport Semantic parity report.
+     * @return array<int, array<string, mixed>>
+     */
+    public function collect(
+        string $transformerSource,
+        array $scriptMetadata,
+        array $fallbacks,
+        array $runtimeIslands,
+        array $blockValidityReport,
+        array $semanticParityReport
+    ): array {
+        $diagnostics = array(
+            array(
+                'code'    => 'html_to_blocks_core_slice',
+                'message' => 'Converted supported core text, layout, media, gallery, embed, file, table, button, shortcode, spacer, definition-list, details, navigation, safe inline SVG images, and wrapper elements; unsupported elements are reported as fallbacks.',
+                'source'  => $transformerSource,
+            ),
+        );
+
+        foreach ( $scriptMetadata as $metadata ) {
+            $diagnostics[] = array(
+                'code'        => 'html_static_script_metadata',
+                'message'     => 'Static script data was preserved as bounded metadata and does not require client script execution.',
+                'source'      => $transformerSource,
+                'reason'      => 'script_static_metadata',
+                'tag'         => 'script',
+                'selector'    => $metadata['selector'] ?? null,
+                'script_role' => $metadata['script_role'] ?? null,
+            );
+        }
+
+        foreach ( $fallbacks as $fallback ) {
+            if ( ! empty($fallback['diagnostic_code']) ) {
+                $diagnostics[] = array(
+                    'code'                => $fallback['diagnostic_code'],
+                    'message'             => $fallback['message'] ?? 'HTML element preserved as fallback metadata.',
+                    'source'              => $transformerSource,
+                    'reason'              => $fallback['reason'] ?? null,
+                    'severity'            => $fallback['severity'] ?? null,
+                    'conversion_classification' => $fallback['conversion_classification'] ?? null,
+                    'loss_class'          => $fallback['loss_class'] ?? null,
+                    'diagnostic_class'    => $fallback['diagnostic_class'] ?? null,
+                    'preservation_strategy' => $fallback['preservation_strategy'] ?? null,
+                    'runtime_requirement'             => $fallback['runtime_requirement'] ?? null,
+                    'recoverability'                  => $fallback['recoverability'] ?? null,
+                    'actionability'                   => $fallback['actionability'] ?? null,
+                    'suggested_repair_class'          => $fallback['suggested_repair_class'] ?? null,
+                    'suggested_primitive'             => $fallback['suggested_primitive'] ?? null,
+                    'materialization_hint'            => $fallback['materialization_hint'] ?? null,
+                    'tag'                             => $fallback['tag'] ?? null,
+                    'selector'                        => $fallback['selector'] ?? null,
+                    'pattern_family'                  => $fallback['pattern_family'] ?? null,
+                    'pattern_family_detail'           => $fallback['pattern_family_detail'] ?? null,
+                    'source_selector'                 => $fallback['source_selector'] ?? null,
+                    'source_selector_specificity'     => $fallback['source_selector_specificity'] ?? null,
+                    'parent_reason'                   => $fallback['parent_reason'] ?? null,
+                    'ancestor_reason'                 => $fallback['ancestor_reason'] ?? null,
+                    'suggested_generic_repair_class' => $fallback['suggested_generic_repair_class'] ?? null,
+                );
+            }
+        }
+
+        foreach ( $runtimeIslands as $island ) {
+            $diagnostics[] = array_filter(array(
+                'code'                => 'preserved_runtime_island',
+                'message'             => 'Runtime-dependent source markup was preserved as a bounded runtime island.',
+                'source'              => $transformerSource,
+                'severity'            => 'info',
+                'conversion_classification' => 'runtime_island_preserved',
+                'loss_class'          => 'runtime_island_preserved',
+                'diagnostic_class'    => 'runtime_island_preserved',
+                'suggested_repair_class' => 'preserve_runtime_island',
+                'preservation_strategy' => $island['preservation_strategy'] ?? 'bounded_raw_html_runtime_island',
+                'runtime_requirement' => $island['runtime_requirement'] ?? null,
+                'kind'                => $island['kind'] ?? null,
+                'reason'              => $island['preservation_reason'] ?? null,
+                'tag'                 => $island['tag'] ?? null,
+                'selector'            => $island['selector'] ?? null,
+                'pattern_family'                  => $island['pattern_family'] ?? null,
+                'pattern_family_detail'           => $island['pattern_family_detail'] ?? null,
+                'source_selector'                 => $island['source_selector'] ?? null,
+                'source_selector_specificity'     => $island['source_selector_specificity'] ?? null,
+                'parent_reason'                   => $island['parent_reason'] ?? null,
+                'ancestor_reason'                 => $island['ancestor_reason'] ?? null,
+                'suggested_generic_repair_class' => $island['suggested_generic_repair_class'] ?? null,
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+        }
+
+        foreach ( $blockValidityReport['findings'] ?? array() as $finding ) {
+            if ( ! is_array($finding) ) {
+                continue;
+            }
+
+            $diagnostics[] = array(
+                'code'       => 'wp_block_validity_' . (string) ($finding['code'] ?? 'warning'),
+                'message'    => (string) ($finding['summary'] ?? 'Generated block serialization may trigger WordPress block invalidity warnings.'),
+                'source'     => Runtime::class,
+                'severity'   => $finding['severity'] ?? 'warning',
+                'block_name' => $finding['block_name'] ?? null,
+                'path'       => $finding['path'] ?? null,
+            );
+        }
+
+        foreach ( $semanticParityReport['findings'] ?? array() as $finding ) {
+            if ( ! is_array($finding) ) {
+                continue;
+            }
+
+            $diagnostics[] = array(
+                'code'     => 'html_semantic_parity_' . (string) ($finding['code'] ?? 'warning'),
+                'message'  => (string) ($finding['summary'] ?? 'Generated blocks differ from source semantic structure.'),
+                'source'   => $transformerSource,
+                'severity' => $finding['severity'] ?? 'warning',
+                'selector' => $finding['selector'] ?? null,
+            );
+        }
+
+        return $diagnostics;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformationOptions;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsCollector;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\AccordionPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
@@ -67,6 +68,8 @@ final class HtmlTransformer
     private readonly LogoPattern $logoPattern;
 
     private readonly PatternRecognizerRegistry $patternRecognizers;
+
+    private readonly DiagnosticsCollector $diagnosticsCollector;
 
     /**
      * @var array<string, string>
@@ -145,6 +148,7 @@ final class HtmlTransformer
             new AccordionPattern(),
             new NavigationPattern(),
         ));
+        $this->diagnosticsCollector = new DiagnosticsCollector();
     }
 
     /**
@@ -239,111 +243,14 @@ final class HtmlTransformer
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
         $semanticParityReport = $this->semanticParityReport($body, $blocks, $sourceProvenance, $html, (string) ($options['static_css'] ?? ''));
-        $diagnostics = array(
-            array(
-                'code'    => 'html_to_blocks_core_slice',
-                'message' => 'Converted supported core text, layout, media, gallery, embed, file, table, button, shortcode, spacer, definition-list, details, navigation, safe inline SVG images, and wrapper elements; unsupported elements are reported as fallbacks.',
-                'source'  => self::class,
-            ),
+        $diagnostics = $this->diagnosticsCollector->collect(
+            self::class,
+            $this->scriptMetadata,
+            $fallbacks,
+            $this->runtimeIslands,
+            $blockValidityReport,
+            $semanticParityReport
         );
-
-        foreach ( $this->scriptMetadata as $metadata ) {
-            $diagnostics[] = array(
-                'code'        => 'html_static_script_metadata',
-                'message'     => 'Static script data was preserved as bounded metadata and does not require client script execution.',
-                'source'      => self::class,
-                'reason'      => 'script_static_metadata',
-                'tag'         => 'script',
-                'selector'    => $metadata['selector'] ?? null,
-                'script_role' => $metadata['script_role'] ?? null,
-            );
-        }
-
-        foreach ( $fallbacks as $fallback ) {
-            if ( ! empty($fallback['diagnostic_code']) ) {
-                $diagnostics[] = array(
-                    'code'                => $fallback['diagnostic_code'],
-                    'message'             => $fallback['message'] ?? 'HTML element preserved as fallback metadata.',
-                    'source'              => self::class,
-                    'reason'              => $fallback['reason'] ?? null,
-                    'severity'            => $fallback['severity'] ?? null,
-                    'conversion_classification' => $fallback['conversion_classification'] ?? null,
-                    'loss_class'          => $fallback['loss_class'] ?? null,
-                    'diagnostic_class'    => $fallback['diagnostic_class'] ?? null,
-                    'preservation_strategy' => $fallback['preservation_strategy'] ?? null,
-                    'runtime_requirement'             => $fallback['runtime_requirement'] ?? null,
-                    'recoverability'                  => $fallback['recoverability'] ?? null,
-                    'actionability'                   => $fallback['actionability'] ?? null,
-                    'suggested_repair_class'          => $fallback['suggested_repair_class'] ?? null,
-                    'suggested_primitive'             => $fallback['suggested_primitive'] ?? null,
-                    'materialization_hint'            => $fallback['materialization_hint'] ?? null,
-                    'tag'                             => $fallback['tag'] ?? null,
-                    'selector'                        => $fallback['selector'] ?? null,
-                    'pattern_family'                  => $fallback['pattern_family'] ?? null,
-                    'pattern_family_detail'           => $fallback['pattern_family_detail'] ?? null,
-                    'source_selector'                 => $fallback['source_selector'] ?? null,
-                    'source_selector_specificity'     => $fallback['source_selector_specificity'] ?? null,
-                    'parent_reason'                   => $fallback['parent_reason'] ?? null,
-                    'ancestor_reason'                 => $fallback['ancestor_reason'] ?? null,
-                    'suggested_generic_repair_class' => $fallback['suggested_generic_repair_class'] ?? null,
-                );
-            }
-        }
-
-        foreach ( $this->runtimeIslands as $island ) {
-            $diagnostics[] = array_filter(array(
-                'code'                => 'preserved_runtime_island',
-                'message'             => 'Runtime-dependent source markup was preserved as a bounded runtime island.',
-                'source'              => self::class,
-                'severity'            => 'info',
-                'conversion_classification' => 'runtime_island_preserved',
-                'loss_class'          => 'runtime_island_preserved',
-                'diagnostic_class'    => 'runtime_island_preserved',
-                'suggested_repair_class' => 'preserve_runtime_island',
-                'preservation_strategy' => $island['preservation_strategy'] ?? 'bounded_raw_html_runtime_island',
-                'runtime_requirement' => $island['runtime_requirement'] ?? null,
-                'kind'                => $island['kind'] ?? null,
-                'reason'              => $island['preservation_reason'] ?? null,
-                'tag'                 => $island['tag'] ?? null,
-                'selector'            => $island['selector'] ?? null,
-                'pattern_family'                  => $island['pattern_family'] ?? null,
-                'pattern_family_detail'           => $island['pattern_family_detail'] ?? null,
-                'source_selector'                 => $island['source_selector'] ?? null,
-                'source_selector_specificity'     => $island['source_selector_specificity'] ?? null,
-                'parent_reason'                   => $island['parent_reason'] ?? null,
-                'ancestor_reason'                 => $island['ancestor_reason'] ?? null,
-                'suggested_generic_repair_class' => $island['suggested_generic_repair_class'] ?? null,
-            ), static fn (mixed $value): bool => null !== $value && '' !== $value);
-        }
-
-        foreach ( $blockValidityReport['findings'] ?? array() as $finding ) {
-            if ( ! is_array($finding) ) {
-                continue;
-            }
-
-            $diagnostics[] = array(
-                'code'       => 'wp_block_validity_' . (string) ($finding['code'] ?? 'warning'),
-                'message'    => (string) ($finding['summary'] ?? 'Generated block serialization may trigger WordPress block invalidity warnings.'),
-                'source'     => Runtime::class,
-                'severity'   => $finding['severity'] ?? 'warning',
-                'block_name' => $finding['block_name'] ?? null,
-                'path'       => $finding['path'] ?? null,
-            );
-        }
-
-        foreach ( $semanticParityReport['findings'] ?? array() as $finding ) {
-            if ( ! is_array($finding) ) {
-                continue;
-            }
-
-            $diagnostics[] = array(
-                'code'     => 'html_semantic_parity_' . (string) ($finding['code'] ?? 'warning'),
-                'message'  => (string) ($finding['summary'] ?? 'Generated blocks differ from source semantic structure.'),
-                'source'   => self::class,
-                'severity' => $finding['severity'] ?? 'warning',
-                'selector' => $finding['selector'] ?? null,
-            );
-        }
 
         $metrics = $this->metrics($html, $blocks, $serializedBlocks, $fallbacks, $diagnostics, $startedAt);
         $nativeTargetBlocks = $this->runtime->availableCoreBlockNames();


### PR DESCRIPTION
Refs #242 — slice 1 of the HtmlTransformer decomposition epic: extract the **diagnostics projection** concern.

## What this does
Pure extraction/move. The inline block in `HtmlTransformer::transform()` that projected already-computed conversion signals into the flat result `diagnostics` array is moved into a dedicated, cohesive module:

`src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php`

`HtmlTransformer` now delegates to `DiagnosticsCollector::collect()` with the data it already computed. What moved:
- the `html_to_blocks_core_slice` base diagnostic
- `html_static_script_metadata` projection (from `scriptMetadata`)
- fallback → diagnostic projection (`html_*_fallback`, `interactive_control_behavior_lost`, etc., with full finding enrichment fields: pattern_family, source_selector, parent/ancestor_reason, suggested_generic_repair_class, …)
- `preserved_runtime_island` projection (from `runtimeIslands`)
- `wp_block_validity_*` findings projection (source `Runtime::class`)
- `html_semantic_parity_*` findings projection

`FallbackDiagnostic` is untouched (the new module orchestrates the data it produces). No result schema/key changes. `self::class` attribution is preserved by passing the transformer source string into the collector; `Runtime::class` attribution is preserved by importing `Runtime`.

## Behavior-preserving — parity identical 128→128
Captured a baseline before refactoring and re-ran after:
- `composer test:canonical`: 5 contracts pass (no-WP runtime, WP-stub runtime, plugin bootstrap, HTML-to-blocks, format bridge scaffold) — identical before/after.
- `composer parity`: **128 fixtures pass → 128 fixtures pass** — identical.
- `composer test` (canonical + parity + packaging): green.

No logic changes, no new findings, no renamed codes, no fixture changes. Output is byte-identical.

## Line-count reduction
`HtmlTransformer.php`: **6816 → 6723 lines** (−93), with the projection logic now isolated in a 148-line single-responsibility module that diagnostics work can target without touching transformer core.

## Scope notes
The semantic-parity report builders and the interactive-control behavior-loss / `capture*Fallback` emitters were intentionally **left in place** for this slice: they are deeply interwoven with shared DOM/conversion helpers (`attr`, `elementSelector`, `safeFallbackHtml`, `boundedFallbackHtml`, and `normalizedNavigationLabel` which is also used by navigation de-duplication), so moving them would not be a clean pure move. This slice extracts the largest provably-safe cohesive unit — the projection seam — leaving those emitters for a later slice once their shared helpers are factored out.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)