### PR TITLE
Add per-fixture classification manifests (fixtures/websites)

### DIFF
--- a/fixtures/websites/10-nonprofit/fixture.json
+++ b/fixtures/websites/10-nonprofit/fixture.json
@@ -1,0 +1,10 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "nonprofit",
+    "has-nav",
+    "multipage",
+    "donation"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/11-nonprofit-campaign/fixture.json
+++ b/fixtures/websites/11-nonprofit-campaign/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "nonprofit",
+    "campaign",
+    "advocacy",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/12-portfolio/fixture.json
+++ b/fixtures/websites/12-portfolio/fixture.json
@@ -1,0 +1,10 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "portfolio",
+    "creative",
+    "one-pager",
+    "has-nav"
+  ],
+  "complexity": 1
+}

--- a/fixtures/websites/13-realistic-small-business/fixture.json
+++ b/fixtures/websites/13-realistic-small-business/fixture.json
@@ -1,0 +1,14 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "small-business",
+    "retail",
+    "plant-shop",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "has-shop",
+    "ecommerce"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/14-restaurant/fixture.json
+++ b/fixtures/websites/14-restaurant/fixture.json
@@ -1,0 +1,10 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "restaurant",
+    "food",
+    "one-pager",
+    "has-nav"
+  ],
+  "complexity": 1
+}

--- a/fixtures/websites/15-saas/fixture.json
+++ b/fixtures/websites/15-saas/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "saas",
+    "landing",
+    "one-pager",
+    "has-nav",
+    "pricing"
+  ],
+  "complexity": 1
+}

--- a/fixtures/websites/16-astro-docs-content-collection/fixture.json
+++ b/fixtures/websites/16-astro-docs-content-collection/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "docs",
+    "documentation",
+    "content-collection",
+    "has-nav",
+    "multipage",
+    "sidebar"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/17-markdown-blog-launch-site/fixture.json
+++ b/fixtures/websites/17-markdown-blog-launch-site/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "blog",
+    "markdown",
+    "food",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/18-static-content-library/fixture.json
+++ b/fixtures/websites/18-static-content-library/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "content-library",
+    "resources",
+    "nonprofit",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/19-product-catalog/fixture.json
+++ b/fixtures/websites/19-product-catalog/fixture.json
@@ -1,0 +1,14 @@
+{
+  "class": "ecommerce/catalog",
+  "tags": [
+    "ecommerce",
+    "catalog",
+    "retail",
+    "woodwork",
+    "has-nav",
+    "multipage",
+    "product-grid",
+    "pricing"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/2-onepager-coffee/fixture.json
+++ b/fixtures/websites/2-onepager-coffee/fixture.json
@@ -1,0 +1,10 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "restaurant",
+    "cafe",
+    "one-pager",
+    "has-nav"
+  ],
+  "complexity": 1
+}

--- a/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
+++ b/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
@@ -1,0 +1,16 @@
+{
+  "class": "ecommerce/catalog",
+  "tags": [
+    "ecommerce",
+    "woocommerce",
+    "catalog",
+    "outdoor",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "product-grid",
+    "bundles",
+    "pricing"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/21-studio-web-seafood-popup/fixture.json
+++ b/fixtures/websites/21-studio-web-seafood-popup/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "restaurant",
+    "pop-up",
+    "event",
+    "one-pager",
+    "has-form",
+    "has-nav"
+  ],
+  "complexity": 1
+}

--- a/fixtures/websites/22-fast-beautiful-website/fixture.json
+++ b/fixtures/websites/22-fast-beautiful-website/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "marketing",
+    "landing",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/23-recipe-blog/fixture.json
+++ b/fixtures/websites/23-recipe-blog/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "blog",
+    "recipes",
+    "food",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/24-podcast-show/fixture.json
+++ b/fixtures/websites/24-podcast-show/fixture.json
@@ -1,0 +1,14 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "podcast",
+    "audio",
+    "show",
+    "blog",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "has-audio"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/25-real-estate/fixture.json
+++ b/fixtures/websites/25-real-estate/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "real-estate",
+    "listings",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/26-government-municipal/fixture.json
+++ b/fixtures/websites/26-government-municipal/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "government",
+    "municipal",
+    "civic",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/27-university-department/fixture.json
+++ b/fixtures/websites/27-university-department/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "education",
+    "university",
+    "institutional",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/28-enterprise-b2b/fixture.json
+++ b/fixtures/websites/28-enterprise-b2b/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "b2b",
+    "enterprise",
+    "corporate",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/29-multilingual-i18n/fixture.json
+++ b/fixtures/websites/29-multilingual-i18n/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "nonprofit",
+    "multilingual",
+    "i18n",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/3-artist-music/fixture.json
+++ b/fixtures/websites/3-artist-music/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "music",
+    "artist",
+    "portfolio",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "has-embeds"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/30-cursed-pangolin-fanwiki/fixture.json
+++ b/fixtures/websites/30-cursed-pangolin-fanwiki/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "wiki",
+    "fan-wiki",
+    "experimental",
+    "has-form",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/31-personal-cv-academic/fixture.json
+++ b/fixtures/websites/31-personal-cv-academic/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "cv",
+    "resume",
+    "academic",
+    "personal",
+    "one-pager",
+    "has-nav"
+  ],
+  "complexity": 1
+}

