### PR TITLE
Reclassify superseded nav-toggle selectors as native-interactivity (fix false gate findings)

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -81,7 +81,10 @@ final class ArtifactCompiler
         if ( array() !== $companionPluginPayload ) {
             $sourceReports['companion_plugin_payload'] = $companionPluginPayload;
         }
-        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references'], $entryBlocks['interaction_candidates']);
+        if ( array() !== $entryBlocks['superseded_selectors'] ) {
+            $sourceReports['superseded_selectors'] = $entryBlocks['superseded_selectors'];
+        }
+        $sourceReports['runtime_dependency_parity'] = ( new RuntimeDependencyParityReport() )->fromArtifact($normalized['files'], $html, $serializedBlocks, $entryPath, $entryBlocks['runtime_islands'], $referenceReports['asset_references'], $entryBlocks['interaction_candidates'], $entryBlocks['superseded_selectors']);
         if ( array() !== $entryBlocks['runtime_islands'] ) {
             $sourceReports['runtime_islands'] = $entryBlocks['runtime_islands'];
             $runtimeIslandPackage = ( new RuntimeIslandPackageBuilder() )->fromRuntimeIslands($entryBlocks['runtime_islands'], $normalized['files'], $entryPath);
@@ -138,7 +141,7 @@ final class ArtifactCompiler
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>, superseded_selectors: array<int, string>}
      */
     private function compileEntryBlocks(string $html, string $entryPath, array $files, string $generatedBlockNamespace = ''): array
     {
@@ -153,12 +156,13 @@ final class ArtifactCompiler
             'runtime_islands'   => $result['runtime_islands'],
             'generated_blocks'  => $result['generated_blocks'],
             'interaction_candidates' => $result['interaction_candidates'],
+            'superseded_selectors' => $result['superseded_selectors'],
         );
     }
 
     /**
      * @param array<int, array<string, mixed>> $files
-     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>}
+     * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>, superseded_selectors: array<int, string>}
      */
     private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope, string $generatedBlockNamespace = ''): array
     {
@@ -172,6 +176,7 @@ final class ArtifactCompiler
                 'runtime_islands'   => array(),
                 'generated_blocks'  => array(),
                 'interaction_candidates' => array(),
+                'superseded_selectors' => array(),
             );
         }
 
@@ -185,6 +190,7 @@ final class ArtifactCompiler
                 'runtime_islands'   => array(),
                 'generated_blocks'  => array(),
                 'interaction_candidates' => array(),
+                'superseded_selectors' => array(),
             );
         }
 
@@ -208,6 +214,10 @@ final class ArtifactCompiler
             'runtime_islands'   => is_array($result['source_reports']['runtime_islands'] ?? null) ? $result['source_reports']['runtime_islands'] : array(),
             'generated_blocks'  => is_array($result['source_reports']['generated_blocks'] ?? null) ? $result['source_reports']['generated_blocks'] : array(),
             'interaction_candidates' => is_array($result['source_reports']['interaction_candidates'] ?? null) ? $result['source_reports']['interaction_candidates'] : array(),
+            'superseded_selectors' => array_values(array_filter(
+                is_array($result['source_reports']['superseded_selectors'] ?? null) ? $result['source_reports']['superseded_selectors'] : array(),
+                static fn (mixed $selector): bool => is_string($selector) && '' !== $selector
+            )),
         );
     }
 

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -13,16 +13,30 @@ final class RuntimeDependencyParityReport
     public const SCHEMA = 'blocks-engine/php-transformer/runtime-dependency-parity/v1';
 
     /**
+     * Acceptable disposition for a missing-DOM-target finding whose selector the
+     * transformer intentionally removed because a native block now provides the
+     * behavior — the parity loss is expected and editable, not a bug.
+     */
+    public const DISPOSITION_SUPERSEDED = 'superseded_by_native_interactivity';
+
+    /**
      * @param array<int, array<string, mixed>> $files
      * @param array<int, array<string, mixed>> $runtimeIslands
      * @param array<int, array<string, mixed>> $assetReferences
      * @param array<int, array<string, mixed>> $interactionCandidates
+     * @param array<int, string> $supersededSelectors Source id/class selectors
+     *        the transformer intentionally removed because a native block now
+     *        provides the behavior (e.g. a hamburger menu-toggle and the overlay
+     *        it controlled, dropped in favor of core/navigation's own responsive
+     *        overlay). A missing-target finding for one of these is reclassified
+     *        as an acceptable, superseded loss rather than a materialization bug.
      * @return array<string, mixed>
      */
