### PR TITLE
Suppress behavior-loss findings for controls folded into core/details/accordion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -145,6 +145,21 @@ final class HtmlTransformer
     private array $runtimeIslands = array();
 
     /**
+     * Source elements whose subtree was folded into a native zero-JS disclosure
+     * block (`core/details`) or the native `core/accordion` block. The toggle
+     * controls inside these subtrees have their show/hide behavior carried
+     * natively, so they must not be reported as interactive-control behavior
+     * loss (analogous to core/navigation fold-in).
+     *
+     * Keyed by the source element's stable node path (libxml-derived XPath),
+     * since PHP DOM hands out a fresh wrapper object per traversal and
+     * `spl_object_id()` is therefore not stable across passes.
+     *
+     * @var array<string, true>
+     */
+    private array $nativeDisclosureRootIds = array();
+
+    /**
      * Generated dynamic custom-block definitions produced at `core/html`
      * fallback decisions (issue #497). Surfaced under
      * `source_reports.generated_blocks` and packaged into the companion-plugin
@@ -239,6 +254,7 @@ final class HtmlTransformer
         $this->structureProvenance = array();
         $this->scriptMetadata = array();
         $this->runtimeIslands = array();
+        $this->nativeDisclosureRootIds = array();
         $this->generatedBlocks = array();
         $this->generatedBlockNamespace = $this->generatedBlockNamespaceFromOptions($options);
         $this->fallbackEmitter->resetGeneratedBlocks();
@@ -933,7 +949,7 @@ final class HtmlTransformer
         if ( 'ul' === $tagName || 'ol' === $tagName ) {
             $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
             if ( null !== $navigation ) {
-                return $navigation;
+                return $this->rememberAccordionDisclosureRoot($navigation, $element);
             }
 
             $items = $this->listItems($element, $fallbacks);
@@ -1327,7 +1343,7 @@ final class HtmlTransformer
         if ( 'nav' === $tagName ) {
             $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext(false));
             if ( null !== $navigation ) {
-                return $navigation;
+                return $this->rememberAccordionDisclosureRoot($navigation, $element);
             }
         }
 
@@ -1363,7 +1379,7 @@ final class HtmlTransformer
             if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
                 $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
                 if ( null !== $navigation ) {
-                    return $navigation;
+                    return $this->rememberAccordionDisclosureRoot($navigation, $element);
                 }
             }
 
@@ -1376,6 +1392,8 @@ final class HtmlTransformer
                     fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
                 );
                 if ( null !== $disclosure ) {
+                    $this->nativeDisclosureRootIds[ $element->getNodePath() ?? '' ] = true;
+
                     return $disclosure;
                 }
             }
@@ -2359,6 +2377,10 @@ final class HtmlTransformer
             return false;
         }
 
+        if ( $this->isFoldedIntoNativeDisclosure($element) ) {
+            return false;
+        }
+
         if ( $this->isRuntimeDomTarget($element) ) {
             return false;
         }
@@ -2425,6 +2447,57 @@ final class HtmlTransformer
     {
         for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
             if ( $this->isNavigationMenuCandidate($node) && $this->convertsToCoreNavigation($node) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Record a source element whose subtree converted to the native
+     * `core/accordion` block, so its toggle controls are not later flagged as
+     * interactive-control behavior loss. Returns the block unchanged for use as
+     * a passthrough at recognizer call sites.
+     *
+     * @param array<string, mixed> $block
+     * @return array<string, mixed>
+     */
+    private function rememberAccordionDisclosureRoot(array $block, DOMElement $element): array
+    {
+        if ( 'core/accordion' === ( $block['blockName'] ?? '' ) ) {
+            $this->nativeDisclosureRootIds[ $element->getNodePath() ?? '' ] = true;
+        }
+
+        return $block;
+    }
+
+    /**
+     * Whether the element is a disclosure toggle whose containing widget was
+     * folded into a native zero-JS `core/details` block or the native
+     * `core/accordion` block. The show/hide behavior is then carried natively
+     * (no preserved JavaScript), so flagging behavior loss would be a false
+     * positive — the same way `isFoldedIntoCoreNavigation()` excludes controls
+     * rebuilt by `core/navigation`.
+     *
+     * The toggle is recognized structurally (its `aria-expanded`/`aria-controls`
+     * disclosure state), never by class string, and only inside a subtree that
+     * actually converted to a native disclosure block.
+     */
+    private function isFoldedIntoNativeDisclosure(DOMElement $element): bool
+    {
+        if ( array() === $this->nativeDisclosureRootIds ) {
+            return false;
+        }
+
+        $hasDisclosureState = '' !== trim($this->attr($element, 'aria-expanded'))
+            || '' !== trim($this->attr($element, 'aria-controls'));
+        if ( ! $hasDisclosureState ) {
+            return false;
+        }
+
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( isset($this->nativeDisclosureRootIds[ $node->getNodePath() ?? '' ]) ) {
                 return true;
             }
         }