--- a/fixtures/websites/32-wedding-microsite/fixture.json
+++ b/fixtures/websites/32-wedding-microsite/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "wedding",
+    "microsite",
+    "event",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/33-sports-team-league/fixture.json
+++ b/fixtures/websites/33-sports-team-league/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "sports",
+    "league",
+    "team",
+    "has-nav",
+    "multipage",
+    "schedule",
+    "roster"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/34-comparison-review-site/fixture.json
+++ b/fixtures/websites/34-comparison-review-site/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "review",
+    "comparison",
+    "blog",
+    "affiliate",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/35-hyper-minimal-blog/fixture.json
+++ b/fixtures/websites/35-hyper-minimal-blog/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "blog",
+    "minimal",
+    "personal",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 1
+}

--- a/fixtures/websites/36-church-community/fixture.json
+++ b/fixtures/websites/36-church-community/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "church",
+    "community",
+    "nonprofit",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/37-art-gallery-exhibition/fixture.json
+++ b/fixtures/websites/37-art-gallery-exhibition/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "art-gallery",
+    "exhibition",
+    "portfolio",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/38-medical-clinic/fixture.json
+++ b/fixtures/websites/38-medical-clinic/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "medical",
+    "clinic",
+    "healthcare",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/39-old-internet-cms/fixture.json
+++ b/fixtures/websites/39-old-internet-cms/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "local-business",
+    "rental",
+    "retro",
+    "catalog",
+    "has-form",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/4-course-education/fixture.json
+++ b/fixtures/websites/4-course-education/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "education",
+    "course",
+    "landing",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/40-job-board/fixture.json
+++ b/fixtures/websites/40-job-board/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "job-board",
+    "listings",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "has-filter"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/41-generative-art-studio/fixture.json
+++ b/fixtures/websites/41-generative-art-studio/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "generative-art",
+    "creative-tech",
+    "portfolio",
+    "canvas",
+    "webgl",
+    "has-form",
+    "has-nav"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/42-immersive-product-launch/fixture.json
+++ b/fixtures/websites/42-immersive-product-launch/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "product-launch",
+    "automotive",
+    "immersive",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "scroll-animation"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/43-interactive-space-explorer/fixture.json
+++ b/fixtures/websites/43-interactive-space-explorer/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "interactive",
+    "space",
+    "explorer",
+    "canvas",
+    "animation",
+    "has-nav"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/44-experimental-zine/fixture.json
+++ b/fixtures/websites/44-experimental-zine/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "zine",
+    "experimental",
+    "editorial",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "animation"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/45-markdown-ssg-blog/fixture.json
+++ b/fixtures/websites/45-markdown-ssg-blog/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "blog",
+    "markdown",
+    "ssg",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/46-mdx-design-system/fixture.json
+++ b/fixtures/websites/46-mdx-design-system/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "docs",
+    "design-system",
+    "component-library",
+    "mdx",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/47-digital-garden/fixture.json
+++ b/fixtures/websites/47-digital-garden/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "digital-garden",
+    "notes",
+    "blog",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/48-desktop-os-sim/fixture.json
+++ b/fixtures/websites/48-desktop-os-sim/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "os-sim",
+    "desktop",
+    "simulation",
+    "canvas",
+    "audio",
+    "app"
+  ],
+  "complexity": 5
+}

