### PR TITLE
Emit @font-face/font CSS and actionable font-coverage diagnostic (#247)

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\FigmaTransformer\Contract\FigmaTransformResult;
 use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\LayoutMismatchReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\RenderStyleMismatchReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader;
+use Automattic\BlocksEngine\FigmaTransformer\Html\FontResolver;
 use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\ParityReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphFrameInspector;
@@ -859,7 +860,6 @@ final class FigmaTransformer
         );
         $fontFamilies = array();
         $fontUsage = array();
-        $missingCss = array();
         $fontCssSupplied = false;
         $fontMaterialized = false;
         $diagnosticCodes = array();
@@ -905,7 +905,6 @@ final class FigmaTransformer
             $pageFonts = is_array($diagnostics['fonts'] ?? null) ? $diagnostics['fonts'] : array();
             $fontFamilies = $this->mergeFontFamilies($fontFamilies, is_array($pageFonts['families'] ?? null) ? $pageFonts['families'] : array());
             $fontUsage = $this->mergeFontUsage($fontUsage, is_array($pageFonts['usage'] ?? null) ? $pageFonts['usage'] : array());
-            $missingCss = $this->mergeFontFamilies($missingCss, is_array($pageFonts['missing_css'] ?? null) ? $pageFonts['missing_css'] : array());
             $fontCssSupplied = $fontCssSupplied || true === ($pageFonts['css_supplied'] ?? false);
             $fontMaterialized = $fontMaterialized || true === ($pageFonts['materialized'] ?? false);
 
@@ -1000,13 +999,17 @@ final class FigmaTransformer
             $layout['render_style_mismatch_status'] = 'not_run';
         }
         ksort($diagnosticCodes);