-    public function fromArtifact(array $files, string $sourceHtml, string $generatedHtml, string $sourcePath = '', array $runtimeIslands = array(), array $assetReferences = array(), array $interactionCandidates = array()): array
+    public function fromArtifact(array $files, string $sourceHtml, string $generatedHtml, string $sourcePath = '', array $runtimeIslands = array(), array $assetReferences = array(), array $interactionCandidates = array(), array $supersededSelectors = array()): array
     {
         $sourceTargets = $this->sourceTargets($sourceHtml, $sourcePath);
         $generatedTargets = $this->withRuntimeIslandTargets($this->htmlTargets($generatedHtml), $runtimeIslands);
+        $superseded = $this->normalizeSupersededSelectors($supersededSelectors);
         $dependencies = array();
         $findings = array();
         $flaggedSelectors = array();
@@ -91,6 +105,7 @@ final class RuntimeDependencyParityReport
                     'materialization_hint' => $canvasApi ? 'preserve_canvas_id_class_and_markup_for_runtime_mapping' : 'preserve_id_class_or_wrapper_markup_required_by_first_party_script',
                     'message'           => sprintf('Script %s references %s, but the generated block markup does not expose that DOM target.', $scriptPath, $selector),
                 ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value);
+                $findings[count($findings) - 1] = $this->withSupersededDisposition($findings[count($findings) - 1], $superseded);
             }
         }
 