--- a/fixtures/websites/49-terminal-text-adventure/fixture.json
+++ b/fixtures/websites/49-terminal-text-adventure/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "game",
+    "text-adventure",
+    "terminal",
+    "interactive-fiction",
+    "has-form"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/5-documentation-knowledge-base/fixture.json
+++ b/fixtures/websites/5-documentation-knowledge-base/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "docs",
+    "knowledge-base",
+    "release-notes",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/50-web-audio-synth/fixture.json
+++ b/fixtures/websites/50-web-audio-synth/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "synth",
+    "web-audio",
+    "audio",
+    "music",
+    "canvas",
+    "instrument"
+  ],
+  "complexity": 5
+}

--- a/fixtures/websites/51-cursed-arg-site/fixture.json
+++ b/fixtures/websites/51-cursed-arg-site/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "arg",
+    "experimental",
+    "interactive",
+    "canvas",
+    "has-form",
+    "multipage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/52-css-3d-world/fixture.json
+++ b/fixtures/websites/52-css-3d-world/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "3d",
+    "webgl",
+    "css-3d",
+    "walkthrough",
+    "interactive",
+    "has-nav"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/53-live-ops-dashboard/fixture.json
+++ b/fixtures/websites/53-live-ops-dashboard/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "dashboard",
+    "ops",
+    "analytics",
+    "data-viz",
+    "canvas",
+    "app"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/54-physics-sandbox/fixture.json
+++ b/fixtures/websites/54-physics-sandbox/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "physics",
+    "sandbox",
+    "simulation",
+    "canvas",
+    "interactive"
+  ],
+  "complexity": 5
+}

--- a/fixtures/websites/55-algorithm-visualizer/fixture.json
+++ b/fixtures/websites/55-algorithm-visualizer/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "algorithm",
+    "visualizer",
+    "education",
+    "canvas",
+    "animation",
+    "data-viz"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/56-code-playground/fixture.json
+++ b/fixtures/websites/56-code-playground/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "code-editor",
+    "playground",
+    "app",
+    "developer-tool",
+    "canvas"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/57-webgl-shader-gallery/fixture.json
+++ b/fixtures/websites/57-webgl-shader-gallery/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "webgl",
+    "shader",
+    "gallery",
+    "canvas",
+    "graphics"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/58-infinite-whiteboard/fixture.json
+++ b/fixtures/websites/58-infinite-whiteboard/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "whiteboard",
+    "diagramming",
+    "canvas",
+    "app",
+    "productivity"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/59-spreadsheet/fixture.json
+++ b/fixtures/websites/59-spreadsheet/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "spreadsheet",
+    "app",
+    "productivity",
+    "formula-engine",
+    "data-viz"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/6-editorial-magazine/fixture.json
+++ b/fixtures/websites/6-editorial-magazine/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "docs/blog",
+  "tags": [
+    "magazine",
+    "editorial",
+    "news",
+    "blog",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/60-node-editor/fixture.json
+++ b/fixtures/websites/60-node-editor/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "node-editor",
+    "procedural",
+    "app",
+    "canvas",
+    "creative-tool"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/61-photo-editor/fixture.json
+++ b/fixtures/websites/61-photo-editor/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "photo-editor",
+    "image-editor",
+    "canvas",
+    "app",
+    "creative-tool"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/62-platformer-game/fixture.json
+++ b/fixtures/websites/62-platformer-game/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "game",
+    "platformer",
+    "canvas",
+    "audio",
+    "interactive"
+  ],
+  "complexity": 5
+}