+        $fontResolution = ( new FontResolver() )->resolve($fontUsage, $fontCssSupplied ? 'operator-supplied' : '');
         $fonts = array(
             'families' => $fontFamilies,
             'usage' => $fontUsage,
             'count' => count($fontFamilies),
             'css_supplied' => $fontCssSupplied,
             'materialized' => $fontMaterialized,
-            'missing_css' => $missingCss,
+            'missing_css' => $fontResolution['unresolved_families'],
+            'resolved_css' => $fontResolution['resolved_families'],
+            'cdn_families' => $fontResolution['cdn_families'],
+            'coverage' => $fontResolution['coverage'],
         );
         $assets = array(
             'emitted_files' => count($assetReport),
@@ -1261,17 +1264,27 @@ final class FigmaTransformer
      */
     private function mergeCssChunks(array $chunks): string
     {
+        $imports = array();
         $rules = array();
         foreach ( $chunks as $chunk ) {
             foreach ( explode("\n", $chunk) as $line ) {
                 $line = trim($line);
-                if ( '' !== $line ) {
-                    $rules[$line] = true;
+                if ( '' === $line ) {
+                    continue;
                 }
+                // `@import` (and any leading font-source comment) must precede all
+                // other rules to stay valid after chunks are concatenated.
+                if ( str_starts_with($line, '@import') || ( str_starts_with($line, '/*') && str_contains($line, 'web fonts') ) ) {
+                    $imports[$line] = true;
+                    continue;
+                }
+                $rules[$line] = true;
             }
         }
 
-        return implode("\n", array_keys($rules)) . (empty($rules) ? '' : "\n");
+        $ordered = array_merge(array_keys($imports), array_keys($rules));
+
+        return implode("\n", $ordered) . (empty($ordered) ? '' : "\n");
     }
 
     /**

--- a/figma-transformer/src/Html/FontResolver.php
+++ b/figma-transformer/src/Html/FontResolver.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Resolves source font families to emittable font CSS.
+ *
+ * Two resolution sources, in priority order:
+ *  1. Operator-supplied `font_css` passthrough (overrides everything).
+ *  2. Well-known web fonts available from the Google Fonts CDN, emitted as a
+ *     weight-aware `@import` that pulls real `@font-face` rules.
+ *
+ * Web-safe families need no CSS. Anything else is reported as unresolved so an
+ * operator can supply the missing font, keeping the font-coverage diagnostic
+ * actionable rather than a bare count.
+ */
+final class FontResolver
+{
+    /**
+     * Well-known Google Fonts families. Lowercased lookup key => canonical
+     * family name + generic CSS fallback class.
+     *
+     * @var array<string, array{family: string, generic: string}>
+     */
+    private const GOOGLE_FONTS = array(
+        'archivo'           => array('family' => 'Archivo', 'generic' => 'sans-serif'),
+        'barlow'            => array('family' => 'Barlow', 'generic' => 'sans-serif'),
+        'bricolage grotesque' => array('family' => 'Bricolage Grotesque', 'generic' => 'sans-serif'),
+        'cabin'             => array('family' => 'Cabin', 'generic' => 'sans-serif'),
+        'dm sans'           => array('family' => 'DM Sans', 'generic' => 'sans-serif'),
+        'dm serif display'  => array('family' => 'DM Serif Display', 'generic' => 'serif'),
+        'figtree'           => array('family' => 'Figtree', 'generic' => 'sans-serif'),
+        'fira sans'         => array('family' => 'Fira Sans', 'generic' => 'sans-serif'),
+        'ibm plex mono'     => array('family' => 'IBM Plex Mono', 'generic' => 'monospace'),
+        'ibm plex sans'     => array('family' => 'IBM Plex Sans', 'generic' => 'sans-serif'),
+        'ibm plex serif'    => array('family' => 'IBM Plex Serif', 'generic' => 'serif'),
+        'inter'             => array('family' => 'Inter', 'generic' => 'sans-serif'),
+        'josefin sans'      => array('family' => 'Josefin Sans', 'generic' => 'sans-serif'),
+        'jost'              => array('family' => 'Jost', 'generic' => 'sans-serif'),
+        'karla'             => array('family' => 'Karla', 'generic' => 'sans-serif'),
+        'lato'              => array('family' => 'Lato', 'generic' => 'sans-serif'),
+        'libre baskerville' => array('family' => 'Libre Baskerville', 'generic' => 'serif'),
+        'libre franklin'    => array('family' => 'Libre Franklin', 'generic' => 'sans-serif'),
+        'lora'              => array('family' => 'Lora', 'generic' => 'serif'),
+        'manrope'           => array('family' => 'Manrope', 'generic' => 'sans-serif'),
+        'merriweather'      => array('family' => 'Merriweather', 'generic' => 'serif'),
+        'montserrat'        => array('family' => 'Montserrat', 'generic' => 'sans-serif'),
+        'mulish'            => array('family' => 'Mulish', 'generic' => 'sans-serif'),
+        'noto sans'         => array('family' => 'Noto Sans', 'generic' => 'sans-serif'),
+        'noto serif'        => array('family' => 'Noto Serif', 'generic' => 'serif'),
+        'nunito'            => array('family' => 'Nunito', 'generic' => 'sans-serif'),
+        'nunito sans'       => array('family' => 'Nunito Sans', 'generic' => 'sans-serif'),
+        'open sans'         => array('family' => 'Open Sans', 'generic' => 'sans-serif'),
+        'oswald'            => array('family' => 'Oswald', 'generic' => 'sans-serif'),
+        'playfair display'  => array('family' => 'Playfair Display', 'generic' => 'serif'),
+        'plus jakarta sans' => array('family' => 'Plus Jakarta Sans', 'generic' => 'sans-serif'),
+        'poppins'           => array('family' => 'Poppins', 'generic' => 'sans-serif'),
+        'pt sans'           => array('family' => 'PT Sans', 'generic' => 'sans-serif'),
+        'pt serif'          => array('family' => 'PT Serif', 'generic' => 'serif'),
+        'quicksand'         => array('family' => 'Quicksand', 'generic' => 'sans-serif'),
+        'raleway'           => array('family' => 'Raleway', 'generic' => 'sans-serif'),
+        'roboto'            => array('family' => 'Roboto', 'generic' => 'sans-serif'),
+        'roboto mono'       => array('family' => 'Roboto Mono', 'generic' => 'monospace'),
+        'roboto slab'       => array('family' => 'Roboto Slab', 'generic' => 'serif'),
+        'rubik'             => array('family' => 'Rubik', 'generic' => 'sans-serif'),
+        'source sans 3'     => array('family' => 'Source Sans 3', 'generic' => 'sans-serif'),
+        'source sans pro'   => array('family' => 'Source Sans Pro', 'generic' => 'sans-serif'),
+        'source serif 4'    => array('family' => 'Source Serif 4', 'generic' => 'serif'),
+        'source serif pro'  => array('family' => 'Source Serif Pro', 'generic' => 'serif'),
+        'space grotesk'     => array('family' => 'Space Grotesk', 'generic' => 'sans-serif'),
+        'titillium web'     => array('family' => 'Titillium Web', 'generic' => 'sans-serif'),
+        'work sans'         => array('family' => 'Work Sans', 'generic' => 'sans-serif'),
+    );
+
+    /**
+     * Web-safe families that render correctly without any emitted font CSS.
+     *
+     * @var array<string, string>
+     */
+    private const WEB_SAFE = array(
+        'arial'           => 'sans-serif',
+        'helvetica'       => 'sans-serif',
+        'tahoma'          => 'sans-serif',
+        'trebuchet ms'    => 'sans-serif',
+        'verdana'         => 'sans-serif',
+        'courier'         => 'monospace',
+        'courier new'     => 'monospace',
+        'georgia'         => 'serif',
+        'times'           => 'serif',
+        'times new roman' => 'serif',
+        'monospace'       => 'monospace',
+        'sans-serif'      => 'sans-serif',
+        'serif'           => 'serif',
+    );
+
+    /**
+     * Resolve font usage into emittable font CSS plus an actionable coverage
+     * report.
+     *
+     * @param array<int, array<string, mixed>> $fontUsage Font usage entries
+     *        (family/weights/text_node_count), as produced by the emitter.
+     * @param string $operatorFontCss Operator-supplied `font_css` override.
+     * @return array{
+     *     css: string,
+     *     operator_supplied: bool,
+     *     resolved_families: array<int, string>,
+     *     unresolved_families: array<int, string>,
+     *     cdn_families: array<int, string>,
+     *     coverage: array<int, array<string, mixed>>
+     * }
+     */
+    public function resolve(array $fontUsage, string $operatorFontCss = ''): array
+    {
+        $operatorSupplied = '' !== trim($operatorFontCss);
+        $coverage = array();
+        $resolved = array();
+        $unresolved = array();
+        $cdnFamilies = array();
+
+        foreach ( $fontUsage as $usage ) {
+            if ( ! is_array($usage) ) {
+                continue;
+            }
+
+            $family = $this->primaryFamily((string) ($usage['family'] ?? ''));
+            if ( '' === $family ) {
+                continue;
+            }
+
+            $key = strtolower($family);
+            $weights = $this->normalizeWeights(is_array($usage['weights'] ?? null) ? $usage['weights'] : array());
+
+            if ( $operatorSupplied ) {
+                $resolution = 'operator_supplied';
+            } elseif ( isset(self::WEB_SAFE[$key]) ) {
+                $resolution = 'web_safe';
+            } elseif ( isset(self::GOOGLE_FONTS[$key]) ) {
+                $resolution = 'cdn_google_fonts';
+                $canonical = self::GOOGLE_FONTS[$key]['family'];
+                $cdnFamilies[$canonical] = $this->normalizeWeights(array_merge($cdnFamilies[$canonical] ?? array(), $weights));
+            } else {
+                $resolution = 'unresolved';
+            }
+
+            $isResolved = 'unresolved' !== $resolution;
+            if ( $isResolved ) {
+                $resolved[] = $family;
+            } else {
+                $unresolved[] = $family;
+            }
+
+            $entry = array(
+                'family'              => $family,
+                'weights'             => $weights,
+                'text_node_count'     => (int) ($usage['text_node_count'] ?? 0),
+                'resolution'          => $resolution,
+                'resolved'            => $isResolved,
+                'needs_operator_font' => 'unresolved' === $resolution,
+                'fallback_stack'      => $this->fallbackStack($family),
+            );
+            if ( 'cdn_google_fonts' === $resolution ) {
+                $entry['source_url'] = $this->googleFontUrl(self::GOOGLE_FONTS[$key]['family'], $weights);
+            }
+            $coverage[] = $entry;
+        }
+
+        $css = $operatorSupplied ? trim($operatorFontCss) : $this->cdnImportCss($cdnFamilies);
+
+        return array(
+            'css'                 => $css,
+            'operator_supplied'   => $operatorSupplied,
+            'resolved_families'   => array_values(array_unique($resolved)),
+            'unresolved_families' => array_values(array_unique($unresolved)),
+            'cdn_families'        => array_keys($cdnFamilies),
+            'coverage'            => $coverage,
+        );
+    }
+
+    /**
+     * Build a CSS font-family stack for a family name, with a sane generic
+     * fallback so the browser degrades to the right generic family if the
+     * resolved font fails to load.
+     */
+    public function fallbackStack(string $family): string
+    {
+        $family = $this->primaryFamily($family);
+        if ( '' === $family ) {
+            return 'sans-serif';
+        }
+
+        $generic = $this->genericFor($family);
+        if ( strtolower($family) === $generic ) {
+            return $generic;
+        }
+
+        return '"' . str_replace(array('\\', '"'), array('\\\\', '\\"'), $family) . '", ' . $generic;
+    }
+
+    private function genericFor(string $family): string
+    {
+        $key = strtolower($family);
+        if ( isset(self::WEB_SAFE[$key]) ) {
+            return self::WEB_SAFE[$key];
+        }
+        if ( isset(self::GOOGLE_FONTS[$key]) ) {
+            return self::GOOGLE_FONTS[$key]['generic'];
+        }
+        if ( str_contains($key, 'mono') ) {
+            return 'monospace';
+        }
+        if ( str_contains($key, 'serif') && ! str_contains($key, 'sans') ) {
+            return 'serif';
+        }
+
+        return 'sans-serif';
+    }
+
+    /**
+     * @param array<string, array<int, int>> $cdnFamilies Canonical family => weights.
+     */
+    private function cdnImportCss(array $cdnFamilies): string
+    {
+        if ( empty($cdnFamilies) ) {
+            return '';
+        }
+
+        ksort($cdnFamilies, SORT_NATURAL | SORT_FLAG_CASE);
+        $specs = array();
+        foreach ( $cdnFamilies as $family => $weights ) {
+            $specs[] = 'family=' . $this->googleFontSpec((string) $family, $weights);
+        }
+
+        $url = 'https://fonts.googleapis.com/css2?' . implode('&', $specs) . '&display=swap';
+
+        return "/* Figma Transformer: source web fonts resolved via Google Fonts CDN */\n@import url('" . $url . "');";
+    }
+
+    /**
+     * @param array<int, int> $weights
+     */
+    private function googleFontUrl(string $family, array $weights): string
+    {
+        return 'https://fonts.googleapis.com/css2?family=' . $this->googleFontSpec($family, $weights) . '&display=swap';
+    }
+
+    /**
+     * @param array<int, int> $weights
+     */
+    private function googleFontSpec(string $family, array $weights): string
+    {
+        $spec = str_replace(' ', '+', $family);
+        $weights = $this->normalizeWeights($weights);
+        if ( ! empty($weights) ) {
+            $spec .= ':wght@' . implode(';', $weights);
+        }
+
+        return $spec;
+    }
+
+    /**
+     * Clamp weights to the standard 100-900 axis so Google Fonts css2 accepts
+     * them, de-duplicated and sorted ascending.
+     *
+     * @param array<int, mixed> $weights
+     * @return array<int, int>
+     */
+    private function normalizeWeights(array $weights): array
+    {
+        $normalized = array();
+        foreach ( $weights as $weight ) {
+            if ( ! is_numeric($weight) ) {
+                continue;
+            }
+            $rounded = (int) ( round((float) $weight / 100.0) * 100 );
+            $rounded = max(100, min(900, $rounded));
+            $normalized[$rounded] = true;
+        }
+
+        $values = array_keys($normalized);
+        sort($values, SORT_NUMERIC);
+
+        return $values;
+    }
+
+    private function primaryFamily(string $value): string
+    {
+        $first = explode(',', $value, 2)[0];
+
+        return trim($first, " \t\n\r\0\x0B\"'");
+    }
+}

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -44,6 +44,13 @@ final class StaticHtmlEmitter
 
     private bool $renderTextGlyphPaths = false;
 
+    private ?FontResolver $fontResolver = null;
+
+    private function fontResolver(): FontResolver
+    {
+        return $this->fontResolver ??= new FontResolver();
+    }
+
     /**
      * Resolved destination-node-id => page-path map used to turn NODE/prototype links into slug hrefs.
      *
@@ -91,7 +98,7 @@ final class StaticHtmlEmitter
         if ( $this->renderTextGlyphPaths ) {
             $cssRules[] = '.figma-text-glyphs{display:block;width:100%;height:100%;overflow:visible}';
         }
-        $fontCss = $this->fontCss($options);
+        $operatorFontCss = $this->fontCss($options);
 
         foreach ( $nodes as $node ) {
             if ( ! is_array($node) ) {
@@ -101,6 +108,11 @@ final class StaticHtmlEmitter
         }
 
         $assetFiles = array_merge($this->referencedAssetFiles($assetFiles), array_values($this->generatedAssetFiles));
+
+        $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
+        $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
+        $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
+        $fontCss = (string) $fontResolution['css'];
 
         $css = ('' !== $fontCss ? $fontCss . "\n" : '') . implode("\n", $cssRules) . "\n";
         $files = array(
@@ -125,21 +137,9 @@ final class StaticHtmlEmitter
         $files = $this->withInlineCssFiles($files, $css);
 
         $visualNodeMap = $this->visualNodeMap($nodes);
-        $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
-        $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
-        $transformDiagnostics = $this->transformDiagnostics($nodes, $assetFiles, $fontFamilies, $fontUsage, $fontCss, $css, $diagnostics);
-        if ( '' === $fontCss ) {
-            foreach ( $fontFamilies as $fontFamily ) {
-                if ( $this->isWebSafeFontFamily($fontFamily) ) {
-                    continue;
-                }
-                $diagnostics[] = array(
-                    'severity' => 'info',
-                    'code' => 'font_css_missing_for_source_font',
-                    'message' => 'Source font family was emitted without supplied font CSS; browser font fallback may reduce visual parity.',
-                    'context' => array('font_family' => $fontFamily),
-                );
-            }
+        $transformDiagnostics = $this->transformDiagnostics($nodes, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics);
+        foreach ( $this->unresolvedSourceFontDiagnostics($fontResolution) as $diagnostic ) {
+            $diagnostics[] = $diagnostic;
         }
 
         return array(
@@ -158,7 +158,7 @@ final class StaticHtmlEmitter
                 'visual_node_map'              => $visualNodeMap,
                 'font_families'                => $fontFamilies,
                 'font_usage'                   => $fontUsage,
-                'font_css_supplied'            => '' !== $fontCss,
+                'font_css_supplied'            => (bool) $fontResolution['operator_supplied'],
                 'render_text_glyph_paths'      => $this->renderTextGlyphPaths,
                 'transform_diagnostics'        => $transformDiagnostics,
             ),
@@ -202,7 +202,7 @@ final class StaticHtmlEmitter
         if ( $this->renderTextGlyphPaths ) {
             $cssRules[] = '.figma-text-glyphs{display:block;width:100%;height:100%;overflow:visible}';
         }
-        $fontCss = $this->fontCss($options);
+        $operatorFontCss = $this->fontCss($options);
         $files = array();
         $pages = array();
         $renderedNodes = array();
@@ -274,6 +274,10 @@ final class StaticHtmlEmitter
         }
 
         $assetFiles = array_merge($this->referencedAssetFiles($assetFiles), array_values($this->generatedAssetFiles));
+        $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
+        $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
+        $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
+        $fontCss = (string) $fontResolution['css'];
         $css = ('' !== $fontCss ? $fontCss . "\n" : '') . implode("\n", array_values(array_unique($cssRules))) . "\n";
         $files[] = array(
             'path'      => 'style.css',
@@ -289,21 +293,9 @@ final class StaticHtmlEmitter
         $files = $this->withInlineCssFiles($files, $css);
 
         $visualNodeMap = $this->visualNodeMap($renderedNodes);
-        $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
-        $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
-        $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $assetFiles, $fontFamilies, $fontUsage, $fontCss, $css, $diagnostics);
-        if ( '' === $fontCss ) {
-            foreach ( $fontFamilies as $fontFamily ) {
-                if ( $this->isWebSafeFontFamily($fontFamily) ) {
-                    continue;
-                }
-                $diagnostics[] = array(
-                    'severity' => 'info',
-                    'code' => 'font_css_missing_for_source_font',
-                    'message' => 'Source font family was emitted without supplied font CSS; browser font fallback may reduce visual parity.',
-                    'context' => array('font_family' => $fontFamily),
-                );
-            }
+        $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics);
+        foreach ( $this->unresolvedSourceFontDiagnostics($fontResolution) as $diagnostic ) {
+            $diagnostics[] = $diagnostic;
         }
 
         return array(
@@ -323,7 +315,7 @@ final class StaticHtmlEmitter
                 'visual_node_map'              => $visualNodeMap,
                 'font_families'                => $fontFamilies,
                 'font_usage'                   => $fontUsage,
-                'font_css_supplied'            => '' !== $fontCss,
+                'font_css_supplied'            => (bool) $fontResolution['operator_supplied'],
                 'render_text_glyph_paths'      => $this->renderTextGlyphPaths,
                 'transform_diagnostics'        => $transformDiagnostics,
             ),
@@ -647,8 +639,8 @@ final class StaticHtmlEmitter
         $families = array();
         foreach ( $nodeStyleDiagnostics as $diagnostic ) {
             $family = $diagnostic['expected']['font_family'] ?? null;
-            if ( is_scalar($family) && '' !== (string) $family ) {
-                $families[] = trim((string) $family, '"');
+            if ( is_scalar($family) && '' !== $this->primaryFontFamily((string) $family) ) {
+                $families[] = $this->primaryFontFamily((string) $family);
             }
         }
 
@@ -669,7 +661,7 @@ final class StaticHtmlEmitter
                 continue;
             }
 
-            $family = trim((string) $expected['font_family'], " \t\n\r\0\x0B\"");
+            $family = $this->primaryFontFamily((string) $expected['font_family']);
             if ( '' === $family ) {
                 continue;
             }
@@ -729,9 +721,38 @@ final class StaticHtmlEmitter
         return preg_match('/^-?\d+(?:\.\d+)?px$/', $value) ? (float) substr($value, 0, -2) : 0.0;
     }
 
-    private function isWebSafeFontFamily(string $family): bool
+    /**
+     * Extract the primary family from a (possibly multi-value) font-family
+     * declaration, dropping the generic fallback so font detection keys on the
+     * source family.
+     */
+    private function primaryFontFamily(string $value): string
     {
-        return in_array(strtolower($family), array('arial', 'georgia', 'helvetica', 'serif', 'sans-serif', 'times new roman', 'verdana'), true);
+        $first = explode(',', $value, 2)[0];
+
+        return trim($first, " \t\n\r\0\x0B\"'");
+    }
+
+    /**
+     * Build one info diagnostic per unresolved source font family so operators
+     * know exactly which families still need a supplied font.
+     *
+     * @param array<string, mixed> $fontResolution
+     * @return array<int, array<string, mixed>>
+     */
+    private function unresolvedSourceFontDiagnostics(array $fontResolution): array
+    {
+        $diagnostics = array();
+        foreach ( array_values($fontResolution['unresolved_families'] ?? array()) as $fontFamily ) {
+            $diagnostics[] = array(
+                'severity' => 'info',
+                'code' => 'font_css_missing_for_source_font',
+                'message' => 'Source font family could not be resolved to embedded or CDN font CSS; supply font_css to restore visual parity.',
+                'context' => array('font_family' => (string) $fontFamily),
+            );
+        }
+
+        return $diagnostics;
     }
 
     /**
@@ -919,10 +940,12 @@ final class StaticHtmlEmitter
      * @param array<int, array<string, mixed>> $nodes
      * @param array<int, array<string, mixed>> $assetFiles
      * @param array<int, string> $fontFamilies
+     * @param array<int, array<string, mixed>> $fontUsage
+     * @param array<string, mixed> $fontResolution
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    private function transformDiagnostics(array $nodes, array $assetFiles, array $fontFamilies, array $fontUsage, string $fontCss, string $css, array $diagnostics): array
+    private function transformDiagnostics(array $nodes, array $assetFiles, array $fontFamilies, array $fontUsage, array $fontResolution, string $css, array $diagnostics): array
     {
         $image = array(
             'paint_refs'      => 0,
@@ -973,13 +996,17 @@ final class StaticHtmlEmitter
             'emitted_files' => count($assetFiles),
             'paths'         => array_values(array_map(static fn (array $file): string => (string) ($file['path'] ?? ''), $assetFiles)),
         );
+        $fontCss = (string) ($fontResolution['css'] ?? '');
         $fonts = array(
             'families'      => $fontFamilies,
             'usage'         => $fontUsage,
             'count'         => count($fontFamilies),
-            'css_supplied'  => '' !== $fontCss,
+            'css_supplied'  => (bool) ($fontResolution['operator_supplied'] ?? false),
             'materialized'  => '' !== $fontCss,
-            'missing_css'   => '' === $fontCss ? array_values(array_filter($fontFamilies, fn (string $family): bool => ! $this->isWebSafeFontFamily($family))) : array(),
+            'missing_css'   => array_values($fontResolution['unresolved_families'] ?? array()),
+            'resolved_css'  => array_values($fontResolution['resolved_families'] ?? array()),
+            'cdn_families'  => array_values($fontResolution['cdn_families'] ?? array()),
+            'coverage'      => array_values($fontResolution['coverage'] ?? array()),
         );
 
         $links = $this->linkDiagnostics();
@@ -2827,7 +2854,7 @@ final class StaticHtmlEmitter
         $styles = array();
 
         if ( isset($style['font_family']) && is_scalar($style['font_family']) ) {
-            $styles[] = 'font-family:' . $this->cssString((string) $style['font_family']);
+            $styles[] = 'font-family:' . $this->fontResolver()->fallbackStack((string) $style['font_family']);
         }
 
         if ( isset($style['font_size']) && is_numeric($style['font_size']) ) {

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3492,11 +3492,11 @@ $metadataDiagnosticCodes = array_map(
 $assert(str_contains($metadataHtml, '<span style="font-weight:400">Hello </span><span style="font-weight:700;text-decoration:underline">World</span>'), 'styled-text-segments-emit');
 $assert(str_contains($metadataCss, 'p,h1,h2,h3,h4,h5,h6{margin:0}'), 'text-elements-reset-default-margins');
 $assert(str_contains($metadataCss, '.figma-node-4-1-metadata-frame{position:relative;background:rgba(51,102,153,0.5);opacity:0.75;border-radius:12px;border:2px solid #000000;box-shadow:0px 0px 0px 0px rgba(0,0,0,0.25)}'), 'normalized-frame-paint-box-style');
-$assert(str_contains($metadataCss, '.figma-node-4-2-mixed-text{position:absolute;font-family:"Example Sans";font-size:20px;font-weight:600;line-height:125%;letter-spacing:0.5px;color:rgba(255,128,0,0.8);text-align:center;vertical-align:top;text-decoration:underline}'), 'normalized-text-style');
+$assert(str_contains($metadataCss, '.figma-node-4-2-mixed-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:20px;font-weight:600;line-height:125%;letter-spacing:0.5px;color:rgba(255,128,0,0.8);text-align:center;vertical-align:top;text-decoration:underline}'), 'normalized-text-style');
 $assert(str_contains($metadataCss, '.figma-node-4-3-uneven-radius{position:absolute;border-top-left-radius:4px;border-top-right-radius:8px;border-bottom-right-radius:12px;border-bottom-left-radius:16px}'), 'individual-radius-style');
-$assert(str_contains($metadataCss, '.figma-node-4-4-raw-line-height-text{position:absolute;font-family:"Example Sans";font-size:18px;font-weight:600;line-height:1.15}'), 'font-style-weight-and-raw-line-height');
-$assert(str_contains($metadataCss, '.figma-node-4-5-wp-cloud-text-metrics{position:absolute;font-family:"DM Sans";font-size:80px;font-weight:700;line-height:1.05;letter-spacing:-0.02em}'), 'wp-cloud-text-metrics-style');
-$assert(str_contains($metadataCss, '.figma-node-4-6-zero-line-height-text{position:absolute;font-family:"Example Sans";font-size:16px;font-weight:400}') && ! str_contains($metadataCss, 'line-height:0'), 'zero-line-height-omitted');
+$assert(str_contains($metadataCss, '.figma-node-4-4-raw-line-height-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px;font-weight:600;line-height:1.15}'), 'font-style-weight-and-raw-line-height');
+$assert(str_contains($metadataCss, '.figma-node-4-5-wp-cloud-text-metrics{position:absolute;font-family:"DM Sans", sans-serif;font-size:80px;font-weight:700;line-height:1.05;letter-spacing:-0.02em}'), 'wp-cloud-text-metrics-style');
+$assert(str_contains($metadataCss, '.figma-node-4-6-zero-line-height-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:16px;font-weight:400}') && ! str_contains($metadataCss, 'line-height:0'), 'zero-line-height-omitted');
 $assert(in_array('unsupported_figma_paint_type', $metadataDiagnosticCodes, true), 'unsupported-paint-diagnostic');
 $assert(! in_array('unsupported_figma_effect_type', $metadataDiagnosticCodes, true), 'supported-effect-no-diagnostic');
 $assert(in_array('font_css_missing_for_source_font', $metadataDiagnosticCodes, true), 'missing-font-css-diagnostic');
@@ -3515,13 +3515,28 @@ $assert(true === ($metadataWithFontCssResult['source_reports']['figma']['html'][
 $metadataTransformDiagnostics = $metadataResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
 $metadataWithFontCssTransformDiagnostics = $metadataWithFontCssResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
 $assert(array('DM Sans', 'Example Sans') === ($metadataTransformDiagnostics['fonts']['families'] ?? null), 'transform-diagnostics-font-families');
-$assert(false === ($metadataTransformDiagnostics['fonts']['materialized'] ?? null), 'transform-diagnostics-font-not-materialized-without-css');
-$assert(array('DM Sans', 'Example Sans') === ($metadataTransformDiagnostics['fonts']['missing_css'] ?? null), 'transform-diagnostics-font-missing-css');
+// DM Sans is a known Google Fonts family so it resolves to a CDN @font-face import,
+// while the fictional "Example Sans" stays unresolved and actionable for an operator.
+$assert(true === ($metadataTransformDiagnostics['fonts']['materialized'] ?? null), 'transform-diagnostics-font-materialized-via-cdn');
+$assert(str_contains($metadataCss, "@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@700&display=swap');"), 'cdn-font-import-emitted');
+$assert(str_starts_with(ltrim($metadataCss), '/*') || str_starts_with($metadataCss, '@import'), 'cdn-font-import-hoisted-to-top');
+$assert(array('Example Sans') === ($metadataTransformDiagnostics['fonts']['missing_css'] ?? null), 'transform-diagnostics-font-missing-css');
+$assert(array('DM Sans') === ($metadataTransformDiagnostics['fonts']['resolved_css'] ?? null), 'transform-diagnostics-font-resolved-css');
+$assert(array('DM Sans') === ($metadataTransformDiagnostics['fonts']['cdn_families'] ?? null), 'transform-diagnostics-font-cdn-families');
+$fontCoverage = $metadataTransformDiagnostics['fonts']['coverage'] ?? array();
+$coverageByFamily = array();
+foreach ( is_array($fontCoverage) ? $fontCoverage : array() as $coverageEntry ) {
+    $coverageByFamily[(string) ($coverageEntry['family'] ?? '')] = $coverageEntry;
+}
+$assert('cdn_google_fonts' === ($coverageByFamily['DM Sans']['resolution'] ?? null) && true === ($coverageByFamily['DM Sans']['resolved'] ?? null), 'font-coverage-dm-sans-resolved-via-cdn');
+$assert(false === ($coverageByFamily['DM Sans']['needs_operator_font'] ?? null) && str_contains((string) ($coverageByFamily['DM Sans']['source_url'] ?? ''), 'fonts.googleapis.com'), 'font-coverage-dm-sans-cdn-source-url');
+$assert('unresolved' === ($coverageByFamily['Example Sans']['resolution'] ?? null) && true === ($coverageByFamily['Example Sans']['needs_operator_font'] ?? null), 'font-coverage-example-sans-needs-operator-font');
+$assert('"Example Sans", sans-serif' === ($coverageByFamily['Example Sans']['fallback_stack'] ?? null), 'font-coverage-example-sans-fallback-stack');
 $missingFontCssSignal = $artifactQualitySignal($metadataResult, 'font_css_missing');
 $assert('warning' === ($missingFontCssSignal['severity'] ?? null), 'font-css-missing-quality-warning');
 $assert('needs_review' === ($metadataTransformDiagnostics['artifact_quality']['status'] ?? null), 'font-css-missing-quality-needs-review');
 $assert('warn' === ($metadataTransformDiagnostics['artifact_quality']['quality_status'] ?? null), 'font-css-missing-quality-status-warn');
-$assert(2 === ($missingFontCssSignal['count'] ?? null), 'font-css-missing-quality-count');
+$assert(1 === ($missingFontCssSignal['count'] ?? null), 'font-css-missing-quality-count');
 $assert(! in_array('font_css_missing', $artifactQualitySignalCodes($metadataWithFontCssResult), true), 'font-css-supplied-suppresses-quality-warning');
 $assert(true === ($metadataWithFontCssTransformDiagnostics['fonts']['materialized'] ?? null), 'transform-diagnostics-font-materialized-with-css');
 $styleDiagnostics = $metadataResult['source_reports']['figma']['html']['node_style_diagnostics'] ?? array();
@@ -3536,8 +3551,8 @@ foreach ( $styleDiagnostics as $styleDiagnostic ) {
     }
 }
 $assert(null !== $mixedTextStyleDiagnostic, 'node-style-diagnostics-text-node-present');
-$assert('"Example Sans"' === ($mixedTextStyleDiagnostic['expected']['font_family'] ?? null), 'node-style-diagnostics-expected-font-family');
-$assert('"Example Sans"' === ($mixedTextStyleDiagnostic['emitted']['font_family'] ?? null), 'node-style-diagnostics-emitted-font-family');
+$assert('"Example Sans", sans-serif' === ($mixedTextStyleDiagnostic['expected']['font_family'] ?? null), 'node-style-diagnostics-expected-font-family');
+$assert('"Example Sans", sans-serif' === ($mixedTextStyleDiagnostic['emitted']['font_family'] ?? null), 'node-style-diagnostics-emitted-font-family');
 $assert('20px' === ($mixedTextStyleDiagnostic['expected']['font_size'] ?? null), 'node-style-diagnostics-expected-font-size');
 $assert('20px' === ($mixedTextStyleDiagnostic['emitted']['font_size'] ?? null), 'node-style-diagnostics-emitted-font-size');
 $assert('rgba(255,128,0,0.8)' === ($mixedTextStyleDiagnostic['expected']['text_color'] ?? null), 'node-style-diagnostics-expected-text-color');
@@ -3545,6 +3560,55 @@ $assert('rgba(255,128,0,0.8)' === ($mixedTextStyleDiagnostic['emitted']['text_co
 $assert(null !== $frameStyleDiagnostic, 'node-style-diagnostics-frame-node-present');
 $assert('rgba(51,102,153,0.5)' === ($frameStyleDiagnostic['expected']['background'] ?? null), 'node-style-diagnostics-expected-background');
 $assert('rgba(51,102,153,0.5)' === ($frameStyleDiagnostic['emitted']['background'] ?? null), 'node-style-diagnostics-emitted-background');
+
+// Font embedding: a known web font (Inter) resolves to a weight-aware Google Fonts
+// @font-face import, while an unknown family (Skolar Latin) stays actionable. This
+// mirrors the David Perell .fig matrix where Inter + Skolar Latin rendered in a
+// fallback system font because no font CSS was emitted.
+$fontEmbeddingResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Font Embedding Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'fe:1',
+            'type'     => 'FRAME',
+            'name'     => 'Typography frame',
+            'children' => array(
+                array('id' => 'fe:2', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Bold heading', 'fontName' => array('family' => 'Inter', 'style' => 'Bold'), 'fontSize' => 48),
+                array('id' => 'fe:3', 'type' => 'TEXT', 'name' => 'Body', 'characters' => 'Regular body copy', 'fontName' => array('family' => 'Inter', 'style' => 'Regular'), 'fontSize' => 18),
+                array('id' => 'fe:4', 'type' => 'TEXT', 'name' => 'Serif accent', 'characters' => 'Serif accent', 'fontName' => array('family' => 'Skolar Latin', 'style' => 'Medium'), 'fontSize' => 24, 'style' => array('fontWeight' => 500)),
+            ),
+        ),
+    ),
+));
+$fontEmbeddingCss = $fileContent($fontEmbeddingResult, 'style.css');
+$fontEmbeddingDiagnostics = $fontEmbeddingResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$fontEmbeddingFonts = $fontEmbeddingDiagnostics['fonts'] ?? array();
+$fontEmbeddingCodes = array_map(static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''), $fontEmbeddingResult['diagnostics'] ?? array());
+$fontEmbeddingCoverage = array();
+foreach ( is_array($fontEmbeddingFonts['coverage'] ?? null) ? $fontEmbeddingFonts['coverage'] : array() as $coverageEntry ) {
+    $fontEmbeddingCoverage[(string) ($coverageEntry['family'] ?? '')] = $coverageEntry;
+}
+$assert(str_contains($fontEmbeddingCss, "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');"), 'font-embedding-inter-cdn-import');
+$assert(str_contains($fontEmbeddingCss, 'font-family:"Inter", sans-serif'), 'font-embedding-inter-fallback-stack');
+$assert(str_contains($fontEmbeddingCss, 'font-family:"Skolar Latin", sans-serif'), 'font-embedding-skolar-fallback-stack');
+$assert(true === ($fontEmbeddingFonts['materialized'] ?? null), 'font-embedding-materialized');
+$assert(false === ($fontEmbeddingFonts['css_supplied'] ?? null), 'font-embedding-not-operator-supplied');
+$assert(array('Inter') === ($fontEmbeddingFonts['resolved_css'] ?? null), 'font-embedding-inter-resolved');
+$assert(array('Skolar Latin') === ($fontEmbeddingFonts['missing_css'] ?? null), 'font-embedding-skolar-unresolved');
+$assert('cdn_google_fonts' === ($fontEmbeddingCoverage['Inter']['resolution'] ?? null) && array(400, 700) === ($fontEmbeddingCoverage['Inter']['weights'] ?? null), 'font-embedding-inter-coverage-weights');
+$assert(true === ($fontEmbeddingCoverage['Skolar Latin']['needs_operator_font'] ?? null), 'font-embedding-skolar-needs-operator-font');
+$assert(in_array('font_css_missing_for_source_font', $fontEmbeddingCodes, true) && 1 === count(array_filter($fontEmbeddingCodes, static fn (string $code): bool => 'font_css_missing_for_source_font' === $code)), 'font-embedding-single-unresolved-diagnostic');
+$fontOverrideResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Font Override Fixture',
+    'nodes' => array(
+        array('id' => 'fo:1', 'type' => 'TEXT', 'name' => 'Override text', 'characters' => 'Override', 'fontName' => array('family' => 'Inter', 'style' => 'Regular'), 'fontSize' => 20),
+    ),
+), array('font_css' => '@font-face{font-family:"Inter";src:url("assets/inter.woff2") format("woff2")}'));
+$fontOverrideCss = $fileContent($fontOverrideResult, 'style.css');
+$fontOverrideFonts = $fontOverrideResult['source_reports']['figma']['html']['transform_diagnostics']['fonts'] ?? array();
+$assert(str_starts_with($fontOverrideCss, '@font-face{font-family:"Inter";src:url("assets/inter.woff2") format("woff2")}'), 'font-embedding-operator-override-passthrough');
+$assert(! str_contains($fontOverrideCss, 'fonts.googleapis.com'), 'font-embedding-operator-override-skips-cdn');
+$assert(true === ($fontOverrideFonts['css_supplied'] ?? null) && array() === ($fontOverrideFonts['missing_css'] ?? null), 'font-embedding-operator-override-clears-missing');
 
 $assetReferenceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'   => 'Asset Reference Fixture',


### PR DESCRIPTION
## Summary

Part of #247 (Figma transform fidelity). Implements the **font embedding** slice: emit real `@font-face` / font CSS so text renders in (or close to) the source font, and make the font diagnostic actionable.

### Motivation (data)

Running the fixture matrix against the real 185MB "David Perell" `.fig` showed the transformer detecting fonts but emitting **no font CSS**, so every text node fell back to a system font:

- `quality_summary.missing_font_css: 6`
- `diagnostic_codes.font_css_missing_for_source_font: 15`
- The design uses **Inter** (weights **400 / 500 / 600 / 700 / 800** across ~**153 text nodes**) and **Skolar Latin** — none of it materialized into CSS.

`missing_css` / `font_css_missing_for_source_font` also flagged every non-web-safe family with no resolution path, so the diagnostic was a bare count instead of something an operator could act on.

## What changed

New `FontResolver` resolves source font usage (reusing the existing `font_usage` family+weight detection) in priority order:

1. **Operator-supplied `font_css` passthrough** — unchanged override (`--font-css` / `--font-css-file` still win).
2. **Well-known web fonts → Google Fonts CDN** — a weight-aware `@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap')` that pulls real `@font-face` rules.
3. **Web-safe families** — no CSS needed.
4. **Everything else** — stays unresolved and actionable.

Other changes:
- Emitted text `font-family` now carries a sane generic fallback (e.g. `"Inter", sans-serif`) so the browser degrades to the right generic family if the CDN font fails to load.
- Resolved families **clear** `missing_css` and no longer raise `font_css_missing_for_source_font`; only genuinely unresolved families do.
- The `fonts` diagnostic gains `resolved_css`, `cdn_families`, and a per-family **coverage** report (`family`, `weights`, `resolution` source, `resolved`, `needs_operator_font`, CDN `source_url`, `fallback_stack`) — reports now say *which families got fixed and which still need an operator-supplied font*.
- Multi-page CSS chunk merging hoists `@import` lines to the top to stay valid CSS.

### On embedded font bytes

The `.fig` scenegraph captures font **metadata** only (`fontMetaData`: family/style/weight/lineHeight) — no embedded font byte assets — so the "embed font bytes" source has nothing to emit here. Resolution is CDN + web-safe + operator override. Families like Skolar Latin (no CDN entry) remain unresolved and are reported as needing an operator-supplied font.

## Tests

`cd figma-transformer && php tests/contract/run.php` → **"Figma Transformer contract tests passed."**

Added a focused, synthetic contract test mirroring the data: **Inter** (weights 400/700) resolves to a CDN `@font-face` import and is marked resolved in the coverage report, while **Skolar Latin** stays unresolved with `needs_operator_font: true`; plus an operator-`font_css`-override passthrough case. Updated the existing font-metadata assertions to the new behavior (DM Sans now resolves via CDN; Example Sans stays unresolved). No large local `.fig` files were run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Implementing @font-face / font-CSS emission + actionable font-coverage diagnostic for #247.