### PR TITLE
figma-transformer: decode ready fillGeometry/strokeGeometry paths to inline SVG (#247)

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -771,6 +771,7 @@ final class StaticHtmlEmitter
         $image['missing_assets'] = array_values($image['missing_assets']);
         $image['image_block_nodes'] = array_values($image['image_block_nodes']);
         $vectors['placeholder_nodes'] = array_values($vectors['placeholder_nodes']);
+        $vectors['decode_coverage'] = $this->vectorDecodeCoverage($vectors);
         $layout['decorative_underlays']['nodes'] = array_values($layout['decorative_underlays']['nodes']);
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
         $layout['large_absolute_offset_nodes'] = array_values($layout['large_absolute_offset_nodes']);
@@ -908,6 +909,10 @@ final class StaticHtmlEmitter
                 'image_node_density' => round($imageNodeDensity, 3),
                 'total_node_count' => $totalNodeCount,
                 'vector_image_fallbacks' => (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
+                'vector_nodes' => (int) ($vectors['nodes'] ?? 0),
+                'vector_decoded_to_svg' => (int) ($vectors['rendered_paths'] ?? 0),
+                'vector_decode_coverage_ratio' => (float) ($vectors['decode_coverage']['coverage_ratio'] ?? 0.0),
+                'vector_placeholder_reason_categories' => is_array($vectors['decode_coverage']['placeholder_reason_categories'] ?? null) ? $vectors['decode_coverage']['placeholder_reason_categories'] : array(),
                 'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
@@ -989,6 +994,52 @@ final class StaticHtmlEmitter
         }
 
         return $count;
+    }
+
+    /**
+     * Summarize vector-decode coverage: how many vector-like nodes became real
+     * inline SVG geometry versus how many remain placeholders, with the remaining
+     * placeholders grouped into actionable reason categories.
+     *
+     * @param array<string, mixed> $vectors
+     * @return array<string, mixed>
+     */
+    private function vectorDecodeCoverage(array $vectors): array
+    {
+        $nodes = (int) ($vectors['nodes'] ?? 0);
+        $decoded = (int) ($vectors['rendered_paths'] ?? 0);
+        $assetFallbacks = (int) ($vectors['rendered_asset_fallbacks'] ?? 0);
+        $placeholders = (int) ($vectors['placeholders'] ?? 0);
+        $reasons = is_array($vectors['placeholder_reasons'] ?? null) ? $vectors['placeholder_reasons'] : array();
+
+        $categoryByReason = array(
+            'missing_vector_geometry'                => 'no_geometry_available',
+            'missing_dimensions'                     => 'no_geometry_available',
+            'unsupported_vector_network_blob'        => 'vector_network_blob_unsupported',
+            'unsupported_path_data'                  => 'path_data_unsupported',
+            'oversized_path_data'                    => 'path_data_unsupported',
+            'unsupported_vector_geometry'            => 'path_data_unsupported',
+            'unsupported_boolean_operation_children' => 'boolean_operation_unsupported',
+            'unresolved_asset_fallback'              => 'asset_unresolved',
+        );
+
+        $categories = array();
+        foreach ( $reasons as $reason => $count ) {
+            $category = $categoryByReason[(string) $reason] ?? 'other';
+            $categories[$category] = (int) ($categories[$category] ?? 0) + (int) $count;
+        }
+        ksort($categories);
+
+        return array(
+            'schema'                     => 'blocks-engine/figma-transformer/vector-decode-coverage/v1',
+            'vector_nodes'               => $nodes,
+            'decoded_to_svg'             => $decoded,
+            'asset_fallbacks'            => $assetFallbacks,
+            'placeholders'               => $placeholders,
+            'coverage_ratio'             => $nodes > 0 ? round($decoded / $nodes, 3) : 0.0,
+            'placeholder_reasons'        => $reasons,
+            'placeholder_reason_categories' => $categories,
+        );
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1932,11 +1932,22 @@ final class ScenegraphNormalizer
             }
 
             foreach ( $node[$geometryKey] as $geometry ) {
-                if ( ! is_array($geometry) || ! isset($geometry['commandsBlob']) ) {
+                if ( ! is_array($geometry) ) {
                     continue;
                 }
 
-                $normalized = $this->normalizeVectorCommandBlob($geometry['commandsBlob'], $blobs, $nodeId, $geometryKey, $diagnostics);
+                // Prefer ready-to-use SVG path commands (Figma REST/plugin geometry
+                // shape: `{ path, windingRule }`). This emits real vectors directly,
+                // without decoding the raw Kiwi command blob.
+                $readyPath = $this->extractReadyVectorPath($geometry);
+                if ( null !== $readyPath ) {
+                    $normalized = array('data' => $readyPath, 'source' => $geometryKey . '.path');
+                } elseif ( isset($geometry['commandsBlob']) ) {
+                    $normalized = $this->normalizeVectorCommandBlob($geometry['commandsBlob'], $blobs, $nodeId, $geometryKey, $diagnostics);
+                } else {
+                    continue;
+                }
+
                 if ( null === $normalized ) {
                     continue;
                 }
@@ -1956,6 +1967,44 @@ final class ScenegraphNormalizer
         }
 
         return $paths;
+    }
+
+    /**
+     * Extract ready-to-use SVG path commands from a Figma geometry entry.
+     *
+     * Figma's REST API and plugin geometry expose `fillGeometry`/`strokeGeometry`
+     * as `{ path: "<SVG path commands>", windingRule }`. When that pre-decoded
+     * string is present we can emit it directly as an inline `<path>` rather than
+     * decoding the raw Kiwi command blob.
+     *
+     * @param array<string, mixed> $geometry
+     */
+    private function extractReadyVectorPath(array $geometry): ?string
+    {
+        foreach ( array('path', 'pathData', 'd', 'data') as $key ) {
+            if ( ! isset($geometry[$key]) || ! is_scalar($geometry[$key]) ) {
+                continue;
+            }
+
+            $candidate = trim(preg_replace('/\s+/', ' ', (string) $geometry[$key]) ?? '');
+            if ( '' === $candidate ) {
+                continue;
+            }
+
+            // Require well-formed SVG path data: a leading move command and only
+            // path-command/number characters. The emitter re-validates and
+            // byte-limits before rendering.
+            if ( 1 !== preg_match('/^[Mm][\s,]*-?\d/', $candidate) ) {
+                continue;
+            }
+            if ( 1 !== preg_match('/^[MmZzLlHhVvCcSsQqTtAa0-9,\.\-+\s]+$/', $candidate) ) {
+                continue;
+            }
+
+            return $candidate;
+        }
+
+        return null;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -946,6 +946,51 @@ $assert('oversized_path_data' === ($largeRawPlaceholder['reason'] ?? null), 'lar
 $assert(array('pathData') === ($largeRawPlaceholder['source_fields'] ?? null), 'large-raw-vector-placeholder-source-field');
 $assert(1 === ($largeDecodedVectorDiagnostics['placeholder_reasons']['oversized_path_data'] ?? null), 'large-raw-vector-placeholder-reason-count');
 
+// Figma REST/plugin geometry shape: fillGeometry/strokeGeometry carry ready-to-use
+// SVG path strings. They must emit real inline <svg><path> (not placeholders) and be
+// counted by the vector-decode-coverage diagnostic.
+$readyGeometryVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Ready Geometry Vector Fixture',
+    'nodes' => array(
+        array(
+            'id'           => 'vector:ready-fill-geometry',
+            'type'         => 'VECTOR',
+            'name'         => 'Brand Logo',
+            'width'        => 24,
+            'height'       => 24,
+            'fillPaints'   => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0))),
+            'fillGeometry' => array(
+                array('path' => 'M 0 0 L 24 0 L 24 24 L 0 24 Z', 'windingRule' => 'NONZERO'),
+            ),
+        ),
+        array(
+            'id'     => 'vector:no-geometry',
+            'type'   => 'VECTOR',
+            'name'   => 'Geometryless Mark',
+            'width'  => 24,
+            'height' => 24,
+        ),
+    ),
+));
+$readyGeometryVectorHtml = $fileContent($readyGeometryVectorResult, 'index.html');
+$readyGeometryVectors = $readyGeometryVectorResult['source_reports']['figma']['html']['transform_diagnostics']['vectors'] ?? array();
+$readyGeometryCoverage = $readyGeometryVectors['decode_coverage'] ?? array();
+$readyGeometryNode = null;
+foreach ( $readyGeometryVectors['placeholder_nodes'] ?? array() as $placeholderNode ) {
+    if ( is_array($placeholderNode) && 'vector:ready-fill-geometry' === ($placeholderNode['node_id'] ?? null) ) {
+        $readyGeometryNode = $placeholderNode;
+        break;
+    }
+}
+$assert(str_contains($readyGeometryVectorHtml, 'data-figma-node-id="vector:ready-fill-geometry"') && str_contains($readyGeometryVectorHtml, 'data-figma-vector="true"'), 'ready-fill-geometry-renders-inline-svg');
+$assert(str_contains($readyGeometryVectorHtml, '<path d="M0 0L24 0 24 24 0 24Z"') && str_contains($readyGeometryVectorHtml, 'fill-rule="nonzero"'), 'ready-fill-geometry-emits-path');
+$assert(null === $readyGeometryNode, 'ready-fill-geometry-is-not-a-placeholder');
+$assert(2 === (int) ($readyGeometryCoverage['vector_nodes'] ?? 0), 'ready-geometry-decode-coverage-node-count');
+$assert(1 === (int) ($readyGeometryCoverage['decoded_to_svg'] ?? 0), 'ready-geometry-decode-coverage-decoded-count');
+$assert(1 === (int) ($readyGeometryCoverage['placeholders'] ?? 0), 'ready-geometry-decode-coverage-placeholder-count');
+$assert(0.5 === ($readyGeometryCoverage['coverage_ratio'] ?? null), 'ready-geometry-decode-coverage-ratio');
+$assert(1 === (int) ($readyGeometryCoverage['placeholder_reason_categories']['no_geometry_available'] ?? 0), 'ready-geometry-decode-coverage-no-geometry-category');
+
 $externalizedVectorPath = 'M 0.0000 0.0000' . str_repeat(' L 10.000001 10.000001', 12000) . ' Z';
 $externalizedEquivalentVectorPath = 'M0,0' . str_repeat('L10,10', 12000) . 'Z';
 $externalizedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary

