### PR TITLE
Remove retired bfb/bac test residue from php-transformer

### DIFF
--- a/php-transformer/tests/migration/examples.php
+++ b/php-transformer/tests/migration/examples.php
@@ -71,41 +71,6 @@ PHP
         continue;
     }
 
-    if ( 'block-format-bridge-wrapper.php' === $name ) {
-        $smoke(
-            $name,
-            $example,
-            $assertions . <<<'PHP'
-$serialized = bfb_convert( '<h2>Hello</h2>', 'html', 'blocks' );
-$assert( str_contains( $serialized, '<!-- wp:heading' ), 'BFB convert returns serialized heading block' );
-$blocks = bfb_to_blocks( '<p>Hello</p>', 'html' );
-$assert( isset( $blocks[0]['blockName'] ) && 'core/paragraph' === $blocks[0]['blockName'], 'BFB to_blocks returns block arrays' );
-$assert( "# Hello\n" === bfb_normalize( "# Hello\r\n", 'markdown' ), 'BFB normalize maps markdown newlines' );
-$fragment = bfb_convert_fragment( '<p>Scoped</p>', array( 'source_id' => 'fixture' ) );
-$assert( true === $fragment['success'] && 'fixture' === $fragment['scope']['source_id'], 'BFB fragment wrapper returns scoped envelope' );
-$capabilities = bfb_capabilities();
-$assert( isset( $capabilities['formats']['html'] ), 'BFB capabilities report includes html format' );
-PHP
-        );
-        continue;
-    }
-
-    if ( 'block-artifact-compiler-wrapper.php' === $name ) {
-        $smoke(
-            $name,
-            $example,
-            $assertions . <<<'PHP'
-$compiled = bac_compile_website_artifact( array( 'generated_html' => '<main><h1>Hello</h1></main>' ) );
-$assert( isset( $compiled['serialized_blocks'] ) && str_contains( $compiled['serialized_blocks'], '<!-- wp:html -->' ), 'BAC wrapper compiles generated HTML' );
-$fragment = bac_compile_fragment( '<p>Fragment</p>', 'fragment', 'html' );
-$assert( isset( $fragment['schema'] ), 'BAC fragment wrapper returns result envelope' );
-$summary = bac_summarize_result( $compiled );
-$assert( isset( $summary['diagnostic_count'] ), 'BAC summary wrapper returns counts' );
-PHP
-        );
-        continue;
-    }
-
     if ( 'static-site-importer-transformer-adapter.php' === $name ) {
         $smoke(
             $name,

--- a/php-transformer/tests/parity/run.php
+++ b/php-transformer/tests/parity/run.php
@@ -415,8 +415,6 @@ function legacyRepoForOperation(string $operation): string
 {
     return match ( $operation ) {
         'html_transformer.transform' => 'html-to-blocks-converter',
-        'format_bridge.normalize' => 'block-format-bridge',
-        'artifact_compiler.compile' => 'block-artifact-compiler',
         default => '',
     };
 }
@@ -425,8 +423,6 @@ function legacyCallableForOperation(string $operation): string
 {
     return match ( $operation ) {
         'html_transformer.transform' => 'html_to_blocks_convert',
-        'format_bridge.normalize' => 'bfb_normalize',
-        'artifact_compiler.compile' => 'bac_compile_website_artifact',
         default => '',
     };
 }
@@ -434,7 +430,7 @@ function legacyCallableForOperation(string $operation): string
 function legacyBootstrapForRepo(string $repo): string
 {
     return match ( $repo ) {
-        'html-to-blocks-converter', 'block-format-bridge', 'block-artifact-compiler' => 'library.php',
+        'html-to-blocks-converter' => 'library.php',
         default => '',
     };
 }


### PR DESCRIPTION
## What
Removes the remaining retired **block-format-bridge (bfb)** / **block-artifact-compiler (bac)** dead references from the php-transformer test surface. Complements #234 (which retires the bfb/bac consumer-PR *docs*); together they finish removing bfb/bac from the package.

## Changes
- `tests/migration/examples.php` — removed the two dead smoke branches for the retired `block-format-bridge-wrapper.php` / `block-artifact-compiler-wrapper.php` examples (the `bfb_*` / `bac_*` assertions). The test still globs+lints every example file and smoke-calls the live html-to-blocks-converter and static-site-importer adapter examples.
- `tests/parity/run.php` — removed the retired entries from the three `BLOCKS_ENGINE_PARITY_LEGACY` comparison maps (`legacyRepoForOperation`, `legacyCallableForOperation`, `legacyBootstrapForRepo`). Only the external legacy-package comparison path was removed — it could never run since the packages are gone. The 26 live `artifact_compiler.compile` + 1 `format_bridge.normalize` fixtures exercise the in-repo `src/ArtifactCompiler`/`src/FormatBridge` and are unaffected.
- (The parity-fixture schema enum item was a no-op — no such schema file exists in the repo.)

## Verification
- `composer test` + `composer parity` → **128 fixtures green**; `test:migration:examples` and the opt-in `test:migration:legacy-parity` both pass (legacy comparisons skip gracefully).
- Re-grep of the touched surfaces and repo-wide (excluding `vendor` + the out-of-scope `docs/consumer-prs/`) → **zero** `block-format-bridge`/`block-artifact-compiler`/`bfb_`/`bac_` matches.
- Independent adversarial verify: corpus fallback output byte-identical to trunk.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context) — multi-agent workflow
- **Used for:** Identifying and removing the dead references + verification under human review.
