### PR TITLE
Emit responsive @media breakpoints from page-plan variants (#247 item 2)

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -207,6 +207,7 @@ final class StaticHtmlEmitter
         $pages = array();
         $renderedNodes = array();
         $seenPaths = array();
+        $mediaBlocks = array();
         $plannedPages = $this->plannedPages($pagePlan);
 
         foreach ( $plannedPages as $index => $page ) {
@@ -248,6 +249,11 @@ final class StaticHtmlEmitter
                 'content'   => $this->htmlDocument($this->sanitizeText($pageName), $this->stylesheetHref($path), $body),
             );
             $renderedNodes[] = $frameNode;
+
+            foreach ( $this->breakpointMediaBlocks($page, $frameNode, $nodeMap) as $mediaBlock ) {
+                $mediaBlocks[] = $mediaBlock;
+            }
+
             $pages[] = array(
                 'frame_id'   => $frameId,
                 'name'       => $pageName,
@@ -279,6 +285,11 @@ final class StaticHtmlEmitter
         $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
         $fontCss = (string) $fontResolution['css'];
         $css = ('' !== $fontCss ? $fontCss . "\n" : '') . implode("\n", array_values(array_unique($cssRules))) . "\n";
+        if ( ! empty($mediaBlocks) ) {
+            // Responsive overrides cascade AFTER the widest-first base rules so
+            // narrower breakpoints win at their own viewport width.
+            $css .= implode("\n", $mediaBlocks) . "\n";
+        }
         $files[] = array(
             'path'      => 'style.css',
             'role'      => 'stylesheet',
@@ -325,6 +336,150 @@ final class StaticHtmlEmitter
                 'page_count'  => count($pages),
             ),
         );
+    }
+
+    /**
+     * Build the `@media (max-width: …)` CSS blocks for one responsive page.
+     *
+     * The primary (widest) variant frame is already rendered as the base layout
+     * by {@see emitSite}. For every narrower breakpoint variant this walks the
+     * variant frame, computes per-node style declarations with the same
+     * machinery the base used, maps each variant node onto its base counterpart
+     * by structural position, and emits only the declarations that DIFFER from
+     * the base inside a `max-width` media block keyed on the variant viewport.
+     *
+     * Single-variant pages return an empty list, so they render exactly as
+     * before with no `@media` output.
+     *
+     * @param array<string, mixed>                $page     Planned page (carries `variants`).
+     * @param array<string, mixed>                $baseNode Primary variant frame node.
+     * @param array<string, array<string, mixed>> $nodeMap  Id => node lookup.
+     * @return array<int, string>
+     */
+    private function breakpointMediaBlocks(array $page, array $baseNode, array $nodeMap): array
+    {
+        $variants = is_array($page['variants'] ?? null) ? array_values($page['variants']) : array();
+        if ( count($variants) < 2 ) {
+            return array();
+        }
+
+        $baseStyles = array();
+        $this->collectVariantNodeStyles($baseNode, 0, null, 'r', $baseStyles);
+
+        $blocks = array();
+        // Variants are ordered widest-first, so iterating in order emits the
+        // narrower breakpoints later in the cascade — exactly the precedence
+        // overlapping `max-width` queries need.
+        foreach ( $variants as $variant ) {
+            if ( ! is_array($variant) || true === ($variant['primary'] ?? false) ) {
+                continue;
+            }
+
+            $variantId = isset($variant['frame_id']) && is_scalar($variant['frame_id']) ? (string) $variant['frame_id'] : '';
+            $viewportWidth = $variant['viewport_width'] ?? null;
+            if ( '' === $variantId || ! isset($nodeMap[$variantId]) || ! is_numeric($viewportWidth) ) {
+                continue;
+            }
+
+            $variantStyles = array();
+            $this->collectVariantNodeStyles($nodeMap[$variantId], 0, null, 'r', $variantStyles);
+
+            $rules = $this->breakpointDiffRules($baseStyles, $variantStyles);
+            if ( empty($rules) ) {
+                continue;
+            }
+
+            $blocks[] = '@media (max-width:' . $this->number((float) $viewportWidth) . 'px){'
+                . "\n" . implode("\n", $rules) . "\n}";
+        }
+
+        return $blocks;
+    }
+
+    /**
+     * Walk a variant frame and record each node's emitted class name and ordered
+     * style declarations, keyed by a deterministic structural path. The
+     * traversal mirrors {@see emitNode} (same child skipping and the same
+     * BOOLEAN_OPERATION vector short-circuit) so a node at a given position
+     * always resolves to the same key across breakpoint variants — that key is
+     * what lets base and narrower styles be diffed without re-deriving layout.
+     *
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $map  pathKey => array{class: string, styles: array<int, string>}
+     */
+    private function collectVariantNodeStyles(array $node, int $depth, ?array $parentNode, string $pathKey, array &$map): void
+    {
+        $id = $this->sanitizeAttribute((string) ($node['id'] ?? ''));
+        $name = (string) ($node['name'] ?? '');
+        $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
+        $className = 'figma-node-' . $this->slug($id . '-' . $name);
+
+        $map[$pathKey] = array(
+            'class'  => $className,
+            'styles' => $this->styleDeclarations($node, $type, $parentNode),
+        );
+
+        $vectorSvg = $this->supportedVectorSvg($node, $type, $parentNode);
+        if ( 'BOOLEAN_OPERATION' === $type && null !== $vectorSvg ) {
+            return;
+        }
+
+        $childOrdinal = 0;
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) || $this->isFullyClippedDecorativeChild($child, $node) ) {
+                continue;
+            }
+
+            $childType = strtoupper((string) ($child['type'] ?? 'FRAME'));
+            $childKey = $pathKey . '/' . $childOrdinal . ':' . $childType;
+            $this->collectVariantNodeStyles($child, $depth + 1, $node, $childKey, $map);
+            ++$childOrdinal;
+        }
+    }
+
+    /**
+     * Diff a narrower variant's per-node styles against the base styles, keeping
+     * only declarations whose value changed (or that the base lacked). Rules are
+     * keyed on the BASE class name so the overrides land on the already-rendered
+     * elements, and are emitted in base-traversal order for deterministic output.
+     *
+     * @param array<string, array<string, mixed>> $baseStyles
+     * @param array<string, array<string, mixed>> $variantStyles
+     * @return array<int, string>
+     */
+    private function breakpointDiffRules(array $baseStyles, array $variantStyles): array
+    {
+        $rules = array();
+        foreach ( $baseStyles as $pathKey => $base ) {
+            if ( ! isset($variantStyles[$pathKey]) ) {
+                continue;
+            }
+
+            $baseMap = $this->styleDeclarationMap(is_array($base['styles'] ?? null) ? $base['styles'] : array());
+            $variantDeclarations = is_array($variantStyles[$pathKey]['styles'] ?? null) ? $variantStyles[$pathKey]['styles'] : array();
+
+            $changed = array();
+            foreach ( $variantDeclarations as $declaration ) {
+                $parts = explode(':', (string) $declaration, 2);
+                if ( 2 !== count($parts) ) {
+                    continue;
+                }
+
+                $property = trim($parts[0]);
+                $value = trim($parts[1]);
+                if ( ! array_key_exists($property, $baseMap) || $baseMap[$property] !== $value ) {
+                    $changed[] = $property . ':' . $value;
+                }
+            }
+
+            if ( empty($changed) ) {
+                continue;
+            }
+
+            $rules[] = '.' . (string) $base['class'] . '{' . implode(';', $changed) . '}';
+        }
+
+        return $rules;
     }
 
     private function htmlDocument(string $title, string $stylesheetHref, string $body): string

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2001,6 +2001,132 @@ $assert(null !== $responsiveAboutPage, 'page-plan-responsive-about-stays-its-own
 $assert(false === ($responsiveAboutPage['responsive'] ?? null) && 1 === ($responsiveAboutPage['breakpoint_count'] ?? null), 'page-plan-non-responsive-frame-single-variant');
 $assert(1 === count($responsiveAboutPage['variants'] ?? array()) && 'frame:about-desktop' === ($responsiveAboutPage['variants'][0]['frame_id'] ?? null), 'page-plan-non-responsive-frame-self-variant');
 
+// RESPONSIVE EMISSION (#247 item 2): StaticHtmlEmitter::emitSite consumes a
+// page plan's `variants[]` and renders the primary (widest) variant as the base
+// layout, then emits `@media (max-width: …)` blocks carrying ONLY the per-node
+// style declarations that differ at each narrower breakpoint. A single-variant
+// page emits no `@media` at all. Variant frames are matched onto the base frame
+// by structural position so the overrides key on the base class names.
+$responsiveEmitFrame = static function (string $id, string $name, float $width, float $height, array $children): array {
+    return array(
+        'id'         => $id,
+        'type'       => 'FRAME',
+        'name'       => $name,
+        'box'        => array('width' => $width, 'height' => $height),
+        'background' => '#ffffff',
+        'children'   => $children,
+    );
+};
+$responsiveEmitCard = static function (string $id, string $name, float $width, float $height, string $background): array {
+    return array(
+        'id'         => $id,
+        'type'       => 'RECTANGLE',
+        'name'       => $name,
+        'box'        => array('width' => $width, 'height' => $height),
+        'background' => $background,
+    );
+};
+$responsiveEmitScenegraph = array(
+    'name'  => 'Responsive Emission Site',
+    'nodes' => array(
+        $responsiveEmitFrame('frame:home-desktop', 'Home Desktop', 1440.0, 3000.0, array(
+            $responsiveEmitCard('card:desktop', 'Hero Card', 1200.0, 400.0, '#ff0000'),
+        )),
+        $responsiveEmitFrame('frame:home-tablet', 'Home Tablet', 834.0, 3000.0, array(
+            $responsiveEmitCard('card:tablet', 'Hero Card', 700.0, 400.0, '#ff0000'),
+        )),
+        $responsiveEmitFrame('frame:home-mobile', 'Home Mobile', 390.0, 3200.0, array(
+            $responsiveEmitCard('card:mobile', 'Hero Card', 350.0, 500.0, '#00ff00'),
+        )),
+        $responsiveEmitFrame('frame:about', 'About', 1440.0, 2000.0, array(
+            $responsiveEmitCard('card:about', 'About Card', 1100.0, 300.0, '#0000ff'),
+        )),
+    ),
+);
+$responsiveEmitPagePlan = array(
+    'pages' => array(
+        array(
+            'frame_id'         => 'frame:home-desktop',
+            'name'             => 'Home',
+            'path'             => 'index.html',
+            'entrypoint'       => true,
+            'responsive'       => true,
+            'breakpoint_count' => 3,
+            'variants'         => array(
+                array('frame_id' => 'frame:home-desktop', 'device_hint' => 'desktop', 'viewport_width' => 1440.0, 'primary' => true, 'order' => 0),
+                array('frame_id' => 'frame:home-tablet', 'device_hint' => 'tablet', 'viewport_width' => 834.0, 'primary' => false, 'order' => 1),
+                array('frame_id' => 'frame:home-mobile', 'device_hint' => 'mobile', 'viewport_width' => 390.0, 'primary' => false, 'order' => 2),
+            ),
+        ),
+        array(
+            'frame_id'         => 'frame:about',
+            'name'             => 'About',
+            'path'             => 'about.html',
+            'entrypoint'       => false,
+            'responsive'       => false,
+            'breakpoint_count' => 1,
+            'variants'         => array(
+                array('frame_id' => 'frame:about', 'device_hint' => 'desktop', 'viewport_width' => 1440.0, 'primary' => true, 'order' => 0),
+            ),
+        ),
+    ),
+);
+$responsiveEmitResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite($responsiveEmitScenegraph, $responsiveEmitPagePlan);
+$responsiveEmitCss = '';
+foreach ( $responsiveEmitResult['files'] ?? array() as $responsiveEmitFile ) {
+    if ( is_array($responsiveEmitFile) && 'style.css' === ($responsiveEmitFile['path'] ?? null) ) {
+        $responsiveEmitCss = (string) ($responsiveEmitFile['content'] ?? '');
+    }
+}
+$assert('success' === ($responsiveEmitResult['status'] ?? null), 'responsive-emit-status-success');
+$assert('' !== $responsiveEmitCss, 'responsive-emit-stylesheet-present');
+// Two narrower breakpoints => exactly two media blocks at the variant widths.
+$assert(2 === substr_count($responsiveEmitCss, '@media'), 'responsive-emit-two-media-blocks');
+$assert(str_contains($responsiveEmitCss, '@media (max-width:834px){'), 'responsive-emit-tablet-media-query');
+$assert(str_contains($responsiveEmitCss, '@media (max-width:390px){'), 'responsive-emit-mobile-media-query');
+// Base layout uses the primary (desktop) variant styles, emitted before media.
+$responsiveEmitBasePos = strpos($responsiveEmitCss, '.figma-node-card-desktop-hero-card{width:1200px;height:400px;background:#ff0000}');
+$assert(false !== $responsiveEmitBasePos, 'responsive-emit-base-uses-primary-variant');
+$responsiveEmitFirstMediaPos = strpos($responsiveEmitCss, '@media');
+$assert(false !== $responsiveEmitFirstMediaPos && $responsiveEmitBasePos < $responsiveEmitFirstMediaPos, 'responsive-emit-base-precedes-media');
+// Narrower-wins cascade: tablet block precedes mobile block.
+$assert(strpos($responsiveEmitCss, '@media (max-width:834px)') < strpos($responsiveEmitCss, '@media (max-width:390px)'), 'responsive-emit-cascade-widest-first');
+// Media blocks override on the BASE class names, carrying only changed props.
+$responsiveEmitTabletBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:834px)'), strpos($responsiveEmitCss, '@media (max-width:390px)') - strpos($responsiveEmitCss, '@media (max-width:834px)'));
+$assert(str_contains($responsiveEmitTabletBlock, '.figma-node-card-desktop-hero-card{width:700px}'), 'responsive-emit-tablet-card-width-diff-only');
+$assert(! str_contains($responsiveEmitTabletBlock, 'background:'), 'responsive-emit-tablet-omits-unchanged-background');
+$responsiveEmitMobileBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:390px)'));
+$assert(str_contains($responsiveEmitMobileBlock, '.figma-node-card-desktop-hero-card{width:350px;height:500px;background:#00ff00}'), 'responsive-emit-mobile-card-diffs-width-height-background');
+// The single-variant About page contributes NO media override for its nodes.
+$assert(0 === preg_match('/@media[^@]*figma-node-card-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-no-media');
+
+// SINGLE-VARIANT PAGE PARITY: a page plan with only primary variants emits the
+// SAME CSS as today — zero `@media` queries.
+$singleVariantPagePlan = array(
+    'pages' => array(
+        array(
+            'frame_id'         => 'frame:about',
+            'name'             => 'About',
+            'path'             => 'index.html',
+            'entrypoint'       => true,
+            'responsive'       => false,
+            'breakpoint_count' => 1,
+            'variants'         => array(
+                array('frame_id' => 'frame:about', 'device_hint' => 'desktop', 'viewport_width' => 1440.0, 'primary' => true, 'order' => 0),
+            ),
+        ),
+    ),
+);
+$singleVariantResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite($responsiveEmitScenegraph, $singleVariantPagePlan);
+$singleVariantCss = '';
+foreach ( $singleVariantResult['files'] ?? array() as $singleVariantFile ) {
+    if ( is_array($singleVariantFile) && 'style.css' === ($singleVariantFile['path'] ?? null) ) {
+        $singleVariantCss = (string) ($singleVariantFile['content'] ?? '');
+    }
+}
+$assert('' !== $singleVariantCss, 'responsive-emit-single-variant-stylesheet-present');
+$assert(! str_contains($singleVariantCss, '@media'), 'responsive-emit-single-variant-no-media-query');
+
 $planDiagnosticByCode = static function (array $plan, string $code): ?array {
     foreach ( $plan['diagnostics'] ?? array() as $diagnostic ) {
         if ( is_array($diagnostic) && $code === ($diagnostic['code'] ?? null) ) {


### PR DESCRIPTION
## What

Wires `StaticHtmlEmitter` to consume the responsive `variants[]` that `ScenegraphPagePlanner` already produces, so a responsive frame-group renders as **one HTML page that is responsive across breakpoints** — the missing emission half of #247 (item 2: responsive emission).

The plumbing existed (the planner collapses desktop/tablet/mobile sibling frames into a single page plan with an ordered, widest-first `variants[]` list), but the emitter rendered only the primary frame and emitted **zero `@media` queries**.

## How

In `emitSite`:

- A page with more than one variant renders the **primary (widest) variant as the base layout** (unchanged behavior), then for each narrower variant emits an `@media (max-width: <viewport_width>px)` block.
- Each media block carries **only the per-node style declarations that DIFFER from the base**. Variant frames are matched onto the base frame by **structural position** — a deterministic path key whose traversal mirrors `emitNode` (same child skipping, same `BOOLEAN_OPERATION` vector short-circuit) — so overrides key on the **base class names** and reuse the existing `styleDeclarations` machinery instead of re-deriving layout.
- Media blocks cascade **after** the base rules in widest-first order, so narrower breakpoints win at their own viewport width.
- **Single-variant pages emit no `@media`** and render exactly as before.

The planner's variant shape exposes `frame_id` / `viewport_width` / `primary` / `order` per variant but no node-level correspondence between breakpoint frames; node matching is therefore derived structurally in the emitter. No planner change was required.

## Tests

Contract tests in `figma-transformer/tests/contract/run.php` (synthetic fixtures only):

- A desktop+tablet+mobile page emits base styles plus exactly two `@media (max-width: …)` blocks carrying only the changed declarations (tablet: card width only; mobile: width + height + background), base precedes media, tablet block precedes mobile block, and the single-variant About page contributes no media override.
- A single-variant-only page plan emits zero `@media`.

`cd figma-transformer && php tests/contract/run.php` prints `Figma Transformer contract tests passed.`

Per the RAM ban, the large `fixtures/*.fig` files were not run; real-design parity validation is the orchestrator's lab follow-up.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Emitting @media breakpoints from responsive frame-group variants for #247.