### PR TITLE
Formalize generic conversion-finding contract (producer side)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -46,6 +46,7 @@
       "php tests/contract/runtime-wordpress-stubs.php",
       "php tests/contract/plugin-bootstrap.php",
       "php tests/contract/run.php",
+      "php tests/contract/finding-contract.php",
       "@test:unit"
     ],
     "test:unit": [

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use DOMDocument;
 use DOMElement;
@@ -102,10 +103,11 @@ final class RuntimeDependencyParityReport
         }
 
         return array_filter(array(
-            'schema'       => self::SCHEMA,
-            'status'       => array() === $findings ? 'pass' : 'warning',
-            'dependencies' => $this->dedupeRows($dependencies),
-            'findings'     => $this->dedupeRows($findings),
+            'schema'         => self::SCHEMA,
+            'finding_schema' => ConversionFindingContract::SCHEMA,
+            'status'         => array() === $findings ? 'pass' : 'warning',
+            'dependencies'   => $this->dedupeRows($dependencies),
+            'findings'       => $this->dedupeRows($findings),
         ), static fn (mixed $value): bool => array() !== $value);
     }
 

--- a/php-transformer/src/Contract/ConversionFindingContract.php
+++ b/php-transformer/src/Contract/ConversionFindingContract.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Contract;
+
+use InvalidArgumentException;
+
+/**
+ * Versioned contract for the generic conversion-finding shape emitted by the
+ * transformer's diagnostic producers.
+ *
+ * The transformer surfaces conversion findings/diagnostics from several
+ * producers — the fallback emitter, the flat diagnostics collector, the
+ * semantic-parity reporter, the runtime-dependency parity report, and the
+ * conversion-report projection. Historically each producer emitted a loose
+ * array with informally matched keys, with no formal schema, which is a
+ * silent-drift risk: a producer can rename a value, drop the identifier, or
+ * emit an out-of-band severity and nothing fails.
+ *
+ * This contract formalizes that shape. It is intentionally TOLERANT: it
+ * captures only the invariants that actually hold across every finding produced
+ * today, so existing valid findings keep validating. It mirrors
+ * {@see VisualParityReportContract} (a `SCHEMA` version constant plus static
+ * `assert*()` methods that throw {@see InvalidArgumentException}).
+ *
+ * Boundary note: this is blocks-engine's OWN generic output schema. It carries
+ * no knowledge of any consumer — producers emit findings conforming to this
+ * shape and downstream consumers adapt to it. Nothing here references a consumer
+ * concept.
+ *
+ * Reality of the finding shape (the union observed across producers):
+ *  - A stable identifier is the ONLY universally present field. Producers carry
+ *    it under `code` (diagnostics collector, semantic parity, runtime
+ *    dependency parity) OR `diagnostic_code` (fallback emitter, conversion
+ *    report fallback projection). At least one, non-empty, is REQUIRED.
+ *  - `severity`, when present, is drawn from a closed set; this is the highest
+ *    value invariant the contract guards against drift.
+ *  - A human-readable descriptor is carried under `message` OR `summary`; it is
+ *    present on the producer-owned findings but absent from the compact
+ *    conversion-report fallback projection, so it is OPTIONAL (type-checked when
+ *    present).
+ *  - Everything else (provenance, classification, repair guidance, structural
+ *    counts, nested context) is OPTIONAL and producer-specific; well-known
+ *    fields are type-checked when present, and unknown fields are tolerated so
+ *    producers can carry additive metadata without breaking the contract.
+ */
+final class ConversionFindingContract
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/conversion-finding/v1';
+
+    /**
+     * Closed set of finding severities. Forward-compatible with
+     * {@see VisualParityReportContract}; producers emit `info` and `warning`
+     * today, with the rest reserved.
+     */
+    private const SEVERITIES = array('none', 'info', 'warning', 'error', 'critical');
+
+    /**
+     * Identifier keys, in resolution priority. A finding must carry a non-empty
+     * string under at least one of these.
+     */
+    private const CODE_KEYS = array('code', 'diagnostic_code');
+
+    /**
+     * Human-readable descriptor keys. Optional; type-checked when present.
+     */
+    private const MESSAGE_KEYS = array('message', 'summary');
+
+    /**
+     * Well-known optional scalar string fields, validated for type only when
+     * present. Unknown fields are tolerated.
+     *
+     * @var array<int, string>
+     */
+    private const STRING_FIELDS = array(
+        'message', 'summary', 'source', 'source_format', 'scope',
+        'reason', 'reason_code', 'tag', 'kind',
+        'selector', 'source_selector', 'source_path',
+        'pattern_family', 'pattern_family_detail', 'parent_reason', 'ancestor_reason',
+        'conversion_classification', 'loss_class', 'diagnostic_class', 'preservation_strategy',
+        'runtime_requirement', 'recoverability', 'actionability',
+        'repair_bucket', 'suggested_repair_class', 'suggested_generic_repair_class',
+        'suggested_primitive', 'materialization_hint',
+        'script_role', 'block_name', 'path',
+    );
+
+    /**
+     * Well-known optional array (object/list) fields, validated for type only
+     * when present.
+     *
+     * @var array<int, string>
+     */
+    private const ARRAY_FIELDS = array(
+        'source_selector_specificity', 'context', 'events', 'classification',
+        'controls', 'control', 'form', 'readable_blocks', 'signals',
+        'source_items', 'block_items', 'source_item', 'block_item',
+    );
+
+    /**
+     * Validate a single conversion finding against the contract.
+     *
+     * @param array<string, mixed> $finding
+     */
+    public static function assertFinding(array $finding, string $label = 'conversion finding'): void
+    {
+        if ( '' === self::findingCode($finding) ) {
+            throw new InvalidArgumentException(sprintf('%s is missing a non-empty "code"/"diagnostic_code" identifier.', ucfirst($label)));
+        }
+
+        // Optional fields may be carried as an explicit `null` placeholder: the
+        // flat diagnostics projection emits a fixed key set with `?? null` for
+        // fields that do not apply to a given finding, so `null` is a legitimate
+        // emitted value and is tolerated wherever a typed value is also allowed.
+        if ( array_key_exists('severity', $finding) && null !== $finding['severity'] && ! in_array($finding['severity'], self::SEVERITIES, true) ) {
+            throw new InvalidArgumentException(sprintf('%s has an unsupported severity.', ucfirst($label)));
+        }
+
+        foreach ( self::STRING_FIELDS as $field ) {
+            if ( array_key_exists($field, $finding) && null !== $finding[$field] && ! is_string($finding[$field]) ) {
+                throw new InvalidArgumentException(sprintf('%s field "%s" must be a string.', ucfirst($label), $field));
+            }
+        }
+
+        foreach ( self::ARRAY_FIELDS as $field ) {
+            if ( array_key_exists($field, $finding) && null !== $finding[$field] && ! is_array($finding[$field]) ) {
+                throw new InvalidArgumentException(sprintf('%s field "%s" must be an array.', ucfirst($label), $field));
+            }
+        }
+
+        // `observed_block` is the one field producers emit as either a string
+        // ("none") or an array (the observed block payload).
+        if ( array_key_exists('observed_block', $finding) && null !== $finding['observed_block'] && ! is_string($finding['observed_block']) && ! is_array($finding['observed_block']) ) {
+            throw new InvalidArgumentException(sprintf('%s field "observed_block" must be a string or an array.', ucfirst($label)));
+        }
+    }
+
+    /**
+     * Validate every entry in a list of conversion findings.
+     *
+     * @param array<int, mixed> $findings
+     */
+    public static function assertFindings(array $findings, string $label = 'conversion findings'): void
+    {
+        if ( array_values($findings) !== $findings ) {
+            throw new InvalidArgumentException(sprintf('%s must be a list.', ucfirst($label)));
+        }
+
+        foreach ( $findings as $index => $finding ) {
+            if ( ! is_array($finding) ) {
+                throw new InvalidArgumentException(sprintf('%s.%d must be an object.', $label, $index));
+            }
+
+            self::assertFinding($finding, sprintf('%s.%d', $label, $index));
+        }
+    }
+
+    /**
+     * Resolve a finding's stable identifier, honoring the `code` /
+     * `diagnostic_code` producer split. Returns '' when neither is a non-empty
+     * string.
+     *
+     * @param array<string, mixed> $finding
+     */
+    public static function findingCode(array $finding): string
+    {
+        foreach ( self::CODE_KEYS as $key ) {
+            if ( is_string($finding[$key] ?? null) && '' !== trim($finding[$key]) ) {
+                return (string) $finding[$key];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Whether a value is a conversion finding that satisfies the contract.
+     * Tolerant predicate for walking heterogeneous diagnostic collections.
+     */
+    public static function isFinding(mixed $finding): bool
+    {
+        if ( ! is_array($finding) ) {
+            return false;
+        }
+
+        try {
+            self::assertFinding($finding);
+        } catch ( InvalidArgumentException ) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -20,6 +20,7 @@ final class ConversionReportProjection
     {
         $report = array(
             'schema'                => self::SCHEMA,
+            'finding_schema'        => ConversionFindingContract::SCHEMA,
             'source_format'         => $sourceFormat,
             'source'                => self::firstString($provenance, 'source'),
             'scope'                 => self::firstString($provenance, 'scope'),

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TypographyParityAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
@@ -61,6 +62,7 @@ final class SemanticParityReporter
 
         return array(
             'schema' => 'blocks-engine/php-transformer/semantic-parity/v1',
+            'finding_schema' => ConversionFindingContract::SCHEMA,
             'status' => array() === $findings ? 'pass' : 'warning',
             'landmarks' => array(
                 'source' => $sourceLandmarks['counts'],

--- a/php-transformer/tests/contract/finding-contract.php
+++ b/php-transformer/tests/contract/finding-contract.php
@@ -1,0 +1,205 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$assert = static function (bool $condition, string $message, string $detail = ''): void {
+    if ( $condition ) {
+        return;
+    }
+
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+    exit(1);
+};
+
+$assertThrows = static function (callable $callback, string $message): void {
+    try {
+        $callback();
+    } catch ( InvalidArgumentException ) {
+        return;
+    }
+
+    fwrite(STDERR, 'FAIL: expected InvalidArgumentException - ' . $message . PHP_EOL);
+    exit(1);
+};
+
+// --- Direct contract unit coverage -----------------------------------------
+
+$assert(
+    'blocks-engine/php-transformer/conversion-finding/v1' === ConversionFindingContract::SCHEMA,
+    'finding contract exposes the versioned schema constant'
+);
+
+// A finding identified by `code` (collectors / parity reports) validates.
+ConversionFindingContract::assertFinding(array(
+    'code'     => 'landmark_count_mismatch',
+    'severity' => 'warning',
+    'summary'  => 'Source header landmarks exceed generated core block representation.',
+    'selector' => 'header:nth-of-type(1)',
+));
+
+// A finding identified by `diagnostic_code` (fallback emitter) validates.
+ConversionFindingContract::assertFinding(array(
+    'diagnostic_code' => 'html_script_fallback',
+    'severity'        => 'warning',
+    'message'         => 'Script HTML requires runtime behavior.',
+    'classification'  => array('bucket' => 'unknown', 'confidence' => 0.1, 'signals' => array()),
+    'observed_block'  => 'none',
+));
+
+$assert(
+    'html_script_fallback' === ConversionFindingContract::findingCode(array('diagnostic_code' => 'html_script_fallback')),
+    'findingCode resolves the diagnostic_code identifier'
+);
+$assert(
+    'landmark_count_mismatch' === ConversionFindingContract::findingCode(array('code' => 'landmark_count_mismatch')),
+    'findingCode resolves the code identifier'
+);
+$assert(
+    '' === ConversionFindingContract::findingCode(array('severity' => 'warning')),
+    'findingCode returns empty string when no identifier is present'
+);
+
+$assert(ConversionFindingContract::isFinding(array('code' => 'x')), 'isFinding accepts an identified finding');
+$assert(! ConversionFindingContract::isFinding(array('severity' => 'warning')), 'isFinding rejects a finding without an identifier');
+$assert(! ConversionFindingContract::isFinding('not-an-array'), 'isFinding rejects a non-array');
+
+$assertThrows(
+    static fn () => ConversionFindingContract::assertFinding(array('severity' => 'warning', 'message' => 'no id')),
+    'finding without an identifier is rejected'
+);
+$assertThrows(
+    static fn () => ConversionFindingContract::assertFinding(array('code' => 'x', 'severity' => 'fatal')),
+    'finding with an out-of-band severity is rejected'
+);
+$assertThrows(
+    static fn () => ConversionFindingContract::assertFinding(array('code' => 'x', 'selector' => array('not', 'a', 'string'))),
+    'finding with a non-string scalar field is rejected'
+);
+$assertThrows(
+    static fn () => ConversionFindingContract::assertFinding(array('code' => 'x', 'events' => 'not-an-array')),
+    'finding with a non-array structured field is rejected'
+);
+$assertThrows(
+    static fn () => ConversionFindingContract::assertFindings(array(array('code' => 'ok'), 'not-an-array'), 'sample findings'),
+    'a non-array entry in a findings list is rejected'
+);
+
+// `observed_block` is the one field producers emit as string OR array.
+ConversionFindingContract::assertFinding(array('code' => 'x', 'observed_block' => array('block_names' => array('core/navigation'))));
+$assertThrows(
+    static fn () => ConversionFindingContract::assertFinding(array('code' => 'x', 'observed_block' => 42)),
+    'finding with a numeric observed_block is rejected'
+);
+
+// --- Walk every finding the transformer actually emits ----------------------
+
+/**
+ * Collect every conversion finding carried by a transformer/compiler result,
+ * across all producers (flat diagnostics, fallbacks, and the report-scoped
+ * findings), and assert each one conforms to the contract. Also verifies the
+ * report-level `finding_schema` stamp is present and versioned.
+ *
+ * @param array<string, mixed> $result
+ */
+$walk = static function (array $result, string $context) use ($assert): int {
+    $count = 0;
+
+    $diagnostics = $result['diagnostics'] ?? array();
+    $assert(is_array($diagnostics), "{$context}: diagnostics is an array");
+    ConversionFindingContract::assertFindings(array_values($diagnostics), "{$context} diagnostics");
+    $count += count($diagnostics);
+
+    $fallbacks = $result['fallbacks'] ?? array();
+    $assert(is_array($fallbacks), "{$context}: fallbacks is an array");
+    ConversionFindingContract::assertFindings(array_values($fallbacks), "{$context} fallbacks");
+    $count += count($fallbacks);
+
+    $sourceReports = is_array($result['source_reports'] ?? null) ? $result['source_reports'] : array();
+
+    $reportFindingPaths = array(
+        'semantic_parity'           => $sourceReports['semantic_parity'] ?? null,
+        'runtime_dependency_parity' => $sourceReports['runtime_dependency_parity'] ?? null,
+    );
+    foreach ( $reportFindingPaths as $name => $report ) {
+        if ( ! is_array($report) ) {
+            continue;
+        }
+
+        $assert(
+            ConversionFindingContract::SCHEMA === ($report['finding_schema'] ?? null),
+            "{$context}: {$name} report stamps the finding_schema version"
+        );
+
+        $findings = $report['findings'] ?? array();
+        $assert(is_array($findings), "{$context}: {$name} findings is an array");
+        ConversionFindingContract::assertFindings(array_values($findings), "{$context} {$name} findings");
+        $count += count($findings);
+    }
+
+    $conversionReport = $sourceReports['conversion_report'] ?? null;
+    if ( is_array($conversionReport) ) {
+        $assert(
+            ConversionFindingContract::SCHEMA === ($conversionReport['finding_schema'] ?? null),
+            "{$context}: conversion report stamps the finding_schema version"
+        );
+
+        $fallbackDiagnostics = $conversionReport['fallback_diagnostics'] ?? array();
+        $assert(is_array($fallbackDiagnostics), "{$context}: conversion report fallback_diagnostics is an array");
+        ConversionFindingContract::assertFindings(array_values($fallbackDiagnostics), "{$context} conversion report fallback_diagnostics");
+        $count += count($fallbackDiagnostics);
+    }
+
+    return $count;
+};
+
+$htmlCases = array(
+    'unsafe-inline-svg'   => '<main><svg onload="alert(1)"><path d="M0 0h1v1z"></path></svg></main>',
+    'script-fallback'     => '<main><div id="widget">Hi</div><script>document.getElementById("widget").addEventListener("click", function () { window.__x = 1; });</script></main>',
+    'template-fallback'   => '<main><template id="card"><div data-role="card"><script>render()</script></div></template></main>',
+    'iframe-embed'        => '<main><iframe src="https://example.com/widget"></iframe></main>',
+    'unsupported-element' => '<main><marquee>Scrolling</marquee></main>',
+    'header-footer-nav'   => '<body><header><nav><a href="/a">A</a><a href="/b">B</a></nav></header><main><p>Body</p></main><footer><nav><a href="/c">C</a><a href="/d">D</a></nav></footer></body>',
+);
+
+$totalFindings = 0;
+foreach ( $htmlCases as $name => $html ) {
+    $result = ( new HtmlTransformer() )->transform($html)->toArray();
+    $totalFindings += $walk($result, "html:{$name}");
+}
+
+// Canvas requires a runtime selector hint to be flagged as a runtime island.
+$canvasResult = ( new HtmlTransformer() )->transform(
+    '<main><canvas id="scene">Fallback</canvas><script>document.getElementById("scene").getContext("2d");</script></main>',
+    array('runtime_canvas_selectors' => array('#scene'))
+)->toArray();
+$totalFindings += $walk($canvasResult, 'html:canvas-runtime');
+
+// Artifact compilation exercises the runtime-dependency parity producer: a
+// first-party script references a DOM target that the generated markup drops.
+$artifactResult = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'index.html',
+    'files'      => array(
+        'index.html' => '<main><div class="hero">Welcome</div><script src="js/app.js"></script></main>',
+        'js/app.js'  => 'document.getElementById("ghost").addEventListener("click", function () { window.__y = 1; });',
+    ),
+))->toArray();
+$totalFindings += $walk($artifactResult, 'artifact:runtime-dependency');
+
+$runtimeDependencyParity = $artifactResult['source_reports']['runtime_dependency_parity'] ?? array();
+$assert(
+    'warning' === ($runtimeDependencyParity['status'] ?? ''),
+    'artifact runtime dependency parity flags the missing DOM target'
+);
+$assert(
+    array() !== ($runtimeDependencyParity['findings'] ?? array()),
+    'artifact runtime dependency parity emits at least one finding to validate'
+);
+
+$assert($totalFindings > 0, 'the contract walk validated a non-empty set of real conversion findings');
+
+fwrite(STDOUT, "Conversion finding contract passed: {$totalFindings} finding(s) validated.\n");


### PR DESCRIPTION
Refs #242 (ws2, slice 1)

## What

Conversion findings/diagnostics are emitted as loose arrays with informally matched keys across several producers, with no formal schema — a silent-drift risk. This formalizes blocks-engine's **own generic, versioned conversion-finding contract** on the producer side.

- **New `Contract/ConversionFindingContract`** — `SCHEMA = blocks-engine/php-transformer/conversion-finding/v1`, mirroring `VisualParityReportContract` (SCHEMA constant + static `assert*()`). API: `assertFinding()`, `assertFindings()`, `findingCode()` (resolves the `code` / `diagnostic_code` producer split), `isFinding()`.
- **Versioned stamp** — `finding_schema` added to the three finding-bearing reports (conversion-report projection, semantic-parity reporter, runtime-dependency parity report) so consumers can version-check.
- **Contract test** — `tests/contract/finding-contract.php` (wired into `test:canonical`) walks every finding the transformer/compiler emits (flat `diagnostics`, `fallbacks`, and report-scoped `findings`) and asserts each conforms; 39 real findings validated.

## Contract shape (deliberately tolerant — matches reality)

Inventoried from `FallbackEmitter`, `DiagnosticsCollector`, `SemanticParityReporter`, `RuntimeDependencyParityReport`, `FallbackDiagnostic`, and `ConversionReportProjection`.

- **Required:** a non-empty string identifier under `code` **or** `diagnostic_code` (the only universally-present field — producers split on these two keys).
- **Validated when present:** `severity` ∈ {none, info, warning, error, critical}; well-known scalar string fields (`message`, `summary`, `source`, `reason`, `reason_code`, `selector`, `source_selector`, `source_path`, `tag`, `kind`, `pattern_family`, `loss_class`, `diagnostic_class`, `conversion_classification`, `preservation_strategy`, `runtime_requirement`, `recoverability`, `actionability`, `repair_bucket`, `suggested_repair_class`, `suggested_generic_repair_class`, `suggested_primitive`, `materialization_hint`, …); well-known array fields (`source_selector_specificity`, `context`, `events`, `classification`, `controls`, `source_items`, `block_items`, …); `observed_block` as string **or** array. `null` placeholders are tolerated (the flat diagnostics projection emits a fixed key set with `?? null`), and unknown additive fields pass.

## Boundary

blocks-engine-owned generic output schema; **carries no consumer knowledge** (no SSI / rig / fixture-matrix concepts). Consumer-side adoption (SSI + homeboy-rigs validating against the versioned schema) is an explicit follow-up slice and is **not** touched here.

## Behavior-preserving

Additive schema/version + validation only — finding **values** unchanged. `composer test` green; canonical + `php -l` clean; **parity identical at 144 fixtures** (baseline and post-change). Parity assertions are path-scoped to leaf scalars/array lengths, so the additive `finding_schema` scalar perturbs none.

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)