### PR TITLE
Add Figma responsive frame detection (device hints + sibling groups)

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -1135,6 +1135,9 @@ function matrix_selected_frame_records(array $inspection, array $frameIds): arra
             'score' => $candidate['score'] ?? null,
             'rank' => matrix_candidate_rank($candidate),
             'bucket' => matrix_candidate_bucket($candidate),
+            'device_hint' => $candidate['device_hint'] ?? null,
+            'sibling_group_key' => $candidate['sibling_group_key'] ?? null,
+            'responsive_siblings' => is_array($candidate['responsive_siblings'] ?? null) ? $candidate['responsive_siblings'] : array(),
             'selection_reasons' => matrix_candidate_selection_reasons($candidate),
         );
     }

--- a/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
@@ -43,7 +43,7 @@ final class ScenegraphFrameInspector
 
             $stats = $this->subtreeStats($id, $nodes, $childrenIndex, $statsMemo);
             $dimensions = $this->dimensions($node);
-            $candidates[] = array_filter(
+            $candidates[$id] = array_filter(
                 array(
                     'id'                    => $id,
                     'name'                  => (string) ($node['name'] ?? ''),
@@ -58,10 +58,18 @@ final class ScenegraphFrameInspector
                     'text_count'            => $stats['texts'],
                     'asset_reference_count' => $stats['assets'],
                     'score'                 => $this->score($type, $dimensions, $stats),
+                    'device_hint'           => $this->deviceHint((string) ($node['name'] ?? ''), $dimensions),
+                    'sibling_group_key'     => $this->siblingGroupKey($id, $node, $nodes, $parentIndex),
                 ),
                 static fn (mixed $value): bool => null !== $value
             );
         }
