### PR TITLE
Map resolved CSS to canonical block style attributes (#261, #259)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -3,11 +3,20 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
+
 /**
  * @internal Block construction is owned by HtmlTransformer.
  */
 final class BlockFactory
 {
+    private ?StyleAttributeMapper $styleMapper = null;
+
+    private function styleMapper(): StyleAttributeMapper
+    {
+        return $this->styleMapper ??= new StyleAttributeMapper();
+    }
+
     /**
      * @param array<string, mixed> $attrs
      * @param array<int, array<string, mixed>> $innerBlocks
@@ -102,9 +111,10 @@ final class BlockFactory
         }
 
         if ( 'core/icon' === $name ) {
+            $support = $this->styleSupport($attrs['style'] ?? null);
             $iconAttrs = array(
-                'class'       => $this->mergeClassNames('wp-block-icon', (string) ($attrs['className'] ?? '')),
-                'style'       => (string) ($attrs['style'] ?? ''),
+                'class'       => $this->mergeClassNames('wp-block-icon', $support['classes'], (string) ($attrs['className'] ?? '')),
+                'style'       => $support['style'],
                 'aria-label'  => (string) ($attrs['label'] ?? ''),
                 'aria-hidden' => ! empty($attrs['ariaHidden']) ? 'true' : '',
             );
@@ -499,12 +509,33 @@ final class BlockFactory
      */
     private function blockSupportAttrs(array $attrs, string $baseClass = ''): string
     {
-        $classes = $this->mergeClassNames($baseClass, (string) ($attrs['className'] ?? ''));
+        $support = $this->styleSupport($attrs['style'] ?? null);
+        $classes = $this->mergeClassNames($baseClass, $support['classes'], (string) ($attrs['className'] ?? ''));
         return $this->htmlAttrs(array(
             'id'    => (string) ($attrs['anchor'] ?? ''),
             'class' => $classes,
-            'style' => (string) ($attrs['style'] ?? ''),
+            'style' => $support['style'],
         ));
+    }
+
+    /**
+     * Serialize the canonical block `style` OBJECT into the has-* support classes
+     * and inline CSS string WordPress emits in `save()`. A legacy raw `style`
+     * string is passed through unchanged for backward compatibility.
+     *
+     * @param mixed $style
+     * @return array{classes: string, style: string}
+     */
+    private function styleSupport(mixed $style): array
+    {
+        if ( is_array($style) ) {
+            return $this->styleMapper()->serialize($style);
+        }
+
+        return array(
+            'classes' => '',
+            'style'   => is_string($style) ? $style : '',
+        );
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -93,6 +93,14 @@ final class HtmlTransformer
     private array $presentationProvenance = array();
 
     /**
+     * Responsive/JS-revealed hidden base states normalized away during style
+     * resolution (#259), surfaced for diagnostics.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $frozenHiddenStateFindings = array();
+
+    /**
      * @var array<int, array<string, mixed>>
      */
     private array $sourceProvenance = array();
@@ -176,6 +184,7 @@ final class HtmlTransformer
         $startedAt                = hrtime(true);
         $this->fallbackProvenance = TransformationOptions::provenance($options);
         $this->presentationProvenance = array();
+        $this->frozenHiddenStateFindings = array();
         $this->sourceProvenance = array();
         $this->structureProvenance = array();
         $this->scriptMetadata = array();
@@ -280,6 +289,7 @@ final class HtmlTransformer
             'semantic_parity' => $semanticParityReport,
             'html' => array(
                 'presentation_signals' => $this->presentationProvenance,
+                'frozen_hidden_state'  => $this->frozenHiddenStateFindings,
                 'source_provenance'    => $sourceProvenance,
                 'structure_signals'    => $this->structureProvenance,
                 'script_metadata'      => $this->scriptMetadata,
@@ -1072,6 +1082,7 @@ final class HtmlTransformer
                 $element,
                 fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
                 fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
                 fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
@@ -1094,6 +1105,7 @@ final class HtmlTransformer
             return $this->buttonsPattern->matchButton(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
                 fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
             );
@@ -1274,6 +1286,7 @@ final class HtmlTransformer
             $buttons = $this->buttonsPattern->matchContainer(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
                 fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
                 fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
@@ -4301,16 +4314,10 @@ final class HtmlTransformer
         }
 
         $attrs = $this->presentationAttributes($element);
+        // The aspect ratio rides on the preserved placeholder/ratio classNames and
+        // companion-plugin CSS; a raw inline `style` string would invalidate the
+        // core/group block, so it is intentionally not emitted here (#261).
         $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), 'blocks-engine-placeholder-media');
-
-        $style = trim((string) ($attrs['style'] ?? ''));
-        $ratio = $this->placeholderAspectRatio($element);
-        if ( '' !== $ratio && ! preg_match('/(?:^|;)\s*aspect-ratio\s*:/i', $style) ) {
-            $style = rtrim($style, ';') . ( '' !== $style ? ';' : '' ) . 'aspect-ratio:' . $ratio;
-        }
-        if ( '' !== $style ) {
-            $attrs['style'] = $style;
-        }
 
         $label = $this->placeholderLabel($element);
         $children = '' !== $label ? array( $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) )) ) : array();

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -19,12 +19,13 @@ final class ButtonsPattern
     /**
      * @param callable(DOMElement): array<string, mixed>|null $fileBlockFromAnchor
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $resolvedStyle
      * @param callable(DOMElement): string $innerHtml
      * @param callable(DOMElement, string): string $attr
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>|null
      */
-    public function matchAnchor(DOMElement $anchor, callable $fileBlockFromAnchor, callable $presentationAttributes, callable $innerHtml, callable $attr, callable $createBlock): ?array
+    public function matchAnchor(DOMElement $anchor, callable $fileBlockFromAnchor, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $attr, callable $createBlock): ?array
     {
         $fileBlock = $fileBlockFromAnchor($anchor);
         if ( null !== $fileBlock ) {
@@ -35,20 +36,21 @@ final class ButtonsPattern
             return null;
         }
 
-        return $createBlock('core/buttons', array(), array( $this->buttonBlockFromAnchor($anchor, $presentationAttributes, $innerHtml, $attr, $createBlock) ), $anchor);
+        return $createBlock('core/buttons', array(), array( $this->buttonBlockFromAnchor($anchor, $presentationAttributes, $resolvedStyle, $innerHtml, $attr, $createBlock) ), $anchor);
     }
 
     /**
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $resolvedStyle
      * @param callable(DOMElement): string $innerHtml
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>
      */
