### PR TITLE
Refactor: extract shared DOM/HTML helpers into DomHelpersTrait (slice 2)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -14,6 +14,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use DOMDocument;
 use DOMElement;
@@ -21,6 +22,8 @@ use DOMNode;
 
 final class HtmlTransformer
 {
+    use DomHelpersTrait;
+
     private const MAX_INTERACTION_CANDIDATES = 100;
 
     /**
@@ -806,11 +809,6 @@ final class HtmlTransformer
                 $this->collectBlockNavigationItems($block['innerBlocks'], $items);
             }
         }
-    }
-
-    private function normalizedNavigationLabel(string $label): string
-    {
-        return trim(preg_replace('/\s+/', ' ', html_entity_decode($this->runtime->stripAllTags($label), ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? $label);
     }
 
     private function sourceNavigationAnchorLabel(DOMElement $anchor): string
@@ -2224,36 +2222,6 @@ final class HtmlTransformer
         );
     }
 
-    private function innerHtml(DOMElement $element): string
-    {
-        $html = '';
-        foreach ( $element->childNodes as $child ) {
-            $html .= $element->ownerDocument->saveHTML($child);
-        }
-
-        return trim($html);
-    }
-
-    private function innerHtmlPreservingWhitespace(DOMElement $element): string
-    {
-        $html = '';
-        foreach ( $element->childNodes as $child ) {
-            $html .= $element->ownerDocument->saveHTML($child);
-        }
-
-        return $html;
-    }
-
-    private function outerHtml(DOMElement $element): string
-    {
-        return trim($element->ownerDocument->saveHTML($element) ?: '');
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
-    }
-
     /**
      * @return array<string, mixed>
      */
@@ -2267,16 +2235,6 @@ final class HtmlTransformer
             'style'     => $style,
             'layout'    => $this->layoutAttribute($element, $style),
         ), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
-    }
-
-    private function safeAnchor(string $id): string
-    {
-        $id = trim($id);
-        if ( '' === $id || ! preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/', $id) ) {
-            return '';
-        }
-
-        return $id;
     }
 
     private function mergedPresentationStyle(DOMElement $element): string
@@ -2949,44 +2907,6 @@ final class HtmlTransformer
         return $this->attr($element, 'data-prefix') . $value . $this->attr($element, 'data-suffix');
     }
 
-    private function hasClass(DOMElement $element, string $className): bool
-    {
-        return in_array($className, preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array(), true);
-    }
-
-    private function elementSelector(DOMElement $element): string
-    {
-        $parts = array();
-        $current = $element;
-        while ( $current instanceof DOMElement && 'body' !== strtolower($current->tagName) ) {
-            $tagName = strtolower($current->tagName);
-            $index = 1;
-            for ( $sibling = $current->previousSibling; $sibling instanceof DOMNode; $sibling = $sibling->previousSibling ) {
-                if ( $sibling instanceof DOMElement && strtolower($sibling->tagName) === $tagName ) {
-                    ++$index;
-                }
-            }
-            array_unshift($parts, $tagName . ':nth-of-type(' . $index . ')');
-            $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null;
-        }
-
-        return implode(' > ', $parts);
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function htmlAttributes(DOMElement $element): array
-    {
-        $attributes = array();
-        foreach ( $element->attributes ?? array() as $attribute ) {
-            $attributes[$attribute->nodeName] = $attribute->nodeValue ?? '';
-        }
-
-        ksort($attributes);
-        return $attributes;
-    }
-
     /**
      * @return array<string, string>
      */
@@ -3022,19 +2942,6 @@ final class HtmlTransformer
         ), static fn (mixed $value): bool => '' !== $value && array() !== $value);
     }
 
