### PR TITLE
Add generic frame role + page-type classification (#247)

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphFrameClassifier.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphFrameClassifier.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Classifies top-level FRAME candidates into ROLES so the page planner can keep
+ * style-guide / design-system frames out of page selection and tag every real
+ * page with a WordPress-template-aligned page type.
+ *
+ * This is the foundational "abstract known-truths" layer: before any pixels are
+ * emitted, the transformer decides WHAT each top-level frame IS. The classifier
+ * is generic and signal-based — it reads the frame's NAME plus light
+ * content-shape metrics (text/asset density, repeating sibling structure) the
+ * planner already gathers, never a hardcoded list of file-specific frame names.
+ *
+ * Roles:
+ *   - {@see ROLE_DESIGN_SYSTEM}: a style guide / design system / token /
+ *     component-gallery frame. These INFORM the design system (another layer
+ *     extracts their tokens) and must be EXCLUDED from page selection.
+ *   - {@see ROLE_PAGE}: a real page frame. Every page carries a `page_type`
+ *     aligned to the WordPress template hierarchy so the downstream
+ *     php-transformer can map it to a WP template:
+ *       - {@see PAGE_TYPE_FRONT_PAGE} (front-page.php / front page)
+ *       - {@see PAGE_TYPE_SINGLE}     (single.php — a single post/article)
+ *       - {@see PAGE_TYPE_ARCHIVE}    (archive.php / index.php — a list of cards)
+ *       - {@see PAGE_TYPE_PAGE}       (page.php — a generic content page)
+ *       - {@see PAGE_TYPE_UNKNOWN}    (fallback when no signal is decisive)
+ *
+ * Every classification carries the ordered list of signals that drove it, so the
+ * diagnostic surface can explain WHY a frame landed in a role / page type.
+ */
+final class ScenegraphFrameClassifier
+{
+    public const ROLE_DESIGN_SYSTEM = 'design_system';
+    public const ROLE_PAGE          = 'page';
+
+    public const PAGE_TYPE_FRONT_PAGE = 'front_page';
+    public const PAGE_TYPE_SINGLE     = 'single';
+    public const PAGE_TYPE_ARCHIVE    = 'archive';
+    public const PAGE_TYPE_PAGE       = 'page';
+    public const PAGE_TYPE_UNKNOWN    = 'unknown';
+
+    /**
+     * Minimum count of near-uniform, small, leaf-like siblings under a frame for
+     * its content shape to read as a swatch/specimen grid (a design-system tell)
+     * rather than ordinary page content.
+     */
+    private const SWATCH_GRID_MIN_TILES = 6;
+
+    /**
+     * Minimum count of structurally-similar repeating sibling subtrees for a
+     * frame's content shape to read as a list of post cards (an archive tell).
+     */
+    private const CARD_LIST_MIN_CARDS = 3;
+
+    /**
+     * Classify one top-level frame from frame-level signals.
+     *
+     * @param array{
+     *     name?: string,
+     *     width?: float|null,
+     *     height?: float|null,
+     *     text_count?: int,
+     *     asset_count?: int,
+     *     uniform_tile_count?: int,
+     *     repeating_card_count?: int,
+     *     section_name?: string|null,
+     *     page_name?: string|null
+     * } $signals
+     * @return array{
+     *     role: string,
+     *     page_type: string|null,
+     *     signals: array<int, string>,
+     *     is_page: bool
+     * }
+     */
+    public function classify(array $signals): array
+    {
+        $name = trim((string) ($signals['name'] ?? ''));
+        $sectionName = trim((string) ($signals['section_name'] ?? ''));
+        $pageName = trim((string) ($signals['page_name'] ?? ''));
+        $scopeNames = trim($name . ' ' . $sectionName . ' ' . $pageName);
+
+        $designSystem = $this->assessDesignSystem($name, $scopeNames, $signals);
+        if ( $designSystem['is_design_system'] ) {
+            return array(
+                'role'      => self::ROLE_DESIGN_SYSTEM,
+                'page_type' => null,
+                'signals'   => $designSystem['signals'],
+                'is_page'   => false,
+            );
+        }
+
+        $pageType = $this->assessPageType($name, $signals);
+
+        return array(
+            'role'      => self::ROLE_PAGE,
+            'page_type' => $pageType['page_type'],
+            'signals'   => $pageType['signals'],
+            'is_page'   => true,
+        );
+    }
+
+    /**
+     * Decide whether a frame is a design-system / style-guide frame.
+     *
+     * Name signals win first (the explicit "Style Guide" / "Design System" /
+     * "Tokens" / "Components" / "Styles" family). When the name is silent, the
+     * content shape can still betray a style guide: a grid of near-uniform color
+     * swatches, or a dense type-specimen frame with many text nodes and almost no
+     * imagery and no card structure.
+     *
+     * @param array<string, mixed> $signals
+     * @return array{is_design_system: bool, signals: array<int, string>}
+     */
+    private function assessDesignSystem(string $name, string $scopeNames, array $signals): array
+    {
+        $reasons = array();
+
+        if ( $this->matchesDesignSystemName($name) ) {
+            $reasons[] = 'name:design_system';
+        } elseif ( $this->matchesDesignSystemName($scopeNames) ) {
+            // Scoped under a "Style Guide" section/page even when the frame's own
+            // name is generic (e.g. a "Colors" frame inside a "Design System"
+            // section).
+            $reasons[] = 'scope:design_system';
+        }
+
+        $uniformTiles = (int) ($signals['uniform_tile_count'] ?? 0);
+        $repeatingCards = (int) ($signals['repeating_card_count'] ?? 0);
+        if ( $uniformTiles >= self::SWATCH_GRID_MIN_TILES && $repeatingCards < self::CARD_LIST_MIN_CARDS ) {
+            // A grid of many near-uniform small tiles with no card structure reads
+            // as a swatch/specimen palette, not page content.
+            $reasons[] = 'content:swatch_grid';
+        }
+
+        // A name/scope match alone is decisive. A pure content-shape match is
+        // only decisive when nothing about the frame looks like a real page (no
+        // page-type name signal), so a "Colors" hero section on a marketing page
+        // is not misread as a style guide.
+        $nameMatched = in_array('name:design_system', $reasons, true)
+            || in_array('scope:design_system', $reasons, true);
+        $contentMatched = in_array('content:swatch_grid', $reasons, true);
+        $looksLikePage = '' !== $this->pageTypeNameMatch($name);
+
+        $isDesignSystem = $nameMatched || ( $contentMatched && ! $looksLikePage );
+
+        // Suppress a name match if the frame ALSO carries a strong page-type name
+        // ("Components Landing Page") — the explicit page intent wins.
+        if ( in_array('name:design_system', $reasons, true) && '' !== $this->pageTypeNameMatch($name) && $this->hasPageIntentSuffix($name) ) {
+            $isDesignSystem = false;
+            $reasons[] = 'override:page_intent';
+        }
+
+        return array(
+            'is_design_system' => $isDesignSystem,
+            'signals'          => $reasons,
+        );
+    }
+
+    /**
+     * Resolve the WordPress-template-aligned page type for a real page frame.
+     *
+     * Name signals are authoritative when present (front page, single, archive,
+     * generic page); when the name is silent the content shape decides: a single
+     * long article body (one dominant text-heavy column, little repetition) reads
+     * as `single`; a repeating list of post cards reads as `archive`; otherwise
+     * `page`, falling to `unknown` only when even that is unclear.
+     *
+     * @param array<string, mixed> $signals
+     * @return array{page_type: string, signals: array<int, string>}
+     */
+    private function assessPageType(string $name, array $signals): array
+    {
+        $reasons = array();
+
+        $nameType = $this->pageTypeNameMatch($name);
+        if ( '' !== $nameType ) {
+            $reasons[] = 'name:' . $nameType;
+
+            return array('page_type' => $nameType, 'signals' => $reasons);
+        }
+
+        $textCount = (int) ($signals['text_count'] ?? 0);
+        $repeatingCards = (int) ($signals['repeating_card_count'] ?? 0);
+
+        if ( $repeatingCards >= self::CARD_LIST_MIN_CARDS ) {
+            $reasons[] = 'content:card_list';
+
+            return array('page_type' => self::PAGE_TYPE_ARCHIVE, 'signals' => $reasons);
+        }
+
+        if ( $textCount > 0 && $repeatingCards < self::CARD_LIST_MIN_CARDS && $this->isArticleShape($signals) ) {
+            $reasons[] = 'content:article_body';
+
+            return array('page_type' => self::PAGE_TYPE_SINGLE, 'signals' => $reasons);
+        }
+
+        if ( $textCount > 0 ) {
+            $reasons[] = 'content:generic_content';
+
+            return array('page_type' => self::PAGE_TYPE_PAGE, 'signals' => $reasons);
+        }
+
+        $reasons[] = 'fallback:unknown';
+
+        return array('page_type' => self::PAGE_TYPE_UNKNOWN, 'signals' => $reasons);
+    }
+
+    private function matchesDesignSystemName(string $value): bool
+    {
+        return 1 === preg_match(
+            '/\b(style\s*guide|styleguide|design\s*system|design\s*tokens?|tokens?|components?|component\s*library|ui\s*kit|pattern\s*library|styles?|typography|color\s*palette|swatches?)\b/i',
+            $value
+        );
+    }
+
+    /**
+     * Map a frame name to a page type, or '' when the name carries no page
+     * signal. The ordering matters: front page first (most specific), then the
+     * single/archive families, then the generic page fallback.
+     */
+    private function pageTypeNameMatch(string $name): string
+    {
+        if ( 1 === preg_match('/\b(home\s*page|homepage|home|landing(\s*page)?|front\s*page)\b/i', $name) ) {
+            return self::PAGE_TYPE_FRONT_PAGE;
+        }
+
+        // Archive / list views before single, so "Blog" (an index) is not read as
+        // a single article. "Blog Post" / "Article" / "Post" detail read single.
+        if ( 1 === preg_match('/\b(blog\s*post|article|post\s*detail|single\s*post)\b/i', $name) ) {
+            return self::PAGE_TYPE_SINGLE;
+        }
+
+        if ( 1 === preg_match('/\b(archive|blog|index|news|articles|posts|category|categories|tag|search\s*results|listing)\b/i', $name) ) {
+            return self::PAGE_TYPE_ARCHIVE;
+        }
+
+        if ( 1 === preg_match('/\b(about|contact|pricing|services?|team|faq|privacy|terms|page|portfolio|gallery|product|shop)\b/i', $name) ) {
+            return self::PAGE_TYPE_PAGE;
+        }
+
+        return '';
+    }
+
+    /**
+     * Whether a name carries an explicit page-intent suffix ("... Page",
+     * "... Landing"), used to let page intent override a design-system name token
+     * in mixed names like "Components Landing Page".
+     */
+    private function hasPageIntentSuffix(string $name): bool
+    {
+        return 1 === preg_match('/\b(page|landing|home\s*page|homepage)\b/i', $name);
+    }
+
+    /**
+     * Content-shape heuristic for a single article body: a text-dominant frame
+     * with no card repetition and a tall, narrow-ish reading column. The planner
+     * supplies the raw metrics; we keep the rule conservative so generic content
+     * pages fall to `page`, not `single`.
+     *
+     * @param array<string, mixed> $signals
+     */
+    private function isArticleShape(array $signals): bool
+    {
+        $textCount = (int) ($signals['text_count'] ?? 0);
+        $assetCount = (int) ($signals['asset_count'] ?? 0);
+        $width = is_numeric($signals['width'] ?? null) ? (float) $signals['width'] : 0.0;
+        $height = is_numeric($signals['height'] ?? null) ? (float) $signals['height'] : 0.0;
+
+        $textDominant = $textCount >= 6 && $textCount >= ($assetCount * 2 + 1);
+        $tallReadingColumn = $height > 0 && $width > 0 && $height >= $width;
+
+        return $textDominant && $tallReadingColumn;
+    }
+}

--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -42,7 +42,8 @@ final class ScenegraphPagePlanner
 
     public function __construct(
         private readonly ScenegraphIndex $index = new ScenegraphIndex(),
-        private readonly ScenegraphFrameInspector $frameInspector = new ScenegraphFrameInspector()
+        private readonly ScenegraphFrameInspector $frameInspector = new ScenegraphFrameInspector(),
+        private readonly ScenegraphFrameClassifier $frameClassifier = new ScenegraphFrameClassifier()
     ) {
     }
 
@@ -67,6 +68,16 @@ final class ScenegraphPagePlanner
      *         'slug'                  => string,   // deduped, derived from primary
      *         'path'                  => string,   // index.html for the entrypoint
      *         'entrypoint'            => bool,
+     *         // Frame role classification (#247). Only ROLE_PAGE frames are
+     *         // selected as pages; design_system frames are excluded upstream.
+     *         'role'                  => string,   // ScenegraphFrameClassifier::ROLE_PAGE
+     *         'page_type'             => string,   // front_page|single|archive|page|unknown
+     *                                              //   (maps to the WP template hierarchy:
+     *                                              //    front_page→front-page.php,
+     *                                              //    single→single.php,
+     *                                              //    archive→archive.php/index.php,
+     *                                              //    page→page.php, unknown→fallback)
+     *         'classification_signals' => array<int, string>, // why this page_type was chosen
      *         'figma_page_id'         => string|null,
      *         'figma_page_name'       => string|null,
      *         'section_id'            => string|null,
@@ -130,6 +141,28 @@ final class ScenegraphPagePlanner
             );
         }
 
