### PR TITLE
figma-transformer: harden responsive grouping (false-positive guard + memory-safe detection + diagnostics)

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -9,6 +9,32 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
  */
 final class ScenegraphPagePlanner
 {
+    /**
+     * Node-count ceiling for planning-time responsive detection.
+     *
+     * Detection re-inspects the source, which rebuilds a full
+     * {@see ScenegraphIndex} over the entire scenegraph. On very large designs
+     * (e.g. the 293MB "WP.Cloud 2.0" .fig) that second full index OOMs in
+     * ScenegraphIndex::build(). Above this ceiling the planner skips the
+     * full-node inspection and degrades to one-page-per-frame, emitting a
+     * {@see ScenegraphPagePlanner::plan()} `responsive_detection_bounded`
+     * diagnostic so callers learn WHY grouping was limited. Overridable via the
+     * `responsive_detection_node_limit` plan option.
+     */
+    private const RESPONSIVE_DETECTION_NODE_LIMIT = 25000;
+
+    /**
+     * Minimum absolute width delta (px) for a sibling-group to count as a real
+     * responsive breakpoint spread rather than same-width duplicate drafts.
+     */
+    private const RESPONSIVE_WIDTH_MATERIAL_PX = 200.0;
+
+    /**
+     * Minimum relative width spread (max-min / max) for a responsive group when
+     * device hints alone do not distinguish the members.
+     */
+    private const RESPONSIVE_WIDTH_MATERIAL_RATIO = 0.2;
+
     public function __construct(
         private readonly ScenegraphIndex $index = new ScenegraphIndex(),
         private readonly ScenegraphFrameInspector $frameInspector = new ScenegraphFrameInspector()
@@ -135,8 +161,23 @@ final class ScenegraphPagePlanner
             }
         }
 
-        $detectionById = $this->detectionById($source, count($nodes));
-        $responsiveGroups = $this->responsiveGroups($candidates, $detectionById);
+        $detectionResult = $this->detectResponsive($source, count($nodes), $options);
+        $detectionById = $detectionResult['detection'];
+        if ( $detectionResult['bounded'] ) {
+            $diagnostics[] = array(
+                'severity'   => 'info',
+                'code'       => 'responsive_detection_bounded',
+                'message'    => 'Responsive sibling detection was skipped because the scenegraph exceeded the planning node limit; emitting one page per frame.',
+                'node_count' => $detectionResult['node_count'],
+                'node_limit' => $detectionResult['node_limit'],
+            );
+        }
+
+        $grouping = $this->responsiveGroups($candidates, $detectionById);
+        $responsiveGroups = $grouping['groups'];
+        foreach ( $grouping['diagnostics'] as $groupDiagnostic ) {
+            $diagnostics[] = $groupDiagnostic;
+        }
 
         $slugs = array();
         $pages = array();
@@ -215,12 +256,53 @@ final class ScenegraphPagePlanner
     }
 
     /**
+     * Resolve responsive detection, bounding it against scenegraph size.
+     *
+     * Detection re-inspects the source, which forces a second full
+     * {@see ScenegraphIndex} build. On unbounded scenegraphs that second index
+     * OOMs (ScenegraphIndex::build, observed on the 293MB "WP.Cloud 2.0" .fig).
+     * When the already-built node count exceeds the configured ceiling the
+     * inspection is SKIPPED entirely — no second index is built — and detection
+     * falls back to empty, which the page loop renders as one-page-per-frame.
+     * The `bounded` flag lets {@see ScenegraphPagePlanner::plan()} surface a
+     * `responsive_detection_bounded` diagnostic instead of dying silently.
+     *
+     * @param array<string, mixed> $source
+     * @param array<string, mixed> $options
+     * @return array{detection: array<string, array<string, mixed>>, bounded: bool, node_count: int, node_limit: int}
+     */
+    private function detectResponsive(array $source, int $nodeCount, array $options): array
+    {
+        $limit = isset($options['responsive_detection_node_limit']) && is_numeric($options['responsive_detection_node_limit'])
+            ? max(1, (int) $options['responsive_detection_node_limit'])
+            : self::RESPONSIVE_DETECTION_NODE_LIMIT;
+
+        if ( $nodeCount > $limit ) {
+            return array(
+                'detection'  => array(),
+                'bounded'    => true,
+                'node_count' => $nodeCount,
+                'node_limit' => $limit,
+            );
+        }
+
+        return array(
+            'detection'  => $this->detectionById($source, $nodeCount),
+            'bounded'    => false,
+            'node_count' => $nodeCount,
+            'node_limit' => $limit,
+        );
+    }
+
+    /**
      * Consume the frame inspector's detection report keyed by frame id.
      *
      * Detection (device_hint / sibling_group_key / responsive_siblings) lives in
      * {@see ScenegraphFrameInspector}; the planner reuses it rather than
      * re-deriving responsive relationships. The inspection limit is widened so
-     * every candidate's detection survives slicing.
+     * every candidate's detection survives slicing. Callers must gate this
+     * behind {@see ScenegraphPagePlanner::detectResponsive()} so it never runs
+     * over an unbounded scenegraph.
      *
      * @return array<string, array<string, mixed>>
      */
