### PR TITLE
Make core/button valid-by-construction + add canonical-save-shape validator

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -214,6 +214,18 @@ final class BlockFactory
         if ( 'core/button' === $name ) {
             $support = $this->buttonStyleSupport($attrs);
 
+            // Match core/button save(): useBlockProps.save() lives on the OUTER
+            // wrapper <div>, so the block className and the anchor id belong on
+            // the wrapper. The inner <a>/<button> carries only the structural
+            // wp-block-button__link / wp-element-button classes plus color and
+            // border support classes/styles. Routing the source className onto
+            // the inner element instead leaves the stored markup divergent from
+            // save() and the editor flags the block invalid.
+            $wrapperAttrs = array(
+                'id'    => (string) ($attrs['anchor'] ?? ''),
+                'class' => $this->mergeClassNames('wp-block-button', (string) ($attrs['className'] ?? '')),
+            );
+
             if ( 'button' === ($attrs['tagName'] ?? '') ) {
                 $buttonAttrs = array_intersect_key($attrs, array_flip(array( 'type', 'role', 'aria-label', 'aria-controls', 'aria-expanded', 'aria-haspopup' )));
                 foreach ( $attrs as $attrName => $attrValue ) {
@@ -222,21 +234,19 @@ final class BlockFactory
                     }
                 }
                 $buttonAttrs = array_merge(array(
-                    'id'    => (string) ($attrs['anchor'] ?? ''),
-                    'class' => $this->mergeClassNames('wp-block-button__link', $support['classes'], 'wp-element-button', (string) ($attrs['className'] ?? '')),
+                    'class' => $this->mergeClassNames('wp-block-button__link', $support['classes'], 'wp-element-button'),
                     'style' => $support['style'],
                 ), $buttonAttrs);
 
-                return '<div class="wp-block-button"><button' . $this->htmlAttrs($buttonAttrs) . '>' . ($attrs['text'] ?? '') . '</button></div>';
+                return '<div' . $this->htmlAttrs($wrapperAttrs) . '><button' . $this->htmlAttrs($buttonAttrs) . '>' . ($attrs['text'] ?? '') . '</button></div>';
             }
 
             $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
-            $wrapperClass = $this->mergeClassNames('wp-block-button', in_array('is-style-outline', preg_split('/\s+/', (string) ($attrs['className'] ?? '')) ?: array(), true) ? 'is-style-outline' : '');
             $linkAttrs = array(
-                'class' => $this->mergeClassNames('wp-block-button__link', $support['classes'], 'wp-element-button', (string) ($attrs['className'] ?? '')),
+                'class' => $this->mergeClassNames('wp-block-button__link', $support['classes'], 'wp-element-button'),
                 'style' => $support['style'],
             );