--- a/fixtures/websites/63-map-explorer/fixture.json
+++ b/fixtures/websites/63-map-explorer/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "map",
+    "explorer",
+    "interactive",
+    "app",
+    "data-viz"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/64-kanban-board/fixture.json
+++ b/fixtures/websites/64-kanban-board/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "kanban",
+    "board",
+    "app",
+    "productivity",
+    "drag-and-drop"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/65-terminal-emulator/fixture.json
+++ b/fixtures/websites/65-terminal-emulator/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "terminal",
+    "emulator",
+    "developer-tool",
+    "canvas",
+    "app"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/66-regex-tester/fixture.json
+++ b/fixtures/websites/66-regex-tester/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "regex",
+    "tester",
+    "developer-tool",
+    "app",
+    "utility"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/67-dataviz-studio/fixture.json
+++ b/fixtures/websites/67-dataviz-studio/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "data-viz",
+    "charts",
+    "studio",
+    "canvas",
+    "app"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/68-drum-machine/fixture.json
+++ b/fixtures/websites/68-drum-machine/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "drum-machine",
+    "web-audio",
+    "audio",
+    "music",
+    "canvas",
+    "sequencer"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/69-markdown-editor/fixture.json
+++ b/fixtures/websites/69-markdown-editor/fixture.json
@@ -1,0 +1,11 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "markdown-editor",
+    "writing",
+    "app",
+    "productivity",
+    "editor"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/7-event-conference/fixture.json
+++ b/fixtures/websites/7-event-conference/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "event",
+    "conference",
+    "landing",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "schedule"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/70-typing-test/fixture.json
+++ b/fixtures/websites/70-typing-test/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "app/dashboard",
+  "tags": [
+    "typing-test",
+    "utility",
+    "app",
+    "canvas",
+    "audio",
+    "data-viz",
+    "has-stats"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/71-beyond-the-block/fixture.json
+++ b/fixtures/websites/71-beyond-the-block/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "canvas/webgl/audio/runtime-heavy",
+  "tags": [
+    "demo",
+    "interactive",
+    "canvas",
+    "webgl",
+    "audio",
+    "showcase",
+    "has-nav"
+  ],
+  "complexity": 4
+}

--- a/fixtures/websites/72-why-wordpress/fixture.json
+++ b/fixtures/websites/72-why-wordpress/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "marketing",
+    "editorial",
+    "wordpress",
+    "has-form",
+    "has-nav",
+    "multipage",
+    "scroll-animation"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/73-h44-lacrosse/fixture.json
+++ b/fixtures/websites/73-h44-lacrosse/fixture.json
@@ -1,0 +1,13 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "sports",
+    "lacrosse",
+    "club",
+    "local",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/8-local-service-business/fixture.json
+++ b/fixtures/websites/8-local-service-business/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "local-business",
+    "services",
+    "plumbing",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}

--- a/fixtures/websites/9-membership-community/fixture.json
+++ b/fixtures/websites/9-membership-community/fixture.json
@@ -1,0 +1,12 @@
+{
+  "class": "marketing/static",
+  "tags": [
+    "membership",
+    "community",
+    "club",
+    "has-form",
+    "has-nav",
+    "multipage"
+  ],
+  "complexity": 2
+}


### PR DESCRIPTION
## Summary

Adds a `fixture.json` classification manifest to each of the **72** fixture directories under `fixtures/websites/`. This is **data only** — no fixture HTML/CSS/JS content and no source code (incl. `php-transformer/`) was modified.

Each manifest has the shape:

```json
{ "class": "marketing/static", "tags": ["restaurant","has-form","multipage"], "complexity": 1 }
```

- **`class`** — one of the canonical `FIXTURE_CLASSES` (sourced from homeboy-rigs `lib/fixture-matrix.mjs`): `marketing/static`, `docs/blog`, `ecommerce/catalog`, `app/dashboard`, `canvas/webgl/audio/runtime-heavy`, `unknown`.
- **`tags`** — lowercase-kebab strings capturing industry/type (e.g. `restaurant`, `saas`, `portfolio`, `nonprofit`) and detected components/features (`has-form`, `has-nav`, `multipage`, `canvas`, `webgl`, `audio`, `data-viz`, `pricing`, etc.).
- **`complexity`** — int `1` (trivial static one-pager) → `5` (full runtime app).

Classes were assigned by inspecting each fixture's actual markup, CSS, and JS rather than directory names alone.

## Focus: the `marketing/static` lane

Per the brief, the static/marketing lane was prioritized and kept **conservative** — sites that are genuinely runtime apps (canvas/webgl/audio/games/simulations) are classified as such rather than inflated into the static lane. Heavy-JS *marketing* pages (e.g. scroll-driven product launches) with no canvas/webgl/audio runtime stay in `marketing/static`.

## Class distribution (72 total)

| class | count |
|-------|-------|
| `marketing/static` | 30 |
| `docs/blog` | 14 |
| `app/dashboard` | 13 |
| `canvas/webgl/audio/runtime-heavy` | 13 |
| `ecommerce/catalog` | 2 |

## Validation

- Every fixture dir under `fixtures/websites/` has a `fixture.json` (72/72).
- Every `class` value is in the canonical vocabulary.
- All files are valid JSON, 2-space indent, consistent shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Inspecting fixture markup/CSS/JS, assigning class/tags/complexity, and authoring the 72 manifest files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)