-    /**
-     * @return array<int, string>
-     */
-    private function ancestorTags(DOMElement $element): array
-    {
-        $tags = array();
-        for ( $parent = $element->parentNode; $parent instanceof DOMElement && 'body' !== strtolower($parent->tagName); $parent = $parent->parentNode ) {
-            $tags[] = strtolower($parent->tagName);
-        }
-
-        return $tags;
-    }
-
     private function nearestPreviousHeadingText(DOMElement $element): string
     {
         for ( $node = $element->previousSibling; $node instanceof DOMNode; $node = $node->previousSibling ) {
@@ -3044,14 +2951,6 @@ final class HtmlTransformer
         }
 
         return '';
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function classNames(DOMElement $element): array
-    {
-        return array_values(array_filter(preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array()));
     }
 
     /**
@@ -3198,18 +3097,6 @@ final class HtmlTransformer
         }
 
         return $html;
-    }
-
-    private function childElementCount(DOMElement $element): int
-    {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
     }
 
     /**
@@ -3567,21 +3454,6 @@ final class HtmlTransformer
         };
     }
 
-    private function closestTagName(DOMElement $element): ?string
-    {
-        return $element->parentNode instanceof DOMElement ? strtolower($element->parentNode->tagName) : null;
-    }
-
-    private function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
-    {
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement && strtolower($child->tagName) === $tagName ) {
-                return $child;
-            }
-        }
-        return null;
-    }
-
     private function figureMediaElement(DOMElement $figure, string $tagName): ?DOMElement
     {
         $direct = $this->firstChildElement($figure, $tagName);
@@ -3633,39 +3505,6 @@ final class HtmlTransformer
         }
 
         return $anchor instanceof DOMElement && $this->isImageOnlyAnchor($anchor) ? $anchor : null;
-    }
-
-    private function onlyChildElement(DOMElement $element, string $tagName): ?DOMElement
-    {
-        $match = null;
-        foreach ( $element->childNodes as $child ) {
-            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
-                continue;
-            }
-
-            if ( ! $child instanceof DOMElement || strtolower($child->tagName) !== $tagName || null !== $match ) {
-                return null;
-            }
-
-            $match = $child;
-        }
-
-        return $match;
-    }
-
-    /**
-     * @param array<int, string> $excludedTags
-     */
-    private function innerHtmlWithoutTags(DOMElement $element, array $excludedTags): string
-    {
-        $html = '';
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), $excludedTags, true) ) {
-                continue;
-            }
-            $html .= $element->ownerDocument->saveHTML($child);
-        }
-        return trim($html);
     }
 
     private function citationFromElement(DOMElement $element): string
@@ -3912,16 +3751,6 @@ final class HtmlTransformer
         }
 
         return $items;
