### PR TITLE
custom-block generation first slice: core/html → PHP-only dynamic block via classifier, fed to companion_plugin_payload

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -48,7 +48,10 @@
       "php tests/contract/run.php",
       "@test:unit"
     ],
-    "test:unit": "php tests/unit/subtree-classifier.php",
+    "test:unit": [
+      "php tests/unit/subtree-classifier.php",
+      "php tests/unit/custom-block-generator.php"
+    ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",
     "test:migration:legacy-parity": "BLOCKS_ENGINE_PARITY_LEGACY=1 php tests/parity/run.php --migration-comparison",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -37,7 +37,8 @@ final class ArtifactCompiler
         $referenceReports = $this->referenceReports($normalized['files']);
         $components = $this->detectComponents($normalized['files'], $entryPath, $documents['components']);
         $blockTypes = $this->detectBlockTypes($normalized['files'], $diagnostics);
-        $entryBlocks = $this->compileEntryBlocks($html, $entryPath, $normalized['files']);
+        $companionPluginPayloadBuilder = new CompanionPluginPayload();
+        $entryBlocks = $this->compileEntryBlocks($html, $entryPath, $normalized['files'], $companionPluginPayloadBuilder->blockNamespace($artifact));
         $assets = array_merge($this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references']), $entryBlocks['assets']);
         $diagnostics = array_merge($diagnostics, $entryBlocks['diagnostics']);
         $serializedBlocks = $entryBlocks['serialized_blocks'];
@@ -76,7 +77,7 @@ final class ArtifactCompiler
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
         $sourceReports['materialization_plan'] = ( new MaterializationPlanBuilder() )->fromCompiledSite($sourceReports['compiled_site']);
-        $companionPluginPayload = ( new CompanionPluginPayload() )->fromBlockTypes($blockTypes, $normalized['files'], $artifact);
+        $companionPluginPayload = $companionPluginPayloadBuilder->fromBlockTypes($blockTypes, $normalized['files'], $artifact, $entryBlocks['generated_blocks']);
         if ( array() !== $companionPluginPayload ) {
             $sourceReports['companion_plugin_payload'] = $companionPluginPayload;
         }
@@ -137,11 +138,11 @@ final class ArtifactCompiler
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
      */
-    private function compileEntryBlocks(string $html, string $entryPath, array $files): array
+    private function compileEntryBlocks(string $html, string $entryPath, array $files, string $generatedBlockNamespace = ''): array
     {
-        $result = $this->compileHtmlDocumentBlocks($html, $entryPath, $files, 'artifact-entry');
+        $result = $this->compileHtmlDocumentBlocks($html, $entryPath, $files, 'artifact-entry', $generatedBlockNamespace);
 
         return array(
             'blocks'            => $result['blocks'],
@@ -150,15 +151,16 @@ final class ArtifactCompiler
             'fallbacks'         => $result['fallbacks'],
             'assets'            => $result['assets'],
             'runtime_islands'   => $result['runtime_islands'],
+            'generated_blocks'  => $result['generated_blocks'],
             'interaction_candidates' => $result['interaction_candidates'],
         );
     }
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
      */
-    private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope): array
+    private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope, string $generatedBlockNamespace = ''): array
     {
         if ( $this->containsBlockMarkup($html) ) {
             return array(
@@ -168,6 +170,7 @@ final class ArtifactCompiler
                 'fallbacks'         => array(),
                 'assets'            => array(),
                 'runtime_islands'   => array(),
+                'generated_blocks'  => array(),
                 'interaction_candidates' => array(),
             );
         }
@@ -180,6 +183,7 @@ final class ArtifactCompiler
                 'fallbacks'         => array(),
                 'assets'            => array(),
                 'runtime_islands'   => array(),
+                'generated_blocks'  => array(),
                 'interaction_candidates' => array(),
             );
         }
@@ -192,6 +196,7 @@ final class ArtifactCompiler
             'runtime_script_metadata'   => $this->runtimeScriptMetadataForSource($html, $sourcePath, $files),
             'runtime_dom_selectors'     => $this->runtimeDomSelectors($html, $sourcePath, $files),
             'runtime_canvas_selectors' => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
+            'generated_block_namespace' => $generatedBlockNamespace,
         ))->toArray();
 
         return array(
@@ -201,6 +206,7 @@ final class ArtifactCompiler
             'fallbacks'         => is_array($result['fallbacks'] ?? null) ? $result['fallbacks'] : array(),
             'assets'            => is_array($result['assets'] ?? null) ? $result['assets'] : array(),
             'runtime_islands'   => is_array($result['source_reports']['runtime_islands'] ?? null) ? $result['source_reports']['runtime_islands'] : array(),
+            'generated_blocks'  => is_array($result['source_reports']['generated_blocks'] ?? null) ? $result['source_reports']['generated_blocks'] : array(),
             'interaction_candidates' => is_array($result['source_reports']['interaction_candidates'] ?? null) ? $result['source_reports']['interaction_candidates'] : array(),
         );
     }

