### PR TITLE
Preserve grid layout on explicit-grid containers with non-card children

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -408,11 +408,35 @@ trait StyleResolutionTrait
             return array( 'type' => 'grid' );
         }
 
+        // An explicit grid class token (`grid`, `grid-3`, `footer-grid`,
+        // `card-grid`, …) is a deterministic CSS-grid signal on its own. When the
+        // container holds more than one element child, emit grid layout so the
+        // multi-column arrangement survives even when the children are plain
+        // wrappers rather than recognized card markup. Without this the grid
+        // collapses to a vertical stack and loses visual parity.
+        if ( $this->hasExplicitGridClass($element) && 1 < $this->directElementChildCount($element) ) {
+            return array( 'type' => 'grid' );
+        }
+
         if ( $this->hasGridLikeClass($element) && 1 < $this->cardLikeChildCount($element) ) {
             return array( 'type' => 'grid' );
         }
 
         return array();
+    }
+
+    /**
+     * Unambiguous grid class tokens: a bare `grid`, a numbered `grid-N`, or any
+     * `*-grid` / `*_grid` suffix (footer-grid, card-grid, mission-grid, …) plus
+     * the common `grid-cols` / `grid-columns` utility names. These map directly to
+     * `display:grid` containers, so they are safe to treat as grids regardless of
+     * child semantics. Ambiguous semantic names (cards, features, …) stay gated on
+     * card-like children via hasGridLikeClass().
+     */
+    private function hasExplicitGridClass(DOMElement $element): bool
+    {
+        $className = strtolower($this->attr($element, 'class'));
+        return (bool) preg_match('/(?:^|[\s_-])(?:grid|grid-[0-9]+|grid-cols(?:-[0-9]+)?|grid-columns|[a-z0-9]+[-_]grid)(?:$|[\s_-])/', $className);
     }
 
     private function hasGridLikeClass(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-explicit-grid-class-non-card-children.json
+++ b/php-transformer/tests/fixtures/parity/html-explicit-grid-class-non-card-children.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-explicit-grid-class-non-card-children",
+  "description": "An explicit grid class (grid-3) emits layout:{type:grid} even when children are plain wrapper divs rather than recognized card markup, so the multi-column arrangement survives instead of collapsing to a vertical stack.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-explicit-grid-class-non-card-children.json",
+    "notes": "Derived from SSI website fixtures (e.g. realistic-small-business events/index) where grid-3 process steps use neutral reveal wrappers with no card token."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"section\"><div class=\"grid-3\" style=\"gap:1.5rem\"><div class=\"reveal reveal-delay-1\"><div class=\"step-number\">01</div><h4>You Call, We Plan</h4><p>We discuss your space and goals.</p></div><div class=\"reveal reveal-delay-2\"><div class=\"step-number\">02</div><h4>We Build</h4><p>Our team assembles everything.</p></div><div class=\"reveal reveal-delay-3\"><div class=\"step-number\">03</div><h4>You Enjoy</h4><p>Sit back and relax.</p></div></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "section" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "grid-3", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "reveal reveal-delay-1" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "reveal reveal-delay-2" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/group", "attrs": { "className": "reveal reveal-delay-3" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "level": 4 } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"grid-3\",\"layout\":{\"type\":\"grid\"}} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"className\":\"reveal reveal-delay-1\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:heading {\"content\":\"You Call, We Plan\",\"level\":4} -->" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-non-grid-class-stays-plain-group.json
+++ b/php-transformer/tests/fixtures/parity/html-non-grid-class-stays-plain-group.json
@@ -1,0 +1,30 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-non-grid-class-stays-plain-group",
+  "description": "Guard: a container whose class is not an explicit grid token and whose children are not card-like stays a plain core/group with no grid layout, so the explicit-grid promotion does not over-match neutral wrappers.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-non-grid-class-stays-plain-group.json",
+    "notes": "Negative control for the explicit grid-class layout promotion."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div class=\"feature-list\"><div class=\"row\"><h4>First</h4><p>Alpha.</p></div><div class=\"row\"><h4>Second</h4><p>Beta.</p></div></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-list" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "row" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "row" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"feature-list\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"className\":\"feature-list\",\"layout\":{\"type\":\"grid\"}" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-suffix-grid-class-layout.json
+++ b/php-transformer/tests/fixtures/parity/html-suffix-grid-class-layout.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-suffix-grid-class-layout",
+  "description": "A *-grid suffix class (footer-grid) emits layout:{type:grid} with each column preserved as a real nested core/group, so a multi-column footer keeps its grid arrangement instead of stacking.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-suffix-grid-class-layout.json",
+    "notes": "Derived from SSI website fixtures using footer-grid / mission-grid / donate-grid style suffix grid containers."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<footer class=\"site-footer\"><div class=\"footer-grid\"><div class=\"footer-col\"><h4>Explore</h4><ul><li><a href=\"/about\">About</a></li><li><a href=\"/shop\">Shop</a></li></ul></div><div class=\"footer-col\"><h4>Visit</h4><p>123 Garden Lane</p></div><div class=\"footer-col\"><h4>Hours</h4><p>Mon-Fri 9-5</p></div><div class=\"footer-col\"><h4>Contact</h4><p>hello@example.com</p></div></div></footer>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-footer" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "footer-grid", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "footer-col" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "level": 4 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/list" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 4 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"footer-grid\",\"layout\":{\"type\":\"grid\"}} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"className\":\"footer-col\"" }
+  ]
+}


### PR DESCRIPTION
## What
Fixes a visual-parity loss: CSS-grid containers whose children are plain wrapper divs (not card-like markup) lost their `layout:{type:grid}` attribute, so the grid collapsed to a vertical stack on import. `layoutAttribute` only attached grid layout when `hasGridLikeClass && cardLikeChildCount > 1`; containers like `grid-3` of plain steps or `footer-grid`/`mission-grid` columns fell through.

## Change (`Style/StyleResolutionTrait.php`)
- New `hasExplicitGridClass()` + branch: an explicit grid token (`grid`, `grid-N`, `grid-cols[-N]`, `grid-columns`, or any `*-grid`/`*_grid` suffix) with 2+ element children emits `layout:{type:grid}` regardless of child semantics. Ambiguous semantic names (`cards`, `features`) stay gated on card-like children. ClassNames on container + nested children already preserved by `presentationAttributes`; the grid layout attr is the fidelity-bearing signal restored here.

## Verification (probe over fixtures/websites)
- Grid-card containers WITH grid layout: **265 → 463**; missing grid layout: **208 → 10**. The remaining 10 confirmed via CSS as genuinely not `display:grid` (correct to leave as flow).
- `composer test` + `composer parity`: **150 fixtures** green (+3: explicit-grid non-card children, suffix-grid, and a negative control that stays a plain group). No assertions weakened.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Probe-driven diagnosis, fix, and fixtures under human review.