Vector fidelity slice of #247. Running the fixture matrix on the real 185MB "David Perell" `.fig` showed `quality_status: fail` driven by **38 vector placeholders** (`unsupported_vector_network_blob: 20` + `unsupported_vector_node_placeholder: 12`) with `generated_svg_count: 0` — logos, icons, and illustrations rendering as empty placeholders.

This PR closes a real gap in vector geometry intake. The `ScenegraphNormalizer` only consumed the raw Kiwi `commandsBlob` shape of `fillGeometry`/`strokeGeometry`. Figma's REST API and plugin geometry instead expose those as `{ path: "<SVG path commands>", windingRule }` — a ready-to-use string. Those pre-decoded paths were silently dropped, so the affected vector nodes fell back to empty placeholders.

### Implementation
- `ScenegraphNormalizer::normalizeVectorPaths()` now prefers a ready-to-use SVG `path` string (validated leading move command + path-character allowlist) and emits it directly into `figma_vector_paths`, falling back to `commandsBlob` decoding when no ready path is present. Winding rule, node size/position, and paint are preserved. The emitter's existing `safeSvgPathData`/canonicalization re-validates and byte-limits before rendering, so output stays deterministic and externalizes oversized paths exactly as before.
- Where geometry is genuinely unavailable, the node stays a placeholder with a precise reason code (unchanged behavior).