--- a/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
+++ b/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
@@ -23,11 +23,13 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
  *   - preserved_js[] (array) each: content, handle, src, block. Slot for the
  *                            JS->plugin wire-up (SSI #488); empty for now.
  *
- * When the artifact carries no generated custom blocks (the common case today,
- * since mapping still prefers core/Automattic blocks with a core/html
- * fallback), the payload is empty and the compiler omits it. This class does
- * not decide what becomes a custom block; it only packages blocks the artifact
- * already declares via block.json.
+ * When the artifact carries no custom blocks (mapping still prefers
+ * core/Automattic blocks with a core/html fallback, and no subtree qualified for
+ * generation), the payload is empty and the compiler omits it. This class does
+ * not decide what becomes a custom block; it packages two sources into the
+ * scaffold contract: block types the artifact already declares via block.json,
+ * and the dynamic blocks the transformer generated at core/html fallbacks
+ * (issue #497), which already arrive in the per-block shape.
  */
 final class CompanionPluginPayload
 {
@@ -42,14 +44,16 @@ final class CompanionPluginPayload
     /**
      * Build the companion-plugin payload from detected generated blocks.
      *
-     * @param array<int, array<string, mixed>> $blockTypes Block-type artifacts from detectBlockTypes().
-     * @param array<int, array<string, mixed>> $files      Normalized artifact files (carry content).
-     * @param array<string, mixed>             $artifact   Raw artifact envelope (for site identity).
+     * @param array<int, array<string, mixed>> $blockTypes      Block-type artifacts from detectBlockTypes().
+     * @param array<int, array<string, mixed>> $files           Normalized artifact files (carry content).
+     * @param array<string, mixed>             $artifact        Raw artifact envelope (for site identity).
+     * @param array<int, array<string, mixed>> $generatedBlocks Dynamic blocks generated at core/html fallbacks (issue #497).
      * @return array<string, mixed> Empty array when there are no generated blocks.
      */
-    public function fromBlockTypes(array $blockTypes, array $files, array $artifact): array
+    public function fromBlockTypes(array $blockTypes, array $files, array $artifact, array $generatedBlocks = array()): array
     {
         $blocks = array();
+        $seenNames = array();
         foreach ( $blockTypes as $blockType ) {
             if ( ! is_array($blockType) ) {
                 continue;
@@ -57,7 +61,25 @@ final class CompanionPluginPayload
             $block = $this->buildBlock($blockType, $files);
             if ( array() !== $block ) {
                 $blocks[] = $block;
+                $seenNames[(string) ($block['name'] ?? '')] = true;
             }
+        }
+
+        // Append dynamically generated custom blocks (the classify -> route ->
+        // generate producer link). These already arrive in scaffold()'s per-block
+        // shape, so they only need normalizing and name-deduping against detected
+        // block types.
+        foreach ( $generatedBlocks as $generatedBlock ) {
+            $block = $this->normalizeGeneratedBlock($generatedBlock);
+            if ( array() === $block ) {
+                continue;
+            }
+            $name = (string) $block['name'];
+            if ( isset($seenNames[$name]) ) {
+                continue;
+            }
+            $seenNames[$name] = true;
+            $blocks[] = $block;
         }
 
         if ( array() === $blocks ) {
@@ -87,6 +109,60 @@ final class CompanionPluginPayload
         }
 
         return $payload;
+    }
+
+    /**
+     * Per-site companion-plugin block namespace (`ssi-<site_slug>`), or '' when
+     * the artifact carries no resolvable site identity. The producer emits
+     * generated-block references under this namespace so they match the blocks
+     * the SSI scaffold registers.
+     *
+     * @param array<string, mixed> $artifact Raw artifact envelope.
+     */
+    public function blockNamespace(array $artifact): string
+    {
+        $slug = $this->siteSlug($artifact);
+
+        return '' === $slug ? '' : 'ssi-' . $slug;
+    }
+
+    /**
+     * Normalize a generated-block entry to scaffold()'s per-block contract.
+     * Generated blocks already declare a sanitizable name, a block_json object,
+     * and a dynamic render; producer-only diagnostic keys (e.g. signature) are
+     * dropped so only contract keys reach SSI.
+     *
+     * @param array<string, mixed> $block Generated-block entry from the transformer.
+     * @return array<string, mixed> Empty array when the entry is unusable.
+     */
+    private function normalizeGeneratedBlock(array $block): array
+    {
+        $name = is_scalar($block['name'] ?? null) ? $this->sanitizeSlug((string) $block['name']) : '';
+        if ( '' === $name ) {
+            return array();
+        }
+
+        $blockJson = is_array($block['block_json'] ?? null) ? $block['block_json'] : array();
+        if ( array() === $blockJson ) {
+            return array();
+        }
+
+        $normalized = array(
+            'name'       => $name,
+            'block_json' => $blockJson,
+        );
+
+        if ( is_scalar($block['render'] ?? null) && '' !== (string) $block['render'] ) {
+            $normalized['render'] = (string) $block['render'];
+        }
+        if ( is_scalar($block['view_js'] ?? null) && '' !== (string) $block['view_js'] ) {
+            $normalized['view_js'] = (string) $block['view_js'];
+        }
+        if ( is_array($block['assets'] ?? null) && array() !== $block['assets'] ) {
+            $normalized['assets'] = $block['assets'];
+        }
+
+        return $normalized;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/CustomBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/CustomBlockGenerator.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/**
+ * Builds dynamic (PHP-only) custom block definitions for source subtrees that
+ * the {@see Classification\SubtreeClassifier} identifies as cohesive custom-block
+ * content units which map to nothing native/Automattic.
+ *
+ * This is the producer link of the classify -> route -> generate chain
+ * (epic #497, keystone #491): the classifier decides a `core/html`-fallback
+ * subtree IS a `custom_block`, and this generator turns it into an installable
+ * dynamic block. The output shape (`name`, `block_json`, `render`) exactly
+ * matches what the SSI companion-plugin scaffolder consumes
+ * (Static_Site_Importer_Companion_Plugin::scaffold()) and what
+ * {@see \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CompanionPluginPayload}
+ * packages into `companion_plugin_payload.blocks[]`.
+ *
+ * First-slice design (conservative):
+ *  - Dynamic / server-rendered: the editable content lives in the block's
+ *    `content` attribute and is echoed by render.php, so there is no static
+ *    save()/render mismatch. The block type is content-agnostic; per-instance
+ *    content travels on the self-closing block reference's attrs.
+ *  - GENERIC only: the block definition (attributes + render) is identical
+ *    across generated blocks; only the structurally-derived name differs. Names
+ *    and titles derive from generic structure, never fixture/site strings.
+ *  - Pure: no I/O, no global state; the same inputs always yield the same
+ *    definition.
+ */
+final class CustomBlockGenerator
+{
+    /**
+     * Block-editor category for generated blocks. `widgets` is the generic
+     * catch-all category that always exists in a stock editor.
+     */
+    public const CATEGORY = 'widgets';
+
+    /**
+     * Build the block.json descriptor (as an array) for a generated block type.
+     *
+     * @param string $blockName Fully-qualified block name (`namespace/local`).
+     * @param string $title     Human-readable, generically-derived title.
+     * @return array<string, mixed>
+     */
+    public function blockJson(string $blockName, string $title): array
+    {
+        return array(
+            'apiVersion' => 3,
+            'name'       => $blockName,
+            'title'      => $title,
+            'category'   => self::CATEGORY,
+            'attributes' => array(
+                // The captured, sanitized subtree markup. Editable, so the block
+                // is a real content unit rather than frozen raw HTML.
+                'content' => array(
+                    'type'    => 'string',
+                    'default' => '',
+                ),
+            ),
+            // Dynamic block: no static save(), so no editor validation mismatch.
+            'supports'   => array(
+                'html' => false,
+            ),
+            'render'     => 'file:./render.php',
+        );
+    }
+
+    /**
+     * The render.php body for a generated dynamic block. Identical across all
+     * generated blocks; the variable content arrives via the `content`
+     * attribute, so this is a content-agnostic, server-rendered template.
+     */
+    public function render(): string
+    {
+        return <<<'PHP'
+<?php
+/**
+ * Server-rendered output for a generated custom block.
+ *
+ * Dynamic (PHP-only) render: the editable content lives in the block's
+ * `content` attribute, so there is no static save()/render mismatch. Generated
+ * by the blocks-engine PHP transformer (issue #497).
+ *
+ * @var array<string,mixed> $attributes Block attributes.
+ */
+
+$content = isset( $attributes['content'] ) && is_scalar( $attributes['content'] ) ? (string) $attributes['content'] : '';
+$content = function_exists( 'wp_kses_post' ) ? wp_kses_post( $content ) : $content;
+$wrapper = function_exists( 'get_block_wrapper_attributes' ) ? get_block_wrapper_attributes() : '';
+
+// get_block_wrapper_attributes() returns markup WordPress has already escaped.
+echo '<div' . ( '' !== $wrapper ? ' ' . $wrapper : '' ) . '>' . $content . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+PHP;
+    }
+
+    /**
+     * Per-instance attributes for the self-closing block reference emitted in
+     * the converted output. Carries only the captured content; no innerHTML.
+     *
+     * @return array<string, mixed>
+     */
+    public function referenceAttributes(string $content): array
+    {
+        return array(
+            'content' => $content,
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\ClassificationContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SubtreeClassifier;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\CustomBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
@@ -67,6 +68,27 @@ final class FallbackEmitter
 
     private readonly SubtreeClassifier $classifier;
 
+    private readonly CustomBlockGenerator $blockGenerator;
+
+    /**
+     * Minimum classifier confidence for a `custom_block` verdict to actually
+     * trigger generation. Conservative: the classifier's own MIN_SCORE/MARGIN
+     * gates already reject weak/ambiguous verdicts (capping UNKNOWN at 0.4), and
+     * this floor keeps generation to the high-confidence custom_block tail. On
+     * anything below it we keep the existing core/html fallback behavior.
+     */
+    private const GENERATION_CONFIDENCE_THRESHOLD = 0.7;
+
+    /**
+     * Per-transform dedup registry: structural signature => generated local
+     * block name. Same-shape subtrees reuse ONE generated block type (the
+     * varying content rides the per-instance reference attrs), so we never emit
+     * near-duplicate block types ("no zoo").
+     *
+     * @var array<string, string>
+     */
+    private array $generatedBlockNames = array();
+
     /**
      * @param Closure(DOMElement): array<string, mixed> $sourceContextResolver
      *        Resolves the shared `sourceContext` enrichment for an element. The
@@ -78,7 +100,176 @@ final class FallbackEmitter
         private readonly Runtime $runtime,
         private readonly Closure $sourceContextResolver
     ) {
-        $this->classifier = new SubtreeClassifier();
+        $this->classifier     = new SubtreeClassifier();
+        $this->blockGenerator = new CustomBlockGenerator();
+    }
+
+    /**
+     * Reset the per-transform custom-block dedup registry. Called once per
+     * transform so generated-block names/dedup never leak across documents.
+     */
+    public function resetGeneratedBlocks(): void
+    {
+        $this->generatedBlockNames = array();
+    }
+
+    /**
+     * Producer link of the classify -> route -> generate chain (issue #497).
+     *
+     * At a `core/html` fallback decision (a subtree that mapped to nothing
+     * native/Automattic), consult the structural classifier. When it returns
+     * `custom_block` with high confidence, generate a dynamic (PHP-only) block
+     * definition, register it on the passed-by-reference `$generatedBlocks`
+     * accumulator (deduped by structural signature), and return a self-closing
+     * block REFERENCE (block name + per-instance attrs, no innerHTML) for the
+     * caller to emit instead of raw `core/html`. Returns null to keep the
+     * existing fallback behavior whenever the conservative gate is not met.
+     *
+     * @param array<int, array<string, mixed>> $generatedBlocks Accumulator of generated block-type definitions.
+     * @return array{blockName: string, attrs: array<string, mixed>}|null
+     */
+    public function maybeGenerateCustomBlock(DOMElement $element, array &$generatedBlocks, string $namespace): ?array
+    {
+        $result = $this->classifier->classify($element, $this->classificationContext($element));
+        if ( ! $result->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK) ) {
+            return null;
+        }
+        if ( $result->confidence() < self::GENERATION_CONFIDENCE_THRESHOLD ) {
+            return null;
+        }
+
+        // Sanitize the subtree markup that becomes the editable, server-rendered
+        // content. Nothing to carry => keep the existing fallback behavior.
+        $content = $this->sanitizeHtmlString($this->innerHtml($element));
+        if ( '' === trim($content) ) {
+            return null;
+        }
+
+        $namespace = $this->sanitizeNameSegment($namespace);
+        if ( '' === $namespace ) {
+            $namespace = 'custom';
+        }
+
+        $signature = $this->structuralSignature($element);
+        if ( isset($this->generatedBlockNames[$signature]) ) {
+            // Dedup: a same-shape subtree already minted this block type; reuse
+            // it and emit only a second reference.
+            $localName = $this->generatedBlockNames[$signature];
+        } else {
+            $localName = $this->generatedBlockLocalName($result->signals(), $signature);
+            $this->generatedBlockNames[$signature] = $localName;
+            $generatedBlocks[] = array(
+                'name'       => $localName,
+                'block_json' => $this->blockGenerator->blockJson($namespace . '/' . $localName, $this->generatedBlockTitle($result->signals())),
+                'render'     => $this->blockGenerator->render(),
+                // Diagnostic-only: the structural signature that this type
+                // covers. Stripped before the payload reaches SSI.
+                'signature'  => $signature,
+            );
+        }
+
+        return array(
+            'blockName' => $namespace . '/' . $localName,
+            'attrs'     => $this->blockGenerator->referenceAttributes($content),
+        );
+    }
+
+    /**
+     * Canonical structural signature of a subtree: the tag-only DOM skeleton,
+     * ignoring text and attributes. Same shape => same signature => one block
+     * type. Depth-bounded for safety on pathological trees.
+     */
+    private function structuralSignature(DOMElement $element, int $depth = 0): string
+    {
+        $tag = strtolower($element->tagName);
+        if ( $depth >= 6 ) {
+            return $tag;
+        }
+
+        $children = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                $children[] = $this->structuralSignature($child, $depth + 1);
+            }
+        }
+
+        return array() === $children ? $tag : $tag . '(' . implode(',', $children) . ')';
+    }
+
+    /**
+     * Generic, structurally-derived local block name. The stem reflects the
+     * dominant structural shape (never fixture/site strings); the short hash of
+     * the structural signature makes it unique per shape and stable across runs.
+     *
+     * @param array<string, mixed> $signals Classifier structural signals.
+     */
+    private function generatedBlockLocalName(array $signals, string $signature): string
+    {
+        return $this->generatedBlockStem($signals) . '-' . substr(hash('sha256', $signature), 0, 8);
+    }
+
+    /**
+     * @param array<string, mixed> $signals Classifier structural signals.
+     */
+    private function generatedBlockTitle(array $signals): string
+    {
+        $titles = array(
+            'gallery'    => 'Custom Gallery',
+            'collection' => 'Custom Collection',
+            'panel'      => 'Custom Panel',
+            'card'       => 'Custom Card',
+            'block'      => 'Custom Content Block',
+        );
+
+        return $titles[$this->generatedBlockStem($signals)] ?? 'Custom Content Block';
+    }
+
+    /**
+     * @param array<string, mixed> $signals Classifier structural signals.
+     */
+    private function generatedBlockStem(array $signals): string
+    {
+        if ( ! empty($signals['media_gallery']) ) {
+            return 'gallery';
+        }
+        if ( (int) ($signals['repeatable_children'] ?? 0) >= 2 ) {
+            return 'collection';
+        }
+        if ( ! empty($signals['interactive_role']) ) {
+            return 'panel';
+        }
+        if ( ! empty($signals['cohesive_content_unit']) ) {
+            return 'card';
+        }
+
+        return 'block';
+    }
+
+    /**
+     * Sanitize a raw HTML string for safe server-render storage, mirroring the
+     * stripping {@see DomHelpersTrait::safeFallbackHtml()} applies to elements
+     * (drop script/style bodies, inline event handlers, and javascript: URLs).
+     */
+    private function sanitizeHtmlString(string $html): string
+    {
+        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $html) ?? '';
+        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace('/\s+(?:href|src|xlink:href)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|javascript:[^\s>]+)/i', '', $html) ?? '';
+        $html = preg_replace('/\s+srcdoc\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
+
+        return trim($html);
+    }
+
+    /**
+     * Lowercase, hyphen-delimited block-name segment (namespace or local stem),
+     * matching WordPress block-name constraints. Portable; WP is not loaded.
+     */
+    private function sanitizeNameSegment(string $value): string
+    {
+        $value = strtolower(trim($value));
+        $value = preg_replace('/[^a-z0-9]+/', '-', $value) ?? '';
+
+        return trim($value, '-');
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -121,6 +121,24 @@ final class HtmlTransformer
     private array $runtimeIslands = array();
 
     /**
+     * Generated dynamic custom-block definitions produced at `core/html`
+     * fallback decisions (issue #497). Surfaced under
+     * `source_reports.generated_blocks` and packaged into the companion-plugin
+     * payload by the ArtifactCompiler.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $generatedBlocks = array();
+
+    /**
+     * Block namespace for generated custom-block references. The ArtifactCompiler
+     * sets this to the per-site companion-plugin namespace (`ssi-<site_slug>`) so
+     * emitted references match the blocks SSI registers; standalone transforms
+     * fall back to a generic namespace.
+     */
+    private string $generatedBlockNamespace = 'custom';
+
+    /**
      * @var array<int, array<string, mixed>>
      */
     private array $runtimeScriptMetadata = array();
@@ -189,6 +207,9 @@ final class HtmlTransformer
         $this->structureProvenance = array();
         $this->scriptMetadata = array();
         $this->runtimeIslands = array();
+        $this->generatedBlocks = array();
+        $this->generatedBlockNamespace = $this->generatedBlockNamespaceFromOptions($options);
+        $this->fallbackEmitter->resetGeneratedBlocks();
         $this->runtimeScriptMetadata = $this->runtimeScriptMetadataFromOptions($options);
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->generatedAssets = array();
@@ -284,6 +305,7 @@ final class HtmlTransformer
             'native_target_blocks' => $nativeTargetBlocks,
             'available_core_blocks' => $nativeTargetBlocks,
             'runtime_islands' => $this->runtimeIslands,
+            'generated_blocks' => $this->generatedBlocks,
             'interaction_candidates' => $interactionCandidates,
             'wp_block_validity' => $blockValidityReport,
             'semantic_parity' => $semanticParityReport,
@@ -1385,6 +1407,16 @@ final class HtmlTransformer
         }
 
         if ( $captureUnsupported ) {
+            // Producer link (issue #497): this is a core/html fallback decision —
+            // the element mapped to nothing native/Automattic. If the structural
+            // classifier identifies it as a high-confidence custom_block, generate
+            // a dynamic block and emit a self-closing reference instead of raw
+            // core/html. Otherwise keep the existing fallback diagnostic.
+            $generated = $this->fallbackEmitter->maybeGenerateCustomBlock($element, $this->generatedBlocks, $this->generatedBlockNamespace);
+            if ( null !== $generated ) {
+                return $this->createBlock($generated['blockName'], $generated['attrs'], array(), $element);
+            }
+
             $fallback = array(
                 'type'            => 'unsupported_element',
                 'reason'          => 'unsupported_element',
@@ -3056,6 +3088,19 @@ final class HtmlTransformer
         }
 
         return $this->dedupeArrayRows($metadata);
+    }
+
+    /**
+     * Resolve the generated custom-block namespace from transform options,
+     * defaulting to a generic namespace for standalone transforms.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function generatedBlockNamespaceFromOptions(array $options): string
+    {
+        $namespace = is_scalar($options['generated_block_namespace'] ?? null) ? trim((string) $options['generated_block_namespace']) : '';
+
+        return '' !== $namespace ? $namespace : 'custom';
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/artifact-custom-block-companion-payload.json
+++ b/php-transformer/tests/fixtures/parity/artifact-custom-block-companion-payload.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-custom-block-companion-payload",
+  "description": "End-to-end producer link: an artifact whose entry HTML contains a high-confidence custom_block subtree compiles to a companion_plugin_payload whose blocks[] carries the generated dynamic block (name, block_json, dynamic render) in the exact shape the SSI companion-plugin scaffolder consumes. The block.json name is namespaced to the per-site companion plugin (ssi-<site_slug>) so emitted references match the registered block (issues #497 / #491).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-custom-block-companion-payload.json",
+    "notes": "Product-neutral custom element; the payload entry is generic and derived from structure only."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New producer-link behavior with no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "schema": "blocks-engine/php-transformer/site-artifact/v1",
+      "site_slug": "acme-co",
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<html><body><main><my-pricing><div class=\"tier\"><h3>Basic</h3><p>$9</p></div><div class=\"tier\"><h3>Pro</h3><p>$19</p></div><div class=\"tier\"><h3>Max</h3><p>$49</p></div></my-pricing></main></body></html>"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.companion_plugin_payload.schema", "assert": "equals", "value": "static-site-importer/companion-plugin/v1" },
+    { "path": "source_reports.companion_plugin_payload.site_slug", "assert": "equals", "value": "acme-co" },
+    { "path": "source_reports.companion_plugin_payload.blocks", "assert": "count", "count": 1 },
+    { "path": "source_reports.companion_plugin_payload.blocks.0.name", "assert": "equals", "value": "collection-623e0f92" },
+    { "path": "source_reports.companion_plugin_payload.blocks.0.block_json.name", "assert": "equals", "value": "ssi-acme-co/collection-623e0f92" },
+    { "path": "source_reports.companion_plugin_payload.blocks.0.block_json.render", "assert": "equals", "value": "file:./render.php" },
+    { "path": "source_reports.companion_plugin_payload.blocks.0.render", "assert": "contains", "value": "wp_kses_post" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp:ssi-acme-co/collection-623e0f92" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-custom-block-generation-dedup.json
+++ b/php-transformer/tests/fixtures/parity/html-custom-block-generation-dedup.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-custom-block-generation-dedup",
+  "description": "Two structurally identical custom_block subtrees generate ONE block TYPE, reused: the output carries two self-closing references to the same generated block name (varying content travels on each reference's attrs) and source_reports.generated_blocks holds a single type definition. Structural-signature dedup means no near-duplicate block types (issue #497).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-custom-block-generation-dedup.json",
+    "notes": "Same shape twice; the block name is derived from the structural signature so both subtrees collapse to one type."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New producer-link behavior with no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<my-pricing><div class=\"tier\"><h3>Basic</h3><p>$9</p></div><div class=\"tier\"><h3>Pro</h3><p>$19</p></div><div class=\"tier\"><h3>Max</h3><p>$49</p></div></my-pricing><my-pricing><div class=\"tier\"><h3>Team</h3><p>$99</p></div><div class=\"tier\"><h3>Scale</h3><p>$199</p></div><div class=\"tier\"><h3>Enterprise</h3><p>$499</p></div></my-pricing>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "custom/collection-623e0f92" },
+    { "path": "blocks.1", "name": "custom/collection-623e0f92" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "custom/collection-623e0f92" },
+    { "path": "blocks.1.blockName", "assert": "equals", "value": "custom/collection-623e0f92" },
+    { "path": "blocks.0.attrs.content", "assert": "contains", "value": "<h3>Basic</h3>" },
+    { "path": "blocks.1.attrs.content", "assert": "contains", "value": "<h3>Team</h3>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.generated_blocks", "assert": "count", "count": 1 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-custom-block-generation.json
+++ b/php-transformer/tests/fixtures/parity/html-custom-block-generation.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-custom-block-generation",
+  "description": "A high-confidence custom_block subtree that maps to nothing native/Automattic (a custom-element wrapping repeated content tiles) is generated as a dynamic PHP-only block: the output carries a self-closing block reference (attrs only, no innerHTML) and a matching generated_blocks type definition, instead of a raw core/html fallback (issue #497).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-custom-block-generation.json",
+    "notes": "Product-neutral custom element; name/title derive from generic structure (repeatable children) only."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New producer-link behavior with no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<my-pricing><div class=\"tier\"><h3>Basic</h3><p>$9</p></div><div class=\"tier\"><h3>Pro</h3><p>$19</p></div><div class=\"tier\"><h3>Max</h3><p>$49</p></div></my-pricing>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "custom/collection-623e0f92" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "custom/collection-623e0f92" },
+    { "path": "blocks.0.innerHTML", "assert": "equals", "value": "" },
+    { "path": "blocks.0.attrs.content", "assert": "contains", "value": "<h3>Basic</h3>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.generated_blocks", "assert": "count", "count": 1 },
+    { "path": "source_reports.generated_blocks.0.name", "assert": "equals", "value": "collection-623e0f92" },
+    { "path": "source_reports.generated_blocks.0.block_json.title", "assert": "equals", "value": "Custom Collection" },
+    { "path": "source_reports.generated_blocks.0.block_json.render", "assert": "equals", "value": "file:./render.php" },
+    { "path": "source_reports.generated_blocks.0.render", "assert": "contains", "value": "wp_kses_post" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:custom/collection-623e0f92 " }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-custom-block-low-confidence-unchanged.json
+++ b/php-transformer/tests/fixtures/parity/html-custom-block-low-confidence-unchanged.json
@@ -1,0 +1,26 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-custom-block-low-confidence-unchanged",
+  "description": "A custom-element subtree with weak/ambiguous structural signals does NOT clear the conservative custom_block gate (classifier returns unknown), so behavior is unchanged: no block is generated and the existing core/html-equivalent unsupported_element fallback diagnostic is still emitted. When in doubt, fall back (issue #497).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-custom-block-low-confidence-unchanged.json",
+    "notes": "Negative control: a single inline child carries no custom_block signal, so generation must not trigger."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Negative control for new producer-link behavior; no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<my-widget><span>hello there</span></my-widget>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 0 },
+    { "path": "source_reports.generated_blocks", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_unsupported_element" },
+    { "path": "fallbacks.0.classification.bucket", "assert": "equals", "value": "unknown" }
+  ]
+}

--- a/php-transformer/tests/unit/custom-block-generator.php
+++ b/php-transformer/tests/unit/custom-block-generator.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the custom-block generator (issue #497).
+ *
+ * Plain-PHP test script in the style of tests/unit/subtree-classifier.php — no
+ * PHPUnit. Covers the pure {@see CustomBlockGenerator} definition shape plus the
+ * conservative generation gate / structural-signature dedup wired through
+ * {@see FallbackEmitter} and the {@see HtmlTransformer} core/html fallback path.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\CustomBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+// ---------------------------------------------------------------------------
+// 1. Pure generator: dynamic block.json + render + reference-attr shape.
+// ---------------------------------------------------------------------------
+$generator = new CustomBlockGenerator();
+$blockJson = $generator->blockJson('ssi-acme/collection-1234abcd', 'Custom Collection');
+
+$assert(($blockJson['apiVersion'] ?? null) === 3, '1: block.json declares apiVersion 3');
+$assert(($blockJson['name'] ?? null) === 'ssi-acme/collection-1234abcd', '1: block.json carries the fully-qualified name');
+$assert(($blockJson['render'] ?? null) === 'file:./render.php', '1: dynamic block.json points render at render.php');
+$assert(isset($blockJson['attributes']['content']['type']) && 'string' === $blockJson['attributes']['content']['type'], '1: content attribute is a string');
+$assert(($blockJson['supports']['html'] ?? null) === false, '1: generated block disables raw-HTML support');
+
+$render = $generator->render();
+$assert(str_starts_with($render, '<?php'), '2: render is a PHP file body');
+$assert(str_contains($render, "\$attributes['content']"), '2: render reads the content attribute');
+$assert(str_contains($render, 'wp_kses_post'), '2: render sanitizes content on output');
+
+$refAttrs = $generator->referenceAttributes('<p>hello</p>');
+$assert($refAttrs === array('content' => '<p>hello</p>'), '3: reference carries per-instance content only');
+
+// ---------------------------------------------------------------------------
+// 4. Gate (positive): high-confidence custom_block subtree -> generated ref.
+// ---------------------------------------------------------------------------
+$tiles = '<my-pricing>'
+    . '<div class="tier"><h3>Basic</h3><p>$9</p></div>'
+    . '<div class="tier"><h3>Pro</h3><p>$19</p></div>'
+    . '<div class="tier"><h3>Max</h3><p>$49</p></div>'
+    . '</my-pricing>';
+
+$result = ( new HtmlTransformer() )->transform($tiles, array('generated_block_namespace' => 'ssi-acme'))->toArray();
+$generated = $result['source_reports']['generated_blocks'] ?? array();
+
+$assert('success' === ($result['status'] ?? ''), '4: qualifying transform succeeds');
+$assert(count($result['blocks']) === 1, '4: one block emitted', json_encode($result['blocks']));
+$assert(($result['blocks'][0]['blockName'] ?? '') === 'ssi-acme/collection-623e0f92', '4: emits a namespaced dynamic block reference', $result['blocks'][0]['blockName'] ?? '');
+$assert('' === ($result['blocks'][0]['innerHTML'] ?? 'x'), '4: reference is self-closing (no innerHTML)');
+$assert(count($result['fallbacks']) === 0, '4: no core/html fallback emitted for the generated subtree');
+$assert(count($generated) === 1, '4: one generated block type recorded');
+$assert(($generated[0]['name'] ?? '') === 'collection-623e0f92', '4: generated type name is structurally derived (generic)');
+
+// ---------------------------------------------------------------------------
+// 5. Dedup: two identical shapes -> one type, two references.
+// ---------------------------------------------------------------------------
+$dedup = ( new HtmlTransformer() )->transform($tiles . $tiles)->toArray();
+$assert(count($dedup['blocks']) === 2, '5: two references emitted for two identical subtrees');
+$assert(($dedup['blocks'][0]['blockName'] ?? '') === ($dedup['blocks'][1]['blockName'] ?? ''), '5: both references point to the same generated type');
+$assert(count($dedup['source_reports']['generated_blocks'] ?? array()) === 1, '5: only ONE block type is generated (no zoo)');
+
+// ---------------------------------------------------------------------------
+// 6. Gate (negative): weak signals stay UNKNOWN -> unchanged fallback.
+// ---------------------------------------------------------------------------
+$weak = ( new HtmlTransformer() )->transform('<my-widget><span>hello there</span></my-widget>')->toArray();
+$assert(count($weak['source_reports']['generated_blocks'] ?? array()) === 0, '6: low-confidence subtree generates nothing');
+$assert(count($weak['blocks']) === 0, '6: low-confidence subtree emits no block');
+$assert(count($weak['fallbacks']) === 1, '6: existing fallback behavior is preserved');
+$assert(($weak['fallbacks'][0]['classification']['bucket'] ?? '') === 'unknown', '6: classifier verdict is unknown', json_encode($weak['fallbacks'][0]['classification'] ?? array()));
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, PHP_EOL . "CustomBlockGenerator unit tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);
+    exit(1);
+}
+
+fwrite(STDOUT, "CustomBlockGenerator unit tests: {$passes} passed" . PHP_EOL);


### PR DESCRIPTION
Refs #497

## What

First slice of custom-block **generation** — the producer link of the classify → route → generate chain (epic spine #497, keystone #491). The classifier (#258 wiring) already runs at the `core/html` fallback point and attaches a verdict; `ArtifactCompiler` already emits a `companion_plugin_payload` that SSI scaffolds into PHP-only dynamic blocks (#240 / #492 / #498 / #500). This PR adds the **missing producer link**: when the classifier says a `core/html`-fallback subtree is a `custom_block`, GENERATE a block definition, emit a block REFERENCE instead of raw `core/html`, and add the definition to `companion_plugin_payload.blocks[]`.

## Generation flow

At the `core/html` fallback decision (the `unsupported_element` path — a subtree that mapped to nothing native/Automattic), `FallbackEmitter::maybeGenerateCustomBlock()` consults the already-wired `SubtreeClassifier`. When it returns **bucket=`custom_block`** with **confidence ≥ 0.7** and the sanitized subtree is non-empty:

1. **Generate a dynamic (PHP-only) block** via the new `CustomBlockGenerator`: a generic, structurally-derived local name (e.g. `collection-<sig8>`), a single editable `content` attribute, `supports.html=false`, and a server-rendered `render.php` (`wp_kses_post($attributes['content'])` inside `get_block_wrapper_attributes()`). Dynamic/server-rendered → no `save()` mismatch.
2. **Emit a self-closing dynamic block reference** in output (blockName = `<namespace>/<local>`, attrs only, no innerHTML) instead of `core/html`.
3. **Add the definition to `companion_plugin_payload.blocks[]`** — `HtmlTransformer` surfaces `source_reports.generated_blocks`; `ArtifactCompiler` threads them into `CompanionPluginPayload` (verified against the SSI consumer's `name` / `block_json` / `render` contract) and namespaces references to the per-site companion plugin (`ssi-<site_slug>`) so emitted refs match the registered blocks.

## Gate + dedup

- **Conservative gate:** generate ONLY when bucket=`custom_block`, confidence ≥ 0.7 (the classifier's own MIN_SCORE/MARGIN already caps UNKNOWN at 0.4), and nothing native/Automattic matched. Otherwise keep the existing fallback behavior. Generic only — name/title derive from structure, never fixture/site strings.
- **Dedup by structural signature:** a tag-only DOM skeleton (ignoring text/attributes) keys a per-transform registry. Same-shape subtrees → ONE generated block TYPE, reused; per-instance content rides each reference's attrs. No near-duplicate block types ("no zoo").

## Before / after (qualifying subtree)

Input `<my-pricing><div class="tier"><h3>Basic</h3><p>$9</p></div> …×3… </my-pricing>`:
- **Before:** dropped to an `html_unsupported_element` fallback diagnostic (raw-HTML-equivalent), no block, no payload.
- **After:** one generated type `collection-623e0f92` (title "Custom Collection", dynamic `render.php`) in `source_reports.generated_blocks` / `companion_plugin_payload.blocks[]`, and a self-closing reference `<!-- wp:ssi-<slug>/collection-623e0f92 {"content":"…"} /-->` in output. Two identical `<my-pricing>` blocks → **one** type, **two** references.

## Scope

Wired only at the `unsupported_element` fallback for a minimal, green end-to-end slice; the `div`/`section` paths already convert repeated content natively (e.g. `html-class-grid-card-layout`), so they are intentionally untouched. Classifier + `Style/`/`Classification/` internals are read-only.

## Verification

Intentional behavior change for qualifying subtrees (`core/html` → generated dynamic block + payload entry). Baseline `composer test:canonical` + `composer parity` (131) were green first; **no existing fixtures changed**.

Added tests:
- `html-custom-block-generation` — high-confidence custom_block fallback → generated dynamic block reference + `generated_blocks` entry.
- `html-custom-block-generation-dedup` — two identical shapes → one type, two refs.
- `artifact-custom-block-companion-payload` — end-to-end → matching `companion_plugin_payload.blocks[]` entry (SSI-shaped, namespaced `block_json.name`).
- `html-custom-block-low-confidence-unchanged` — negative control: weak signals stay `unknown`, fallback unchanged.
- `tests/unit/custom-block-generator.php` — generator shape + gate + dedup.

Full `composer test` green (135 parity fixtures), `php -l` clean.

**DO NOT MERGE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)