### PR TITLE
Add per-breakpoint parity contract to figma-transformer (#247)

### DIFF
--- a/figma-transformer/README.md
+++ b/figma-transformer/README.md
@@ -141,6 +141,20 @@ Parity report statuses:
 
 Parity runners can attach evidence through the `parity` transform option or the CLI metadata flags. The contract accepts source screenshot URL/path metadata, generated screenshot artifact metadata, diff image artifact metadata, pixel mismatch count/ratio, threshold, viewport, and frame id. The transformer stores those references; it does not fetch, render, compare, or commit screenshot files.
 
+### Per-breakpoint parity
+
+Responsiveness is unfalsifiable when parity is measured at a single width. A runner can supply a `breakpoints` list so one transform records parity for several viewports at once. Each entry uses the same evidence vocabulary as the single-viewport fields — its own viewport (width/height), frame id, source/generated/diff artifact references, pixel mismatch count/ratio, threshold, and status — and is normalized into the same `source` / `generated` / `diff` / `diff_summary` / `metrics` shape inside `breakpoints[]`.
+
+The envelope derives an `aggregate_status` roll-up from the per-breakpoint statuses:
+
+- `pass` only when **every** breakpoint passes.
+- `fail` when **any** breakpoint fails.
+- `not_run` when no breakpoint has run.
+- `pending` when some breakpoints have run but others are still `pending`/`not_run`.
+- `compared` when comparisons completed without a pass/fail verdict.
+
+The list is additive: the top-level single-viewport fields (`status`, `source`, `generated`, `diff`, `viewport`, `metrics`, ...) remain unchanged and authoritative for legacy consumers. When no `breakpoints` are supplied, `breakpoints` is an empty list and `aggregate_status` mirrors the top-level `status`, so existing single-viewport callers are unaffected. The schema string stays `blocks-engine/figma-transformer/parity-report/v1`; the new fields extend the envelope additively rather than bumping the version.
+
 ```php
 $result = blocks_engine_figma_transformer_transform_scenegraph($scenegraph, array(
     'frame_id' => '1:1',
@@ -159,6 +173,45 @@ $result = blocks_engine_figma_transformer_transform_scenegraph($scenegraph, arra
         ),
     ),
 ));
+```
+
+Multi-breakpoint evidence adds a `breakpoints` list; the aggregate roll-up below is `pass` only because both entries pass:
+
+```php
+$result = blocks_engine_figma_transformer_transform_scenegraph($scenegraph, array(
+    'frame_id' => '1:1',
+    'parity' => array(
+        'status' => 'pass',
+        'breakpoints' => array(
+            array(
+                'status' => 'pass',
+                'frame_id' => '1:1',
+                'source_screenshot_url' => 'https://artifacts.example.test/mobile-source.png',
+                'generated_screenshot_url' => 'https://artifacts.example.test/mobile-generated.png',
+                'diff_image_url' => 'https://artifacts.example.test/mobile-diff.png',
+                'pixel_mismatch_count' => 8,
+                'pixel_mismatch_ratio' => 0.004,
+                'threshold' => 0.01,
+                'viewport' => array(
+                    'width' => 375,
+                    'height' => 812,
+                ),
+            ),
+            array(
+                'status' => 'pass',
+                'frame_id' => '1:1',
+                'pixel_mismatch_count' => 12,
+                'pixel_mismatch_ratio' => 0.006,
+                'threshold' => 0.01,
+                'viewport' => array(
+                    'width' => 1200,
+                    'height' => 800,
+                ),
+            ),
+        ),
+    ),
+));
+// $result['parity']['aggregate_status'] === 'pass'
 ```
 
 ```sh

--- a/figma-transformer/src/Parity/ParityReportBuilder.php
+++ b/figma-transformer/src/Parity/ParityReportBuilder.php
@@ -6,6 +6,12 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Parity;
 
 /**
  * Builds the stable parity report envelope from runner-supplied evidence.
+ *
+ * The envelope keeps the original single-viewport fields (`status`, `source`,
+ * `generated`, `diff`, `viewport`, `metrics`, ...) for backward compatibility.
+ * Runners that exercise multiple breakpoints can additionally supply a
+ * `breakpoints` list; each entry is normalized through the same vocabulary as
+ * the single-viewport evidence and rolled up into an `aggregate_status`.
  */
 final class ParityReportBuilder
 {
@@ -20,51 +26,19 @@ final class ParityReportBuilder
      */
     public function build(array $evidence = array(), array $overrides = array()): array
     {
-        $status = (string) ($overrides['status'] ?? $evidence['status'] ?? 'not_run');
-        if ( ! in_array($status, self::KNOWN_STATUSES, true) ) {
-            $status = 'pending';
-        }
-        $reason = (string) ($overrides['reason'] ?? $evidence['reason'] ?? '');
+        $visual = $this->normalizeVisualEvidence($evidence, $overrides);
 
         $artifacts = $this->arrayValue($evidence, 'artifacts');
         $layoutDiagnostics = $this->arrayValue($evidence, 'layout_diagnostics');
         $layoutEvidence = $this->arrayValue($evidence, 'layout_evidence');
         $renderStyleEvidence = $this->arrayValue($evidence, 'render_style_evidence');
-        $source = $this->arrayValue($evidence, 'source');
-        $generated = $this->arrayValue($evidence, 'generated');
-        $diff = $this->nullableArrayValue($evidence, 'diff');
-        $diffSummary = $this->arrayValue($evidence, 'diff_summary');
-        $metrics = $this->arrayValue($evidence, 'metrics');
-        $viewport = $this->arrayValue($evidence, 'viewport');
 
-        $this->copyScalar($evidence, 'source_screenshot_path', $source, 'screenshot_path');
-        $this->copyScalar($evidence, 'source_screenshot_url', $source, 'screenshot_url');
-        $this->copyScalar($evidence, 'source_screenshot_artifact', $source, 'screenshot_artifact');
-        $this->copyBool($evidence, 'source_screenshot_exists', $source, 'screenshot_exists');
-        $this->copyBool($evidence, 'source_screenshot_readable', $source, 'screenshot_readable');
-        $this->copyScalar($evidence, 'generated_screenshot_path', $generated, 'screenshot_path');
-        $this->copyScalar($evidence, 'generated_screenshot_url', $generated, 'screenshot_url');
-        $this->copyScalar($evidence, 'generated_screenshot_artifact', $generated, 'screenshot_artifact');
-        $this->copyBool($evidence, 'generated_screenshot_exists', $generated, 'screenshot_exists');
-        $this->copyBool($evidence, 'generated_screenshot_readable', $generated, 'screenshot_readable');
-        $this->copyScalar($evidence, 'diff_image_path', $diff, 'image_path');
-        $this->copyScalar($evidence, 'diff_image_url', $diff, 'image_url');
-        $this->copyScalar($evidence, 'diff_image_artifact', $diff, 'image_artifact');
-        $this->copyBool($evidence, 'diff_image_exists', $diff, 'image_exists');
-        $this->copyBool($evidence, 'diff_image_readable', $diff, 'image_readable');
         $this->copyScalar($evidence, 'report_path', $artifacts, 'report_path');
         $this->copyScalar($evidence, 'report_artifact', $artifacts, 'report_artifact');
         $this->copyScalar($evidence, 'dom_boxes_path', $artifacts, 'dom_boxes_path');
         $this->copyScalar($evidence, 'layout_report_path', $artifacts, 'layout_report_path');
         $this->copyScalar($evidence, 'layout_mismatch_report_path', $artifacts, 'layout_mismatch_report_path');
         $this->copyScalar($evidence, 'render_evidence_path', $artifacts, 'render_evidence_path');
-        $this->copyScalar($evidence, 'frame_id', $source, 'frame_id');
-        $this->copyScalar($evidence, 'frame_id', $generated, 'frame_id');
-        $this->copyNumeric($evidence, 'pixel_mismatch_count', $diffSummary, 'pixel_mismatch_count');
-        $this->copyNumeric($evidence, 'pixel_mismatch_count', $metrics, 'pixel_mismatch_count');
-        $this->copyNumeric($evidence, 'pixel_mismatch_ratio', $diffSummary, 'pixel_mismatch_ratio');
-        $this->copyNumeric($evidence, 'pixel_mismatch_ratio', $metrics, 'pixel_mismatch_ratio');
-        $this->copyNumeric($evidence, 'threshold', $diffSummary, 'threshold');
         $this->copyNumeric($evidence, 'layout_mismatch_count', $layoutDiagnostics, 'mismatch_count');
 
         if ( isset($evidence['layout_top_nodes']) && is_array($evidence['layout_top_nodes']) ) {
@@ -90,6 +64,86 @@ final class ParityReportBuilder
             );
         }
 
+        $breakpoints = $this->buildBreakpoints($evidence);
+        $aggregateStatus = $this->aggregateStatus($visual['status'], $breakpoints);
+
+        return array(
+            'schema'       => self::SCHEMA,
+            'status'       => $visual['status'],
+            'reason'       => $visual['reason'],
+            'artifacts'    => $artifacts,
+            'source'       => $visual['source'],
+            'generated'    => $visual['generated'],
+            'side_by_side' => $evidence['side_by_side'] ?? null,
+            'diff'         => empty($visual['diff']) ? null : $visual['diff'],
+            'diff_summary' => $visual['diff_summary'],
+            'layout_diagnostics' => $layoutDiagnostics,
+            'layout_evidence' => $layoutEvidence,
+            'render_style_evidence' => $renderStyleEvidence,
+            'visual_pixel_status' => $visual['visual_pixel_status'],
+            'metrics'      => $visual['metrics'],
+            'viewport'     => $visual['viewport'],
+            'breakpoints'  => $breakpoints,
+            'aggregate_status' => $aggregateStatus,
+        );
+    }
+
+    /**
+     * Normalize the screenshot/diff/viewport evidence shared by the
+     * single-viewport envelope and each per-breakpoint entry.
+     *
+     * @param array<string, mixed> $evidence
+     * @param array<string, mixed> $overrides
+     * @return array{
+     *     status: string,
+     *     reason: string,
+     *     source: array<string, mixed>,
+     *     generated: array<string, mixed>,
+     *     diff: array<string, mixed>,
+     *     diff_summary: array<string, mixed>,
+     *     metrics: array<string, mixed>,
+     *     viewport: array<string, mixed>,
+     *     visual_pixel_status: string
+     * }
+     */
+    private function normalizeVisualEvidence(array $evidence, array $overrides = array()): array
+    {
+        $status = (string) ($overrides['status'] ?? $evidence['status'] ?? 'not_run');
+        if ( ! in_array($status, self::KNOWN_STATUSES, true) ) {
+            $status = 'pending';
+        }
+        $reason = (string) ($overrides['reason'] ?? $evidence['reason'] ?? '');
+
+        $source = $this->arrayValue($evidence, 'source');
+        $generated = $this->arrayValue($evidence, 'generated');
+        $diff = $this->nullableArrayValue($evidence, 'diff');
+        $diffSummary = $this->arrayValue($evidence, 'diff_summary');
+        $metrics = $this->arrayValue($evidence, 'metrics');
+        $viewport = $this->arrayValue($evidence, 'viewport');
+
+        $this->copyScalar($evidence, 'source_screenshot_path', $source, 'screenshot_path');
+        $this->copyScalar($evidence, 'source_screenshot_url', $source, 'screenshot_url');
+        $this->copyScalar($evidence, 'source_screenshot_artifact', $source, 'screenshot_artifact');
+        $this->copyBool($evidence, 'source_screenshot_exists', $source, 'screenshot_exists');
+        $this->copyBool($evidence, 'source_screenshot_readable', $source, 'screenshot_readable');
+        $this->copyScalar($evidence, 'generated_screenshot_path', $generated, 'screenshot_path');
+        $this->copyScalar($evidence, 'generated_screenshot_url', $generated, 'screenshot_url');
+        $this->copyScalar($evidence, 'generated_screenshot_artifact', $generated, 'screenshot_artifact');
+        $this->copyBool($evidence, 'generated_screenshot_exists', $generated, 'screenshot_exists');
+        $this->copyBool($evidence, 'generated_screenshot_readable', $generated, 'screenshot_readable');
+        $this->copyScalar($evidence, 'diff_image_path', $diff, 'image_path');
+        $this->copyScalar($evidence, 'diff_image_url', $diff, 'image_url');
+        $this->copyScalar($evidence, 'diff_image_artifact', $diff, 'image_artifact');
+        $this->copyBool($evidence, 'diff_image_exists', $diff, 'image_exists');
+        $this->copyBool($evidence, 'diff_image_readable', $diff, 'image_readable');
+        $this->copyScalar($evidence, 'frame_id', $source, 'frame_id');
+        $this->copyScalar($evidence, 'frame_id', $generated, 'frame_id');
+        $this->copyNumeric($evidence, 'pixel_mismatch_count', $diffSummary, 'pixel_mismatch_count');
+        $this->copyNumeric($evidence, 'pixel_mismatch_count', $metrics, 'pixel_mismatch_count');
+        $this->copyNumeric($evidence, 'pixel_mismatch_ratio', $diffSummary, 'pixel_mismatch_ratio');
+        $this->copyNumeric($evidence, 'pixel_mismatch_ratio', $metrics, 'pixel_mismatch_ratio');
+        $this->copyNumeric($evidence, 'threshold', $diffSummary, 'threshold');
+
         if ( array_key_exists('threshold', $diffSummary) && array_key_exists('pixel_mismatch_ratio', $diffSummary) ) {
             $diffSummary['passed'] = (float) $diffSummary['pixel_mismatch_ratio'] <= (float) $diffSummary['threshold'];
         }
@@ -106,22 +160,101 @@ final class ParityReportBuilder
         $visualPixelStatus = $hasPixelEvidence ? $status : 'not_run';
 
         return array(
-            'schema'       => self::SCHEMA,
-            'status'       => $status,
-            'reason'       => $reason,
-            'artifacts'    => $artifacts,
-            'source'       => $source,
-            'generated'    => $generated,
-            'side_by_side' => $evidence['side_by_side'] ?? null,
-            'diff'         => empty($diff) ? null : $diff,
-            'diff_summary' => $diffSummary,
-            'layout_diagnostics' => $layoutDiagnostics,
-            'layout_evidence' => $layoutEvidence,
-            'render_style_evidence' => $renderStyleEvidence,
+            'status'              => $status,
+            'reason'              => $reason,
+            'source'              => $source,
+            'generated'           => $generated,
+            'diff'                => $diff,
+            'diff_summary'        => $diffSummary,
+            'metrics'             => $metrics,
+            'viewport'            => $viewport,
             'visual_pixel_status' => $visualPixelStatus,
-            'metrics'      => $metrics,
-            'viewport'     => $viewport,
         );
+    }
+
+    /**
+     * Build the per-breakpoint parity entries from runner-supplied evidence.
+     *
+     * @param array<string, mixed> $evidence
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildBreakpoints(array $evidence): array
+    {
+        if ( ! isset($evidence['breakpoints']) || ! is_array($evidence['breakpoints']) ) {
+            return array();
+        }
+
+        $entries = array();
+        foreach ( $evidence['breakpoints'] as $entry ) {
+            if ( ! is_array($entry) ) {
+                continue;
+            }
+            $entries[] = $this->buildBreakpointEntry($entry);
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Normalize a single breakpoint entry into the stable parity vocabulary.
+     *
+     * @param array<string, mixed> $entry
+     * @return array<string, mixed>
+     */
+    private function buildBreakpointEntry(array $entry): array
+    {
+        $visual = $this->normalizeVisualEvidence($entry);
+        $frameId = $visual['source']['frame_id'] ?? ($visual['generated']['frame_id'] ?? null);
+
+        return array(
+            'status'              => $visual['status'],
+            'reason'              => $visual['reason'],
+            'viewport'            => $visual['viewport'],
+            'frame_id'            => $frameId,
+            'source'              => $visual['source'],
+            'generated'           => $visual['generated'],
+            'diff'                => empty($visual['diff']) ? null : $visual['diff'],
+            'diff_summary'        => $visual['diff_summary'],
+            'visual_pixel_status' => $visual['visual_pixel_status'],
+            'metrics'             => $visual['metrics'],
+        );
+    }
+
+    /**
+     * Roll a list of per-breakpoint statuses up into a single aggregate status.
+     *
+     * `pass` requires every breakpoint to pass; any failing breakpoint fails the
+     * aggregate. When no breakpoints are supplied the single-viewport status is
+     * authoritative, preserving the original contract.
+     *
+     * @param array<int, array<string, mixed>> $breakpoints
+     */
+    private function aggregateStatus(string $singleViewportStatus, array $breakpoints): string
+    {
+        if ( empty($breakpoints) ) {
+            return $singleViewportStatus;
+        }
+
+        $statuses = array();
+        foreach ( $breakpoints as $breakpoint ) {
+            $statuses[] = (string) ($breakpoint['status'] ?? 'not_run');
+        }
+
+        if ( in_array('fail', $statuses, true) ) {
+            return 'fail';
+        }
+        $runStatuses = array_filter($statuses, static fn (string $status): bool => 'not_run' !== $status);
+        if ( empty($runStatuses) ) {
+            return 'not_run';
+        }
+        if ( in_array('pending', $statuses, true) || in_array('not_run', $statuses, true) ) {
+            return 'pending';
+        }
+        if ( in_array('compared', $statuses, true) ) {
+            return 'compared';
+        }
+
+        return 'pass';
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2445,6 +2445,82 @@ $assert(false === ($failingParity['diff_summary']['passed'] ?? null), 'parity-fa
 $assert('not_run' === ($notRunParity['status'] ?? null), 'parity-not-run-status');
 $assert('pending' === ($unknownParity['status'] ?? null), 'parity-unknown-status-falls-back-to-pending');
 
+// Single-viewport input remains backward compatible: no breakpoints list, aggregate mirrors status.
+$assert(array() === ($comparedParity['breakpoints'] ?? null), 'parity-single-viewport-no-breakpoints');
+$assert('compared' === ($comparedParity['aggregate_status'] ?? null), 'parity-single-viewport-aggregate-mirrors-status');
+$assert('not_run' === ($notRunParity['aggregate_status'] ?? null), 'parity-not-run-aggregate-mirrors-status');
+
+// Multi-breakpoint envelope: each entry is normalized and rolled up into aggregate_status.
+$multiBreakpointPass = $parityBuilder->build(array(
+    'status'   => 'pass',
+    'frame_id' => '10:0',
+    'breakpoints' => array(
+        array(
+            'status'   => 'pass',
+            'frame_id' => '10:1',
+            'source_screenshot_url'    => 'https://artifacts.example.test/mobile-source.png',
+            'generated_screenshot_url' => 'https://artifacts.example.test/mobile-generated.png',
+            'diff_image_url'           => 'https://artifacts.example.test/mobile-diff.png',
+            'pixel_mismatch_count'     => 8,
+            'pixel_mismatch_ratio'     => 0.004,
+            'threshold'                => 0.01,
+            'viewport'                 => array('width' => 375, 'height' => 812),
+        ),
+        array(
+            'status'   => 'pass',
+            'frame_id' => '10:2',
+            'pixel_mismatch_count' => 12,
+            'pixel_mismatch_ratio' => 0.006,
+            'threshold'            => 0.01,
+            'viewport'             => array('width' => 1200, 'height' => 800),
+        ),
+    ),
+));
+$multiBreakpointFail = $parityBuilder->build(array(
+    'status' => 'compared',
+    'breakpoints' => array(
+        array(
+            'status'               => 'pass',
+            'pixel_mismatch_ratio' => 0.004,
+            'threshold'            => 0.01,
+            'viewport'             => array('width' => 375, 'height' => 812),
+        ),
+        array(
+            'status'               => 'fail',
+            'pixel_mismatch_ratio' => 0.08,
+            'threshold'            => 0.01,
+            'viewport'             => array('width' => 1200, 'height' => 800),
+        ),
+    ),
+));
+$multiBreakpointPending = $parityBuilder->build(array(
+    'status' => 'pending',
+    'breakpoints' => array(
+        array(
+            'status'               => 'pass',
+            'pixel_mismatch_ratio' => 0.004,
+            'threshold'            => 0.01,
+            'viewport'             => array('width' => 375, 'height' => 812),
+        ),
+        array(
+            'status'   => 'not_run',
+            'viewport' => array('width' => 1200, 'height' => 800),
+        ),
+    ),
+));
+
+$assert(2 === count($multiBreakpointPass['breakpoints'] ?? array()), 'parity-breakpoints-count');
+$assert(375 === ($multiBreakpointPass['breakpoints'][0]['viewport']['width'] ?? null), 'parity-breakpoint-viewport-width');
+$assert('10:1' === ($multiBreakpointPass['breakpoints'][0]['frame_id'] ?? null), 'parity-breakpoint-frame-id');
+$assert('https://artifacts.example.test/mobile-source.png' === ($multiBreakpointPass['breakpoints'][0]['source']['screenshot_url'] ?? null), 'parity-breakpoint-source-url');
+$assert('https://artifacts.example.test/mobile-diff.png' === ($multiBreakpointPass['breakpoints'][0]['diff']['image_url'] ?? null), 'parity-breakpoint-diff-url');
+$assert(8 === ($multiBreakpointPass['breakpoints'][0]['metrics']['pixel_mismatch_count'] ?? null), 'parity-breakpoint-pixel-count');
+$assert(true === ($multiBreakpointPass['breakpoints'][0]['diff_summary']['passed'] ?? null), 'parity-breakpoint-passed-threshold');
+$assert('pass' === ($multiBreakpointPass['breakpoints'][1]['status'] ?? null), 'parity-breakpoint-second-pass');
+$assert('pass' === ($multiBreakpointPass['aggregate_status'] ?? null), 'parity-aggregate-all-pass');
+$assert('fail' === ($multiBreakpointFail['aggregate_status'] ?? null), 'parity-aggregate-any-fail');
+$assert('pending' === ($multiBreakpointPending['aggregate_status'] ?? null), 'parity-aggregate-partial-not-run-pending');
+
 if ( function_exists('imagecreatetruecolor') && function_exists('imagepng') ) {
     $sourceImagePath = tempnam(sys_get_temp_dir(), 'figma-source-') . '.png';
     $generatedImagePath = tempnam(sys_get_temp_dir(), 'figma-generated-') . '.png';


### PR DESCRIPTION
## Summary

Implements scope item 4 ("Per-breakpoint parity contract") of #247. Today visual parity is recorded for a single viewport, which makes responsiveness unfalsifiable. This extends `ParityReportBuilder` so a transform can record an array of per-breakpoint parity entries alongside the existing single-viewport fields.

- Each `breakpoints[]` entry carries its own viewport (width/height), frame id, source/generated/diff artifact references, pixel mismatch count/ratio, threshold, and status — normalized through the same evidence vocabulary as the single-viewport shape (shared `normalizeVisualEvidence()` helper).
- A derived `aggregate_status` rolls the per-breakpoint statuses up: `pass` only when every breakpoint passes, `fail` when any fails, and `pending`/`compared`/`not_run` per existing semantics. When no breakpoints are supplied, the list is empty and the aggregate mirrors the top-level `status`.
- Fully backward compatible: top-level single-viewport fields are unchanged and authoritative for legacy consumers.

## Schema versioning

The change is **additive** within the existing `blocks-engine/figma-transformer/parity-report/v1` schema — no fields removed or repurposed, only `breakpoints` and `aggregate_status` added. The package's convention is additive evolution (fields read with `??` defaults, no prior version bumps, no migration mechanism), and a contract test pins the schema string to `v1`. Bumping to `v2` would break that assertion and any `v1`-pinned consumer with no upside, so the version is intentionally held at `v1`.

## Tests

`php tests/contract/run.php` → `Figma Transformer contract tests passed.` Added focused assertions proving the multi-breakpoint envelope (per-entry viewport/frame_id/source/diff/metrics normalization) and the aggregate roll-up behavior (all-pass → `pass`, any-fail → `fail`, partial not-run → `pending`), plus backward-compat assertions that single-viewport input yields an empty `breakpoints` list and a mirrored aggregate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Implementing the per-breakpoint parity contract slice of #247.