### PR TITLE
Dedupe transformer helpers duplicated by decomposition slices 3/4

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -708,42 +708,6 @@ final class FallbackEmitter
         ), static fn (mixed $value): bool => array() !== $value);
     }
 
-    private function runtimeIslandSelector(DOMElement $element): string
-    {
-        $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id ) {
-            return '#' . $id;
-        }
-
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class ) {
-                return '.' . $class;
-            }
-        }
-
-        return $this->elementSelector($element);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $rows
-     * @return array<int, array<string, mixed>>
-     */
-    private function dedupeArrayRows(array $rows): array
-    {
-        $seen = array();
-        $deduped = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
-    }
-
     private function templateRequiresRuntimePreservation(DOMElement $element): bool
     {
         foreach ( $this->htmlAttributes($element) as $name => $value ) {
@@ -897,32 +861,4 @@ final class FallbackEmitter
         return $attributes;
     }
 
-    /**
-     * @return array<int, array<string, string>>
-     */
-    private function eventMetadata(DOMElement $element): array
-    {
-        $events = array();
-        foreach ( $this->htmlAttributes($element) as $name => $value ) {
-            if ( preg_match('/^on([a-z]+)$/i', $name, $matches) ) {
-                $events[] = array(
-                    'type'      => strtolower($matches[1]),
-                    'attribute' => strtolower($name),
-                );
-            }
-            if ( preg_match('/^data-(?:action|on|event)$/i', $name) && '' !== trim($value) ) {
-                $events[] = array(
-                    'type'      => 'declared',
-                    'attribute' => $name,
-                );
-            }
-        }
-
-        return $events;
-    }
-
-    private function isSafeSvgContent(string $content): bool
-    {
-        return '' !== trim($content) && preg_match('/<svg(?:\s|>)/i', $content) && ! preg_match('/<\s*script\b|\son[a-z]+\s*=|javascript\s*:/i', $content);
-    }
 }

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -139,20 +139,6 @@ final class SemanticParityReporter
     }
 
     /**
-     * @param array<int, string> $tagNames
-     */
-    private function hasAncestorTag(DOMElement $element, array $tagNames): bool
-    {
-        for ( $node = $element->parentNode; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); $node = $node->parentNode ) {
-            if ( in_array(strtolower($node->tagName), $tagNames, true) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * @param array<int, array<string, mixed>> $blocks
      * @param array<int, array<string, mixed>> $sourceProvenance
      * @param array{counts: array<string, int>, selectors: array<string, array<int, string>>} $sourceLandmarks
@@ -365,23 +351,6 @@ final class SemanticParityReporter
         }
 
         return (bool) preg_match('/(?:^|[^a-z0-9])(?:hamburger|menu|toggle)(?:[^a-z0-9]|$)/', strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-label')));
-    }
-
-    private function hasSourceNavigationSignal(DOMElement $element): bool
-    {
-        if ( 'navigation' === strtolower($this->attr($element, 'role')) ) {
-            return true;
-        }
-
-        foreach ( array( 'class', 'id' ) as $attribute ) {
-            foreach ( preg_split('/[^a-z0-9]+/', strtolower($this->attr($element, $attribute))) ?: array() as $token ) {
-                if ( in_array($token, array( 'nav', 'navbar', 'navigation', 'menu', 'links' ), true) ) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -840,18 +809,4 @@ final class SemanticParityReporter
         return implode('|', $parts);
     }
 
-    /**
-     * Sanitize a navigation URL, dropping control characters and javascript:
-     * schemes. Copied from HtmlTransformer (which retains it for non-parity
-     * callers) so the parity reporter has no dependency on transformer state.
-     */
-    private function safeNavigationUrl(string $url): string
-    {
-        $url = trim($url);
-        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
-            return '';
-        }
-
-        return $url;
-    }
 }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -422,36 +422,6 @@ final class HtmlTransformer
     }
 
     /**
-     * @param array<int, string> $tagNames
-     */
-    private function hasAncestorTag(DOMElement $element, array $tagNames): bool
-    {
-        for ( $node = $element->parentNode; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); $node = $node->parentNode ) {
-            if ( in_array(strtolower($node->tagName), $tagNames, true) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-    private function hasSourceNavigationSignal(DOMElement $element): bool
-    {
-        if ( 'navigation' === strtolower($this->attr($element, 'role')) ) {
-            return true;
-        }
-
-        foreach ( array( 'class', 'id' ) as $attribute ) {
-            foreach ( preg_split('/[^a-z0-9]+/', strtolower($this->attr($element, $attribute))) ?: array() as $token ) {
-                if ( in_array($token, array( 'nav', 'navbar', 'navigation', 'menu', 'links' ), true) ) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * @param array<int, array<string, mixed>> $blocks
      * @param array<string, bool> $seen
      * @return array<int, array<string, mixed>>
@@ -3031,22 +3001,6 @@ final class HtmlTransformer
         $this->fallbackEmitter->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeIslands);
     }
 
-    private function runtimeIslandSelector(DOMElement $element): string
-    {
-        $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id ) {
-            return '#' . $id;
-        }
-
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class ) {
-                return '.' . $class;
-            }
-        }
-
-        return $this->elementSelector($element);
-    }
-
     /**
      * @return array<int, array<string, mixed>>
      */
