### PR TITLE
Populate companion preserved_js from runtime islands (+ fix silent JS loss in generated blocks)

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -77,14 +77,20 @@ final class ArtifactCompiler
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks);
         $sourceReports['materialization_plan'] = ( new MaterializationPlanBuilder() )->fromCompiledSite($sourceReports['compiled_site']);
-        $companionPluginPayload = $companionPluginPayloadBuilder->fromBlockTypes($blockTypes, $normalized['files'], $artifact, $entryBlocks['generated_blocks']);
+        // Build the generic runtime-island package first so the product-named
+        // companion-plugin payload can map preserved island JS into its
+        // preserved_js slot (issue #488). The package is the engine-neutral feed;
+        // CompanionPluginPayload owns the SSI-named projection.
+        $runtimeIslandPackage = array() !== $entryBlocks['runtime_islands']
+            ? ( new RuntimeIslandPackageBuilder() )->fromRuntimeIslands($entryBlocks['runtime_islands'], $normalized['files'], $entryPath)
+            : array();
+        $companionPluginPayload = $companionPluginPayloadBuilder->fromBlockTypes($blockTypes, $normalized['files'], $artifact, $entryBlocks['generated_blocks'], $runtimeIslandPackage);
         if ( array() !== $companionPluginPayload ) {
             $sourceReports['companion_plugin_payload'] = $companionPluginPayload;
         }
         $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references'], $entryBlocks['interaction_candidates']);
         if ( array() !== $entryBlocks['runtime_islands'] ) {
             $sourceReports['runtime_islands'] = $entryBlocks['runtime_islands'];
-            $runtimeIslandPackage = ( new RuntimeIslandPackageBuilder() )->fromRuntimeIslands($entryBlocks['runtime_islands'], $normalized['files'], $entryPath);
             if ( array() !== $runtimeIslandPackage ) {
                 $sourceReports['runtime_island_package'] = $runtimeIslandPackage;
             }

--- a/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
+++ b/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
@@ -20,14 +20,19 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
  *   - site_name   (string)  optional human-readable name; defaults to slug.
  *   - mu_plugin   (bool)    optional; emit as a must-use loader.
  *   - blocks[]    (array)   each: name, block_json, render, view_js, assets{}.
- *   - preserved_js[] (array) each: content, handle, src, block. The JS->plugin
- *                            wire-up (SSI #488): verbatim island JS projected from
- *                            the generic runtime-island package, scoped to the
- *                            generated block that owns it.
- *   - preserved_js_deferred[] (array) each: content, handle, src, reason.
- *                            Preserve-worthy island JS with no sound generated-block
- *                            scope; surfaced (not silently dropped) because the
- *                            consumer drops unscoped entries.
+ *   - preserved_js[] (array) verbatim island JS projected from the generic
+ *                            runtime-island package (SSI #488). Two shapes:
+ *                            block-scoped entries carry content, handle, src, block
+ *                            and are enqueued via render_block when that block renders;
+ *                            site-wide entries carry content, handle, src, scope='site',
+ *                            order (no `block` key) and are enqueued for the whole site.
+ *                            Free-standing behavior islands with no generated-block
+ *                            owner take the site-wide shape so their JS lands instead
+ *                            of being parked.
+ *   - preserved_js_deferred[] (array) each: content, handle, src, reason. Island JS
+ *                            whose owning block exists but was not packaged into this
+ *                            payload (owner_block_not_packaged) — a genuine anomaly,
+ *                            surfaced rather than silently dropped or guessed.
  *
  * When the artifact carries no custom blocks (mapping still prefers
  * core/Automattic blocks with a core/html fallback, and no subtree qualified for
@@ -100,8 +105,9 @@ final class CompanionPluginPayload
         $payload = array(
             'schema' => self::SCHEMA,
             'blocks' => $blocks,
-            // Preserved island JS projected from the generic runtime-island package
-            // and scoped to its owning generated block (SSI #488).
+            // Preserved island JS projected from the generic runtime-island package:
+            // block-scoped to its owning generated block, or site-wide for free-standing
+            // behavior islands with no generated-block owner (SSI #488).
             'preserved_js' => $preserved['preserved_js'],
         );
         if ( array() !== $preserved['deferred'] ) {
@@ -128,20 +134,22 @@ final class CompanionPluginPayload
      * scaffold's preserved_js contract (issue #488), gated by the
      * preserve-vs-rebuild signal (issue #224).
      *
-     * Only islands the engine could soundly associate with a generated block are
-     * scoped and emitted: a script captured at custom-block generation carries the
-     * owning block's fully-qualified name (`owner_block`), and the consumer enqueues
-     * its JS via render_block only when that block renders. Free-standing islands
-     * (canvas, form, and standalone scripts elsewhere in the DOM) have no sound
-     * generated-block owner — the consumer drops unscoped entries — so they are
-     * surfaced as declared deferrals rather than emitted with a guessed scope or
-     * dropped silently. Telemetry/droppable and external-unmaterialized scripts
-     * carry no verbatim JS body, so they contribute neither an entry nor a deferral.
+     * An island captured at custom-block generation carries the owning block's
+     * fully-qualified name (`owner_block`). When that block ships in this payload the
+     * island is emitted block-scoped, and the consumer enqueues its JS via render_block
+     * only when that block renders. Free-standing islands (canvas, form, and standalone
+     * scripts elsewhere in the DOM) have no generated-block owner; they are promoted to
+     * site-wide entries (`scope='site'`, no `block`, deterministic `order`) so the
+     * consumer enqueues them for the whole site instead of parking the JS. The narrow
+     * anomaly where an owner_block is named but was not packaged is still deferred
+     * (owner_block_not_packaged) rather than guessed into a site-wide scope.
+     * Telemetry/droppable and external-unmaterialized scripts carry no verbatim JS body,
+     * so they contribute neither an entry nor a deferral.
      *
      * @param array<string, mixed>             $runtimeIslandPackage Generic runtime-island package.
      * @param array<int, array<string, mixed>> $blocks               Packaged companion blocks.
      * @param string                           $blockNamespace       Per-site block namespace (`ssi-<slug>`).
-     * @return array{preserved_js: array<int, array<string, string>>, deferred: array<int, array<string, string>>}
+     * @return array{preserved_js: array<int, array<string, mixed>>, deferred: array<int, array<string, string>>}
      */
     private function preservedJs(array $runtimeIslandPackage, array $blocks, string $blockNamespace): array
     {
@@ -164,7 +172,7 @@ final class CompanionPluginPayload
 
         $preserved = array();
         $deferred  = array();
-        foreach ( $islands as $island ) {
+        foreach ( $islands as $index => $island ) {
             if ( ! is_array($island) ) {
                 continue;
             }
@@ -189,14 +197,29 @@ final class CompanionPluginPayload
 
             $owner = is_scalar($island['owner_block'] ?? null) ? (string) $island['owner_block'] : '';
             if ( '' !== $owner && isset($ownedBlocks[$owner]) ) {
+                // Scoped to the owning generated block: the consumer enqueues it via
+                // render_block only when that block renders (UNCHANGED, #488).
                 $entry['block'] = $owner;
                 $preserved[]    = $entry;
                 continue;
             }
 
-            // No sound generated-block scope: surface as a declared deferral so the
-            // JS loss is visible rather than silent.
-            $entry['reason'] = '' !== $owner ? 'owner_block_not_packaged' : 'no_generated_block_owner';
+            if ( '' === $owner ) {
+                // Free-standing behavior island with no generated-block owner: promote
+                // to a site-wide preserved_js entry. The consumer enqueues these for
+                // the whole site rather than gating on a block, so the JS lands instead
+                // of being parked. Islands arrive ordered, so the package index gives a
+                // deterministic enqueue order. No `block` key by contract.
+                $entry['scope'] = 'site';
+                $entry['order'] = (int) $index;
+                $preserved[]    = $entry;
+                continue;
+            }
+
+            // The owning block exists but was not packaged into this payload — a
+            // genuine anomaly. Keep deferring (rather than guessing a site-wide scope)
+            // so the loss is visible for follow-up.
+            $entry['reason'] = 'owner_block_not_packaged';
             $deferred[]      = $entry;
         }
 

--- a/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
+++ b/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
@@ -20,8 +20,14 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
  *   - site_name   (string)  optional human-readable name; defaults to slug.
  *   - mu_plugin   (bool)    optional; emit as a must-use loader.
  *   - blocks[]    (array)   each: name, block_json, render, view_js, assets{}.
- *   - preserved_js[] (array) each: content, handle, src, block. Slot for the
- *                            JS->plugin wire-up (SSI #488); empty for now.
+ *   - preserved_js[] (array) each: content, handle, src, block. The JS->plugin
+ *                            wire-up (SSI #488): verbatim island JS projected from
+ *                            the generic runtime-island package, scoped to the
+ *                            generated block that owns it.
+ *   - preserved_js_deferred[] (array) each: content, handle, src, reason.
+ *                            Preserve-worthy island JS with no sound generated-block
+ *                            scope; surfaced (not silently dropped) because the
+ *                            consumer drops unscoped entries.
  *
  * When the artifact carries no custom blocks (mapping still prefers
  * core/Automattic blocks with a core/html fallback, and no subtree qualified for
@@ -48,9 +54,10 @@ final class CompanionPluginPayload
      * @param array<int, array<string, mixed>> $files           Normalized artifact files (carry content).
      * @param array<string, mixed>             $artifact        Raw artifact envelope (for site identity).
      * @param array<int, array<string, mixed>> $generatedBlocks Dynamic blocks generated at core/html fallbacks (issue #497).
+     * @param array<string, mixed>             $runtimeIslandPackage Generic runtime-island package feed (issue #488).
      * @return array<string, mixed> Empty array when there are no generated blocks.
      */
-    public function fromBlockTypes(array $blockTypes, array $files, array $artifact, array $generatedBlocks = array()): array
+    public function fromBlockTypes(array $blockTypes, array $files, array $artifact, array $generatedBlocks = array(), array $runtimeIslandPackage = array()): array
     {
         $blocks = array();
         $seenNames = array();
@@ -88,13 +95,18 @@ final class CompanionPluginPayload
             return array();
         }
 
+        $preserved = $this->preservedJs($runtimeIslandPackage, $blocks, $this->blockNamespace($artifact));
+
         $payload = array(
             'schema' => self::SCHEMA,
             'blocks' => $blocks,
-            // Slot for preserved island JS. Populated by the JS->plugin wire-up
-            // (SSI #488); empty here so the producer seam exists today.
-            'preserved_js' => array(),
+            // Preserved island JS projected from the generic runtime-island package
+            // and scoped to its owning generated block (SSI #488).
+            'preserved_js' => $preserved['preserved_js'],
         );
+        if ( array() !== $preserved['deferred'] ) {
+            $payload['preserved_js_deferred'] = $preserved['deferred'];
+        }
 
         $siteSlug = $this->siteSlug($artifact);
         if ( '' !== $siteSlug ) {
@@ -109,6 +121,109 @@ final class CompanionPluginPayload
         }
 
         return $payload;
+    }
+
+    /**
+     * Project preserved island JS from the generic runtime-island package into the
+     * scaffold's preserved_js contract (issue #488), gated by the
+     * preserve-vs-rebuild signal (issue #224).
+     *
+     * Only islands the engine could soundly associate with a generated block are
+     * scoped and emitted: a script captured at custom-block generation carries the
+     * owning block's fully-qualified name (`owner_block`), and the consumer enqueues
+     * its JS via render_block only when that block renders. Free-standing islands
+     * (canvas, form, and standalone scripts elsewhere in the DOM) have no sound
+     * generated-block owner — the consumer drops unscoped entries — so they are
+     * surfaced as declared deferrals rather than emitted with a guessed scope or
+     * dropped silently. Telemetry/droppable and external-unmaterialized scripts
+     * carry no verbatim JS body, so they contribute neither an entry nor a deferral.
+     *
+     * @param array<string, mixed>             $runtimeIslandPackage Generic runtime-island package.
+     * @param array<int, array<string, mixed>> $blocks               Packaged companion blocks.
+     * @param string                           $blockNamespace       Per-site block namespace (`ssi-<slug>`).
+     * @return array{preserved_js: array<int, array<string, string>>, deferred: array<int, array<string, string>>}
+     */
+    private function preservedJs(array $runtimeIslandPackage, array $blocks, string $blockNamespace): array
+    {
+        $islands = is_array($runtimeIslandPackage['islands'] ?? null) ? $runtimeIslandPackage['islands'] : array();
+        if ( array() === $islands ) {
+            return array( 'preserved_js' => array(), 'deferred' => array() );
+        }
+
+        // Fully-qualified names of the generated blocks this payload actually
+        // packages, so an island scope is only honored when its owning block ships.
+        $ownedBlocks = array();
+        if ( '' !== $blockNamespace ) {
+            foreach ( $blocks as $block ) {
+                $name = (string) ($block['name'] ?? '');
+                if ( '' !== $name ) {
+                    $ownedBlocks[$blockNamespace . '/' . $name] = true;
+                }
+            }
+        }
+
+        $preserved = array();
+        $deferred  = array();
+        foreach ( $islands as $island ) {
+            if ( ! is_array($island) ) {
+                continue;
+            }
+            // Preserve-vs-rebuild gate (#224): only verbatim-preserve islands carry JS.
+            if ( 'preserve' !== ($island['disposition'] ?? '') || 'preserve_verbatim' !== ($island['js_handling'] ?? '') ) {
+                continue;
+            }
+            $content = $this->islandScriptContent($island);
+            $handle  = is_scalar($island['handle_hint'] ?? null) ? (string) $island['handle_hint'] : '';
+            if ( '' === $content || '' === $handle ) {
+                // Nothing carryable (telemetry-only or external-unmaterialized) or
+                // no stable handle: the consumer requires both, so emit neither an
+                // entry nor a deferral.
+                continue;
+            }
+
+            $entry = array(
+                'content' => $content,
+                'handle'  => $handle,
+                'src'     => 'islands/' . $handle . '.js',
+            );
+
+            $owner = is_scalar($island['owner_block'] ?? null) ? (string) $island['owner_block'] : '';
+            if ( '' !== $owner && isset($ownedBlocks[$owner]) ) {
+                $entry['block'] = $owner;
+                $preserved[]    = $entry;
+                continue;
+            }
+
+            // No sound generated-block scope: surface as a declared deferral so the
+            // JS loss is visible rather than silent.
+            $entry['reason'] = '' !== $owner ? 'owner_block_not_packaged' : 'no_generated_block_owner';
+            $deferred[]      = $entry;
+        }
+
+        return array( 'preserved_js' => $preserved, 'deferred' => $deferred );
+    }
+
+    /**
+     * The first preserve-worthy verbatim JS body carried by an island's scripts:
+     * an inline body or materialized external content. Telemetry/droppable scripts
+     * and external-but-unmaterialized scripts contribute no carryable content.
+     *
+     * @param array<string, mixed> $island One runtime-island-package island.
+     */
+    private function islandScriptContent(array $island): string
+    {
+        $scripts = is_array($island['scripts'] ?? null) ? $island['scripts'] : array();
+        foreach ( $scripts as $script ) {
+            if ( ! is_array($script) || ! empty($script['droppable']) || 'telemetry' === ($script['role'] ?? '') ) {
+                continue;
+            }
+            $content = is_scalar($script['content'] ?? null) ? (string) $script['content'] : '';
+            if ( '' !== trim($content) ) {
+                return $content;
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/RuntimeIslandPackageBuilder.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeIslandPackageBuilder.php
@@ -136,6 +136,11 @@ final class RuntimeIslandPackageBuilder
             'disposition'         => $disposition,
             'js_handling'         => 'drop' === $disposition ? 'drop' : 'preserve_verbatim',
             'handle_hint'         => $this->handleHint($kind, $selector, $markup),
+            // Generic association: the generated block this island lives inside,
+            // when the transformer recorded one (a script captured at custom-block
+            // generation, issue #488). Product-neutral — it is a generated-block
+            // reference, not a host-product name. Absent for free-standing islands.
+            'owner_block'         => is_scalar($runtimeIsland['owner_block'] ?? null) ? (string) $runtimeIsland['owner_block'] : '',
             'attributes'          => is_array($runtimeIsland['attributes'] ?? null) ? $runtimeIsland['attributes'] : array(),
             'scripts'             => $scripts,
         );

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -126,9 +126,10 @@ final class FallbackEmitter
      * existing fallback behavior whenever the conservative gate is not met.
      *
      * @param array<int, array<string, mixed>> $generatedBlocks Accumulator of generated block-type definitions.
+     * @param array<int, array<string, mixed>> $runtimeIslands  Accumulator of preserved runtime islands.
      * @return array{blockName: string, attrs: array<string, mixed>}|null
      */
-    public function maybeGenerateCustomBlock(DOMElement $element, array &$generatedBlocks, string $namespace): ?array
+    public function maybeGenerateCustomBlock(DOMElement $element, array &$generatedBlocks, array &$runtimeIslands, string $namespace): ?array
     {
         $result = $this->classifier->classify($element, $this->classificationContext($element));
         if ( ! $result->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK) ) {
@@ -168,10 +169,72 @@ final class FallbackEmitter
             );
         }
 
+        $ownerBlock = $namespace . '/' . $localName;
+        $this->recordGeneratedBlockScriptIslands($element, $ownerBlock, $runtimeIslands);
+
         return array(
-            'blockName' => $namespace . '/' . $localName,
+            'blockName' => $ownerBlock,
             'attrs'     => $this->blockGenerator->referenceAttributes($content),
         );
+    }
+
+    /**
+     * Record the runtime behavior scripts that live inside a subtree being turned
+     * into a generated custom block, each scoped to that block via `owner_block`.
+     *
+     * The generated block consumes its source subtree wholesale — the caller
+     * emits a single self-closing reference and never recurses — and
+     * {@see sanitizeHtmlString()} strips `<script>` bodies from the captured
+     * content, so any behavior script inside the subtree would otherwise be lost.
+     * Recording it as a script runtime island carrying the owning block's
+     * fully-qualified name is the one sound island->generated-block association
+     * point (issue #488): the block name is known here and the script lives
+     * literally inside that block's subtree, so a downstream materializer can
+     * carry the verbatim JS forward and enqueue it only when the block renders.
+     * Telemetry/analytics scripts are still classified and dropped downstream by
+     * the runtime-island package builder (issue #224); only executable runtime
+     * scripts are captured here (data/JSON-LD scripts carry no behavior).
+     *
+     * @param array<int, array<string, mixed>> $runtimeIslands
+     */
+    private function recordGeneratedBlockScriptIslands(DOMElement $element, string $ownerBlock, array &$runtimeIslands): void
+    {
+        foreach ( $this->subtreeElements($element) as $node ) {
+            if ( 'script' !== strtolower($node->tagName) || 'runtime' !== $this->scriptRole($node) ) {
+                continue;
+            }
+            $metadata                = $this->scriptIslandMetadata($node);
+            $metadata['owner_block'] = $ownerBlock;
+            $this->recordRuntimeIsland($node, 'script', 'script_requires_runtime', 'client_script_execution', $metadata, $runtimeIslands);
+        }
+    }
+
+    /**
+     * Build the runtime-island metadata for a `<script>` element: its safe
+     * attributes (external src), role, source kind, and — for an inline script —
+     * the verbatim inline body (bounded). safeFallbackHtml() strips `<script>`
+     * bodies from the island source_snippet for safety, so the inline body is
+     * preserved here so a downstream consumer can carry the script forward verbatim
+     * (issue #224: verbatim JS on verbatim island markup).
+     *
+     * @return array<string, mixed>
+     */
+    private function scriptIslandMetadata(DOMElement $element): array
+    {
+        $scriptSourceKind = '' !== trim($this->attr($element, 'src')) ? 'external' : 'inline';
+        $metadata         = array(
+            'attributes'         => $this->safeScriptAttributes($element),
+            'script_role'        => $this->scriptRole($element),
+            'script_source_kind' => $scriptSourceKind,
+        );
+        if ( 'inline' === $scriptSourceKind ) {
+            $boundedBody                    = $this->boundedFallbackText(trim($element->textContent ?? ''));
+            $metadata['script_body']        = $boundedBody['text'];
+            $metadata['body_bytes']         = $boundedBody['bytes'];
+            $metadata['body_truncated']     = $boundedBody['truncated'];
+        }
+
+        return $metadata;
     }
 
     /**
@@ -367,23 +430,7 @@ final class FallbackEmitter
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
         $boundedBody = $this->boundedFallbackText(trim($element->textContent ?? ''));
         $scriptRole = $this->scriptRole($element);
-        $scriptSourceKind = '' !== trim($this->attr($element, 'src')) ? 'external' : 'inline';
-        $scriptIslandMetadata = array(
-            'attributes'         => $this->safeScriptAttributes($element),
-            'script_role'        => $scriptRole,
-            'script_source_kind' => $scriptSourceKind,
-        );
-        if ( 'inline' === $scriptSourceKind ) {
-            // safeFallbackHtml() strips <script> bodies from source_snippet for
-            // safety, so an inline script island would otherwise carry no JS.
-            // Preserve the verbatim inline body (bounded) so a downstream
-            // consumer can carry the script forward (issue #224: verbatim JS on
-            // verbatim island markup).
-            $scriptIslandMetadata['script_body']    = $boundedBody['text'];
-            $scriptIslandMetadata['body_bytes']     = $boundedBody['bytes'];
-            $scriptIslandMetadata['body_truncated'] = $boundedBody['truncated'];
-        }
-        $this->recordRuntimeIsland($element, 'script', 'script_requires_runtime', 'client_script_execution', $scriptIslandMetadata, $runtimeIslands);
+        $this->recordRuntimeIsland($element, 'script', 'script_requires_runtime', 'client_script_execution', $this->scriptIslandMetadata($element), $runtimeIslands);
         $fallbacks[] = FallbackDiagnostic::build(array(
             'type'            => 'html',
             'reason'          => 'script_requires_runtime',

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1506,7 +1506,7 @@ final class HtmlTransformer
             // classifier identifies it as a high-confidence custom_block, generate
             // a dynamic block and emit a self-closing reference instead of raw
             // core/html. Otherwise keep the existing fallback diagnostic.
-            $generated = $this->fallbackEmitter->maybeGenerateCustomBlock($element, $this->generatedBlocks, $this->generatedBlockNamespace);
+            $generated = $this->fallbackEmitter->maybeGenerateCustomBlock($element, $this->generatedBlocks, $this->runtimeIslands, $this->generatedBlockNamespace);
             if ( null !== $generated ) {
                 return $this->createBlock($generated['blockName'], $generated['attrs'], array(), $element);
             }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1830,9 +1830,10 @@ $assert(! isset($companionBlock['assets']['block.json']), 'block.json is not dup
 // Preserved island JS producer (issue #488): verbatim behavior JS captured at
 // custom-block generation is projected into preserved_js, scoped to the block
 // that owns it (the consumer enqueues it via render_block only when that block
-// renders). A free-standing script island with no sound generated-block owner is
-// surfaced as a declared deferral — never silently dropped or scoped by guess —
-// and telemetry JS is dropped entirely (preserve-vs-rebuild, issue #224).
+// renders). A free-standing script island with no generated-block owner is
+// promoted to a site-wide preserved_js entry (scope='site', no `block`) so its JS
+// lands instead of being parked, and telemetry JS is dropped entirely
+// (preserve-vs-rebuild, issue #224).
 $companionJs = $compiler->compile(
     array(
         'site'  => array( 'name' => 'Acme Co', 'slug' => 'acme' ),
@@ -1855,18 +1856,88 @@ $companionJsPayload = $companionJs['source_reports']['companion_plugin_payload']
 $preservedJs       = $companionJsPayload['preserved_js'] ?? array();
 $generatedName     = (string) ($companionJsPayload['blocks'][0]['name'] ?? '');
 $assert('' !== $generatedName, 'companion JS fixture generates a custom block to scope island JS against');
-$assert(1 === count($preservedJs), 'preserved_js carries exactly the one scoped island entry');
-$scopedIsland = $preservedJs[0] ?? array();
+$assert(2 === count($preservedJs), 'preserved_js carries the scoped owner island and the promoted site-wide island');
+
+// The owned island stays block-scoped (UNCHANGED, #488): carries a `block` key and
+// no `scope` key.
+$scopedIsland = null;
+$siteWideIsland = null;
+foreach ( $preservedJs as $islandEntry ) {
+    if ( isset($islandEntry['block']) ) {
+        $scopedIsland = $islandEntry;
+    } elseif ( 'site' === ($islandEntry['scope'] ?? '') ) {
+        $siteWideIsland = $islandEntry;
+    }
+}
+$assert(is_array($scopedIsland), 'preserved_js still carries a block-scoped island entry');
+$assert(! array_key_exists('scope', $scopedIsland), 'block-scoped island carries no scope key (scoped path unchanged)');
 $assert('ssi-acme/' . $generatedName === ($scopedIsland['block'] ?? ''), 'preserved island JS is scoped to its owning generated block');
 $assert(str_contains((string) ($scopedIsland['content'] ?? ''), 'window.__pricing'), 'preserved island entry carries the verbatim inline JS body');
 $assert(str_starts_with((string) ($scopedIsland['handle'] ?? ''), 'runtime-island-'), 'preserved island entry derives a stable generic handle');
 $assert('islands/' . ($scopedIsland['handle'] ?? '') . '.js' === ($scopedIsland['src'] ?? ''), 'preserved island entry points at a per-handle island file');
-$deferredJs = $companionJsPayload['preserved_js_deferred'] ?? array();
-$assert(1 === count($deferredJs), 'a free-standing script island with no generated-block owner is deferred, not dropped');
-$assert('no_generated_block_owner' === ($deferredJs[0]['reason'] ?? ''), 'deferred island records why it could not be scoped');
-$assert(str_contains((string) ($deferredJs[0]['content'] ?? ''), '__standalone'), 'deferred island still carries its verbatim JS for the scoping follow-up');
+
+// The free-standing standalone island is now promoted to a site-wide preserved_js
+// entry (the producer half of site-wide companion JS): scope='site', no `block`
+// key, carries the verbatim JS, a stable handle/src, and a deterministic order.
+$assert(is_array($siteWideIsland), 'free-standing standalone island is promoted to a site-wide preserved_js entry');
+$assert('site' === ($siteWideIsland['scope'] ?? ''), 'promoted free-standing island declares site scope');
+$assert(! array_key_exists('block', $siteWideIsland), 'site-wide island carries no block key by contract');
+$assert(str_contains((string) ($siteWideIsland['content'] ?? ''), '__standalone'), 'site-wide island carries its verbatim standalone JS body');
+$assert(str_starts_with((string) ($siteWideIsland['handle'] ?? ''), 'runtime-island-'), 'site-wide island derives a stable generic handle');
+$assert('islands/' . ($siteWideIsland['handle'] ?? '') . '.js' === ($siteWideIsland['src'] ?? ''), 'site-wide island points at a per-handle island file');
+$assert(is_int($siteWideIsland['order'] ?? null), 'site-wide island carries a deterministic integer order');
+
+// With the standalone island promoted and no owner_block_not_packaged anomaly, the
+// payload defers nothing.
+$assert(! array_key_exists('preserved_js_deferred', $companionJsPayload), 'no deferral list when every preserve-worthy island is emitted');
 $companionJsBlob = json_encode($companionJsPayload, JSON_UNESCAPED_SLASHES);
 $assert(is_string($companionJsBlob) && ! str_contains($companionJsBlob, 'gtag'), 'telemetry island JS is dropped, never carried into the payload');
+
+// owner_block_not_packaged anomaly (a named owner block that did not ship in this
+// payload) is still deferred — never promoted to a site-wide scope by guess. Built
+// directly against the producer since the compiler path does not naturally orphan a
+// named owner. A sibling no-owner island in the same package proves the site-wide
+// promotion and the deferral coexist.
+$companionDirectPayload = ( new \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CompanionPluginPayload() )->fromBlockTypes(
+    array(),
+    array(),
+    array( 'site' => array( 'slug' => 'acme', 'name' => 'Acme Co' ) ),
+    array(
+        array(
+            'name'       => 'pricing',
+            'block_json' => array( 'apiVersion' => 3, 'name' => 'ssi-acme/pricing', 'render' => 'file:./render.php' ),
+            'render'     => '<?php echo "pricing";',
+        ),
+    ),
+    array(
+        'islands' => array(
+            array(
+                'disposition' => 'preserve',
+                'js_handling' => 'preserve_verbatim',
+                'handle_hint' => 'runtime-island-orphan',
+                'owner_block' => 'ssi-acme/missing',
+                'scripts'     => array( array( 'content' => 'window.__orphan=1;' ) ),
+            ),
+            array(
+                'disposition' => 'preserve',
+                'js_handling' => 'preserve_verbatim',
+                'handle_hint' => 'runtime-island-floating',
+                'owner_block' => '',
+                'scripts'     => array( array( 'content' => 'window.__floating=1;' ) ),
+            ),
+        ),
+    )
+);
+$directPreservedJs = $companionDirectPayload['preserved_js'] ?? array();
+$directDeferred    = $companionDirectPayload['preserved_js_deferred'] ?? array();
+$assert(1 === count($directPreservedJs), 'no-owner island promotes to a single site-wide entry alongside the deferred anomaly');
+$assert('site' === ($directPreservedJs[0]['scope'] ?? ''), 'no-owner island promotes to a site-wide entry');
+$assert(! array_key_exists('block', $directPreservedJs[0]), 'promoted site-wide entry carries no block key');
+$assert(str_contains((string) ($directPreservedJs[0]['content'] ?? ''), '__floating'), 'promoted site-wide entry carries the no-owner JS');
+$assert(1 === count($directDeferred), 'owner_block_not_packaged island is still deferred, not promoted');
+$assert('owner_block_not_packaged' === ($directDeferred[0]['reason'] ?? ''), 'orphaned owner island defers with the owner_block_not_packaged reason');
+$assert(! array_key_exists('scope', $directDeferred[0]), 'owner_block_not_packaged deferral is not given a site-wide scope');
+$assert(str_contains((string) ($directDeferred[0]['content'] ?? ''), '__orphan'), 'owner_block_not_packaged deferral still carries its verbatim JS');
 
 $companionNoSite = $compiler->compile(
     array(

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1813,7 +1813,8 @@ $assert(is_array($companionPayload), 'companion_plugin_payload is emitted when a
 $assert('static-site-importer/companion-plugin/v1' === ($companionPayload['schema'] ?? ''), 'companion payload stamps the shared consumer schema');
 $assert('acme' === ($companionPayload['site_slug'] ?? ''), 'companion payload derives site_slug from the artifact');
 $assert('Acme Co' === ($companionPayload['site_name'] ?? ''), 'companion payload derives site_name from the artifact');
-$assert(array() === ($companionPayload['preserved_js'] ?? null), 'companion payload exposes an empty preserved_js slot');
+$assert(array() === ($companionPayload['preserved_js'] ?? null), 'companion payload preserved_js is empty when the artifact carries no preserved island JS');
+$assert(! array_key_exists('preserved_js_deferred', $companionPayload), 'no deferral list when there is no preserved island JS');
 $assert(1 === count($companionPayload['blocks'] ?? array()), 'companion payload carries one block');
 $companionBlock = $companionPayload['blocks'][0] ?? array();
 $assert('hero' === ($companionBlock['name'] ?? ''), 'companion block name is the local slug for SSI namespacing');
@@ -1825,6 +1826,47 @@ $assert(isset($companionBlock['assets']['index.js']), 'companion block carries e
 $assert(! isset($companionBlock['assets']['render.php']), 'render is not duplicated into the assets map');
 $assert(! isset($companionBlock['assets']['view.js']), 'view JS is not duplicated into the assets map');
 $assert(! isset($companionBlock['assets']['block.json']), 'block.json is not duplicated into the assets map');
+
+// Preserved island JS producer (issue #488): verbatim behavior JS captured at
+// custom-block generation is projected into preserved_js, scoped to the block
+// that owns it (the consumer enqueues it via render_block only when that block
+// renders). A free-standing script island with no sound generated-block owner is
+// surfaced as a declared deferral — never silently dropped or scoped by guess —
+// and telemetry JS is dropped entirely (preserve-vs-rebuild, issue #224).
+$companionJs = $compiler->compile(
+    array(
+        'site'  => array( 'name' => 'Acme Co', 'slug' => 'acme' ),
+        'files' => array(
+            'index.html' =>
+                '<main>'
+                . '<my-pricing>'
+                . '<div class="tier"><h3>Basic</h3><p>$9</p></div>'
+                . '<div class="tier"><h3>Pro</h3><p>$19</p></div>'
+                . '<div class="tier"><h3>Max</h3><p>$49</p></div>'
+                . '<script>window.__pricing=function(){return 42;};</script>'
+                . '</my-pricing>'
+                . '<script>document.addEventListener("DOMContentLoaded",function(){window.__standalone=1;});</script>'
+                . '<script src="https://www.googletagmanager.com/gtag/js?id=GA"></script>'
+                . '</main>',
+        ),
+    )
+)->toArray();
+$companionJsPayload = $companionJs['source_reports']['companion_plugin_payload'] ?? array();
+$preservedJs       = $companionJsPayload['preserved_js'] ?? array();
+$generatedName     = (string) ($companionJsPayload['blocks'][0]['name'] ?? '');
+$assert('' !== $generatedName, 'companion JS fixture generates a custom block to scope island JS against');
+$assert(1 === count($preservedJs), 'preserved_js carries exactly the one scoped island entry');
+$scopedIsland = $preservedJs[0] ?? array();
+$assert('ssi-acme/' . $generatedName === ($scopedIsland['block'] ?? ''), 'preserved island JS is scoped to its owning generated block');
+$assert(str_contains((string) ($scopedIsland['content'] ?? ''), 'window.__pricing'), 'preserved island entry carries the verbatim inline JS body');
+$assert(str_starts_with((string) ($scopedIsland['handle'] ?? ''), 'runtime-island-'), 'preserved island entry derives a stable generic handle');
+$assert('islands/' . ($scopedIsland['handle'] ?? '') . '.js' === ($scopedIsland['src'] ?? ''), 'preserved island entry points at a per-handle island file');
+$deferredJs = $companionJsPayload['preserved_js_deferred'] ?? array();
+$assert(1 === count($deferredJs), 'a free-standing script island with no generated-block owner is deferred, not dropped');
+$assert('no_generated_block_owner' === ($deferredJs[0]['reason'] ?? ''), 'deferred island records why it could not be scoped');
+$assert(str_contains((string) ($deferredJs[0]['content'] ?? ''), '__standalone'), 'deferred island still carries its verbatim JS for the scoping follow-up');
+$companionJsBlob = json_encode($companionJsPayload, JSON_UNESCAPED_SLASHES);
+$assert(is_string($companionJsBlob) && ! str_contains($companionJsBlob, 'gtag'), 'telemetry island JS is dropped, never carried into the payload');
 
 $companionNoSite = $compiler->compile(
     array(


### PR DESCRIPTION
## What
Populates `CompanionPluginPayload.preserved_js[]` from runtime-island data so behavior JS embedded in generated custom blocks is carried into the SSI companion plugin (scoped per block), instead of being lost. The consumer already merged (SSI #496); this builds the producer half (#488).

## Notable: fixes a silent JS-loss bug
While building the island→block association (which did **not** exist — generated blocks and runtime islands came from disjoint elements, and `sanitizeHtmlString` stripped `<script>` bodies from generated content), I found inline behavior scripts inside generated custom blocks were being **silently dropped**. The fix mints the association at generation time.

## Change (`php-transformer`)
- `FallbackEmitter::maybeGenerateCustomBlock()` now scans the generated subtree for runtime `<script>`s and records each as a `script` island tagged with the owning block's FQN via a generic `owner_block` field (shared `scriptIslandMetadata()` helper).
- `RuntimeIslandPackageBuilder` carries `owner_block` through (stays product-neutral).
- `CompanionPluginPayload::preservedJs()` projects islands → `preserved_js`, gated by #224: only `disposition=preserve` + `js_handling=preserve_verbatim`, skipping telemetry/`droppable`. Per entry: `content` (verbatim JS), `handle`, `src`. Islands with a matching `owner_block` are **scoped** (`block=ssi-<slug>/<name>`); preserve-worthy islands with no sound owner go to **`preserved_js_deferred[]`** with a `reason` — never scoped by guess, never silently dropped.

## Scope (honest)
- **Built end-to-end:** scripts living inside a generated custom block → scoped, enqueued only when that block renders.
- **Deferred (declared):** free-standing islands (standalone scripts, canvas/form) — no sound generated-block owner exists yet (`reason: no_generated_block_owner`), the #488 follow-up.
- External unmaterialized scripts: skipped (consumer requires `content`). Materialized external: carried.

## Verification
- `composer test` + `composer parity` → **144 fixtures green**; new contract coverage asserts the populated scoped entry, the deferral path, and that telemetry JS never reaches the payload. Parity unaffected (only adds source-report data; serialized output unchanged).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Verification, the association design, implementation, and tests under human review.