### Diagnostic (the "improve diagnostics" half)
- New `vectors.decode_coverage` block in the transform-diagnostics surface: `decoded_to_svg` vs `placeholders`, `coverage_ratio`, and remaining placeholder reasons grouped into actionable categories that distinguish `no_geometry_available` from `vector_network_blob_unsupported` (also `path_data_unsupported`, `boolean_operation_unsupported`, `asset_unresolved`).
- Compact coverage signals (`vector_nodes`, `vector_decoded_to_svg`, `vector_decode_coverage_ratio`, `vector_placeholder_reason_categories`) added to `artifact_quality.summary` next to the existing `vector_placeholders` / `generated_svg_count` signals.

### Test
Added a focused contract test: a `VECTOR` node carrying ready `fillGeometry` emits inline `<svg><path>` (not a placeholder) and is counted by the decode-coverage diagnostic, while a geometryless sibling stays a placeholder under `no_geometry_available`. `php tests/contract/run.php` prints **"Figma Transformer contract tests passed."**

### Caveats
- This converts the REST/plugin `path`-string shape. The 20 `unsupported_vector_network_blob` cases in the David Perell fixture come from raw `vectorNetwork` Kiwi blobs that lack a ready `path` and are not decoded by the existing partial decoders — those still fall back to placeholders, now precisely attributed under `vector_network_blob_unsupported` in the coverage diagnostic. No large `.fig` files were run locally (synthetic fixtures only).

Built on trunk (all prior vector PRs are already merged; no in-flight `cook/figma-vector-fidelity` branch exists).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Implementing fillGeometry/strokeGeometry → inline SVG emission + vector-decode diagnostic for #247.