### PR TITLE
Rein in <section> over-emission to genuine top-level regions (#247)

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -83,6 +83,15 @@ final class StaticHtmlEmitter
     private array $listItemIdCache = array();
 
     /**
+     * Tree depth at which a frame can read as a top-level <section> for the page
+     * being emitted. When the page is a single wrapping frame, its bands sit one
+     * level down (depth 1); when bands are emitted as sibling root nodes, they
+     * sit at the root (depth 0). Set per emitted page; everything deeper than
+     * this is nested structure and stays a <div>.
+     */
+    private int $sectionDepth = 0;
+
+    /**
      * Maps each per-node CSS class (the `figma-node-*` hook) to a human-readable
      * base name derived from the node's name/role. Used to mint shared,
      * authored-looking class names when several nodes share identical styles.
@@ -112,6 +121,8 @@ final class StaticHtmlEmitter
         $diagnostics = array();
         $nodeStyleDiagnostics = array();
         $assetFiles = $this->normalizeAssets($scenegraph['assets'] ?? array(), $diagnostics);
+
+        $this->sectionDepth = $this->sectionDepthFor($nodes);
 
         $body = '';
         $cssRules = array(
@@ -277,6 +288,9 @@ final class StaticHtmlEmitter
 
             $this->listItemIdCache = array();
             $this->prepareHeadingRanking(array($frameNode));
+            // A planned page is a single wrapping frame; its bands are its
+            // direct children one level down.
+            $this->sectionDepth = 1;
             $body = $this->emitNode($frameNode, $cssRules, $diagnostics, $nodeStyleDiagnostics, 0, null);
             $files[] = array(
                 'path'      => $path,
@@ -300,6 +314,7 @@ final class StaticHtmlEmitter
         }
 
         if ( empty($files) ) {
+            $this->sectionDepth = $this->sectionDepthFor($this->nodeList($scenegraph));
             foreach ( $this->nodeList($scenegraph) as $node ) {
                 if ( ! is_array($node) ) {
                     continue;
@@ -690,11 +705,97 @@ final class StaticHtmlEmitter
             return 'ul';
         }
 
-        if ( 'FRAME' === $type ) {
+        // A <section> is reserved for genuine top-level content regions — the
+        // page bands a hand-author would wrap in <section>. Every other frame
+        // (nested wrappers, rows, columns, cards, decorative groups) stays a
+        // <div>, so a typical page emits a handful of sections, not hundreds.
+        if ( 'FRAME' === $type && $this->isTopLevelSection($node, $depth, $parentNode, $children) ) {
             return 'section';
         }
 
         return 'div';
+    }
+
+    /**
+     * Decides whether a frame is a genuine top-level content region worthy of a
+     * <section>, rather than a nested structural container. The signals are
+     * generic and position/size/content based — no file-specific names:
+     *
+     *  - Position: a top-level page band — exactly one level below the page
+     *    root ({@see $sectionDepth}), so only the bands a hand-author wraps in
+     *    <section> qualify, never the structure nested inside them.
+     *  - Size: spans most of the page width, like a full-width content band.
+     *  - Significance: holds meaningful mixed content (multiple text runs, or
+     *    sub-regions), not a thin wrapper around a single element.
+     *
+     * Deeper frames — rows, columns, cards, wrappers, and decorative groups —
+     * are never sections; they stay <div>. That is what keeps a page to a
+     * handful of sections instead of hundreds.
+     *
+     * @param array<string, mixed>             $node
+     * @param array<string, mixed>|null        $parentNode
+     * @param array<int, array<string, mixed>> $children
+     */
+    private function isTopLevelSection(array $node, int $depth, ?array $parentNode, array $children): bool
+    {
+        // Only the page's top-level bands qualify: the single level directly
+        // below the page root. Anything deeper is nested structure (a <div>).
+        if ( $depth !== $this->sectionDepth ) {
+            return false;
+        }
+
+        // A band needs real content, not an empty or single-element wrapper:
+        // either several text runs, or more than one structural sub-region.
+        $textRuns = $this->textDescendantCount($node);
+        if ( $textRuns < 2 && count($children) < 2 ) {
+            return false;
+        }
+
+        // A band spans most of the page: its width is a large fraction of the
+        // wrapping page frame's width. Narrow columns and side rails stay <div>.
+        // Root-level bands (depth 0) have no parent frame to measure against;
+        // their content significance alone settles it.
+        if ( null !== $parentNode ) {
+            $width = $this->boxValue($node, 'width');
+            $parentWidth = $this->boxValue($parentNode, 'width');
+            if ( null !== $width && null !== $parentWidth && $parentWidth > 0.0 ) {
+                return ( $width / $parentWidth ) >= 0.6;
+            }
+        }
+
+        // Without reliable geometry, fall back to the content signal alone: a
+        // top-level band carrying meaningful mixed content reads as a section.
+        return true;
+    }
+
+    /**
+     * Determines the tree depth at which top-level page bands live for a set of
+     * root nodes. When the page is a single frame that wraps several band
+     * frames, the bands are its direct children (depth 1). When the bands are
+     * emitted as sibling root nodes — or when the single root frame is itself a
+     * content region rather than a wrapper — the bands sit at the root (depth 0).
+     *
+     * @param array<int, mixed> $rootNodes
+     */
+    private function sectionDepthFor(array $rootNodes): int
+    {
+        $frames = array_values(array_filter(
+            $rootNodes,
+            static fn ($node): bool => is_array($node) && 'FRAME' === strtoupper((string) ($node['type'] ?? ''))
+        ));
+
+        // A single root frame is a page wrapper only when it groups several band
+        // frames of its own. Otherwise it is itself a content region.
+        if ( 1 === count($frames) ) {
+            $childFrames = array_filter(
+                $this->nodeList($frames[0]),
+                static fn ($child): bool => is_array($child) && 'FRAME' === strtoupper((string) ($child['type'] ?? ''))
+            );
+
+            return count($childFrames) >= 2 ? 1 : 0;
+        }
+
+        return 0;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5591,6 +5591,105 @@ $assert(str_contains($semanticHtml, '<ul class="figma-node-body-cards-feature-ca
 $assert(str_contains($semanticHtml, '<li class="figma-node-card-1-card-one"'), 'semantic-repeated-item-emits-list-item');
 $assert(str_contains($semanticHtml, '<button class="figma-node-body-cta-get-started"'), 'semantic-button-like-node-emits-button');
 $assert(! str_contains($semanticHtml, '<div class="figma-node-region-top-top-bar"'), 'semantic-header-not-generic-div');
+// The middle content band (not a header/nav/footer landmark) is the genuine
+// top-level region and reads as the page's single <section>; the deeply nested
+// card/cta frames inside it do NOT each become their own <section>.
+$assert(str_contains($semanticHtml, '<section class="figma-node-region-body-content"'), 'semantic-top-level-band-emits-section');
+$assert(1 === substr_count($semanticHtml, '<section'), 'semantic-page-has-single-section');
+
+// Section refinement (#247 / #288 follow-up): a page with a few genuine
+// top-level bands wrapped around many deeply-nested containers (rows, columns,
+// cards, wrappers) emits <section> only for the top-level bands. Nested
+// structural frames stay <div>, so the page has single-digit sections rather
+// than one per container (the real FSE fixture over-emitted 347 <section>s).
+$buildNestedContainer = static function (string $idPrefix, int $depth) use (&$buildNestedContainer): array {
+    $node = array(
+        'id'     => $idPrefix,
+        'type'   => 'FRAME',
+        'name'   => 'Wrapper ' . $idPrefix,
+        'x'      => 0,
+        'y'      => 0,
+        'width'  => 1000,
+        'height' => 400,
+    );
+    if ( $depth > 0 ) {
+        $node['children'] = array(
+            $buildNestedContainer($idPrefix . '-row', $depth - 1),
+            $buildNestedContainer($idPrefix . '-col', $depth - 1),
+        );
+    } else {
+        $node['children'] = array(
+            array('id' => $idPrefix . '-t', 'type' => 'TEXT', 'name' => 'Copy ' . $idPrefix, 'characters' => 'Some descriptive body copy for the band.', 'fontSize' => 16),
+        );
+    }
+
+    return $node;
+};
+// Distinct top-level bands (different heading copy, different child shape and
+// nesting depth) so they read as separate content regions, not as repeated
+// list items. Each carries a deep wrapper tree of nested frames.
+$makeBand = static function (string $id, string $name, float $y, int $wrapDepth, int $headingSize, string $body, float $height = 800.0) use ($buildNestedContainer): array {
+    return array(
+        'id'       => $id,
+        'type'     => 'FRAME',
+        'name'     => $name,
+        'x'        => 0,
+        'y'        => $y,
+        'width'    => 1200,
+        'height'   => $height,
+        'children' => array(
+            // A heading run plus a deeply-nested wrapper tree per band. Each
+            // wrapper subtree contains many nested frames that, under the old
+            // "every FRAME is a <section>" rule, each became a <section>.
+            array('id' => $id . '-head', 'type' => 'TEXT', 'name' => $name . ' Heading', 'characters' => $name, 'fontSize' => $headingSize, 'fontWeight' => 700),
+            array('id' => $id . '-sub', 'type' => 'TEXT', 'name' => $name . ' Sub', 'characters' => $body, 'fontSize' => 18),
+            $buildNestedContainer($id . '-wrap', $wrapDepth),
+        ),
+    );
+};
+$nestingResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Section Refinement Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'sr:root',
+            'type'     => 'FRAME',
+            'name'     => 'Page Root',
+            'x'        => 0,
+            'y'        => 0,
+            'width'    => 1200,
+            'height'   => 4000,
+            'children' => array(
+                // Distinct heights so the bands read as separate regions, not a
+                // repeated card list, while each nests a deep wrapper subtree.
+                $makeBand('sr:band-1', 'Overview Band', 0.0, 4, 40, 'A broad introduction to what this page is about.', 600.0),
+                $makeBand('sr:band-2', 'Features Band', 700.0, 3, 34, 'The key capabilities, grouped for scanning.', 1000.0),
+                $makeBand('sr:band-3', 'Pricing Band', 1800.0, 2, 30, 'Plans and prices laid out side by side.', 1400.0),
+            ),
+        ),
+    ),
+));
+$nestingHtml = $fileContent($nestingResult, 'index.html');
+$assert('success' === ($nestingResult['status'] ?? null), 'section-refinement-transform-success');
+$nestingSectionCount = substr_count($nestingHtml, '<section');
+// Exactly the three top-level bands are sections; the dozens of nested wrapper
+// frames are not. A small, hand-authored-looking count, not hundreds.
+$assert(3 === $nestingSectionCount, 'section-refinement-only-top-level-bands-are-sections');
+$assert(str_contains($nestingHtml, '<section class="figma-node-sr-band-1-overview-band"'), 'section-refinement-band-1-is-section');
+$assert(str_contains($nestingHtml, '<section class="figma-node-sr-band-3-pricing-band"'), 'section-refinement-band-3-is-section');
+// Nested structural wrappers (depth >= 2) default to <div>, never <section>.
+$assert(str_contains($nestingHtml, '<div class="figma-node-sr-band-1-wrap-wrapper-sr-band-1-wrap'), 'section-refinement-nested-wrapper-is-div');
+$assert(! str_contains($nestingHtml, '<section class="figma-node-sr-band-1-wrap'), 'section-refinement-no-nested-section');
+// A page whose top-level bands are emitted as root-level nodes (no single page
+// wrapper) still gets each band as a <section> via the depth-0 path.
+$rootLevelBandsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Root Level Bands Fixture',
+    'nodes' => array(
+        $makeBand('rl:band-1', 'Intro Band', 0.0, 3, 40, 'The opening statement for the whole page.', 700.0),
+        $makeBand('rl:band-2', 'Detail Band', 900.0, 2, 30, 'Deeper detail in its own distinct region.', 1200.0),
+    ),
+));
+$rootLevelHtml = $fileContent($rootLevelBandsResult, 'index.html');
+$assert(2 === substr_count($rootLevelHtml, '<section'), 'section-refinement-root-level-bands-are-sections');
 
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 


