### PR TITLE
Fix Figma dev-status enum: BUILD is "Ready for dev" (validated on real FSE fixture)

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphDevStatus.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphDevStatus.php
@@ -18,11 +18,12 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
  *     dev-handoff state keyed by node.
  *   - `NodeStatusChange` with `currentStatus` / `statusInfo`.
  *
- * The enum carries tokens `DEV_HANDOFF`, `DEVELOPMENT`, and `COMPLETED`. Those
- * are normalized onto a clean public value while the raw internal token is kept
- * for auditability. The class never invents a normalized value: when an enum
- * token is not in the known map, the raw token is carried and the normalized
- * value stays null.
+ * The `SectionStatus` enum carries tokens `NONE`, `BUILD`, and `COMPLETED`
+ * (`BUILD` is Figma's internal name for the public "Ready for dev" status).
+ * These are normalized onto a clean public value while the raw internal token
+ * is kept for auditability. The class never invents a normalized value: when an
+ * enum token is not in the known map, the raw token is carried and the
+ * normalized value stays null.
  */
 final class ScenegraphDevStatus
 {
@@ -32,20 +33,21 @@ final class ScenegraphDevStatus
     /**
      * Internal Kiwi enum tokens → normalized public dev status.
      *
-     * `COMPLETED` is the only unambiguous "done" state. The handoff/development
-     * tokens all describe a section that has been explicitly marked for dev
-     * work, which is the "Ready for dev" public state, so they normalize to
-     * {@see self::READY_FOR_DEV}. Tokens outside this map carry their raw value
-     * with a null normalized status rather than guessing.
+     * The `SectionStatus` enum has exactly three members: `NONE`, `BUILD`,
+     * `COMPLETED` (verified against real `.fig` schema + the FSE Pilot fixture
+     * decoded on the lab). Figma's internal token for the public "Ready for dev"
+     * status is `BUILD`; `COMPLETED` is "Completed"; `NONE` is unset. The
+     * public-API names (`READY_FOR_DEV`) are kept as defensive aliases for
+     * REST/plugin-sourced scenegraphs. Tokens outside this map (e.g. section
+     * TYPE values like `DEV_HANDOFF`, which are not statuses) carry their raw
+     * value with a null normalized status rather than guessing.
      *
      * @var array<string, string>
      */
     private const ENUM_MAP = array(
-        'COMPLETED'             => self::COMPLETED,
-        'DEV_HANDOFF'           => self::READY_FOR_DEV,
-        'DEVELOPMENT'           => self::READY_FOR_DEV,
-        'READY_FOR_DEV'         => self::READY_FOR_DEV,
-        'READY_FOR_DEVELOPMENT' => self::READY_FOR_DEV,
+        'BUILD'         => self::READY_FOR_DEV,
+        'COMPLETED'     => self::COMPLETED,
+        'READY_FOR_DEV' => self::READY_FOR_DEV,
     );
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5171,7 +5171,7 @@ $devStatusSource = array(
                     'id'            => 'section:ready',
                     'type'          => 'SECTION',
                     'name'          => 'Ready section',
-                    'sectionStatus' => 'DEV_HANDOFF',
+                    'sectionStatus' => 'BUILD',
                     'children'      => array(
                         array(
                             'id'       => 'frame:ready-home',
@@ -5220,7 +5220,7 @@ $devStatusSource = array(
 $devStatusNormalized = $devStatusNormalizer->normalize($devStatusSource);
 $devStatusNodeMap = is_array($devStatusNormalized['node_map'] ?? null) ? $devStatusNormalized['node_map'] : array();
 $assert('ready_for_dev' === ($devStatusNodeMap['section:ready']['dev_status'] ?? null), 'dev-status-normalizes-ready-for-dev');
-$assert('DEV_HANDOFF' === ($devStatusNodeMap['section:ready']['dev_status_raw'] ?? null), 'dev-status-carries-raw-handoff-token');
+$assert('BUILD' === ($devStatusNodeMap['section:ready']['dev_status_raw'] ?? null), 'dev-status-carries-raw-build-token');
 $assert('completed' === ($devStatusNodeMap['section:done']['dev_status'] ?? null), 'dev-status-normalizes-completed');
 $assert('COMPLETED' === ($devStatusNodeMap['section:done']['dev_status_raw'] ?? null), 'dev-status-carries-raw-completed-token');
 $assert(! array_key_exists('dev_status', $devStatusNodeMap['frame:wip'] ?? array()), 'dev-status-absent-on-unmarked-frame');
@@ -5442,11 +5442,11 @@ function blocks_engine_figma_transformer_kiwi_message_fixture(): string
 function blocks_engine_figma_transformer_kiwi_dev_status_schema_fixture(): string
 {
     return blocks_engine_figma_transformer_wire_varint(3)
-        // def0: ENUM SectionStatusType { DEV_HANDOFF = 1, COMPLETED = 2 }
-        . blocks_engine_figma_transformer_kiwi_string('SectionStatusType')
+        // def0: ENUM SectionStatus { BUILD = 1, COMPLETED = 2 } (real Figma enum; BUILD = "Ready for dev")
+        . blocks_engine_figma_transformer_kiwi_string('SectionStatus')
         . chr(0)
         . blocks_engine_figma_transformer_wire_varint(2)
-        . blocks_engine_figma_transformer_kiwi_schema_field('DEV_HANDOFF', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('BUILD', 0, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('COMPLETED', 0, false, 2)
         // def1: MESSAGE NodeChange { type, name, sectionStatus }
         . blocks_engine_figma_transformer_kiwi_string('NodeChange')


### PR DESCRIPTION
## What

Corrects the Figma dev-status enum mapping introduced in #280/#281. The real `SectionStatus` enum is `{ NONE, BUILD, COMPLETED }` — Figma's **internal token for the public "Ready for dev" status is `BUILD`**.

The original mapping guessed `DEV_HANDOFF`/`DEVELOPMENT → ready_for_dev`, but those tokens are section/file **TYPE** values (they sit among `WHITEBOARD`/`SLIDES`/`SITES`/`ILLUSTRATION`/`FIGMAKE` in the schema), not statuses. So real BUILD-marked frames decoded as `unmapped` and selection fell back to heuristics.

## How this was found

Decoded the real **FSE Pilot Build Theme** fixture on `homeboy-lab` (75MB, schema version 106). The dev-status diagnostic reported `raw_tokens: {"BUILD": 2}`, `frames.unmapped: 2`, `selection_source: heuristic`. Inspecting the schema enum confirmed `SectionStatus { NONE, BUILD, COMPLETED }`. The Kiwi decode plumbing (#281) was correct — only the normalization table was guessed.

## Change

- `ScenegraphDevStatus::ENUM_MAP` → `BUILD → ready_for_dev`, `COMPLETED → completed` (kept `READY_FOR_DEV` as a defensive REST/plugin alias); dropped the `DEV_HANDOFF`/`DEVELOPMENT` type-token guesses.
- Contract schema fixture + assertions updated to the real `SectionStatus { BUILD, COMPLETED }` enum.

Refs #280, #247. Next: re-decode FSE on the lab to confirm the 2 BUILD frames now resolve to `ready_for_dev` and drive `selection_source: dev_status`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Diagnosing the wrong enum mapping against real lab-decoded data and correcting it.