### PR TITLE
Carry source base/body font-family into materialized typography

### DIFF
--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -53,7 +53,34 @@ final class FontMaterializationPlanBuilder
         );
         $roles = $this->fontRolesFromCss($css);
 
+        // The base/body `font-family` is the document's foundational typography
+        // and must survive into the materialized output even when it is declared
+        // only in an inline `<style>` block (no external stylesheet, no linked
+        // web-font). Carry that base font into the plan so the generated base
+        // typography keeps the source's body face. Heading-only inline fonts are
+        // deliberately NOT materialized here: a custom heading face with no
+        // loaded web-font cannot render, so it stays a reported drop.
+        $inlineBody = (string) ($this->fontRolesFromCss($this->styleBlockCss($html))['body'] ?? '');
+        if ( '' !== $inlineBody ) {
+            $fontUsage[] = array('family' => $inlineBody, 'weights' => array(400));
+            if ( '' === (string) ($roles['body'] ?? '') ) {
+                $roles['body'] = $inlineBody;
+            }
+        }
+
         return $this->googleFonts($fontUsage, $roles);
+    }
+
+    /**
+     * Concatenate the CSS inside every `<style>` block of an HTML document.
+     */
+    private function styleBlockCss(string $html): string
+    {
+        if ( '' === trim($html) || ! preg_match_all('/<style\b[^>]*>(.*?)<\/style>/is', $html, $matches) ) {
+            return '';
+        }
+
+        return implode("\n", $matches[1]);
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1642,6 +1642,33 @@ $materializedTypographyFindings = array_filter(
 );
 $assert(array() === $materializedTypographyFindings, 'materialized web-font produces no typography parity finding');
 
+// Negative: the base/body font-family is the document's foundational typography
+// and must survive into materialized output even when declared only in an inline
+// <style> block (no link, no static css). It is carried into the base typography
+// the transformer emits, so it must NOT surface a typography_font_family_dropped:body finding.
+$inlineBodyFontResult = ( new HtmlTransformer() )->transform(
+    '<!doctype html><html><head><style>body{font-family:"Brand Sans",sans-serif}</style></head><body><main><h1>Heading</h1><p>Copy</p></main></body></html>',
+    array()
+)->toArray();
+$inlineBodyDropped = $findingsByCode($semanticFindings($inlineBodyFontResult), 'typography_font_family_dropped');
+$assert(array() === $inlineBodyDropped, 'inline <style> base/body font-family is materialized and not reported dropped');
+$inlineBodyPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
+    '<head><style>body{font-family:"Brand Sans",sans-serif}</style></head>',
+    ''
+);
+$assert('Brand Sans' === ($inlineBodyPlan['roles']['body'] ?? null), 'inline <style> base/body font-family flows into materialized body role');
+$assert('Brand Sans' === ($inlineBodyPlan['fonts'][0]['family'] ?? null), 'inline <style> base/body font-family is preserved in materialized fonts');
+
+// Positive: a heading-only font in an inline <style> block (no body declaration)
+// still requires a loaded web-font to render, so it remains a reported drop.
+$inlineHeadingOnlyResult = ( new HtmlTransformer() )->transform(
+    '<!doctype html><html><head><style>h1,h2{font-family:"Display Custom",sans-serif}</style></head><body><main><h1>Heading</h1></main></body></html>',
+    array()
+)->toArray();
+$inlineHeadingOnlyDropped = $findingsByCode($semanticFindings($inlineHeadingOnlyResult), 'typography_font_family_dropped');
+$assert(array() !== $inlineHeadingOnlyDropped, 'inline <style> heading-only font without a loaded web-font is still reported dropped');
+$assert('heading' === ($inlineHeadingOnlyDropped[0]['font_role'] ?? null), 'inline <style> heading-only drop carries the heading role');
+
 // Enrichment: every semantic-parity finding (landmark/navigation) carries source_snippet, observed_block, and reason_code.
 $underSpecifiedResult = ( new HtmlTransformer() )->transform(
     '<body><header><nav><span>Menu</span></nav></header><main><p>Copy</p></main></body>',


### PR DESCRIPTION
## Problem

A 12-site live corpus run flagged `html_semantic_parity_typography_font_family_dropped:body` on **4 different sites**. The source page/body `font-family` was not surviving into the output, so imported sites lost their base typography.

## Root cause

`FontMaterializationPlanBuilder::fromWebFontSources()` derived the materialized typefaces only from:
1. `<link>` web-font stylesheets (Google Fonts), and
2. `font-family` declarations in the **external** static CSS.

A base/body `font-family` declared in an inline `<style>` block in the page head (no linked web-font, not present in the external CSS) was never carried into the materialization plan. The transformer therefore emitted no base typography for it, and `TypographyParityAnalyzer` — which checks the body declaration against the same plan — **correctly** reported the body font dropped. It was a real drop, not an over-firing diagnostic.

## Fix

Generic, keyed off the declared base font-family (never a font name or site string): resolve the base/body font-family from the document's inline `<style>` blocks (`body`/`html`/`:root`/`*` selectors) and carry it into the materialization plan's body role, `fonts`, and CSS.

The base/body font is the document's foundational typography and must survive into base/global styles even without a loaded web-font. Heading-only inline fonts remain **unmaterialized** — a custom heading face with no loaded web-font cannot render, so it stays a reported drop (existing `typography_font_family_dropped:heading` contract preserved).

## Before / after

Page with `<style>body{font-family:"Brand Sans",sans-serif}</style>` and no link/external CSS:

- **Before:** `typography_font_family_dropped role=body family=Brand Sans` fires; base font dropped from output.
- **After:** no finding; the plan carries `roles.body = Brand Sans`, `fonts[0].family = Brand Sans`, and a deterministic `@import` for it — base typography preserved.

Unchanged controls: body font declared in external static CSS still clean; heading-only inline `<style>` font still reported dropped.

## Tests

- Baseline `composer test:canonical` + `composer parity` green before the change.
- No existing parity fixtures changed (the change is additive — none of the 144 fixtures declared a base font solely in an inline `<style>` block).
- Added contract assertions: inline `<style>` base/body font is materialized and not reported dropped; heading-only inline font still reported dropped.
- Full `composer test` green (canonical + parity 144 fixtures + packaging proof); `php -l` clean.

**DO NOT MERGE** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)