### PR TITLE
Add standalone subtree classifier module (Refs #497)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -45,8 +45,10 @@
       "php tests/contract/runtime-no-wordpress.php",
       "php tests/contract/runtime-wordpress-stubs.php",
       "php tests/contract/plugin-bootstrap.php",
-      "php tests/contract/run.php"
+      "php tests/contract/run.php",
+      "@test:unit"
     ],
+    "test:unit": "php tests/unit/subtree-classifier.php",
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",
     "test:migration:legacy-parity": "BLOCKS_ENGINE_PARITY_LEGACY=1 php tests/parity/run.php --migration-comparison",

--- a/php-transformer/src/HtmlToBlocks/Classification/ClassificationContext.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/ClassificationContext.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification;
+
+/**
+ * Immutable input context for {@see SubtreeClassifier}.
+ *
+ * Carries the non-DOM evidence associated with a source subtree: the CSS rules
+ * declared for it (or its scope) and any JavaScript / handler source linked to
+ * it. Ancestry is derived directly from the {@see \DOMElement} passed to the
+ * classifier, but callers may supply an explicit ancestor-tag list when the
+ * element has been detached from its original document.
+ *
+ * The classifier consumes this as opaque text and extracts only GENERIC
+ * structural signals (no site- or fixture-specific strings), so callers can
+ * populate it from whatever CSS/JS association the pipeline already computes.
+ */
+final class ClassificationContext
+{
+    /**
+     * @param string             $cssText      CSS rules declared for / scoped to the subtree.
+     * @param string             $jsText       JavaScript / handler source associated with the subtree.
+     * @param array<int, string> $ancestorTags Optional explicit ancestor tag names (outermost-last not required);
+     *                                         used only when the element is detached from its document.
+     */
+    public function __construct(
+        private readonly string $cssText = '',
+        private readonly string $jsText = '',
+        private readonly array $ancestorTags = array()
+    ) {
+    }
+
+    public function cssText(): string
+    {
+        return $this->cssText;
+    }
+
+    public function jsText(): string
+    {
+        return $this->jsText;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function explicitAncestorTags(): array
+    {
+        return $this->ancestorTags;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Classification/ClassificationResult.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/ClassificationResult.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification;
+
+/**
+ * Immutable classification verdict produced by {@see SubtreeClassifier}.
+ *
+ * `bucket` is one of the {@see SubtreeClassifier} BUCKET_* constants, `confidence`
+ * is a 0..1 score, and `signals` is the structural evidence (booleans, counts and
+ * per-bucket scores) that drove the verdict — surfaced purely for diagnostics.
+ */
+final class ClassificationResult
+{
+    /**
+     * @param array<string, mixed> $signals
+     */
+    public function __construct(
+        private readonly string $bucket,
+        private readonly float $confidence,
+        private readonly array $signals = array()
+    ) {
+    }
+
+    public function bucket(): string
+    {
+        return $this->bucket;
+    }
+
+    public function confidence(): float
+    {
+        return $this->confidence;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function signals(): array
+    {
+        return $this->signals;
+    }
+
+    public function is(string $bucket): bool
+    {
+        return $this->bucket === $bucket;
+    }
+
+    /**
+     * @return array{bucket: string, confidence: float, signals: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return array(
+            'bucket'     => $this->bucket,
+            'confidence' => $this->confidence,
+            'signals'    => $this->signals,
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Classification/SubtreeClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/SubtreeClassifier.php
@@ -1,0 +1,480 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
+use DOMElement;
+
+/**
+ * Coarse, structural classifier for source subtrees (issue #497).
+ *
+ * Given a {@see DOMElement} subtree plus its {@see ClassificationContext} (declared
+ * CSS, associated JS, ancestry), it returns the fundamental BUCKET the subtree
+ * represents. This is the layer ABOVE the recognizers: it decides *what a thing
+ * is* (presentation vs content unit vs application vs site-wide functionality) so
+ * downstream routing (theme vs companion plugin, native-vs-carry) can be correct.
+ * It does NOT duplicate recognizer-level conversion logic.
+ *
+ * Design principles:
+ *  - GENERIC structural signals only — no fixture/site-specific strings.
+ *  - Conservative and confidence-scored: when evidence is weak or conflicting it
+ *    returns {@see self::BUCKET_UNKNOWN} (low confidence) so the caller can fall
+ *    back to `core/html` + a diagnostic rather than misclassify.
+ *  - Pure: no I/O, no global state; the same inputs always yield the same verdict.
+ *
+ * This module is intentionally standalone and is NOT wired into the conversion
+ * flow yet; wiring lands as a follow-up after the HtmlTransformer decomposition
+ * (#242). See PR for issue #497.
+ */
+final class SubtreeClassifier
+{
+    use DomHelpersTrait;
+
+    public const BUCKET_THEME_PRESENTATION = 'theme_presentation';
+    public const BUCKET_CUSTOM_BLOCK       = 'custom_block';
+    public const BUCKET_CUSTOM_APPLICATION = 'custom_application';
+    public const BUCKET_CUSTOM_PLUGIN      = 'custom_plugin';
+    public const BUCKET_UNKNOWN            = 'unknown';
+
+    /**
+     * Minimum winning score for a confident verdict; below this we stay UNKNOWN.
+     */
+    private const MIN_SCORE = 2.0;
+
+    /**
+     * Minimum lead a winner must have over the runner-up; ties stay UNKNOWN.
+     */
+    private const MIN_MARGIN = 1.5;
+
+    private const INTERACTIVE_ROLES = array(
+        'tablist',
+        'tab',
+        'tabpanel',
+        'dialog',
+        'menu',
+        'menubar',
+        'combobox',
+        'listbox',
+        'slider',
+        'spinbutton',
+        'accordion',
+    );
+
+    private const FORM_CONTROL_TAGS = array( 'input', 'select', 'textarea' );
+
+    public function classify(DOMElement $element, ?ClassificationContext $context = null): ClassificationResult
+    {
+        $context = $context ?? new ClassificationContext();
+        $signals = $this->gatherSignals($element, $context);
+        $scores  = $this->scoreBuckets($signals);
+
+        arsort($scores);
+        $buckets = array_keys($scores);
+        $max     = $scores[$buckets[0]];
+        $second  = $scores[$buckets[1]] ?? 0.0;
+        $total   = array_sum($scores);
+
+        $signals['scores'] = $scores;
+
+        if ( $max < self::MIN_SCORE || ( $max - $second ) < self::MIN_MARGIN ) {
+            $strength   = min(1.0, $max / 6.0);
+            $dominance  = $total > 0.0 ? $max / $total : 0.0;
+            $confidence = round(min(0.4, 0.1 + $dominance * 0.3 + $strength * 0.2), 2);
+
+            return new ClassificationResult(self::BUCKET_UNKNOWN, $confidence, $signals);
+        }
+
+        $dominance  = $total > 0.0 ? $max / $total : 0.0;
+        $strength   = min(1.0, $max / 6.0);
+        $confidence = round(min(0.97, 0.35 + $dominance * 0.4 + $strength * 0.25), 2);
+
+        return new ClassificationResult($buckets[0], $confidence, $signals);
+    }
+
+    /**
+     * @param array<string, mixed> $s
+     * @return array<string, float>
+     */
+    private function scoreBuckets(array $s): array
+    {
+        $scores = array(
+            self::BUCKET_THEME_PRESENTATION => 0.0,
+            self::BUCKET_CUSTOM_BLOCK       => 0.0,
+            self::BUCKET_CUSTOM_APPLICATION => 0.0,
+            self::BUCKET_CUSTOM_PLUGIN      => 0.0,
+        );
+
+        $formControls   = (int) $s['form_controls'];
+        $inputDriven    = $formControls > 0 || $s['js_reads_input'] || $s['canvas'];
+        $functionalJs   = $s['js_network'] || $s['js_storage'] || $s['js_state_mutation'];
+        $isContentUnit  = $s['repeatable_children'] >= 3
+            || $s['media_gallery']
+            || $s['interactive_role']
+            || $s['cohesive_content_unit'];
+        $decorativeJs   = ( $s['js_classlist_toggle'] || $s['js_scroll_listener'] || $s['js_parallax'] )
+            && ! $functionalJs
+            && ! $s['js_reads_input'];
+
+        // --- custom_application: input drives logic / state, or canvas / Interactivity API.
+        if ( $formControls >= 1 ) {
+            $scores[self::BUCKET_CUSTOM_APPLICATION] += 2.0;
+        }
+        if ( $formControls >= 2 ) {
+            $scores[self::BUCKET_CUSTOM_APPLICATION] += 1.0;
+        }
+        if ( $s['js_reads_input'] ) {
+            $scores[self::BUCKET_CUSTOM_APPLICATION] += 3.0;
+        }
+        if ( $s['canvas'] ) {
+            $scores[self::BUCKET_CUSTOM_APPLICATION] += 3.0;
+        }
+        if ( $s['interactivity_api'] ) {
+            $scores[self::BUCKET_CUSTOM_APPLICATION] += 2.0;
+        }
+        // Functional JS only reinforces an application when the subtree is itself
+        // input-driven; otherwise site-wide functional JS belongs to custom_plugin.
+        if ( $inputDriven || $s['interactivity_api'] ) {
+            if ( $s['js_network'] ) {
+                $scores[self::BUCKET_CUSTOM_APPLICATION] += 1.0;
+            }
+            if ( $s['js_storage'] ) {
+                $scores[self::BUCKET_CUSTOM_APPLICATION] += 1.0;
+            }
+            if ( $s['js_state_mutation'] ) {
+                $scores[self::BUCKET_CUSTOM_APPLICATION] += 1.0;
+            }
+        }
+
+        // --- custom_plugin: site-wide functional JS not tied to one component.
+        if (
+            $s['js_global_scope']
+            && ( $functionalJs || $s['js_style_mutation'] || $s['js_classlist_toggle'] )
+            && ! $inputDriven
+            && ! $isContentUnit
+            && ! $decorativeJs
+            && ! $s['interactivity_api']
+        ) {
+            $scores[self::BUCKET_CUSTOM_PLUGIN] += 2.0;
+            if ( $s['js_network'] ) {
+                $scores[self::BUCKET_CUSTOM_PLUGIN] += 2.0;
+            }
+            if ( $s['js_storage'] ) {
+                $scores[self::BUCKET_CUSTOM_PLUGIN] += 1.0;
+            }
+            if ( $s['js_state_mutation'] ) {
+                $scores[self::BUCKET_CUSTOM_PLUGIN] += 1.0;
+            }
+        }
+
+        // --- theme_presentation: appearance only (CSS animation / JS that only
+        //     toggles classes/styles for visual effect; no input/data/state).
+        if ( $s['css_keyframes'] ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 3.0;
+        }
+        if ( $s['css_animation'] ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 2.0;
+        }
+        if ( $s['css_transition'] ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 2.0;
+        }
+        if ( $s['css_transform'] ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 1.0;
+        }
+        if ( $s['css_sticky_fixed'] ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 1.0;
+        }
+        if ( $s['js_parallax'] ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 3.0;
+        } elseif ( $s['js_scroll_listener'] ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 1.0;
+        }
+        if ( $s['js_classlist_toggle'] && ! $inputDriven && ! $functionalJs ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] += 2.0;
+        }
+        // Animation on an interactive app is incidental polish, not the essence.
+        if ( $inputDriven ) {
+            $scores[self::BUCKET_THEME_PRESENTATION] *= 0.3;
+        }
+
+        // --- custom_block: cohesive, repeatable content unit a user edits, with
+        //     at most component-local interactivity.
+        if ( $s['repeatable_children'] >= 3 ) {
+            $scores[self::BUCKET_CUSTOM_BLOCK] += 3.0;
+        } elseif ( $s['repeatable_children'] === 2 ) {
+            $scores[self::BUCKET_CUSTOM_BLOCK] += 2.0;
+        }
+        if ( $s['media_gallery'] ) {
+            $scores[self::BUCKET_CUSTOM_BLOCK] += 2.0;
+        }
+        if ( $s['interactive_role'] ) {
+            $scores[self::BUCKET_CUSTOM_BLOCK] += 2.0;
+        }
+        if ( $s['cohesive_content_unit'] ) {
+            $scores[self::BUCKET_CUSTOM_BLOCK] += 1.0;
+        }
+        // Component-local interactivity that is neither input-driven nor site-wide.
+        if (
+            ( $s['inline_event_handlers'] || $s['js_component_scoped'] )
+            && ! $inputDriven
+            && ! ( $s['js_global_scope'] && $functionalJs )
+        ) {
+            $scores[self::BUCKET_CUSTOM_BLOCK] += 1.0;
+        }
+
+        return $scores;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function gatherSignals(DOMElement $element, ClassificationContext $context): array
+    {
+        $elements = $this->collectElements($element);
+        $css      = $context->cssText();
+        $js       = $context->jsText();
+
+        $jsClasslist = $this->matches($js, '/classList\s*\.\s*(?:add|remove|toggle|replace)\s*\(/i');
+        $jsStyle     = $this->matches($js, '/\.style\s*\.\s*[a-zA-Z$_]/i');
+        $jsScroll    = $this->matches($js, '/addEventListener\s*\(\s*[\'"](?:scroll|mousemove|wheel)[\'"]/i')
+            || $this->matches($js, '/on(?:scroll|mousemove|wheel)\b/i');
+        $jsTransform = $this->matches($js, '/transform/i');
+        $jsReadsInput = $this->matches($js, '/\.value\b/i')
+            || $this->matches($js, '/\bFormData\b/i')
+            || $this->matches($js, '/\.checked\b/i')
+            || $this->matches($js, '/\.files\b/i')
+            || $this->matches($js, '/addEventListener\s*\(\s*[\'"](?:input|change|submit|keyup|keydown)[\'"]/i');
+        $jsNetwork = $this->matches($js, '/\bfetch\s*\(/i')
+            || $this->matches($js, '/\bXMLHttpRequest\b/i')
+            || $this->matches($js, '/\$\.ajax\b/i')
+            || $this->matches($js, '/\.ajax\s*\(/i')
+            || $this->matches($js, '/\baxios\s*\./i');
+        $jsStorage = $this->matches($js, '/\blocalStorage\b/i')
+            || $this->matches($js, '/\bsessionStorage\b/i')
+            || $this->matches($js, '/document\s*\.\s*cookie\b/i');
+        $jsState = $this->matches($js, '/\bsetState\b/i')
+            || $this->matches($js, '/\bthis\s*\.\s*state\b/i')
+            || $this->matches($js, '/\bstate\s*\.\s*\w+\s*=/i')
+            || $this->matches($js, '/\bstate\s*\[[^\]]+\]\s*=/i');
+        $jsGlobal = $this->matches($js, '/document\s*\.\s*(?:addEventListener|querySelector|querySelectorAll|getElementById|getElementsBy)/i')
+            || $this->matches($js, '/window\s*\.\s*addEventListener/i');
+        $jsScoped = $this->matches($js, '/\b(?:this|el|element|root|container|node|self)\s*\.\s*(?:querySelector|addEventListener|classList|closest)/i');
+
+        return array(
+            // DOM-derived structural signals.
+            'form_controls'         => $this->countDescendants($elements, self::FORM_CONTROL_TAGS),
+            'submit_or_form'        => $this->hasTag($elements, array( 'form' )) || $this->hasSubmit($elements),
+            'canvas'               => $this->hasTag($elements, array( 'canvas' )),
+            'contenteditable'      => $this->hasAttributeNamed($elements, 'contenteditable'),
+            'interactivity_api'    => $this->hasAttributePrefix($elements, 'data-wp-'),
+            'interactive_role'     => $this->hasInteractiveRole($elements),
+            'inline_event_handlers' => $this->hasInlineEventHandler($elements),
+            'repeatable_children'  => $this->repeatableChildCount($element),
+            'media_gallery'        => $this->countDescendants($elements, array( 'img', 'picture', 'figure', 'video' )) >= 2,
+            'cohesive_content_unit' => $this->isCohesiveContentUnit($elements),
+            'ancestor_form'        => in_array('form', $this->resolveAncestorTags($element, $context), true),
+
+            // CSS-derived signals (appearance only).
+            'css_keyframes'    => $this->matches($css, '/@(?:-[a-z]+-)?keyframes\b/i'),
+            'css_animation'    => $this->matches($css, '/(?:^|[;{\s])animation(?:-[a-z]+)?\s*:/i'),
+            'css_transition'   => $this->matches($css, '/(?:^|[;{\s])transition(?:-[a-z]+)?\s*:/i'),
+            'css_transform'    => $this->matches($css, '/(?:^|[;{\s])transform\s*:/i'),
+            'css_sticky_fixed' => $this->matches($css, '/position\s*:\s*(?:sticky|fixed)\b/i'),
+
+            // JS-derived signals.
+            'js_present'         => trim($js) !== '',
+            'js_classlist_toggle' => $jsClasslist,
+            'js_style_mutation'  => $jsStyle,
+            'js_scroll_listener' => $jsScroll,
+            'js_parallax'        => $jsScroll && ( $jsStyle || $jsTransform ),
+            'js_reads_input'     => $jsReadsInput,
+            'js_network'         => $jsNetwork,
+            'js_storage'         => $jsStorage,
+            'js_state_mutation'  => $jsState,
+            'js_global_scope'    => $jsGlobal,
+            'js_component_scoped' => $jsScoped,
+        );
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function collectElements(DOMElement $element): array
+    {
+        $out = array( $element );
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement ) {
+                $out[] = $descendant;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     * @param array<int, string>     $tags
+     */
+    private function countDescendants(array $elements, array $tags): int
+    {
+        $count = 0;
+        foreach ( $elements as $element ) {
+            if ( in_array(strtolower($element->tagName), $tags, true) ) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     * @param array<int, string>     $tags
+     */
+    private function hasTag(array $elements, array $tags): bool
+    {
+        return $this->countDescendants($elements, $tags) > 0;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     */
+    private function hasSubmit(array $elements): bool
+    {
+        foreach ( $elements as $element ) {
+            $tag = strtolower($element->tagName);
+            if ( 'button' === $tag && 'submit' === strtolower($this->attr($element, 'type')) ) {
+                return true;
+            }
+            if ( 'input' === $tag && in_array(strtolower($this->attr($element, 'type')), array( 'submit', 'button' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     */
+    private function hasAttributeNamed(array $elements, string $name): bool
+    {
+        foreach ( $elements as $element ) {
+            if ( $element->hasAttribute($name) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     */
+    private function hasAttributePrefix(array $elements, string $prefix): bool
+    {
+        foreach ( $elements as $element ) {
+            foreach ( $element->attributes ?? array() as $attribute ) {
+                if ( str_starts_with(strtolower($attribute->nodeName), $prefix) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     */
+    private function hasInlineEventHandler(array $elements): bool
+    {
+        foreach ( $elements as $element ) {
+            foreach ( $element->attributes ?? array() as $attribute ) {
+                $name = strtolower($attribute->nodeName);
+                if ( str_starts_with($name, 'on') && strlen($name) > 2 ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     */
+    private function hasInteractiveRole(array $elements): bool
+    {
+        foreach ( $elements as $element ) {
+            $role = strtolower(trim($this->attr($element, 'role')));
+            if ( '' !== $role && in_array($role, self::INTERACTIVE_ROLES, true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * A heading grouped with media or body text — the shape of an editable
+     * content unit (card / pricing / feature panel).
+     *
+     * @param array<int, DOMElement> $elements
+     */
+    private function isCohesiveContentUnit(array $elements): bool
+    {
+        $hasHeading = false;
+        $hasBody    = false;
+        foreach ( $elements as $element ) {
+            $tag = strtolower($element->tagName);
+            if ( in_array($tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ), true) ) {
+                $hasHeading = true;
+            }
+            if ( in_array($tag, array( 'p', 'img', 'figure', 'picture' ), true) ) {
+                $hasBody = true;
+            }
+        }
+
+        return $hasHeading && $hasBody;
+    }
+
+    /**
+     * Largest group of direct child elements that share the same tag + class
+     * signature — the structural hallmark of a repeatable content unit. Returns
+     * the size of that group (0 or 1 means "not repeatable").
+     */
+    private function repeatableChildCount(DOMElement $element): int
+    {
+        $signatures = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            $classes = $this->classNames($child);
+            sort($classes);
+            $signature = strtolower($child->tagName) . '|' . implode('.', $classes);
+            $signatures[$signature] = ( $signatures[$signature] ?? 0 ) + 1;
+        }
+
+        return empty($signatures) ? 0 : max($signatures);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveAncestorTags(DOMElement $element, ClassificationContext $context): array
+    {
+        $explicit = $context->explicitAncestorTags();
+        if ( ! empty($explicit) ) {
+            return array_map('strtolower', $explicit);
+        }
+
+        return $this->ancestorTags($element);
+    }
+
+    private function matches(string $haystack, string $pattern): bool
+    {
+        return '' !== $haystack && 1 === preg_match($pattern, $haystack);
+    }
+}

--- a/php-transformer/tests/unit/subtree-classifier.php
+++ b/php-transformer/tests/unit/subtree-classifier.php
@@ -1,0 +1,192 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the standalone subtree classifier (issue #497).
+ *
+ * Plain-PHP test script in the style of tests/contract/run.php — no PHPUnit.
+ * Each case builds a DOMElement subtree + a ClassificationContext (declared CSS
+ * and associated JS) and asserts the resulting bucket / confidence behaviour.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\ClassificationContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SubtreeClassifier;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+/**
+ * Build the first element child of the given HTML fragment as a DOMElement.
+ */
+$element = static function (string $html): DOMElement {
+    $doc = new DOMDocument();
+    libxml_use_internal_errors(true);
+    $doc->loadHTML(
+        '<!DOCTYPE html><html><body>' . $html . '</body></html>',
+        LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+    );
+    libxml_clear_errors();
+    $body = $doc->getElementsByTagName('body')->item(0);
+    foreach ( $body->childNodes as $child ) {
+        if ( $child instanceof DOMElement ) {
+            return $child;
+        }
+    }
+    throw new RuntimeException('No element found in fixture HTML.');
+};
+
+$classifier = new SubtreeClassifier();
+
+$summarize = static function ($result): string {
+    return $result->bucket() . ' @ ' . $result->confidence();
+};
+
+// ---------------------------------------------------------------------------
+// 1. theme_presentation — scroll-reveal: CSS keyframes/transition + JS that only
+//    toggles a class on scroll. No input, data, or state — appearance only.
+// ---------------------------------------------------------------------------
+$reveal = $element('<div class="reveal"><h2>Our story</h2><p>Lorem ipsum dolor.</p></div>');
+$revealCtx = new ClassificationContext(
+    "@keyframes fade { from { opacity: 0 } to { opacity: 1 } } .reveal { opacity: 0; transition: opacity .4s; transform: translateY(20px); }",
+    "document.querySelectorAll('.reveal').forEach(function(el){ window.addEventListener('scroll', function(){ el.classList.toggle('visible'); }); });"
+);
+$r = $classifier->classify($reveal, $revealCtx);
+$assert($r->is(SubtreeClassifier::BUCKET_THEME_PRESENTATION), '1: scroll-reveal -> theme_presentation', $summarize($r));
+$assert($r->confidence() >= 0.6, '1: scroll-reveal confident', $summarize($r));
+// Negative: a decorative animation is NOT a content block.
+$assert(! $r->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK), '1neg: decorative animation is not a block', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 2. custom_block — a repeatable, cohesive content unit a user edits (card grid).
+//    No state/network. Hover transition styling must NOT flip it to theme.
+// ---------------------------------------------------------------------------
+$cards = $element(
+    '<section class="cards">'
+    . '<article class="card"><img src="a.jpg"><h3>One</h3><p>First card.</p></article>'
+    . '<article class="card"><img src="b.jpg"><h3>Two</h3><p>Second card.</p></article>'
+    . '<article class="card"><img src="c.jpg"><h3>Three</h3><p>Third card.</p></article>'
+    . '</section>'
+);
+$cardsCtx = new ClassificationContext('.card { border: 1px solid #ccc; transition: transform .2s; }', '');
+$r = $classifier->classify($cards, $cardsCtx);
+$assert($r->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK), '2: card grid -> custom_block', $summarize($r));
+$assert($r->confidence() >= 0.6, '2: card grid confident', $summarize($r));
+// Negative: a static content block is NOT an application.
+$assert(! $r->is(SubtreeClassifier::BUCKET_CUSTOM_APPLICATION), '2neg: static content is not an application', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 3. custom_application — stateful, data-driven: form controls feed JS that reads
+//    input, fetches data, and mutates state. Input drives logic.
+// ---------------------------------------------------------------------------
+$configurator = $element(
+    '<div class="configurator">'
+    . '<h3>Build yours</h3>'
+    . '<select name="size"><option>S</option><option>L</option></select>'
+    . '<input type="number" name="qty" value="1">'
+    . '<button type="button">Update</button>'
+    . '<div class="price">$0</div>'
+    . '</div>'
+);
+$configuratorCtx = new ClassificationContext(
+    '.configurator { display: grid; }',
+    "el.querySelector('select').addEventListener('change', function(){ var qty = el.querySelector('input').value; fetch('/api/price?qty=' + qty).then(function(r){ return r.json(); }).then(function(d){ state.total = d.total; }); });"
+);
+$r = $classifier->classify($configurator, $configuratorCtx);
+$assert($r->is(SubtreeClassifier::BUCKET_CUSTOM_APPLICATION), '3: configurator -> custom_application', $summarize($r));
+$assert($r->confidence() >= 0.6, '3: configurator confident', $summarize($r));
+$assert(! $r->is(SubtreeClassifier::BUCKET_CUSTOM_PLUGIN), '3neg: input-driven app is not a plugin', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 4. custom_plugin — site-wide functional JS not tied to one component, no input
+//    in the subtree, no editable content unit (cookie/consent + analytics).
+// ---------------------------------------------------------------------------
+$banner = $element('<div id="consent"><span>We use cookies.</span></div>');
+$bannerCtx = new ClassificationContext(
+    '',
+    "document.addEventListener('DOMContentLoaded', function(){ if (!localStorage.getItem('consent')) { fetch('/analytics/init'); } document.querySelectorAll('a[href^=\"http\"]').forEach(function(a){ a.setAttribute('rel','noopener'); }); });"
+);
+$r = $classifier->classify($banner, $bannerCtx);
+$assert($r->is(SubtreeClassifier::BUCKET_CUSTOM_PLUGIN), '4: site-wide script -> custom_plugin', $summarize($r));
+$assert($r->confidence() >= 0.6, '4: plugin confident', $summarize($r));
+$assert(! $r->is(SubtreeClassifier::BUCKET_CUSTOM_APPLICATION), '4neg: no-input site-wide JS is not an application', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 5. unknown — conflicting/weak: a 2-item list with only a hover transition.
+//    Repeatable-content signal ties with presentation signal -> stay UNKNOWN.
+// ---------------------------------------------------------------------------
+$ambiguous = $element('<ul class="items"><li>Alpha</li><li>Beta</li></ul>');
+$ambiguousCtx = new ClassificationContext('.items li { transition: color .2s; }', '');
+$r = $classifier->classify($ambiguous, $ambiguousCtx);
+$assert($r->is(SubtreeClassifier::BUCKET_UNKNOWN), '5: conflicting signals -> unknown', $summarize($r));
+$assert($r->confidence() <= 0.4, '5: unknown low confidence', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 6. unknown — a plain static content block (single paragraph, plain styling).
+//    Not an app, not a block: too little signal -> conservative fallback.
+// ---------------------------------------------------------------------------
+$plain = $element('<div class="wrap"><p>Just a paragraph of content.</p></div>');
+$plainCtx = new ClassificationContext('.wrap { padding: 20px; color: #333; }', '');
+$r = $classifier->classify($plain, $plainCtx);
+$assert($r->is(SubtreeClassifier::BUCKET_UNKNOWN), '6: plain static content -> unknown', $summarize($r));
+$assert(! $r->is(SubtreeClassifier::BUCKET_CUSTOM_APPLICATION), '6neg: plain content is not an application', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 7. unknown — a single (non-repeated) content unit is too weak to call a block.
+// ---------------------------------------------------------------------------
+$single = $element('<article class="feature"><img src="x.jpg"><h3>Solo</h3><p>One card only.</p></article>');
+$r = $classifier->classify($single, new ClassificationContext());
+$assert($r->is(SubtreeClassifier::BUCKET_UNKNOWN), '7: single content unit -> unknown', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 8. custom_application — Interactivity API markup signals a stateful component.
+// ---------------------------------------------------------------------------
+$interactive = $element('<div data-wp-interactive="my/store" data-wp-context=\'{"open":false}\'><button data-wp-on--click="actions.toggle">Toggle</button></div>');
+$r = $classifier->classify($interactive, new ClassificationContext());
+$assert($r->is(SubtreeClassifier::BUCKET_CUSTOM_APPLICATION), '8: data-wp-* -> custom_application', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 9. custom_block — accordion/tabs via interactive role with component-local JS.
+// ---------------------------------------------------------------------------
+$tabs = $element(
+    '<div class="tabs" role="tablist">'
+    . '<button role="tab">Tab A</button>'
+    . '<button role="tab">Tab B</button>'
+    . '<div role="tabpanel"><p>Panel A content.</p></div>'
+    . '<div role="tabpanel"><p>Panel B content.</p></div>'
+    . '</div>'
+);
+$tabsCtx = new ClassificationContext(
+    '',
+    "this.querySelectorAll('[role=tab]').forEach(function(t){ t.addEventListener('click', function(){ t.classList.toggle('active'); }); });"
+);
+$r = $classifier->classify($tabs, $tabsCtx);
+$assert($r->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK), '9: tabs (role + local JS) -> custom_block', $summarize($r));
+$assert(! $r->is(SubtreeClassifier::BUCKET_CUSTOM_PLUGIN), '9neg: component-local tabs are not a plugin', $summarize($r));
+
+// ---------------------------------------------------------------------------
+// 10. signals diagnostics are populated for the caller.
+// ---------------------------------------------------------------------------
+$assert(array_key_exists('scores', $r->signals()), '10: result exposes per-bucket scores');
+$assert($r->signals()['interactive_role'] === true, '10: result exposes structural signals', json_encode($r->signals()));
+$assert(isset($r->toArray()['bucket'], $r->toArray()['confidence'], $r->toArray()['signals']), '10: toArray shape');
+
+// ---------------------------------------------------------------------------
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, PHP_EOL . "SubtreeClassifier unit tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
+    exit(1);
+}
+
+fwrite(STDOUT, "SubtreeClassifier unit tests: {$passes} passed" . PHP_EOL);


### PR DESCRIPTION
Refs #497

## Summary
Standalone classifier **v1** for the subtree classification taxonomy (#497). It is a pure, tested unit that decides the coarse *bucket* a source subtree fundamentally represents — the layer **above** the recognizers. **Wiring it into the conversion flow is a deliberate follow-up after the HtmlTransformer decomposition (#242)**, which is actively in flight; this PR adds the module + tests only.

New namespace: `Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification`
- `SubtreeClassifier` — `classify(DOMElement, ClassificationContext): ClassificationResult`
- `ClassificationContext` — declared CSS + associated JS + optional ancestry
- `ClassificationResult` — `bucket`, `confidence` (0..1), `signals` (diagnostics)

## Buckets & generic signals (per #497)
- **theme_presentation** — CSS keyframes/transition/animation/transform/sticky, or JS that only toggles classes/styles for visual effect (scroll-reveal, parallax); no input/data/state.
- **custom_block** — cohesive, repeatable content unit a user edits (card grid, gallery, tabs/accordion via interactive role); component-local interactivity only.
- **custom_application** — stateful/data-driven: form controls + JS that reads input, fetches data, mutates state; Interactivity API (`data-wp-*`); canvas. Input drives logic.
- **custom_plugin** — site-wide functional JS not tied to one component (global-scope handlers + network/storage), no editable content unit, not decorative, not input-driven.
- **unknown** — weak or conflicting evidence; conservative fallback so the caller can route to `core/html` + a diagnostic.

Only **generic structural signals** are used (DOM shape, declared CSS text, associated JS text) — no fixture/site-specific strings. Conservative + confidence-scored: a minimum winning score and a minimum margin over the runner-up are required, otherwise `unknown`.

## Tests
Plain-PHP unit suite `tests/unit/subtree-classifier.php` (style of `tests/contract/run.php`), wired into `composer test:canonical` via a new `test:unit` script. 23 assertions across 10 cases: one confident case per bucket, ambiguous/weak → `unknown`, and negatives (decorative animation is not a block; static content is not an application; input-driven app is not a plugin; component-local tabs are not a plugin; single non-repeated unit → unknown).

## Gates
- `composer test:canonical` — green (includes the new unit suite)
- `composer parity` — green, **128 fixtures** unaffected
- `php -l` clean on all new files

## Scope guarantee
`HtmlTransformer.php` and all existing converters/recognizers are **untouched** — additive only (3 source files + 1 test + `composer.json` script wiring).

**DO NOT MERGE** — standalone classifier v1; wiring into the conversion flow is a follow-up post-#242 decomposition.