### PR TITLE
figma-transformer: decode raw vectorNetwork blobs + compose boolean-op vectors to SVG (#247)

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -384,7 +384,7 @@ final class FigKiwiDecoder
                 'useAbsoluteBounds', 'cornerRadius', 'rectangleTopLeftCornerRadius',
                 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius',
                 'rectangleBottomRightCornerRadius', 'fillPaints', 'strokePaints', 'backgroundPaints',
-                'fillGeometry', 'strokeGeometry', 'vectorData', 'key', 'componentKey',
+                'fillGeometry', 'strokeGeometry', 'vectorData', 'booleanOperation', 'key', 'componentKey',
                 'componentOrStateGroupKey', 'originComponentKey', 'componentId', 'mainComponentId',
                 'mainComponent', 'component', 'symbolData', 'derivedSymbolData', 'guidPath',
                 'fontSize', 'fontName', 'textData', 'lineHeight', 'letterSpacing',

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -821,7 +821,7 @@ final class FigmaTransformer
     private function mergePageTransformDiagnostics(array $pageReports, array $assetReport): array
     {
         $images = array('paint_refs' => 0, 'node_refs' => 0, 'resolved_assets' => 0, 'image_block_count' => 0, 'total_node_count' => 0, 'image_block_nodes' => array(), 'missing_assets' => array());
-        $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'placeholders' => 0, 'placeholder_nodes' => array(), 'placeholder_reasons' => array());
+        $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'vector_network_decoded' => 0, 'boolean_operations_composed' => 0, 'placeholders' => 0, 'placeholder_nodes' => array(), 'placeholder_reasons' => array());
         $layout = array(
             'large_negative_left_count' => 0,
             'large_absolute_offset_count' => 0,
@@ -890,7 +890,7 @@ final class FigmaTransformer
             }
 
             $pageVectors = is_array($diagnostics['vectors'] ?? null) ? $diagnostics['vectors'] : array();