@@ -3090,26 +3044,6 @@ final class HtmlTransformer
         $namespace = is_scalar($options['generated_block_namespace'] ?? null) ? trim((string) $options['generated_block_namespace']) : '';
 
         return '' !== $namespace ? $namespace : 'custom';
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $rows
-     * @return array<int, array<string, mixed>>
-     */
-    private function dedupeArrayRows(array $rows): array
-    {
-        $seen = array();
-        $deduped = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
     }
 
     /**
@@ -4153,16 +4087,6 @@ final class HtmlTransformer
         return (bool) preg_match('/(?:^|[\s_-])(?:nav|navbar|navigation|menu|links)(?:$|[\s_-])/', $name);
     }
 
-    private function safeNavigationUrl(string $url): string
-    {
-        $url = trim($url);
-        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
-            return '';
-        }
-
-        return $url;
-    }
-
     private function hasDirectChildElement(DOMElement $element, string $tagName): bool
     {
         foreach ( $element->childNodes as $child ) {
@@ -4684,11 +4608,6 @@ final class HtmlTransformer
         return $this->safeImageUrl($url);
     }
 
-    private function isSafeSvgContent(string $content): bool
-    {
-        return '' !== trim($content) && preg_match('/<svg(?:\s|>)/i', $content) && ! preg_match('/<\s*script\b|\son[a-z]+\s*=|javascript\s*:/i', $content);
-    }
-
     /**
      * @return array<string, string>
      */
@@ -4787,33 +4706,6 @@ final class HtmlTransformer
         }
 
         return $html;
-    }
-
-    /**
-     * @param array<string, string> $attrs
-     */
-    /**
-     * @return array<int, array<string, string>>
-     */
-    private function eventMetadata(DOMElement $element): array
-    {
-        $events = array();
-        foreach ( $this->htmlAttributes($element) as $name => $value ) {
-            if ( preg_match('/^on([a-z]+)$/i', $name, $matches) ) {
-                $events[] = array(
-                    'type'      => strtolower($matches[1]),
-                    'attribute' => strtolower($name),
-                );
-            }
-            if ( preg_match('/^data-(?:action|on|event)$/i', $name) && '' !== trim($value) ) {
-                $events[] = array(
-                    'type'      => 'declared',
-                    'attribute' => $name,
-                );
-            }
-        }
-
-        return $events;
     }
 
 }

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -266,4 +266,113 @@ trait DomHelpersTrait
         }
         return $html;
     }
