### PR TITLE
figma-transformer: PagePlanner responsive-grouping into breakpoint variants (#247 item 1)

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -10,11 +10,60 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
 final class ScenegraphPagePlanner
 {
     public function __construct(
-        private readonly ScenegraphIndex $index = new ScenegraphIndex()
+        private readonly ScenegraphIndex $index = new ScenegraphIndex(),
+        private readonly ScenegraphFrameInspector $frameInspector = new ScenegraphFrameInspector()
     ) {
     }
 
     /**
+     * Build deterministic page plans, collapsing responsive sibling-groups.
+     *
+     * When {@see ScenegraphFrameInspector} reports that several FRAME nodes
+     * represent the same page at different widths (a responsive sibling-group),
+     * those frames collapse into a SINGLE page plan that carries an ordered list
+     * of breakpoint variants instead of emitting one page per frame. Frames with
+     * no detected siblings still produce one single-variant page each, so the
+     * top-level page fields stay backward compatible. If the inspector cannot
+     * determine a group, the planner falls back to one-page-per-frame.
+     *
+     * Each entry in the returned `pages` list has this shape (the contract the
+     * downstream `@media`-aware emitter consumes):
+     *
+     *     array(
+     *         // Primary (widest/desktop) variant drives these page-level fields.
+     *         'frame_id'              => string,   // primary variant frame id
+     *         'name'                  => string,
+     *         'slug'                  => string,   // deduped, derived from primary
+     *         'path'                  => string,   // index.html for the entrypoint
+     *         'entrypoint'            => bool,
+     *         'figma_page_id'         => string|null,
+     *         'figma_page_name'       => string|null,
+     *         'section_id'            => string|null,
+     *         'section_name'          => string|null,
+     *         'width'                 => float|null, // primary variant width
+     *         'height'                => float|null, // primary variant height
+     *         'node_count'            => int,
+     *         'text_count'            => int,
+     *         'asset_reference_count' => int,
+     *         // Responsive grouping contract.
+     *         'responsive'            => bool, // true when more than one variant
+     *         'breakpoint_count'      => int,  // count($variants)
+     *         'variants'              => array<int, array{
+     *             frame_id: string,
+     *             name: string,
+     *             slug: string,           // identity for the variant frame
+     *             device_hint: string,    // desktop|tablet|mobile|unknown
+     *             viewport_width: float|null,
+     *             viewport_height: float|null,
+     *             primary: bool,          // true for the widest/desktop variant
+     *             order: int,             // 0-based, widest first
+     *         }>,
+     *         'diagnostics'           => array<int, array<string, mixed>>,
+     *     )
+     *
+     * Variants are ordered widest-first (desktop, tablet, mobile, unknown), so
+     * `variants[0]` is always the primary that drives the page slug/identity.
+     *
      * @param array<string, mixed> $source Decoded Figma scenegraph source array.
      * @param array<string, mixed> $options Page planning options.
      * @return array<string, mixed>
@@ -86,22 +135,39 @@ final class ScenegraphPagePlanner
             }
         }
 
+        $detectionById = $this->detectionById($source, count($nodes));
+        $responsiveGroups = $this->responsiveGroups($candidates, $detectionById);
+
         $slugs = array();
         $pages = array();
-        foreach ( $selectedIds as $position => $id ) {
-            $candidate = $candidates[$id];
+        $consumed = array();
+        $emittedPosition = 0;
+        foreach ( $selectedIds as $id ) {
+            if ( isset($consumed[$id]) ) {
+                continue;
+            }
+
+            $members = $responsiveGroups[$id] ?? array($id);
+            foreach ( $members as $memberId ) {
+                $consumed[$memberId] = true;
+            }
+
+            $primaryId = $members[0];
+            $candidate = $candidates[$primaryId];
             $node = $candidate['node'];
-            $page = $this->nearestAncestor($id, array('CANVAS'), $nodes, $parentIndex);
-            $section = $this->nearestAncestor($id, array('SECTION'), $nodes, $parentIndex);
-            $name = (string) ($node['name'] ?? $id);
-            $slug = $this->dedupeSlug($this->configuredSlug($id, $slugMap) ?? $this->slugify($name), $slugs);
+            $page = $this->nearestAncestor($primaryId, array('CANVAS'), $nodes, $parentIndex);
+            $section = $this->nearestAncestor($primaryId, array('SECTION'), $nodes, $parentIndex);
+            $name = (string) ($node['name'] ?? $primaryId);
+            $slug = $this->dedupeSlug($this->configuredSlug($primaryId, $slugMap) ?? $this->slugify($name), $slugs);
+            $entrypoint = null !== $entryFrameId ? in_array($entryFrameId, $members, true) : 0 === $emittedPosition;
+            $variants = $this->breakpointVariants($members, $primaryId, $candidates, $detectionById);
 
             $pages[] = array(
-                'frame_id'              => $id,
+                'frame_id'              => $primaryId,
                 'name'                  => $name,
                 'slug'                  => $slug,
-                'path'                  => (null !== $entryFrameId ? $id === $entryFrameId : 0 === $position) ? 'index.html' : $slug . '.html',
-                'entrypoint'            => null !== $entryFrameId ? $id === $entryFrameId : 0 === $position,
+                'path'                  => $entrypoint ? 'index.html' : $slug . '.html',
+                'entrypoint'            => $entrypoint,
                 'figma_page_id'         => $page['id'] ?? null,
                 'figma_page_name'       => $page['name'] ?? null,
                 'section_id'            => $section['id'] ?? null,
@@ -111,8 +177,12 @@ final class ScenegraphPagePlanner
                 'node_count'            => $candidate['stats']['nodes'],
                 'text_count'            => $candidate['stats']['texts'],
                 'asset_reference_count' => $candidate['stats']['assets'],
-                'diagnostics'           => $this->pageDiagnostics($id, $node, $candidate['dimensions'], $explicitSelected),
+                'responsive'            => count($members) > 1,
+                'breakpoint_count'      => count($members),
+                'variants'              => $variants,
+                'diagnostics'           => $this->pageDiagnostics($primaryId, $node, $candidate['dimensions'], $explicitSelected),
             );
+            ++$emittedPosition;
         }
 
         return array(
@@ -142,6 +212,157 @@ final class ScenegraphPagePlanner
         }
 
         return array_values(array_unique(array_filter($ids, static fn (string $id): bool => '' !== $id)));
+    }
+
+    /**
+     * Consume the frame inspector's detection report keyed by frame id.
+     *
+     * Detection (device_hint / sibling_group_key / responsive_siblings) lives in
+     * {@see ScenegraphFrameInspector}; the planner reuses it rather than
+     * re-deriving responsive relationships. The inspection limit is widened so
+     * every candidate's detection survives slicing.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function detectionById(array $source, int $nodeCount): array
+    {
+        $inspection = $this->frameInspector->inspect($source, array('frame_inspection_limit' => max(1, $nodeCount)));
+        $candidates = is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array();
+        $detection = array();
+        foreach ( $candidates as $candidate ) {
+            if ( ! is_array($candidate) ) {
+                continue;
+            }
+            $id = isset($candidate['id']) && is_scalar($candidate['id']) ? (string) $candidate['id'] : '';
+            if ( '' !== $id ) {
+                $detection[$id] = $candidate;
+            }
+        }
+
+        return $detection;
+    }
+
+    /**
+     * Cluster FRAME candidates into responsive sibling-groups.
+     *
+     * Builds connected components over the inspector's `responsive_siblings`
+     * edges (restricted to FRAME ids the planner tracks). Returns a map from
+     * every member frame id to its full, ordered variant list so the page loop
+     * can look up the group from whichever member was selected first.
+     *
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, array<string, mixed>> $detectionById
+     * @return array<string, array<int, string>>
+     */
+    private function responsiveGroups(array $candidates, array $detectionById): array
+    {
+        $parent = array();
+        foreach ( array_keys($candidates) as $id ) {
+            $parent[(string) $id] = (string) $id;
+        }
+
+        $find = static function (string $node) use (&$parent): string {
+            while ( $parent[$node] !== $node ) {
+                $parent[$node] = $parent[$parent[$node]];
+                $node = $parent[$node];
+            }
+
+            return $node;
+        };
+
+        foreach ( array_keys($candidates) as $id ) {
+            $id = (string) $id;
+            $siblings = is_array($detectionById[$id]['responsive_siblings'] ?? null) ? $detectionById[$id]['responsive_siblings'] : array();
+            foreach ( $siblings as $sibling ) {
+                $siblingId = is_array($sibling) && isset($sibling['id']) && is_scalar($sibling['id']) ? (string) $sibling['id'] : '';
+                if ( '' !== $siblingId && isset($parent[$siblingId]) ) {
+                    $parent[$find($id)] = $find($siblingId);
+                }
+            }
+        }
+
+        $components = array();
+        foreach ( array_keys($candidates) as $id ) {
+            $components[$find((string) $id)][] = (string) $id;
+        }
+
+        $groups = array();
+        foreach ( $components as $members ) {
+            $ordered = $this->orderVariantIds($members, $candidates, $detectionById);
+            foreach ( $ordered as $memberId ) {
+                $groups[$memberId] = $ordered;
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Order group members widest-first so the primary variant sorts first.
+     *
+     * @param array<int, string>                  $ids
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, array<string, mixed>> $detectionById
+     * @return array<int, string>
+     */
+    private function orderVariantIds(array $ids, array $candidates, array $detectionById): array
+    {
+        usort(
+            $ids,
+            function (string $left, string $right) use ($candidates, $detectionById): int {
+                $leftWidth = (float) ($candidates[$left]['dimensions']['width'] ?? 0);
+                $rightWidth = (float) ($candidates[$right]['dimensions']['width'] ?? 0);
+                if ( $leftWidth !== $rightWidth ) {
+                    return $rightWidth <=> $leftWidth;
+                }
+
+                $leftRank = $this->deviceRank((string) ($detectionById[$left]['device_hint'] ?? 'unknown'));
+                $rightRank = $this->deviceRank((string) ($detectionById[$right]['device_hint'] ?? 'unknown'));
+
+                return $leftRank <=> $rightRank ?: strcmp($left, $right);
+            }
+        );
+
+        return array_values($ids);
+    }
+
+    private function deviceRank(string $deviceHint): int
+    {
+        return match ( $deviceHint ) {
+            'desktop' => 0,
+            'tablet'  => 1,
+            'mobile'  => 2,
+            default   => 3,
+        };
+    }
+
+    /**
+     * Build the ordered breakpoint-variant list for one page plan.
+     *
+     * @param array<int, string>                  $members Ordered frame ids (widest first).
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, array<string, mixed>> $detectionById
+     * @return array<int, array<string, mixed>>
+     */
+    private function breakpointVariants(array $members, string $primaryId, array $candidates, array $detectionById): array
+    {
+        $variants = array();
+        foreach ( $members as $order => $memberId ) {
+            $candidate = $candidates[$memberId];
+            $name = (string) ($candidate['node']['name'] ?? $memberId);
+            $variants[] = array(
+                'frame_id'        => $memberId,
+                'name'            => $name,
+                'slug'            => $this->slugify($name),
+                'device_hint'     => (string) ($detectionById[$memberId]['device_hint'] ?? 'unknown'),
+                'viewport_width'  => $candidate['dimensions']['width'],
+                'viewport_height' => $candidate['dimensions']['height'],
+                'primary'         => $memberId === $primaryId,
+                'order'           => $order,
+            );
+        }
+
+        return $variants;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -18,6 +18,7 @@ use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiParser;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\ParityReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\VisualAttributionReportBuilder;
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphPagePlanner;
 
 $failures = array();
 
@@ -1738,6 +1739,97 @@ $assert(1 === ($frameInspectionHome['asset_reference_count'] ?? null), 'frame-in
 $assert('desktop' === ($frameInspectionHome['device_hint'] ?? null), 'frame-inspection-desktop-device-hint');
 $assert('frame:home-mobile' === ($frameInspectionHome['responsive_siblings'][0]['id'] ?? null), 'frame-inspection-responsive-sibling-id');
 $assert('mobile' === ($frameInspectionHome['responsive_siblings'][0]['device_hint'] ?? null), 'frame-inspection-responsive-sibling-device-hint');
+
+$responsivePagePlanSource = array(
+    'nodes' => array(
+        array(
+            'id'       => 'page:responsive',
+            'type'     => 'CANVAS',
+            'name'     => 'Responsive Pages',
+            'children' => array(
+                array(
+                    'id'       => 'section:responsive',
+                    'type'     => 'SECTION',
+                    'name'     => 'Marketing',
+                    'width'    => 4000,
+                    'height'   => 5000,
+                    'children' => array(
+                        array(
+                            'id'       => 'frame:home-desktop',
+                            'type'     => 'FRAME',
+                            'name'     => 'Home Page Desktop',
+                            'width'    => 1440,
+                            'height'   => 3200,
+                            'children' => array(
+                                array('id' => 'text:home-desktop', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                            ),
+                        ),
+                        array(
+                            'id'       => 'frame:home-tablet',
+                            'type'     => 'FRAME',
+                            'name'     => 'Home Page Tablet',
+                            'width'    => 834,
+                            'height'   => 3200,
+                            'children' => array(
+                                array('id' => 'text:home-tablet', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                            ),
+                        ),
+                        array(
+                            'id'       => 'frame:home-mobile',
+                            'type'     => 'FRAME',
+                            'name'     => 'Home Page Mobile',
+                            'width'    => 390,
+                            'height'   => 3200,
+                            'children' => array(
+                                array('id' => 'text:home-mobile', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                            ),
+                        ),
+                        array(
+                            'id'       => 'frame:about-desktop',
+                            'type'     => 'FRAME',
+                            'name'     => 'About Page',
+                            'width'    => 1440,
+                            'height'   => 3000,
+                            'children' => array(
+                                array('id' => 'text:about', 'type' => 'TEXT', 'name' => 'About', 'characters' => 'About us'),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$responsivePagePlan = ( new ScenegraphPagePlanner() )->plan($responsivePagePlanSource, array('include_all_pages' => true));
+$responsivePageByFrame = static function (array $plan, string $frameId): ?array {
+    foreach ( $plan['pages'] ?? array() as $page ) {
+        if ( is_array($page) && $frameId === ($page['frame_id'] ?? null) ) {
+            return $page;
+        }
+    }
+
+    return null;
+};
+$responsiveHomePage = $responsivePageByFrame($responsivePagePlan, 'frame:home-desktop');
+$responsiveAboutPage = $responsivePageByFrame($responsivePagePlan, 'frame:about-desktop');
+$assert(4 === ($responsivePagePlan['candidate_count'] ?? null), 'page-plan-responsive-candidate-count');
+$assert(2 === ($responsivePagePlan['page_count'] ?? null), 'page-plan-responsive-collapses-to-two-pages');
+$assert(null !== $responsiveHomePage, 'page-plan-responsive-home-primary-is-desktop');
+$assert(true === ($responsiveHomePage['responsive'] ?? null), 'page-plan-responsive-home-flagged-responsive');
+$assert(3 === ($responsiveHomePage['breakpoint_count'] ?? null), 'page-plan-responsive-home-three-breakpoints');
+$assert('home-page-desktop' === ($responsiveHomePage['slug'] ?? null), 'page-plan-responsive-primary-drives-slug');
+$assert(array('frame:home-desktop', 'frame:home-tablet', 'frame:home-mobile')
+    === array_map(static fn (array $variant): string => (string) ($variant['frame_id'] ?? ''), $responsiveHomePage['variants'] ?? array()), 'page-plan-responsive-variants-ordered-widest-first');
+$assert(array('desktop', 'tablet', 'mobile')
+    === array_map(static fn (array $variant): string => (string) ($variant['device_hint'] ?? ''), $responsiveHomePage['variants'] ?? array()), 'page-plan-responsive-variant-device-hints');
+$assert(true === ($responsiveHomePage['variants'][0]['primary'] ?? null)
+    && false === ($responsiveHomePage['variants'][1]['primary'] ?? null)
+    && false === ($responsiveHomePage['variants'][2]['primary'] ?? null), 'page-plan-responsive-only-widest-is-primary');
+$assert(1440.0 === ($responsiveHomePage['variants'][0]['viewport_width'] ?? null)
+    && 390.0 === ($responsiveHomePage['variants'][2]['viewport_width'] ?? null), 'page-plan-responsive-variant-viewport-widths');
+$assert(null !== $responsiveAboutPage, 'page-plan-responsive-about-stays-its-own-page');
+$assert(false === ($responsiveAboutPage['responsive'] ?? null) && 1 === ($responsiveAboutPage['breakpoint_count'] ?? null), 'page-plan-non-responsive-frame-single-variant');
+$assert(1 === count($responsiveAboutPage['variants'] ?? array()) && 'frame:about-desktop' === ($responsiveAboutPage['variants'][0]['frame_id'] ?? null), 'page-plan-non-responsive-frame-self-variant');
 
 $matrixWebsiteCandidate = array(
     'id'         => 'matrix:site:home',


### PR DESCRIPTION
## Summary

Foundational slice 1 of #247 (responsive emission for the Figma transformer): the **PagePlanner now consumes the responsive detection** that `ScenegraphFrameInspector` already surfaces (`device_hint`, `sibling_group_key`, `responsive_siblings`) and collapses a responsive sibling-group — multiple FRAME nodes representing the same page at different widths — into a **single page plan that carries N ordered breakpoint variants**, instead of emitting one page per frame.

### Output shape (the contract the emitter will consume)

Each grouped page keeps its existing top-level fields (now sourced from the **primary/widest variant**, which drives the page slug/identity) and adds:

```php
'responsive'       => bool,  // true when more than one variant
'breakpoint_count' => int,
'variants'         => array<int, array{
    frame_id, name, slug,
    device_hint,        // desktop|tablet|mobile|unknown
    viewport_width, viewport_height,
    primary,            // true for the widest/desktop variant
    order,              // 0-based, widest first
}>,
```

Variants are ordered **widest-first** (desktop → tablet → mobile → unknown), so `variants[0]` is always the primary. The new shape is fully documented in the `plan()` docblock so the future `@media`-aware emitter (#247 item 2) has a clear, deterministic contract.

### Behavior

- Responsive sibling-group → **one page** with ordered breakpoint variants.
- Frames with no detected siblings → **one single-variant page each** (top-level fields unchanged, backward compatible).
- Grouping is built as connected components over the inspector's `responsive_siblings` edges (restricted to FRAME candidates the planner tracks); if grouping cannot be determined it **falls back to one-page-per-frame**.
- Detection logic is **consumed, not reinvented** — the inspector remains the single source of responsive detection.

### Tests

Added focused contract assertions in `tests/contract/run.php` proving a 3-frame (desktop/tablet/mobile) sibling-group collapses to one page with ordered variants (real behavior, not shape-only), while a sibling non-responsive frame stays its own single-variant page. `php tests/contract/run.php` prints `Figma Transformer contract tests passed.`

## Stacking

This PR is **STACKED on #248** (the detection branch `cook/figma-selection-responsive`) and targets that branch as its base. It should merge **after** #248. Detection (#248) surfaces the signals; this PR is the first consumer. The emitter that turns these variants into `@media` blocks is a later wave of #247 and is intentionally untouched here.

Refs #247.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Implementing the PagePlanner responsive-grouping slice of #247 (stacked on #248).