-            foreach ( array('nodes', 'rendered_paths', 'rendered_asset_fallbacks', 'placeholders') as $key ) {
+            foreach ( array('nodes', 'rendered_paths', 'rendered_asset_fallbacks', 'vector_network_decoded', 'boolean_operations_composed', 'placeholders') as $key ) {
                 $vectors[$key] += (int) ($pageVectors[$key] ?? 0);
             }
             foreach ( is_array($pageVectors['placeholder_nodes'] ?? null) ? $pageVectors['placeholder_nodes'] : array() as $item ) {
@@ -1124,7 +1124,13 @@ final class FigmaTransformer
                 'image_node_density' => round($imageNodeDensity, 3),
                 'total_node_count' => $totalNodeCount,
                 'vector_image_fallbacks' => (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
-                'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
+                'vector_nodes' => (int) ($vectors['nodes'] ?? 0),
+                'vector_decoded_to_svg' => (int) ($vectors['rendered_paths'] ?? 0),
+                'vector_network_decoded' => (int) ($vectors['vector_network_decoded'] ?? 0),
+                'boolean_operations_composed' => (int) ($vectors['boolean_operations_composed'] ?? 0),
+                'vector_decode_coverage_ratio' => (int) ($vectors['nodes'] ?? 0) > 0 ? round((int) ($vectors['rendered_paths'] ?? 0) / (int) $vectors['nodes'], 3) : 0.0,
+                'generated_svg_count' => (int) ($vectors['rendered_paths'] ?? 0),
+                'externalized_svg_asset_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
                 'render_style_mismatch_count' => (int) ($layout['render_style_mismatch_count'] ?? 0),

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -957,12 +957,14 @@ final class StaticHtmlEmitter
             'missing_assets'  => array(),
         );
         $vectors = array(
-            'nodes'                    => 0,
-            'rendered_paths'           => 0,
-            'rendered_asset_fallbacks' => 0,
-            'placeholders'             => 0,
-            'placeholder_reasons'      => array(),
-            'placeholder_nodes'        => array(),
+            'nodes'                       => 0,
+            'rendered_paths'              => 0,
+            'rendered_asset_fallbacks'    => 0,
+            'vector_network_decoded'      => 0,
+            'boolean_operations_composed' => 0,
+            'placeholders'                => 0,
+            'placeholder_reasons'         => array(),
+            'placeholder_nodes'           => array(),
         );
         $layout = array(
             'large_negative_left_count' => preg_match_all('/left:-[0-9]{3,}/', $css),
@@ -1142,9 +1144,12 @@ final class StaticHtmlEmitter
                 'vector_image_fallbacks' => (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
                 'vector_nodes' => (int) ($vectors['nodes'] ?? 0),
                 'vector_decoded_to_svg' => (int) ($vectors['rendered_paths'] ?? 0),
+                'vector_network_decoded' => (int) ($vectors['vector_network_decoded'] ?? 0),
+                'boolean_operations_composed' => (int) ($vectors['boolean_operations_composed'] ?? 0),
                 'vector_decode_coverage_ratio' => (float) ($vectors['decode_coverage']['coverage_ratio'] ?? 0.0),
                 'vector_placeholder_reason_categories' => is_array($vectors['decode_coverage']['placeholder_reason_categories'] ?? null) ? $vectors['decode_coverage']['placeholder_reason_categories'] : array(),
-                'generated_svg_count' => (int) ($generatedSvgAssets['count'] ?? 0),
+                'generated_svg_count' => (int) ($vectors['rendered_paths'] ?? 0),
+                'externalized_svg_asset_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
@@ -1243,6 +1248,8 @@ final class StaticHtmlEmitter
         $nodes = (int) ($vectors['nodes'] ?? 0);
         $decoded = (int) ($vectors['rendered_paths'] ?? 0);
         $assetFallbacks = (int) ($vectors['rendered_asset_fallbacks'] ?? 0);
+        $networkDecoded = (int) ($vectors['vector_network_decoded'] ?? 0);
+        $booleanComposed = (int) ($vectors['boolean_operations_composed'] ?? 0);
         $placeholders = (int) ($vectors['placeholders'] ?? 0);
         $reasons = is_array($vectors['placeholder_reasons'] ?? null) ? $vectors['placeholder_reasons'] : array();
 
@@ -1268,6 +1275,8 @@ final class StaticHtmlEmitter
             'schema'                     => 'blocks-engine/figma-transformer/vector-decode-coverage/v1',
             'vector_nodes'               => $nodes,
             'decoded_to_svg'             => $decoded,
+            'vector_network_decoded'     => $networkDecoded,
+            'boolean_operations_composed' => $booleanComposed,
             'asset_fallbacks'            => $assetFallbacks,
             'placeholders'               => $placeholders,
             'coverage_ratio'             => $nodes > 0 ? round($decoded / $nodes, 3) : 0.0,
@@ -1418,10 +1427,19 @@ final class StaticHtmlEmitter
         }
 
         $type = strtoupper((string) ($node['type'] ?? ''));
+        $booleanComposedChildren = false;
         if ( $this->isUnsupportedVectorType($type) ) {
             ++$vectors['nodes'];
-            if ( null !== $this->supportedVectorSvg($node, $type, $parentNode) ) {
+            $vectorSvg = $this->supportedVectorSvg($node, $type, $parentNode);
+            if ( null !== $vectorSvg ) {
                 ++$vectors['rendered_paths'];
+                if ( $this->vectorPathsIncludeNetworkSource($node) ) {
+                    ++$vectors['vector_network_decoded'];
+                }
+                if ( 'BOOLEAN_OPERATION' === $type && ! empty($this->nodeList($node)) ) {
+                    ++$vectors['boolean_operations_composed'];
+                    $booleanComposedChildren = true;
+                }
             } elseif ( null !== $this->nodeAssetPath($node) ) {
                 ++$vectors['rendered_asset_fallbacks'];
             } else {
@@ -1433,6 +1451,13 @@ final class StaticHtmlEmitter
             }
         }
 
+        // A composed boolean operation folds its child geometry into one SVG, so
+        // the children are not emitted separately; mirror that here to keep the
+        // vector counts aligned with what is actually rendered.
+        if ( $booleanComposedChildren ) {
+            return;
+        }
+
         foreach ( $this->nodeList($node) as $child ) {
             if ( is_array($child) ) {
                 if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
@@ -1441,6 +1466,28 @@ final class StaticHtmlEmitter
                 $this->collectTransformDiagnostics($child, $image, $vectors, $layout, $node);
             }
         }
+    }
+
+    /**
+     * Whether a node's decoded vector geometry originates from a raw Figma
+     * vectorNetwork blob, used to credit network-decode coverage distinctly
+     * from ready-made path/command-blob geometry.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function vectorPathsIncludeNetworkSource(array $node): bool
+    {
+        if ( ! is_array($node['figma_vector_paths'] ?? null) ) {
+            return false;
+        }
+
+        foreach ( $node['figma_vector_paths'] as $path ) {
+            if ( is_array($path) && str_starts_with((string) ($path['source'] ?? ''), 'vectorData.vectorNetworkBlob') ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -3496,6 +3543,13 @@ final class StaticHtmlEmitter
             return null;
         }
 
+        if ( 'BOOLEAN_OPERATION' === $type && ! $this->hasExplicitVectorSource($node) && ! empty($this->nodeList($node)) ) {
+            $composed = $this->booleanOperationSvg($node, $parentNode);
+            if ( null !== $composed ) {
+                return $composed;
+            }
+        }
+
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $width = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width']) : 0.0;
         $height = isset($box['height']) && is_numeric($box['height']) ? max(0.0, (float) $box['height']) : 0.0;
@@ -3654,6 +3708,29 @@ final class StaticHtmlEmitter
      */
     private function vectorPathElements(array $node): array
     {
+        $paint = $this->svgPaintAttributes($node);
+        $elements = array();
+        foreach ( $this->nodeVectorPathData($node) as $path ) {
+            $attributes = $paint;
+            if ( null !== ($path['windingRule'] ?? null) ) {
+                $attributes[] = 'fill-rule="' . $path['windingRule'] . '"';
+            }
+            $elements[] = '<path d="' . $this->sanitizeAttribute($path['d']) . '" ' . implode(' ', $attributes) . '/>';
+        }
+
+        return $elements;
+    }
+
+    /**
+     * Extract validated SVG path data and winding rule from a node's vector
+     * geometry sources, independent of paint, so the same geometry can drive
+     * inline `<path>` emission and boolean-operation composition.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, array{d: string, windingRule: string|null}>
+     */
+    private function nodeVectorPathData(array $node): array
+    {
         $rawPaths = array();
         if ( is_array($node['figma_vector_paths'] ?? null) ) {
             $rawPaths = array_merge($rawPaths, $node['figma_vector_paths']);
@@ -3669,7 +3746,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        $elements = array();
+        $paths = array();
         foreach ( $rawPaths as $rawPath ) {
             $path = is_array($rawPath) ? (string) ($rawPath['data'] ?? $rawPath['pathData'] ?? $rawPath['path'] ?? $rawPath['d'] ?? '') : (string) $rawPath;
             $path = $this->safeSvgPathData($path, $this->svgPathDataByteLimit($rawPath));
@@ -3677,18 +3754,186 @@ final class StaticHtmlEmitter
                 continue;
             }
 
-            $paint = $this->svgPaintAttributes($node);
+            $rule = null;
             if ( is_array($rawPath) && isset($rawPath['windingRule']) && is_scalar($rawPath['windingRule']) ) {
-                $rule = strtolower((string) $rawPath['windingRule']);
-                if ( in_array($rule, array('evenodd', 'nonzero'), true) ) {
-                    $paint[] = 'fill-rule="' . $rule . '"';
+                $candidate = strtolower((string) $rawPath['windingRule']);
+                if ( in_array($candidate, array('evenodd', 'nonzero'), true) ) {
+                    $rule = $candidate;
                 }
             }
 
-            $elements[] = '<path d="' . $this->sanitizeAttribute($path) . '" ' . implode(' ', $paint) . '/>';
+            $paths[] = array('d' => $path, 'windingRule' => $rule);
         }
 
-        return $elements;
+        return $paths;
+    }
+
+    /**
+     * Compose a BOOLEAN_OPERATION node from its child vector geometry.
+     *
+     * True path-boolean evaluation is out of scope in pure PHP, so this emits
+     * the child vector paths together inside one `<svg>`. For UNION (the common
+     * icon case) overlaying the child paths is visually correct. For
+     * SUBTRACT/INTERSECT/EXCLUDE the combined child geometry is rendered as one
+     * `fill-rule:evenodd` path when the children share the operation origin,
+     * which approximates hole-cutting; otherwise it falls back to the overlay.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function booleanOperationSvg(array $node, ?array $parentNode): ?string
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $width = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width']) : 0.0;
+        $height = isset($box['height']) && is_numeric($box['height']) ? max(0.0, (float) $box['height']) : 0.0;
+        if ( $width <= 0 || $height <= 0 ) {
+            return null;
+        }
+
+        $children = $this->booleanOperationChildVectors($node);
+        if ( empty($children) ) {
+            return null;
+        }
+
+        $operation = strtoupper(trim((string) ($node['booleanOperation'] ?? 'UNION')));
+        $body = null;
+        if ( in_array($operation, array('SUBTRACT', 'INTERSECT', 'EXCLUDE'), true) ) {
+            $body = $this->booleanEvenOddBody($node, $children);
+        }
+        if ( null === $body ) {
+            $body = $this->booleanUnionBody($children);
+        }
+        if ( '' === $body ) {
+            return null;
+        }
+
+        $attributes = array(
+            'xmlns="http://www.w3.org/2000/svg"',
+            'viewBox="0 0 ' . $this->number($width) . ' ' . $this->number($height) . '"',
+            'width="100%"',
+            'height="100%"',
+            'role="img"',
+            'aria-label="' . $this->sanitizeAttribute((string) ($node['name'] ?? $operation)) . '"',
+            'data-figma-vector="true"',
+            'data-figma-boolean-operation="' . $this->sanitizeAttribute(strtolower($operation)) . '"',
+        );
+
+        return '<svg ' . implode(' ', $attributes) . '>' . $body . '</svg>';
+    }
+
+    /**
+     * Collect renderable vector geometry from a boolean node's descendants,
+     * translated into the boolean node's local coordinate space.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, array{paths: array<int, array{d: string, windingRule: string|null}>, paint: array<int, string>, dx: float, dy: float}>
+     */
+    private function booleanOperationChildVectors(array $node): array
+    {
+        $originBox = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : (is_array($node['box'] ?? null) ? $node['box'] : array());
+        $originX = isset($originBox['x']) && is_numeric($originBox['x']) ? (float) $originBox['x'] : 0.0;
+        $originY = isset($originBox['y']) && is_numeric($originBox['y']) ? (float) $originBox['y'] : 0.0;
+
+        $collected = array();
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $this->collectBooleanChildVectors($child, $originX, $originY, $collected);
+            }
+        }
+
+        return $collected;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<int, array<string, mixed>> $collected
+     */
+    private function collectBooleanChildVectors(array $node, float $originX, float $originY, array &$collected): void
+    {
+        $paths = $this->nodeVectorPathData($node);
+        if ( ! empty($paths) ) {
+            $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : (is_array($node['box'] ?? null) ? $node['box'] : array());
+            $dx = isset($box['x']) && is_numeric($box['x']) ? (float) $box['x'] - $originX : 0.0;
+            $dy = isset($box['y']) && is_numeric($box['y']) ? (float) $box['y'] - $originY : 0.0;
+            $collected[] = array(
+                'paths' => $paths,
+                'paint' => $this->svgPaintAttributes($node),
+                'dx'    => $dx,
+                'dy'    => $dy,
+            );
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $this->collectBooleanChildVectors($child, $originX, $originY, $collected);
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $children
+     */
+    private function booleanUnionBody(array $children): string
+    {
+        $body = '';
+        foreach ( $children as $child ) {
+            $paint = is_array($child['paint'] ?? null) && ! empty($child['paint']) ? $child['paint'] : array('fill="currentColor"');
+            $elements = '';
+            foreach ( is_array($child['paths'] ?? null) ? $child['paths'] : array() as $path ) {
+                $attributes = $paint;
+                if ( null !== ($path['windingRule'] ?? null) ) {
+                    $attributes[] = 'fill-rule="' . $path['windingRule'] . '"';
+                }
+                $elements .= '<path d="' . $this->sanitizeAttribute((string) $path['d']) . '" ' . implode(' ', $attributes) . '/>';
+            }
+            if ( '' === $elements ) {
+                continue;
+            }
+
+            $dx = (float) ($child['dx'] ?? 0.0);
+            $dy = (float) ($child['dy'] ?? 0.0);
+            if ( abs($dx) >= 0.0001 || abs($dy) >= 0.0001 ) {
+                $body .= '<g transform="translate(' . $this->number($dx) . ' ' . $this->number($dy) . ')">' . $elements . '</g>';
+            } else {
+                $body .= $elements;
+            }
+        }
+
+        return $body;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<int, array<string, mixed>> $children
+     */
+    private function booleanEvenOddBody(array $node, array $children): ?string
+    {
+        $combined = array();
+        foreach ( $children as $child ) {
+            $dx = (float) ($child['dx'] ?? 0.0);
+            $dy = (float) ($child['dy'] ?? 0.0);
+            if ( abs($dx) >= 0.0001 || abs($dy) >= 0.0001 ) {
+                return null;
+            }
+            foreach ( is_array($child['paths'] ?? null) ? $child['paths'] : array() as $path ) {
+                $combined[] = (string) $path['d'];
+            }
+        }
+        if ( empty($combined) ) {
+            return null;
+        }
+
+        $paint = $this->svgPaintAttributes($node);
+        if ( ( 'fill="none"' === ($paint[0] ?? '') ) && ! $this->hasSvgStroke($paint) ) {
+            foreach ( $children as $child ) {
+                if ( ! empty($child['paint']) && 'fill="none"' !== ($child['paint'][0] ?? '') ) {
+                    $paint = $child['paint'];
+                    break;
+                }
+            }
+        }
+
+        $paint[] = 'fill-rule="evenodd"';
+        return '<path d="' . $this->sanitizeAttribute(implode(' ', $combined)) . '" ' . implode(' ', $paint) . '/>';
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2253,6 +2253,11 @@ final class ScenegraphNormalizer
             return array('data' => $path, 'source' => 'vectorData.vectorNetworkBlob.closedRectFallback', 'windingRule' => 'NONZERO');
         }
 
+        $general = $this->decodeGeneralVectorNetworkBlob($bytes);
+        if ( null !== $general ) {
+            return $general;
+        }
+
         if ( ! $this->looksLikeVectorNetworkBlob($bytes) ) {
             $path = $this->decodeVectorCommandBlob($bytes);
             if ( null !== $path ) {
@@ -2267,6 +2272,207 @@ final class ScenegraphNormalizer
             'context'  => array('node_id' => $nodeId, 'geometry' => 'vectorData.vectorNetworkBlob') + $this->vectorNetworkBlobDiagnosticContext($blobReference, $bytes),
         );
         return null;
+    }
+
+    /**
+     * General-purpose Figma vectorNetwork blob decoder.
+     *
+     * Parses the raw vectorNetwork buffer — a 12-byte header
+     * (vertexCount, segmentCount, regionCount), a vertex table (x/y at a
+     * 20-byte stride), a segment table (start/end vertex index, with optional
+     * cubic-bezier tangents), and a per-region list of directed segment loops —
+     * into one SVG path made of one subpath per region. Straight segments emit
+     * `L`; segments carrying non-zero tangents emit a cubic `C` using
+     * `vertex + tangent` control points. The region winding rule is carried so
+     * the emitter can map NONZERO/EVENODD onto `fill-rule`.
+     *
+     * The segment stride is auto-detected (24 bytes when tangents are present,
+     * 16 bytes when they are not) by requiring a fully consistent parse: every
+     * vertex/segment index must be in range, each region must form a continuous
+     * closed loop, and the region table must consume the buffer exactly. A wrong
+     * stride guess fails these checks and is rejected rather than emitted as
+     * garbage geometry.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function decodeGeneralVectorNetworkBlob(string $bytes): ?array
+    {
+        $counts = $this->vectorNetworkCounts($bytes);
+        if ( null === $counts ) {
+            return null;
+        }
+
+        [$vertexCount, $segmentCount, $regionCount] = $counts;
+        if ( $vertexCount < 2 || $vertexCount > 20000 || $segmentCount < 1 || $segmentCount > 40000 || $regionCount < 1 || $regionCount > 20000 ) {
+            return null;
+        }
+
+        $vertexBytes = $vertexCount * 20;
+        if ( strlen($bytes) < 12 + $vertexBytes ) {
+            return null;
+        }
+
+        $vertices = array();
+        for ( $index = 0; $index < $vertexCount; $index++ ) {
+            $point = $this->readFloatPair($bytes, 12 + ( $index * 20 ) + 4);
+            if ( null === $point || ! is_finite($point[0]) || ! is_finite($point[1]) ) {
+                return null;
+            }
+            $vertices[] = $point;
+        }
+
+        $segmentOffset = 12 + $vertexBytes;
+        foreach ( array(24, 16) as $stride ) {
+            $decoded = $this->decodeVectorNetworkWithSegmentStride($bytes, $vertices, $segmentOffset, $segmentCount, $regionCount, $stride);
+            if ( null !== $decoded ) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array{0: float, 1: float}> $vertices
+     * @return array<string, mixed>|null
+     */
+    private function decodeVectorNetworkWithSegmentStride(string $bytes, array $vertices, int $segmentOffset, int $segmentCount, int $regionCount, int $stride): ?array
+    {
+        $vertexCount = count($vertices);
+        $regionOffset = $segmentOffset + ( $segmentCount * $stride );
+        if ( strlen($bytes) < $regionOffset ) {
+            return null;
+        }
+
+        $segments = array();
+        for ( $index = 0; $index < $segmentCount; $index++ ) {
+            $base = $segmentOffset + ( $index * $stride );
+            $start = $this->readUint32($bytes, $base);
+            if ( 24 === $stride ) {
+                $tangentStart = $this->readFloatPair($bytes, $base + 4);
+                $end = $this->readUint32($bytes, $base + 12);
+                $tangentEnd = $this->readFloatPair($bytes, $base + 16);
+            } else {
+                $tangentStart = array(0.0, 0.0);
+                $end = $this->readUint32($bytes, $base + 4);
+                $tangentEnd = array(0.0, 0.0);
+            }
+
+            if ( null === $start || null === $end || null === $tangentStart || null === $tangentEnd ) {
+                return null;
+            }
+            if ( $start < 0 || $start >= $vertexCount || $end < 0 || $end >= $vertexCount || $start === $end ) {
+                return null;
+            }
+            if ( ! is_finite($tangentStart[0]) || ! is_finite($tangentStart[1]) || ! is_finite($tangentEnd[0]) || ! is_finite($tangentEnd[1]) ) {
+                return null;
+            }
+
+            $segments[] = array('start' => $start, 'end' => $end, 'tangentStart' => $tangentStart, 'tangentEnd' => $tangentEnd);
+        }
+
+        $offset = $regionOffset;
+        $subpaths = array();
+        $windingRule = 'NONZERO';
+        for ( $region = 0; $region < $regionCount; $region++ ) {
+            $entryCount = $this->readUint32($bytes, $offset);
+            $rule = $this->readUint32($bytes, $offset + 4);
+            $reserved = $this->readUint32($bytes, $offset + 8);
+            if ( null === $entryCount || null === $rule || null === $reserved ) {
+                return null;
+            }
+            if ( $entryCount < 1 || $entryCount > $segmentCount || ( 0 !== $rule && 1 !== $rule ) ) {
+                return null;
+            }
+            $offset += 12;
+            if ( strlen($bytes) < $offset + ( $entryCount * 8 ) ) {
+                return null;
+            }
+
+            $entries = array();
+            for ( $entry = 0; $entry < $entryCount; $entry++ ) {
+                $segmentIndex = $this->readUint32($bytes, $offset);
+                $direction = $this->readUint32($bytes, $offset + 4);
+                $offset += 8;
+                if ( null === $segmentIndex || null === $direction || $segmentIndex < 0 || $segmentIndex >= $segmentCount || ( 0 !== $direction && 1 !== $direction ) ) {
+                    return null;
+                }
+                $entries[] = array($segmentIndex, $direction);
+            }
+
+            $subpath = $this->vectorNetworkRegionSubpath($vertices, $segments, $entries);
+            if ( null === $subpath ) {
+                return null;
+            }
+            $subpaths[] = $subpath;
+            if ( 1 === $rule ) {
+                $windingRule = 'EVENODD';
+            }
+        }
+
+        if ( $offset !== strlen($bytes) || empty($subpaths) ) {
+            return null;
+        }
+
+        return array(
+            'data'        => implode(' ', $subpaths),
+            'source'      => 'vectorData.vectorNetworkBlob.network',
+            'windingRule' => $windingRule,
+        );
+    }
+
+    /**
+     * Trace one region's directed segment list into a single closed SVG subpath.
+     *
+     * @param array<int, array{0: float, 1: float}>                                          $vertices
+     * @param array<int, array{start: int, end: int, tangentStart: array{0: float, 1: float}, tangentEnd: array{0: float, 1: float}}> $segments
+     * @param array<int, array{0: int, 1: int}>                                              $entries
+     */
+    private function vectorNetworkRegionSubpath(array $vertices, array $segments, array $entries): ?string
+    {
+        $first = null;
+        $cursor = null;
+        $parts = array();
+
+        foreach ( $entries as $entry ) {
+            [$segmentIndex, $direction] = $entry;
+            $segment = $segments[$segmentIndex];
+            $start = $segment['start'];
+            $end = $segment['end'];
+            $tangentStart = $segment['tangentStart'];
+            $tangentEnd = $segment['tangentEnd'];
+            if ( 1 === $direction ) {
+                [$start, $end] = array($end, $start);
+                [$tangentStart, $tangentEnd] = array($tangentEnd, $tangentStart);
+            }
+
+            if ( null === $first ) {
+                $first = $start;
+                $cursor = $start;
+                $point = $vertices[$start];
+                $parts[] = 'M ' . $this->svgNumber($point[0]) . ' ' . $this->svgNumber($point[1]);
+            } elseif ( $start !== $cursor ) {
+                return null;
+            }
+
+            $from = $vertices[$start];
+            $to = $vertices[$end];
+            $hasCurve = abs($tangentStart[0]) > 0.000001 || abs($tangentStart[1]) > 0.000001 || abs($tangentEnd[0]) > 0.000001 || abs($tangentEnd[1]) > 0.000001;
+            if ( $hasCurve ) {
+                $parts[] = 'C ' . $this->svgNumber($from[0] + $tangentStart[0]) . ' ' . $this->svgNumber($from[1] + $tangentStart[1])
+                    . ' ' . $this->svgNumber($to[0] + $tangentEnd[0]) . ' ' . $this->svgNumber($to[1] + $tangentEnd[1])
+                    . ' ' . $this->svgNumber($to[0]) . ' ' . $this->svgNumber($to[1]);
+            } else {
+                $parts[] = 'L ' . $this->svgNumber($to[0]) . ' ' . $this->svgNumber($to[1]);
+            }
+            $cursor = $end;
+        }
+
+        if ( null === $first || count($parts) < 3 || $cursor !== $first ) {
+            return null;
+        }
+
+        return implode(' ', $parts) . ' Z';
     }
 
     private function decodeSimpleChevronVectorNetworkBlob(string $bytes): ?string

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1239,6 +1239,129 @@ $assert(2 === ($vectorNetworkDiagnostic['context']['affected_node_count'] ?? nul
 $assert(array('vector:data-malformed', 'vector:data-painted-fallback') === ($vectorNetworkDiagnostic['context']['sample_node_ids'] ?? null), 'vector-network-diagnostic-sample-nodes');
 $assert(array('1') === ($vectorNetworkDiagnostic['context']['sample_blob_refs'] ?? null), 'vector-network-diagnostic-sample-blob-refs');
 
+// General vectorNetwork decode: 3 vertices, 3 segments (one carrying bezier
+// tangents), one NONZERO region. Stride is 24 bytes (tangent-bearing), so the
+// blob is rejected by the legacy exact-match decoders and handled by the new
+// general decoder, emitting a real cubic-curve path rather than a placeholder.
+$curvedNetworkVertices = array(array(0.0, 0.0), array(10.0, 0.0), array(10.0, 10.0));
+$curvedNetworkSegments = array(
+    array('start' => 0, 'end' => 1, 'ts' => array(0.0, 0.0), 'te' => array(0.0, 0.0)),
+    array('start' => 1, 'end' => 2, 'ts' => array(2.0, 0.0), 'te' => array(0.0, -2.0)),
+    array('start' => 2, 'end' => 0, 'ts' => array(0.0, 0.0), 'te' => array(0.0, 0.0)),
+);
+$curvedNetworkEntries = array(array(0, 0), array(1, 0), array(2, 0));
+$curvedNetworkBlob = pack('V3', count($curvedNetworkVertices), count($curvedNetworkSegments), 1);
+foreach ( $curvedNetworkVertices as $point ) {
+    $curvedNetworkBlob .= pack('V', 0) . pack('g', $point[0]) . pack('g', $point[1]) . pack('V2', 0, 0);
+}
+foreach ( $curvedNetworkSegments as $segment ) {
+    $curvedNetworkBlob .= pack('V', $segment['start']) . pack('g', $segment['ts'][0]) . pack('g', $segment['ts'][1])
+        . pack('V', $segment['end']) . pack('g', $segment['te'][0]) . pack('g', $segment['te'][1]);
+}
+$curvedNetworkBlob .= pack('V3', count($curvedNetworkEntries), 0, 0);
+foreach ( $curvedNetworkEntries as $entry ) {
+    $curvedNetworkBlob .= pack('V2', $entry[0], $entry[1]);
+}
+
+$curvedNetworkResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Curved Vector Network Fixture',
+    'blobs' => array(array('bytes' => $curvedNetworkBlob)),
+    'nodes' => array(
+        array(
+            'id'         => 'vector:curved-network',
+            'type'       => 'VECTOR',
+            'name'       => 'Curved Network',
+            'width'      => 10,
+            'height'     => 10,
+            'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.1, 'g' => 0.2, 'b' => 0.3))),
+            'vectorData' => array('vectorNetworkBlob' => 0),
+        ),
+    ),
+));
+$curvedNetworkHtml = $fileContent($curvedNetworkResult, 'index.html');
+$curvedNetworkVectors = $curvedNetworkResult['source_reports']['figma']['html']['transform_diagnostics']['vectors'] ?? array();
+$curvedNetworkSummary = $curvedNetworkResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['summary'] ?? array();
+$assert(str_contains($curvedNetworkHtml, 'data-figma-node-id="vector:curved-network"') && str_contains($curvedNetworkHtml, 'data-figma-vector="true"'), 'curved-network-renders-svg');
+$assert(str_contains($curvedNetworkHtml, 'd="M0 0L10 0C12 0 10 8 10 10L0 0Z"'), 'curved-network-renders-cubic-path');
+$assert(! str_contains($curvedNetworkHtml, 'data-figma-unsupported-vector="true"'), 'curved-network-not-placeholder');
+$assert(1 === (int) ($curvedNetworkVectors['rendered_paths'] ?? 0), 'curved-network-counted-rendered');
+$assert(0 === (int) ($curvedNetworkVectors['placeholders'] ?? 0), 'curved-network-no-placeholder-count');
+$assert(1 === (int) ($curvedNetworkVectors['vector_network_decoded'] ?? 0), 'curved-network-network-decoded-count');
+$assert(1 === (int) ($curvedNetworkVectors['decode_coverage']['vector_network_decoded'] ?? 0), 'curved-network-coverage-network-decoded');
+$assert(1 === (int) ($curvedNetworkSummary['vector_network_decoded'] ?? 0), 'curved-network-summary-network-decoded');
+// Summary rollup reflects rendered vectors instead of only externalized SVG files.
+$assert(1 === (int) ($curvedNetworkSummary['generated_svg_count'] ?? -1), 'curved-network-summary-generated-svg-count');
+$assert(1 === (int) ($curvedNetworkSummary['vector_decoded_to_svg'] ?? -1), 'curved-network-summary-decoded-to-svg');
+$assert(0 === (int) ($curvedNetworkSummary['externalized_svg_asset_count'] ?? -1), 'curved-network-summary-externalized-count');
+
+// Boolean operation: compose two child vector paths into one SVG. The default
+// (UNION) overlays both child paths; the parent is no longer a placeholder.
+$booleanOperationResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Boolean Operation Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'bool:union',
+            'type'     => 'BOOLEAN_OPERATION',
+            'name'     => 'Union Icon',
+            'width'    => 20,
+            'height'   => 20,
+            'children' => array(
+                array(
+                    'id'         => 'bool:child-a',
+                    'type'       => 'VECTOR',
+                    'name'       => 'A',
+                    'width'      => 10,
+                    'height'     => 10,
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0, 'b' => 0))),
+                    'pathData'   => 'M0 0L10 0L10 10L0 10Z',
+                ),
+                array(
+                    'id'         => 'bool:child-b',
+                    'type'       => 'VECTOR',
+                    'name'       => 'B',
+                    'width'      => 10,
+                    'height'     => 10,
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 1))),
+                    'pathData'   => 'M5 5L15 5L15 15L5 15Z',
+                ),
+            ),
+        ),
+    ),
+));
+$booleanOperationHtml = $fileContent($booleanOperationResult, 'index.html');
+$booleanOperationVectors = $booleanOperationResult['source_reports']['figma']['html']['transform_diagnostics']['vectors'] ?? array();
+$assert(str_contains($booleanOperationHtml, 'data-figma-boolean-operation="union"'), 'boolean-operation-marks-union');
+$assert(str_contains($booleanOperationHtml, 'd="M0 0L10 0 10 10 0 10Z" fill="#ff0000"'), 'boolean-operation-includes-child-a-path');
+$assert(str_contains($booleanOperationHtml, 'd="M5 5L15 5 15 15 5 15Z" fill="#0000ff"'), 'boolean-operation-includes-child-b-path');
+$assert(! str_contains($booleanOperationHtml, 'data-figma-unsupported-vector="true"'), 'boolean-operation-not-placeholder');
+$assert(1 === (int) ($booleanOperationVectors['boolean_operations_composed'] ?? 0), 'boolean-operation-composed-count');
+$assert(1 === (int) ($booleanOperationVectors['rendered_paths'] ?? 0), 'boolean-operation-rendered-count');
+$assert(0 === (int) ($booleanOperationVectors['placeholders'] ?? 0), 'boolean-operation-no-placeholder');
+
+// Boolean SUBTRACT over children sharing the operation origin approximates
+// hole-cutting with a single fill-rule:evenodd path.
+$booleanSubtractResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Boolean Subtract Fixture',
+    'nodes' => array(
+        array(
+            'id'              => 'bool:subtract',
+            'type'            => 'BOOLEAN_OPERATION',
+            'name'            => 'Subtract Icon',
+            'width'           => 20,
+            'height'          => 20,
+            'booleanOperation' => 'SUBTRACT',
+            'fillPaints'      => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0))),
+            'children'        => array(
+                array('id' => 'bool:outer', 'type' => 'VECTOR', 'name' => 'Outer', 'width' => 20, 'height' => 20, 'pathData' => 'M0 0L20 0L20 20L0 20Z'),
+                array('id' => 'bool:inner', 'type' => 'VECTOR', 'name' => 'Inner', 'width' => 10, 'height' => 10, 'pathData' => 'M5 5L15 5L15 15L5 15Z'),
+            ),
+        ),
+    ),
+));
+$booleanSubtractHtml = $fileContent($booleanSubtractResult, 'index.html');
+$assert(str_contains($booleanSubtractHtml, 'data-figma-boolean-operation="subtract"'), 'boolean-subtract-marks-subtract');
+$assert(str_contains($booleanSubtractHtml, 'd="M5 5L15 5 15 15 5 15Z M0 0L20 0 20 20 0 20Z" fill="#000000" fill-rule="evenodd"'), 'boolean-subtract-evenodd-composite');
+
 $multiPageVectorPlaceholderResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Multi Page Vector Placeholder Fixture',
     'nodes' => array(


### PR DESCRIPTION
## What

Closes the dominant remaining `.fig` fidelity gap in the `figma-transformer` package: raw Figma `vectorNetworkBlob` geometry and `BOOLEAN_OPERATION` nodes, plus a vector-success undercount in the diagnostics summary. Tracking issue: #247.

### Data motivation
On a fixture-matrix run over real `.fig` designs (David Perell), the transform left placeholders with reasons `unsupported_vector_network_blob` (24) and `unsupported_boolean_operation_children` (~14). Separately, the matrix/quality summary reported `generated_svg_count: 0` / `vector_placeholders: 38` even though the result artifact showed 141 paths actually rendered — the summary was reading the externalized-SVG-file count, not the rendered-path count.

## Changes

**vectorNetwork → SVG (`ScenegraphNormalizer`)**
- New general decoder parses the raw vectorNetwork buffer: header counts, a 20-byte vertex table (x/y), a segment table (start/end vertex + optional bezier tangents), and a per-region list of directed segment loops.
- Straight segments emit `L`; segments with non-zero tangents emit a cubic `C` using `vertex + tangent` control points. Region winding rule (NONZERO/EVENODD) is carried through to `fill-rule`.
- Segment stride is auto-detected (16 bytes without tangents, 24 with) by requiring a fully consistent parse — every index in range, each region a continuous closed loop, and the region table consuming the buffer exactly — so a wrong layout guess is rejected rather than emitted as garbage geometry.
- Runs as a fallback **after** the existing exact-match decoders, so legacy/synthetic shapes are unchanged. Reuses the existing Kiwi/blob plumbing (`readUint32`/`readFloatPair`/`vectorNetworkCounts`).

**Boolean operations (`StaticHtmlEmitter`)**
- `BOOLEAN_OPERATION` nodes are composed from their child vector geometry into one `<svg>`. UNION (and unknown ops) overlay the child paths — visually correct for the common icon case. SUBTRACT/INTERSECT/EXCLUDE approximate hole-cutting with a single `fill-rule:evenodd` path when children share the operation origin; otherwise they fall back to the overlay. `data-figma-boolean-operation` records the op.
- `booleanOperation` is carried through the Kiwi field policy so real files get the correct op type.

**Diagnostics undercount fix (`FigmaTransformer` + `StaticHtmlEmitter`)**
- The single-page **and** multi-page (matrix) quality summaries now set `generated_svg_count` from actual `rendered_paths`, with the externalized-asset count exposed separately as `externalized_svg_asset_count`.
- Added `vector_network_decoded` and `boolean_operations_composed` outcome counts across the vectors aggregate, decode coverage, and both summary surfaces; the multi-page summary now also carries `vector_nodes` / `vector_decoded_to_svg` / `vector_decode_coverage_ratio`.

## Tests
Added focused contract coverage in `tests/contract/run.php`:
- a synthetic curved `vectorNetwork` (3 vertices, one curved segment, one region) decodes to a real `<svg><path d="M0 0L10 0C…Z">` (not a placeholder) and is counted as network-decoded by both the coverage diagnostic and the summary rollup;
- a UNION `BOOLEAN_OPERATION` composes two child paths into one svg;
- a SUBTRACT `BOOLEAN_OPERATION` produces a single `fill-rule:evenodd` composite.

`cd figma-transformer && php tests/contract/run.php` → "Figma Transformer contract tests passed." Synthetic fixtures only; the large local `.fig` files were not run.

## Honest caveats
- The 24-byte tangent-bearing segment layout and the per-region winding field are validated against synthetic fixtures and the proven 16-byte layout, not against a real curved `.fig` blob in this session (large local fixtures were intentionally not run). The auto-detection requires an exactly-consuming, index-valid parse, so a wrong layout is rejected to a placeholder rather than mis-rendered — but blobs whose real layout differs from this model will still fall back honestly.
- Region decoding handles one loop per region (multiple regions → multiple subpaths with the region winding rule). Multi-loop-per-region byte layouts are not yet modeled and fall back.
- True path-boolean geometry is not computed; SUBTRACT/INTERSECT/EXCLUDE across children at different origins fall back to overlay (recorded in the op attribute), and only same-origin children get the evenodd composite.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Decoding vectorNetwork blobs + boolean-op vectors to SVG and fixing the vector summary undercount for #247.