-            return '<div class="' . htmlspecialchars($wrapperClass, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"><a' . $this->htmlAttrs($linkAttrs) . $href . '>' . ($attrs['text'] ?? '') . '</a></div>';
+            return '<div' . $this->htmlAttrs($wrapperAttrs) . '><a' . $this->htmlAttrs($linkAttrs) . $href . '>' . ($attrs['text'] ?? '') . '</a></div>';
         }
 
         if ( 'core/navigation' === $name ) {

--- a/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
+++ b/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
@@ -1,0 +1,231 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\WordPress;
+
+/**
+ * Asserts that every emitted static core wrapper block carries only the class
+ * and id tokens WordPress' own block `save()` would reproduce, so the block
+ * round-trips cleanly through `wp.blocks.validateBlock` in the editor.
+ *
+ * Gutenberg validates a stored block by re-running its registered `save()` and
+ * diffing the result against the saved markup. For a static core block the
+ * wrapper element (the one carrying `useBlockProps.save()`) only ever emits:
+ *
+ *   - the `wp-block-*` / `wp-element-*` base classes,
+ *   - support-derived classes (`has-*`, `is-*`, `align*`),
+ *   - the verbatim tokens of the block's `className` attribute,
+ *   - and an `id` taken solely from the `anchor` attribute.
+ *
+ * When the transformer puts a source class on a structural child instead of the
+ * wrapper (the historic `core/button` leak routed `className` onto the inner
+ * `<a>`/`<button>` rather than the `wp-block-button` wrapper), or drops the
+ * `anchor` id, the stored markup diverges from `save()` and the editor flags the
+ * block invalid. This validator catches that class of regression in the fast
+ * pure-PHP loop — no WordPress runtime required — so most invalid-block
+ * detection moves off the editor gate.
+ *
+ * Scope is deliberately the static structural wrappers. Registry-versioned and
+ * dynamic blocks (`core/navigation` family, `core/icon`) are skipped: their
+ * `save()` returns a ref/wrapper or is plugin-provided, so a pure-PHP shape
+ * assertion would false-flag them. Those stay the editor gate's job.
+ */
+final class CanonicalSaveShapeValidator
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/canonical-save-shape-report/v1';
+
+    public const FINDING_CODE = 'canonical_save_shape_violation';
+
+    /**
+     * Static core wrappers whose canonical save() shape is fully determined by
+     * the block name + attributes, so a pure-PHP assertion is sound.
+     *
+     * @var array<int, string>
+     */
+    private const TARGET_BLOCKS = array(
+        'core/group',
+        'core/columns',
+        'core/column',
+        'core/buttons',
+        'core/button',
+        'core/details',
+    );
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<int, array<string, mixed>>
+     */
+    public function findings(array $blocks): array
+    {
+        $findings = array();
+        foreach ( $blocks as $index => $block ) {
+            if ( is_array($block) ) {
+                $this->validateBlock($block, 'blocks.' . $index, $findings);
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     * @param array<int, array<string, mixed>> $findings
+     */
+    private function validateBlock(array $block, string $path, array &$findings): void
+    {
+        $blockName = is_string($block['blockName'] ?? null) ? $block['blockName'] : null;
+
+        if ( null !== $blockName && in_array($blockName, self::TARGET_BLOCKS, true) ) {
+            $this->validateWrapper($block, $blockName, $path, $findings);
+        }
+
+        $innerBlocks = is_array($block['innerBlocks'] ?? null) ? array_values($block['innerBlocks']) : array();
+        foreach ( $innerBlocks as $index => $innerBlock ) {
+            if ( is_array($innerBlock) ) {
+                $this->validateBlock($innerBlock, $path . '.innerBlocks.' . $index, $findings);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     * @param array<int, array<string, mixed>> $findings
+     */
+    private function validateWrapper(array $block, string $blockName, string $path, array &$findings): void
+    {
+        $innerHTML = is_string($block['innerHTML'] ?? null) ? $block['innerHTML'] : '';
+        if ( ! preg_match('/<[a-zA-Z][^>]*>/', $innerHTML, $match) ) {
+            return;
+        }
+
+        $wrapper       = $match[0];
+        $wrapperClasses = $this->classTokens($wrapper);
+        $wrapperId      = $this->attributeValue($wrapper, 'id');
+
+        $attrs          = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+        $classNameValue = is_string($attrs['className'] ?? null) ? $attrs['className'] : '';
+        $classNameTokens = $this->tokens($classNameValue);
+        $anchor          = is_string($attrs['anchor'] ?? null) ? $attrs['anchor'] : '';
+
+        // Every wrapper class must be either a structural/support class or a
+        // token core would reproduce from the className attribute. A leftover
+        // source class core's save() never regenerates breaks the round-trip.
+        foreach ( $wrapperClasses as $class ) {
+            if ( $this->isStructuralClass($class) || in_array($class, $classNameTokens, true) ) {
+                continue;
+            }
+
+            $this->addFinding(
+                $findings,
+                $path,
+                $blockName,
+                'Wrapper carries class "' . $class . '" that core save() will not reproduce; route it through the block className attribute or downgrade the wrapper to core/html.',
+                array( 'reason' => 'unexpected_wrapper_class', 'class' => $class )
+            );
+        }
+
+        // Every className token must land on the wrapper, because core's
+        // save() merges className verbatim onto the wrapper element. A token
+        // routed onto a structural child instead (the core/button inner anchor
+        // leak) leaves the wrapper missing it and the child carrying it.
+        foreach ( $classNameTokens as $class ) {
+            if ( in_array($class, $wrapperClasses, true) ) {
+                continue;
+            }
+
+            $this->addFinding(
+                $findings,
+                $path,
+                $blockName,
+                'className token "' . $class . '" is missing from the block wrapper; core save() emits className on the wrapper element, so the stored markup diverges from save().',
+                array( 'reason' => 'classname_not_on_wrapper', 'class' => $class )
+            );
+        }
+
+        // An id on the wrapper is only valid when it equals the anchor
+        // attribute; core save() derives the wrapper id solely from anchor.
+        if ( null !== $wrapperId && '' !== $wrapperId && $wrapperId !== $anchor ) {
+            $this->addFinding(
+                $findings,
+                $path,
+                $blockName,
+                'Wrapper id "' . $wrapperId . '" is not derived from the anchor attribute; core save() only emits an id from anchor.',
+                array( 'reason' => 'unexpected_wrapper_id', 'id' => $wrapperId )
+            );
+        }
+
+        // When anchor is set, core save() emits it as the wrapper id. A missing
+        // or relocated id diverges from save().
+        if ( '' !== $anchor && $anchor !== $wrapperId ) {
+            $this->addFinding(
+                $findings,
+                $path,
+                $blockName,
+                'anchor "' . $anchor . '" is not emitted as the wrapper id; core save() places the anchor id on the wrapper element.',
+                array( 'reason' => 'anchor_not_on_wrapper', 'anchor' => $anchor )
+            );
+        }
+    }
+
+    /**
+     * A class WordPress' block supports reproduce in save() without any source
+     * input: the block base class, element classes, and attribute-derived
+     * support classes (alignment, color/border has-*, and is-* state/style).
+     */
+    private function isStructuralClass(string $class): bool
+    {
+        return str_starts_with($class, 'wp-block-')
+            || str_starts_with($class, 'wp-element-')
+            || str_starts_with($class, 'wp-container-')
+            || str_starts_with($class, 'has-')
+            || str_starts_with($class, 'is-')
+            || str_starts_with($class, 'align');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function classTokens(string $openingTag): array
+    {
+        return $this->tokens($this->attributeValue($openingTag, 'class') ?? '');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function tokens(string $value): array
+    {
+        $tokens = preg_split('/\s+/', trim($value)) ?: array();
+
+        return array_values(array_filter($tokens, static fn (string $token): bool => '' !== $token));
+    }
+
+    private function attributeValue(string $openingTag, string $attribute): ?string
+    {
+        if ( preg_match('/\s' . preg_quote($attribute, '/') . '="([^"]*)"/i', $openingTag, $match) ) {
+            return $match[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $findings
+     * @param array<string, mixed> $details
+     */
+    private function addFinding(array &$findings, string $path, ?string $blockName, string $summary, array $details): void
+    {
+        $findings[] = array_filter(
+            array(
+                'code'       => self::FINDING_CODE,
+                'severity'   => 'warning',
+                'category'   => 'wp_block_validity',
+                'path'       => $path,
+                'block_name' => $blockName,
+                'summary'    => $summary,
+                'details'    => $details,
+            ),
+            static fn (mixed $value): bool => null !== $value && array() !== $value
+        );
+    }
+}

--- a/php-transformer/src/WordPress/Runtime.php
+++ b/php-transformer/src/WordPress/Runtime.php
@@ -259,7 +259,7 @@ final class Runtime
     {
         if ( is_string($serializedBlocksOrBlocks) ) {
             $blocks = $this->parseBlocks($serializedBlocksOrBlocks);
-            $report = ( new BlockValidityValidator() )->validateBlocks($blocks);
+            $report = $this->buildBlockValidityReport($blocks);
 
             if ( array() === $blocks && str_contains($serializedBlocksOrBlocks, '<!-- wp:') ) {
                 $report['status'] = 'warning';
@@ -276,7 +276,33 @@ final class Runtime
             return $report;
         }
 
-        return ( new BlockValidityValidator() )->validateBlocks($serializedBlocksOrBlocks);
+        return $this->buildBlockValidityReport($serializedBlocksOrBlocks);
+    }
+
+    /**
+     * Run the serialization-structure validator and the canonical save()-shape
+     * validator over the same parsed block tree and merge their findings into a
+     * single wp_block_validity report. Both are pure-PHP and need no WordPress
+     * runtime, so the report stays usable in the standalone transformer loop.
+     *
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<string, mixed>
+     */
+    private function buildBlockValidityReport(array $blocks): array
+    {
+        $report = ( new BlockValidityValidator() )->validateBlocks($blocks);
+
+        $saveShapeFindings = ( new CanonicalSaveShapeValidator() )->findings($blocks);
+        if ( array() !== $saveShapeFindings ) {
+            $report['findings'] = array_merge(
+                is_array($report['findings'] ?? null) ? $report['findings'] : array(),
+                $saveShapeFindings
+            );
+            $report['summary']['finding_count'] = count($report['findings']);
+            $report['status'] = 'warning';
+        }
+
+        return $report;
     }
 
     public function stripAllTags(string $text, bool $removeBreaks = false): string

--- a/php-transformer/tests/fixtures/contract/wp-block-validity.json
+++ b/php-transformer/tests/fixtures/contract/wp-block-validity.json
@@ -25,6 +25,42 @@
       ]
     },
     {
+      "name": "valid-group-canonical-save-shape",
+      "input": "<!-- wp:group {\"className\":\"grid-3\",\"anchor\":\"foo\"} --><div class=\"wp-block-group grid-3\" id=\"foo\"></div><!-- /wp:group -->",
+      "expected_status": "pass",
+      "expected_codes": []
+    },
+    {
+      "name": "invalid-group-leaked-wrapper-class",
+      "input": "<!-- wp:group --><div class=\"wp-block-group sneaky-leak\"></div><!-- /wp:group -->",
+      "expected_status": "warning",
+      "expected_codes": [
+        "canonical_save_shape_violation"
+      ]
+    },
+    {
+      "name": "invalid-group-leaked-wrapper-id",
+      "input": "<!-- wp:group --><div class=\"wp-block-group\" id=\"leaked-id\"></div><!-- /wp:group -->",
+      "expected_status": "warning",
+      "expected_codes": [
+        "canonical_save_shape_violation"
+      ]
+    },
+    {
+      "name": "invalid-button-classname-routed-to-inner-anchor",
+      "input": "<!-- wp:button {\"className\":\"btn-primary\",\"text\":\"Go\",\"url\":\"/x\"} --><div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button btn-primary\" href=\"/x\">Go</a></div><!-- /wp:button -->",
+      "expected_status": "warning",
+      "expected_codes": [
+        "canonical_save_shape_violation"
+      ]
+    },
+    {
+      "name": "valid-button-classname-on-wrapper",
+      "input": "<!-- wp:button {\"className\":\"btn-primary\",\"text\":\"Go\",\"url\":\"/x\"} --><div class=\"wp-block-button btn-primary\"><a class=\"wp-block-button__link wp-element-button\" href=\"/x\">Go</a></div><!-- /wp:button -->",
+      "expected_status": "pass",
+      "expected_codes": []
+    },
+    {
       "name": "invalid-navigation-serialized-child-comments",
       "blocks": [
         {

--- a/php-transformer/tests/fixtures/parity/html-button-block-label-inline-richtext.json
+++ b/php-transformer/tests/fixtures/parity/html-button-block-label-inline-richtext.json
@@ -23,7 +23,8 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-button__link wp-element-button primary-button\" href=\"/book\">Reserve now</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button primary-button\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-button__link wp-element-button\" href=\"/book\">Reserve now</a>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<h3>Reserve now</h3>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "aria-hidden=\"true\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 }

--- a/php-transformer/tests/fixtures/parity/html-button-custom-filled-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-custom-filled-cta-style.json
@@ -22,7 +22,8 @@
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button hero-cta brand-primary\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button hero-cta brand-primary\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#fff;background-color:#135e96;border-color:#135e96;border-width:2px;border-style:solid;border-radius:999px;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700;text-transform:uppercase\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color:#f7f7f7" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-generic-class-and-style-signal.json
+++ b/php-transformer/tests/fixtures/parity/html-button-generic-class-and-style-signal.json
@@ -25,7 +25,8 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:buttons -->" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button btnPrimary\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btnPrimary\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#ffffff;background-color:#0a66c2;border-radius:6px;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:paragraph" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
@@ -22,8 +22,8 @@
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-border-color wp-element-button cta ghost-link is-style-outline\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button cta ghost-link is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#135e96;border-color:currentColor;border-width:2px;border-style:solid;border-radius:8px;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px;font-weight:600;text-transform:none\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-filled-from-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-filled-from-css.json
@@ -22,7 +22,8 @@
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background wp-element-button btn btn-primary\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-primary\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#ffffff;background-color:#13314f;border-radius:6px;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "is-style-outline" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
@@ -22,8 +22,8 @@
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-border-color wp-element-button btn btn-ghost is-style-outline\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-ghost is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#135e96;border-color:#135e96;border-width:2px;border-style:solid;border-radius:8px;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "has-background" }

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-unstyled-default.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-unstyled-default.json
@@ -22,7 +22,7 @@
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button\"><a class=\"wp-block-button__link wp-element-button btn cta-link\" href=\"/go\">Go now</a></div>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn cta-link\"><a class=\"wp-block-button__link wp-element-button\" href=\"/go\">Go now</a></div>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "has-background" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "has-text-color" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "style=" }

--- a/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
@@ -23,10 +23,11 @@
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button primary\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button primary\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#fff;background-color:#2563eb;border-color:#2563eb;border-width:2px;border-style:solid;border-radius:999px;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700\"" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button is-style-outline\"" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-border-color wp-element-button secondary is-style-outline\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button secondary is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#2563eb;border-color:currentColor;border-width:2px;border-style:solid;border-radius:999px;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700\"" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-group-wrapper-canonical-save-shape.json
+++ b/php-transformer/tests/fixtures/parity/html-group-wrapper-canonical-save-shape.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-group-wrapper-canonical-save-shape",
+  "description": "A source wrapper <div class=\"grid-3 custom-x\" id=\"foo\"> emits a core/group whose source classes ride in the className attribute and whose id rides in the anchor attribute, so the saved wrapper markup matches core save() and round-trips through the editor block validator (valid by construction).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-group-wrapper-canonical-save-shape.json",
+    "notes": "Guards the canonical save()-shape contract for static core wrappers: source class/id never leak onto the wrapper element outside className/anchor."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Canonical save()-shape routing has no legacy converter equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><div class=\"grid-3 custom-x\" id=\"foo\"><div class=\"card\"><h3>A</h3></div><div class=\"card\"><h3>B</h3></div></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "anchor": "foo", "className": "grid-3 custom-x" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div id=\"foo\" class=\"wp-block-group grid-3 custom-x\">" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "id=\"foo\" class=\"wp-block-group grid-3 custom-x\" id=" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-source-styled-button-preserves-style.json
+++ b/php-transformer/tests/fixtures/parity/html-source-styled-button-preserves-style.json
@@ -22,7 +22,8 @@
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background wp-element-button checkout-button\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button checkout-button\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"color:#f9fafb;background-color:#111827;border-radius:6px;padding-top:10px;padding-right:20px;padding-bottom:10px;padding-left:20px;font-weight:800;text-transform:uppercase\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color:#f7f7f7" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "border-width" }


### PR DESCRIPTION
## What
Eliminates the statically-preventable half of the editor block-validity failures, and adds a fast pure-PHP validator so it can't regress — moving most invalid-block detection off the WP editor into the 0.33s parity loop.

## The real leak (verified, narrower than expected)
A corpus probe found **0 class/id leaks across 4,695 group/columns/column/buttons/details wrappers** — `presentationAttributes()` already routes `class→className` / `id→anchor` for those. The actual statically-preventable failure is **`core/button`**: core's `save()` applies `useBlockProps.save()` to the OUTER `wp-block-button` div, so `className` + the anchor `id` belong on the wrapper. The transformer was putting `className` on the inner `<a>` and the id on the inner element → editor round-trip mismatch.

## Changes
1. **Valid-by-construction** (`BlockFactory.php`, core/button): route `className` + anchor `id` onto the outer `wp-block-button` wrapper; inner element keeps only structural classes + the resolved inline style (visual fidelity preserved — matches how an editor-authored button is structured).
2. **`CanonicalSaveShapeValidator`** (`src/WordPress/CanonicalSaveShapeValidator.php`): pure-PHP, no WP runtime, wired through the existing `wp_block_validity` report → `DiagnosticsCollector` channel (CI gets it free). Per static core wrapper asserts class/id set ⊆ {wp-block-*/wp-element-*/has-*/is-*/align*, className tokens, anchor-derived id}. Finding code `canonical_save_shape_violation`. Skips the registry-dependent residual (core/navigation family, core/icon) so dynamic/plugin blocks aren't false-flagged.

## Verification
- New validator over `fixtures/websites`: **1004 → 0** findings (863 classname-not-on-wrapper + 141 anchor-not-on-wrapper, all core/button). 15-saas 21→0, 38-medical-clinic 6→0 — the entire core/button slice of the editor's statically-preventable invalid bucket should now pass.
- `composer test` + `composer parity`: **153 parity fixtures** green. Updated 9 button fixtures to the canonical wrapper shape (strengthening — old assertions encoded editor-invalid markup), added a group-wrapper canonical fixture + 5 validator contract cases.

## Residual (intentionally editor-only)
`core/navigation` family (dynamic save) and `core/icon` (registry block) stay on the editor gate — not statically reducible. Noted follow-up: other static blocks (e.g. `core/code`) may have smaller analogous className leaks; extend the validator's target set once audited.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Probe-driven diagnosis, the valid-by-construction fix, the validator, and fixtures under human review.