+
+    /**
+     * @param array<int, string> $tagNames
+     */
+    private function hasAncestorTag(DOMElement $element, array $tagNames): bool
+    {
+        for ( $node = $element->parentNode; $node instanceof DOMElement && 'body' !== strtolower($node->tagName); $node = $node->parentNode ) {
+            if ( in_array(strtolower($node->tagName), $tagNames, true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasSourceNavigationSignal(DOMElement $element): bool
+    {
+        if ( 'navigation' === strtolower($this->attr($element, 'role')) ) {
+            return true;
+        }
+
+        foreach ( array( 'class', 'id' ) as $attribute ) {
+            foreach ( preg_split('/[^a-z0-9]+/', strtolower($this->attr($element, $attribute))) ?: array() as $token ) {
+                if ( in_array($token, array( 'nav', 'navbar', 'navigation', 'menu', 'links' ), true) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Sanitize a navigation URL, dropping control characters and javascript: schemes.
+     */
+    private function safeNavigationUrl(string $url): string
+    {
+        $url = trim($url);
+        if ( '' === $url || preg_match('/[\x00-\x1f\x7f]|javascript\s*:/i', $url) ) {
+            return '';
+        }
+
+        return $url;
+    }
+
+    private function runtimeIslandSelector(DOMElement $element): string
+    {
+        $id = trim($this->attr($element, 'id'));
+        if ( '' !== $id ) {
+            return '#' . $id;
+        }
+
+        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
+            if ( '' !== $class ) {
+                return '.' . $class;
+            }
+        }
+
+        return $this->elementSelector($element);
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function eventMetadata(DOMElement $element): array
+    {
+        $events = array();
+        foreach ( $this->htmlAttributes($element) as $name => $value ) {
+            if ( preg_match('/^on([a-z]+)$/i', $name, $matches) ) {
+                $events[] = array(
+                    'type'      => strtolower($matches[1]),
+                    'attribute' => strtolower($name),
+                );
+            }
+            if ( preg_match('/^data-(?:action|on|event)$/i', $name) && '' !== trim($value) ) {
+                $events[] = array(
+                    'type'      => 'declared',
+                    'attribute' => $name,
+                );
+            }
+        }
+
+        return $events;
+    }
+
+    private function isSafeSvgContent(string $content): bool
+    {
+        return '' !== trim($content) && preg_match('/<svg(?:\s|>)/i', $content) && ! preg_match('/<\s*script\b|\son[a-z]+\s*=|javascript\s*:/i', $content);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function dedupeArrayRows(array $rows): array
+    {
+        $seen = array();
+        $deduped = array();
+        foreach ( $rows as $row ) {
+            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
+            if ( ! is_string($key) || isset($seen[$key]) ) {
+                continue;
+            }
+            $seen[$key] = true;
+            $deduped[] = $row;
+        }
+
+        return $deduped;
+    }
 }


### PR DESCRIPTION
Refs #242

Dedupe helpers that were duplicated by HtmlTransformer decomposition slices 3 (#246, `Diagnostics/SemanticParityReporter`) and 4 (#249, `Diagnostics/FallbackEmitter`). Those slices were file-scoped, so they copied shared leaf helpers instead of promoting them. This is a pure, behavior-preserving dedupe — parity is identical.

## What changed
Each helper below was confirmed **byte-identical** across all its copies (diffed before collapsing), then consolidated into the single existing home `Support/DomHelpersTrait` (already `use`d by all three classes), with the duplicate copies removed:

| Helper | Was duplicated in |
| --- | --- |
| `hasAncestorTag` | HtmlTransformer + SemanticParityReporter |
| `hasSourceNavigationSignal` | HtmlTransformer + SemanticParityReporter |
| `safeNavigationUrl` | HtmlTransformer + SemanticParityReporter |
| `runtimeIslandSelector` | HtmlTransformer + FallbackEmitter |
| `eventMetadata` | HtmlTransformer + FallbackEmitter |
| `isSafeSvgContent` | HtmlTransformer + FallbackEmitter |
| `dedupeArrayRows` | HtmlTransformer + FallbackEmitter |

Also removed a stray orphan docblock (`@param array<string, string> $attrs`) that was left dangling above `eventMetadata` in HtmlTransformer.

## Intentionally left duplicated
While auditing, several other methods appear in both `HtmlTransformer` and `FallbackEmitter` (`recordRuntimeIsland`, `sourceContext`, `requiredScriptsForElement`, `captureCanvasFallback`, `captureInlineSvgFallback`, `captureScriptFallback`, `captureStaticScriptMetadata`, `captureTemplateFallback`, `isRuntimeCanvasTarget`). These were **diffed and found to have diverged** — they are the decomposition delegation boundary, not duplication (e.g. HtmlTransformer's `recordRuntimeIsland` delegates to `$this->fallbackEmitter`, and its `sourceContext` calls a resolver closure while FallbackEmitter holds the full implementation). They were left untouched.

## Behavior preservation
- `composer test:canonical` — all pass, before and after.
- `composer parity` — **144 fixtures pass, identical** before and after.
- Full `composer test` (canonical + parity + packaging) green.
- `php -l` clean on all four files. No fixtures touched. No logic/signature changes.

Net: +109 / -217 lines (net -108).

Scope limited to `HtmlTransformer.php`, `Diagnostics/SemanticParityReporter.php`, `Diagnostics/FallbackEmitter.php`, `Support/DomHelpersTrait.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

DO NOT MERGE pending review.