### PR TITLE
Wire responsive page assembly into the live transform path (#247)

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -401,6 +401,11 @@ final class FigmaTransformer
             return $this->transformScenegraphPages($scenegraph, $options);
         }
 
+        $responsiveVariants = $this->responsivePageVariants($options);
+        if ( null !== $responsiveVariants ) {
+            return $this->transformResponsivePage($scenegraph, $responsiveVariants, $options);
+        }
+
         $startedAt = microtime(true);
         $normalized = $this->scenegraphNormalizer->normalize($scenegraph, $options);
         $artifact    = $this->htmlEmitter->emit($normalized, $options);
@@ -428,6 +433,109 @@ final class FigmaTransformer
                 'asset_reference_count'  => count($normalized['asset_references'] ?? array()),
                 'asset_count'            => $artifact['metrics']['asset_count'] ?? 0,
                 'file_count'             => count($artifact['files']),
+                'transform_duration_ms'  => (int) round((microtime(true) - $startedAt) * 1000),
+            )
+        );
+    }
+
+    /**
+     * Extract a usable responsive variant list (two or more breakpoint frames)
+     * from the per-page options the multi-page loop forwards. Returns null when
+     * the page is a single-frame (non-responsive) page so the caller keeps the
+     * existing one-frame {@see StaticHtmlEmitter::emit()} path untouched.
+     *
+     * @param array<string, mixed> $options
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function responsivePageVariants(array $options): ?array
+    {
+        if ( ! is_array($options['responsive_variants'] ?? null) ) {
+            return null;
+        }
+
+        $variants = array_values(array_filter(
+            $options['responsive_variants'],
+            static fn (mixed $variant): bool => is_array($variant)
+                && isset($variant['frame_id'])
+                && is_scalar($variant['frame_id'])
+                && '' !== (string) $variant['frame_id']
+        ));
+
+        return count($variants) > 1 ? $variants : null;
+    }
+
+    /**
+     * Emit one responsive page (desktop + mobile/tablet breakpoint variants)
+     * through {@see StaticHtmlEmitter::emitSite()} so the primary (widest)
+     * variant renders as the base layout and narrower variants emit
+     * `@media (max-width: …)` overrides. This is the live wiring point that
+     * turns a planner-detected responsive variant-group into ONE `@media`-aware
+     * page instead of one page per frame (#247).
+     *
+     * The full scenegraph is normalized (no `frame_id` limit) so every variant
+     * frame stays in the emitter's node map; emitSite then walks only the page's
+     * variant frames. The result envelope mirrors {@see emit()} so the
+     * multi-page loop aggregates it identically to a single-frame page.
+     *
+     * @param array<string, mixed>             $scenegraph
+     * @param array<int, array<string, mixed>> $variants Ordered breakpoint variants (widest first).
+     * @param array<string, mixed>             $options
+     */
+    private function transformResponsivePage(array $scenegraph, array $variants, array $options): FigmaTransformResult
+    {
+        $startedAt = microtime(true);
+
+        $primaryFrameId = (string) ($variants[0]['frame_id'] ?? '');
+        $pageName = isset($options['page_name']) && is_scalar($options['page_name']) ? (string) $options['page_name'] : '';
+
+        // Normalize the FULL scenegraph (drop the single-frame selection) so
+        // every variant frame is present in the emitter node map.
+        $normalizeOptions = $options;
+        unset($normalizeOptions['frame_id'], $normalizeOptions['responsive_variants'], $normalizeOptions['page_name']);
+        $normalized = $this->scenegraphNormalizer->normalize($scenegraph, $normalizeOptions);
+
+        $pagePlan = array(
+            'pages' => array(
+                array(
+                    'frame_id'   => $primaryFrameId,
+                    'name'       => '' !== $pageName ? $pageName : ($normalized['name'] ?? $primaryFrameId),
+                    'path'       => 'index.html',
+                    'entrypoint' => true,
+                    'responsive' => true,
+                    'variants'   => $variants,
+                ),
+            ),
+        );
+
+        $emitOptions = $options;
+        unset($emitOptions['responsive_variants'], $emitOptions['frame_id'], $emitOptions['page_name']);
+
+        $artifact    = $this->htmlEmitter->emitSite($normalized, $pagePlan, $emitOptions);
+        $artifact    = $this->withLayoutMismatchReport($artifact, $options);
+        $artifact    = $this->withRenderStyleMismatchReport($artifact, $options);
+        $diagnostics = array_merge($normalized['diagnostics'] ?? array(), $artifact['diagnostics']);
+        $parity      = $this->parityReportBuilder->build($options['parity'] ?? array());
+
+        return FigmaTransformResult::create(
+            $artifact['status'],
+            $diagnostics,
+            $artifact['files'],
+            $artifact['assets'],
+            array(
+                'figma' => array(
+                    'scenegraph' => $normalized['source_report'],
+                    'html'       => $artifact['source_report'],
+                ),
+                'compiled_site' => $this->compiledSiteSourceReport($artifact),
+            ),
+            $parity,
+            array(
+                'node_count'             => $artifact['metrics']['node_count'] ?? 0,
+                'text_node_count'        => count($normalized['text_inventory'] ?? array()),
+                'asset_reference_count'  => count($normalized['asset_references'] ?? array()),
+                'asset_count'            => $artifact['metrics']['asset_count'] ?? 0,
+                'file_count'             => count($artifact['files']),
+                'breakpoint_count'       => count($variants),
                 'transform_duration_ms'  => (int) round((microtime(true) - $startedAt) * 1000),
             )
         );
@@ -483,8 +591,21 @@ final class FigmaTransformer
             $pageOptions['layout_mismatch_options']['page_path'] = $path;
             $pageOptions['render_style_mismatch_options'] = is_array($pageOptions['render_style_mismatch_options'] ?? null) ? $pageOptions['render_style_mismatch_options'] : array();
             $pageOptions['render_style_mismatch_options']['page_path'] = $path;
-            unset($pageOptions['multi_page'], $pageOptions['include_all_pages'], $pageOptions['frame_ids'], $pageOptions['entry_frame_id'], $pageOptions['max_pages'], $pageOptions['frame_slug_map']);
+            unset($pageOptions['multi_page'], $pageOptions['include_all_pages'], $pageOptions['frame_ids'], $pageOptions['entry_frame_id'], $pageOptions['max_pages'], $pageOptions['frame_slug_map'], $pageOptions['responsive_variants'], $pageOptions['page_name']);
             $pageOptions['link_target_paths'] = $linkTargetPaths;
+
+            // When the planner collapsed responsive sibling frames into this one
+            // page (#251), forward the ordered breakpoint variants so the live
+            // transform emits ONE `@media`-aware page (primary base layout +
+            // narrower `max-width` overrides) instead of just the primary frame.
+            // Single-variant pages carry no `responsive_variants`, so they keep
+            // the existing one-frame emission path unchanged.
+            $pageVariants = is_array($page['variants'] ?? null) ? array_values($page['variants']) : array();
+            if ( true === ($page['responsive'] ?? false) && count($pageVariants) > 1 ) {
+                $pageOptions['responsive_variants'] = $pageVariants;
+                $pageOptions['page_name'] = (string) ($page['name'] ?? $frameId);
+            }
+
             $pageResult = $this->transformScenegraph($scenegraph, $pageOptions)->toArray();
             $pageDiagnostics = is_array($pageResult['diagnostics'] ?? null) ? $pageResult['diagnostics'] : array();
             $diagnostics = array_merge($diagnostics, $pageDiagnostics);
@@ -1266,31 +1387,93 @@ final class FigmaTransformer
     }
 
     /**
+     * Merge per-page CSS chunks into one deduplicated stylesheet.
+     *
+     * CSS is tokenized at TOP-LEVEL statement boundaries (tracking brace depth)
+     * rather than per line, so block at-rules — most importantly the responsive
+     * `@media (max-width: …)` blocks emitted for a collapsed responsive page —
+     * stay ATOMIC and are not shattered into stray `{`/`}`/inner-rule lines that
+     * line-level deduping would corrupt. `@import` (and the leading font-source
+     * comment) float to the top to stay valid after concatenation; plain
+     * top-level rules dedupe; `@media` (and other block at-rules) preserve their
+     * widest-first emission order and follow the base rules so narrower
+     * breakpoints still win the cascade at their own viewport width.
+     *
      * @param array<int, string> $chunks
      */
     private function mergeCssChunks(array $chunks): string
     {
         $imports = array();
         $rules = array();
+        $atBlocks = array();
         foreach ( $chunks as $chunk ) {
-            foreach ( explode("\n", $chunk) as $line ) {
-                $line = trim($line);
-                if ( '' === $line ) {
+            foreach ( $this->splitCssStatements($chunk) as $statement ) {
+                $statement = trim($statement);
+                if ( '' === $statement ) {
                     continue;
                 }
                 // `@import` (and any leading font-source comment) must precede all
                 // other rules to stay valid after chunks are concatenated.
-                if ( str_starts_with($line, '@import') || ( str_starts_with($line, '/*') && str_contains($line, 'web fonts') ) ) {
-                    $imports[$line] = true;
+                if ( str_starts_with($statement, '@import') || ( str_starts_with($statement, '/*') && str_contains($statement, 'web fonts') ) ) {
+                    $imports[$statement] = true;
                     continue;
                 }
-                $rules[$line] = true;
+                // Block at-rules (e.g. responsive `@media` breakpoints) must stay
+                // intact and keep their emission order behind the base rules.
+                if ( str_starts_with($statement, '@media') || ( str_starts_with($statement, '@') && str_contains($statement, '{') ) ) {
+                    $atBlocks[$statement] = true;
+                    continue;
+                }
+                $rules[$statement] = true;
             }
         }
 
-        $ordered = array_merge(array_keys($imports), array_keys($rules));
+        $ordered = array_merge(array_keys($imports), array_keys($rules), array_keys($atBlocks));
 
         return implode("\n", $ordered) . (empty($ordered) ? '' : "\n");
+    }
+
+    /**
+     * Split a CSS string into top-level statements, keeping each rule or block
+     * at-rule (with its full brace-balanced body) as one element. Bare `@import`
+     * statements and standalone comments are returned as their own elements.
+     *
+     * @return array<int, string>
+     */
+    private function splitCssStatements(string $css): array
+    {
+        $statements = array();
+        $buffer = '';
+        $depth = 0;
+        $length = strlen($css);
+        for ( $i = 0; $i < $length; $i++ ) {
+            $char = $css[$i];
+            $buffer .= $char;
+            if ( '{' === $char ) {
+                ++$depth;
+                continue;
+            }
+            if ( '}' === $char ) {
+                $depth = max(0, $depth - 1);
+                if ( 0 === $depth ) {
+                    $statements[] = trim($buffer);
+                    $buffer = '';
+                }
+                continue;
+            }
+            if ( ';' === $char && 0 === $depth ) {
+                // Top-level statement with no block body (e.g. `@import …;`).
+                $statements[] = trim($buffer);
+                $buffer = '';
+            }
+        }
+
+        $trailing = trim($buffer);
+        if ( '' !== $trailing ) {
+            $statements[] = $trailing;
+        }
+
+        return array_values(array_filter($statements, static fn (string $statement): bool => '' !== $statement));
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2468,6 +2468,116 @@ $assert(1 === ($multiPageTransformDiagnostics['layout']['render_style']['summary
 $assert(in_array('render_style_mismatch', array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), $multiPageTransformDiagnostics['artifact_quality']['signals'] ?? array()), true), 'multi-page-render-style-artifact-quality-signal');
 $assert('warn' === ($multiPageTransformDiagnostics['artifact_quality']['quality_status'] ?? null), 'multi-page-transform-diagnostics-quality-status-warn');
 
+// RESPONSIVE PAGE ASSEMBLY — LIVE WIRING (#247): a source whose section holds
+// "Home – Desktop" + "Home – Mobile" sibling frames must (1) PAIR into ONE
+// responsive page in the planner (generic name-normalization + device hint +
+// width signals, NOT hardcoded ids) and (2) flow that grouping through the LIVE
+// transform so the emitted page carries the base (desktop) layout PLUS an
+// `@media (max-width: …)` block for the mobile breakpoint. This exercises the
+// full path end-to-end (planner grouping -> transformScenegraphPages ->
+// transformResponsivePage -> StaticHtmlEmitter::emitSite -> merged style.css),
+// proving emitSite is no longer dormant in production.
+$responsiveLiveResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Responsive Live Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'page:responsive-live',
+            'type'     => 'CANVAS',
+            'name'     => 'Site',
+            'children' => array(
+                array(
+                    'id'       => 'section:responsive-live',
+                    'type'     => 'SECTION',
+                    'name'     => 'Home Section',
+                    'children' => array(
+                        array(
+                            'id'       => 'frame:home-desktop-live',
+                            'type'     => 'FRAME',
+                            'name'     => 'Home – Desktop',
+                            'width'    => 1440,
+                            'height'   => 3000,
+                            'children' => array(
+                                array('id' => 'card:home-desktop', 'type' => 'RECTANGLE', 'name' => 'Hero Card', 'width' => 1200, 'height' => 400, 'backgroundColor' => array('r' => 1.0, 'g' => 0.0, 'b' => 0.0, 'a' => 1.0)),
+                                array('id' => 'text:home-desktop', 'type' => 'TEXT', 'name' => 'Hero copy', 'characters' => 'Welcome home', 'fontSize' => 32),
+                            ),
+                        ),
+                        array(
+                            'id'       => 'frame:home-mobile-live',
+                            'type'     => 'FRAME',
+                            'name'     => 'Home – Mobile',
+                            'width'    => 390,
+                            'height'   => 3200,
+                            'children' => array(
+                                array('id' => 'card:home-mobile', 'type' => 'RECTANGLE', 'name' => 'Hero Card', 'width' => 350, 'height' => 500, 'backgroundColor' => array('r' => 0.0, 'g' => 1.0, 'b' => 0.0, 'a' => 1.0)),
+                                array('id' => 'text:home-mobile', 'type' => 'TEXT', 'name' => 'Hero copy', 'characters' => 'Welcome home', 'fontSize' => 32),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+), array(
+    'multi_page'        => true,
+    'include_all_pages' => true,
+));
+$responsiveLiveIndex = $fileContent($responsiveLiveResult, 'index.html');
+$responsiveLiveStyle = $fileContent($responsiveLiveResult, 'style.css');
+$assert(in_array($responsiveLiveResult['status'] ?? null, array('success', 'success_with_warnings'), true), 'responsive-live-transform-success');
+// Desktop + mobile siblings paired into ONE page (not two).
+$assert(1 === ($responsiveLiveResult['metrics']['page_count'] ?? null), 'responsive-live-single-page');
+$assert('' !== $responsiveLiveIndex, 'responsive-live-index-emitted');
+$assert('' !== $responsiveLiveStyle, 'responsive-live-stylesheet-emitted');
+// Base styles present (the widest/desktop variant drives the base layout).
+$assert(str_contains($responsiveLiveStyle, '.figma-root'), 'responsive-live-base-styles-present');
+$assert(str_contains($responsiveLiveStyle, 'width:1200px') || str_contains($responsiveLiveStyle, 'width:1200px;'), 'responsive-live-base-uses-desktop-width');
+// The merged stylesheet carries an `@media` block (the mobile breakpoint),
+// proving the responsive emission fired through the LIVE transform path.
+$assert(str_contains($responsiveLiveStyle, '@media'), 'responsive-live-media-block-present');
+$assert(str_contains($responsiveLiveStyle, '@media (max-width:390px)'), 'responsive-live-mobile-media-query');
+// `@media` block survived chunk merging intact (balanced braces, base before media).
+$assert(strpos($responsiveLiveStyle, '.figma-root') < strpos($responsiveLiveStyle, '@media'), 'responsive-live-base-precedes-media');
+$assert(substr_count($responsiveLiveStyle, '{') === substr_count($responsiveLiveStyle, '}'), 'responsive-live-balanced-braces');
+$responsiveLivePagePlan = $responsiveLiveResult['source_reports']['figma']['pages'] ?? array();
+$assert(true === ($responsiveLivePagePlan['pages'][0]['responsive'] ?? null), 'responsive-live-plan-flagged-responsive');
+$assert(2 === ($responsiveLivePagePlan['pages'][0]['breakpoint_count'] ?? null), 'responsive-live-plan-two-breakpoints');
+
+// SINGLE-FRAME PARITY: a source with one frame still produces ONE
+// non-responsive page with NO `@media` block (the live wiring only fires for
+// detected responsive variant-groups).
+$singleFrameLiveResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Single Frame Live Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'page:single-live',
+            'type'     => 'CANVAS',
+            'name'     => 'Site',
+            'children' => array(
+                array(
+                    'id'       => 'frame:about-live',
+                    'type'     => 'FRAME',
+                    'name'     => 'About',
+                    'width'    => 1440,
+                    'height'   => 2000,
+                    'children' => array(
+                        array('id' => 'card:about-live', 'type' => 'RECTANGLE', 'name' => 'About Card', 'width' => 1100, 'height' => 300, 'backgroundColor' => array('r' => 0.0, 'g' => 0.0, 'b' => 1.0, 'a' => 1.0)),
+                        array('id' => 'text:about-live', 'type' => 'TEXT', 'name' => 'About copy', 'characters' => 'About us', 'fontSize' => 24),
+                    ),
+                ),
+            ),
+        ),
+    ),
+), array(
+    'multi_page'        => true,
+    'include_all_pages' => true,
+));
+$singleFrameLiveStyle = $fileContent($singleFrameLiveResult, 'style.css');
+$assert(in_array($singleFrameLiveResult['status'] ?? null, array('success', 'success_with_warnings'), true), 'single-frame-live-transform-success');
+$assert(1 === ($singleFrameLiveResult['metrics']['page_count'] ?? null), 'single-frame-live-single-page');
+$assert('' !== $singleFrameLiveStyle, 'single-frame-live-stylesheet-emitted');
+$assert(! str_contains($singleFrameLiveStyle, '@media'), 'single-frame-live-no-media-block');
+$assert(false === ($singleFrameLiveResult['source_reports']['figma']['pages']['pages'][0]['responsive'] ?? true), 'single-frame-live-plan-not-responsive');
+
 $imageScaleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'   => 'Image Scale Fixture',
     'assets' => array(


### PR DESCRIPTION
## Summary

Wires the responsive page assembly into the **live** Figma transform path for #247. Previously two halves existed but were disconnected: `ScenegraphPagePlanner` grouped responsive sibling-variants into a page with an ordered `variants[]` list (#251/#265/#272), and `StaticHtmlEmitter::emitSite` could emit responsive `@media` blocks from those variants (#286) — but `emitSite` had **no production caller**. The live transform used `emit()` on a single frame, so responsive emission was dormant.

A transform that yields a responsive variant-group (e.g. "Home – Desktop" + "Home – Mobile") now produces **one** `@media`-aware page per group instead of one page per frame. Single-frame transforms keep working unchanged.

## What changed

- **`transformScenegraphPages`** forwards a page's ordered breakpoint variants into per-page options when the planner collapsed responsive siblings (`responsive` + `variants > 1`).
- **`transformScenegraph`** routes those pages to a new `transformResponsivePage`, which normalizes the **full** scenegraph (so every variant frame stays in the emitter node map) and emits through `StaticHtmlEmitter::emitSite`. The widest variant becomes the base layout; narrower variants emit `@media (max-width: …)` overrides keyed onto the base node classes. The result envelope mirrors `emit()` so the multi-page loop aggregates it identically (fonts, assets, diagnostics, compiled-site report).
- **`mergeCssChunks`** now tokenizes CSS at top-level statement boundaries (brace-depth aware) instead of per line, so `@media` blocks stay **atomic** through chunk merging. `@import` floats to the top; block at-rules keep their widest-first cascade order after the base rules.

## Desktop/mobile pairing

Pairing is the existing planner grouping — generic name-normalization (en-dash/whitespace tolerant) + `device_hint` + width-spread signals, with **no hardcoded frame ids**. It composes with the existing dev-status selection (#283) and design-system / duplicate-draft exclusion.

## Tests

`php tests/contract/run.php` → `Figma Transformer contract tests passed.`

New contract coverage:
- A "Home – Desktop" + "Home – Mobile" source produces **one** page with base styles **plus** an `@media (max-width:390px)` block, end-to-end through the live transform (not `emitSite` in isolation) — with balanced braces proving the block survived chunk merging and base rules preceding the media block.
- A single-frame source still produces **one** non-responsive page with **no** `@media`.

Synthetic fixtures + contract tests only. **Lab validation against the real 185–293MB `.fig` files is the orchestrator's follow-up.**

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Wiring responsive page assembly (desktop+mobile variants → @media pages) into the live transform path for #247.
