### PR TITLE
Emit shared, readably-named CSS classes for authored-looking figma-transformer output

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -83,6 +83,15 @@ final class StaticHtmlEmitter
     private array $listItemIdCache = array();
 
     /**
+     * Maps each per-node CSS class (the `figma-node-*` hook) to a human-readable
+     * base name derived from the node's name/role. Used to mint shared,
+     * authored-looking class names when several nodes share identical styles.
+     *
+     * @var array<string, string>
+     */
+    private array $nodeReadableNames = array();
+
+    /**
      * @param array<string, mixed> $scenegraph Normalized Figma scenegraph.
      * @param array<string, mixed> $options Transformation options.
      * @return array<string, mixed>
@@ -93,6 +102,7 @@ final class StaticHtmlEmitter
         $this->usedAssetPaths = array();
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
+        $this->nodeReadableNames = array();
         $this->linkTargetPaths = $this->normalizeLinkTargetPaths($options);
         $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
@@ -127,6 +137,10 @@ final class StaticHtmlEmitter
         }
 
         $assetFiles = array_merge($this->referencedAssetFiles($assetFiles), array_values($this->generatedAssetFiles));
+
+        $shared   = $this->applySharedStyleClasses($cssRules);
+        $cssRules = $shared['rules'];
+        $body     = $this->applySharedClassMapToHtml($body, $shared['class_map']);
 
         $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
         $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
@@ -200,6 +214,7 @@ final class StaticHtmlEmitter
         $this->usedAssetPaths = array();
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
+        $this->nodeReadableNames = array();
         $this->linkTargetPaths = $this->linkTargetPathsFromPagePlan($pagePlan, $options);
         $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
@@ -295,6 +310,17 @@ final class StaticHtmlEmitter
         }
 
         $assetFiles = array_merge($this->referencedAssetFiles($assetFiles), array_values($this->generatedAssetFiles));
+
+        $shared   = $this->applySharedStyleClasses($cssRules);
+        $cssRules = $shared['rules'];
+        if ( ! empty($shared['class_map']) ) {
+            foreach ( $files as $fileIndex => $file ) {
+                if ( 'text/html' === ($file['mime_type'] ?? '') && isset($file['content']) ) {
+                    $files[$fileIndex]['content'] = $this->applySharedClassMapToHtml((string) $file['content'], $shared['class_map']);
+                }
+            }
+        }
+
         $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
         $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
         $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
@@ -438,6 +464,7 @@ final class StaticHtmlEmitter
         $styles = $this->styleDeclarations($node, $type, $parentNode);
         if ( ! empty($styles) ) {
             $cssRules[] = '.' . $className . '{' . implode(';', $styles) . '}';
+            $this->nodeReadableNames[$className] = $this->sharedClassBaseName($name, $type);
         }
         $nodeStyleDiagnostics[] = $this->nodeStyleDiagnostic($node, $type, $className, $tag, $styles, $parentNode);
 
@@ -5262,6 +5289,128 @@ final class StaticHtmlEmitter
         $slug = trim($slug, '-');
 
         return '' === $slug ? 'node' : $slug;
+    }
+
+    /**
+     * Derive a readable, authored-looking base class name from a node's name,
+     * falling back to its role/type when the node is unnamed. Never embeds raw
+     * Figma node ids, so shared classes read like `.hero-section` or `.card`.
+     */
+    private function sharedClassBaseName(string $name, string $type): string
+    {
+        $base = $this->slug($name);
+        if ( 'node' === $base || '' === $base ) {
+            $base = $this->slug($type);
+            if ( 'node' === $base || '' === $base ) {
+                $base = 'style';
+            }
+        }
+
+        return $base;
+    }
+
+    /**
+     * Collapse repeated per-node style rules into shared, readably-named CSS
+     * classes — the way a hand-authored stylesheet reuses `.card` or `.button`.
+     *
+     * Per-node rules (`.figma-node-*{...}`) whose declaration body is identical
+     * across two or more nodes are replaced by a single shared rule named after
+     * the first such node (deterministically, in stylesheet order). The original
+     * `figma-node-*` hooks remain on the elements for diagnostics; the shared
+     * class is appended so computed styles are byte-for-byte identical.
+     *
+     * @param array<int, string> $cssRules
+     * @return array{rules: array<int, string>, class_map: array<string, string>}
+     */
+    private function applySharedStyleClasses(array $cssRules): array
+    {
+        $pattern = '/^\.(figma-node-[A-Za-z0-9_-]+)\{(.*)\}$/s';
+
+        // Group per-node rules by declaration body, preserving first-seen order.
+        $bodyToSelectors = array();
+        $bodyFirstIndex  = array();
+        foreach ( $cssRules as $index => $rule ) {
+            if ( 1 === preg_match($pattern, $rule, $matches) ) {
+                $body = $matches[2];
+                $bodyToSelectors[$body][] = $matches[1];
+                if ( ! isset($bodyFirstIndex[$body]) ) {
+                    $bodyFirstIndex[$body] = $index;
+                }
+            }
+        }
+
+        // Mint a deterministic shared class name for every body used 2+ times.
+        $sharedOrder = array();
+        foreach ( $bodyToSelectors as $body => $selectors ) {
+            if ( count($selectors) >= 2 ) {
+                $sharedOrder[$body] = $bodyFirstIndex[$body];
+            }
+        }
+        asort($sharedOrder);
+
+        $reserved = array(
+            'figma-root'         => true,
+            'figma-link'         => true,
+            'figma-text-glyphs'  => true,
+            'figma-vector-asset' => true,
+        );
+        $usedNames        = array();
+        $bodyToSharedClass = array();
+        foreach ( array_keys($sharedOrder) as $body ) {
+            $firstSelector = $bodyToSelectors[$body][0];
+            $base = $this->nodeReadableNames[$firstSelector] ?? 'style';
+            $name = $base;
+            $suffix = 2;
+            while ( isset($usedNames[$name]) || isset($reserved[$name]) ) {
+                $name = $base . '-' . $suffix;
+                ++$suffix;
+            }
+            $usedNames[$name]        = true;
+            $bodyToSharedClass[$body] = $name;
+        }
+
+        // Rewrite the stylesheet: emit each shared rule once (in place of the
+        // first per-node rule that produced it) and drop the duplicates.
+        $rules        = array();
+        $emittedShared = array();
+        $classMap     = array();
+        foreach ( $cssRules as $rule ) {
+            if ( 1 === preg_match($pattern, $rule, $matches) ) {
+                $selector = $matches[1];
+                $body     = $matches[2];
+                if ( isset($bodyToSharedClass[$body]) ) {
+                    $shared            = $bodyToSharedClass[$body];
+                    $classMap[$selector] = $shared;
+                    if ( ! isset($emittedShared[$shared]) ) {
+                        $rules[]              = '.' . $shared . '{' . $body . '}';
+                        $emittedShared[$shared] = true;
+                    }
+                    continue;
+                }
+            }
+            $rules[] = $rule;
+        }
+
+        return array('rules' => $rules, 'class_map' => $classMap);
+    }
+
+    /**
+     * Append shared class names to the `figma-node-*` hooks already present in
+     * an emitted HTML fragment.
+     *
+     * @param array<string, string> $classMap
+     */
+    private function applySharedClassMapToHtml(string $html, array $classMap): string
+    {
+        foreach ( $classMap as $selector => $shared ) {
+            $html = str_replace(
+                'class="' . $selector . '"',
+                'class="' . $selector . ' ' . $shared . '"',
+                $html
+            );
+        }
+
+        return $html;
     }
 
     private function number(float $value): string

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3433,7 +3433,12 @@ $fixedFlexResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     ),
 ));
 $fixedFlexCss = $fileContent($fixedFlexResult, 'style.css');