+
+        foreach ( $candidates as $id => $candidate ) {
+            $candidates[$id]['responsive_siblings'] = $this->responsiveSiblings($id, $candidate, $candidates);
+        }
+
+        $candidates = array_values($candidates);
 
         usort(
             $candidates,
@@ -231,6 +239,126 @@ final class ScenegraphFrameInspector
             + ($area > 300000 ? 80 : 0)
             - (($dimensions['height'] ?? 0) > 0 && ($dimensions['height'] ?? 0) < 1500 && $stats['nodes'] > 200 ? 160 : 0)
             - ($area > 0 && $area < 10000 ? 60 : 0);
+    }
+
+    /**
+     * @param array{width: float|null, height: float|null} $dimensions
+     */
+    private function deviceHint(string $name, array $dimensions): string
+    {
+        $normalized = strtolower($name);
+        $width = isset($dimensions['width']) && is_numeric($dimensions['width']) ? (float) $dimensions['width'] : 0.0;
+
+        if ( 1 === preg_match('/\b(mobile|phone|iphone|android)\b/', $normalized) || ($width > 0 && $width < 700) ) {
+            return 'mobile';
+        }
+        if ( 1 === preg_match('/\b(tablet|ipad)\b/', $normalized) || ($width >= 700 && $width < 1100) ) {
+            return 'tablet';
+        }
+        if ( 1 === preg_match('/\b(desktop|web|1440|1512|1728|1920)\b/', $normalized) || $width >= 1100 ) {
+            return 'desktop';
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * @param array<string, mixed>                 $node
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, string>               $parentIndex
+     */
+    private function siblingGroupKey(string $id, array $node, array $nodes, array $parentIndex): string
+    {
+        $page = $this->nearestAncestor($id, array('CANVAS'), $nodes, $parentIndex);
+        $section = $this->nearestAncestor($id, array('SECTION'), $nodes, $parentIndex);
+        $scope = (string) (($section['id'] ?? null) ?: ($page['id'] ?? 'root'));
+
+        return $scope . ':' . $this->normalizedPageName((string) ($node['name'] ?? ''));
+    }
+
+    /**
+     * @param array<string, mixed>                $candidate
+     * @param array<string, array<string, mixed>> $candidates
+     * @return array<int, array<string, mixed>>
+     */
+    private function responsiveSiblings(string $id, array $candidate, array $candidates): array
+    {
+        $siblings = array();
+        $groupKey = (string) ($candidate['sibling_group_key'] ?? '');
+        $deviceHint = (string) ($candidate['device_hint'] ?? 'unknown');
+        $pageId = (string) ($candidate['page']['id'] ?? '');
+        $sectionId = (string) ($candidate['section']['id'] ?? '');
+        $parentId = (string) ($candidate['parent']['id'] ?? '');
+
+        foreach ( $candidates as $siblingId => $sibling ) {
+            if ( $siblingId === $id || ! is_array($sibling) ) {
+                continue;
+            }
+
+            $sameScope = '' !== $groupKey && $groupKey === (string) ($sibling['sibling_group_key'] ?? '');
+            $sameContainer = ('' !== $sectionId && $sectionId === (string) ($sibling['section']['id'] ?? ''))
+                || ('' !== $parentId && $parentId === (string) ($sibling['parent']['id'] ?? ''))
+                || ('' !== $pageId && $pageId === (string) ($sibling['page']['id'] ?? ''));
+            $nameSimilarity = $this->nameSimilarity((string) ($candidate['name'] ?? ''), (string) ($sibling['name'] ?? ''));
+            $siblingDeviceHint = (string) ($sibling['device_hint'] ?? 'unknown');
+
+            if ( ! $sameScope && ( ! $sameContainer || $nameSimilarity < 70 ) ) {
+                continue;
+            }
+
+            $confidence = ($sameScope ? 55 : 0)
+                + ($sameContainer ? 20 : 0)
+                + min(25, max(0, $nameSimilarity - 60))
+                + ('unknown' !== $deviceHint && 'unknown' !== $siblingDeviceHint && $deviceHint !== $siblingDeviceHint ? 15 : 0);
+
+            $siblings[] = array_filter(
+                array(
+                    'id' => (string) ($sibling['id'] ?? $siblingId),
+                    'name' => (string) ($sibling['name'] ?? ''),
+                    'device_hint' => $siblingDeviceHint,
+                    'width' => $sibling['width'] ?? null,
+                    'height' => $sibling['height'] ?? null,
+                    'name_similarity' => $nameSimilarity,
+                    'confidence' => min(100, $confidence),
+                ),
+                static fn (mixed $value): bool => null !== $value
+            );
+        }
+
+        usort(
+            $siblings,
+            static fn (array $left, array $right): int => ((int) ($right['confidence'] ?? 0) <=> (int) ($left['confidence'] ?? 0))
+                ?: strcmp((string) ($left['id'] ?? ''), (string) ($right['id'] ?? ''))
+        );
+
+        return array_slice($siblings, 0, 5);
+    }
+
+    private function normalizedPageName(string $name): string
+    {
+        $normalized = strtolower($name);
+        $normalized = (string) preg_replace('/\b(desktop|mobile|tablet|phone|web|copy|variant|version|v\d+|i\d+)\b/', ' ', $normalized);
+        $normalized = (string) preg_replace('/\b\d{3,4}\s*x\s*\d{3,5}\b/', ' ', $normalized);
+        $normalized = (string) preg_replace('/\b(320|375|390|393|414|428|768|834|1024|1280|1366|1440|1512|1728|1920)\b/', ' ', $normalized);
+        $normalized = trim((string) preg_replace('/[^a-z0-9]+/', '-', $normalized), '-');
+
+        return '' === $normalized ? 'frame' : $normalized;
+    }
+
+    private function nameSimilarity(string $left, string $right): int
+    {
+        $leftName = $this->normalizedPageName($left);
+        $rightName = $this->normalizedPageName($right);
+        if ( $leftName === $rightName ) {
+            return 100;
+        }
+
+        $max = max(strlen($leftName), strlen($rightName));
+        if ( 0 === $max ) {
+            return 0;
+        }
+
+        return (int) round((1 - (levenshtein($leftName, $rightName) / $max)) * 100);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1660,12 +1660,22 @@ $frameInspection = blocks_engine_figma_transformer_inspect_frames_scenegraph(arr
                                 array('id' => 'image:hero', 'type' => 'RECTANGLE', 'name' => 'Hero image', 'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'hero'))),
                             ),
                         ),
+                        array(
+                            'id' => 'frame:home-mobile',
+                            'type' => 'FRAME',
+                            'name' => 'Home Page Mobile',
+                            'width' => 390,
+                            'height' => 1200,
+                            'children' => array(
+                                array('id' => 'text:hero-mobile', 'type' => 'TEXT', 'name' => 'Hero Mobile', 'characters' => 'Hello'),
+                            ),
+                        ),
                     ),
                 ),
             ),
         ),
     ),