@@ -99,7 +114,7 @@ final class RuntimeDependencyParityReport
         }
 
         foreach ( $this->scriptTargetParityFindings($files, $interactionCandidates, $sourceTargets, $generatedTargets, $sourcePath, $flaggedSelectors) as $finding ) {
-            $findings[] = $finding;
+            $findings[] = $this->withSupersededDisposition($finding, $superseded);
         }
 
         return array_filter(array(
@@ -317,6 +332,66 @@ final class RuntimeDependencyParityReport
         }
 
         return '';
+    }
+
+    /**
+     * Normalize the transformer-recorded superseded selectors into a lookup set
+     * keyed by clean `#id` / `.class` selector. Other selector shapes are
+     * ignored because the parity report only checks id/class presence.
+     *
+     * @param array<int, string> $selectors
+     * @return array<string, bool>
+     */
+    private function normalizeSupersededSelectors(array $selectors): array
+    {
+        $normalized = array();
+        foreach ( $selectors as $selector ) {
+            if ( ! is_string($selector) ) {
+                continue;
+            }
+            $selector = $this->normalizedTargetSelector($selector);
+            if ( '' !== $selector ) {
+                $normalized[$selector] = true;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Reclassify a missing-DOM-target finding as an acceptable, superseded loss
+     * when its selector is one the transformer intentionally removed in favor of
+     * a native block's behavior (e.g. a hamburger menu-toggle and the overlay it
+     * controlled, dropped because the navigation became a core/navigation with
+     * its own responsive overlay). The finding is kept for transparency but its
+     * severity is lowered and an acceptable disposition is attached, so a
+     * preserved site script still referencing the removed selector is recorded
+     * as an expected, editable approximation rather than a materialization bug.
+     * Findings for selectors NOT in the superseded set are returned unchanged,
+     * so genuinely-broken targets stay flagged.
+     *
+     * @param array<string, mixed> $finding
+     * @param array<string, bool> $superseded
+     * @return array<string, mixed>
+     */
+    private function withSupersededDisposition(array $finding, array $superseded): array
+    {
+        $selector = $this->normalizedTargetSelector((string) ($finding['selector'] ?? ''));
+        if ( '' === $selector || ! isset($superseded[$selector]) ) {
+            return $finding;
+        }
+
+        return array_merge($finding, array(
+            'severity'             => 'info',
+            'disposition'          => self::DISPOSITION_SUPERSEDED,
+            'loss_class'           => 'editable_approximation',
+            'recoverability'       => 'acceptable_loss',
+            'repair_bucket'        => 'runtime_behavior_superseded_by_native_block',
+            'suggested_primitive'  => 'native_navigation_overlay',
+            'actionability'        => 'no_action_native_navigation_overlay_supersedes_the_removed_menu_toggle',
+            'materialization_hint' => 'none_native_block_provides_the_responsive_navigation_overlay',
+            'message'              => sprintf('Script references %s, which the transformer intentionally removed because the navigation became a core/navigation with its own responsive overlay; the missing target is an expected, editable approximation, not a materialization bug.', $selector),
+        ));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -197,6 +197,21 @@ final class HtmlTransformer
      */
     private array $runtimeCanvasSelectors = array();
 
+    /**
+     * Source DOM selectors (id/class) the transformer intentionally removed
+     * because the element was superseded by a native block's own behavior — e.g.
+     * a redundant JS hamburger menu-toggle (and the menu/overlay it controlled)
+     * dropped because the navigation became a core/navigation with its own
+     * responsive overlay. Surfaced under `source_reports.superseded_selectors`
+     * so the runtime-dependency parity report can reclassify a "missing DOM
+     * target" finding for these selectors as an acceptable, superseded loss
+     * rather than a materialization bug (a preserved site script may still
+     * reference the removed selector, which is expected, not broken).
+     *
+     * @var array<string, bool>
+     */
+    private array $supersededRuntimeSelectors = array();
+
     private int $nextSourceProvenanceId = 1;
 
     public function __construct(private readonly Runtime $runtime = new Runtime())
@@ -249,6 +264,7 @@ final class HtmlTransformer
         $this->staticStyleRules = $this->staticStyleRules($html, (string) ($options['static_css'] ?? ''));
         $this->runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
         $this->runtimeCanvasSelectors = $this->runtimeCanvasSelectorsFromOptions($options);
+        $this->supersededRuntimeSelectors = array();
         $this->fallbackEmitter->configure($this->fallbackProvenance, $this->runtimeScriptMetadata, $this->runtimeCanvasSelectors);
         $this->nextSourceProvenanceId = 1;
         $provenance               = array(
@@ -316,6 +332,7 @@ final class HtmlTransformer
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
+        $this->collectSupersededNavToggleSelectors($body);
         $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));
         $this->appendInteractiveControlBehaviorLossFallbacks($body, $fallbacks);
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
@@ -339,6 +356,7 @@ final class HtmlTransformer
             'runtime_islands' => $this->runtimeIslands,
             'generated_blocks' => $this->generatedBlocks,
             'interaction_candidates' => $interactionCandidates,
+            'superseded_selectors' => array_keys($this->supersededRuntimeSelectors),
             'wp_block_validity' => $blockValidityReport,
             'semantic_parity' => $semanticParityReport,
             'html' => array(
@@ -672,6 +690,69 @@ final class HtmlTransformer
         }
 
         return $this->hasAssociatedNavigationMenu($element);
+    }
+
+    /**
+     * Authoritatively record, in a single deterministic pass over the source
+     * document, the selectors made redundant by every hamburger menu-toggle the
+     * transformer treats as superseded by native navigation. A redundant
+     * menu-toggle is always dropped from the output — whether by the element
+     * converter, the navigation pattern's chrome handling, or the buttons
+     * container — so scanning the source by the same `isRedundantMenuToggleControl`
+     * predicate captures the superseded selectors independently of which drop
+     * path executed, with no per-path bookkeeping.
+     */
+    private function collectSupersededNavToggleSelectors(DOMElement $root): void
+    {
+        foreach ( $root->getElementsByTagName('*') as $element ) {
+            if ( $element instanceof DOMElement && $this->isRedundantMenuToggleControl($element) ) {
+                $this->recordSupersededNavToggleSelectors($element);
+            }
+        }
+    }
+
+    /**
+     * Record the source selectors made redundant when a hamburger menu-toggle is
+     * dropped in favor of the native navigation overlay: the toggle's own id and
+     * class selectors, plus the id/class selectors of the menu/overlay it
+     * controlled via `aria-controls`. A preserved site script may still reference
+     * these selectors (e.g. `.nav-toggle`, `#nav-mobile`); the runtime-dependency
+     * parity report uses this set to mark a resulting "missing DOM target"
+     * finding as a superseded, acceptable loss rather than a materialization bug.
+     * Only selectors of menu-toggles the transformer actually removed are
+     * recorded, so genuinely-broken targets stay flagged.
+     */
+    private function recordSupersededNavToggleSelectors(DOMElement $toggle): void
+    {
+        $this->recordSupersededSelectorsForElement($toggle);
+
+        foreach ( preg_split('/\s+/', trim($this->attr($toggle, 'aria-controls'))) ?: array() as $controlledId ) {
+            $controlledId = ltrim(trim($controlledId), '#');
+            if ( '' === $controlledId ) {
+                continue;
+            }
+
+            $this->supersededRuntimeSelectors['#' . $controlledId] = true;
+
+            $target = $this->elementWithId($toggle, $controlledId);
+            if ( $target instanceof DOMElement && ! $target->isSameNode($toggle) ) {
+                $this->recordSupersededSelectorsForElement($target);
+            }
+        }
+    }
+
+    private function recordSupersededSelectorsForElement(DOMElement $element): void
+    {
+        $id = trim($this->attr($element, 'id'));
+        if ( '' !== $id ) {
+            $this->supersededRuntimeSelectors['#' . $id] = true;
+        }
+
+        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
+            if ( '' !== $class ) {
+                $this->supersededRuntimeSelectors['.' . $class] = true;
+            }
+        }
     }
 
     private function isHamburgerMenuToggleControl(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/artifact-runtime-nav-toggle-superseded-disposition.json
+++ b/php-transformer/tests/fixtures/parity/artifact-runtime-nav-toggle-superseded-disposition.json
@@ -1,0 +1,56 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-runtime-nav-toggle-superseded-disposition",
+  "description": "Reclassifies a missing-DOM-target finding as an acceptable, superseded loss when the selector belongs to a hamburger menu-toggle (and the menu it controlled) the transformer intentionally dropped in favor of core/navigation's own responsive overlay, while a genuinely-missing target the script depends on stays an unacceptable parity loss.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-runtime-nav-toggle-superseded-disposition.json",
+    "notes": "The .nav-toggle hamburger is folded into core/navigation and its aria-controls menu (#nav-links) loses its id, so a preserved script referencing .nav-toggle / #nav-links is an expected, editable approximation (disposition superseded_by_native_interactivity, severity info). The same script also references .search-results, which does not exist in the output and was never a dropped nav toggle, so it remains an unacceptable runtime_dom_target_preservation loss (severity warning)."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<header class=\"site-header\"><nav class=\"site-nav\" aria-label=\"Primary\"><button class=\"nav-toggle\" aria-label=\"Toggle menu\" aria-expanded=\"false\" aria-controls=\"nav-links\"><span></span><span></span><span></span></button><ul class=\"nav-links\" id=\"nav-links\"><li><a href=\"/\">Home</a></li><li><a href=\"/about\">About</a></li></ul></nav><script src=\"js/app.js\"></script></header>"
+        },
+        {
+          "path": "js/app.js",
+          "kind": "js",
+          "content": "var t = document.querySelector('.nav-toggle'); t.addEventListener('click', function(){});\nvar r = document.querySelector('.search-results'); r.addEventListener('scroll', function(){});\n"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "warning" },
+    { "path": "source_reports.runtime_dependency_parity.findings", "assert": "count", "count": 3 },
+    { "path": "source_reports.superseded_selectors.0", "assert": "equals", "value": ".nav-toggle" },
+
+    { "path": "source_reports.runtime_dependency_parity.findings.0.code", "assert": "equals", "value": "runtime_dependency_target_missing" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.selector", "assert": "equals", "value": ".nav-toggle" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.severity", "assert": "equals", "value": "info" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.disposition", "assert": "equals", "value": "superseded_by_native_interactivity" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.loss_class", "assert": "equals", "value": "editable_approximation" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.recoverability", "assert": "equals", "value": "acceptable_loss" },
+    { "path": "source_reports.runtime_dependency_parity.findings.0.repair_bucket", "assert": "equals", "value": "runtime_behavior_superseded_by_native_block" },
+
+    { "path": "source_reports.runtime_dependency_parity.findings.1.code", "assert": "equals", "value": "runtime_dependency_target_missing" },
+    { "path": "source_reports.runtime_dependency_parity.findings.1.selector", "assert": "equals", "value": ".search-results" },
+    { "path": "source_reports.runtime_dependency_parity.findings.1.severity", "assert": "equals", "value": "warning" },
+    { "path": "source_reports.runtime_dependency_parity.findings.1.repair_bucket", "assert": "equals", "value": "runtime_dom_target_preservation" },
+
+    { "path": "source_reports.runtime_dependency_parity.findings.2.code", "assert": "equals", "value": "runtime_script_target_missing" },
+    { "path": "source_reports.runtime_dependency_parity.findings.2.selector", "assert": "equals", "value": "#nav-links" },
+    { "path": "source_reports.runtime_dependency_parity.findings.2.severity", "assert": "equals", "value": "info" },
+    { "path": "source_reports.runtime_dependency_parity.findings.2.disposition", "assert": "equals", "value": "superseded_by_native_interactivity" }
+  ]
+}


