### PR TITLE
Extract Figma style-guide frames into a global design system (#247)

### DIFF
--- a/figma-transformer/src/Html/DesignSystemExtractor.php
+++ b/figma-transformer/src/Html/DesignSystemExtractor.php
@@ -1,0 +1,789 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Extracts a global design system (color, typography and spacing tokens) from
+ * Figma "style guide" / "design system" frames and authors it as global CSS.
+ *
+ * A Figma style-guide frame is the SOURCE of a design system: its color
+ * swatches, type specimens and spacing/component galleries describe the tokens
+ * the rest of the file is built from. Rather than rendering such a frame as a
+ * page, this extractor mines it for tokens and emits them as authored global
+ * CSS — `:root{--color-…;--font-size-…;--space-…}` custom properties plus a
+ * reusable type scale (`.type-heading-1`, `.type-body`, …) — that the generated
+ * pages can reference. The work is purely data-driven: detection comes from the
+ * frame name and its content shape, never from file-specific names.
+ *
+ * The emitted CSS complements {@see StaticHtmlEmitter}'s shared-class work — it
+ * sits at the top of `style.css`, before the per-page rules — and builds on top
+ * of the font @font-face emission rather than duplicating it.
+ */
+final class DesignSystemExtractor
+{
+    /**
+     * Frame-name signals that mark a frame as the design-system source.
+     */
+    private const NAME_SIGNALS = array(
+        'style guide',
+        'styleguide',
+        'design system',
+        'design-system',
+        'designsystem',
+        'tokens',
+        'design tokens',
+        'components',
+        'styles',
+        'typography',
+        'color palette',
+        'colour palette',
+        'color styles',
+        'foundations',
+    );
+
+    /**
+     * Build the authored design-system CSS for a normalized scenegraph.
+     *
+     * Walks the scenegraph, locates style-guide/design-system frames (by name or
+     * content shape), extracts color/typography/spacing tokens from them, and
+     * returns both the global CSS block and a coverage diagnostic describing how
+     * many tokens of each kind were extracted.
+     *
+     * @param array<string, mixed> $scenegraph Normalized Figma scenegraph.
+     * @return array{css: string, coverage: array<string, int>, frame_names: array<int, string>}
+     */
+    public function extract(array $scenegraph): array
+    {
+        $frames = array();
+        foreach ( $this->nodeList($scenegraph) as $node ) {
+            if ( is_array($node) ) {
+                $this->collectDesignSystemFrames($node, 0, $frames);
+            }
+        }
+
+        $empty = array(
+            'css'         => '',
+            'coverage'    => array('color_tokens' => 0, 'type_tokens' => 0, 'spacing_tokens' => 0, 'frame_count' => 0),
+            'frame_names' => array(),
+        );
+        if ( empty($frames) ) {
+            return $empty;
+        }
+
+        $colors = array();
+        $textStyles = array();
+        $spacings = array();
+        $frameNames = array();
+        foreach ( $frames as $frame ) {
+            $frameNames[] = (string) ($frame['name'] ?? '');
+            $this->collectColorTokens($frame, $colors);
+            $this->collectTextStyleTokens($frame, $textStyles);
+            $this->collectSpacingTokens($frame, $spacings);
+        }
+
+        $colorTokens   = $this->buildColorTokens($colors);
+        $typeTokens    = $this->buildTypeTokens($textStyles);
+        $spacingTokens = $this->buildSpacingTokens($spacings);
+
+        $css = $this->renderCss($colorTokens, $typeTokens['variables'], $spacingTokens, $typeTokens['classes']);
+
+        return array(
+            'css'         => $css,
+            'coverage'    => array(
+                'color_tokens'   => count($colorTokens),
+                'type_tokens'    => count($typeTokens['classes']),
+                'spacing_tokens' => count($spacingTokens),
+                'frame_count'    => count($frames),
+            ),
+            'frame_names' => array_values(array_filter($frameNames, static fn (string $name): bool => '' !== $name)),
+        );
+    }
+
+    /**
+     * Walk the tree collecting frames that read as a design-system source. A
+     * matched frame's subtree is not descended into for further matches — the
+     * whole subtree is the system, and its inner sections are not separate
+     * systems.
+     *
+     * @param array<string, mixed> $node
+     * @param array<int, array<string, mixed>> $frames
+     */
+    private function collectDesignSystemFrames(array $node, int $depth, array &$frames): void
+    {
+        if ( $depth <= 4 && $this->isDesignSystemFrame($node, $depth) ) {
+            $frames[] = $node;
+            return;
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $this->collectDesignSystemFrames($child, $depth + 1, $frames);
+            }
+        }
+    }
+
+    /**
+     * A frame is a design-system source when its name signals one, or when its
+     * content shape does: a grid of solid-color swatches, and/or a set of
+     * distinct type specimens. Detection is generic — it never matches on
+     * file-specific names.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function isDesignSystemFrame(array $node, int $depth): bool
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( ! in_array($type, array('FRAME', 'GROUP', 'SECTION', 'CANVAS', 'PAGE'), true) ) {
+            return false;
+        }
+
+        if ( $this->nameSignalsDesignSystem((string) ($node['name'] ?? '')) ) {
+            return true;
+        }
+
+        // Content-shape detection only applies to reasonably top-level frames so
+        // an inner swatch row of a real page is not mistaken for a whole system.
+        if ( $depth > 2 ) {
+            return false;
+        }
+
+        $swatchCount = $this->solidSwatchCount($node);
+        $specimenCount = count($this->distinctTextStyleKeys($node));
+
+        return $swatchCount >= 4 || ( $swatchCount >= 2 && $specimenCount >= 3 );
+    }
+
+    private function nameSignalsDesignSystem(string $name): bool
+    {
+        $lower = strtolower(trim($name));
+        if ( '' === $lower ) {
+            return false;
+        }
+        foreach ( self::NAME_SIGNALS as $signal ) {
+            if ( str_contains($lower, $signal) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Count solid-filled leaf rectangles/ellipses/frames that read as color
+     * swatches (small, square-ish, solid background, no text).
+     *
+     * @param array<string, mixed> $node
+     */
+    private function solidSwatchCount(array $node): int
+    {
+        $count = 0;
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            if ( $this->isColorSwatch($child) ) {
+                ++$count;
+            }
+            $count += $this->solidSwatchCount($child);
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isColorSwatch(array $node): bool
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( ! in_array($type, array('RECTANGLE', 'ROUNDED_RECTANGLE', 'ELLIPSE', 'FRAME', 'COMPONENT', 'INSTANCE'), true) ) {
+            return false;
+        }
+        if ( null === $this->solidFill($node) ) {
+            return false;
+        }
+        // A swatch carries a flat color, not nested text/imagery.
+        if ( $this->subtreeHasText($node) ) {
+            return false;
+        }
+
+        $width = $this->boxValue($node, 'width');
+        $height = $this->boxValue($node, 'height');
+        if ( null === $width || null === $height || $width <= 0.0 || $height <= 0.0 ) {
+            // Solid fill with no usable box still reads as a swatch token.
+            return true;
+        }
+        if ( $width > 480.0 || $height > 480.0 ) {
+            return false;
+        }
+        $ratio = $width / $height;
+
+        return $ratio >= 0.25 && $ratio <= 4.0;
+    }
+
+    /**
+     * Collect every distinct swatch color in the frame, paired with the best
+     * nearby text label so named tokens can use the author's intended name.
+     *
+     * @param array<string, mixed> $node
+     * @param array<string, array<string, mixed>> $colors keyed by css color
+     */
+    private function collectColorTokens(array $node, array &$colors): void
+    {
+        $children = array_values(array_filter($this->nodeList($node), 'is_array'));
+        foreach ( $children as $index => $child ) {
+            if ( $this->isColorSwatch($child) ) {
+                $css = $this->solidFill($child);
+                if ( null !== $css && ! isset($colors[$css]) ) {
+                    $colors[$css] = array(
+                        'css'   => $css,
+                        'label' => $this->swatchLabel($child, $children, $index),
+                    );
+                }
+            }
+            $this->collectColorTokens($child, $colors);
+        }
+    }
+
+    /**
+     * Find a human label for a swatch: its own name (when meaningful), a text
+     * child, or a sibling text node positioned beside/below it.
+     *
+     * @param array<string, mixed> $swatch
+     * @param array<int, array<string, mixed>> $siblings
+     */
+    private function swatchLabel(array $swatch, array $siblings, int $index): string
+    {
+        $ownName = trim((string) ($swatch['name'] ?? ''));
+        if ( '' !== $ownName && ! $this->isGenericName($ownName) ) {
+            return $ownName;
+        }
+
+        $childText = trim($this->subtreePlainText($swatch));
+        if ( '' !== $childText ) {
+            return $childText;
+        }
+
+        // A swatch is often a grouping frame containing the rect + a caption
+        // text node; otherwise the caption is the next sibling.
+        $next = $siblings[$index + 1] ?? null;
+        if ( is_array($next) && 'TEXT' === strtoupper((string) ($next['type'] ?? '')) ) {
+            $label = trim($this->subtreePlainText($next));
+            if ( '' !== $label ) {
+                return $label;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Collect distinct text styles in the frame as type specimens, keyed by a
+     * stable signature (family + size + weight + line-height).
+     *
+     * @param array<string, mixed> $node
+     * @param array<string, array<string, mixed>> $textStyles keyed by signature
+     */
+    private function collectTextStyleTokens(array $node, array &$textStyles): void
+    {
+        if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
+            $style = $this->textStyle($node);
+            if ( null !== $style ) {
+                $key = $this->textStyleKey($style);
+                if ( '' !== $key && ! isset($textStyles[$key]) ) {
+                    $style['label'] = trim((string) ($node['name'] ?? ''));
+                    $textStyles[$key] = $style;
+                }
+            }
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $this->collectTextStyleTokens($child, $textStyles);
+            }
+        }
+    }
+
+    /**
+     * Collect consistent auto-layout gaps and paddings as spacing candidates.
+     *
+     * @param array<string, mixed> $node
+     * @param array<int, float> $spacings
+     */
+    private function collectSpacingTokens(array $node, array &$spacings): void
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        if ( isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ) {
+            $value = (float) $layout['item_spacing'];
+            if ( $value > 0.0 ) {
+                $spacings[] = $value;
+            }
+        }
+        $padding = is_array($layout['padding'] ?? null) ? $layout['padding'] : array();
+        foreach ( $padding as $edge ) {
+            if ( is_numeric($edge) && (float) $edge > 0.0 ) {
+                $spacings[] = (float) $edge;
+            }
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $this->collectSpacingTokens($child, $spacings);
+            }
+        }
+    }
+
+    /**
+     * Distinct text-style signatures found in a subtree — used by content-shape
+     * detection to count type specimens.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function distinctTextStyleKeys(array $node): array
+    {
+        $styles = array();
+        $this->collectTextStyleTokens($node, $styles);
+
+        return array_keys($styles);
+    }
+
+    /**
+     * Mint deterministic color tokens: stable order (by appearance), unique
+     * `--color-*` names derived from labels (falling back to an index), values
+     * are the swatch CSS colors.
+     *
+     * @param array<string, array<string, mixed>> $colors
+     * @return array<int, array{name: string, value: string}>
+     */
+    private function buildColorTokens(array $colors): array
+    {
+        $tokens = array();
+        $used = array();
+        $autoIndex = 1;
+        foreach ( $colors as $color ) {
+            $css = (string) $color['css'];
+            $label = (string) ($color['label'] ?? '');
+            $base = $this->colorTokenBaseName($label);
+            if ( '' === $base ) {
+                $base = (string) $autoIndex;
+                ++$autoIndex;
+            }
+            $name = 'color-' . $base;
+            $suffix = 2;
+            while ( isset($used[$name]) ) {
+                $name = 'color-' . $base . '-' . $suffix;
+                ++$suffix;
+            }
+            $used[$name] = true;
+            $tokens[] = array('name' => $name, 'value' => $css);
+        }
+
+        return $tokens;
+    }
+
+    private function colorTokenBaseName(string $label): string
+    {
+        $slug = $this->slug($label);
+        if ( 'node' === $slug || '' === $slug ) {
+            return '';
+        }
+        // A label that is just the hex value carries no semantic name.
+        if ( 1 === preg_match('/^[0-9a-f]{3}([0-9a-f]{3})?$/', $slug) ) {
+            return '';
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Mint a type scale from the distinct text styles. The most-common-looking
+     * specimens are ordered largest-first; each becomes a `--font-size-*` var
+     * plus a reusable `.type-*` class carrying family/size/weight/line-height.
+     * Heading-sized specimens become `heading-1..n`; the smallest common size is
+     * the body class.
+     *
+     * @param array<string, array<string, mixed>> $textStyles
+     * @return array{variables: array<int, array{name: string, value: string}>, classes: array<int, array{name: string, declarations: array<int, string>}>}
+     */
+    private function buildTypeTokens(array $textStyles): array
+    {
+        if ( empty($textStyles) ) {
+            return array('variables' => array(), 'classes' => array());
+        }
+
+        $styles = array_values($textStyles);
+        // Largest size first; heavier weight wins ties so display styles lead.
+        usort($styles, static function (array $a, array $b): int {
+            $sizeCmp = ($b['font_size'] ?? 0.0) <=> ($a['font_size'] ?? 0.0);
+            if ( 0 !== $sizeCmp ) {
+                return $sizeCmp;
+            }
+
+            return ($b['font_weight'] ?? 0.0) <=> ($a['font_weight'] ?? 0.0);
+        });
+
+        $count = count($styles);
+        $variables = array();
+        $classes = array();
+        $usedVarNames = array();
+        $headingLevel = 1;
+
+        foreach ( $styles as $index => $style ) {
+            // The single smallest specimen reads as body copy; everything above
+            // it is a descending heading level.
+            $isBody = ( $index === $count - 1 ) && $count > 1;
+            $role = $isBody ? 'body' : 'heading-' . $headingLevel;
+            if ( ! $isBody ) {
+                ++$headingLevel;
+            }
+
+            $size = isset($style['font_size']) && is_numeric($style['font_size']) ? (float) $style['font_size'] : null;
+            $declarations = array();
+
+            if ( isset($style['font_family']) && is_scalar($style['font_family']) && '' !== (string) $style['font_family'] ) {
+                $declarations[] = 'font-family:' . $this->fallbackFontStack((string) $style['font_family']);
+            }
+            if ( null !== $size ) {
+                $varName = 'font-size-' . $role;
+                $unique = $varName;
+                $dupe = 2;
+                while ( isset($usedVarNames[$unique]) ) {
+                    $unique = $varName . '-' . $dupe;
+                    ++$dupe;
+                }
+                $usedVarNames[$unique] = true;
+                $variables[] = array('name' => $unique, 'value' => $this->number($size) . 'px');
+                $declarations[] = 'font-size:var(--' . $unique . ')';
+            }
+            if ( isset($style['font_weight']) && is_numeric($style['font_weight']) ) {
+                $declarations[] = 'font-weight:' . $this->number((float) $style['font_weight']);
+            }
+            if ( isset($style['line_height']) && is_numeric($style['line_height']) && (float) $style['line_height'] > 0.0 ) {
+                $declarations[] = 'line-height:' . $this->number((float) $style['line_height']) . 'px';
+            }
+
+            if ( empty($declarations) ) {
+                continue;
+            }
+
+            $classes[] = array('name' => 'type-' . $role, 'declarations' => $declarations);
+        }
+
+        return array('variables' => $variables, 'classes' => $classes);
+    }
+
+    /**
+     * Mint spacing tokens from spacing values that recur often enough to be a
+     * deliberate scale step. Returns ascending `--space-*` tokens.
+     *
+     * @param array<int, float> $spacings
+     * @return array<int, array{name: string, value: string}>
+     */
+    private function buildSpacingTokens(array $spacings): array
+    {
+        if ( empty($spacings) ) {
+            return array();
+        }
+
+        $counts = array();
+        foreach ( $spacings as $value ) {
+            $key = $this->number($value);
+            if ( ! isset($counts[$key]) ) {
+                $counts[$key] = array('value' => $value, 'count' => 0);
+            }
+            ++$counts[$key]['count'];
+        }
+
+        // A spacing step is a token when it recurs (a real scale value) — a
+        // one-off gap is layout noise, not a token. If nothing recurs, fall back
+        // to the distinct values so a sparse system still yields a scale.
+        $recurring = array_filter($counts, static fn (array $entry): bool => $entry['count'] >= 2);
+        $source = ! empty($recurring) ? $recurring : $counts;
+
+        $values = array();
+        foreach ( $source as $entry ) {
+            $values[] = (float) $entry['value'];
+        }
+        sort($values);
+
+        $tokens = array();
+        $step = 1;
+        foreach ( $values as $value ) {
+            $tokens[] = array('name' => 'space-' . $step, 'value' => $this->number($value) . 'px');
+            ++$step;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Assemble the authored global CSS: a `:root` block of custom properties
+     * followed by the reusable type-scale classes. Empty when nothing was
+     * extracted.
+     *
+     * @param array<int, array{name: string, value: string}> $colorTokens
+     * @param array<int, array{name: string, value: string}> $typeVariables
+     * @param array<int, array{name: string, value: string}> $spacingTokens
+     * @param array<int, array{name: string, declarations: array<int, string>}> $typeClasses
+     */
+    private function renderCss(array $colorTokens, array $typeVariables, array $spacingTokens, array $typeClasses): string
+    {
+        $rootDeclarations = array();
+        foreach ( $colorTokens as $token ) {
+            $rootDeclarations[] = '--' . $token['name'] . ':' . $token['value'];
+        }
+        foreach ( $typeVariables as $token ) {
+            $rootDeclarations[] = '--' . $token['name'] . ':' . $token['value'];
+        }
+        foreach ( $spacingTokens as $token ) {
+            $rootDeclarations[] = '--' . $token['name'] . ':' . $token['value'];
+        }
+
+        $blocks = array();
+        if ( ! empty($rootDeclarations) ) {
+            $blocks[] = ':root{' . implode(';', $rootDeclarations) . '}';
+        }
+        foreach ( $typeClasses as $class ) {
+            $blocks[] = '.' . $class['name'] . '{' . implode(';', $class['declarations']) . '}';
+        }
+
+        return empty($blocks) ? '' : implode("\n", $blocks) . "\n";
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>|null
+     */
+    private function textStyle(array $node): ?array
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $style = is_array($text['style'] ?? null) ? $text['style'] : array();
+        if ( empty($style) ) {
+            return null;
+        }
+
+        $result = array();
+        if ( isset($style['font_family']) && is_scalar($style['font_family']) ) {
+            $result['font_family'] = (string) $style['font_family'];
+        }
+        if ( isset($style['font_size']) && is_numeric($style['font_size']) ) {
+            $result['font_size'] = (float) $style['font_size'];
+        }
+        if ( isset($style['font_weight']) && is_numeric($style['font_weight']) ) {
+            $result['font_weight'] = (float) $style['font_weight'];
+        }
+        if ( isset($style['line_height_px']) && is_numeric($style['line_height_px']) && (float) $style['line_height_px'] > 0.0 ) {
+            $result['line_height'] = (float) $style['line_height_px'];
+        }
+
+        // A style with no usable typographic fields is not a specimen.
+        if ( ! isset($result['font_size']) && ! isset($result['font_family']) ) {
+            return null;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $style
+     */
+    private function textStyleKey(array $style): string
+    {
+        $family = isset($style['font_family']) ? strtolower((string) $style['font_family']) : '';
+        $size = isset($style['font_size']) ? $this->number((float) $style['font_size']) : '';
+        $weight = isset($style['font_weight']) ? $this->number((float) $style['font_weight']) : '';
+        $lineHeight = isset($style['line_height']) ? $this->number((float) $style['line_height']) : '';
+        $key = $family . '|' . $size . '|' . $weight . '|' . $lineHeight;
+
+        return '|||' === $key ? '' : $key;
+    }
+
+    /**
+     * The first solid-paint fill of a node as a CSS color, if any.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function solidFill(array $node): ?string
+    {
+        $paints = is_array($node['figma_paints']['fills'] ?? null) ? $node['figma_paints']['fills'] : array();
+        foreach ( $paints as $paint ) {
+            if ( ! is_array($paint) || 'SOLID' !== ($paint['type'] ?? null) ) {
+                continue;
+            }
+            $color = $this->color($paint['color'] ?? null, $paint['opacity'] ?? null);
+            if ( null !== $color ) {
+                return $color;
+            }
+        }
+
+        // Fall back to the simpler color carriers the normalizer may leave in
+        // place, mirroring StaticHtmlEmitter::backgroundColor.
+        return $this->color($node['backgroundColor'] ?? $node['background'] ?? $node['fill'] ?? null);
+    }
+
+    private function color(mixed $value, mixed $opacity = null): ?string
+    {
+        if ( is_string($value) && preg_match('/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/', $value) ) {
+            return strtolower($value);
+        }
+        if ( ! is_array($value) ) {
+            return null;
+        }
+
+        $red = $this->colorChannel($value['r'] ?? $value['red'] ?? null);
+        $green = $this->colorChannel($value['g'] ?? $value['green'] ?? null);
+        $blue = $this->colorChannel($value['b'] ?? $value['blue'] ?? null);
+        if ( null === $red || null === $green || null === $blue ) {
+            return null;
+        }
+
+        $alpha = $opacity;
+        if ( null === $alpha && isset($value['a']) ) {
+            $alpha = $value['a'];
+        }
+        if ( is_numeric($alpha) && (float) $alpha < 1 ) {
+            return sprintf('rgba(%d,%d,%d,%s)', $red, $green, $blue, $this->number(max(0, (float) $alpha)));
+        }
+
+        return sprintf('#%02x%02x%02x', $red, $green, $blue);
+    }
+
+    private function colorChannel(mixed $value): ?int
+    {
+        if ( ! is_numeric($value) ) {
+            return null;
+        }
+        $channel = (float) $value;
+        if ( $channel <= 1 ) {
+            $channel *= 255;
+        }
+
+        return max(0, min(255, (int) round($channel)));
+    }
+
+    /**
+     * Build a CSS font-family stack from a single family name, mirroring the
+     * generic fallback that FontResolver applies so the type scale and the
+     * per-node text styles agree.
+     */
+    private function fallbackFontStack(string $family): string
+    {
+        $name = trim($family);
+        if ( '' === $name ) {
+            return 'sans-serif';
+        }
+        $quoted = str_contains($name, ' ') ? '"' . str_replace('"', '\\"', $name) . '"' : $name;
+
+        return $quoted . ',sans-serif';
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function subtreeHasText(array $node): bool
+    {
+        return '' !== trim($this->subtreePlainText($node));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function subtreePlainText(array $node): string
+    {
+        $parts = array();
+        if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
+            $own = $this->nodePlainText($node);
+            if ( '' !== $own ) {
+                $parts[] = $own;
+            }
+        }
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            $childText = $this->subtreePlainText($child);
+            if ( '' !== $childText ) {
+                $parts[] = $childText;
+            }
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodePlainText(array $node): string
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        if ( isset($text['characters']) && is_scalar($text['characters']) ) {
+            return (string) $text['characters'];
+        }
+        foreach ( array('characters', 'text') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) ) {
+                return (string) $node[$key];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * A generic node name (e.g. "Rectangle", "Frame 12") carries no token
+     * semantics and should not become a token base name.
+     */
+    private function isGenericName(string $name): bool
+    {
+        $lower = strtolower(trim($name));
+
+        return 1 === preg_match('/^(rectangle|ellipse|frame|group|vector|component|instance|shape|swatch|color|colour)(\s*\d+)?$/', $lower);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function boxValue(array $node, string $key): ?float
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        if ( isset($box[$key]) && is_numeric($box[$key]) ) {
+            return (float) $box[$key];
+        }
+        if ( isset($node[$key]) && is_numeric($node[$key]) ) {
+            return (float) $node[$key];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $container
+     * @return array<int, mixed>
+     */
+    private function nodeList(array $container): array
+    {
+        if ( is_array($container['nodes'] ?? null) ) {
+            return array_values($container['nodes']);
+        }
+        if ( is_array($container['children'] ?? null) ) {
+            return array_values($container['children']);
+        }
+
+        return array();
+    }
+
+    private function slug(string $value): string
+    {
+        $slug = strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', $value) ?? '');
+        $slug = trim($slug, '-');
+
+        return '' === $slug ? 'node' : $slug;
+    }
+
+    private function number(float $value): string
+    {
+        return rtrim(rtrim(sprintf('%.3F', $value), '0'), '.');
+    }
+}

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -51,6 +51,13 @@ final class StaticHtmlEmitter
         return $this->fontResolver ??= new FontResolver();
     }
 
+    private ?DesignSystemExtractor $designSystemExtractor = null;
+
+    private function designSystemExtractor(): DesignSystemExtractor
+    {
+        return $this->designSystemExtractor ??= new DesignSystemExtractor();
+    }
+
     /**
      * Resolved destination-node-id => page-path map used to turn NODE/prototype links into slug hrefs.
      *
@@ -147,7 +154,14 @@ final class StaticHtmlEmitter
         $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
         $fontCss = (string) $fontResolution['css'];
 
-        $css = ('' !== $fontCss ? $fontCss . "\n" : '') . implode("\n", $cssRules) . "\n";
+        $designSystem = $this->designSystemExtractor()->extract($scenegraph);
+        foreach ( $this->designSystemDiagnostics($designSystem) as $diagnostic ) {
+            $diagnostics[] = $diagnostic;
+        }
+
+        $css = ('' !== $fontCss ? $fontCss . "\n" : '')
+            . ('' !== $designSystem['css'] ? $designSystem['css'] : '')
+            . implode("\n", $cssRules) . "\n";
         $files = array(
             array(
                 'path'      => 'index.html',
@@ -193,6 +207,10 @@ final class StaticHtmlEmitter
                 'font_usage'                   => $fontUsage,
                 'font_css_supplied'            => (bool) $fontResolution['operator_supplied'],
                 'render_text_glyph_paths'      => $this->renderTextGlyphPaths,
+                'design_system'                => array(
+                    'coverage'    => $designSystem['coverage'],
+                    'frame_names' => $designSystem['frame_names'],
+                ),
                 'transform_diagnostics'        => $transformDiagnostics,
             ),
             'metrics'       => array(
@@ -331,7 +349,13 @@ final class StaticHtmlEmitter
         $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
         $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
         $fontCss = (string) $fontResolution['css'];
-        $css = ('' !== $fontCss ? $fontCss . "\n" : '') . implode("\n", array_values(array_unique($cssRules))) . "\n";
+        $designSystem = $this->designSystemExtractor()->extract($scenegraph);
+        foreach ( $this->designSystemDiagnostics($designSystem) as $diagnostic ) {
+            $diagnostics[] = $diagnostic;
+        }
+        $css = ('' !== $fontCss ? $fontCss . "\n" : '')
+            . ('' !== $designSystem['css'] ? $designSystem['css'] : '')
+            . implode("\n", array_values(array_unique($cssRules))) . "\n";
         if ( ! empty($mediaBlocks) ) {
             // Responsive overrides cascade AFTER the widest-first base rules so
             // narrower breakpoints win at their own viewport width.
@@ -375,6 +399,10 @@ final class StaticHtmlEmitter
                 'font_usage'                   => $fontUsage,
                 'font_css_supplied'            => (bool) $fontResolution['operator_supplied'],
                 'render_text_glyph_paths'      => $this->renderTextGlyphPaths,
+                'design_system'                => array(
+                    'coverage'    => $designSystem['coverage'],
+                    'frame_names' => $designSystem['frame_names'],
+                ),
                 'transform_diagnostics'        => $transformDiagnostics,
             ),
             'metrics'       => array(
@@ -1229,6 +1257,36 @@ final class StaticHtmlEmitter
         }
 
         return null;
+    }
+
+    /**
+     * Build the design-system coverage diagnostic: an informational record of
+     * how many color/type/spacing tokens were extracted from how many detected
+     * style-guide frames. Returns an empty list when no design-system frame was
+     * detected, so files without one stay silent.
+     *
+     * @param array{css: string, coverage: array<string, int>, frame_names: array<int, string>} $designSystem
+     * @return array<int, array<string, mixed>>
+     */
+    private function designSystemDiagnostics(array $designSystem): array
+    {
+        $coverage = is_array($designSystem['coverage'] ?? null) ? $designSystem['coverage'] : array();
+        if ( (int) ($coverage['frame_count'] ?? 0) < 1 ) {
+            return array();
+        }
+
+        return array(
+            array(
+                'severity'       => 'info',
+                'code'           => 'design_system_extracted',
+                'message'        => 'Extracted a global design system from detected style-guide frames.',
+                'frame_count'    => (int) ($coverage['frame_count'] ?? 0),
+                'color_tokens'   => (int) ($coverage['color_tokens'] ?? 0),
+                'type_tokens'    => (int) ($coverage['type_tokens'] ?? 0),
+                'spacing_tokens' => (int) ($coverage['spacing_tokens'] ?? 0),
+                'frame_names'    => is_array($designSystem['frame_names'] ?? null) ? $designSystem['frame_names'] : array(),
+            ),
+        );
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5661,6 +5661,136 @@ $authoredCssRerunResult = blocks_engine_figma_transformer_transform_scenegraph($
 $assert($authoredCss === $fileContent($authoredCssRerunResult, 'style.css'), 'authored-css-stylesheet-deterministic');
 $assert($authoredHtml === $fileContent($authoredCssRerunResult, 'index.html'), 'authored-css-html-deterministic');
 
+// Design system: a "Style Guide" frame is the SOURCE of the design system. Its
+// color swatches become `:root` custom properties, its distinct text styles
+// become a reusable type scale, consistent spacing becomes spacing tokens, and a
+// coverage diagnostic counts what was extracted. The frame feeds global CSS — it
+// is not rendered as the design itself.
+$designSystemScenegraph = array(
+    'name'  => 'Design System Fixture',
+    'nodes' => array(
+        array(
+            'id'         => 'ds:guide',
+            'type'       => 'FRAME',
+            'name'       => 'Style Guide',
+            'width'      => 1200,
+            'height'     => 800,
+            'layoutMode' => 'VERTICAL',
+            'itemSpacing' => 24,
+            'paddingTop'  => 32,
+            'paddingLeft' => 32,
+            'children'   => array(
+                array(
+                    'id'         => 'ds:swatch-primary',
+                    'type'       => 'RECTANGLE',
+                    'name'       => 'Primary',
+                    'width'      => 80,
+                    'height'     => 80,
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.2, 'g' => 0.4, 'b' => 0.8))),
+                ),
+                array(
+                    'id'         => 'ds:swatch-accent',
+                    'type'       => 'RECTANGLE',
+                    'name'       => 'Accent',
+                    'width'      => 80,
+                    'height'     => 80,
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0.9, 'g' => 0.3, 'b' => 0.2))),
+                ),
+                array(
+                    'id'       => 'ds:type-heading',
+                    'type'     => 'TEXT',
+                    'name'     => 'Heading',
+                    'text'     => 'Heading specimen',
+                    'fontSize' => 48,
+                    'style'    => array('fontFamily' => 'Inter', 'fontSize' => 48, 'fontWeight' => 700, 'lineHeightPx' => 56),
+                ),
+                array(
+                    'id'       => 'ds:type-body',
+                    'type'     => 'TEXT',
+                    'name'     => 'Body',
+                    'text'     => 'Body specimen',
+                    'fontSize' => 16,
+                    'style'    => array('fontFamily' => 'Inter', 'fontSize' => 16, 'fontWeight' => 400, 'lineHeightPx' => 24),
+                ),
+            ),
+        ),
+    ),
+);
+$designSystemResult = blocks_engine_figma_transformer_transform_scenegraph($designSystemScenegraph);
+$designSystemCss = $fileContent($designSystemResult, 'style.css');
+
+// Colors become `:root` custom properties, named from swatch labels.
+$assert(str_contains($designSystemCss, ':root{'), 'design-system-root-block-emitted');
+$assert(str_contains($designSystemCss, '--color-primary:#3366cc'), 'design-system-primary-color-token');
+$assert(str_contains($designSystemCss, '--color-accent:#e64d33'), 'design-system-accent-color-token');
+
+// Typography becomes custom properties plus a reusable type-scale class set.
+$assert(str_contains($designSystemCss, '--font-size-heading-1:48px'), 'design-system-heading-font-size-token');
+$assert(str_contains($designSystemCss, '--font-size-body:16px'), 'design-system-body-font-size-token');
+$assert(str_contains($designSystemCss, '.type-heading-1{'), 'design-system-heading-type-class');
+$assert(str_contains($designSystemCss, '.type-body{'), 'design-system-body-type-class');
+$assert(str_contains($designSystemCss, 'font-size:var(--font-size-heading-1)'), 'design-system-type-class-references-token');
+$assert(str_contains($designSystemCss, 'line-height:56px'), 'design-system-type-class-carries-line-height');
+
+// Consistent spacing becomes a spacing token.
+$assert(str_contains($designSystemCss, '--space-1:32px'), 'design-system-spacing-token');
+
+// The `:root` block leads the stylesheet, before the per-node page rules.
+$rootPos = strpos($designSystemCss, ':root{');
+$nodePos = strpos($designSystemCss, '.figma-node-');
+$assert(false !== $rootPos && false !== $nodePos && $rootPos < $nodePos, 'design-system-root-precedes-page-rules');
+
+// The coverage diagnostic counts the extracted tokens.
+$designSystemReport = is_array($designSystemResult['source_reports']['figma']['html']['design_system'] ?? null)
+    ? $designSystemResult['source_reports']['figma']['html']['design_system']
+    : array();
+$designSystemCoverage = is_array($designSystemReport['coverage'] ?? null) ? $designSystemReport['coverage'] : array();
+$assert(1 === ($designSystemCoverage['frame_count'] ?? 0), 'design-system-coverage-frame-count');
+$assert(2 === ($designSystemCoverage['color_tokens'] ?? 0), 'design-system-coverage-color-count');
+$assert(2 === ($designSystemCoverage['type_tokens'] ?? 0), 'design-system-coverage-type-count');
+$assert(($designSystemCoverage['spacing_tokens'] ?? 0) >= 1, 'design-system-coverage-spacing-count');
+
+// A matching coverage diagnostic is surfaced for operators.
+$designSystemDiagnostic = null;
+foreach ( (is_array($designSystemResult['diagnostics'] ?? null) ? $designSystemResult['diagnostics'] : array()) as $diagnostic ) {
+    if ( is_array($diagnostic) && 'design_system_extracted' === ($diagnostic['code'] ?? '') ) {
+        $designSystemDiagnostic = $diagnostic;
+        break;
+    }
+}
+$assert(null !== $designSystemDiagnostic, 'design-system-coverage-diagnostic-emitted');
+$assert(null !== $designSystemDiagnostic && 2 === ($designSystemDiagnostic['color_tokens'] ?? 0), 'design-system-diagnostic-color-count');
+
+// A plain site without a style-guide frame extracts no design system, so the
+// `:root` token block never pollutes ordinary pages.
+$plainSiteScenegraph = array(
+    'name'  => 'Plain Site Fixture',
+    'nodes' => array(
+        array(
+            'id'         => 'plain:hero',
+            'type'       => 'FRAME',
+            'name'       => 'Hero Section',
+            'width'      => 1200,
+            'height'     => 400,
+            'layoutMode' => 'VERTICAL',
+            'children'   => array(
+                array('id' => 'plain:title', 'type' => 'TEXT', 'name' => 'Title', 'text' => 'Welcome', 'fontSize' => 40, 'style' => array('fontSize' => 40)),
+            ),
+        ),
+    ),
+);
+$plainSiteResult = blocks_engine_figma_transformer_transform_scenegraph($plainSiteScenegraph);
+$plainSiteCss = $fileContent($plainSiteResult, 'style.css');
+$assert(! str_contains($plainSiteCss, ':root{'), 'design-system-absent-for-plain-site');
+$plainCoverage = is_array($plainSiteResult['source_reports']['figma']['html']['design_system']['coverage'] ?? null)
+    ? $plainSiteResult['source_reports']['figma']['html']['design_system']['coverage']
+    : array();
+$assert(0 === ($plainCoverage['frame_count'] ?? -1), 'design-system-plain-site-zero-frames');
+
+// Determinism: re-running yields byte-identical design-system CSS.
+$designSystemRerun = blocks_engine_figma_transformer_transform_scenegraph($designSystemScenegraph);
+$assert($designSystemCss === $fileContent($designSystemRerun, 'style.css'), 'design-system-css-deterministic');
+
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");
     exit(1);


### PR DESCRIPTION
## Summary

A Figma **Style Guide** / **Design System** frame is the SOURCE of a design system, not a page to render. This adds a `DesignSystemExtractor` (`figma-transformer/src/Html/DesignSystemExtractor.php`) that detects such frames and extracts design tokens into authored global CSS at the top of `style.css`, complementing the shared-class work in #287 and building on top of the @font-face fonts work in #267.

Part of #247 (real, coherently-styled website artifact).

### Detection (generic, data-driven)
- **Name signals:** frame name matches Style Guide / Design System / Tokens / Components / Styles / Typography / Foundations, etc.
- **Content shape:** a grid of solid-color swatches (small, square-ish, solid fill, no text) and/or a set of distinct type specimens — so an unnamed system is still caught. Matched subtrees are not re-descended, and a matched frame is never rendered as a page (a sibling cook owns PAGE exclusion; this PR owns EXTRACTION).

### Token extraction → `style.css`
- **Colors** → `:root` `--color-*` custom properties from swatch solid fills, named from the swatch's own name or a nearby caption text node, falling back to an index.
- **Typography** → a type scale: `--font-size-*` custom properties plus reusable `.type-heading-n` / `.type-body` classes carrying family/size/weight/line-height. The largest specimens become descending heading levels; the smallest common specimen is body. Font stacks are built on the existing font emission rather than duplicating `@font-face`.
- **Spacing** → ascending `--space-*` tokens from recurring auto-layout gaps/paddings (a value that recurs is a deliberate scale step; one-offs are layout noise).

The `:root` block is emitted ahead of the per-node/shared-class rules in both `emit()` and `emitSite()`, so generated pages can reference the tokens. A `design_system_extracted` coverage diagnostic and a `source_report.design_system.coverage` block count the extracted color/type/spacing tokens and detected frames. A site with no style-guide frame emits no design-system CSS.

### Tests
Synthetic contract tests only (no large `.fig` files). A "Style Guide" fixture with 2 swatches + 2 text styles yields `:root` `--color-*` properties, `--font-size-*` + `.type-*` classes, a `--space-*` token, correct coverage counts, the diagnostic, the negative (plain-site) case, and byte-identical determinism. Run: `cd figma-transformer && php tests/contract/run.php` → `Figma Transformer contract tests passed.`

Lab validation against real `.fig` files is the orchestrator's follow-up.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Extracting Figma style-guide frames into a global design system (CSS variables + type scale) for #247.