@@ -246,13 +328,21 @@ final class ScenegraphPagePlanner
      * Cluster FRAME candidates into responsive sibling-groups.
      *
      * Builds connected components over the inspector's `responsive_siblings`
-     * edges (restricted to FRAME ids the planner tracks). Returns a map from
-     * every member frame id to its full, ordered variant list so the page loop
-     * can look up the group from whichever member was selected first.
+     * edges (restricted to FRAME ids the planner tracks), then GUARDS each
+     * multi-member component: a real responsive group must have distinct device
+     * hints OR a material width spread. Same-name + same-device-hint + ~same
+     * width siblings are duplicate/iteration drafts (e.g. the "For Hosts" frame
+     * that grouped 4 desktop-1440 drafts differing only in height) — they stay
+     * as separate pages and surface a `duplicate_draft_frames` diagnostic rather
+     * than collapsing into bogus breakpoint variants.
+     *
+     * Returns a map from every grouped member frame id to its full, ordered
+     * variant list (so the page loop can look up the group from whichever member
+     * was selected first) plus the grouping-rationale / rejection diagnostics.
      *
      * @param array<string, array<string, mixed>> $candidates
      * @param array<string, array<string, mixed>> $detectionById
-     * @return array<string, array<int, string>>
+     * @return array{groups: array<string, array<int, string>>, diagnostics: array<int, array<string, mixed>>}
      */
     private function responsiveGroups(array $candidates, array $detectionById): array
     {
@@ -287,14 +377,125 @@ final class ScenegraphPagePlanner
         }
 
         $groups = array();
