### PR TITLE
Surface dev_status on inspector candidates so matrix selection uses it

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
@@ -60,6 +60,7 @@ final class ScenegraphFrameInspector
                     'score'                 => $this->score($type, $dimensions, $stats),
                     'device_hint'           => $this->deviceHint((string) ($node['name'] ?? ''), $dimensions),
                     'sibling_group_key'     => $this->siblingGroupKey($id, $node, $nodes, $parentIndex),
+                    'dev_status'            => $this->candidateDevStatus($node),
                 ),
                 static fn (mixed $value): bool => null !== $value
             );
@@ -86,6 +87,20 @@ final class ScenegraphFrameInspector
             'candidates'      => array_slice($candidates, 0, $limit),
             'diagnostics'     => is_array($index['diagnostics'] ?? null) ? $index['diagnostics'] : array(),
         );
+    }
+
+    /**
+     * Resolve a candidate frame's own normalized dev status (ready_for_dev|
+     * completed), so the matrix frame-selector can prefer dev-marked frames.
+     * Returns null when the node carries no dev status.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function candidateDevStatus(array $node): ?string
+    {
+        $resolved = ScenegraphDevStatus::resolve($node);
+
+        return is_array($resolved) ? ($resolved['normalized'] ?? null) : null;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5304,6 +5304,35 @@ $assert('heuristic' === matrix_selection_source(array(
     array('id' => 'h:home', 'name' => 'Home', 'type' => 'FRAME', 'score' => 100, 'parent' => array('type' => 'CANVAS'), 'page' => array('name' => 'Pages')),
 )), 'matrix-reports-heuristic-source-without-dev-status');
 
+// INSPECT: candidates must surface the frame's own dev_status so the matrix
+// frame-selector (which keys on $candidate['dev_status']) can prefer dev-marked
+// frames. Without this the inspector handed the selector statusless candidates,
+// so selection_source stayed 'heuristic' even when the file had dev statuses.
+$inspectorDevStatusSource = array(
+    'name'  => 'Inspector Dev Status',
+    'nodes' => array(
+        array(
+            'id'       => 'canvas:1',
+            'type'     => 'CANVAS',
+            'name'     => 'Page 1',
+            'children' => array(
+                array('id' => 'frame:build', 'type' => 'FRAME', 'name' => 'Marked Home', 'width' => 1440, 'height' => 1400, 'sectionStatus' => 'BUILD', 'children' => array()),
+                array('id' => 'frame:plain', 'type' => 'FRAME', 'name' => 'Plain Page', 'width' => 1440, 'height' => 1200, 'children' => array()),
+            ),
+        ),
+    ),
+);
+$inspectorDevStatusResult = ( new Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphFrameInspector() )->inspect($inspectorDevStatusSource);
+$inspectorCandidates = array();
+foreach ( ( is_array($inspectorDevStatusResult['candidates'] ?? null) ? $inspectorDevStatusResult['candidates'] : array() ) as $inspectorCandidate ) {
+    if ( is_array($inspectorCandidate) && isset($inspectorCandidate['id']) ) {
+        $inspectorCandidates[(string) $inspectorCandidate['id']] = $inspectorCandidate;
+    }
+}
+$assert('ready_for_dev' === ($inspectorCandidates['frame:build']['dev_status'] ?? null), 'inspector-surfaces-dev-status-on-candidate');
+$assert(! array_key_exists('dev_status', $inspectorCandidates['frame:plain'] ?? array()), 'inspector-omits-dev-status-on-unmarked-candidate');
+$assert('dev_status' === matrix_selection_source(array_values($inspectorCandidates)), 'inspector-candidates-drive-dev-status-selection');
+
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 
 if ( ! empty($failures) ) {


### PR DESCRIPTION
## What

Completes the dev-status frame-selection feature (#280/#281, enum fix #282) by surfacing `dev_status` on the candidates the matrix selector actually consumes.

## Why

The matrix frame-selector (`figma-fixture-selection.php`) already had full dev-status logic — `matrix_selection_source` and candidate filtering key on `$candidate['dev_status']`. But `ScenegraphFrameInspector` (which builds the candidate list) never attached `dev_status`. So candidates arrived statusless, the selector's dev-status path was dead, and `selection_source` stayed `heuristic` even when the file had dev statuses.

## How this was found

Validated on `homeboy-lab` against the real **FSE Pilot** fixture (75MB). After the #282 enum fix, the diagnostic showed `file_has_dev_status: true` and 2 `BUILD` frames correctly normalized to `ready_for_dev` — but `selection_source` stayed `heuristic`. Tracing it: the planner's dev-status selection only runs without explicit frame ids, and the matrix pre-selects via the inspector candidates, which carried no `dev_status`.

## Change

- `ScenegraphFrameInspector` now resolves each candidate's own normalized dev status via `ScenegraphDevStatus::resolve()` and attaches `dev_status`.
- Contract test: a `BUILD`-marked frame yields a candidate with `dev_status: ready_for_dev`, an unmarked frame has none, and `matrix_selection_source` then reports `dev_status`.

Refs #280, #247. Next: re-decode FSE on the lab to confirm `selection_source` flips to `dev_status`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Tracing the heuristic-selection gap against real lab-decoded FSE data and wiring dev_status through the inspector candidates.