+        // Frame role classification (#247): decide WHAT each top-level frame IS
+        // before any pixels are emitted. Design-system / style-guide frames are
+        // excluded from page selection; real pages carry a WP-template-aligned
+        // page_type. Classification runs over the frame-level signals already in
+        // memory, so it adds no extra scenegraph traversal.
+        $classifications = array();
+        foreach ( $candidates as $candidateId => $candidate ) {
+            $classifications[(string) $candidateId] = $this->classifyCandidate(
+                (string) $candidateId,
+                $candidate,
+                $nodes,
+                $childrenIndex,
+                $parentIndex
+            );
+        }
+        $designSystemIds = array();
+        foreach ( $classifications as $candidateId => $classification ) {
+            if ( ScenegraphFrameClassifier::ROLE_DESIGN_SYSTEM === ($classification['role'] ?? '') ) {
+                $designSystemIds[(string) $candidateId] = true;
+            }
+        }
+
         // Figma Dev Mode status (#280): when ANY node in the file carries a
         // normalized dev status, it becomes the PRIMARY frame-selection signal.
         $nodeDevStatus = $this->resolveNodeDevStatus($nodes);
@@ -158,14 +191,16 @@ final class ScenegraphPagePlanner
             // Prefer ready_for_dev/completed frames (and frames under a marked
             // section); skip WIP/unmarked frames. Heuristics stay as the order
             // within the marked set and as the fallback when no frame qualifies.
