### PR TITLE
figma-transformer: surface role/page_type on inspector candidates (#295)

### DIFF
--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -10,6 +10,14 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
 {
     $candidates = is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array();
 
+    // Exclude design-system frames (style guides, token sheets, component
+    // libraries) before any other filtering. They inform the generated
+    // design system but are never page candidates.
+    $candidates = array_values(array_filter(
+        $candidates,
+        static fn (mixed $candidate): bool => is_array($candidate) && 'design_system' !== matrix_candidate_role($candidate)
+    ));
+
     // Figma Dev Mode status (#280) is the PRIMARY signal when present: restrict
     // to ready_for_dev/completed candidates and let heuristics order them.
     if ( 'dev_status' === matrix_selection_source($candidates) ) {
@@ -137,6 +145,23 @@ function matrix_candidate_dev_status(array $candidate): ?string
 }
 
 /**
+ * Return the candidate's classifier role (design_system|page), or null when
+ * no role is present (e.g., candidates from an older inspection without role
+ * classification). The caller is responsible for the null-is-unknown fallback.
+ *
+ * @param array<string, mixed> $candidate
+ */
+function matrix_candidate_role(array $candidate): ?string
+{
+    $role = $candidate['role'] ?? null;
+    if ( in_array($role, array('design_system', 'page'), true) ) {
+        return (string) $role;
+    }
+
+    return null;
+}
+
+/**
  * @param array<string, mixed> $candidate
  */
 function matrix_candidate_rank(array $candidate): int
@@ -148,6 +173,18 @@ function matrix_candidate_rank(array $candidate): int
         $score += 1200;
     } elseif ( 'ready_for_dev' === $devStatus ) {
         $score += 800;
+    }
+
+    // Page-type classification (#295): prefer real pages with known WP template
+    // types. front_page first (it's the entry point), then single/archive/page,
+    // and unknown last. This breaks dev-status ties when multiple dev-marked
+    // frames compete (e.g., "Home Page – Desktop" beats "Blog Post – Desktop"
+    // within the same ready_for_dev band).
+    $pageType = (string) ($candidate['page_type'] ?? '');
+    if ( 'front_page' === $pageType ) {
+        $score += 300;
+    } elseif ( in_array($pageType, array('single', 'archive', 'page'), true) ) {
+        $score += 120;
     }
 
     $name = strtolower((string) ($candidate['name'] ?? ''));
@@ -274,11 +311,21 @@ function matrix_is_page_like_candidate(array $candidate): bool
     if ( 'FRAME' !== $type ) {
         return false;
     }
-    if ( 1 === preg_match('/\b(style guide|style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
+    // Role classification (#295): design_system frames are excluded upstream in
+    // matrix_select_frame_ids(); guard here too so this function is safe to call
+    // in isolation. When role is absent (older inspection), fall through to name
+    // heuristics.
+    if ( 'design_system' === matrix_candidate_role($candidate) ) {
         return false;
     }
-    if ( 1 === preg_match('/\b(style guide|style tile|style tiles|presentation|template|templates|components)\b/', $pageName) ) {
-        return false;
+    // Fallback name-based exclusion for frames without role classification.
+    if ( null === matrix_candidate_role($candidate) ) {
+        if ( 1 === preg_match('/\b(style guide|style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
+            return false;
+        }
+        if ( 1 === preg_match('/\b(style guide|style tile|style tiles|presentation|template|templates|components)\b/', $pageName) ) {
+            return false;
+        }
     }
 
     return $width >= 900.0 && $height >= 500.0 && $textCount > 0 && in_array($parentType, array('CANVAS', 'SECTION'), true);

--- a/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
@@ -10,7 +10,8 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
 final class ScenegraphFrameInspector
 {
     public function __construct(
-        private readonly ScenegraphIndex $index = new ScenegraphIndex()
+        private readonly ScenegraphIndex $index = new ScenegraphIndex(),
+        private readonly ScenegraphFrameClassifier $frameClassifier = new ScenegraphFrameClassifier()
     ) {
     }
 
@@ -43,6 +44,7 @@ final class ScenegraphFrameInspector
 
             $stats = $this->subtreeStats($id, $nodes, $childrenIndex, $statsMemo);
             $dimensions = $this->dimensions($node);
+            $classification = $this->candidateClassification($id, $node, $dimensions, $stats, $nodes, $parentIndex);
             $candidates[$id] = array_filter(
                 array(
                     'id'                    => $id,
@@ -61,6 +63,8 @@ final class ScenegraphFrameInspector
                     'device_hint'           => $this->deviceHint((string) ($node['name'] ?? ''), $dimensions),
                     'sibling_group_key'     => $this->siblingGroupKey($id, $node, $nodes, $parentIndex),
                     'dev_status'            => $this->candidateDevStatus($node),
+                    'role'                  => $classification['role'],
+                    'page_type'             => $classification['page_type'],
                 ),
                 static fn (mixed $value): bool => null !== $value
             );
@@ -101,6 +105,47 @@ final class ScenegraphFrameInspector
         $resolved = ScenegraphDevStatus::resolve($node);
 
         return is_array($resolved) ? ($resolved['normalized'] ?? null) : null;
+    }
+
+    /**
+     * Classify a candidate frame's role (design_system|page) and page_type
+     * (front_page|single|archive|page|unknown) so the matrix frame-selector can
+     * exclude design-system frames and prefer real pages by WP template type.
+     *
+     * Uses name signals and basic content metrics (text/asset counts). Content-
+     * shape signals (swatch-grid density, card-list repetition) are not computed
+     * at inspection time because the full subtree traversal is not warranted
+     * here; name signals are authoritative for well-named frames.
+     *
+     * @param array<string, mixed>                $node
+     * @param array{width:float|null,height:float|null} $dimensions
+     * @param array{nodes:int,texts:int,assets:int} $stats
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, string>               $parentIndex
+     * @return array{role:string,page_type:string|null,signals:array<int,string>,is_page:bool}
+     */
+    private function candidateClassification(
+        string $id,
+        array $node,
+        array $dimensions,
+        array $stats,
+        array $nodes,
+        array $parentIndex
+    ): array {
+        $section = $this->nearestAncestor($id, array('SECTION'), $nodes, $parentIndex);
+        $page    = $this->nearestAncestor($id, array('CANVAS'), $nodes, $parentIndex);
+
+        return $this->frameClassifier->classify(array(
+            'name'                 => (string) ($node['name'] ?? ''),
+            'width'                => $dimensions['width'] ?? null,
+            'height'               => $dimensions['height'] ?? null,
+            'text_count'           => (int) ($stats['texts'] ?? 0),
+            'asset_count'          => (int) ($stats['assets'] ?? 0),
+            'uniform_tile_count'   => 0,
+            'repeating_card_count' => 0,
+            'section_name'         => $section['name'] ?? null,
+            'page_name'            => $page['name'] ?? null,
+        ));
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5579,6 +5579,53 @@ $assert('ready_for_dev' === ($inspectorCandidates['frame:build']['dev_status'] ?
 $assert(! array_key_exists('dev_status', $inspectorCandidates['frame:plain'] ?? array()), 'inspector-omits-dev-status-on-unmarked-candidate');
 $assert('dev_status' === matrix_selection_source(array_values($inspectorCandidates)), 'inspector-candidates-drive-dev-status-selection');
 
+// INSPECT: candidates must surface role + page_type so the matrix frame-selector
+// can exclude design-system frames and prefer real pages by WP template type.
+// Same plumbing pattern as dev_status (#283): the classifier runs on each
+// candidate at inspect time so the selector sees role/page_type without needing
+// to re-run classification downstream.
+$inspectorRoleSource = array(
+    'name'  => 'Inspector Role Classification',
+    'nodes' => array(
+        array(
+            'id'       => 'canvas:rc',
+            'type'     => 'CANVAS',
+            'name'     => 'Pages',
+            'children' => array(
+                array('id' => 'frame:sg', 'type' => 'FRAME', 'name' => 'Style Guide', 'width' => 1440, 'height' => 2000, 'children' => array(
+                    array('id' => 'sg:text', 'type' => 'TEXT', 'name' => 'Colors', 'characters' => 'Brand Colors'),
+                )),
+                array('id' => 'frame:home', 'type' => 'FRAME', 'name' => 'Home Page', 'width' => 1440, 'height' => 1600, 'children' => array(
+                    array('id' => 'home:text', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                )),
+                array('id' => 'frame:post', 'type' => 'FRAME', 'name' => 'Blog Post', 'width' => 1440, 'height' => 2400, 'children' => array(
+                    array('id' => 'post:text', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'A Post'),
+                )),
+            ),
+        ),
+    ),
+);
+$inspectorRoleResult = ( new Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphFrameInspector() )->inspect($inspectorRoleSource);
+$inspectorRoleCandidates = array();
+foreach ( ( is_array($inspectorRoleResult['candidates'] ?? null) ? $inspectorRoleResult['candidates'] : array() ) as $rc ) {
+    if ( is_array($rc) && isset($rc['id']) ) {
+        $inspectorRoleCandidates[(string) $rc['id']] = $rc;
+    }
+}
+// Design-system frames carry role=design_system and no page_type.
+$assert(ScenegraphFrameClassifier::ROLE_DESIGN_SYSTEM === ($inspectorRoleCandidates['frame:sg']['role'] ?? null), 'inspector-surfaces-design-system-role');
+$assert(! array_key_exists('page_type', $inspectorRoleCandidates['frame:sg'] ?? array()), 'inspector-omits-page-type-on-design-system');
+// Real page frames carry role=page and the correct WP-template page_type.
+$assert(ScenegraphFrameClassifier::ROLE_PAGE === ($inspectorRoleCandidates['frame:home']['role'] ?? null), 'inspector-surfaces-page-role-on-home');
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_FRONT_PAGE === ($inspectorRoleCandidates['frame:home']['page_type'] ?? null), 'inspector-surfaces-front-page-type-on-home');
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_SINGLE === ($inspectorRoleCandidates['frame:post']['page_type'] ?? null), 'inspector-surfaces-single-type-on-blog-post');
+// Matrix selector must exclude design-system candidates before page selection.
+$inspectorRoleCandidateList = array_values($inspectorRoleCandidates);
+$matrixRoleIds = matrix_select_frame_ids(array('candidates' => $inspectorRoleCandidateList), 5);
+$assert(! in_array('frame:sg', $matrixRoleIds, true), 'matrix-excludes-design-system-from-selection');
+$assert(in_array('frame:home', $matrixRoleIds, true), 'matrix-selects-home-page-candidate');
+$assert(in_array('frame:post', $matrixRoleIds, true), 'matrix-selects-blog-post-candidate');
+
 // FRAME ROLE CLASSIFICATION (#247): top-level frames are classified into roles
 // before any pixels are emitted. A "Style Guide" frame is a design_system frame
 // (EXCLUDED from page selection); real pages each carry a WP-template-aligned


### PR DESCRIPTION
## Summary

- **`ScenegraphFrameInspector`** now runs `ScenegraphFrameClassifier` on every candidate frame at inspect time, attaching `role` (`design_system`|`page`) and `page_type` (`front_page`|`single`|`archive`|`page`|`unknown`) to each candidate record — the same plumbing pattern as the `dev_status` fix in #283.
- **`figma-fixture-selection.php`** consumes the new fields: excludes `design_system` candidates before dev-status filtering so a BUILD-marked "Style Guide" can no longer be mis-selected as the primary page; boosts real pages by `page_type` in `matrix_candidate_rank()` (`front_page +300`, `single/archive/page +120`) so "Home Page" wins correctly within the same dev-status band.
- **7 new contract test assertions** prove inspector surfaces `role`/`page_type` and matrix excludes `design_system` while selecting real pages.

## Root cause

`ScenegraphFrameClassifier` (#291) classified frames correctly in the planner, but `ScenegraphFrameInspector` candidates (which the matrix selector reads) carried no classification. The matrix selector saw `role=None, page_type=None` on all candidates — so a BUILD-marked "Style Guide" (score 816) outranked real pages (score 653/491) and was selected.

## What changes

| File | Change |
|------|--------|
| `ScenegraphFrameInspector.php` | Add `ScenegraphFrameClassifier` dep; add `candidateClassification()` private method; add `role`/`page_type` to candidate array in `inspect()` |
| `figma-fixture-selection.php` | `matrix_candidate_role()` helper; design_system exclusion block in `matrix_select_frame_ids()`; `matrix_is_page_like_candidate()` role guard; `page_type` rank boosts in `matrix_candidate_rank()` |
| `tests/contract/run.php` | 7 assertions for inspector role/page_type and matrix exclusion |

## Test plan

- [x] All contract tests pass (`php tests/contract/run.php`)
- [ ] Lab validate on `fse-pilot.fig`: expect Style Guide excluded, Home Page/Blog Post/Archive/Page selected, responsive pairs grouped, `@media` blocks emitted

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 / Claude Code
- **Used for:** Implementation, contract test assertions