### PR TITLE
Recognize generic accordion/disclosure widgets as core/details

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1367,6 +1367,19 @@ final class HtmlTransformer
                 }
             }
 
+            if ( in_array($tagName, array( 'div', 'section', 'article' ), true) ) {
+                $disclosure = $this->detailsPattern->matchDisclosure(
+                    $element,
+                    fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
+                    fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+                    fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
+                );
+                if ( null !== $disclosure ) {
+                    return $disclosure;
+                }
+            }
+
             $columns = $this->columnsPattern->match(
                 $element,
                 $fallbacks,

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -28,6 +28,189 @@ final class DetailsPattern
         )), static fn ($value): bool => '' !== $value), $children, $element);
     }
 
+    /**
+     * Recognize a generic accordion/disclosure widget that is NOT a native
+     * `<details>` in the source and convert it to `core/details` so the
+     * show/hide behavior is carried by the native disclosure block instead of
+     * being lost as dead JavaScript.
+     *
+     * Recognition is purely STRUCTURAL/semantic — it keys off the WAI-ARIA
+     * disclosure shape (a single toggle control carrying `aria-expanded` and/or
+     * `aria-controls`, plus an associated collapsible region) and never off any
+     * class string such as `faq-*`. A plain heading followed by text — with no
+     * toggle control, aria-expanded, or aria-controls — is not a disclosure and
+     * is intentionally left untouched. Multi-item accordions are handled earlier
+     * by the dedicated accordion recognizer (`core/accordion`); this only fires
+     * for a single leftover disclosure widget.
+     *
+     * @param callable(DOMElement): array<int, array<string, mixed>> $convertChildren
+     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $innerHtml
+     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
+     * @return array<string, mixed>|null
+     */
+    public function matchDisclosure(DOMElement $element, callable $convertChildren, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
+    {
+        if ( $this->hasRuntimeHeavyDescendant($element) ) {
+            return null;
+        }
+
+        $toggles = $this->disclosureToggles($element);
+        if ( 1 !== count($toggles) ) {
+            return null;
+        }
+
+        $toggle = $toggles[0];
+
+        $summaryHtml = $this->toggleLabelHtml($toggle, $innerHtml);
+        if ( '' === trim(strip_tags($summaryHtml)) ) {
+            return null;
+        }
+
+        $header = $this->headerForToggle($element, $toggle);
+        if ( ! $header instanceof DOMElement ) {
+            return null;
+        }
+
+        $panel = $this->disclosurePanel($element, $toggle, $header);
+        if ( ! $panel instanceof DOMElement || $this->isNavigationLandmark($panel) ) {
+            return null;
+        }
+
+        $panelBlocks = $convertChildren($panel);
+        if ( array() === $panelBlocks ) {
+            return null;
+        }
+
+        return $createBlock('core/details', array_filter(array_merge($presentationAttributes($element), array(
+            'summary' => $summaryHtml,
+        )), static fn ($value): bool => '' !== $value), $panelBlocks, $element);
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function disclosureToggles(DOMElement $element): array
+    {
+        $toggles = array();
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( $candidate instanceof DOMElement && $this->isDisclosureToggle($candidate) ) {
+                $toggles[] = $candidate;
+            }
+        }
+
+        return $toggles;
+    }
+
+    /**
+     * A toggle control carries explicit disclosure semantics: an
+     * `aria-expanded` state, or a button-like control that points at the region
+     * it reveals via `aria-controls`.
+     */
+    private function isDisclosureToggle(DOMElement $element): bool
+    {
+        if ( $element->hasAttribute('aria-expanded') ) {
+            return true;
+        }
+
+        if ( ! $element->hasAttribute('aria-controls') ) {
+            return false;
+        }
+
+        $tagName = strtolower($element->tagName);
+        $role = strtolower($this->attr($element, 'role'));
+
+        return 'button' === $tagName || 'summary' === $tagName || 'button' === $role
+            || ( 'a' === $tagName && 'button' === $role );
+    }
+
+    /**
+     * The collapsible region the toggle reveals: the element referenced by
+     * `aria-controls`, otherwise the toggle header's next sibling region.
+     */
+    private function disclosurePanel(DOMElement $element, DOMElement $toggle, DOMElement $header): ?DOMElement
+    {
+        $controlledId = trim($this->attr($toggle, 'aria-controls'));
+        if ( '' !== $controlledId ) {
+            foreach ( $element->getElementsByTagName('*') as $candidate ) {
+                if ( ! $candidate instanceof DOMElement || $candidate->getAttribute('id') !== $controlledId ) {
+                    continue;
+                }
+
+                if ( $candidate->isSameNode($header) || $this->containsNode($candidate, $toggle) || $this->containsNode($header, $candidate) ) {
+                    continue;
+                }
+
+                return $candidate;
+            }
+        }
+
+        for ( $node = $header->nextSibling; null !== $node; $node = $node->nextSibling ) {
+            if ( $node instanceof DOMElement ) {
+                return $node;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The ancestor-or-self of the toggle that is a direct child of the widget
+     * container — the clickable header whose text becomes the summary.
+     */
+    private function headerForToggle(DOMElement $element, DOMElement $toggle): ?DOMElement
+    {
+        for ( $node = $toggle; $node instanceof DOMElement; $node = $node->parentNode ) {
+            $parent = $node->parentNode;
+            if ( $parent instanceof DOMElement && $parent->isSameNode($element) ) {
+                return $node;
+            }
+        }
+
+        return null;
+    }
+
+    private function toggleLabelHtml(DOMElement $toggle, callable $innerHtml): string
+    {
+        $html = $innerHtml($toggle);
+        $html = preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html;
+        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>.*?<\/\1>/is', '', $html) ?? $html;
+
+        return trim($html);
+    }
+
+    private function isNavigationLandmark(DOMElement $element): bool
+    {
+        return 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->attr($element, 'role'));
+    }
+
+    private function hasRuntimeHeavyDescendant(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( $candidate instanceof DOMElement && in_array(strtolower($candidate->tagName), array( 'script', 'canvas', 'template', 'iframe', 'form' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function containsNode(DOMElement $ancestor, DOMElement $node): bool
+    {
+        for ( $current = $node; $current instanceof DOMElement; $current = $current->parentNode ) {
+            if ( $current->isSameNode($ancestor) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function attr(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? trim($element->getAttribute($name)) : '';
+    }
+
     private function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
     {
         foreach ( $element->childNodes as $child ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -279,6 +279,33 @@ $assert(true === ($detailsAccordionItems[0]['attrs']['openByDefault'] ?? null), 
 $assert('Can I reschedule?' === ($detailsAccordionItems[0]['innerBlocks'][0]['attrs']['title'] ?? null), 'details summary text maps to accordion heading');
 $assert('Yes, with notice.' === ($detailsAccordionItems[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? null), 'details body text maps to accordion panel');
 
+// A single disclosure widget (toggle control + collapsible region) carries no
+// faq/accordion class, only the structural WAI-ARIA disclosure shape, and is
+// converted to a native zero-JS core/details block instead of leaking a dead
+// toggle button and an always-visible panel.
+$disclosureResult = ( new HtmlTransformer() )->transform('<div><button aria-expanded="false" aria-controls="answer-1">What is your refund policy?</button><div id="answer-1" hidden><p>Full refund within 30 days.</p></div></div>')->toArray();
+$disclosureBlock = $disclosureResult['blocks'][0] ?? array();
+$assert('core/details' === ($disclosureBlock['blockName'] ?? null), 'a single aria disclosure widget converts to core/details');
+$assert('What is your refund policy?' === ($disclosureBlock['attrs']['summary'] ?? null), 'disclosure toggle text maps to the details summary');
+$assert('Full refund within 30 days.' === ($disclosureBlock['innerBlocks'][0]['attrs']['content'] ?? null), 'disclosure panel content is preserved inside core/details');
+$assert(str_contains((string) ($disclosureResult['serialized_blocks'] ?? ''), '<!-- wp:details'), 'disclosure conversion serializes a native details block comment');
+
+// A heading-wrapped toggle (button nested inside the header) is recognized by
+// the same structural signal.
+$headingDisclosureResult = ( new HtmlTransformer() )->transform('<div class="item"><h3><button aria-expanded="false" aria-controls="panel-1">Shipping times?</button></h3><div id="panel-1" role="region"><p>Ships in 2 days.</p></div></div>')->toArray();
+$assert('core/details' === (($headingDisclosureResult['blocks'][0] ?? array())['blockName'] ?? null), 'a heading-wrapped disclosure toggle converts to core/details');
+$assert('Shipping times?' === (($headingDisclosureResult['blocks'][0] ?? array())['attrs']['summary'] ?? null), 'heading-wrapped disclosure toggle text maps to the details summary');
+
+// Negative guard: a plain heading followed by text is NOT a disclosure (no
+// toggle control, aria-expanded, or aria-controls) and must stay as a heading +
+// paragraph rather than being forced into core/details.
+$plainResult = ( new HtmlTransformer() )->transform('<div><h3>About us</h3><p>We are a company.</p></div>')->toArray();
+$plainBlock = $plainResult['blocks'][0] ?? array();
+$assert('core/details' !== ($plainBlock['blockName'] ?? null), 'a plain heading followed by text is not converted to core/details');
+$plainInner = $plainBlock['innerBlocks'] ?? array();
+$assert('core/heading' === ($plainInner[0]['blockName'] ?? null), 'plain heading remains a core/heading');
+$assert('core/paragraph' === ($plainInner[1]['blockName'] ?? null), 'plain body text remains a core/paragraph');
+
 $fixture = file_get_contents(dirname(__DIR__) . '/fixtures/simple-html.html');
 $result  = ( new HtmlTransformer() )->transform($fixture . "\n<ul><li>One</li><li><strong>Two</strong></li></ul><canvas>Fallback</canvas>")->toArray();
 


### PR DESCRIPTION
## What

Teaches the PHP transformer to recognize a **generic accordion/disclosure widget** (a clickable toggle header + a collapsible body, typically toggled by JS) and convert it to the native **`core/details`** (`<details><summary>`) block — server-rendered, working with **zero JS**.

## Why

A 12-site live corpus run surfaced a recurring `runtime_target_gap` dead-JS finding: FAQ/accordion structures (`faq-question` / `faq-answer` / `faq-item`) showed up as dead-JS runtime islands because their show/hide JavaScript couldn't be carried. A *single* disclosure widget previously leaked a dead toggle `core/button` plus an always-visible panel group — the disclosure behavior was lost.

Multi-item accordions already convert to `core/accordion`. This fills the remaining gap for the single leftover disclosure widget by mapping it to the native `core/details` disclosure block, turning a dead-JS runtime island into a working native block.

## How (generic, structural — never class strings)

`DetailsPattern::matchDisclosure()` keys off the **WAI-ARIA disclosure shape**, never off any site/fixture/class string such as `faq-*`:

- **Toggle control:** exactly one element carrying `aria-expanded`, or a button-like control (`button` / `summary` / `role=button` / `a[role=button]`) carrying `aria-controls`.
- **Collapsible region:** the element referenced by `aria-controls`, otherwise the toggle header's next sibling region.
- **Mapping:** toggle header text → `summary`; the collapsible region's children → inner content. Text is preserved.

Wired into `HtmlTransformer` for `div`/`section`/`article` containers, **after** the multi-item accordion recognizer so true accordions still map to `core/accordion`.

### Guards (no over-matching)

- A plain heading followed by text — **no** toggle control, `aria-expanded`, or `aria-controls` — is left untouched (stays `core/heading` + `core/paragraph`).
- Navigation toggles are excluded: nav-landmark panels (`<nav>` / `role=navigation`) and empty/decorative hamburger labels don't become disclosures, so site chrome is not mistaken for content.
- Runtime-heavy subtrees (`script`/`iframe`/`form`/`canvas`/`template`) bail.
- Requires exactly one toggle, so multi-toggle containers fall through (accordion territory).

## Before / after

Input:
```html
<div><button aria-expanded="false" aria-controls="a1">What is your refund policy?</button><div id="a1" hidden><p>Full refund within 30 days.</p></div></div>
```
- **Before:** `core/group` → `core/buttons`/`core/button` (dead toggle) + `core/group` (always-visible panel) — disclosure behavior lost.
- **After:** `core/details` (summary = "What is your refund policy?") → `core/paragraph` ("Full refund within 30 days.") — native, zero-JS.

## Tests

- Positive: aria disclosure + heading-wrapped disclosure → `core/details` (summary + panel preserved, serializes `<!-- wp:details`).
- Negative: plain heading + text stays `core/heading` + `core/paragraph`.
- Full suite green: `composer test` (canonical + parity 144 fixtures + packaging), `php -l` clean. No parity fixture churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)