-$assert(str_contains($fixedFlexCss, '.figma-node-flex-child-a-fixed-child-a{width:70px;height:40px;flex-shrink:0}'), 'fixed-flex-child-does-not-shrink');
+$fixedFlexHtml = $fileContent($fixedFlexResult, 'index.html');
+// Authored CSS: the two siblings have identical styles, so the fixed (non-shrinking)
+// declarations collapse into a single shared, readably-named class referenced by both.
+$assert(str_contains($fixedFlexCss, '.fixed-child-a{width:70px;height:40px;flex-shrink:0}'), 'fixed-flex-child-does-not-shrink');
+$assert(1 === substr_count($fixedFlexCss, 'width:70px;height:40px;flex-shrink:0'), 'fixed-flex-shared-style-not-duplicated');
+$assert(str_contains($fixedFlexHtml, 'class="figma-node-flex-child-a-fixed-child-a fixed-child-a"') && str_contains($fixedFlexHtml, 'class="figma-node-flex-child-b-fixed-child-b fixed-child-a"'), 'fixed-flex-children-share-authored-class');
 
 $fixedRootFlexResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Fixed Root Flex Fixture',
@@ -4648,8 +4653,12 @@ $assert(str_contains($instanceVectorChildrenHtml, 'data-figma-node-id="icon:two/
 $assert(strpos($instanceVectorChildrenHtml, 'data-figma-node-id="icon:one/icon:vector"') !== strpos($instanceVectorChildrenHtml, 'data-figma-node-id="icon:vector"'), 'instance-vector-child-source-id-is-not-reused-by-instance-one');
 $assert(strpos($instanceVectorChildrenHtml, 'data-figma-node-id="icon:two/icon:vector"') !== strpos($instanceVectorChildrenHtml, 'data-figma-node-id="icon:vector"'), 'instance-vector-child-source-id-is-not-reused-by-instance-two');
 $assert(3 === substr_count($instanceVectorChildrenHtml, 'data-figma-vector="true"'), 'instance-vector-children-render-with-definition');
-$assert(str_contains($instanceVectorChildrenCss, '.figma-node-icon-one-icon-vector-vector{width:10px;height:10px'), 'instance-vector-css-one');
-$assert(str_contains($instanceVectorChildrenCss, '.figma-node-icon-two-icon-vector-vector{width:10px;height:10px'), 'instance-vector-css-two');
+// Authored CSS: both instance vector children share identical sizing, so they
+// reference one shared `.vector` class rather than duplicating per-node rules,
+// while each keeps its namespaced `figma-node-*` hook.
+$assert(str_contains($instanceVectorChildrenCss, '.vector{width:10px;height:10px'), 'instance-vector-css-shared-class');
+$assert(str_contains($instanceVectorChildrenHtml, 'class="figma-node-icon-one-icon-vector-vector vector"'), 'instance-vector-css-one');
+$assert(str_contains($instanceVectorChildrenHtml, 'class="figma-node-icon-two-icon-vector-vector vector"'), 'instance-vector-css-two');
 
 $instanceSimpleNetworkVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Instance Simple Network Vector Fixture',
@@ -5451,13 +5460,80 @@ $assert(str_contains($semanticHtml, '<nav class="figma-node-top-menu-primary-lin
 $assert(str_contains($semanticHtml, '<footer class="figma-node-region-bottom-bottom-bar"'), 'semantic-bottom-region-emits-footer');
 $assert(str_contains($semanticHtml, '<h1 class="figma-node-body-h1-hero"'), 'semantic-largest-text-emits-h1');
 $assert(str_contains($semanticHtml, '<h2 class="figma-node-body-h2-subhead"'), 'semantic-second-text-emits-h2');
-$assert(str_contains($semanticHtml, '<p class="figma-node-body-p1-intro"'), 'semantic-body-copy-emits-paragraph');
+$assert(str_contains($semanticHtml, '<p class="figma-node-body-p1-intro'), 'semantic-body-copy-emits-paragraph');
 $assert(str_contains($semanticHtml, '<ul class="figma-node-body-cards-feature-cards"'), 'semantic-repeated-items-emit-list');
 $assert(str_contains($semanticHtml, '<li class="figma-node-card-1-card-one"'), 'semantic-repeated-item-emits-list-item');
 $assert(str_contains($semanticHtml, '<button class="figma-node-body-cta-get-started"'), 'semantic-button-like-node-emits-button');
 $assert(! str_contains($semanticHtml, '<div class="figma-node-region-top-top-bar"'), 'semantic-header-not-generic-div');
 
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
+
+// Authored CSS classes: repeated per-node styles collapse into shared, readably
+// named classes (like a hand-authored site reuses `.card`), names derive from
+// node names/roles, and class names + stylesheet ordering stay deterministic.
+$authoredCssScenegraph = array(
+    'name'  => 'Authored CSS Fixture',
+    'nodes' => array(
+        array(
+            'id'         => 'authored:hero',
+            'type'       => 'FRAME',
+            'name'       => 'Hero Section',
+            'width'      => 1200,
+            'height'     => 400,
+            'layoutMode' => 'VERTICAL',
+            'children'   => array(
+                array(
+                    'id'              => 'authored:card-1',
+                    'type'            => 'FRAME',
+                    'name'            => 'Primary Card',
+                    'width'           => 300,
+                    'height'          => 200,
+                    'backgroundColor' => '#ffffff',
+                    'cornerRadius'    => 8,
+                ),
+                array(
+                    'id'              => 'authored:card-2',
+                    'type'            => 'FRAME',
+                    'name'            => 'Secondary Card',
+                    'width'           => 300,
+                    'height'          => 200,
+                    'backgroundColor' => '#ffffff',
+                    'cornerRadius'    => 8,
+                ),
+            ),
+        ),
+        array(
+            'id'              => 'authored:hero-twin',
+            'type'            => 'FRAME',
+            'name'            => 'Hero Section',
+            'width'           => 1200,
+            'height'          => 400,
+            'layoutMode'      => 'VERTICAL',
+        ),
+    ),
+);
+$authoredCssResult = blocks_engine_figma_transformer_transform_scenegraph($authoredCssScenegraph);
+$authoredCss = $fileContent($authoredCssResult, 'style.css');
+$authoredHtml = $fileContent($authoredCssResult, 'index.html');
+
+// Two cards with identical styles share ONE emitted class, not duplicated rules.
+$assert(1 === substr_count($authoredCss, 'background:#ffffff;border-radius:8px'), 'authored-css-shared-card-style-emitted-once');
+$assert(str_contains($authoredHtml, 'class="figma-node-authored-card-1-primary-card primary-card"'), 'authored-css-first-card-references-shared-class');
+$assert(str_contains($authoredHtml, 'class="figma-node-authored-card-2-secondary-card primary-card"'), 'authored-css-second-card-references-shared-class');
+$assert(str_contains($authoredCss, '.primary-card{'), 'authored-css-shared-class-readably-named');
+
+// A node named "Hero Section" yields a readable `hero-section` class (no node id).
+$assert(str_contains($authoredCss, '.hero-section{'), 'authored-css-hero-section-readable-class');
+$assert(! preg_match('/\.hero-section[^{]*authored/', $authoredCss), 'authored-css-shared-name-has-no-node-id');
+$assert(str_contains($authoredHtml, 'class="figma-node-authored-hero-hero-section hero-section"'), 'authored-css-hero-references-shared-class');
+
+// No inline style attributes leak onto emitted node elements.
+$assert(! str_contains($authoredHtml, 'data-figma-node-id="authored:hero" style='), 'authored-css-prefers-classes-over-inline-style');
+
+// Determinism: two runs produce byte-identical stylesheets and HTML.
+$authoredCssRerunResult = blocks_engine_figma_transformer_transform_scenegraph($authoredCssScenegraph);
+$assert($authoredCss === $fileContent($authoredCssRerunResult, 'style.css'), 'authored-css-stylesheet-deterministic');
+$assert($authoredHtml === $fileContent($authoredCssRerunResult, 'index.html'), 'authored-css-html-deterministic');
 
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");


### PR DESCRIPTION
## Summary

Part of the authored-CSS effort for #247. The `figma-transformer` static HTML emitter previously emitted a separate per-node `figma-node-*` CSS rule for every node, so repeated styling read like machine output instead of a hand-authored stylesheet.

This change collapses repeated style declarations into **shared, readably-named CSS classes** — the way an authored site reuses `.card`, `.button`, or `.hero-section`.

### Dedupe + naming strategy
- After a page's stylesheet is assembled, per-node rules (`.figma-node-*{...}`) whose **declaration body is byte-identical** across two or more nodes are collapsed into a single shared rule.
- The shared class name is derived from a **human-readable node name/role** (e.g. "Hero Section" → `.hero-section`, "Primary Card" → `.primary-card`), sanitized to a valid CSS identifier. Unnamed nodes fall back to their role/type, then to a stable `style` base. Shared names **never embed raw Figma node ids**.
- Naming is deterministic: the shared name comes from the first contributing node in stylesheet order, and collisions resolve with numeric suffixes (`-2`, `-3`).
- The original `figma-node-*` hook stays on each element (preserving diagnostics and node-id attribution); the shared class is appended alongside it.
- Both the single-page (`emit`) and multi-page (`emitSite`) paths run the dedup over the assembled stylesheet and rewrite the emitted HTML.

### No visual change
The shared rule carries the **exact same declarations** that the per-node rules carried, applied to the same elements — computed styles are byte-for-byte identical. Singleton styles keep their per-node rule unchanged. Rich-text run spans (intra-text `style=`) are intentionally left as-is since they represent inline character runs, not node styling.

### Determinism
Class names and stylesheet ordering are stable across runs; a contract test asserts two transforms of the same scenegraph produce byte-identical `style.css` and `index.html`.

### Tests
Synthetic fixtures + contract tests only (no large `.fig` files run locally). New contract cases: two identical-style nodes share one emitted class (not duplicated); a node named "Hero Section" gets `.hero-section`; stylesheet + HTML byte-identical across two runs. Three existing fixtures whose sibling nodes share styles were updated to assert the new shared-class behavior.

```
$ cd figma-transformer && php tests/contract/run.php
Figma Transformer contract tests passed.
```

### Follow-up
Real-design validation against the large `fixtures/*.fig` files is deferred to the orchestrator's lab run (RAM-banned locally).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Emitting shared, readably-named CSS classes (authored-looking CSS) for #247.