+            // Design-system frames never become pages even when dev-marked.
             $selectionSource = 'dev_status';
-            $markedCandidates = array_intersect_key($candidates, $frameDevStatus);
+            $markedCandidates = array_diff_key(array_intersect_key($candidates, $frameDevStatus), $designSystemIds);
             $selectedIds = $this->rankedCandidateIdsByDevStatus($markedCandidates, $frameDevStatus);
             if ( ! $includeAllPages ) {
                 $selectedIds = array_slice($selectedIds, 0, 1);
             }
         } else {
-            $selectedIds = $this->rankedCandidateIds($candidates);
+            $selectableCandidates = array_diff_key($candidates, $designSystemIds);
+            $selectedIds = $this->rankedCandidateIds($selectableCandidates);
             if ( ! $includeAllPages ) {
                 $selectedIds = array_slice($selectedIds, 0, 1);
             }
@@ -224,6 +259,7 @@ final class ScenegraphPagePlanner
             $slug = $this->dedupeSlug($this->configuredSlug($primaryId, $slugMap) ?? $this->slugify($name), $slugs);
             $entrypoint = null !== $entryFrameId ? in_array($entryFrameId, $members, true) : 0 === $emittedPosition;
             $variants = $this->breakpointVariants($members, $primaryId, $candidates, $detectionById);
+            $classification = $classifications[$primaryId] ?? $this->classifyCandidate($primaryId, $candidate, $nodes, $childrenIndex, $parentIndex);
 
             $pages[] = array(
                 'frame_id'              => $primaryId,
@@ -231,6 +267,9 @@ final class ScenegraphPagePlanner
                 'slug'                  => $slug,
                 'path'                  => $entrypoint ? 'index.html' : $slug . '.html',
                 'entrypoint'            => $entrypoint,
+                'role'                  => $classification['role'],
+                'page_type'             => $classification['page_type'] ?? ScenegraphFrameClassifier::PAGE_TYPE_UNKNOWN,
+                'classification_signals' => $classification['signals'],
                 'figma_page_id'         => $page['id'] ?? null,
                 'figma_page_name'       => $page['name'] ?? null,
                 'section_id'            => $section['id'] ?? null,
@@ -246,6 +285,26 @@ final class ScenegraphPagePlanner
                 'diagnostics'           => $this->pageDiagnostics($primaryId, $node, $candidate['dimensions'], $explicitSelected),
             );
             ++$emittedPosition;
+        }
+
+        $classificationCoverage = $this->classificationCoverage($candidates, $classifications, $pages);
+        // The full coverage report is always available via the
+        // `classification_coverage` plan key. Emit it as a diagnostic only when
+        // it carries actionable signal — a design-system frame was excluded from
+        // pages, or a selected page fell to an `unknown` page type — so files
+        // whose every frame classifies cleanly keep an empty diagnostics list
+        // (and a clean `success` transform status).
+        $excludedDesignSystem = (int) ($classificationCoverage['excluded_design_system_count'] ?? 0);
+        $unknownPageTypes = (int) ($classificationCoverage['page_types'][ScenegraphFrameClassifier::PAGE_TYPE_UNKNOWN] ?? 0);
+        if ( $excludedDesignSystem > 0 || $unknownPageTypes > 0 ) {
+            $diagnostics[] = array(
+                'severity' => $unknownPageTypes > 0 ? 'warning' : 'info',
+                'code'     => 'figma_frame_classification_coverage',
+                'message'  => $excludedDesignSystem > 0
+                    ? 'Excluded design-system frames from page selection; see coverage for role/page-type breakdown.'
+                    : 'Some selected pages fell to an unknown page type; see coverage for the breakdown.',
+                'coverage' => $classificationCoverage,
+            );
         }
 
         $devStatusCoverage = $this->devStatusCoverage($nodes, $frameDevStatus, $selectionSource, $fileHasDevStatus);