-    }
-
-    private function safeFallbackHtml(DOMElement $element): string
-    {
-        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '';
-        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
-        $html = preg_replace('/\s+(?:href|src|xlink:href)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|javascript:[^\s>]+)/i', '', $html) ?? '';
-        $html = preg_replace('/\s+srcdoc\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
-
-        return trim($html);
     }
 
     /**
@@ -4598,48 +4427,6 @@ final class HtmlTransformer
         }
 
         return $safe;
-    }
-
-    /**
-     * @return array{html: string, bytes: int, truncated: bool}
-     */
-    private function boundedFallbackHtml(string $html): array
-    {
-        $bytes = strlen($html);
-        if ( $bytes > 2000 ) {
-            return array(
-                'html'      => substr($html, 0, 2000) . '...',
-                'bytes'     => $bytes,
-                'truncated' => true,
-            );
-        }
-
-        return array(
-            'html'      => $html,
-            'bytes'     => $bytes,
-            'truncated' => false,
-        );
-    }
-
-    /**
-     * @return array{text: string, bytes: int, truncated: bool}
-     */
-    private function boundedFallbackText(string $text): array
-    {
-        $bytes = strlen($text);
-        if ( $bytes > 2000 ) {
-            return array(
-                'text'      => substr($text, 0, 2000) . '...',
-                'bytes'     => $bytes,
-                'truncated' => true,
-            );
-        }
-
-        return array(
-            'text'      => $text,
-            'bytes'     => $bytes,
-            'truncated' => false,
-        );
     }
 
     /**
@@ -5766,18 +5553,6 @@ final class HtmlTransformer
         return (bool) preg_match('/(?:^|[\s_-])(?:split|two[\s_-]?col|media[\s_-]?text|text[\s_-]?media|feature[\s_-]?row|hero[\s_-]?(?:inner|grid|content|layout)|content[\s_-]?grid)(?:$|[\s_-])/', $name);
     }
 
-    private function directElementChildCount(DOMElement $element): int
-    {
-        $count = 0;
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement ) {
-                ++$count;
-            }
-        }
-
-        return $count;
-    }
-
     private function looksLikeDocumentationLayout(DOMElement $element): bool
     {
         $name = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id')));
@@ -6565,20 +6340,6 @@ final class HtmlTransformer
         return implode(' ', $classes);
     }
 
-    private function mergeClassNames(string ...$classNames): string
-    {
-        $classes = array();
-        foreach ( $classNames as $className ) {
-            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
-                if ( '' !== $class && ! in_array($class, $classes, true) ) {
-                    $classes[] = $class;
-                }
-            }
-        }
-
-        return implode(' ', $classes);
-    }
-
     /**
      * @return array<string, mixed>
      */
@@ -6687,15 +6448,6 @@ final class HtmlTransformer
     /**
      * @param array<string, string> $attrs
      */
-    private function htmlAttributeString(array $attrs): string
-    {
-        $html = '';
-        foreach ( $attrs as $name => $value ) {
-            $html .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
-        }
-        return $html;
-    }
-
     /**
      * @return array<int, array<string, string>>
      */

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
+
+use DOMElement;
+use DOMNode;
+
+/**
+ * Shared low-level DOM/HTML/string helpers.
+ *
+ * These are broadly-shared, behavior-neutral utilities (DOM traversal,
+ * selector computation, attribute/class access, bounded/safe HTML extraction,
+ * and label normalization) extracted verbatim from HtmlTransformer so future
+ * decomposition slices can depend on them without dragging HtmlTransformer
+ * along. Pure move: no logic or signature changes.
+ */
+trait DomHelpersTrait
+{
+    private function normalizedNavigationLabel(string $label): string
+    {
+        return trim(preg_replace('/\s+/', ' ', html_entity_decode($this->runtime->stripAllTags($label), ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?? $label);
+    }
+
+    private function innerHtml(DOMElement $element): string
+    {
+        $html = '';
+        foreach ( $element->childNodes as $child ) {
+            $html .= $element->ownerDocument->saveHTML($child);
+        }
+
+        return trim($html);
+    }
+
+    private function innerHtmlPreservingWhitespace(DOMElement $element): string
+    {
+        $html = '';
+        foreach ( $element->childNodes as $child ) {
+            $html .= $element->ownerDocument->saveHTML($child);
+        }
+
+        return $html;
+    }
+
+    private function outerHtml(DOMElement $element): string
+    {
+        return trim($element->ownerDocument->saveHTML($element) ?: '');
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? $element->getAttribute($name) : '';
+    }
+
+    private function safeAnchor(string $id): string
+    {
+        $id = trim($id);
+        if ( '' === $id || ! preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/', $id) ) {
+            return '';
+        }
+
+        return $id;
+    }
+
+    private function hasClass(DOMElement $element, string $className): bool
+    {
+        return in_array($className, preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array(), true);
+    }
+
+    private function elementSelector(DOMElement $element): string
+    {
+        $parts = array();
+        $current = $element;
+        while ( $current instanceof DOMElement && 'body' !== strtolower($current->tagName) ) {
+            $tagName = strtolower($current->tagName);
+            $index = 1;
+            for ( $sibling = $current->previousSibling; $sibling instanceof DOMNode; $sibling = $sibling->previousSibling ) {
+                if ( $sibling instanceof DOMElement && strtolower($sibling->tagName) === $tagName ) {
+                    ++$index;
+                }
+            }
+            array_unshift($parts, $tagName . ':nth-of-type(' . $index . ')');
+            $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null;
+        }
+
+        return implode(' > ', $parts);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function htmlAttributes(DOMElement $element): array
+    {
+        $attributes = array();
+        foreach ( $element->attributes ?? array() as $attribute ) {
+            $attributes[$attribute->nodeName] = $attribute->nodeValue ?? '';
+        }
+
+        ksort($attributes);
+        return $attributes;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function ancestorTags(DOMElement $element): array
+    {
+        $tags = array();
+        for ( $parent = $element->parentNode; $parent instanceof DOMElement && 'body' !== strtolower($parent->tagName); $parent = $parent->parentNode ) {
+            $tags[] = strtolower($parent->tagName);
+        }
+
+        return $tags;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function classNames(DOMElement $element): array
+    {
+        return array_values(array_filter(preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array()));
+    }
+
+    private function childElementCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    private function closestTagName(DOMElement $element): ?string
+    {
+        return $element->parentNode instanceof DOMElement ? strtolower($element->parentNode->tagName) : null;
+    }
+
+    private function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && strtolower($child->tagName) === $tagName ) {
+                return $child;
+            }
+        }
+        return null;
+    }
+
+    private function onlyChildElement(DOMElement $element, string $tagName): ?DOMElement
+    {
+        $match = null;
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement || strtolower($child->tagName) !== $tagName || null !== $match ) {
+                return null;
+            }
+
+            $match = $child;
+        }
+
+        return $match;
+    }
+
+    /**
+     * @param array<int, string> $excludedTags
+     */
+    private function innerHtmlWithoutTags(DOMElement $element, array $excludedTags): string
+    {
+        $html = '';
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), $excludedTags, true) ) {
+                continue;
+            }
+            $html .= $element->ownerDocument->saveHTML($child);
+        }
+        return trim($html);
+    }
+
+    private function safeFallbackHtml(DOMElement $element): string
+    {
+        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '';
+        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace('/\s+(?:href|src|xlink:href)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|javascript:[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace('/\s+srcdoc\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+
+        return trim($html);
+    }
+
+    /**
+     * @return array{html: string, bytes: int, truncated: bool}
+     */
+    private function boundedFallbackHtml(string $html): array
+    {
+        $bytes = strlen($html);
+        if ( $bytes > 2000 ) {
+            return array(
+                'html'      => substr($html, 0, 2000) . '...',
+                'bytes'     => $bytes,
+                'truncated' => true,
+            );
+        }
+
+        return array(
+            'html'      => $html,
+            'bytes'     => $bytes,
+            'truncated' => false,
+        );
+    }
+
+    /**
+     * @return array{text: string, bytes: int, truncated: bool}
+     */
+    private function boundedFallbackText(string $text): array
+    {
+        $bytes = strlen($text);
+        if ( $bytes > 2000 ) {
+            return array(
+                'text'      => substr($text, 0, 2000) . '...',
+                'bytes'     => $bytes,
+                'truncated' => true,
+            );
+        }
+
+        return array(
+            'text'      => $text,
+            'bytes'     => $bytes,
+            'truncated' => false,
+        );
+    }
+
+    private function directElementChildCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    private function mergeClassNames(string ...$classNames): string
+    {
+        $classes = array();
+        foreach ( $classNames as $className ) {
+            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
+                if ( '' !== $class && ! in_array($class, $classes, true) ) {
+                    $classes[] = $class;
+                }
+            }
+        }
+
+        return implode(' ', $classes);
+    }
+
+    private function htmlAttributeString(array $attrs): string
+    {
+        $html = '';
+        foreach ( $attrs as $name => $value ) {
+            $html .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+        return $html;
+    }
+}


