### PR TITLE
Write overlayMenu into saved core/navigation content (native mobile overlay)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4220,7 +4220,11 @@ final class HtmlTransformer
                 'kind'  => 'custom',
             ), static fn ($value): bool => '' !== $value), array(), $anchor);
         }
-        $blocks[] = $this->createBlock('core/navigation', array(), $links, $element);
+        // Declare responsive-overlay intent explicitly (see NavigationPattern):
+        // `overlayMenu` => `mobile` matches the core default so WP renders the
+        // responsive overlay and enqueues the navigation view module instead of
+        // depending on the render-time default being applied.
+        $blocks[] = $this->createBlock('core/navigation', array( 'overlayMenu' => 'mobile' ), $links, $element);
 
         return $this->createBlock('core/group', $this->presentationAttributes($element), array_values(array_filter($blocks)), $element);
     }

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -33,7 +33,15 @@ final class NavigationPattern implements PatternRecognizerInterface
             return null;
         }
 
-        return $createBlock('core/navigation', $presentationAttributes($element), $links, $element);
+        // Declare responsive-overlay intent explicitly so the saved block carries
+        // its interactive behavior in the content itself rather than relying on
+        // WordPress applying the block.json `overlayMenu` default at render time.
+        // `mobile` matches the core default: WP renders the responsive overlay
+        // container and enqueues the `navigation/view` Interactivity module so the
+        // hamburger menu functions on the rendered site (#native-interactivity).
+        return $createBlock('core/navigation', array_merge($presentationAttributes($element), array(
+            'overlayMenu' => 'mobile',
+        )), $links, $element);
     }
 
     private function safeNavigationUrl(string $url): string

--- a/php-transformer/tests/fixtures/parity/html-list-navigation-classification.json
+++ b/php-transformer/tests/fixtures/parity/html-list-navigation-classification.json
@@ -18,11 +18,11 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph" },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "site-nav" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "site-nav", "overlayMenu": "mobile" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "/", "kind": "custom" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Services", "url": "/services", "kind": "custom" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.2", "name": "core/navigation-link", "attrs": { "label": "<span>Contact</span>", "url": "/contact", "kind": "custom" } },
-    { "path": "blocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "nav-cta" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "nav-cta", "overlayMenu": "mobile" } },
     { "path": "blocks.1", "name": "core/list", "attrs": { "className": "features" } }
   ],
   "expected_fallbacks": [],
@@ -32,7 +32,7 @@
     { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 3 },
     { "path": "blocks.1.innerBlocks", "assert": "count", "count": 2 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"className\":\"site-nav\"}" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"className\":\"site-nav\",\"overlayMenu\":\"mobile\"}" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:list {\"className\":\"features\"}" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-native-details-to-core-details.json
+++ b/php-transformer/tests/fixtures/parity/html-native-details-to-core-details.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-native-details-to-core-details",
+  "description": "A native HTML <details>/<summary> disclosure converts to a real core/details block: the summary text becomes the block summary attribute and the disclosure body becomes inner blocks, so the show/hide behavior is carried by the native zero-JS disclosure block instead of being emitted as raw <details> markup inside a generic group.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-native-details-to-core-details.json",
+    "notes": "Product-neutral fixture proving the native <details> path emits core/details with inner blocks. Detection is structural (native details/summary element), never a class string."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<details class=\"faq-item\"><summary>How does shipping work?</summary><p>Orders ship within two business days.</p></details>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/details", "attrs": { "summary": "How does shipping work?", "className": "faq-item" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Orders ship within two business days." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/details" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:details" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<details class=\"wp-block-details faq-item\"><summary>How does shipping work?</summary>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nav-overlay-menu-interactivity.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-overlay-menu-interactivity.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-overlay-menu-interactivity",
+  "description": "A source navigation menu converts to a core/navigation block with real inner core/navigation-link children and an explicit overlayMenu='mobile' attribute, so the saved content declares its responsive-overlay intent. WordPress renders the responsive overlay container and enqueues the navigation/view Interactivity module from that attribute, making the mobile hamburger menu function on the rendered site instead of relying on the render-time default being applied.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-overlay-menu-interactivity.json",
+    "notes": "Product-neutral fixture proving native-interactivity wiring for navigation. Detection is structural (nav landmark + anchor links); the overlayMenu value is the generic core default and is not site-specific."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<nav class=\"main-nav\" aria-label=\"Primary\"><ul><li><a href=\"/\">Home</a></li><li><a href=\"/about\">About</a></li><li><a href=\"/contact\">Contact</a></li></ul></nav>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "main-nav", "overlayMenu": "mobile" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "/", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "About", "url": "/about", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/navigation-link", "attrs": { "label": "Contact", "url": "/contact", "kind": "custom" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.attrs.overlayMenu", "assert": "equals", "value": "mobile" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"overlayMenu\":\"mobile\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"Home\",\"url\":\"/\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"className\":\"main-nav\",\"overlayMenu\":\"mobile\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-semantic-selector-preservation.json
+++ b/php-transformer/tests/fixtures/parity/html-semantic-selector-preservation.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "anchor": "site-header", "className": "site-header" } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation", "attrs": { "anchor": "mobile-nav", "className": "site-nav" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation", "attrs": { "anchor": "mobile-nav", "className": "site-nav", "overlayMenu": "mobile" } },
     { "path": "blocks.1", "name": "core/group", "attrs": { "anchor": "feature-section", "className": "feature-section reveal" } }
   ],
   "expected_fallbacks": [],
@@ -26,7 +26,7 @@
     { "path": "blocks", "assert": "count", "count": 2 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"anchor\":\"site-header\",\"className\":\"site-header\"} -->" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"anchor\":\"mobile-nav\",\"className\":\"site-nav\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"anchor\":\"mobile-nav\",\"className\":\"site-nav\",\"overlayMenu\":\"mobile\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"anchor\":\"feature-section\",\"className\":\"feature-section reveal\"} -->" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "js-site-header" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "jsHeader" },


### PR DESCRIPTION
## What
Writes `overlayMenu:"mobile"` into the saved content of generated `core/navigation` blocks. Previously the responsive mobile overlay relied solely on WordPress's render-time `block.json` default — so the attribute existed at render but **not in saved content**. Any path that doesn't apply render defaults (editor load, block migration, re-serialization) would silently drop the responsive hamburger menu and the `navigation/view` Interactivity module enqueue.

## Change
- `Patterns/NavigationPattern.php` and `HtmlTransformer::navigationSectionBlockFromElement()` now emit `overlayMenu => 'mobile'` explicitly. Inner `core/navigation-link`/`navigation-submenu` structure unchanged.

## Verification
- End-to-end through `do_blocks()` on a converted nav: responsive-container present, open-toggle button present, `data-wp-interactive` present, real menu links present. A control with `overlayMenu:"never"` produces no responsive container — confirming the attribute gates the overlay + view-module enqueue.
- Probe (3-artist-music, 7-event-conference, 15-saas, 38-medical-clinic): nav-with-overlayMenu 0→all; inner links already present.
- `composer test` + `composer parity`: **149 fixtures** green (+2 new: overlay-menu interactivity, native-details→core/details). Existing nav fixtures updated to assert the attr.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and end-to-end render verification under human review.