+        $diagnostics = array();
         foreach ( $components as $members ) {
+            if ( count($members) < 2 ) {
+                continue;
+            }
+
             $ordered = $this->orderVariantIds($members, $candidates, $detectionById);
-            foreach ( $ordered as $memberId ) {
-                $groups[$memberId] = $ordered;
+            $assessment = $this->assessResponsiveGroup($ordered, $candidates, $detectionById);
+
+            if ( $assessment['is_responsive'] ) {
+                foreach ( $ordered as $memberId ) {
+                    $groups[$memberId] = $ordered;
+                }
+                $diagnostics[] = array(
+                    'severity'              => 'info',
+                    'code'                  => 'responsive_group_formed',
+                    'message'               => 'Collapsed frames into one responsive page.',
+                    'primary_frame_id'      => $ordered[0],
+                    'frame_ids'             => $ordered,
+                    'reasons'               => $assessment['reasons'],
+                    'device_hints'          => $assessment['device_hints'],
+                    'distinct_device_hints' => $assessment['distinct_hint_count'],
+                    'width_spread_px'       => $assessment['width_spread_px'],
+                );
+                continue;
+            }
+
+            // Duplicate/iteration drafts: keep them as separate pages (omitted
+            // from the group map so the page loop falls back to one-per-frame).
+            $canonicalId = $this->canonicalDraftId($ordered, $candidates);
+            $diagnostics[] = array(
+                'severity'           => 'warning',
+                'code'               => 'duplicate_draft_frames',
+                'message'            => 'Frames share a name, device hint, and width; treated as duplicate drafts rather than responsive breakpoints.',
+                'canonical_frame_id' => $canonicalId,
+                'draft_frame_ids'    => array_values(array_filter($ordered, static fn (string $id): bool => $id !== $canonicalId)),
+                'frame_ids'          => $ordered,
+                'device_hint'        => $assessment['device_hints'][0] ?? 'unknown',
+                'width'              => (float) ($candidates[$canonicalId]['dimensions']['width'] ?? 0),
+            );
+        }
+
+        return array('groups' => $groups, 'diagnostics' => $diagnostics);
+    }
+
+    /**
+     * Decide whether an ordered sibling cluster is a genuine responsive group.
+     *
+     * A cluster qualifies when it has at least two distinct (non-unknown) device
+     * hints OR a material width spread (both an absolute and a relative
+     * threshold), which separates real breakpoints from same-width duplicate
+     * drafts. The rationale is returned so the caller can emit it as a
+     * diagnostic.
+     *
+     * @param array<int, string>                  $members Ordered frame ids (widest first).
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, array<string, mixed>> $detectionById
+     * @return array{is_responsive: bool, reasons: array<int, string>, device_hints: array<int, string>, distinct_hint_count: int, width_spread_px: float, width_spread_ratio: float}
+     */
+    private function assessResponsiveGroup(array $members, array $candidates, array $detectionById): array
+    {
+        $hints = array();
+        $widths = array();
+        foreach ( $members as $id ) {
+            $hints[] = (string) ($detectionById[$id]['device_hint'] ?? 'unknown');
+            $width = $candidates[$id]['dimensions']['width'] ?? null;
+            if ( is_numeric($width) ) {
+                $widths[] = (float) $width;
             }
         }
 
-        return $groups;
+        $distinctKnownHints = array_values(array_unique(array_filter(
+            $hints,
+            static fn (string $hint): bool => 'unknown' !== $hint
+        )));
+        $distinctHintCount = count($distinctKnownHints);
+
+        $minWidth = array() === $widths ? 0.0 : min($widths);
+        $maxWidth = array() === $widths ? 0.0 : max($widths);
+        $spread = $maxWidth - $minWidth;
+        $ratio = $maxWidth > 0.0 ? $spread / $maxWidth : 0.0;
+
+        $reasons = array();
+        if ( $distinctHintCount >= 2 ) {
+            $reasons[] = 'device_hint_diversity';
+        }
+        if ( $spread >= self::RESPONSIVE_WIDTH_MATERIAL_PX && $ratio >= self::RESPONSIVE_WIDTH_MATERIAL_RATIO ) {
+            $reasons[] = 'width_spread';
+        }
+
+        return array(
+            'is_responsive'       => array() !== $reasons,
+            'reasons'             => $reasons,
+            'device_hints'        => $hints,
+            'distinct_hint_count' => $distinctHintCount,
+            'width_spread_px'     => $spread,
+            'width_spread_ratio'  => $ratio,
+        );
+    }
+
+    /**
+     * Pick the canonical frame from a duplicate-draft cluster (highest score,
+     * then deterministic id tiebreak) for the diagnostic record.
+     *
+     * @param array<int, string>                  $members
+     * @param array<string, array<string, mixed>> $candidates
+     */
+    private function canonicalDraftId(array $members, array $candidates): string
+    {
+        $canonical = $members[0];
+        foreach ( $members as $id ) {
+            $score = (int) ($candidates[$id]['score'] ?? 0);
+            $bestScore = (int) ($candidates[$canonical]['score'] ?? 0);
+            if ( $score > $bestScore || ( $score === $bestScore && strcmp($id, $canonical) < 0 ) ) {
+                $canonical = $id;
+            }
+        }
+
+        return $canonical;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1831,6 +1831,110 @@ $assert(null !== $responsiveAboutPage, 'page-plan-responsive-about-stays-its-own
 $assert(false === ($responsiveAboutPage['responsive'] ?? null) && 1 === ($responsiveAboutPage['breakpoint_count'] ?? null), 'page-plan-non-responsive-frame-single-variant');
 $assert(1 === count($responsiveAboutPage['variants'] ?? array()) && 'frame:about-desktop' === ($responsiveAboutPage['variants'][0]['frame_id'] ?? null), 'page-plan-non-responsive-frame-self-variant');
 
+$planDiagnosticByCode = static function (array $plan, string $code): ?array {
+    foreach ( $plan['diagnostics'] ?? array() as $diagnostic ) {
+        if ( is_array($diagnostic) && $code === ($diagnostic['code'] ?? null) ) {
+            return $diagnostic;
+        }
+    }
+
+    return null;
+};
+
+// (b) A genuine desktop/tablet/mobile group STILL collapses AND records its
+// grouping rationale (distinct device hints).
+$responsiveGroupDiagnostic = $planDiagnosticByCode($responsivePagePlan, 'responsive_group_formed');
+$assert(null !== $responsiveGroupDiagnostic, 'page-plan-responsive-group-rationale-emitted');
+$assert(in_array('device_hint_diversity', $responsiveGroupDiagnostic['reasons'] ?? array(), true), 'page-plan-responsive-group-rationale-device-diversity');
+$assert('frame:home-desktop' === ($responsiveGroupDiagnostic['primary_frame_id'] ?? null), 'page-plan-responsive-group-rationale-primary');
+
+// (a) FALSE-POSITIVE GUARD: four same-name, same-device-hint (desktop),
+// same-width (1440) frames differing only in height are duplicate/iteration
+// drafts (the real "For Hosts" data finding), NOT responsive breakpoints. They
+// must stay as separate pages and surface a duplicate_draft_frames diagnostic.
+$duplicateDraftSource = array(
+    'nodes' => array(
+        array(
+            'id'       => 'page:hosts',
+            'type'     => 'CANVAS',
+            'name'     => 'Hosts Pages',
+            'children' => array(
+                array(
+                    'id'       => 'section:hosts',
+                    'type'     => 'SECTION',
+                    'name'     => 'Marketing',
+                    'width'    => 4000,
+                    'height'   => 40000,
+                    'children' => array(
+                        array(
+                            'id'       => 'frame:hosts-a',
+                            'type'     => 'FRAME',
+                            'name'     => 'For Hosts',
+                            'width'    => 1440,
+                            'height'   => 9777,
+                            'children' => array(array('id' => 'text:hosts-a', 'type' => 'TEXT', 'name' => 'Headline', 'characters' => 'For Hosts')),
+                        ),
+                        array(
+                            'id'       => 'frame:hosts-b',
+                            'type'     => 'FRAME',
+                            'name'     => 'For Hosts',
+                            'width'    => 1440,
+                            'height'   => 8613,
+                            'children' => array(array('id' => 'text:hosts-b', 'type' => 'TEXT', 'name' => 'Headline', 'characters' => 'For Hosts')),
+                        ),
+                        array(
+                            'id'       => 'frame:hosts-c',
+                            'type'     => 'FRAME',
+                            'name'     => 'For Hosts',
+                            'width'    => 1440,
+                            'height'   => 9188,
+                            'children' => array(array('id' => 'text:hosts-c', 'type' => 'TEXT', 'name' => 'Headline', 'characters' => 'For Hosts')),
+                        ),
+                        array(
+                            'id'       => 'frame:hosts-d',
+                            'type'     => 'FRAME',
+                            'name'     => 'For Hosts',
+                            'width'    => 1440,
+                            'height'   => 9000,
+                            'children' => array(array('id' => 'text:hosts-d', 'type' => 'TEXT', 'name' => 'Headline', 'characters' => 'For Hosts')),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$duplicateDraftPlan = ( new ScenegraphPagePlanner() )->plan($duplicateDraftSource, array('include_all_pages' => true));
+$assert(4 === ($duplicateDraftPlan['page_count'] ?? null), 'page-plan-duplicate-drafts-stay-separate-pages');
+$duplicateDraftResponsive = false;
+foreach ( $duplicateDraftPlan['pages'] ?? array() as $duplicatePage ) {
+    if ( is_array($duplicatePage) && true === ($duplicatePage['responsive'] ?? null) ) {
+        $duplicateDraftResponsive = true;
+    }
+}
+$assert(false === $duplicateDraftResponsive, 'page-plan-duplicate-drafts-not-responsive');
+$duplicateDraftDiagnostic = $planDiagnosticByCode($duplicateDraftPlan, 'duplicate_draft_frames');
+$assert(null !== $duplicateDraftDiagnostic, 'page-plan-duplicate-drafts-diagnostic-emitted');
+$assert('desktop' === ($duplicateDraftDiagnostic['device_hint'] ?? null), 'page-plan-duplicate-drafts-diagnostic-device-hint');
+$assert(4 === count($duplicateDraftDiagnostic['frame_ids'] ?? array()), 'page-plan-duplicate-drafts-diagnostic-frame-count');
+$assert(null === $planDiagnosticByCode($duplicateDraftPlan, 'responsive_group_formed'), 'page-plan-duplicate-drafts-not-grouped');
+
+// (c) MEMORY SAFETY: when the scenegraph exceeds the responsive-detection node
+// limit, detection is skipped (no second full index build), the transform
+// COMPLETES, a responsive_detection_bounded diagnostic is emitted, and frames
+// fall back to one-page-per-frame instead of collapsing.
+$boundedPlan = ( new ScenegraphPagePlanner() )->plan(
+    $responsivePagePlanSource,
+    array('include_all_pages' => true, 'responsive_detection_node_limit' => 3)
+);
+$boundedDiagnostic = $planDiagnosticByCode($boundedPlan, 'responsive_detection_bounded');
+$assert(null !== $boundedDiagnostic, 'page-plan-bounded-detection-diagnostic-emitted');
+$assert(3 === ($boundedDiagnostic['node_limit'] ?? null), 'page-plan-bounded-detection-node-limit');
+$assert(($boundedDiagnostic['node_count'] ?? 0) > 3, 'page-plan-bounded-detection-node-count');
+$assert(4 === ($boundedPlan['page_count'] ?? null), 'page-plan-bounded-detection-one-page-per-frame');
+$boundedHomePage = $responsivePageByFrame($boundedPlan, 'frame:home-desktop');
+$assert(null !== $boundedHomePage && false === ($boundedHomePage['responsive'] ?? null), 'page-plan-bounded-detection-no-collapse');
+
 $matrixWebsiteCandidate = array(
     'id'         => 'matrix:site:home',
     'type'       => 'FRAME',


### PR DESCRIPTION
## Summary

Hardens the responsive sibling-group collapsing introduced in #251, based on two real-data failures found running the fixture matrix on real designs. Refs #247.

**STACKED ON #251** (`cook/figma-pageplanner-responsive-grouping`). This PR fixes code that only exists on that branch and should merge **after** it.

## Data findings addressed

1. **False-positive grouping (real "WP.Cloud 2.0" .fig).** The "For Hosts" cluster grouped four "siblings", but all four frames are `device_hint: desktop`, `width: 1440`, differing only in height (9777 / 8613 / 9188 px). These are duplicate/iteration **drafts** of one desktop page, not responsive breakpoints — #251 would wrongly collapse them into one "page with 4 variants".
2. **Memory regression / OOM.** `detectionById()` re-inspected the source with `frame_inspection_limit = full node count`, forcing `ScenegraphFrameInspector::inspect()` → a **second** full `ScenegraphIndex::build()` over the whole scenegraph during planning. On the 293MB "WP.Cloud 2.0" design that fatally OOMed ("Allowed memory size of 1610612736 bytes exhausted in ScenegraphIndex.php:39", i.e. 1536M), failing the whole transform with exit 255 and no diagnostic.

## Changes

**Grouping guard (false-positive).** A sibling-group collapses into one responsive page only when members have **distinct device hints** OR a **material width spread** (`>= 200px` absolute AND `>= 20%` relative). Same-name + same-device-hint + ~same-width clusters are treated as duplicate drafts: they stay as **separate pages** and emit a `duplicate_draft_frames` diagnostic (with the picked canonical + draft ids) instead of becoming breakpoint variants.

**Memory safety.** Planning-time detection is bounded by a node-count ceiling (default **25000**, overridable via the `responsive_detection_node_limit` plan option). Above the ceiling the full-node inspection is **skipped entirely** — the second full index is never built — and the planner degrades to one-page-per-frame so the transform **completes** rather than OOMing.

**Diagnostics.** New planner diagnostics:
- `responsive_detection_bounded` — detection was size-degraded; carries `node_count` + `node_limit`.
- `responsive_group_formed` — grouping rationale (`reasons`: `device_hint_diversity` / `width_spread`, plus hints + width spread).
- `duplicate_draft_frames` — rejected duplicate-draft cluster (canonical + draft frame ids, shared device hint + width).

The `ScenegraphFrameInspector` detection output contract is unchanged; the emitter is untouched.

## Tests

`figma-transformer/tests/contract/run.php` adds three cases proving both fixes:
- (a) a 4× same-width / same-desktop-hint "For Hosts" cluster does **not** collapse — stays 4 separate pages, none responsive, `duplicate_draft_frames` emitted, no `responsive_group_formed`. (Verified the inspector *does* link all four as siblings, so the guard — not absence of detection — is what keeps them apart.)
- (b) a genuine desktop/tablet/mobile group **still** collapses to one page with ordered variants and emits `responsive_group_formed` with `device_hint_diversity`.
- (c) a synthetic over-limit scenegraph triggers `responsive_detection_bounded`, the transform **completes**, and frames fall back to one-page-per-frame.

```
$ cd figma-transformer && php tests/contract/run.php
Figma Transformer contract tests passed.
```

Memory safety is validated with a **synthetic large-node fixture**, not the real 293MB `.fig` (which OOMs / exhausts this machine). Full real-file validation should run on the **Homeboy fixture-matrix rig**, not locally.

## Caveats / thresholds
- Node ceiling default **25000** and width thresholds (**200px / 20%**) are tuned conservatively from the observed data; revisit if real designs surface legitimate breakpoint pairs below them.
- Real-293MB end-to-end validation needs a Homeboy offload run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Hardening responsive grouping (false-positive guard + memory-safe bounded detection + diagnostics) for #247, stacked on #251.