### PR TITLE
Render Figma page roots as centered fluid containers

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -795,8 +795,6 @@ final class FigmaTransformer
         $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'placeholders' => 0, 'placeholder_nodes' => array(), 'placeholder_reasons' => array());
         $layout = array(
             'large_negative_left_count' => 0,
-            'fixed_root_width_count' => 0,
-            'fixed_root_width_nodes' => array(),
             'large_absolute_offset_count' => 0,
             'large_absolute_offset_nodes' => array(),
             'decorative_underlays' => array('count' => 0, 'nodes' => array()),
@@ -885,13 +883,7 @@ final class FigmaTransformer
 
             $pageLayout = is_array($diagnostics['layout'] ?? null) ? $diagnostics['layout'] : array();
             $layout['large_negative_left_count'] += (int) ($pageLayout['large_negative_left_count'] ?? 0);
-            $layout['fixed_root_width_count'] += (int) ($pageLayout['fixed_root_width_count'] ?? 0);
             $layout['large_absolute_offset_count'] += (int) ($pageLayout['large_absolute_offset_count'] ?? 0);
-            foreach ( is_array($pageLayout['fixed_root_width_nodes'] ?? null) ? $pageLayout['fixed_root_width_nodes'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $layout['fixed_root_width_nodes'][] = array_merge($pageContext, $item);
-                }
-            }
             foreach ( is_array($pageLayout['large_absolute_offset_nodes'] ?? null) ? $pageLayout['large_absolute_offset_nodes'] : array() as $item ) {
                 if ( is_array($item) ) {
                     $layout['large_absolute_offset_nodes'][] = array_merge($pageContext, $item);
@@ -1040,14 +1032,6 @@ final class FigmaTransformer
         if ( ! empty($layout['large_negative_left_count']) ) {
             $signals[] = array('severity' => 'warning', 'code' => 'off_canvas_left_css', 'count' => (int) $layout['large_negative_left_count']);
         }
-        if ( ! empty($layout['fixed_root_width_count']) ) {
-            $signals[] = array(
-                'severity' => 'warning',
-                'code' => 'fixed_root_width',
-                'count' => (int) $layout['fixed_root_width_count'],
-                'sample_nodes' => array_slice(is_array($layout['fixed_root_width_nodes'] ?? null) ? $layout['fixed_root_width_nodes'] : array(), 0, 10),
-            );
-        }
         if ( ! empty($layout['large_absolute_offset_count']) ) {
             $signals[] = array(
                 'severity' => 'warning',
@@ -1114,7 +1098,6 @@ final class FigmaTransformer
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
                 'render_style_mismatch_count' => (int) ($layout['render_style_mismatch_count'] ?? 0),
                 'render_style_mismatch_status' => (string) ($layout['render_style_mismatch_status'] ?? 'not_run'),
-                'fixed_root_width_count' => (int) ($layout['fixed_root_width_count'] ?? 0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
                 'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -9,6 +9,15 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
  */
 final class StaticHtmlEmitter
 {
+    /**
+     * Minimum intrinsic width (px) at which a page root frame is rendered as a
+     * centered fluid container instead of a fixed canvas width. Roots at least
+     * this wide are treated as full-page desktop canvases that must fit the
+     * viewport; narrower roots are typically embedded components and keep their
+     * intrinsic size.
+     */
+    private const FLUID_ROOT_MIN_WIDTH = 1024.0;
+
     private const MAX_RAW_SVG_PATH_DATA_BYTES = 20000;
     private const MAX_DECODED_FIGMA_SVG_PATH_DATA_BYTES = 4194304;
     private const EXTERNAL_VECTOR_SVG_BYTES = 65536;
@@ -57,7 +66,7 @@ final class StaticHtmlEmitter
             'html{box-sizing:border-box}',
             '*,*::before,*::after{box-sizing:inherit}',
             'body{margin:0}',
-            '.figma-root{position:relative;min-width:100%;width:max-content}',
+            '.figma-root{position:relative;width:100%}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -165,7 +174,7 @@ final class StaticHtmlEmitter
             'html{box-sizing:border-box}',
             '*,*::before,*::after{box-sizing:inherit}',
             'body{margin:0}',
-            '.figma-root{position:relative;min-width:100%;width:max-content}',
+            '.figma-root{position:relative;width:100%}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -742,8 +751,6 @@ final class StaticHtmlEmitter
         );
         $layout = array(
             'large_negative_left_count' => preg_match_all('/left:-[0-9]{3,}/', $css),
-            'fixed_root_width_count'    => 0,
-            'fixed_root_width_nodes'    => array(),
             'large_absolute_offset_count' => 0,
             'large_absolute_offset_nodes' => array(),
             'decorative_underlays'      => array(
@@ -766,7 +773,6 @@ final class StaticHtmlEmitter
         $vectors['placeholder_nodes'] = array_values($vectors['placeholder_nodes']);
         $layout['decorative_underlays']['nodes'] = array_values($layout['decorative_underlays']['nodes']);
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
-        $layout['fixed_root_width_nodes'] = array_values($layout['fixed_root_width_nodes']);
         $layout['large_absolute_offset_nodes'] = array_values($layout['large_absolute_offset_nodes']);
         $layout['image_heavy_landmark_candidates'] = array_values($layout['image_heavy_landmark_candidates']);
         $generatedSvgAssets = $this->generatedSvgAssetDiagnostics($assetFiles);
@@ -839,14 +845,6 @@ final class StaticHtmlEmitter
                 'count' => (int) $layout['large_negative_left_count'],
             );
         }
-        if ( ! empty($layout['fixed_root_width_count']) ) {
-            $signals[] = array(
-                'severity' => 'warning',
-                'code' => 'fixed_root_width',
-                'count' => (int) $layout['fixed_root_width_count'],
-                'sample_nodes' => array_slice(is_array($layout['fixed_root_width_nodes'] ?? null) ? $layout['fixed_root_width_nodes'] : array(), 0, 10),
-            );
-        }
         if ( ! empty($layout['large_absolute_offset_count']) ) {
             $signals[] = array(
                 'severity' => 'warning',
@@ -913,7 +911,6 @@ final class StaticHtmlEmitter
                 'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
-                'fixed_root_width_count' => (int) ($layout['fixed_root_width_count'] ?? 0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
                 'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
@@ -1090,17 +1087,6 @@ final class StaticHtmlEmitter
         ++$image['total_node_count'];
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
-        $nodeLayout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-
-        if ( null === $parentNode && isset($box['width']) && is_numeric($box['width']) && (float) $box['width'] >= 1024.0 && 'FILL' !== strtoupper((string) ($nodeLayout['sizing_horizontal'] ?? '')) ) {
-            ++$layout['fixed_root_width_count'];
-            $layout['fixed_root_width_nodes'][] = array(
-                'node_id' => (string) ($node['id'] ?? ''),
-                'name'    => (string) ($node['name'] ?? ''),
-                'type'    => strtoupper((string) ($node['type'] ?? '')),
-                'width'   => $this->reportNumericValue($box['width'] ?? null),
-            );
-        }
 
         if ( null !== $parentNode ) {
             $offset = $this->largeAbsoluteOffsetDiagnostic($node, $parentNode);
@@ -1436,9 +1422,20 @@ final class StaticHtmlEmitter
             } elseif ( 'FILL' === $sizing ) {
                 $styles[] = $dimension . ':100%';
             } elseif ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
-                $property = $dimension;
-                $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
-                $styles[] = $property . ':' . $this->number($value) . 'px';
+                if ( 'width' === $dimension && null === $parentNode && (float) $box['width'] >= self::FLUID_ROOT_MIN_WIDTH ) {
+                    // Page root: centered fluid container. width:100% lets it shrink
+                    // below the design width without forcing horizontal scroll, while
+                    // max-width pins the intrinsic frame width so rendering stays
+                    // pixel-faithful at and above the native canvas size.
+                    $styles[] = 'width:100%';
+                    $styles[] = 'max-width:' . $this->number((float) $box['width']) . 'px';
+                    $styles[] = 'margin-left:auto';
+                    $styles[] = 'margin-right:auto';
+                } else {
+                    $property = $dimension;
+                    $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
+                    $styles[] = $property . ':' . $this->number($value) . 'px';
+                }
             }
         }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -190,7 +190,7 @@ $assert(str_contains($html, '<h2 class="figma-node-1-2-hero-title"'), 'title-emi
 $assert(str_contains($html, '<div class="figma-node-1-3-cards-group"'), 'group-emits-div');
 $assert(! str_contains($html, '<FRAME') && ! str_contains($html, '<GROUP') && ! str_contains($html, '<TEXT') && ! str_contains($html, '<RECTANGLE'), 'html-avoids-custom-tags');
 $assert(! str_contains($html, 'cdn.example.com') && ! str_contains($css, 'cdn.example.com'), 'html-css-avoid-external-cdn');
-$assert(str_contains($css, '.figma-node-1-1-hero-section{width:1200px;height:600px;background:#ffffff;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;padding-top:40px;padding-right:32px;padding-bottom:40px;padding-left:32px;gap:24px}'), 'css-frame-layout-style');
+$assert(str_contains($css, '.figma-node-1-1-hero-section{width:100%;max-width:1200px;margin-left:auto;margin-right:auto;height:600px;background:#ffffff;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;padding-top:40px;padding-right:32px;padding-bottom:40px;padding-left:32px;gap:24px}'), 'css-frame-layout-style');
 $assert(str_contains($css, '.figma-node-1-2-hero-title{font-size:48px;font-weight:700;color:#1a334d;flex-shrink:0}'), 'css-text-style');
 $assert(str_contains($css, '.figma-node-1-4-hero-image-rectangle{width:320px;height:180px;position:absolute;left:10px;top:20px;background:#ff0000;background-image:url("assets/hero-image.svg")'), 'css-rectangle-asset-style');
 $assert(str_contains($css, '.figma-node-1-5-nested-image-paint{') && str_contains($css, 'background-image:url("assets/fixture-photo.jpg")'), 'css-nested-image-hash-asset-style');
@@ -237,7 +237,9 @@ $assert(str_contains((string) file_get_contents($cliOutputRoot . '/artifact/styl
 $assert(str_contains($html, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"'), 'html-vector-blob-svg');
 $assert(str_contains($html, 'd="M0 0L10 0 10 10Z"'), 'html-vector-blob-path');
 $assert(str_contains($css, 'body{margin:0}'), 'css-static-page-body-shell');
-$assert(str_contains($css, '.figma-root{position:relative;min-width:100%;width:max-content}'), 'css-static-page-root-shell');
+$assert(str_contains($css, '.figma-root{position:relative;width:100%}'), 'css-static-page-root-shell');
+$assert(! str_contains($css, 'width:max-content'), 'css-static-page-root-shell-not-fixed-canvas');
+$assert(str_contains($css, '.figma-node-1-1-hero-section{width:100%;max-width:1200px;margin-left:auto;margin-right:auto;'), 'css-page-root-frame-is-centered-fluid');
 $assert(! str_contains($css, 'overflow-x:hidden'), 'css-preserves-horizontal-scroll');
 $assert(! str_contains($css, 'order:'), 'css-avoids-source-order');
 $assert(! str_contains($css, 'font-family:Inter') && ! str_contains($css, 'body{margin:0;background') && ! str_contains($css, 'body{margin:0;color'), 'css-avoids-hardcoded-theme-style');
@@ -311,14 +313,14 @@ $qualityDiagnosticsResult = blocks_engine_figma_transformer_transform_scenegraph
     ),
 ));
 $qualitySignalCodes = $artifactQualitySignalCodes($qualityDiagnosticsResult);
-$assert(in_array('fixed_root_width', $qualitySignalCodes, true), 'quality-diagnostics-fixed-root-width');
+$assert(! in_array('fixed_root_width', $qualitySignalCodes, true), 'quality-diagnostics-fixed-root-width-retired');
+$qualityCss = $fileContent($qualityDiagnosticsResult, 'style.css');
+$assert(str_contains($qualityCss, '.figma-node-quality-root-desktop-fixed-root{width:100%;max-width:1440px;margin-left:auto;margin-right:auto;'), 'quality-diagnostics-root-renders-fluid');
 $assert(in_array('large_absolute_offsets', $qualitySignalCodes, true), 'quality-diagnostics-large-absolute-offsets');
 $assert(in_array('image_heavy_landmark_candidate', $qualitySignalCodes, true), 'quality-diagnostics-image-heavy-landmark');
 $assert(in_array('excessive_image_blocks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-image-blocks');
 $assert(in_array('excessive_vector_image_fallbacks', $qualitySignalCodes, true), 'quality-diagnostics-excessive-vector-fallbacks');
-$fixedRootWidthSignal = $artifactQualitySignal($qualityDiagnosticsResult, 'fixed_root_width');
 $largeOffsetSignal = $artifactQualitySignal($qualityDiagnosticsResult, 'large_absolute_offsets');
-$assert('quality:root' === ($fixedRootWidthSignal['sample_nodes'][0]['node_id'] ?? null), 'quality-diagnostics-fixed-root-width-sample-node');
 $assert('quality:offcanvas' === ($largeOffsetSignal['sample_nodes'][0]['node_id'] ?? null), 'quality-diagnostics-large-absolute-offset-sample-node');
 $assert('quality:root' === ($largeOffsetSignal['sample_nodes'][0]['parent_id'] ?? null), 'quality-diagnostics-large-absolute-offset-sample-parent');
 $assert('needs_review' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-status-needs-review');
@@ -469,8 +471,8 @@ $offsetPageCss = $fileContent($offsetPageResult, 'style.css');
 $assert('success' === ($offsetPageResult['status'] ?? null), 'offset-page-transform-success');
 $assert(str_contains($offsetPageHtml, 'Selected page content'), 'offset-page-selected-content-rendered');
 $assert(! str_contains($offsetPageHtml, 'Off Canvas One') && ! str_contains($offsetPageHtml, 'Off Canvas Two'), 'offset-page-off-canvas-siblings-omitted');
-$assert(str_contains($offsetPageCss, '.figma-root{position:relative;min-width:100%;width:max-content}'), 'offset-page-root-expands-to-frame-width');
-$assert(str_contains($offsetPageCss, '.figma-node-frame-selected-selected-website-page{width:1440px;height:900px;position:relative}'), 'offset-page-root-keeps-frame-width');
+$assert(str_contains($offsetPageCss, '.figma-root{position:relative;width:100%}'), 'offset-page-root-shell-is-fluid');
+$assert(str_contains($offsetPageCss, '.figma-node-frame-selected-selected-website-page{width:100%;max-width:1440px;margin-left:auto;margin-right:auto;height:900px;position:relative}'), 'offset-page-root-renders-fluid-centered');
 $assert(str_contains($offsetPageCss, '.figma-node-frame-selected-card-hero-card{width:320px;height:160px;position:absolute;left:40px;top:40px}'), 'offset-page-child-rebased-position');
 $assert(! str_contains($offsetPageCss, 'left:3497px') && ! str_contains($offsetPageCss, 'left:3537px') && ! str_contains($offsetPageCss, 'left:4680px'), 'offset-page-avoids-board-left-values');
 
@@ -3182,7 +3184,7 @@ $fixedRootFlexResult = blocks_engine_figma_transformer_transform_scenegraph(arra
     ),
 ));
 $fixedRootFlexCss = $fileContent($fixedRootFlexResult, 'style.css');
-$assert(str_contains($fixedRootFlexCss, '.figma-node-fixed-root-flex-fixed-root-flex{width:1280px;height:100px;display:flex;flex-direction:column}'), 'fixed-root-flex-emits-fixed-height');
+$assert(str_contains($fixedRootFlexCss, '.figma-node-fixed-root-flex-fixed-root-flex{width:100%;max-width:1280px;margin-left:auto;margin-right:auto;height:100px;display:flex;flex-direction:column}'), 'fixed-root-flex-emits-fixed-height');
 $assert(! str_contains($fixedRootFlexCss, '.figma-node-fixed-root-flex-fixed-root-flex{width:1280px;min-height:100px'), 'fixed-root-flex-does-not-emit-min-height');
 
 $fixedPaddingClampResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -3206,7 +3208,7 @@ $fixedPaddingClampResult = blocks_engine_figma_transformer_transform_scenegraph(
 ));
 $fixedPaddingClampCss = $fileContent($fixedPaddingClampResult, 'style.css');
 $fixedPaddingClampCopy = $findVisualNode($fixedPaddingClampResult, 'padding:copy');
-$assert(str_contains($fixedPaddingClampCss, '.figma-node-padding-frame-impossible-fixed-padding{width:1280px;height:100px;display:flex;flex-direction:column;padding-top:50px;padding-bottom:50px}'), 'fixed-padding-clamped-css');
+$assert(str_contains($fixedPaddingClampCss, '.figma-node-padding-frame-impossible-fixed-padding{width:100%;max-width:1280px;margin-left:auto;margin-right:auto;height:100px;display:flex;flex-direction:column;padding-top:50px;padding-bottom:50px}'), 'fixed-padding-clamped-css');
 $assert(50.0 === ($fixedPaddingClampCopy['rect']['y'] ?? null), 'fixed-padding-clamped-visual-map');
 
 $stylePaintResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary

Part of #247 (figma-transformer responsive emission) — scope item 3, "Fluid root container."

The static HTML emitter previously shipped the page root as a fixed canvas render: `.figma-root{position:relative;min-width:100%;width:max-content}` wrapping a root frame styled `width:Npx`. On viewports narrower than the design this forced horizontal scroll, and a `fixed_root_width` diagnostic flagged root frames >=1024px wide that were not FILL-sized.

This PR renders desktop-canvas page roots (intrinsic width >= 1024px) as **centered fluid containers**:

- The root frame now emits `width:100%;max-width:<intrinsic>px;margin-left:auto;margin-right:auto` instead of a fixed `width:Npx`. It shrinks to fit narrow viewports (no root-driven horizontal scroll) while `max-width` keeps rendering pixel-faithful at and above the native canvas width, and `margin:auto` centers it on wider viewports.
- The `.figma-root` shell is simplified to `position:relative;width:100%` in both emit paths (`emit` and `emitSite`).
- Roots narrower than 1024px are treated as embedded components and keep their intrinsic size (no behavior change).

Because the `fixed_root_width` smell flagged exactly the fixed-width canvas roots this change eliminates, the now-obsolete diagnostic and its plumbing are removed from `StaticHtmlEmitter` and the site-level aggregator in `FigmaTransformer`.

## Tests

Contract tests updated to assert the fluid, centered root behavior (root shell, root frame CSS, and that the retired `fixed_root_width` signal no longer fires), plus a focused assertion that the page-root frame renders centered/fluid. `php tests/contract/run.php` prints `Figma Transformer contract tests passed.`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Implementing the fluid root container slice of #247.