### PR TITLE
Surface Figma dev-status as the primary frame-selection signal (#280)

### DIFF
--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -9,6 +9,16 @@ declare(strict_types=1);
 function matrix_select_frame_ids(array $inspection, int $maxPages): array
 {
     $candidates = is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array();
+
+    // Figma Dev Mode status (#280) is the PRIMARY signal when present: restrict
+    // to ready_for_dev/completed candidates and let heuristics order them.
+    if ( 'dev_status' === matrix_selection_source($candidates) ) {
+        $candidates = array_values(array_filter(
+            $candidates,
+            static fn (mixed $candidate): bool => is_array($candidate) && null !== matrix_candidate_dev_status($candidate)
+        ));
+    }
+
     usort($candidates, static fn (mixed $a, mixed $b): int => matrix_candidate_rank(is_array($b) ? $b : array()) <=> matrix_candidate_rank(is_array($a) ? $a : array()));
 
     $selected = array();
@@ -97,11 +107,49 @@ function matrix_order_selected_frame_ids(array $selected, array $candidates): ar
 }
 
 /**
+ * Determine which signal drives matrix selection: 'dev_status' when any
+ * candidate carries a normalized Figma dev status, otherwise 'heuristic'.
+ *
+ * @param array<int, mixed> $candidates
+ */
+function matrix_selection_source(array $candidates): string
+{
+    foreach ( $candidates as $candidate ) {
+        if ( is_array($candidate) && null !== matrix_candidate_dev_status($candidate) ) {
+            return 'dev_status';
+        }
+    }
+
+    return 'heuristic';
+}
+
+/**
+ * @param array<string, mixed> $candidate
+ */
+function matrix_candidate_dev_status(array $candidate): ?string
+{
+    $status = $candidate['dev_status'] ?? null;
+    if ( in_array($status, array('ready_for_dev', 'completed'), true) ) {
+        return (string) $status;
+    }
+
+    return null;
+}
+
+/**
  * @param array<string, mixed> $candidate
  */
 function matrix_candidate_rank(array $candidate): int
 {
     $score = isset($candidate['score']) && is_numeric($candidate['score']) ? (int) $candidate['score'] : 0;
+
+    $devStatus = matrix_candidate_dev_status($candidate);
+    if ( 'completed' === $devStatus ) {
+        $score += 1200;
+    } elseif ( 'ready_for_dev' === $devStatus ) {
+        $score += 800;
+    }
+
     $name = strtolower((string) ($candidate['name'] ?? ''));
     $pageName = strtolower((string) ($candidate['page']['name'] ?? ''));
     $type = strtoupper((string) ($candidate['type'] ?? ''));

--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -378,8 +378,15 @@ final class FigKiwiDecoder
     private function defaultScenegraphFieldPolicy(): array
     {
         return array(
-            'Message' => array('type', 'nodeChanges', 'blobs', 'blobBaseIndex', 'fileVersion'),
+            // `handoffStatus`/`sectionStatus` may also surface at the file root
+            // as a handoff map, so they are whitelisted on the root Message too.
+            'Message' => array('type', 'nodeChanges', 'blobs', 'blobBaseIndex', 'fileVersion', 'sectionStatus', 'handoffStatus'),
             'NodeChange' => array(
+                // Figma Dev Mode status (#280): Ready-for-dev / Completed signal.
+                // `sectionStatus`/`sectionStatusInfo` ride on SECTION nodes,
+                // `handoffStatus` carries the dev-handoff map, and
+                // `currentStatus`/`statusInfo` mirror NodeStatusChange fields.
+                'sectionStatus', 'sectionStatusInfo', 'handoffStatus', 'currentStatus', 'statusInfo', 'devStatus',
                 'guid', 'parentIndex', 'type', 'name', 'visible', 'opacity', 'size', 'transform',
                 'useAbsoluteBounds', 'cornerRadius', 'rectangleTopLeftCornerRadius',
                 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius',
@@ -417,6 +424,14 @@ final class FigKiwiDecoder
             'DerivedSymbolData' => array('symbolID', 'symbolOverrides', 'uniformScaleFactor'),
             'GUIDPath' => array('guids'),
             'StyleId' => array('guid'),
+            // Dev-status structs (#280). The status enum itself decodes to its
+            // token string automatically, so only the struct/entry field names
+            // that reach it need whitelisting. Over-listing plausible inner
+            // field names is safe: unknown fields are skipped, not mis-read.
+            'SectionStatusInfo' => array('status', 'currentStatus', 'statusInfo', 'type', 'name', 'description'),
+            'HandoffStatusMap' => array('entries', 'values', 'handoffStatuses'),
+            'HandoffStatusMapEntry' => array('key', 'guid', 'nodeId', 'value', 'status', 'statusInfo', 'currentStatus'),
+            'NodeStatusChange' => array('guid', 'nodeId', 'currentStatus', 'statusInfo', 'status'),
         );
     }
 

--- a/figma-transformer/src/Html/VisualNodeMapBuilder.php
+++ b/figma-transformer/src/Html/VisualNodeMapBuilder.php
@@ -85,6 +85,8 @@ final class VisualNodeMapBuilder
                 ),
                 'image' => null === $imagePaint ? null : $this->visualImageMetadata($imagePaint),
                 'text' => empty($text) ? null : $this->visualTextMetadata($text),
+                // Figma Dev Mode status (#280) surfaced for the diagnostics map.
+                'dev_status' => isset($node['dev_status']) && is_string($node['dev_status']) ? $node['dev_status'] : null,
             );
             if ( null !== $visibleRect && $visibleRect !== $nodeRect ) {
                 $entry['visible_rect'] = $visibleRect;

--- a/figma-transformer/src/Scenegraph/ScenegraphDevStatus.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphDevStatus.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Resolves Figma Dev Mode "Ready for dev" / "Completed" status from the raw
+ * Kiwi-decoded scenegraph fields.
+ *
+ * The public Figma REST `devStatus` is a projection of internal Kiwi schema
+ * state. The `.fig` schema (version 106) carries the same signal under internal
+ * names on `NodeChange`/section nodes and a file-level handoff map:
+ *
+ *   - `sectionStatus` / `sectionStatusInfo` (type `SectionStatusInfo`) —
+ *     Ready-for-dev status on SECTION nodes.
+ *   - `handoffStatus` (type `HandoffStatusMap` of `HandoffStatusMapEntry`) —
+ *     dev-handoff state keyed by node.
+ *   - `NodeStatusChange` with `currentStatus` / `statusInfo`.
+ *
+ * The enum carries tokens `DEV_HANDOFF`, `DEVELOPMENT`, and `COMPLETED`. Those
+ * are normalized onto a clean public value while the raw internal token is kept
+ * for auditability. The class never invents a normalized value: when an enum
+ * token is not in the known map, the raw token is carried and the normalized
+ * value stays null.
+ */
+final class ScenegraphDevStatus
+{
+    public const READY_FOR_DEV = 'ready_for_dev';
+    public const COMPLETED     = 'completed';
+
+    /**
+     * Internal Kiwi enum tokens → normalized public dev status.
+     *
+     * `COMPLETED` is the only unambiguous "done" state. The handoff/development
+     * tokens all describe a section that has been explicitly marked for dev
+     * work, which is the "Ready for dev" public state, so they normalize to
+     * {@see self::READY_FOR_DEV}. Tokens outside this map carry their raw value
+     * with a null normalized status rather than guessing.
+     *
+     * @var array<string, string>
+     */
+    private const ENUM_MAP = array(
+        'COMPLETED'             => self::COMPLETED,
+        'DEV_HANDOFF'           => self::READY_FOR_DEV,
+        'DEVELOPMENT'           => self::READY_FOR_DEV,
+        'READY_FOR_DEV'         => self::READY_FOR_DEV,
+        'READY_FOR_DEVELOPMENT' => self::READY_FOR_DEV,
+    );
+
+    /**
+     * Status-bearing field names that may appear directly on a node.
+     *
+     * @var array<int, string>
+     */
+    private const STATUS_KEYS = array(
+        'sectionStatus',
+        'sectionStatusInfo',
+        'handoffStatus',
+        'currentStatus',
+        'statusInfo',
+        'devStatus',
+    );
+
+    /**
+     * Nested keys that carry the status enum inside a status struct/entry.
+     *
+     * @var array<int, string>
+     */
+    private const NESTED_STATUS_KEYS = array(
+        'status',
+        'currentStatus',
+        'statusInfo',
+        'type',
+        'value',
+    );
+
+    private const MAX_DEPTH = 5;
+
+    /**
+     * Resolve a node's dev status from its raw Kiwi-decoded fields.
+     *
+     * @param array<string, mixed> $node
+     * @return array{normalized: ?string, raw: string}|null Null when the node carries no status field.
+     */
+    public static function resolve(array $node): ?array
+    {
+        $raw = self::extractRawToken($node, 0);
+        if ( null === $raw ) {
+            return null;
+        }
+
+        return array(
+            'normalized' => self::ENUM_MAP[strtoupper($raw)] ?? null,
+            'raw'        => $raw,
+        );
+    }
+
+    /**
+     * Normalize a single raw enum token in isolation.
+     */
+    public static function normalizeToken(string $token): ?string
+    {
+        $trimmed = trim($token);
+        if ( '' === $trimmed ) {
+            return null;
+        }
+
+        return self::ENUM_MAP[strtoupper($trimmed)] ?? null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private static function extractRawToken(array $node, int $depth): ?string
+    {
+        foreach ( self::STATUS_KEYS as $key ) {
+            if ( ! array_key_exists($key, $node) ) {
+                continue;
+            }
+
+            $token = self::tokenFromValue($node[$key], $depth + 1);
+            if ( null !== $token ) {
+                return $token;
+            }
+        }
+
+        return null;
+    }
+
+    private static function tokenFromValue(mixed $value, int $depth): ?string
+    {
+        if ( $depth > self::MAX_DEPTH ) {
+            return null;
+        }
+
+        if ( is_string($value) ) {
+            $trimmed = trim($value);
+            return '' === $trimmed ? null : $trimmed;
+        }
+
+        if ( is_int($value) ) {
+            // An enum value the generic decoder could not map to a name still
+            // carries a real signal; keep the numeric token as a string.
+            return (string) $value;
+        }
+
+        if ( ! is_array($value) ) {
+            return null;
+        }
+
+        foreach ( self::NESTED_STATUS_KEYS as $key ) {
+            if ( array_key_exists($key, $value) ) {
+                $token = self::tokenFromValue($value[$key], $depth + 1);
+                if ( null !== $token ) {
+                    return $token;
+                }
+            }
+        }
+
+        // Handoff maps store entries as a list; dig each entry by status keys.
+        foreach ( $value as $entry ) {
+            if ( is_array($entry) ) {
+                $token = self::tokenFromValue($entry, $depth + 1);
+                if ( null !== $token ) {
+                    return $token;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -502,6 +502,14 @@ final class ScenegraphNormalizer
             $node['figma_link'] = $link;
         }
 
+        $devStatus = ScenegraphDevStatus::resolve($node);
+        if ( null !== $devStatus ) {
+            // Clean public value (ready_for_dev|completed|null) plus the raw
+            // internal token for auditability (#280).
+            $node['dev_status']     = $devStatus['normalized'];
+            $node['dev_status_raw'] = $devStatus['raw'];
+        }
+
         foreach ( array('children', 'nodes') as $childrenKey ) {
             if ( ! is_array($node[$childrenKey] ?? null) ) {
                 continue;

--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -130,8 +130,15 @@ final class ScenegraphPagePlanner
             );
         }
 
+        // Figma Dev Mode status (#280): when ANY node in the file carries a
+        // normalized dev status, it becomes the PRIMARY frame-selection signal.
+        $nodeDevStatus = $this->resolveNodeDevStatus($nodes);
+        $frameDevStatus = $this->resolveFrameDevStatus($candidates, $nodeDevStatus, $parentIndex);
+        $fileHasDevStatus = array() !== $nodeDevStatus;
+
         $selectedIds = array();
         $explicitSelected = false;
+        $selectionSource = 'heuristic';
         if ( ! empty($explicitFrameIds) ) {
             $explicitSelected = true;
             foreach ( $explicitFrameIds as $id ) {
@@ -146,6 +153,16 @@ final class ScenegraphPagePlanner
                     'message'  => 'Skipped a requested frame because it was not found as a FRAME node.',
                     'frame_id' => $id,
                 );
+            }
+        } elseif ( $fileHasDevStatus && array() !== $frameDevStatus ) {
+            // Prefer ready_for_dev/completed frames (and frames under a marked
+            // section); skip WIP/unmarked frames. Heuristics stay as the order
+            // within the marked set and as the fallback when no frame qualifies.
+            $selectionSource = 'dev_status';
+            $markedCandidates = array_intersect_key($candidates, $frameDevStatus);
+            $selectedIds = $this->rankedCandidateIdsByDevStatus($markedCandidates, $frameDevStatus);
+            if ( ! $includeAllPages ) {
+                $selectedIds = array_slice($selectedIds, 0, 1);
             }
         } else {
             $selectedIds = $this->rankedCandidateIds($candidates);
@@ -231,12 +248,193 @@ final class ScenegraphPagePlanner
             ++$emittedPosition;
         }
 
+        $devStatusCoverage = $this->devStatusCoverage($nodes, $frameDevStatus, $selectionSource, $fileHasDevStatus);
+        // Emit the coverage as a diagnostic only when a dev-status signal is
+        // actually present, so files without dev-status keep a clean (empty)
+        // diagnostics list. The coverage report is always available via the
+        // `dev_status_coverage` plan key regardless.
+        if ( $fileHasDevStatus ) {
+            $diagnostics[] = array(
+                'severity' => 'info',
+                'code'     => 'figma_dev_status_coverage',
+                'message'  => 'dev_status' === $selectionSource
+                    ? 'Frame selection was driven by Figma dev-status.'
+                    : 'Dev-status present but no FRAME qualified; heuristics drove selection.',
+                'coverage' => $devStatusCoverage,
+            );
+        }
+
         return array(
-            'schema'          => 'blocks-engine/figma-transformer/page-plan/v1',
-            'page_count'      => count($pages),
-            'candidate_count' => count($candidates),
-            'pages'           => $pages,
-            'diagnostics'     => $diagnostics,
+            'schema'              => 'blocks-engine/figma-transformer/page-plan/v1',
+            'page_count'          => count($pages),
+            'candidate_count'     => count($candidates),
+            'pages'               => $pages,
+            'selection_source'    => $selectionSource,
+            'dev_status_coverage' => $devStatusCoverage,
+            'diagnostics'         => $diagnostics,
+        );
+    }
+
+    /**
+     * Resolve normalized dev status (ready_for_dev|completed) for every node
+     * that carries one. Nodes without a status, or with an unmapped raw token,
+     * are omitted so they never count as a selection signal.
+     *
+     * @param array<string, array<string, mixed>> $nodes
+     * @return array<string, string> node id => normalized status
+     */
+    private function resolveNodeDevStatus(array $nodes): array
+    {
+        $statusById = array();
+        foreach ( $nodes as $id => $node ) {
+            if ( ! is_string($id) || ! is_array($node) ) {
+                continue;
+            }
+
+            $resolved = ScenegraphDevStatus::resolve($node);
+            if ( null !== $resolved && null !== $resolved['normalized'] ) {
+                $statusById[$id] = $resolved['normalized'];
+            }
+        }
+
+        return $statusById;
+    }
+
+    /**
+     * Map each FRAME candidate to its effective dev status: the frame's own
+     * normalized status, or the nearest ancestor (e.g. its SECTION) that carries
+     * one. Frames with no marked status anywhere in their ancestry are omitted.
+     *
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, string>               $nodeDevStatus
+     * @param array<string, string|null>          $parentIndex
+     * @return array<string, string> frame id => normalized status
+     */
+    private function resolveFrameDevStatus(array $candidates, array $nodeDevStatus, array $parentIndex): array
+    {
+        if ( array() === $nodeDevStatus ) {
+            return array();
+        }
+
+        $frameStatus = array();
+        foreach ( array_keys($candidates) as $frameId ) {
+            $frameId = (string) $frameId;
+            $cursor = $frameId;
+            $guard = 0;
+            while ( is_string($cursor) && '' !== $cursor && $guard < 4096 ) {
+                if ( isset($nodeDevStatus[$cursor]) ) {
+                    $frameStatus[$frameId] = $nodeDevStatus[$cursor];
+                    break;
+                }
+                $cursor = $parentIndex[$cursor] ?? null;
+                ++$guard;
+            }
+        }
+
+        return $frameStatus;
+    }
+
+    /**
+     * Rank dev-status-marked FRAME candidates: completed first, then
+     * ready_for_dev, with the existing heuristic score as the tiebreak so order
+     * within a status band stays deterministic and backward compatible.
+     *
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, string>               $statusById
+     * @return array<int, string>
+     */
+    private function rankedCandidateIdsByDevStatus(array $candidates, array $statusById): array
+    {
+        uasort(
+            $candidates,
+            function (array $left, array $right) use ($statusById): int {
+                $leftRank = $this->devStatusRank((string) ($statusById[(string) ($left['id'] ?? '')] ?? ''));
+                $rightRank = $this->devStatusRank((string) ($statusById[(string) ($right['id'] ?? '')] ?? ''));
+                if ( $leftRank !== $rightRank ) {
+                    return $leftRank <=> $rightRank;
+                }
+
+                return $right['score'] <=> $left['score']
+                    ?: strcmp((string) ($left['id'] ?? ''), (string) ($right['id'] ?? ''));
+            }
+        );
+
+        $ids = array_keys($candidates);
+        $nonWrapperIds = array_values(array_filter(
+            $ids,
+            fn (string $id): bool => ! $this->isWrapperName((string) ($candidates[$id]['node']['name'] ?? ''))
+        ));
+
+        return empty($nonWrapperIds) ? $ids : $nonWrapperIds;
+    }
+
+    private function devStatusRank(string $status): int
+    {
+        return match ( $status ) {
+            ScenegraphDevStatus::COMPLETED     => 0,
+            ScenegraphDevStatus::READY_FOR_DEV => 1,
+            default                            => 2,
+        };
+    }
+
+    /**
+     * Build the dev-status coverage diagnostic: per-status counts for SECTION
+     * and FRAME nodes, raw-token tallies, and the signal that drove selection.
+     *
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, string>               $frameDevStatus
+     * @return array<string, mixed>
+     */
+    private function devStatusCoverage(array $nodes, array $frameDevStatus, string $selectionSource, bool $fileHasDevStatus): array
+    {
+        $sections = array('ready_for_dev' => 0, 'completed' => 0, 'unmapped' => 0);
+        $frames = array('ready_for_dev' => 0, 'completed' => 0, 'unmapped' => 0);
+        $rawTokens = array();
+        $nodesWithRawStatus = 0;
+
+        foreach ( $nodes as $node ) {
+            if ( ! is_array($node) ) {
+                continue;
+            }
+
+            $resolved = ScenegraphDevStatus::resolve($node);
+            if ( null === $resolved ) {
+                continue;
+            }
+
+            ++$nodesWithRawStatus;
+            $rawKey = $resolved['raw'];
+            $rawTokens[$rawKey] = ($rawTokens[$rawKey] ?? 0) + 1;
+
+            $bucket = match ( $resolved['normalized'] ) {
+                ScenegraphDevStatus::READY_FOR_DEV => 'ready_for_dev',
+                ScenegraphDevStatus::COMPLETED     => 'completed',
+                default                            => 'unmapped',
+            };
+
+            $type = strtoupper((string) ($node['type'] ?? ''));
+            if ( 'SECTION' === $type ) {
+                ++$sections[$bucket];
+            } elseif ( 'FRAME' === $type ) {
+                ++$frames[$bucket];
+            }
+        }
+
+        $frameEffective = array('ready_for_dev' => 0, 'completed' => 0);
+        foreach ( $frameDevStatus as $status ) {
+            if ( isset($frameEffective[$status]) ) {
+                ++$frameEffective[$status];
+            }
+        }
+
+        return array(
+            'selection_source'        => $selectionSource,
+            'file_has_dev_status'     => $fileHasDevStatus,
+            'nodes_with_raw_status'   => $nodesWithRawStatus,
+            'sections'                => $sections,
+            'frames'                  => $frames,
+            'frames_effective'        => $frameEffective,
+            'raw_tokens'              => $rawTokens,
         );
     }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5138,6 +5138,172 @@ $assert('does:not:exist' === ($unresolvedLinks['unresolved_targets'][0]['target_
 $assert(in_array('link_target_unresolved', $unresolvedSignalCodes, true), 'unresolved-link-artifact-quality-signal');
 $assert(in_array('link_target_unresolved', $unresolvedDiagnosticCodes, true), 'unresolved-link-diagnostic-code');
 
+// ---------------------------------------------------------------------------
+// Figma Dev Mode status (#280): decode -> normalize -> select -> diagnose.
+// ---------------------------------------------------------------------------
+
+// DECODE: the extended field policy carries sectionStatus through the REAL
+// generic Kiwi decoder, and the enum resolves to its token string.
+$devStatusDecoder = new FigKiwiDecoder();
+$devStatusSchema = $devStatusDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_dev_status_schema_fixture());
+$assert(null !== ($devStatusSchema['schema'] ?? null), 'dev-status-kiwi-schema-decodes');
+$devStatusMessage = $devStatusDecoder->decodeMessageSelective(
+    blocks_engine_figma_transformer_kiwi_dev_status_message_fixture(),
+    $devStatusSchema['schema'] ?? array()
+);
+$devStatusNodeChange = $devStatusMessage['message']['nodeChanges'][0] ?? array();
+$assert('DOCUMENT' === ($devStatusMessage['message']['type'] ?? null), 'dev-status-kiwi-message-root-decodes');
+$assert('SECTION' === ($devStatusNodeChange['type'] ?? null), 'dev-status-kiwi-section-node-decodes');
+$assert('COMPLETED' === ($devStatusNodeChange['sectionStatus'] ?? null), 'dev-status-field-policy-carries-section-status');
+
+// NORMALIZE: raw sectionStatus tokens map onto a clean dev_status with the raw
+// value carried for auditability.
+$devStatusNormalizer = new \Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer();
+$devStatusSource = array(
+    'name'  => 'Dev Status Site',
+    'nodes' => array(
+        array(
+            'id'       => 'page:dev',
+            'type'     => 'CANVAS',
+            'name'     => 'Pages',
+            'children' => array(
+                array(
+                    'id'            => 'section:ready',
+                    'type'          => 'SECTION',
+                    'name'          => 'Ready section',
+                    'sectionStatus' => 'DEV_HANDOFF',
+                    'children'      => array(
+                        array(
+                            'id'       => 'frame:ready-home',
+                            'type'     => 'FRAME',
+                            'name'     => 'Ready Home',
+                            'width'    => 1440,
+                            'height'   => 1400,
+                            'children' => array(
+                                array('id' => 'text:ready', 'type' => 'TEXT', 'name' => 'Ready title', 'characters' => 'Ready Hero'),
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'                => 'section:done',
+                    'type'              => 'SECTION',
+                    'name'              => 'Done section',
+                    'sectionStatusInfo' => array('status' => 'COMPLETED'),
+                    'children'          => array(
+                        array(
+                            'id'       => 'frame:done-about',
+                            'type'     => 'FRAME',
+                            'name'     => 'Done About',
+                            'width'    => 1440,
+                            'height'   => 1300,
+                            'children' => array(
+                                array('id' => 'text:done', 'type' => 'TEXT', 'name' => 'Done title', 'characters' => 'Done Hero'),
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'       => 'frame:wip',
+                    'type'     => 'FRAME',
+                    'name'     => 'WIP Draft',
+                    'width'    => 1440,
+                    'height'   => 1200,
+                    'children' => array(
+                        array('id' => 'text:wip', 'type' => 'TEXT', 'name' => 'WIP title', 'characters' => 'WIP Hero'),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$devStatusNormalized = $devStatusNormalizer->normalize($devStatusSource);
+$devStatusNodeMap = is_array($devStatusNormalized['node_map'] ?? null) ? $devStatusNormalized['node_map'] : array();
+$assert('ready_for_dev' === ($devStatusNodeMap['section:ready']['dev_status'] ?? null), 'dev-status-normalizes-ready-for-dev');
+$assert('DEV_HANDOFF' === ($devStatusNodeMap['section:ready']['dev_status_raw'] ?? null), 'dev-status-carries-raw-handoff-token');
+$assert('completed' === ($devStatusNodeMap['section:done']['dev_status'] ?? null), 'dev-status-normalizes-completed');
+$assert('COMPLETED' === ($devStatusNodeMap['section:done']['dev_status_raw'] ?? null), 'dev-status-carries-raw-completed-token');
+$assert(! array_key_exists('dev_status', $devStatusNodeMap['frame:wip'] ?? array()), 'dev-status-absent-on-unmarked-frame');
+
+// SELECT: dev-status is the PRIMARY signal — marked frames selected (completed
+// first), unmarked WIP frame skipped, and selection_source records the signal.
+$devStatusPlanner = new ScenegraphPagePlanner();
+$devStatusPlan = $devStatusPlanner->plan($devStatusSource, array('include_all_pages' => true));
+$devStatusPlanFrameIds = array_map(
+    static fn (array $page): string => (string) ($page['frame_id'] ?? ''),
+    is_array($devStatusPlan['pages'] ?? null) ? $devStatusPlan['pages'] : array()
+);
+$assert('dev_status' === ($devStatusPlan['selection_source'] ?? null), 'dev-status-drives-selection-source');
+$assert(in_array('frame:ready-home', $devStatusPlanFrameIds, true), 'dev-status-selects-ready-frame');
+$assert(in_array('frame:done-about', $devStatusPlanFrameIds, true), 'dev-status-selects-completed-frame');
+$assert(! in_array('frame:wip', $devStatusPlanFrameIds, true), 'dev-status-skips-unmarked-wip-frame');
+$assert('frame:done-about' === ($devStatusPlanFrameIds[0] ?? null), 'dev-status-completed-frame-ranks-first');
+
+// DIAGNOSE: coverage report + selection_source populated and emitted.
+$devStatusCoverage = is_array($devStatusPlan['dev_status_coverage'] ?? null) ? $devStatusPlan['dev_status_coverage'] : array();
+$assert(true === ($devStatusCoverage['file_has_dev_status'] ?? null), 'dev-status-coverage-flags-presence');
+$assert(1 === ($devStatusCoverage['sections']['ready_for_dev'] ?? null), 'dev-status-coverage-counts-ready-section');
+$assert(1 === ($devStatusCoverage['sections']['completed'] ?? null), 'dev-status-coverage-counts-completed-section');
+$assert(1 === ($devStatusCoverage['frames_effective']['ready_for_dev'] ?? null), 'dev-status-coverage-counts-ready-frame');
+$assert(1 === ($devStatusCoverage['frames_effective']['completed'] ?? null), 'dev-status-coverage-counts-completed-frame');
+$devStatusPlanDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    is_array($devStatusPlan['diagnostics'] ?? null) ? $devStatusPlan['diagnostics'] : array()
+);
+$assert(in_array('figma_dev_status_coverage', $devStatusPlanDiagnosticCodes, true), 'dev-status-coverage-diagnostic-emitted');
+
+// FALLBACK: with NO dev-status anywhere, heuristics drive selection unchanged.
+$heuristicSource = array(
+    'name'  => 'Heuristic Site',
+    'nodes' => array(
+        array(
+            'id'       => 'page:heur',
+            'type'     => 'CANVAS',
+            'name'     => 'Pages',
+            'children' => array(
+                array(
+                    'id'       => 'frame:heur-home',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home',
+                    'width'    => 1440,
+                    'height'   => 1400,
+                    'children' => array(
+                        array('id' => 'text:heur', 'type' => 'TEXT', 'name' => 'Heur title', 'characters' => 'Heur Hero'),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$heuristicPlan = $devStatusPlanner->plan($heuristicSource, array('include_all_pages' => true));
+$heuristicFrameIds = array_map(
+    static fn (array $page): string => (string) ($page['frame_id'] ?? ''),
+    is_array($heuristicPlan['pages'] ?? null) ? $heuristicPlan['pages'] : array()
+);
+$heuristicDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    is_array($heuristicPlan['diagnostics'] ?? null) ? $heuristicPlan['diagnostics'] : array()
+);
+$assert('heuristic' === ($heuristicPlan['selection_source'] ?? null), 'no-dev-status-falls-back-to-heuristic');
+$assert(false === ($heuristicPlan['dev_status_coverage']['file_has_dev_status'] ?? null), 'no-dev-status-coverage-flags-absence');
+$assert(array('frame:heur-home') === $heuristicFrameIds, 'no-dev-status-selects-heuristic-frame');
+$assert(! in_array('figma_dev_status_coverage', $heuristicDiagnosticCodes, true), 'no-dev-status-omits-coverage-diagnostic');
+
+// MATRIX: the standalone selector reports the driving signal and prefers
+// dev-status candidates when present.
+$matrixDevStatusCandidates = array(
+    array('id' => 'm:ready', 'name' => 'Ready Home', 'type' => 'FRAME', 'score' => 100, 'width' => 1440, 'height' => 1400, 'text_count' => 4, 'dev_status' => 'ready_for_dev', 'parent' => array('type' => 'SECTION'), 'page' => array('name' => 'Pages')),
+    array('id' => 'm:done', 'name' => 'Done About', 'type' => 'FRAME', 'score' => 90, 'width' => 1440, 'height' => 1300, 'text_count' => 3, 'dev_status' => 'completed', 'parent' => array('type' => 'SECTION'), 'page' => array('name' => 'Pages')),
+    array('id' => 'm:wip', 'name' => 'WIP Draft', 'type' => 'FRAME', 'score' => 500, 'width' => 1440, 'height' => 1200, 'text_count' => 5, 'parent' => array('type' => 'CANVAS'), 'page' => array('name' => 'Pages')),
+);
+$assert('dev_status' === matrix_selection_source($matrixDevStatusCandidates), 'matrix-reports-dev-status-source');
+$matrixDevStatusSelection = matrix_select_frame_ids(array('candidates' => $matrixDevStatusCandidates), 5);
+$assert(in_array('m:done', $matrixDevStatusSelection, true) && in_array('m:ready', $matrixDevStatusSelection, true), 'matrix-selects-dev-status-frames');
+$assert(! in_array('m:wip', $matrixDevStatusSelection, true), 'matrix-skips-unmarked-frame-despite-higher-score');
+$assert('heuristic' === matrix_selection_source(array(
+    array('id' => 'h:home', 'name' => 'Home', 'type' => 'FRAME', 'score' => 100, 'parent' => array('type' => 'CANVAS'), 'page' => array('name' => 'Pages')),
+)), 'matrix-reports-heuristic-source-without-dev-status');
+
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 
 if ( ! empty($failures) ) {
@@ -5265,6 +5431,55 @@ function blocks_engine_figma_transformer_kiwi_message_fixture(): string
         . blocks_engine_figma_transformer_wire_varint(2)
         . blocks_engine_figma_transformer_kiwi_string('alpha')
         . blocks_engine_figma_transformer_kiwi_string('beta')
+        . blocks_engine_figma_transformer_wire_varint(0);
+}
+
+/**
+ * Kiwi schema (version-106 shape) that defines a dev-status enum plus a
+ * NodeChange/Message pair carrying `sectionStatus`. Proves the field-policy
+ * extension (#280) reads the status through the REAL generic decoder.
+ */
+function blocks_engine_figma_transformer_kiwi_dev_status_schema_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(3)
+        // def0: ENUM SectionStatusType { DEV_HANDOFF = 1, COMPLETED = 2 }
+        . blocks_engine_figma_transformer_kiwi_string('SectionStatusType')
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('DEV_HANDOFF', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('COMPLETED', 0, false, 2)
+        // def1: MESSAGE NodeChange { type, name, sectionStatus }
+        . blocks_engine_figma_transformer_kiwi_string('NodeChange')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sectionStatus', 0, false, 3)
+        // def2: MESSAGE Message { type, nodeChanges[] }
+        . blocks_engine_figma_transformer_kiwi_string('Message')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 1, true, 2);
+}
+
+/**
+ * Kiwi message for {@see blocks_engine_figma_transformer_kiwi_dev_status_schema_fixture()}:
+ * one NodeChange of type SECTION with sectionStatus = COMPLETED (enum value 2).
+ */
+function blocks_engine_figma_transformer_kiwi_dev_status_message_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('DOCUMENT')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('SECTION')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('Completed Section')
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
 }
 


### PR DESCRIPTION
Refs #280, #247.

Surfaces Figma Dev Mode **"Ready for dev" / "Completed"** status from the **real schema-driven Kiwi decode** and uses it as the **primary** frame-selection signal, with today's heuristics demoted to fallback. No synthetic byte-guessing — the dev-status fields are already in the `.fig` Kiwi schema (v106), so the generic decoder reads them once whitelisted.

## Field-policy extension (DECODE)
Extends `FigKiwiDecoder::defaultScenegraphFieldPolicy()` — the same whitelist that already carries `booleanOperation` — so the real generic decoder carries:
- `NodeChange`: `sectionStatus`, `sectionStatusInfo`, `handoffStatus`, `currentStatus`, `statusInfo`, `devStatus`
- new struct types: `SectionStatusInfo`, `HandoffStatusMap`, `HandoffStatusMapEntry`, `NodeStatusChange`
- `Message` root: `sectionStatus`, `handoffStatus` (file-level handoff map)

Status enum tokens (`DEV_HANDOFF`, `DEVELOPMENT`, `COMPLETED`) resolve to their names through the existing ENUM machinery — over-listing plausible inner field names is safe because unknown fields are skipped, not mis-read.

## Enum mapping (NORMALIZE)
New `ScenegraphDevStatus` resolver maps the internal enum onto a clean `dev_status`:
- `COMPLETED` → `completed`
- `DEV_HANDOFF` / `DEVELOPMENT` → `ready_for_dev` (both are explicit "marked for dev" states)
- anything else → raw value carried, normalized stays `null` (no guessing)

The raw internal token is carried alongside as `dev_status_raw` for auditability. `ScenegraphNormalizer` sets both on nodes.

## Selection change (SELECT)
`ScenegraphPagePlanner`: when any node carries a normalized `dev_status`, it becomes the primary signal — prefer marked frames (completed first, then ready_for_dev) and frames under a marked section, **skip WIP/unmarked frames**, with the existing heuristic score as the in-band tiebreak. When no dev-status is present anywhere, selection falls back to today's heuristics **unchanged**.

## Diagnostics (DIAGNOSE)
Adds a `dev_status_coverage` report (per-status section/frame counts, raw-token tallies, `selection_source` = `dev_status` | `heuristic`) to the page plan, emitted as a diagnostic only when a signal is present. `dev_status` surfaced per node in `VisualNodeMapBuilder`; the fixture-matrix selector now prefers dev-status candidates and reports the driving signal.

## Tests
`figma-transformer/tests/contract/run.php` proves: decode-through (synthetic v106 schema → `sectionStatus=COMPLETED` carried), normalize mapping + raw token, dev-status-driven selection (ready/completed selected, WIP skipped, completed ranked first), heuristic fallback unchanged when absent, and coverage/`selection_source` population. `php tests/contract/run.php` → **"Figma Transformer contract tests passed."**

## Caveats
- **Enum→public mapping confidence:** `COMPLETED → completed` is unambiguous; `DEV_HANDOFF`/`DEVELOPMENT → ready_for_dev` is the most defensible reading of the handoff/in-dev states but is not yet value-confirmed against a real file.
- **Value-level validation needs a marked fixture** (an FSE re-export with Dev Mode statuses set) decoded on the lab — the large `.fig` fixtures (185-293MB) are RAM-heavy and banned locally, so this PR is validated with synthetic fixtures + contract tests only.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Wiring Figma dev-status (sectionStatus/handoffStatus) through the Kiwi decode into primary frame selection for #280.