### PR DESCRIPTION
## What
Stops a false-positive gate finding: when a nav converts to `core/navigation` (which ships its own responsive overlay via the Interactivity API), the transformer intentionally drops the redundant `.nav-toggle` hamburger button. But the preserved site script still *references* `.nav-toggle`, so the runtime-dependency parity check emitted `runtime_dependency_target_missing` (unacceptable) — failing fixtures for navs that **actually work natively**. This was the single largest unacceptable finding family in the corpus.

## Change
- `HtmlTransformer` records a `superseded_selectors` set in one deterministic pass (`collectSupersededNavToggleSelectors`): every element matching the existing `isRedundantMenuToggleControl` predicate contributes its own id/class selectors plus its `aria-controls` overlay target. Surfaced under `source_reports.superseded_selectors`.
- `ArtifactCompiler` threads it into `RuntimeDependencyParityReport`, which reclassifies a missing-target finding whose selector is superseded → severity `info`, `disposition: superseded_by_native_interactivity`, `loss_class: editable_approximation`, acceptable. Only the exact removed selectors are touched.

## Verification (corpus probe through real ArtifactCompiler)
- Nav-toggle false positives: **38 → 0** (all reclassified to superseded/acceptable).
- Other (real) missing-target findings: **338 → 338 unchanged** — no over-suppression.
- The 6 remaining nav-labeled unacceptable findings are correctly real (secondary navs, theme/CRT toggles, whiteboard menus, a JS-created `.nav-toggle` with no source element).
- `composer test` + `composer parity`: **145 fixtures green** (+1 new asserting a superseded toggle reclassifies while a genuinely-missing target stays unacceptable).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and corpus verification under human review.