### PR DESCRIPTION
Refs #242 — decomposition epic, **slice 2: shared DOM helpers**.

## What
Pure, **behavior-preserving** extraction of 22 broadly-shared low-level helpers out of `src/HtmlToBlocks/HtmlTransformer.php` into a new reusable trait `src/HtmlToBlocks/Support/DomHelpersTrait.php`, which `HtmlTransformer` now `use`s. Slice 1 (#243) showed the big concerns (semantic-parity builders, behavior-loss emitters, style, nav-chrome, runtime islands) were blocked precisely because they depend on these shared utilities. This moves them to a shared home so future slices can extract those concerns without dragging `HtmlTransformer` along.

## Why a trait
A `use`d trait is the lowest-risk, most byte-identical move: PHP inlines trait methods into the using class, so private property/method access (`$this->runtime`, `$this->outerHtml()`, etc.) is unchanged. Method bodies and signatures were moved **verbatim** — no logic changes.

## Helpers moved (22)
DOM traversal/structure: `innerHtml`, `innerHtmlPreservingWhitespace`, `outerHtml`, `innerHtmlWithoutTags`, `closestTagName`, `firstChildElement`, `onlyChildElement`, `childElementCount`, `directElementChildCount`, `ancestorTags`.
Attribute/selector/class access: `attr`, `htmlAttributes`, `elementSelector`, `hasClass`, `classNames`.
String/HTML utilities: `safeAnchor`, `mergeClassNames`, `htmlAttributeString`, `normalizedNavigationLabel`, `safeFallbackHtml`, `boundedFallbackHtml`, `boundedFallbackText`.

Concern-specific code was intentionally left in place for later slices.

## Line-count delta
`HtmlTransformer.php`: **6723 → 6475** (−248). New `DomHelpersTrait.php`: 269 lines.

## Verification — behavior-preserving, zero output change
Baseline (before) and after are **identical**:
- `composer test:canonical` — all contracts passed (before & after)
- `composer parity` — **128 → 128** fixtures passed (before & after)
- full `composer test` green; `php -l` clean on both files

No fixtures were edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)