### PR TITLE
Emit real anchor tags from Figma links with a link-coverage diagnostic

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -463,6 +463,7 @@ final class FigmaTransformer
         $nodeCount = 0;
         $textNodeCount = 0;
         $assetReferenceCount = 0;
+        $linkTargetPaths = $this->linkTargetPathsFromPages($pages);
 
         foreach ( $pages as $page ) {
             if ( ! is_array($page) ) {
@@ -482,6 +483,7 @@ final class FigmaTransformer
             $pageOptions['render_style_mismatch_options'] = is_array($pageOptions['render_style_mismatch_options'] ?? null) ? $pageOptions['render_style_mismatch_options'] : array();
             $pageOptions['render_style_mismatch_options']['page_path'] = $path;
             unset($pageOptions['multi_page'], $pageOptions['include_all_pages'], $pageOptions['frame_ids'], $pageOptions['entry_frame_id'], $pageOptions['max_pages'], $pageOptions['frame_slug_map']);
+            $pageOptions['link_target_paths'] = $linkTargetPaths;
             $pageResult = $this->transformScenegraph($scenegraph, $pageOptions)->toArray();
             $pageDiagnostics = is_array($pageResult['diagnostics'] ?? null) ? $pageResult['diagnostics'] : array();
             $diagnostics = array_merge($diagnostics, $pageDiagnostics);
@@ -782,6 +784,32 @@ final class FigmaTransformer
         }
 
         return $artifactQuality;
+    }
+
+    /**
+     * Map planned frame ids to their generated page paths so per-page emission can resolve NODE/prototype links to slugs.
+     *
+     * @param array<int, mixed> $pages
+     * @return array<string, string>
+     */
+    private function linkTargetPathsFromPages(array $pages): array
+    {
+        $map = array();
+        foreach ( $pages as $page ) {
+            if ( ! is_array($page) ) {
+                continue;
+            }
+
+            $frameId = isset($page['frame_id']) && is_scalar($page['frame_id']) ? (string) $page['frame_id'] : '';
+            $path = isset($page['path']) && is_scalar($page['path']) ? (string) $page['path'] : '';
+            if ( '' === $frameId || '' === $path ) {
+                continue;
+            }
+
+            $map[$frameId] = $path;
+        }
+
+        return $map;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -45,6 +45,20 @@ final class StaticHtmlEmitter
     private bool $renderTextGlyphPaths = false;
 
     /**
+     * Resolved destination-node-id => page-path map used to turn NODE/prototype links into slug hrefs.
+     *
+     * @var array<string, string>
+     */
+    private array $linkTargetPaths = array();
+
+    /**
+     * Running link-coverage tallies populated while emitting nodes.
+     *
+     * @var array<string, mixed>
+     */
+    private array $linkCoverage = array();
+
+    /**
      * @param array<string, mixed> $scenegraph Normalized Figma scenegraph.
      * @param array<string, mixed> $options Transformation options.
      * @return array<string, mixed>
@@ -55,6 +69,8 @@ final class StaticHtmlEmitter
         $this->usedAssetPaths = array();
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
+        $this->linkTargetPaths = $this->normalizeLinkTargetPaths($options);
+        $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
         $nodes = $this->nodeList($scenegraph);
         $diagnostics = array();
@@ -69,6 +85,7 @@ final class StaticHtmlEmitter
             '.figma-root{position:relative;width:100%}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
+            'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
         );
         if ( $this->renderTextGlyphPaths ) {
@@ -164,6 +181,8 @@ final class StaticHtmlEmitter
         $this->usedAssetPaths = array();
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
+        $this->linkTargetPaths = $this->linkTargetPathsFromPagePlan($pagePlan, $options);
+        $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
         $diagnostics = array();
         $nodeStyleDiagnostics = array();
@@ -177,6 +196,7 @@ final class StaticHtmlEmitter
             '.figma-root{position:relative;width:100%}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
             'img{display:block;max-width:100%;height:auto}',
+            'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
         );
         if ( $this->renderTextGlyphPaths ) {
@@ -418,7 +438,9 @@ final class StaticHtmlEmitter
             $attributes .= ' role="img" aria-label="' . $this->sanitizeAttribute('' !== $name ? $name : $type) . '"';
         }
 
-        return sprintf("<%1\$s%2\$s>%3\$s</%1\$s>\n", $tag, $attributes, $content);
+        $element = sprintf("<%1\$s%2\$s>%3\$s</%1\$s>\n", $tag, $attributes, $content);
+
+        return $this->wrapWithLink($node, $element, $diagnostics);
     }
 
     private function tagName(string $type, string $name, int $depth): string
@@ -713,6 +735,176 @@ final class StaticHtmlEmitter
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    private function newLinkCoverage(): array
+    {
+        return array(
+            'sources_found'      => 0,
+            'anchors_emitted'    => 0,
+            'url_links'          => 0,
+            'node_links'         => 0,
+            'unresolved'         => 0,
+            'unresolved_targets' => array(),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, string>
+     */
+    private function normalizeLinkTargetPaths(array $options): array
+    {
+        $map = array();
+        $raw = is_array($options['link_target_paths'] ?? null) ? $options['link_target_paths'] : array();
+        foreach ( $raw as $nodeId => $path ) {
+            if ( is_scalar($nodeId) && is_scalar($path) && '' !== (string) $nodeId && '' !== (string) $path ) {
+                $map[(string) $nodeId] = (string) $path;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, mixed> $pagePlan
+     * @param array<string, mixed> $options
+     * @return array<string, string>
+     */
+    private function linkTargetPathsFromPagePlan(array $pagePlan, array $options): array
+    {
+        $map = $this->normalizeLinkTargetPaths($options);
+        foreach ( $this->plannedPages($pagePlan) as $index => $page ) {
+            if ( ! is_array($page) ) {
+                continue;
+            }
+
+            $frameId = isset($page['frame_id']) && is_scalar($page['frame_id']) ? (string) $page['frame_id'] : '';
+            if ( '' === $frameId || isset($map[$frameId]) ) {
+                continue;
+            }
+
+            $name = (string) ($page['name'] ?? $frameId);
+            $map[$frameId] = $this->pagePath($page, $name, is_int($index) ? $index : 0);
+        }
+
+        return $map;
+    }
+
+    /**
+     * Wrap an emitted element in a real anchor when the node carries Figma link data.
+     *
+     * @param array<string, mixed>             $node
+     * @param array<int, array<string, mixed>> $diagnostics
+     */
+    private function wrapWithLink(array $node, string $element, array &$diagnostics): string
+    {
+        $link = is_array($node['figma_link'] ?? null) ? $node['figma_link'] : array();
+        if ( empty($link) ) {
+            return $element;
+        }
+
+        $this->linkCoverage['sources_found']++;
+        $type = (string) ($link['type'] ?? '');
+        $nodeId = (string) ($node['id'] ?? '');
+        $targetNodeId = (string) ($link['target_node_id'] ?? '');
+        $href = null;
+        $resolved = false;
+
+        if ( 'url' === $type ) {
+            $this->linkCoverage['url_links']++;
+            $href = $this->sanitizeLinkUrl((string) ($link['url'] ?? ''));
+            $resolved = '#' !== $href;
+        } elseif ( 'node' === $type ) {
+            $this->linkCoverage['node_links']++;
+            if ( '' !== $targetNodeId && isset($this->linkTargetPaths[$targetNodeId]) ) {
+                $href = $this->linkTargetPaths[$targetNodeId];
+                $resolved = true;
+            } else {
+                $href = '#';
+            }
+        }
+
+        if ( null === $href ) {
+            return $element;
+        }
+
+        if ( ! $resolved ) {
+            $this->linkCoverage['unresolved']++;
+            if ( count($this->linkCoverage['unresolved_targets']) < 50 ) {
+                $this->linkCoverage['unresolved_targets'][] = array(
+                    'node_id'        => $nodeId,
+                    'link_type'      => $type,
+                    'target_node_id' => $targetNodeId,
+                    'source'         => (string) ($link['source'] ?? ''),
+                );
+            }
+            $diagnostics[] = array(
+                'severity' => 'info',
+                'code'     => 'link_target_unresolved',
+                'message'  => 'Figma link target could not be resolved to a generated page and was emitted as a placeholder anchor.',
+                'context'  => array(
+                    'node_id'        => $nodeId,
+                    'link_type'      => $type,
+                    'target_node_id' => $targetNodeId,
+                    'source'         => (string) ($link['source'] ?? ''),
+                ),
+            );
+        }
+
+        $this->linkCoverage['anchors_emitted']++;
+
+        return sprintf(
+            "<a class=\"figma-link\" href=\"%1\$s\" data-figma-link-type=\"%2\$s\">%3\$s</a>\n",
+            $this->sanitizeAttribute($href),
+            $this->sanitizeAttribute($type),
+            $element
+        );
+    }
+
+    private function sanitizeLinkUrl(string $url): string
+    {
+        $url = trim($url);
+        if ( '' === $url ) {
+            return '#';
+        }
+
+        if ( str_starts_with($url, '#') || str_starts_with($url, '/') || str_starts_with($url, '?') ) {
+            return $url;
+        }
+
+        if ( 1 === preg_match('/^(https?:|mailto:|tel:)/i', $url) ) {
+            return $url;
+        }
+
+        // Reject unsafe or unsupported schemes (javascript:, data:, etc.).
+        if ( 1 === preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url) ) {
+            return '#';
+        }
+
+        // Schemeless relative reference (e.g. about.html, ../contact/).
+        return $url;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function linkDiagnostics(): array
+    {
+        $coverage = $this->linkCoverage;
+
+        return array(
+            'schema'             => 'blocks-engine/figma-transformer/link-coverage/v1',
+            'sources_found'      => (int) ($coverage['sources_found'] ?? 0),
+            'anchors_emitted'    => (int) ($coverage['anchors_emitted'] ?? 0),
+            'url_links'          => (int) ($coverage['url_links'] ?? 0),
+            'node_links'         => (int) ($coverage['node_links'] ?? 0),
+            'unresolved'         => (int) ($coverage['unresolved'] ?? 0),
+            'unresolved_targets' => array_values(is_array($coverage['unresolved_targets'] ?? null) ? $coverage['unresolved_targets'] : array()),
+        );
+    }
+
+    /**
      * @param array<int, array<string, mixed>> $nodes
      * @return array<int, array<string, mixed>>
      */
@@ -790,6 +982,8 @@ final class StaticHtmlEmitter
             'missing_css'   => '' === $fontCss ? array_values(array_filter($fontFamilies, fn (string $family): bool => ! $this->isWebSafeFontFamily($family))) : array(),
         );
 
+        $links = $this->linkDiagnostics();
+
         return array(
             'schema' => 'blocks-engine/figma-transformer/transform-diagnostics/v1',
             'selection' => $this->selectionDiagnostics($nodes),
@@ -799,7 +993,8 @@ final class StaticHtmlEmitter
             'assets' => $assets,
             'generated_svg_assets' => $generatedSvgAssets,
             'layout' => $layout,
-            'artifact_quality' => $this->artifactQualityDiagnostics($image, $vectors, $fonts, $assets, $generatedSvgAssets, $layout),
+            'links' => $links,
+            'artifact_quality' => $this->artifactQualityDiagnostics($image, $vectors, $fonts, $assets, $generatedSvgAssets, $layout, $links),
             'diagnostic_codes' => $this->diagnosticCodeCounts($diagnostics),
         );
     }
@@ -811,9 +1006,10 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $assets
      * @param array<string, mixed> $generatedSvgAssets
      * @param array<string, mixed> $layout
+     * @param array<string, mixed> $links
      * @return array<string, mixed>
      */
-    private function artifactQualityDiagnostics(array $image, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout): array
+    private function artifactQualityDiagnostics(array $image, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout, array $links = array()): array
     {
         $signals = array();
 
@@ -889,6 +1085,14 @@ final class StaticHtmlEmitter
                 'bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
             );
         }
+        if ( ! empty($links['unresolved']) ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'link_target_unresolved',
+                'count' => (int) $links['unresolved'],
+                'sample_nodes' => array_slice(is_array($links['unresolved_targets'] ?? null) ? $links['unresolved_targets'] : array(), 0, 10),
+            );
+        }
 
         $failCodes = array('missing_render_assets', 'vector_placeholders');
         $failCount = count(array_filter($signals, static fn (array $signal): bool => in_array((string) ($signal['code'] ?? ''), $failCodes, true)));