### PR DESCRIPTION
## Problem

The semantic-element emitter (#288) selected `<section>` for **every** `FRAME`. Measured on the real FSE fixture on the lab, this produced **347 `<section>`s on a single page** — the opposite of hand-authored structure, where a page carries a handful of sections and most containers are `<div>`. Tracking issue: #247.

## Change

Tighten the `<section>` heuristic in `StaticHtmlEmitter` (`semanticTag` / the former blanket `FRAME -> section` rule). A frame now reads as a `<section>` only when it is a **genuine top-level content band**:

- **Position** — it sits exactly one level below the page root. The section depth is computed per page (`sectionDepthFor`): for a single wrapping page frame the bands are its direct children (depth 1); for sibling root frames the bands are the root nodes (depth 0). A lone root frame that is itself a content region (not a wrapper of multiple band frames) is treated as the section, not its children.
- **Size** — it spans most of the page width (>= 60% of the wrapping frame's width). Narrow columns and side rails stay `<div>`.
- **Significance** — it holds meaningful mixed content (multiple text runs or more than one sub-region), not a thin wrapper around a single element.

Everything deeper — rows, columns, cards, wrappers, decorative groups — defaults to `<div>`. The other #288 semantic tags (`header`/`nav`/`main`/`footer`/`h1`-`h6`/`ul`/`li`/`button`) are untouched. The signal is generic and data-driven (depth relative to the page root, width fraction, content significance), with no file-specific names.

Goal achieved: a typical page emits a small number of `<section>`s (single digits to low double digits) instead of hundreds.

## Tests

Synthetic fixtures + contract tests only (no `.fig` files run; lab validation is the orchestrator's follow-up):

- New fixture: a page with three **distinct** top-level bands, each wrapping a deep nested-container tree (rows/columns/wrappers). Asserts exactly **3** `<section>`s — one per band — while the dozens of nested wrappers are `<div>` and no nested frame becomes a `<section>`.
- New fixture: a **root-level bands** layout (no single page wrapper) still sections each band via the depth-0 path.
- The existing #288 semantic fixture now also asserts the page has a **single** `<section>` (its one genuine content band), with header/nav/footer/heading/list/button assertions intact.

`cd figma-transformer && php tests/contract/run.php` prints `Figma Transformer contract tests passed.`

## Lab validation follow-up

This PR ships the heuristic + synthetic/contract coverage. Re-running the transform against the real FSE `.fig` fixture on the lab to confirm the `<section>` count drops from 347 to a handful is the orchestrator's follow-up; do not run the large `.fig` files locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Reining in <section> over-emission to genuine top-level regions for #247.