-    public function matchButton(DOMElement $button, callable $presentationAttributes, callable $innerHtml, callable $createBlock): array
+    public function matchButton(DOMElement $button, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $createBlock): array
     {
         return $createBlock('core/buttons', array(), array(
             $createBlock('core/button', array_merge(
-                $this->buttonPresentationAttributes($button, $presentationAttributes),
+                $this->buttonPresentationAttributes($button, $presentationAttributes, $resolvedStyle),
                 $this->buttonRuntimeAttributes($button),
                 array(
                     'tagName' => 'button',
@@ -60,18 +62,19 @@ final class ButtonsPattern
 
     /**
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $resolvedStyle
      * @param callable(DOMElement): string $innerHtml
      * @param callable(DOMElement, string): string $attr
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>|null
      */
-    public function matchContainer(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $attr, callable $createBlock): ?array
+    public function matchContainer(DOMElement $element, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $attr, callable $createBlock): ?array
     {
 		$containerHasButtonSignal = $this->hasContainerButtonSignal($element) || $this->isDirectAnchorRow($element);
         $buttons = array();
         foreach ( $element->childNodes as $child ) {
             if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') && ( $containerHasButtonSignal || $this->hasButtonSignal($child) ) ) {
-                $buttons[] = $this->buttonBlockFromAnchor($child, $presentationAttributes, $innerHtml, $attr, $createBlock);
+                $buttons[] = $this->buttonBlockFromAnchor($child, $presentationAttributes, $resolvedStyle, $innerHtml, $attr, $createBlock);
             }
         }
 
@@ -84,14 +87,15 @@ final class ButtonsPattern
 
     /**
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $resolvedStyle
      * @param callable(DOMElement): string $innerHtml
      * @param callable(DOMElement, string): string $attr
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>
      */
-    private function buttonBlockFromAnchor(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $attr, callable $createBlock): array
+    private function buttonBlockFromAnchor(DOMElement $anchor, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $attr, callable $createBlock): array
     {
-        return $createBlock('core/button', array_filter(array_merge($this->buttonPresentationAttributes($anchor, $presentationAttributes), array(
+        return $createBlock('core/button', array_filter(array_merge($this->buttonPresentationAttributes($anchor, $presentationAttributes, $resolvedStyle), array(
             'text' => $this->buttonText($innerHtml($anchor)),
             'url'  => $attr($anchor, 'href'),
         )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $anchor);
@@ -106,12 +110,17 @@ final class ButtonsPattern
 
     /**
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $resolvedStyle
      * @return array<string, mixed>
      */
-    private function buttonPresentationAttributes(DOMElement $element, callable $presentationAttributes): array
+    private function buttonPresentationAttributes(DOMElement $element, callable $presentationAttributes, callable $resolvedStyle): array
     {
         $attrs = $presentationAttributes($element);
-        $resolvedStyle = (string) ($attrs['style'] ?? '');
+        // Buttons resolve styling from the raw merged CSS string, not the canonical
+        // block style object, so the (now object-shaped) presentation `style` is
+        // dropped and re-derived via ButtonStyleResolver below.
+        unset($attrs['style']);
+        $resolvedStyle = (string) $resolvedStyle($element);
         if ( $this->hasOutlineSignal($element, $resolvedStyle) ) {
             $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' is-style-outline');
         }
@@ -121,7 +130,6 @@ final class ButtonsPattern
         // button renders with its source colors/border instead of the theme default.
         // A button with no paintable styling resolves to no native attributes and
         // stays a default button.
-        unset($attrs['style']);
         $native = $this->styleResolver->nativeAttributes($resolvedStyle);
         if ( array() !== $native ) {
             $attrs = array_merge($attrs, $native);

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -250,11 +250,12 @@ final class NavigationPattern implements PatternRecognizerInterface
             $itemAttrs['className'] = $anchorAttrs['className'];
         }
 
+        // The anchor/submenu CSS rides on the preserved classNames + companion CSS;
+        // a raw inline `style` string on the navigation-link/submenu inner markup
+        // would diverge from the block save() output, so it is not emitted (#261).
         return array_filter(array_merge($itemAttrs, $baseAttrs, array(
             'anchorClassName'  => $anchorAttrs['className'] ?? '',
-            'anchorStyle'      => $anchorAttrs['style'] ?? '',
             'submenuClassName' => $submenuAttrs['className'] ?? '',
-            'submenuStyle'     => $submenuAttrs['style'] ?? '',
         )), static fn ($value): bool => '' !== $value);
     }
 

--- a/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
@@ -1,0 +1,431 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/**
+ * Translates a block element's resolved CSS declarations (inline style plus the
+ * matched `<style>`/linked CSS rules the transformer already resolves) into the
+ * canonical WordPress block style attribute OBJECT — never a raw `style` string.
+ *
+ * Core blocks expect a structured `style` object (style.typography / style.color /
+ * style.spacing / style.border) plus the `layout` attribute, and they render that
+ * object back to inline CSS + support classes in `save()`. Storing a raw inline
+ * `style` STRING on a core block makes the stored HTML diverge from `save()`, so
+ * the editor flags "unexpected or invalid content" for every styled element. This
+ * generalizes the `ButtonStyleResolver` (#241) approach to all blocks (#261).
+ *
+ * Declarations that do not map to a block support (position, overflow, transform,
+ * background images, etc.) are returned as `leftover` so the caller can drop them
+ * and rely on the preserved `className` + carried CSS — they are NEVER emitted as
+ * a raw `style` string. Declarations consumed by the block `layout` attribute
+ * (display/flex/grid/gap) are dropped from the style object entirely.
+ */
+final class StyleAttributeMapper
+{
+    /**
+     * CSS properties consumed by the block `layout` attribute rather than the
+     * canonical `style` object. These are never emitted as inline style.
+     */
+    private const LAYOUT_PROPERTIES = array(
+        'display',
+        'flex-direction',
+        'flex-flow',
+        'flex-wrap',
+        'justify-content',
+        'justify-items',
+        'align-content',
+        'align-items',
+        'place-content',
+        'place-items',
+        'gap',
+        'row-gap',
+        'column-gap',
+        'grid-template-columns',
+        'grid-template-rows',
+        'grid-template-areas',
+        'grid-auto-flow',
+        'grid-auto-rows',
+        'grid-auto-columns',
+    );
+
+    /**
+     * Map resolved CSS declarations to canonical block style attributes.
+     *
+     * @param array<string, string> $declarations
+     * @return array{style: array<string, mixed>, leftover: array<string, string>}
+     */
+    public function map(array $declarations): array
+    {
+        $normalized = array();
+        foreach ( $declarations as $name => $value ) {
+            $name  = strtolower(trim((string) $name));
+            $value = trim((string) $value);
+            if ( '' !== $name && '' !== $value ) {
+                $normalized[ $name ] = $value;
+            }
+        }
+
+        $consumed = array();
+        $style    = array();
+
+        $typography = $this->typography($normalized, $consumed);
+        if ( array() !== $typography ) {
+            $style['typography'] = $typography;
+        }
+
+        $color = $this->color($normalized, $consumed);
+        if ( array() !== $color ) {
+            $style['color'] = $color;
+        }
+
+        $spacing = array();
+        $padding = $this->boxSides('padding', $normalized, $consumed);
+        if ( array() !== $padding ) {
+            $spacing['padding'] = $padding;
+        }
+        $margin = $this->boxSides('margin', $normalized, $consumed);
+        if ( array() !== $margin ) {
+            $spacing['margin'] = $margin;
+        }
+        if ( array() !== $spacing ) {
+            $style['spacing'] = $spacing;
+        }
+
+        $border = $this->border($normalized, $consumed);
+        if ( array() !== $border ) {
+            $style['border'] = $border;
+        }
+
+        $leftover = array();
+        foreach ( $normalized as $name => $value ) {
+            if ( isset($consumed[ $name ]) || in_array($name, self::LAYOUT_PROPERTIES, true) ) {
+                continue;
+            }
+            $leftover[ $name ] = $value;
+        }
+
+        return array(
+            'style'    => $style,
+            'leftover' => $leftover,
+        );
+    }
+
+    /**
+     * Serialize a canonical block style object back to the inline CSS string and
+     * the has-* support classes WordPress emits in `save()`. Keeping the rendered
+     * markup in sync with the stored attribute object is what makes the block
+     * validate in the editor.
+     *
+     * @param array<string, mixed> $style
+     * @return array{classes: string, style: string}
+     */
+    public function serialize(array $style): array
+    {
+        $classes      = array();
+        $declarations = array();
+
+        $colorStyle = is_array($style['color'] ?? null) ? $style['color'] : array();
+        $text       = trim((string) ($colorStyle['text'] ?? ''));
+        $background = trim((string) ($colorStyle['background'] ?? ''));
+        $gradient   = trim((string) ($colorStyle['gradient'] ?? ''));
+        if ( '' !== $text ) {
+            $classes[]      = 'has-text-color';
+            $declarations[] = 'color:' . $text;
+        }
+        if ( '' !== $background ) {
+            $classes[]      = 'has-background';
+            $declarations[] = 'background-color:' . $background;
+        }
+        if ( '' !== $gradient ) {
+            $classes[]      = 'has-background';
+            $declarations[] = 'background:' . $gradient;
+        }
+
+        $border = is_array($style['border'] ?? null) ? $style['border'] : array();
+        if ( '' !== trim((string) ($border['color'] ?? '')) ) {
+            $classes[]      = 'has-border-color';
+            $declarations[] = 'border-color:' . trim((string) $border['color']);
+        }
+        if ( '' !== trim((string) ($border['width'] ?? '')) ) {
+            $declarations[] = 'border-width:' . trim((string) $border['width']);
+        }
+        if ( '' !== trim((string) ($border['style'] ?? '')) ) {
+            $declarations[] = 'border-style:' . trim((string) $border['style']);
+        }
+        if ( '' !== trim((string) ($border['radius'] ?? '')) ) {
+            $declarations[] = 'border-radius:' . trim((string) $border['radius']);
+        }
+
+        $spacing = is_array($style['spacing'] ?? null) ? $style['spacing'] : array();
+        foreach ( array( 'padding', 'margin' ) as $box ) {
+            $sides = is_array($spacing[ $box ] ?? null) ? $spacing[ $box ] : array();
+            foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+                $value = trim((string) ($sides[ $side ] ?? ''));
+                if ( '' !== $value ) {
+                    $declarations[] = $box . '-' . $side . ':' . $value;
+                }
+            }
+        }
+
+        $typography    = is_array($style['typography'] ?? null) ? $style['typography'] : array();
+        $typographyMap = array(
+            'fontSize'      => 'font-size',
+            'fontWeight'    => 'font-weight',
+            'lineHeight'    => 'line-height',
+            'letterSpacing' => 'letter-spacing',
+            'textTransform' => 'text-transform',
+            'textDecoration' => 'text-decoration',
+            'fontStyle'     => 'font-style',
+        );
+        foreach ( $typographyMap as $attrName => $cssName ) {
+            $value = trim((string) ($typography[ $attrName ] ?? ''));
+            if ( '' !== $value ) {
+                $declarations[] = $cssName . ':' . $value;
+            }
+        }
+
+        return array(
+            'classes' => implode(' ', array_values(array_unique($classes))),
+            'style'   => implode(';', $declarations),
+        );
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, bool> $consumed
+     * @return array<string, string>
+     */
+    private function typography(array $declarations, array &$consumed): array
+    {
+        $typography = array();
+        $map = array(
+            'font-size'       => 'fontSize',
+            'font-weight'     => 'fontWeight',
+            'line-height'     => 'lineHeight',
+            'letter-spacing'  => 'letterSpacing',
+            'text-transform'  => 'textTransform',
+            'text-decoration' => 'textDecoration',
+            'font-style'      => 'fontStyle',
+        );
+
+        foreach ( $map as $cssName => $attrName ) {
+            $value = trim((string) ($declarations[ $cssName ] ?? ''));
+            if ( '' !== $value ) {
+                $typography[ $attrName ] = $value;
+                $consumed[ $cssName ]    = true;
+            }
+        }
+
+        return $typography;
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, bool> $consumed
+     * @return array<string, string>
+     */
+    private function color(array $declarations, array &$consumed): array
+    {
+        $color = array();
+
+        if ( isset($declarations['color']) ) {
+            $consumed['color'] = true;
+            $text = $this->cssColor($declarations['color']);
+            if ( '' !== $text ) {
+                $color['text'] = $text;
+            }
+        }
+
+        $gradient = $this->gradient($declarations, $consumed);
+        $background = $this->backgroundColor($declarations, $consumed);
+        if ( '' !== $background ) {
+            $color['background'] = $background;
+        }
+        if ( '' !== $gradient ) {
+            $color['gradient'] = $gradient;
+        }
+
+        return $color;
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, bool> $consumed
+     */
+    private function backgroundColor(array $declarations, array &$consumed): string
+    {
+        if ( isset($declarations['background-color']) ) {
+            $consumed['background-color'] = true;
+            return $this->cssColor($declarations['background-color']);
+        }
+
+        $value = trim((string) ($declarations['background'] ?? ''));
+        if ( '' === $value || preg_match('/\b(?:url\s*\(|gradient\s*\()/i', $value) ) {
+            return '';
+        }
+
+        $consumed['background'] = true;
+        return $this->cssColor(preg_split('/\s+/', $value)[0] ?? '');
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, bool> $consumed
+     */
+    private function gradient(array $declarations, array &$consumed): string
+    {
+        foreach ( array( 'background', 'background-image' ) as $name ) {
+            $value = trim((string) ($declarations[ $name ] ?? ''));
+            if ( '' !== $value && preg_match('/\bgradient\s*\(/i', $value) ) {
+                $consumed[ $name ] = true;
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, bool> $consumed
+     * @return array<string, string>
+     */
+    private function boxSides(string $property, array $declarations, array &$consumed): array
+    {
+        $sides = array( 'top' => '', 'right' => '', 'bottom' => '', 'left' => '' );
+
+        $shorthand = trim((string) ($declarations[ $property ] ?? ''));
+        if ( '' !== $shorthand ) {
+            $consumed[ $property ] = true;
+            $parts = preg_split('/\s+/', $shorthand) ?: array();
+            $count = count($parts);
+            if ( 1 === $count ) {
+                $sides = array( 'top' => $parts[0], 'right' => $parts[0], 'bottom' => $parts[0], 'left' => $parts[0] );
+            } elseif ( 2 === $count ) {
+                $sides = array( 'top' => $parts[0], 'right' => $parts[1], 'bottom' => $parts[0], 'left' => $parts[1] );
+            } elseif ( 3 === $count ) {
+                $sides = array( 'top' => $parts[0], 'right' => $parts[1], 'bottom' => $parts[2], 'left' => $parts[1] );
+            } elseif ( $count >= 4 ) {
+                $sides = array( 'top' => $parts[0], 'right' => $parts[1], 'bottom' => $parts[2], 'left' => $parts[3] );
+            }
+        }
+
+        foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
+            $longhand = trim((string) ($declarations[ $property . '-' . $side ] ?? ''));
+            if ( '' !== $longhand ) {
+                $sides[ $side ]                       = $longhand;
+                $consumed[ $property . '-' . $side ]  = true;
+            }
+        }
+
+        return array_filter($sides, static fn (string $value): bool => '' !== trim($value));
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, bool> $consumed
+     * @return array<string, string>
+     */
+    private function border(array $declarations, array &$consumed): array
+    {
+        $border    = array();
+        $shorthand = $this->parseBorderShorthand((string) ($declarations['border'] ?? ''));
+        if ( isset($declarations['border']) ) {
+            $consumed['border'] = true;
+        }
+
+        $width = trim((string) ($declarations['border-width'] ?? $shorthand['width'] ?? ''));
+        $style = strtolower(trim((string) ($declarations['border-style'] ?? $shorthand['style'] ?? '')));
+        $colorValue = $this->cssColor((string) ($declarations['border-color'] ?? $shorthand['color'] ?? ''));
+        foreach ( array( 'border-width', 'border-style', 'border-color' ) as $name ) {
+            if ( isset($declarations[ $name ]) ) {
+                $consumed[ $name ] = true;
+            }
+        }
+
+        $noBorder = 'none' === $style || ( '' !== $width && (float) $width === 0.0 && '' === $colorValue && '' === $style );
+        if ( ! $noBorder ) {
+            if ( '' !== $width && (float) $width !== 0.0 ) {
+                $border['width'] = $width;
+            }
+            if ( '' !== $style && 'none' !== $style ) {
+                $border['style'] = $style;
+            }
+            if ( '' !== $colorValue ) {
+                $border['color'] = $colorValue;
+            }
+        }
+
+        $radius = trim((string) ($declarations['border-radius'] ?? ''));
+        if ( '' !== $radius ) {
+            $consumed['border-radius'] = true;
+            $border['radius']          = $radius;
+        }
+
+        return $border;
+    }
+
+    /**
+     * @return array{width?: string, style?: string, color?: string}
+     */
+    private function parseBorderShorthand(string $value): array
+    {
+        $value = trim($value);
+        if ( '' === $value ) {
+            return array();
+        }
+
+        $parsed = array();
+        foreach ( preg_split('/\s+/', $value) ?: array() as $token ) {
+            $lower = strtolower($token);
+            if ( in_array($lower, array( 'none', 'hidden', 'solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset' ), true) ) {
+                $parsed['style'] = $lower;
+                continue;
+            }
+            if ( preg_match('/^[0-9.]+(?:px|em|rem|%|pt|vw|vh)?$/i', $token) || in_array($lower, array( 'thin', 'medium', 'thick' ), true) ) {
+                $parsed['width'] = $token;
+                continue;
+            }
+            if ( '' !== $this->cssColor($token) ) {
+                $parsed['color'] = $token;
+            }
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Return the value when it is a usable CSS color, otherwise an empty string.
+     */
+    private function cssColor(string $value): string
+    {
+        $value = trim($value);
+        if ( '' === $value ) {
+            return '';
+        }
+
+        $lower = strtolower($value);
+        if ( in_array($lower, array( 'transparent', 'none', 'inherit', 'initial', 'unset', 'revert', 'auto' ), true) ) {
+            return '';
+        }
+
+        if ( preg_match('/^#[0-9a-f]{3,8}$/i', $value) ) {
+            return $value;
+        }
+        if ( preg_match('/^(?:rgb|rgba|hsl|hsla)\s*\(/i', $value) ) {
+            return $value;
+        }
+        if ( preg_match('/^var\s*\(\s*--[a-z0-9_-]+/i', $value) ) {
+            return $value;
+        }
+        if ( 'currentcolor' === $lower ) {
+            return 'currentColor';
+        }
+        if ( preg_match('/^[a-z]+$/', $lower) ) {
+            return $value;
+        }
+
+        return '';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -22,19 +22,107 @@ use DOMElement;
  */
 trait StyleResolutionTrait
 {
+    private ?StyleAttributeMapper $styleAttributeMapper = null;
+
+    private function styleAttributeMapper(): StyleAttributeMapper
+    {
+        return $this->styleAttributeMapper ??= new StyleAttributeMapper();
+    }
+
     /**
+     * Resolve an element's presentation into canonical block attributes.
+     *
+     * The merged CSS is translated into the canonical block `style` OBJECT
+     * (typography/color/spacing/border) plus the `layout` attribute. A raw inline
+     * `style` STRING is never emitted on a block: declarations that do not map to
+     * a block support are dropped and ride on the preserved `className` instead
+     * (#261). Frozen responsive/JS hidden base states are normalized away (#259).
+     *
      * @return array<string, mixed>
      */
     private function presentationAttributes(DOMElement $element): array
     {
-        $style = $this->mergedPresentationStyle($element);
+        $style        = $this->mergedPresentationStyle($element);
+        $declarations = $this->stripFrozenHiddenState($element, $this->cssDeclarations($style));
+        $mapped       = $this->styleAttributeMapper()->map($declarations);
 
         return array_filter(array(
             'anchor'    => $this->safeAnchor($this->attr($element, 'id')),
             'className' => $this->promotedClassName($this->attr($element, 'class')),
-            'style'     => $style,
-            'layout'    => $this->layoutAttribute($element, $style),
+            'style'     => $mapped['style'],
+            'layout'    => $this->layoutAttribute($element, $this->cssDeclarationString($declarations)),
         ), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
+    }
+
+    /**
+     * Remove responsive/JS-revealed hidden base states (display:none /
+     * visibility:hidden / opacity:0) from content-bearing or interactive
+     * elements so they are not frozen permanently invisible (#259). Genuinely
+     * decorative / aria-hidden nodes keep their hidden declarations.
+     *
+     * @param array<string, string> $declarations
+     * @return array<string, string>
+     */
+    private function stripFrozenHiddenState(DOMElement $element, array $declarations): array
+    {
+        if ( array() === $declarations || $this->isDecorativeHiddenElement($element) ) {
+            return $declarations;
+        }
+
+        $stripped = array();
+        if ( isset($declarations['display']) && 'none' === strtolower(trim($declarations['display'])) ) {
+            unset($declarations['display']);
+            $stripped[] = 'display:none';
+        }
+        if ( isset($declarations['visibility']) && 'hidden' === strtolower(trim($declarations['visibility'])) ) {
+            unset($declarations['visibility']);
+            $stripped[] = 'visibility:hidden';
+        }
+        if ( isset($declarations['opacity']) && is_numeric(trim($declarations['opacity'])) && 0.0 === (float) trim($declarations['opacity']) ) {
+            unset($declarations['opacity']);
+            $stripped[] = 'opacity:0';
+        }
+
+        if ( array() !== $stripped ) {
+            $this->frozenHiddenStateFindings[] = array(
+                'tag'          => strtolower($element->tagName),
+                'selector'     => $this->elementSelector($element),
+                'declarations' => $stripped,
+            );
+        }
+
+        return $declarations;
+    }
+
+    /**
+     * An element is treated as genuinely (decoratively) hidden when it carries
+     * no real content or interactivity, or it is explicitly aria-hidden /
+     * presentational. Such nodes may stay hidden; everything else is assumed to
+     * be a responsive/JS-revealed element captured in its base-hidden state.
+     */
+    private function isDecorativeHiddenElement(DOMElement $element): bool
+    {
+        if ( 'true' === strtolower(trim($this->attr($element, 'aria-hidden'))) ) {
+            return true;
+        }
+        if ( in_array(strtolower(trim($this->attr($element, 'role'))), array( 'presentation', 'none' ), true) ) {
+            return true;
+        }
+        if ( in_array(strtolower($element->tagName), array( 'svg', 'canvas' ), true) ) {
+            return true;
+        }
+
+        if ( '' !== trim($element->textContent ?? '') ) {
+            return false;
+        }
+
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && in_array(strtolower($descendant->tagName), array( 'a', 'button', 'input', 'select', 'textarea', 'img', 'picture', 'video', 'audio', 'iframe', 'nav', 'form' ), true) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function mergedPresentationStyle(DOMElement $element): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1965,6 +1965,110 @@ if ( ! str_contains($result['serialized_blocks'], '<!-- wp:heading {"content":"H
     exit(1);
 }
 
+// Canonical block style attributes (#261 / #259): core blocks must carry a
+// structured `style` OBJECT (style.typography/color/spacing/border) plus the
+// `layout` attribute, never a raw inline `style` STRING. Anything unmappable to
+// a block support rides on `className`, and responsive/JS-revealed base hidden
+// states (display:none) are never frozen onto content-bearing elements.
+$canonicalStyleResult = ( new HtmlTransformer() )->transform(
+    '<main>'
+    . '<h2 class="eyebrow" style="font-size:2rem;color:#c0392b;font-weight:700">Styled heading</h2>'
+    . '<p class="lede" style="color:#222;line-height:1.6">Styled paragraph</p>'
+    . '<div class="hero" style="display:flex;gap:1rem;padding:2rem;background:#101010;color:#fff;position:fixed;inset:0;overflow:hidden">'
+    . '<h3>Hero heading</h3><p>Hero content</p></div>'
+    . '<nav class="main-nav" style="display:none;gap:1.6rem"><a href="/a">Home</a></nav>'
+    . '</main>'
+)->toArray();
+
+$collectStyleViolations = static function (array $blocks) use (&$collectStyleViolations): array {
+    $violations = array();
+    foreach ( $blocks as $block ) {
+        if ( ! is_array($block) ) {
+            continue;
+        }
+        $style = $block['attrs']['style'] ?? null;
+        if ( is_string($style) ) {
+            $violations[] = ($block['blockName'] ?? '?') . ' => ' . $style;
+        }
+        $violations = array_merge($violations, $collectStyleViolations($block['innerBlocks'] ?? array()));
+    }
+    return $violations;
+};
+
+$findBlock = static function (array $blocks, string $name) use (&$findBlock): ?array {
+    foreach ( $blocks as $block ) {
+        if ( ! is_array($block) ) {
+            continue;
+        }
+        if ( ($block['blockName'] ?? '') === $name ) {
+            return $block;
+        }
+        $found = $findBlock($block['innerBlocks'] ?? array(), $name);
+        if ( null !== $found ) {
+            return $found;
+        }
+    }
+    return null;
+};
+
+// Guard: no emitted core block carries a raw string `style` attribute.
+$styleViolations = $collectStyleViolations($canonicalStyleResult['blocks']);
+$assert(array() === $styleViolations, 'core blocks must never emit a raw style string', implode('; ', $styleViolations));
+$assert(! str_contains($canonicalStyleResult['serialized_blocks'], 'style="display:'), 'serialized blocks must not carry a raw display style', $canonicalStyleResult['serialized_blocks']);
+
+// Positive: a styled heading maps to canonical typography + color.
+$heading = $findBlock($canonicalStyleResult['blocks'], 'core/heading');
+$assert(is_array($heading), 'styled heading block is emitted');
+$assert(is_array($heading['attrs']['style'] ?? null), 'heading style is a canonical object');
+assertSame('2rem', $heading['attrs']['style']['typography']['fontSize'] ?? null, 'heading font-size maps to style.typography.fontSize');
+assertSame('700', $heading['attrs']['style']['typography']['fontWeight'] ?? null, 'heading font-weight maps to style.typography.fontWeight');
+assertSame('#c0392b', $heading['attrs']['style']['color']['text'] ?? null, 'heading color maps to style.color.text');
+
+// Positive: a styled paragraph maps to canonical color.
+$paragraph = $findBlock($canonicalStyleResult['blocks'], 'core/paragraph');
+$assert(is_array($paragraph), 'styled paragraph block is emitted');
+$assert(is_array($paragraph['attrs']['style'] ?? null), 'paragraph style is a canonical object');
+assertSame('#222', $paragraph['attrs']['style']['color']['text'] ?? null, 'paragraph color maps to style.color.text');
+
+// Positive + negative: display:flex maps to layout; unmappable props (position,
+// inset, overflow) drop to className instead of a raw style string; the mappable
+// color/padding still ride canonically.
+$findBlockByClass = static function (array $blocks, string $class) use (&$findBlockByClass): ?array {
+    foreach ( $blocks as $block ) {
+        if ( ! is_array($block) ) {
+            continue;
+        }
+        $classes = preg_split('/\s+/', (string) ($block['attrs']['className'] ?? '')) ?: array();
+        if ( in_array($class, $classes, true) ) {
+            return $block;
+        }
+        $found = $findBlockByClass($block['innerBlocks'] ?? array(), $class);
+        if ( null !== $found ) {
+            return $found;
+        }
+    }
+    return null;
+};
+
+$hero = $findBlockByClass($canonicalStyleResult['blocks'], 'hero');
+$assert(is_array($hero), 'styled container block is emitted');
+assertSame('flex', $hero['attrs']['layout']['type'] ?? null, 'display:flex maps to the layout attribute');
+$assert(! is_string($hero['attrs']['style'] ?? null), 'container style is never a raw string');
+assertSame('#fff', $hero['attrs']['style']['color']['text'] ?? null, 'container color maps to style.color.text');
+$assert(str_contains((string) ($hero['attrs']['className'] ?? ''), 'hero'), 'container className is preserved for unmappable CSS');
+
+// Hidden-state safety (#259): a base display:none on content-bearing nav is not
+// frozen; it is normalized away and surfaced as a frozen_hidden_state finding.
+$nav = $findBlock($canonicalStyleResult['blocks'], 'core/navigation');
+$assert(is_array($nav), 'navigation block is emitted');
+$assert(! is_string($nav['attrs']['style'] ?? null), 'navigation style is never a raw string');
+$navStyle = $nav['attrs']['style'] ?? array();
+$assert(! (is_array($navStyle) && isset($navStyle['display'])), 'navigation must not freeze display:none');
+$frozen = $canonicalStyleResult['source_reports']['html']['frozen_hidden_state'] ?? array();
+$assert(is_array($frozen) && array() !== $frozen, 'frozen hidden state finding is surfaced for the hidden nav');
+
+fwrite(STDOUT, "Canonical block style attributes contract passed.\n");
+
 fwrite(STDOUT, "HTML-to-blocks contract passed.\n");
 
 $bridge = new FormatBridge();

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-button-card-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-button-card-style-signals.json
@@ -33,9 +33,9 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "btn-primary" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#fff;background-color:#1257ff;border-radius:999px;padding-top:12px;padding-right:20px;padding-bottom:12px;padding-left:20px\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "nav-cta" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "background-color:#101827;color:white;padding:10px 16px;border-radius:8px" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "style=\"background-color:#101827;color:white;padding:10px 16px;border-radius:8px\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "product-card" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "border:1px solid #d8dee9;border-radius:16px;padding:24px" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-color:#d8dee9;border-width:1px;border-style:solid;border-radius:16px;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#ffffff;background-color:#0f766e;border-radius:6px;padding-top:11px;padding-right:18px;padding-bottom:11px;padding-left:18px\"" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
@@ -31,10 +31,10 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "hero-grid" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "display:grid;grid-template-columns:1fr 420px;gap:clamp(24px,4vw,64px);align-items:center" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"hero-grid\",\"layout\":{\"type\":\"grid\"}} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "shift-card" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "display:grid;grid-template-columns:auto 1fr;gap:16px;align-items:start" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"services-cards\",\"style\":\"display:flex;gap:24px;align-items:stretch\",\"layout\":{\"type\":\"flex\"}} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"shift-card\",\"layout\":{\"type\":\"grid\"}} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"services-cards\",\"layout\":{\"type\":\"flex\"}} -->" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-aspect-ratio-placeholder-card.json
+++ b/php-transformer/tests/fixtures/parity/html-aspect-ratio-placeholder-card.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-card" } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "ph ratio-16x9 placeholder blocks-engine-placeholder-media", "style": "aspect-ratio:16/9" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "ph ratio-16x9 placeholder blocks-engine-placeholder-media" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Image placeholder" } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Feature card", "level": 2 } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Copy stays readable." } }
@@ -28,7 +28,8 @@
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
     { "path": "blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/group" },
     { "path": "serialized_blocks", "assert": "contains", "value": "blocks-engine-placeholder-media" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "aspect-ratio:16/9" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "ratio-16x9" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "style=\"aspect-ratio" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
+++ b/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
@@ -16,7 +16,7 @@
     "content": "<section class=\"hero media-hero\" aria-label=\"Mountain clinic exterior\" style=\"background-image:url('/assets/clinic-hero.jpg');background-size:cover\"><div class=\"hero-copy\"><h1>Care that meets you</h1><p>Evidence-based care in a calm space.</p></div></section><div class=\"feature-card\"><div class=\"feature-icon\" aria-hidden=\"true\"><svg viewBox=\"0 0 24 24\" width=\"24\" height=\"24\" fill=\"none\" stroke=\"currentColor\"><path d=\"M4 12h16\"/><path d=\"M12 4v16\"/></svg></div><h3>Fast booking</h3><p>Choose the right visit online.</p></div>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero media-hero", "style": "background-image:url('/assets/clinic-hero.jpg');background-size:cover" } },
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero media-hero" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "url": "/assets/clinic-hero.jpg", "alt": "Mountain clinic exterior", "className": "blocks-engine-background-image" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Care that meets you", "level": 1 } },
     { "path": "blocks.1", "name": "core/group", "attrs": { "className": "feature-card" } },

--- a/php-transformer/tests/fixtures/parity/html-context-syntax-card-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-context-syntax-card-grid.json
@@ -16,7 +16,7 @@
     "content": "<section id=\"features\" class=\"cards-grid\" data-source-kind=\"static\" style=\"display:grid\"><h2>Features</h2><pre><code class=\"language-js\"><span class=\"token keyword\">const</span> count = <span data-token=\"number\">2</span>;</code></pre><article class=\"feature-card\"><p>First card</p></article><article class=\"feature-card\"><p>Second card</p></article><x-widget onclick=\"hydrate()\" data-action=\"open\"><span>Runtime widget</span></x-widget></section><figure class=\"testimonial\"><blockquote><p>Readable output.</p><footer><cite>Casey</cite> Engineer</footer></blockquote></figure>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "cards-grid", "style": "display:grid", "layout": { "type": "grid" } } },
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "cards-grid", "layout": { "type": "grid" } } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Features", "level": 2 } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/code", "attrs": { "className": "language-js", "content": "<span class=\"token keyword\">const</span> count = <span data-token=\"number\">2</span>;" } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/group", "attrs": { "className": "feature-card" } },

--- a/php-transformer/tests/fixtures/parity/html-decorative-fixed-overlay-grain.json
+++ b/php-transformer/tests/fixtures/parity/html-decorative-fixed-overlay-grain.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Atmospheric hero", "level": 1 } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "fixed grain-overlay", "style": "position:fixed;inset:0;pointer-events:none;opacity:.14;background-image:url(noise.png)" } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "fixed grain-overlay" } }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },

--- a/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "decorative-placeholder", "style": "min-height:48px" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "decorative-placeholder" } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "media-shell" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/image", "attrs": { "className": "is-resized", "url": "logo.svg", "alt": "Logo", "width": "120", "height": "80" } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/list" },

--- a/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
@@ -16,8 +16,8 @@
     "content": "<main><section class=\"feature-strip\" style=\"padding:2rem\"><h2 class=\"eyebrow\" style=\"color:red\">Specs</h2><p>Use <span class=\"tone\" style=\"font-weight:700\"><mark>inline</mark></span> marks.</p><dl class=\"definitions\"><dt>Latency</dt><dd><span class=\"metric\">Low</span> response time</dd><dt>Fallback</dt><dd>Preserved safely</dd></dl><address class=\"contact-card\"><strong>Studio</strong><br>142 Bay Street<br>Eureka, CA</address></section><form action=\"/subscribe\"><label>Email <input name=\"email\"></label><script>alert(1)</script></form></main>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-strip", "style": "padding:2rem" } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Specs", "level": 2, "className": "eyebrow", "style": "color:red" } },
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-strip", "style": { "spacing": { "padding": { "top": "2rem", "right": "2rem", "bottom": "2rem", "left": "2rem" } } } } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Specs", "level": 2, "className": "eyebrow", "style": { "color": { "text": "red" } } } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Use <span class=\"tone\" style=\"font-weight:700\"><mark>inline</mark></span> marks." } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/list", "attrs": { "className": "definitions" } },
     { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<strong>Latency</strong> <span class=\"metric\">Low</span> response time" } },

--- a/php-transformer/tests/fixtures/parity/html-figure-quote-media.json
+++ b/php-transformer/tests/fixtures/parity/html-figure-quote-media.json
@@ -19,7 +19,7 @@
     { "path": "blocks.0", "name": "core/quote", "attrs": { "className": "testimonial-card", "citation": "<strong>Ada</strong>, Founder" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Build with care." } },
     { "path": "blocks.1", "name": "core/pullquote", "attrs": { "className": "wp-block-pullquote alignwide", "citation": "Editor", "value": "<p>Pull this.</p>" } },
-    { "path": "blocks.2", "name": "core/image", "attrs": { "className": "aligncenter framed rounded is-resized", "style": "margin:0", "url": "https://example.com/photo.jpg", "alt": "Photo", "width": "800", "height": "600", "caption": "Image <em>caption</em>", "id": 42, "sizeSlug": "large" } },
+    { "path": "blocks.2", "name": "core/image", "attrs": { "className": "aligncenter framed rounded is-resized", "style": { "spacing": { "margin": { "top": "0", "right": "0", "bottom": "0", "left": "0" } } }, "url": "https://example.com/photo.jpg", "alt": "Photo", "width": "800", "height": "600", "caption": "Image <em>caption</em>", "id": 42, "sizeSlug": "large" } },
     { "path": "blocks.3", "name": "core/image", "attrs": { "className": "alignwide", "url": "wrapped.jpg", "alt": "Wrapped media", "caption": "Wrapped caption" } }
   ],
   "expected_fallbacks": [],
@@ -29,7 +29,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "<blockquote class=\"wp-block-quote testimonial-card\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<cite><strong>Ada</strong>, Founder</cite></blockquote>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-pullquote alignwide\"><blockquote><p>Pull this.</p><cite>Editor</cite></blockquote></figure>" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-image aligncenter framed rounded is-resized size-large\" style=\"margin:0\"><img src=\"https://example.com/photo.jpg\" alt=\"Photo\" width=\"800\" height=\"600\" class=\"wp-image-42\"/><figcaption class=\"wp-element-caption\">Image <em>caption</em></figcaption></figure>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-image aligncenter framed rounded is-resized size-large\" style=\"margin-top:0;margin-right:0;margin-bottom:0;margin-left:0\"><img src=\"https://example.com/photo.jpg\" alt=\"Photo\" width=\"800\" height=\"600\" class=\"wp-image-42\"/><figcaption class=\"wp-element-caption\">Image <em>caption</em></figcaption></figure>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<figure class=\"wp-block-image alignwide\"><img src=\"wrapped.jpg\" alt=\"Wrapped media\"/><figcaption class=\"wp-element-caption\">Wrapped caption</figcaption></figure>" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }

--- a/php-transformer/tests/fixtures/parity/html-hero-decorative-wave-layer.json
+++ b/php-transformer/tests/fixtures/parity/html-hero-decorative-wave-layer.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero atmosphere" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Wave hero", "level": 1 } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "hero-wave layer", "style": "position:absolute;left:0;right:0;bottom:0;opacity:.7" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "hero-wave layer" } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Real copy remains content." } }
   ],
   "expect": [

--- a/php-transformer/tests/fixtures/parity/html-linked-media-background-runtime-targets.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-media-background-runtime-targets.json
@@ -20,7 +20,7 @@
     }
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-media", "style": "background-image:url('/assets/hero-bg.jpg')" } },
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-media" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "url": "/assets/hero-bg.jpg", "alt": "Lakeside retreat", "className": "blocks-engine-background-image" } },
     { "path": "blocks.1", "name": "core/image", "attrs": { "url": "/assets/retreat.jpg", "alt": "Retreat house", "caption": "Explore the retreat", "href": "/retreats", "linkDestination": "custom", "linkClass": "media-link", "className": "featured-card card-image" } },
     { "path": "blocks.2", "name": "core/gallery", "attrs": { "anchor": "pattern-gallery", "className": "gallery-cards" } },

--- a/php-transformer/tests/fixtures/parity/html-nav-cta-vs-plain-links.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-cta-vs-plain-links.json
@@ -18,13 +18,14 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "site-nav" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Services", "url": "/services", "kind": "custom" } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Book Now", "url": "/book", "kind": "custom", "anchorClassName": "btn btn-primary cta", "anchorStyle": "border-radius:999px;padding:12px 20px;background:#111;color:#fff" } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Book Now", "url": "/book", "kind": "custom", "anchorClassName": "btn btn-primary cta" } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-navigation-item__content btn btn-primary cta\" style=\"border-radius:999px;padding:12px 20px;background:#111;color:#fff\" href=\"/book\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-navigation-item__content btn btn-primary cta\" href=\"/book\">" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "style=\"border-radius:999px;padding:12px 20px;background:#111;color:#fff\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-navigation-item__content\" href=\"/services\">" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-nav-dropdown-panel-styling.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-dropdown-panel-styling.json
@@ -17,13 +17,14 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-submenu", "attrs": { "label": "Services", "url": "/services", "kind": "custom", "className": "menu-item has-dropdown", "submenuClassName": "dropdown-panel shadow-lg surface", "submenuStyle": "background:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-submenu", "attrs": { "label": "Services", "url": "/services", "kind": "custom", "className": "menu-item has-dropdown", "submenuClassName": "dropdown-panel shadow-lg surface" } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<ul class=\"wp-block-navigation__submenu-container dropdown-panel shadow-lg surface\" style=\"background:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<ul class=\"wp-block-navigation__submenu-container dropdown-panel shadow-lg surface\">" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "style=\"background:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
+++ b/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
@@ -20,7 +20,7 @@
     }
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-shell", "style": "padding: 2rem;", "layout": { "type": "constrained" } } },
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-shell", "style": { "spacing": { "padding": { "top": "2rem", "right": "2rem", "bottom": "2rem", "left": "2rem" } } }, "layout": { "type": "constrained" } } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Only child", "level": 2 } }
   ],
   "expected_fallbacks": [
@@ -39,7 +39,8 @@
     { "path": "source_reports.html.presentation_signals", "assert": "count", "count": 1 },
     { "path": "source_reports.html.presentation_signals.0.selector", "assert": "equals", "value": "section:nth-of-type(1)" },
     { "path": "source_reports.html.presentation_signals.0.signals.className", "assert": "equals", "value": "hero-shell" },
-    { "path": "source_reports.html.presentation_signals.0.signals.style", "assert": "equals", "value": "padding: 2rem;" },
+    { "path": "source_reports.html.presentation_signals.0.signals.style", "assert": "equals", "value": { "spacing": { "padding": { "top": "2rem", "right": "2rem", "bottom": "2rem", "left": "2rem" } } } },
+    { "path": "source_reports.html.presentation_signals.0.source_attributes.style", "assert": "equals", "value": "padding: 2rem;" },
     { "path": "source_reports.html.presentation_signals.0.signals.layout.type", "assert": "equals", "value": "constrained" },
     { "path": "source_reports.html.presentation_signals.0.source_attributes.data-layout", "assert": "equals", "value": "constrained" },
     { "path": "source_reports.html.source_provenance", "assert": "count", "count": 2 },

--- a/php-transformer/tests/fixtures/parity/html-single-child-flex-svg-address.json
+++ b/php-transformer/tests/fixtures/parity/html-single-child-flex-svg-address.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "illustration-frame", "style": "display:flex;align-items:center;justify-content:center;" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "illustration-frame", "layout": { "type": "flex" } } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/html" },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "contact-card", "content": "214 Maple Street<br>Benton Harbor, MI<br><a href=\"tel:+12695550193\">(269) 555-0193</a>" } }
   ],


### PR DESCRIPTION
Closes #261
Closes #259

## Problem
Core blocks were emitted with a raw inline `style` **STRING** attribute (e.g. `wp:paragraph {"style":"color:var(--x)"}`, `wp:heading {"style":"font-size:clamp(...)"}`, `wp:group {"style":"padding:...;background:..."}`). Core blocks expect a structured `style` **OBJECT** (`style.typography`/`color`/`spacing`/`border`) + the `layout` attribute, so the stored HTML diverged from each block's `save()` and the editor threw **"This block contains unexpected or invalid content"** for nearly every styled element. Only buttons were fixed previously (#241).

## Fix — generalize #241 to ALL blocks
New `Style/StyleAttributeMapper` translates an element's resolved CSS declarations (inline + matched `<style>`/linked CSS) into canonical block attributes and serializes them back to the inline CSS + `has-*` support classes WordPress writes in `save()`, keeping stored markup in sync with the block.

Mapping implemented:
- typography → `style.typography.{fontSize,fontWeight,lineHeight,letterSpacing,textTransform,textDecoration,fontStyle}`
- color → `style.color.{text,background,gradient}` (+ `has-text-color`/`has-background` classes)
- spacing → `style.spacing.{padding,margin}` (shorthand expanded to side objects)
- border → `style.border.{width,style,color,radius}` (+ `has-border-color`)
- `display:flex|grid` (+ flex/grid/gap props) → the block's `layout` attribute

Wiring:
- `presentationAttributes()` now returns a canonical `style` object (never a string) + `layout`, used by every block path (group, heading, paragraph, list, quote, columns, icon, …).
- `BlockFactory` serializes the object for all blocks via the shared mapper.
- Buttons keep resolving from the raw merged CSS via a threaded `resolvedStyle` callback (`ButtonStyleResolver` unchanged).

### Hard rule: never a raw `style` string on a core block
Declarations that don't map to a block support (position, inset, overflow, transform, box-shadow, background images, aspect-ratio, nav anchor/submenu CSS, …) are **dropped** and ride on the already-preserved `className` (+ carried theme/companion CSS) — they are never emitted as a `style` string.

### Hidden-state safety (#259)
`display:none` / `visibility:hidden` / `opacity:0` base states (responsive/JS-revealed) are no longer frozen onto content-bearing/interactive elements (nav, CTA) — they are normalized away and surfaced as a `frozen_hidden_state` diagnostic finding. Genuinely decorative / `aria-hidden` nodes may stay hidden.

## Tests
- **New "canonical block style attributes" contract** (`tests/contract/run.php`):
  - **Guard**: walks every emitted block and asserts the `style` attr is an object or absent — **never a raw string** (locks in the fix / prevents regression); also asserts serialized markup carries no raw `display:` style.
  - **Positive**: styled `<h2>`/`<p>` → canonical `style.typography`/`style.color`; styled `<div style="display:flex;...">` → `layout.type=flex` + canonical color/padding.
  - **Negative**: unmappable props (`position/inset/overflow`) → `className`, not a raw style string.
  - **Hidden-state**: `<nav style="display:none">` is not frozen; `frozen_hidden_state` finding surfaced.
- **Fixture churn (behavior fix, justified)**: 15 parity fixtures updated. Only the **style-attribute shape** changed — raw `style` string → canonical object / `layout` / dropped-to-`className`. No content or structure changes.
- `composer test` fully green (contracts, unit, 128 parity fixtures, packaging); `php -l` clean.

## Deferred long-tail (documented)
`text-align` (maps to a per-block `align`/`textAlign` attribute) and `blockGap`/`gap` are dropped for now rather than emitted as raw styles — the no-raw-string guard holds. These can ride in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)