-), array('frame_inspection_limit' => 2));
+), array('frame_inspection_limit' => 3));
 $frameInspectionHome = null;
 foreach ( $frameInspection['candidates'] ?? array() as $candidate ) {
     if ( is_array($candidate) && 'frame:home' === ($candidate['id'] ?? null) ) {
@@ -1674,11 +1684,14 @@ foreach ( $frameInspection['candidates'] ?? array() as $candidate ) {
     }
 }
 $assert('blocks-engine/figma-transformer/frame-inspection/v1' === ($frameInspection['schema'] ?? null), 'frame-inspection-schema');
-$assert(2 === ($frameInspection['returned_count'] ?? null), 'frame-inspection-limit');
+$assert(3 === ($frameInspection['returned_count'] ?? null), 'frame-inspection-limit');
 $assert('Page One' === ($frameInspectionHome['page']['name'] ?? null), 'frame-inspection-page-ancestor');
 $assert('Marketing Pages' === ($frameInspectionHome['section']['name'] ?? null), 'frame-inspection-section-ancestor');
 $assert(1 === ($frameInspectionHome['text_count'] ?? null), 'frame-inspection-text-count');
 $assert(1 === ($frameInspectionHome['asset_reference_count'] ?? null), 'frame-inspection-asset-count');
+$assert('desktop' === ($frameInspectionHome['device_hint'] ?? null), 'frame-inspection-desktop-device-hint');
+$assert('frame:home-mobile' === ($frameInspectionHome['responsive_siblings'][0]['id'] ?? null), 'frame-inspection-responsive-sibling-id');
+$assert('mobile' === ($frameInspectionHome['responsive_siblings'][0]['device_hint'] ?? null), 'frame-inspection-responsive-sibling-device-hint');
 
 $matrixWebsiteCandidate = array(
     'id'         => 'matrix:site:home',


### PR DESCRIPTION
Adds responsive frame **detection** to `ScenegraphFrameInspector` — the input contract for responsive emission tracked in #247.

## What this adds

- `deviceHint()` — classifies a frame `mobile`/`tablet`/`desktop` from its name (regex) and width thresholds (<700 / 700–1100 / ≥1100).
- `siblingGroupKey()` + `responsiveSiblings()` — group frames that represent one page at multiple widths.
- `normalizedPageName()` / `nameSimilarity()` — strip `desktop`/`mobile`/`copy`/`v2`/`variant` suffixes so siblings match by base name.

## Scope boundary

Detection only. `device_hint` / `sibling_group_key` / `responsive_siblings` are surfaced on inspected candidates but consumed by nothing yet — `ScenegraphPagePlanner` and `StaticHtmlEmitter` are unchanged. Wiring these into emission (`@media` output, fluid root, per-breakpoint parity) is #247.

This lands the primitive so it stops rotting unmerged and gives the emission work a documented contract to build against.

## Verification

`php tests/contract/run.php` → `Figma Transformer contract tests passed.`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Investigating the responsive gap, verifying contract tests, and authoring this PR + issue #247. The branch code itself was authored in a prior session.