--- a/php-transformer/tests/fixtures/parity/html-accordion-widget-no-behavior-loss.json
+++ b/php-transformer/tests/fixtures/parity/html-accordion-widget-no-behavior-loss.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-accordion-widget-no-behavior-loss",
+  "description": "Converts a JS-driven multi-item accordion (ul > li with button[aria-expanded] toggles and collapsible regions) into the native core/accordion block, carrying open state via openByDefault, with no interactive-control behavior-loss fallback for the folded toggles and no leftover dead toggle markup.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-accordion-widget-no-behavior-loss.json",
+    "notes": "Product-neutral fixture proving accordion fold-in suppresses the now-redundant behavior-loss diagnostic. The toggle behavior is carried natively (zero preserved JS)."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<ul class=\"accordion\"><li class=\"item\"><button class=\"q\" aria-expanded=\"false\" aria-controls=\"p1\">First question?</button><div id=\"p1\" role=\"region\"><p>First answer.</p></div></li><li class=\"item\"><button class=\"q\" aria-expanded=\"true\" aria-controls=\"p2\">Second question?</button><div id=\"p2\" role=\"region\"><p>Second answer.</p></div></li></ul>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/accordion", "attrs": { "className": "accordion" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/accordion-item", "attrs": { "className": "item" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/accordion-heading", "attrs": { "title": "First question?", "level": 3 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/accordion-panel" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "First answer." } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/accordion-item", "attrs": { "className": "item", "openByDefault": true } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/accordion-heading", "attrs": { "title": "Second question?", "level": 3 } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:accordion" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:accordion-item" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "aria-expanded" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-disclosure-widget-to-details.json
+++ b/php-transformer/tests/fixtures/parity/html-disclosure-widget-to-details.json
@@ -1,0 +1,39 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-disclosure-widget-to-details",
+  "description": "Converts a JS-driven sibling disclosure widget (div + button[aria-expanded][aria-controls] + collapsible panel) into a sequence of native zero-JS core/details blocks, with no interactive-control behavior-loss fallback and no leftover dead toggle markup.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-disclosure-widget-to-details.json",
+    "notes": "Product-neutral fixture covering the generic AI-generated FAQ/disclosure shape. Detection is structural (aria-expanded/aria-controls + control/panel pairing), never a class string."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"qa\"><div class=\"item\"><button class=\"q\" aria-expanded=\"false\" aria-controls=\"a1\">Question one?</button><div id=\"a1\" class=\"panel\"><p>Answer one.</p></div></div><div class=\"item\"><button class=\"q\" aria-expanded=\"false\" aria-controls=\"a2\">Question two?</button><div id=\"a2\" class=\"panel\"><p>Answer two.</p></div></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "qa" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/details", "attrs": { "summary": "Question one?", "className": "item" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Answer one." } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/details", "attrs": { "summary": "Question two?", "className": "item" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Answer two." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<details class=\"wp-block-details item\"><summary>Question one?</summary>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<details class=\"wp-block-details item\"><summary>Question two?</summary>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "aria-expanded" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<button" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## What
Clears false `interactive_control_behavior_lost` findings for disclosure/accordion controls that are correctly folded into native zero-JS blocks. The transformer already converts JS-driven disclosures → `core/details` and multi-item FAQ/accordions → `core/accordion` (landed in #278), but the behavior-loss diagnostic still flagged the source toggle buttons because its "behavior preserved elsewhere" exclusion only covered `core/navigation`, not `core/details`/`core/accordion`. So a real conversion win was masked by a spurious finding per toggle.

## Change (`HtmlTransformer`)
- Record source subtrees that actually convert to `core/details`/`core/accordion` (`$nativeDisclosureRootIds`, keyed by stable `getNodePath()`).
- New `isFoldedIntoNativeDisclosure()`, checked in `isInteractiveControlBehaviorLoss()` right after the existing navigation check. Suppression fires ONLY when the control carries disclosure semantics (`aria-expanded`/`aria-controls`) AND its subtree actually converted to a native disclosure block — generic structural signals, no class strings.

## Verification (corpus probe)
- Disclosure-signed `interactive_control_behavior_lost`: **78 → 14**; total: **131 → 67** (all 64 removed are real fold-ins; 53 non-disclosure losses unchanged).
- `7-event-conference/faq` **14 → 0**, `4-course-education/faq` **12 → 0**, `11-nonprofit-campaign/faq` **13 → 0**. `core/details` (132) / `core/accordion` (20) emission unchanged — only the false findings cleared.
- `composer test` + `composer parity`: **146 fixtures green** (+2 new, both fail without the change).
- Remaining 14 findings are correctly-retained real controls (non-folding hamburgers, tab buttons, `aria-haspopup` menus).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and corpus verification under human review.