@@ -265,13 +324,195 @@ final class ScenegraphPagePlanner
         }
 
         return array(
-            'schema'              => 'blocks-engine/figma-transformer/page-plan/v1',
-            'page_count'          => count($pages),
-            'candidate_count'     => count($candidates),
-            'pages'               => $pages,
-            'selection_source'    => $selectionSource,
-            'dev_status_coverage' => $devStatusCoverage,
-            'diagnostics'         => $diagnostics,
+            'schema'                  => 'blocks-engine/figma-transformer/page-plan/v1',
+            'page_count'              => count($pages),
+            'candidate_count'         => count($candidates),
+            'pages'                   => $pages,
+            'selection_source'        => $selectionSource,
+            'dev_status_coverage'     => $devStatusCoverage,
+            'classification_coverage' => $classificationCoverage,
+            'diagnostics'             => $diagnostics,
+        );
+    }
+
+    /**
+     * Classify a single FRAME candidate into a role + page type via
+     * {@see ScenegraphFrameClassifier}, gathering the content-shape signals
+     * (swatch/specimen tiles, repeating post cards) from the already-built
+     * node/children indexes so no extra scenegraph traversal is required.
+     *
+     * @param array<string, mixed>                $candidate
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, array<int, string>>   $childrenIndex
+     * @param array<string, string|null>          $parentIndex
+     * @return array{role: string, page_type: string|null, signals: array<int, string>, is_page: bool}
+     */
+    private function classifyCandidate(string $id, array $candidate, array $nodes, array $childrenIndex, array $parentIndex): array
+    {
+        $node = is_array($candidate['node'] ?? null) ? $candidate['node'] : array();
+        $stats = is_array($candidate['stats'] ?? null) ? $candidate['stats'] : array();
+        $dimensions = is_array($candidate['dimensions'] ?? null) ? $candidate['dimensions'] : array();
+        $section = $this->nearestAncestor($id, array('SECTION'), $nodes, $parentIndex);
+        $page = $this->nearestAncestor($id, array('CANVAS'), $nodes, $parentIndex);
+        $contentShape = $this->contentShapeSignals($id, $nodes, $childrenIndex);
+
+        return $this->frameClassifier->classify(array(
+            'name'                 => (string) ($node['name'] ?? ''),
+            'width'                => $dimensions['width'] ?? null,
+            'height'               => $dimensions['height'] ?? null,
+            'text_count'           => (int) ($stats['texts'] ?? 0),
+            'asset_count'          => (int) ($stats['assets'] ?? 0),
+            'uniform_tile_count'   => $contentShape['uniform_tile_count'],
+            'repeating_card_count' => $contentShape['repeating_card_count'],
+            'section_name'         => $section['name'] ?? null,
+            'page_name'            => $page['name'] ?? null,
+        ));
+    }
+
+    /**
+     * Derive content-shape signals from a frame's descendant structure:
+     *
+     *   - uniform_tile_count: the largest group of near-uniform, small sibling
+     *     containers sharing one parent (a swatch/type-specimen grid tell).
+     *   - repeating_card_count: the largest group of structurally-similar sibling
+     *     subtrees sharing one parent (a list-of-post-cards / archive tell).
+     *
+     * Both are computed by scanning every node in the frame's subtree once and,
+     * for each parent, bucketing its direct children by a coarse shape signature
+     * (child count + presence of a TEXT/IMAGE descendant). The largest matching
+     * bucket per category wins. This stays frame-local and deterministic.
+     *
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, array<int, string>>   $childrenIndex
+     * @return array{uniform_tile_count: int, repeating_card_count: int}
+     */
+    private function contentShapeSignals(string $rootId, array $nodes, array $childrenIndex): array
+    {
+        $uniformTiles = 0;
+        $repeatingCards = 0;
+
+        $stack = array($rootId);
+        $guard = 0;
+        while ( array() !== $stack && $guard < 200000 ) {
+            ++$guard;
+            $parentId = (string) array_pop($stack);
+            $childIds = is_array($childrenIndex[$parentId] ?? null) ? $childrenIndex[$parentId] : array();
+
+            $tileBuckets = array();
+            $cardBuckets = array();
+            foreach ( $childIds as $childId ) {
+                if ( ! is_string($childId) ) {
+                    continue;
+                }
+                $stack[] = $childId;
+
+                $childNode = is_array($nodes[$childId] ?? null) ? $nodes[$childId] : array();
+                $type = strtoupper((string) ($childNode['type'] ?? ''));
+                if ( ! in_array($type, array('FRAME', 'GROUP', 'INSTANCE', 'COMPONENT', 'RECTANGLE', 'ELLIPSE'), true) ) {
+                    continue;
+                }
+
+                $grandChildren = is_array($childrenIndex[$childId] ?? null) ? $childrenIndex[$childId] : array();
+                $grandCount = count($grandChildren);
+                $dimensions = $this->dimensions($childNode);
+                $width = (float) ($dimensions['width'] ?? 0);
+                $height = (float) ($dimensions['height'] ?? 0);
+                $area = $width * $height;
+
+                if ( $grandCount <= 2 && $area > 0 && $area <= 90000 ) {
+                    // Small, leaf-like tile (swatch / specimen chip).
+                    $tileKey = $this->dimensionBucketKey($width, $height);
+                    $tileBuckets[$tileKey] = ($tileBuckets[$tileKey] ?? 0) + 1;
+                }
+
+                if ( $grandCount >= 2 ) {
+                    // Composite container (a card with media + text). Signature
+                    // groups by child count so a repeating card layout clusters.
+                    $cardKey = $type . ':' . min(12, $grandCount);
+                    $cardBuckets[$cardKey] = ($cardBuckets[$cardKey] ?? 0) + 1;
+                }
+            }
+
+            $uniformTiles = max($uniformTiles, array() === $tileBuckets ? 0 : max($tileBuckets));
+            $repeatingCards = max($repeatingCards, array() === $cardBuckets ? 0 : max($cardBuckets));
+        }
+
+        return array(
+            'uniform_tile_count'   => $uniformTiles,
+            'repeating_card_count' => $repeatingCards,
+        );
+    }
+
+    private function dimensionBucketKey(float $width, float $height): string
+    {
+        // Bucket to the nearest 16px so near-uniform swatches cluster together
+        // while genuinely different shapes stay apart.
+        $bucket = static fn (float $value): int => (int) round($value / 16.0);
+
+        return $bucket($width) . 'x' . $bucket($height);
+    }
+
+    /**
+     * Build the classification coverage report: per-role and per-page-type
+     * counts plus, for every selected page, the signals that drove its
+     * classification — the diagnostic that explains WHY each frame landed where
+     * it did.
+     *
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, array<string, mixed>> $classifications
+     * @param array<int, array<string, mixed>>    $pages
+     * @return array<string, mixed>
+     */
+    private function classificationCoverage(array $candidates, array $classifications, array $pages): array
+    {
+        $roles = array(
+            ScenegraphFrameClassifier::ROLE_DESIGN_SYSTEM => 0,
+            ScenegraphFrameClassifier::ROLE_PAGE          => 0,
+        );
+        $pageTypes = array(
+            ScenegraphFrameClassifier::PAGE_TYPE_FRONT_PAGE => 0,
+            ScenegraphFrameClassifier::PAGE_TYPE_SINGLE     => 0,
+            ScenegraphFrameClassifier::PAGE_TYPE_ARCHIVE    => 0,
+            ScenegraphFrameClassifier::PAGE_TYPE_PAGE       => 0,
+            ScenegraphFrameClassifier::PAGE_TYPE_UNKNOWN    => 0,
+        );
+        $excludedDesignSystemFrameIds = array();
+
+        foreach ( $classifications as $candidateId => $classification ) {
+            $role = (string) ($classification['role'] ?? ScenegraphFrameClassifier::ROLE_PAGE);
+            $roles[$role] = ($roles[$role] ?? 0) + 1;
+            if ( ScenegraphFrameClassifier::ROLE_DESIGN_SYSTEM === $role ) {
+                $excludedDesignSystemFrameIds[] = (string) $candidateId;
+            }
+        }
+
+        $selectedSignals = array();
+        foreach ( $pages as $page ) {
+            if ( ! is_array($page) ) {
+                continue;
+            }
+            $pageType = (string) ($page['page_type'] ?? ScenegraphFrameClassifier::PAGE_TYPE_UNKNOWN);
+            $pageTypes[$pageType] = ($pageTypes[$pageType] ?? 0) + 1;
+            $selectedSignals[] = array(
+                'frame_id'  => (string) ($page['frame_id'] ?? ''),
+                'name'      => (string) ($page['name'] ?? ''),
+                'role'      => (string) ($page['role'] ?? ScenegraphFrameClassifier::ROLE_PAGE),
+                'page_type' => $pageType,
+                'signals'   => is_array($page['classification_signals'] ?? null) ? $page['classification_signals'] : array(),
+            );
+        }
+
+        sort($excludedDesignSystemFrameIds);
+
+        return array(
+            'schema'                          => 'blocks-engine/figma-transformer/frame-classification/v1',
+            'candidate_count'                 => count($candidates),
+            'classified_count'                => count($classifications),
+            'roles'                           => $roles,
+            'page_types'                      => $pageTypes,
+            'excluded_design_system_count'    => count($excludedDesignSystemFrameIds),
+            'excluded_design_system_frame_ids' => $excludedDesignSystemFrameIds,
+            'selected_page_classifications'   => $selectedSignals,
         );
     }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -18,6 +18,7 @@ use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiParser;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\ParityReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\VisualAttributionReportBuilder;
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphFrameClassifier;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphPagePlanner;
 
 $failures = array();