@@ -920,6 +1124,9 @@ final class StaticHtmlEmitter
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
                 'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
                 'layout_mismatch_status' => (string) ($layout['layout_mismatch_status'] ?? 'not_evaluated'),
+                'link_sources_found' => (int) ($links['sources_found'] ?? 0),
+                'anchors_emitted' => (int) ($links['anchors_emitted'] ?? 0),
+                'link_targets_unresolved' => (int) ($links['unresolved'] ?? 0),
             ),
         );
     }

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -497,6 +497,11 @@ final class ScenegraphNormalizer
             $node['figma_effects'] = $effects;
         }
 
+        $link = $this->normalizeLink($node, $type);
+        if ( ! empty($link) ) {
+            $node['figma_link'] = $link;
+        }
+
         foreach ( array('children', 'nodes') as $childrenKey ) {
             if ( ! is_array($node[$childrenKey] ?? null) ) {
                 continue;
@@ -922,7 +927,7 @@ final class ScenegraphNormalizer
         $resolved['type'] = 'INSTANCE';
         $resolved['name'] = (string) ($instance['name'] ?? $resolved['name'] ?? '');
 
-        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_vector_paths', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd') as $key ) {
+        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd') as $key ) {
             if ( array_key_exists($key, $instance) ) {
                 $resolved[$key] = $instance[$key];
             }
@@ -1678,6 +1683,172 @@ final class ScenegraphNormalizer
         }
 
         return $segments;