@@ -5467,6 +5468,176 @@ foreach ( ( is_array($inspectorDevStatusResult['candidates'] ?? null) ? $inspect
 $assert('ready_for_dev' === ($inspectorCandidates['frame:build']['dev_status'] ?? null), 'inspector-surfaces-dev-status-on-candidate');
 $assert(! array_key_exists('dev_status', $inspectorCandidates['frame:plain'] ?? array()), 'inspector-omits-dev-status-on-unmarked-candidate');
 $assert('dev_status' === matrix_selection_source(array_values($inspectorCandidates)), 'inspector-candidates-drive-dev-status-selection');
+
+// FRAME ROLE CLASSIFICATION (#247): top-level frames are classified into roles
+// before any pixels are emitted. A "Style Guide" frame is a design_system frame
+// (EXCLUDED from page selection); real pages each carry a WP-template-aligned
+// page_type derived from name first, then content shape.
+$classificationSource = array(
+    'name'  => 'Classification Site',
+    'nodes' => array(
+        array(
+            'id'       => 'canvas:cls',
+            'type'     => 'CANVAS',
+            'name'     => 'Pages',
+            'children' => array(
+                // Style guide: name-driven design_system, excluded from pages.
+                array(
+                    'id'       => 'frame:styleguide',
+                    'type'     => 'FRAME',
+                    'name'     => 'Style Guide',
+                    'width'    => 1440,
+                    'height'   => 2000,
+                    'children' => array(
+                        array('id' => 'sg:text', 'type' => 'TEXT', 'name' => 'Colors', 'characters' => 'Brand Colors'),
+                    ),
+                ),
+                // Homepage → front_page.
+                array(
+                    'id'       => 'frame:homepage',
+                    'type'     => 'FRAME',
+                    'name'     => 'Homepage',
+                    'width'    => 1440,
+                    'height'   => 1600,
+                    'children' => array(
+                        array('id' => 'hp:text', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome Home'),
+                    ),
+                ),
+                // Blog Post → single.
+                array(
+                    'id'       => 'frame:blogpost',
+                    'type'     => 'FRAME',
+                    'name'     => 'Blog Post',
+                    'width'    => 1440,
+                    'height'   => 2400,
+                    'children' => array(
+                        array('id' => 'bp:text', 'type' => 'TEXT', 'name' => 'Article Title', 'characters' => 'A Long Read'),
+                    ),
+                ),
+                // Archive → archive.
+                array(
+                    'id'       => 'frame:archive',
+                    'type'     => 'FRAME',
+                    'name'     => 'Archive',
+                    'width'    => 1440,
+                    'height'   => 1800,
+                    'children' => array(
+                        array('id' => 'ar:text', 'type' => 'TEXT', 'name' => 'Latest Posts', 'characters' => 'Latest Posts'),
+                    ),
+                ),
+                // About → generic page.
+                array(
+                    'id'       => 'frame:about',
+                    'type'     => 'FRAME',
+                    'name'     => 'About',
+                    'width'    => 1440,
+                    'height'   => 1500,
+                    'children' => array(
+                        array('id' => 'ab:text', 'type' => 'TEXT', 'name' => 'About copy', 'characters' => 'About us'),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$classificationPlan = ( new ScenegraphPagePlanner() )->plan($classificationSource, array('include_all_pages' => true));
+$classificationPages = is_array($classificationPlan['pages'] ?? null) ? $classificationPlan['pages'] : array();
+$classificationByFrame = array();
+foreach ( $classificationPages as $classificationPage ) {
+    if ( is_array($classificationPage) && isset($classificationPage['frame_id']) ) {
+        $classificationByFrame[(string) $classificationPage['frame_id']] = $classificationPage;
+    }
+}
+$classificationFrameIds = array_keys($classificationByFrame);
+
+$assert(! in_array('frame:styleguide', $classificationFrameIds, true), 'classification-style-guide-excluded-from-pages');
+$assert(isset($classificationByFrame['frame:homepage']), 'classification-homepage-selected-as-page');
+$assert(ScenegraphFrameClassifier::ROLE_PAGE === ($classificationByFrame['frame:homepage']['role'] ?? null), 'classification-homepage-role-page');
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_FRONT_PAGE === ($classificationByFrame['frame:homepage']['page_type'] ?? null), 'classification-homepage-front-page');
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_SINGLE === ($classificationByFrame['frame:blogpost']['page_type'] ?? null), 'classification-blog-post-single');
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_ARCHIVE === ($classificationByFrame['frame:archive']['page_type'] ?? null), 'classification-archive-archive');
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_PAGE === ($classificationByFrame['frame:about']['page_type'] ?? null), 'classification-about-generic-page');
+$assert(is_array($classificationByFrame['frame:homepage']['classification_signals'] ?? null) && in_array('name:front_page', $classificationByFrame['frame:homepage']['classification_signals'], true), 'classification-homepage-signal-explained');
+
+// COVERAGE: the page plan reports per-role and per-page-type counts, names the
+// excluded design-system frame, and the diagnostic explains the exclusion.
+$classificationCoverage = is_array($classificationPlan['classification_coverage'] ?? null) ? $classificationPlan['classification_coverage'] : array();
+$assert('blocks-engine/figma-transformer/frame-classification/v1' === ($classificationCoverage['schema'] ?? null), 'classification-coverage-schema');
+$assert(1 === ($classificationCoverage['roles'][ScenegraphFrameClassifier::ROLE_DESIGN_SYSTEM] ?? null), 'classification-coverage-counts-design-system');
+$assert(4 === ($classificationCoverage['roles'][ScenegraphFrameClassifier::ROLE_PAGE] ?? null), 'classification-coverage-counts-pages');
+$assert(1 === ($classificationCoverage['page_types'][ScenegraphFrameClassifier::PAGE_TYPE_FRONT_PAGE] ?? null), 'classification-coverage-counts-front-page');
+$assert(1 === ($classificationCoverage['page_types'][ScenegraphFrameClassifier::PAGE_TYPE_SINGLE] ?? null), 'classification-coverage-counts-single');
+$assert(1 === ($classificationCoverage['page_types'][ScenegraphFrameClassifier::PAGE_TYPE_ARCHIVE] ?? null), 'classification-coverage-counts-archive');
+$assert(1 === ($classificationCoverage['page_types'][ScenegraphFrameClassifier::PAGE_TYPE_PAGE] ?? null), 'classification-coverage-counts-page');
+$assert(in_array('frame:styleguide', $classificationCoverage['excluded_design_system_frame_ids'] ?? array(), true), 'classification-coverage-names-excluded-frame');
+$classificationDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    is_array($classificationPlan['diagnostics'] ?? null) ? $classificationPlan['diagnostics'] : array()
+);
+$assert(in_array('figma_frame_classification_coverage', $classificationDiagnosticCodes, true), 'classification-coverage-diagnostic-emitted');
+
+// CONTENT-SHAPE: classification is generic — a design-system frame with a
+// GENERIC name still classifies as design_system from a swatch grid, and an
+// unnamed list-of-cards page classifies as archive from its repeating structure.
+$contentShapeSwatch = array();
+for ( $swatchIndex = 0; $swatchIndex < 8; ++$swatchIndex ) {
+    $contentShapeSwatch[] = array('id' => 'swatch:' . $swatchIndex, 'type' => 'RECTANGLE', 'name' => 'Swatch ' . $swatchIndex, 'width' => 80, 'height' => 80);
+}
+$contentShapeCards = array();
+for ( $cardIndex = 0; $cardIndex < 4; ++$cardIndex ) {
+    $contentShapeCards[] = array(
+        'id'       => 'card:' . $cardIndex,
+        'type'     => 'FRAME',
+        'name'     => 'Card ' . $cardIndex,
+        'width'    => 360,
+        'height'   => 420,
+        'children' => array(
+            array('id' => 'card-img:' . $cardIndex, 'type' => 'RECTANGLE', 'name' => 'Thumb', 'width' => 360, 'height' => 200, 'fills' => array(array('type' => 'IMAGE', 'imageRef' => 'hash:' . $cardIndex))),
+            array('id' => 'card-title:' . $cardIndex, 'type' => 'TEXT', 'name' => 'Card Title', 'characters' => 'Post ' . $cardIndex),
+        ),
+    );
+}
+$contentShapeSource = array(
+    'name'  => 'Content Shape Site',
+    'nodes' => array(
+        array(
+            'id'       => 'canvas:shape',
+            'type'     => 'CANVAS',
+            'name'     => 'Pages',
+            'children' => array(
+                array(
+                    'id'       => 'frame:palette',
+                    'type'     => 'FRAME',
+                    'name'     => 'Foundations',
+                    'width'    => 1440,
+                    'height'   => 1600,
+                    'children' => $contentShapeSwatch,
+                ),
+                array(
+                    'id'       => 'frame:list',
+                    'type'     => 'FRAME',
+                    'name'     => 'Updates',
+                    'width'    => 1440,
+                    'height'   => 1800,
+                    'children' => $contentShapeCards,
+                ),
+            ),
+        ),
+    ),
+);
+$contentShapePlan = ( new ScenegraphPagePlanner() )->plan($contentShapeSource, array('include_all_pages' => true));
+$contentShapePages = is_array($contentShapePlan['pages'] ?? null) ? $contentShapePlan['pages'] : array();
+$contentShapeByFrame = array();
+foreach ( $contentShapePages as $contentShapePage ) {
+    if ( is_array($contentShapePage) && isset($contentShapePage['frame_id']) ) {
+        $contentShapeByFrame[(string) $contentShapePage['frame_id']] = $contentShapePage;
+    }
+}
+$assert(! isset($contentShapeByFrame['frame:palette']), 'classification-content-swatch-grid-excluded');
+$contentShapeCoverage = is_array($contentShapePlan['classification_coverage'] ?? null) ? $contentShapePlan['classification_coverage'] : array();
+$assert(in_array('frame:palette', $contentShapeCoverage['excluded_design_system_frame_ids'] ?? array(), true), 'classification-content-swatch-grid-design-system');
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_ARCHIVE === ($contentShapeByFrame['frame:list']['page_type'] ?? null), 'classification-content-card-list-archive');
+$assert(in_array('content:card_list', $contentShapeByFrame['frame:list']['classification_signals'] ?? array(), true), 'classification-content-card-list-signal');
 
 // Semantic HTML5 elements: a generically-named page structure maps to landmarks
 // (header/nav/main/section/footer), a font-size hierarchy maps to h1/h2, repeated


### PR DESCRIPTION
## Summary

Adds the foundational frame **role + page-type classification** layer for the `figma-transformer` (refs #247). Before any pixels are emitted, the transformer now decides WHAT each top-level frame IS, so the page plan can keep style-guide / design-system frames out of page selection and tag every real page with a WordPress-template-aligned page type. Generic, deterministic, signal-based — no file-specific hardcoding.

## What changed

- **New `ScenegraphFrameClassifier`** — classifies a frame from its NAME plus light content-shape metrics the planner already gathers (text/asset density, near-uniform swatch tiles, repeating sibling card subtrees). Every classification carries the ordered list of signals that drove it.
  - **`design_system`** — style-guide / design-system / token / component-gallery frames, by name (`Style Guide`, `Design System`, `Tokens`, `Components`, `Styles`, typography/color/swatch family) or by content shape (a grid of near-uniform swatch/specimen tiles). These INFORM the design system (another layer extracts their tokens); they are **excluded from page selection**.
  - **`page`** — real page frames, each tagged with a `page_type` from name first, then content shape.

- **`ScenegraphPagePlanner` integration** — classifies every FRAME candidate, excludes `design_system` frames from both the dev-status and heuristic selection paths, and attaches `role`, `page_type`, and `classification_signals` to each page in the page model. The plan return now exposes `classification_coverage` (per-role / per-page-type counts, excluded design-system frame ids, and per-page driving signals). A `figma_frame_classification_coverage` diagnostic is emitted only when it carries actionable signal (a frame was excluded, or a page fell to `unknown`), so cleanly-classifying files keep an empty diagnostics list and a clean transform status.

## page_type → WP template hierarchy

| `page_type` | WP template |
|-------------|-------------|
| `front_page` | `front-page.php` (front page) |
| `single` | `single.php` (single post / article) |
| `archive` | `archive.php` / `index.php` (list of post cards) |
| `page` | `page.php` (generic content page) |
| `unknown` | fallback |

Downstream php-transformer maps `page_type` → WP template; the page model is the documented contract.

## Tests

Synthetic fixtures + contract tests only (no `.fig` runs — lab validation is the orchestrator's follow-up). New coverage:
- A `Style Guide` frame (role=`design_system`, **not** selected as a page), `Homepage` (`front_page`), `Blog Post` (`single`), `Archive` (`archive`), and `About` (`page`); asserts the classification, the exclusion, and the coverage report/diagnostic.
- Generic content-shape classification: a generically-named swatch-grid frame → `design_system` (excluded), an unnamed list-of-cards frame → `archive`.

`php tests/contract/run.php` → `Figma Transformer contract tests passed.`

## Lab validation follow-up

Real `.fig` validation (185–293MB fixtures) is deferred to the orchestrator per the synthetic-only constraint; this PR ships the generic engine + contract coverage.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Frame role + page-type classification (design-system exclusion, WP-template-aligned page types) for #247.