+    }
+
+    /**
+     * Capture Figma hyperlink and prototype navigation data so the emitter can produce real anchors.
+     *
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function normalizeLink(array $node, string $type): array
+    {
+        if ( 'TEXT' === $type ) {
+            if ( array_key_exists('hyperlink', $node) ) {
+                $link = $this->normalizeHyperlinkValue($node['hyperlink']);
+                if ( null !== $link ) {
+                    $link['source'] = 'hyperlink';
+                    return $link;
+                }
+            }
+
+            $segmentLink = $this->normalizeSegmentHyperlink($node);
+            if ( null !== $segmentLink ) {
+                return $segmentLink;
+            }
+        } elseif ( array_key_exists('hyperlink', $node) ) {
+            $link = $this->normalizeHyperlinkValue($node['hyperlink']);
+            if ( null !== $link ) {
+                $link['source'] = 'hyperlink';
+                return $link;
+            }
+        }
+
+        $reactionLink = $this->normalizeReactionLink($node);
+        if ( null !== $reactionLink ) {
+            return $reactionLink;
+        }
+
+        return array();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function normalizeHyperlinkValue(mixed $hyperlink): ?array
+    {
+        if ( is_string($hyperlink) && '' !== trim($hyperlink) ) {
+            return array('type' => 'url', 'url' => trim($hyperlink));
+        }
+
+        if ( ! is_array($hyperlink) ) {
+            return null;
+        }
+
+        $type = strtoupper((string) ($hyperlink['type'] ?? ''));
+        $url = $this->readString($hyperlink, array('url', 'href'));
+        $nodeId = $this->readString($hyperlink, array('nodeID', 'nodeId', 'node_id'))
+            ?? $this->readGuidId($hyperlink['nodeID'] ?? ($hyperlink['nodeId'] ?? null));
+
+        if ( 'URL' === $type && null !== $url ) {
+            return array('type' => 'url', 'url' => $url);
+        }
+        if ( 'NODE' === $type && null !== $nodeId ) {
+            return array('type' => 'node', 'target_node_id' => $nodeId);
+        }
+        if ( null !== $url ) {
+            return array('type' => 'url', 'url' => $url);
+        }
+        if ( null !== $nodeId ) {
+            return array('type' => 'node', 'target_node_id' => $nodeId);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>|null
+     */
+    private function normalizeSegmentHyperlink(array $node): ?array
+    {
+        foreach ( array('styledTextSegments', 'segments') as $key ) {
+            if ( ! is_array($node[$key] ?? null) ) {
+                continue;
+            }
+
+            foreach ( $node[$key] as $segment ) {
+                if ( ! is_array($segment) || ! array_key_exists('hyperlink', $segment) ) {
+                    continue;
+                }
+
+                $link = $this->normalizeHyperlinkValue($segment['hyperlink']);
+                if ( null !== $link ) {
+                    $link['source'] = 'segment';
+                    $link['partial'] = true;
+                    return $link;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>|null
+     */
+    private function normalizeReactionLink(array $node): ?array
+    {
+        foreach ( is_array($node['reactions'] ?? null) ? $node['reactions'] : array() as $reaction ) {
+            if ( ! is_array($reaction) ) {
+                continue;
+            }
+
+            $actions = is_array($reaction['actions'] ?? null)
+                ? $reaction['actions']
+                : (is_array($reaction['action'] ?? null) ? array($reaction['action']) : array());
+            foreach ( $actions as $action ) {
+                if ( ! is_array($action) ) {
+                    continue;
+                }
+
+                $link = $this->normalizeActionLink($action);
+                if ( null !== $link ) {
+                    $link['source'] = 'reaction';
+                    return $link;
+                }
+            }
+        }
+
+        $transition = $this->readString($node, array('transitionNodeID', 'transitionNodeId'))
+            ?? $this->readGuidId($node['transitionNodeID'] ?? null);
+        if ( null !== $transition && '' !== $transition ) {
+            return array('type' => 'node', 'target_node_id' => $transition, 'source' => 'transition');
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $action
+     * @return array<string, mixed>|null
+     */
+    private function normalizeActionLink(array $action): ?array
+    {
+        $type = strtoupper((string) ($action['type'] ?? ''));
+        $url = $this->readString($action, array('url', 'href'));
+        if ( 'URL' === $type && null !== $url ) {
+            return array('type' => 'url', 'url' => $url);
+        }
+
+        $destination = $this->readString($action, array('destinationId', 'navigationDestinationId', 'transitionNodeID'))
+            ?? $this->readGuidId($action['destinationId'] ?? null);
+        $navigation = strtoupper((string) ($action['navigation'] ?? ''));
+        $navigatesToNode = 'NODE' === $type
+            || in_array($navigation, array('NAVIGATE', 'OVERLAY', 'SWAP', 'SCROLL_TO'), true);
+        if ( $navigatesToNode && null !== $destination && '' !== $destination ) {
+            return array('type' => 'node', 'target_node_id' => $destination);
+        }
+
+        if ( null !== $url ) {
+            return array('type' => 'url', 'url' => $url);
+        }
+        if ( null !== $destination && '' !== $destination ) {
+            return array('type' => 'node', 'target_node_id' => $destination);
+        }
+
+        return null;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4735,6 +4735,121 @@ $assert(! str_contains($derivedSymbolInstanceHtml, '<g transform="scale'), 'deri
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-2-derived-label{width:90px;height:24px;position:absolute;left:12px;top:6px'), 'derived-symbol-instance-label-size-position');
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-3-derived-icon{width:10px;height:10px;position:absolute;left:110px;top:10px'), 'derived-symbol-instance-icon-size-position');
 
+// Real anchor tags: a TEXT node carrying a URL hyperlink emits a real <a href>.
+$urlLinkResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Url Link Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'link:1',
+            'type'     => 'FRAME',
+            'name'     => 'Footer',
+            'width'    => 1200,
+            'height'   => 200,
+            'children' => array(
+                array(
+                    'id'         => 'link:2',
+                    'type'       => 'TEXT',
+                    'name'       => 'External link',
+                    'characters' => 'Visit Automattic',
+                    'hyperlink'  => array('type' => 'URL', 'url' => 'https://automattic.com/about'),
+                ),
+            ),
+        ),
+    ),
+));
+$urlLinkHtml = $fileContent($urlLinkResult, 'index.html');
+$urlLinkCss = $fileContent($urlLinkResult, 'style.css');
+$urlLinks = $urlLinkResult['source_reports']['figma']['html']['transform_diagnostics']['links'] ?? array();
+$assert(str_contains($urlLinkHtml, '<a class="figma-link" href="https://automattic.com/about" data-figma-link-type="url">'), 'url-hyperlink-emits-anchor');
+$assert(str_contains($urlLinkHtml, '<a class="figma-link" href="https://automattic.com/about" data-figma-link-type="url"><p class="figma-node-link-2-external-link"'), 'url-hyperlink-wraps-element-transparently');
+$assert(str_contains($urlLinkCss, 'a.figma-link{display:contents'), 'figma-link-display-contents-rule');
+$assert(1 === ($urlLinks['sources_found'] ?? null) && 1 === ($urlLinks['anchors_emitted'] ?? null) && 1 === ($urlLinks['url_links'] ?? null) && 0 === ($urlLinks['unresolved'] ?? null), 'url-hyperlink-link-coverage');
+
+// Real anchor tags: a NODE/prototype link resolving to a planned frame emits the slug href.
+$navScenegraph = array(
+    'name'  => 'Nav Link Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'nav:home',
+            'type'     => 'FRAME',
+            'name'     => 'Home',
+            'width'    => 1280,
+            'height'   => 900,
+            'children' => array(
+                array(
+                    'id'         => 'nav:home-link',
+                    'type'       => 'TEXT',
+                    'name'       => 'About nav item',
+                    'characters' => 'About',
+                    'hyperlink'  => array('type' => 'NODE', 'nodeID' => 'nav:about'),
+                ),
+                array(
+                    'id'         => 'nav:proto-link',
+                    'type'       => 'FRAME',
+                    'name'       => 'CTA button',
+                    'width'      => 160,
+                    'height'     => 48,
+                    'reactions'  => array(
+                        array(
+                            'trigger' => array('type' => 'ON_CLICK'),
+                            'action'  => array('type' => 'NODE', 'navigation' => 'NAVIGATE', 'destinationId' => 'nav:about'),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'       => 'nav:about',
+            'type'     => 'FRAME',
+            'name'     => 'About',
+            'width'    => 1280,
+            'height'   => 900,
+            'children' => array(
+                array('id' => 'nav:about-title', 'type' => 'TEXT', 'name' => 'About title', 'characters' => 'About us'),
+            ),
+        ),
+    ),
+);
+$navResult = blocks_engine_figma_transformer_transform_scenegraph($navScenegraph, array('include_all_pages' => true, 'entry_frame_id' => 'nav:home'));
+$navHomeHtml = $fileContent($navResult, 'index.html');
+$assert(str_contains($navHomeHtml, '<a class="figma-link" href="about.html" data-figma-link-type="node">'), 'node-hyperlink-resolves-to-slug');
+$assert(2 === substr_count($navHomeHtml, 'href="about.html"'), 'node-and-prototype-links-both-resolve');
+
+// Real anchor tags: an unresolved NODE link is counted in the diagnostic and emitted as a placeholder anchor.
+$unresolvedResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Unresolved Link Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'dead:1',
+            'type'     => 'FRAME',
+            'name'     => 'Nav',
+            'width'    => 1200,
+            'height'   => 120,
+            'children' => array(
+                array(
+                    'id'         => 'dead:2',
+                    'type'       => 'TEXT',
+                    'name'       => 'Broken link',
+                    'characters' => 'Missing page',
+                    'hyperlink'  => array('type' => 'NODE', 'nodeID' => 'does:not:exist'),
+                ),
+            ),
+        ),
+    ),
+));
+$unresolvedHtml = $fileContent($unresolvedResult, 'index.html');
+$unresolvedLinks = $unresolvedResult['source_reports']['figma']['html']['transform_diagnostics']['links'] ?? array();
+$unresolvedSignalCodes = $artifactQualitySignalCodes($unresolvedResult);
+$unresolvedDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $unresolvedResult['diagnostics'] ?? array()
+);
+$assert(str_contains($unresolvedHtml, '<a class="figma-link" href="#" data-figma-link-type="node">'), 'unresolved-node-link-emits-placeholder-anchor');
+$assert(1 === ($unresolvedLinks['unresolved'] ?? null) && 1 === ($unresolvedLinks['node_links'] ?? null), 'unresolved-link-counted-in-coverage');
+$assert('does:not:exist' === ($unresolvedLinks['unresolved_targets'][0]['target_node_id'] ?? null), 'unresolved-link-records-target-node-id');
+$assert(in_array('link_target_unresolved', $unresolvedSignalCodes, true), 'unresolved-link-artifact-quality-signal');
+$assert(in_array('link_target_unresolved', $unresolvedDiagnosticCodes, true), 'unresolved-link-diagnostic-code');
+
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 
 if ( ! empty($failures) ) {


### PR DESCRIPTION
## Motivation (#247)

Verified this session by running the fixture matrix on real 185MB/293MB `.fig` designs: the transformer emitted **zero** real links. `StaticHtmlEmitter` had no `<a href>` emission (only the stylesheet `<link>`), and `ScenegraphNormalizer` dropped all hyperlink/reaction/navigation data. Every navigation item, footer link, and prototype button rendered as an unclickable styled `<div>`. A site you cannot navigate is not a website.

This slice captures Figma link data and emits real `<a href>` elements, plus a link-coverage diagnostic.

## What changed

**Capture (`ScenegraphNormalizer`)** — normalized nodes now carry a `figma_link` derived from:
- Text node `hyperlink` (`URL` -> external href, `NODE` -> destination node id).
- Character-level styled-segment hyperlinks (whole-node anchor, flagged `partial`).
- Frame/instance prototype `reactions` (`action.type`/`navigation`/`destinationId`) and legacy `transitionNodeID`.
- Resolved component instances preserve their own link data.

**Emit (`StaticHtmlEmitter`)** — each linked element is wrapped in a real, transparent `<a class="figma-link">`:
- `display:contents` with inherited `color`/`text-decoration` so the anchor is a transparent wrapper and existing layout/styles do not regress.
- `URL` links emit the href directly, with scheme sanitization (drops `javascript:`/`data:`, keeps http(s)/mailto/tel/relative/anchor).
- `NODE`/prototype links resolve their destination frame id to the planned page path (slug), else emit `href="#"` and record it as unresolved.

**Resolution wiring (`FigmaTransformer`)** — the multi-page transform builds a resolved `frame_id -> page-path` map from the page plan and threads it into each per-page emission so cross-page `NODE`/prototype links resolve to real slug hrefs.

## Diagnostic

New link-coverage signal wired into the same `transform_diagnostics` / `artifact_quality` surface as existing signals:
- `transform_diagnostics.links`: `sources_found`, `anchors_emitted`, `url_links`, `node_links`, `unresolved`, `unresolved_targets` (with node ids).
- `artifact_quality` gains a `link_target_unresolved` signal and summary counts (`link_sources_found`, `anchors_emitted`, `link_targets_unresolved`).
- Each unresolved target also emits a `link_target_unresolved` diagnostic code carrying the source/target node ids.

## Tests

Added focused coverage in `figma-transformer/tests/contract/run.php`:
- A URL-hyperlink text node emits `<a class="figma-link" href="https://...">` wrapping the element, with the `display:contents` rule and correct coverage counts.
- A `NODE` hyperlink and an `ON_CLICK` prototype reaction both resolving to a planned frame emit the slug href (`about.html`).
- An unresolved `NODE` link emits a placeholder `href="#"` anchor and is counted in `links.unresolved`, the `link_target_unresolved` artifact-quality signal, and the diagnostic codes.

`cd figma-transformer && php tests/contract/run.php` -> `Figma Transformer contract tests passed.`

Per instructions, the large local `.fig` files were not run (synthetic fixtures + contract tests only).

## Caveats
- `NODE`/prototype links resolve only when the destination node id is a **planned top-level FRAME** in the page plan; targets to non-planned frames (or single-page transforms with no page plan) emit `href="#"` and are counted as unresolved by design.
- For real Figma sources, resolution depends on reaction `destinationId`/hyperlink node ids matching scenegraph node ids; mismatches surface cleanly through the unresolved diagnostic rather than silently dropping.
- Partial (character-level) text links are captured and emitted as a single whole-node anchor for this first pass to avoid inline layout regressions; full inline-segment anchoring is future work.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Implementing real anchor-tag emission + link-coverage diagnostic for #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)