### PR TITLE
Make conversion findings carry specific, swarmable classification

### DIFF
--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -117,12 +117,21 @@ final class RuntimeDependencyParityReport
             $findings[] = $this->withSupersededDisposition($finding, $superseded);
         }
 
+        // Stamp the canonical classification triplet so each runtime-dependency
+        // finding carries a reason_code and pattern_family alongside the
+        // repair_bucket it already sets, clustering by root cause downstream. The
+        // contract honors the producer's specific repair_bucket values.
+        $findings = array_map(
+            static fn (array $finding): array => ConversionFindingContract::withClassification($finding),
+            $this->dedupeRows($findings)
+        );
+
         return array_filter(array(
             'schema'         => self::SCHEMA,
             'finding_schema' => ConversionFindingContract::SCHEMA,
             'status'         => array() === $findings ? 'pass' : 'warning',
             'dependencies'   => $this->dedupeRows($dependencies),
-            'findings'       => $this->dedupeRows($findings),
+            'findings'       => $findings,
         ), static fn (mixed $value): bool => array() !== $value);
     }
 

--- a/php-transformer/src/Contract/ConversionFindingContract.php
+++ b/php-transformer/src/Contract/ConversionFindingContract.php
@@ -155,6 +155,202 @@ final class ConversionFindingContract
     }
 
     /**
+     * Canonical classification fields. Every emitted finding is expected to carry
+     * a non-empty value for each of these so downstream tooling can cluster by
+     * ROOT cause and route to a repair lane instead of bucketing the finding into
+     * a generic catch-all. They are derived purely from the structural/semantic
+     * signals a finding already carries — never from fixture names, specific class
+     * strings, or URLs.
+     *
+     * @var array<int, string>
+     */
+    public const CLASSIFICATION_FIELDS = array('reason_code', 'repair_bucket', 'pattern_family');
+
+    /**
+     * Derive the canonical classification triplet (`reason_code`,
+     * `pattern_family`, `repair_bucket`) for a finding from the signals it already
+     * carries. This is the single source of truth for the finding taxonomy: every
+     * producer flows its emitted findings through {@see withClassification()} so a
+     * given root cause clusters under one stable code/family/bucket regardless of
+     * which producer surfaced it.
+     *
+     * Genericity contract: derivation reads only structural/semantic signals
+     * (the stable identifier, the source `tag`/`target_kind`, the runtime `kind`,
+     * the `canvas_api` flag, and the producer's own repair hints). Per-instance
+     * noise (specific selectors, classes, URLs) is intentionally NOT folded into
+     * the clustering keys — it lives in detail fields (`pattern_family_detail`,
+     * `selector`, `source_selector`) so the cluster keys stay root-scoped.
+     *
+     * @param array<string, mixed> $finding
+     * @return array{reason_code?: string, pattern_family?: string, repair_bucket?: string}
+     */
+    public static function classify(array $finding): array
+    {
+        $reasonCode    = self::reasonCode($finding);
+        $patternFamily = self::patternFamily($finding);
+        $repairBucket  = self::repairBucket($finding, $patternFamily);
+
+        return array_filter(
+            array(
+                'reason_code'    => $reasonCode,
+                'pattern_family' => $patternFamily,
+                'repair_bucket'  => $repairBucket,
+            ),
+            static fn (mixed $value): bool => is_string($value) && '' !== $value
+        );
+    }
+
+    /**
+     * Return the finding enriched with any missing canonical classification
+     * fields. Values a producer already set (e.g. the fallback emitter's richer
+     * `pattern_family`, or the runtime-dependency report's specific
+     * `repair_bucket`) are authoritative and never overwritten — this only fills
+     * the gaps that would otherwise leave a finding classification-less.
+     *
+     * @param array<string, mixed> $finding
+     * @return array<string, mixed>
+     */
+    public static function withClassification(array $finding): array
+    {
+        $classification = self::classify($finding);
+        foreach ( $classification as $field => $value ) {
+            if ( ! isset($finding[$field]) || ! is_string($finding[$field]) || '' === trim($finding[$field]) ) {
+                $finding[$field] = $value;
+            }
+        }
+
+        return $finding;
+    }
+
+    /**
+     * The stable root identifier used as `reason_code`: an existing `reason_code`,
+     * then the producer's `diagnostic_code`/`code`. These identifiers are
+     * root-scoped (one per loss type), not per-instance, so they double as the
+     * primary clustering key.
+     *
+     * @param array<string, mixed> $finding
+     */
+    private static function reasonCode(array $finding): string
+    {
+        $existing = $finding['reason_code'] ?? null;
+        if ( is_string($existing) && '' !== trim($existing) ) {
+            return (string) $existing;
+        }
+
+        return self::findingCode($finding);
+    }
+
+    /**
+     * Derive the root structural family for a finding. Honors an existing
+     * `pattern_family` (the fallback emitter computes a richer, tag-aware value),
+     * otherwise maps the runtime `kind`, the `canvas_api` flag, the stable
+     * identifier namespace, and finally the source `tag` onto a stable family.
+     *
+     * @param array<string, mixed> $finding
+     */
+    private static function patternFamily(array $finding): string
+    {
+        $existing = $finding['pattern_family'] ?? null;
+        if ( is_string($existing) && '' !== trim($existing) ) {
+            return (string) $existing;
+        }
+
+        $code = self::reasonCode($finding);
+        $kind = strtolower(trim((string) ($finding['kind'] ?? '')));
+        $tag  = strtolower(trim((string) ($finding['tag'] ?? ($finding['target_kind'] ?? ''))));
+
+        if ( true === ( $finding['canvas_api'] ?? false ) || 'canvas' === $kind ) {
+            return 'runtime_canvas';
+        }
+
+        $byKind = match ( $kind ) {
+            'script'   => 'runtime_script',
+            'template' => 'runtime_template',
+            'form', 'control' => 'interactive_form',
+            default    => '',
+        };
+        if ( '' !== $byKind ) {
+            return $byKind;
+        }
+
+        if ( str_starts_with($code, 'wp_block_validity_') ) {
+            return 'block_serialization';
+        }
+
+        if ( str_starts_with($code, 'html_semantic_parity_') || in_array($code, array('landmark_count_mismatch', 'navigation_menu_missing', 'navigation_core_block_missing', 'navigation_item_count_mismatch', 'navigation_item_mismatch'), true) ) {
+            return self::semanticParityFamily($code . ' ' . (string) ($finding['kind'] ?? ''));
+        }
+
+        return match ( $code ) {
+            'runtime_dependency_target_missing' => 'runtime_dom_target',
+            'runtime_script_not_materialized'   => 'runtime_script',
+            'runtime_script_target_missing'     => 'runtime_interactive_behavior',
+            'preserved_runtime_island'          => 'runtime_island',
+            'html_static_script_metadata'       => 'static_script_metadata',
+            'html_to_blocks_core_slice'         => 'conversion_summary',
+            default                             => '' !== $tag ? 'html_' . $tag : ( '' !== $code ? $code : 'html_fallback' ),
+        };
+    }
+
+    /**
+     * Sub-family for a semantic-parity finding, keyed on the structural concept it
+     * compares (landmark, navigation, typography) rather than the specific element.
+     */
+    private static function semanticParityFamily(string $haystack): string
+    {
+        $haystack = strtolower($haystack);
+        if ( str_contains($haystack, 'landmark') ) {
+            return 'semantic_landmark';
+        }
+        if ( str_contains($haystack, 'navigation') || str_contains($haystack, 'nav') ) {
+            return 'navigation_menu';
+        }
+        if ( str_contains($haystack, 'typography') || str_contains($haystack, 'font') ) {
+            return 'typography';
+        }
+
+        return 'semantic_structure';
+    }
+
+    /**
+     * Derive the coarse remediation lane (`repair_bucket`). Honors an existing
+     * `repair_bucket`, then the producer's own repair hints
+     * (`suggested_repair_class` / `suggested_generic_repair_class`), then maps the
+     * structural `pattern_family` onto a stable repair lane. Buckets for the
+     * runtime families intentionally match the values the runtime-dependency
+     * parity report already emits so the taxonomy stays consistent across
+     * producers.
+     *
+     * @param array<string, mixed> $finding
+     */
+    private static function repairBucket(array $finding, string $patternFamily): string
+    {
+        foreach ( array('repair_bucket', 'suggested_repair_class', 'suggested_generic_repair_class') as $key ) {
+            $value = $finding[$key] ?? null;
+            if ( is_string($value) && '' !== trim($value) ) {
+                return (string) $value;
+            }
+        }
+
+        return match ( $patternFamily ) {
+            'block_serialization'           => 'block_serialization_validity_repair',
+            'semantic_landmark', 'navigation_menu', 'semantic_structure' => 'semantic_structure_parity_restoration',
+            'typography'                    => 'typography_parity_restoration',
+            'runtime_canvas'                => 'runtime_canvas_target_preservation',
+            'runtime_dom_target'            => 'runtime_dom_target_preservation',
+            'runtime_script'                => 'runtime_script_materialization',
+            'runtime_interactive_behavior'  => 'runtime_interactive_behavior_restoration',
+            'runtime_template', 'runtime_island', 'interactive_form' => 'preserve_runtime_island',
+            'inert_template_metadata', 'static_script_metadata' => 'preserve_static_metadata',
+            'inline_svg'                    => 'materialize_static_asset',
+            'conversion_summary'            => 'no_repair_needed',
+            default                         => str_starts_with($patternFamily, 'unsupported_')
+                ? 'add_generic_pattern_recognizer'
+                : 'review_generic_mapping',
+        };
+    }
+
+    /**
      * Resolve a finding's stable identifier, honoring the `code` /
      * `diagnostic_code` producer split. Returns '' when neither is a non-empty
      * string.

--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -169,6 +169,10 @@ final class ConversionReportProjection
                 ),
                 static fn (mixed $value): bool => null !== $value && '' !== $value
             );
+            // Stamp the canonical classification triplet so the compact
+            // conversion-report fallback projection clusters by root cause too;
+            // values carried from the source fallback are honored, not overwritten.
+            $diagnostics[count($diagnostics) - 1] = ConversionFindingContract::withClassification($diagnostics[count($diagnostics) - 1]);
         }
 
         return $diagnostics;

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
 
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 /**
@@ -143,6 +144,14 @@ final class DiagnosticsCollector
             );
         }
 
-        return $diagnostics;
+        // Stamp the canonical classification triplet on every flat diagnostic so
+        // the projection's block-validity and semantic-parity findings (which
+        // otherwise carry no repair/family signal) and the carried-through
+        // fallback/runtime-island findings all cluster by root cause downstream
+        // instead of falling into a generic catch-all.
+        return array_map(
+            static fn (array $finding): array => ConversionFindingContract::withClassification($finding),
+            $diagnostics
+        );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -615,7 +615,10 @@ final class SemanticParityReporter
             $finding['observed_block'] = $this->observedBlockForFinding($finding, $sourceProvenance);
         }
 
-        return $finding;
+        // Fill the remaining canonical classification fields (pattern_family /
+        // repair_bucket) so each parity finding routes to a concrete repair lane;
+        // the reason_code set above is honored and not overwritten.
+        return ConversionFindingContract::withClassification($finding);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
+++ b/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+
 final class FallbackDiagnostic
 {
     /**
@@ -35,7 +37,11 @@ final class FallbackDiagnostic
             'suggested_generic_repair_class' => self::genericRepairClass($fields, $patternFamily),
         ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value);
 
-        return array_merge($metadata, $fields);
+        // Stamp the canonical classification triplet (reason_code / repair_bucket
+        // / pattern_family) so every fallback/runtime-island finding clusters by
+        // root cause downstream. The contract honors the richer pattern_family and
+        // suggested_repair_class computed above and only fills what is missing.
+        return ConversionFindingContract::withClassification(array_merge($metadata, $fields));
     }
 
     /**

--- a/php-transformer/tests/contract/finding-contract.php
+++ b/php-transformer/tests/contract/finding-contract.php
@@ -96,6 +96,87 @@ $assertThrows(
     'finding with a numeric observed_block is rejected'
 );
 
+// --- Canonical classification derivation -----------------------------------
+
+// The fallback emitter's richer, tag-aware classification is authoritative and
+// is never overwritten; only the canonical reason_code is filled from the code.
+$svgClassified = ConversionFindingContract::withClassification(array(
+    'diagnostic_code'        => 'html_unsafe_inline_svg',
+    'pattern_family'         => 'inline_svg',
+    'suggested_repair_class' => 'materialize_static_asset',
+));
+$assert('html_unsafe_inline_svg' === ($svgClassified['reason_code'] ?? null), 'reason_code is derived from diagnostic_code');
+$assert('inline_svg' === ($svgClassified['pattern_family'] ?? null), 'existing pattern_family is honored, not overwritten');
+$assert('materialize_static_asset' === ($svgClassified['repair_bucket'] ?? null), 'repair_bucket is derived from the producer suggested_repair_class');
+
+// A block-validity finding carries no repair/family signal of its own; the
+// contract derives a concrete, non-generic triplet from its stable identifier.
+$validityClassified = ConversionFindingContract::withClassification(array(
+    'code'       => 'wp_block_validity_warning',
+    'severity'   => 'warning',
+    'block_name' => 'core/group',
+));
+$assert('wp_block_validity_warning' === ($validityClassified['reason_code'] ?? null), 'block-validity reason_code is the stable identifier');
+$assert('block_serialization' === ($validityClassified['pattern_family'] ?? null), 'block-validity pattern_family is derived structurally');
+$assert('block_serialization_validity_repair' === ($validityClassified['repair_bucket'] ?? null), 'block-validity repair_bucket is concrete');
+
+// A semantic-parity finding clusters under a structural sub-family.
+$navClassified = ConversionFindingContract::withClassification(array(
+    'code' => 'html_semantic_parity_navigation_menu_missing',
+));
+$assert('navigation_menu' === ($navClassified['pattern_family'] ?? null), 'semantic-parity navigation pattern_family is derived from the structural concept');
+$assert('semantic_structure_parity_restoration' === ($navClassified['repair_bucket'] ?? null), 'semantic-parity repair_bucket routes to the parity lane');
+
+// The runtime canvas signal drives the canvas family/bucket without overwriting
+// an existing specific repair_bucket.
+$canvasClassified = ConversionFindingContract::withClassification(array(
+    'code'          => 'runtime_dependency_target_missing',
+    'canvas_api'    => true,
+    'repair_bucket' => 'runtime_canvas_target_preservation',
+));
+$assert('runtime_canvas' === ($canvasClassified['pattern_family'] ?? null), 'canvas_api signal drives the runtime_canvas family');
+$assert('runtime_canvas_target_preservation' === ($canvasClassified['repair_bucket'] ?? null), 'existing specific repair_bucket is honored');
+
+// classify() never folds per-instance noise (selectors/classes/urls) into the
+// clustering keys, so two same-root findings on different elements cluster.
+$a = ConversionFindingContract::classify(array('code' => 'runtime_dependency_target_missing', 'selector' => '#alpha'));
+$b = ConversionFindingContract::classify(array('code' => 'runtime_dependency_target_missing', 'selector' => '.beta-widget'));
+$assert($a === $b, 'same-root findings cluster identically regardless of per-instance selector');
+
+// --- Walk every finding the transformer actually emits ----------------------
+
+/**
+ * The generic catch-all reason codes/buckets a downstream classifier would
+ * collapse into a single "needs triage" family. The point of this PR is that
+ * the transformer no longer emits findings that land here for the common loss
+ * types, so the specificity walk treats these as failures.
+ */
+$genericSentinels = array('', 'generic_finding_family', 'unknown', 'finding', 'unclassified', 'generic', 'review_generic_mapping', 'html_fallback');
+
+/**
+ * Assert every finding in a list carries a concrete, non-generic classification
+ * triplet (reason_code / repair_bucket / pattern_family). This is the guard that
+ * keeps the transformer's findings swarmable: a missing or generic value here is
+ * exactly what previously bucketed 143/173 corpus findings as generic.
+ *
+ * @param array<int, array<string, mixed>> $findings
+ */
+$assertClassified = static function (array $findings, string $context) use ($assert, $genericSentinels): void {
+    foreach ( array_values($findings) as $index => $finding ) {
+        if ( ! is_array($finding) ) {
+            continue;
+        }
+        foreach ( ConversionFindingContract::CLASSIFICATION_FIELDS as $field ) {
+            $value = $finding[$field] ?? '';
+            $assert(
+                is_string($value) && '' !== trim($value) && ! in_array($value, $genericSentinels, true),
+                "{$context}.{$index}: finding carries a specific, non-generic {$field}",
+                sprintf('code=%s %s=%s', ConversionFindingContract::findingCode($finding), $field, var_export($value, true))
+            );
+        }
+    }
+};
+
 // --- Walk every finding the transformer actually emits ----------------------
 
 /**
@@ -106,17 +187,19 @@ $assertThrows(
  *
  * @param array<string, mixed> $result
  */
-$walk = static function (array $result, string $context) use ($assert): int {
+$walk = static function (array $result, string $context) use ($assert, $assertClassified): int {
     $count = 0;
 
     $diagnostics = $result['diagnostics'] ?? array();
     $assert(is_array($diagnostics), "{$context}: diagnostics is an array");
     ConversionFindingContract::assertFindings(array_values($diagnostics), "{$context} diagnostics");
+    $assertClassified(array_values($diagnostics), "{$context} diagnostics");
     $count += count($diagnostics);
 
     $fallbacks = $result['fallbacks'] ?? array();
     $assert(is_array($fallbacks), "{$context}: fallbacks is an array");
     ConversionFindingContract::assertFindings(array_values($fallbacks), "{$context} fallbacks");
+    $assertClassified(array_values($fallbacks), "{$context} fallbacks");
     $count += count($fallbacks);
 
     $sourceReports = is_array($result['source_reports'] ?? null) ? $result['source_reports'] : array();
@@ -138,6 +221,7 @@ $walk = static function (array $result, string $context) use ($assert): int {
         $findings = $report['findings'] ?? array();
         $assert(is_array($findings), "{$context}: {$name} findings is an array");
         ConversionFindingContract::assertFindings(array_values($findings), "{$context} {$name} findings");
+        $assertClassified(array_values($findings), "{$context} {$name} findings");
         $count += count($findings);
     }
 
@@ -151,6 +235,7 @@ $walk = static function (array $result, string $context) use ($assert): int {
         $fallbackDiagnostics = $conversionReport['fallback_diagnostics'] ?? array();
         $assert(is_array($fallbackDiagnostics), "{$context}: conversion report fallback_diagnostics is an array");
         ConversionFindingContract::assertFindings(array_values($fallbackDiagnostics), "{$context} conversion report fallback_diagnostics");
+        $assertClassified(array_values($fallbackDiagnostics), "{$context} conversion report fallback_diagnostics");
         $count += count($fallbackDiagnostics);
     }
 


### PR DESCRIPTION
## The blind spot

A 12-site live corpus run bucketed **143 of 173** transformer findings into a generic catch-all (`generic_finding_family` — *"Findings need a specific type, repair bucket, or reason code before fanout"*). The diagnostic producers were emitting findings that lacked the canonical classification triplet downstream tooling reads to cluster by root cause and route to a repair lane.

Empirically (across the contract walk's emission paths), **0 of 39** findings carried a complete, non-generic `reason_code` / `repair_bucket` / `pattern_family`:

- `reason_code` — absent everywhere except semantic-parity nested findings
- `repair_bucket` — absent everywhere except the runtime-dependency parity report
- `pattern_family` — present only on fallback-family findings

## The fix

Add a single **generic** classifier to the shape-owning `ConversionFindingContract` (`classify()` / `withClassification()`) and flow every producer's findings through it:

- `FallbackEmitter` / `FallbackDiagnostic` (fallbacks + runtime islands)
- `DiagnosticsCollector` (flat diagnostics — incl. block-validity and semantic-parity projections that previously carried no repair/family signal)
- `SemanticParityReporter` (nested parity findings)
- `RuntimeDependencyParityReport`
- `ConversionReportProjection` (the compact conversion-report fallback projection)

Classification is derived **only from structural/semantic signals each finding already carries** — the stable identifier, source `tag`/`target_kind`, runtime `kind`, the `canvas_api` flag, and the producer's own repair hints — never from fixture names, class strings, or URLs. Producer-specific richer values (the fallback emitter's tag-aware `pattern_family`, the runtime report's specific `repair_bucket`) are authoritative and are never overwritten; the contract only fills the gaps. Per-instance noise (selectors/classes/URLs) stays in detail fields so the clustering keys stay **root-scoped** and two same-root findings cluster identically.

## Taxonomy applied

| reason_code (root identifier) | pattern_family | repair_bucket |
|---|---|---|
| `html_script_fallback` | `runtime_script` | `preserve_runtime_island` |
| `html_canvas_runtime_fallback` | `runtime_canvas` | `preserve_runtime_island` |
| `html_iframe_embed_fallback` | `external_embed` | `preserve_runtime_island` |
| `html_unsafe_inline_svg` | `inline_svg` | `materialize_static_asset` |
| `wp_block_validity_*` | `block_serialization` | `block_serialization_validity_repair` |
| `html_semantic_parity_*` (landmark/nav/typography) | `semantic_landmark` / `navigation_menu` / `typography` | `semantic_structure_parity_restoration` / `typography_parity_restoration` |
| `runtime_dependency_target_missing` | `runtime_dom_target` (or `runtime_canvas`) | `runtime_dom_target_preservation` / `runtime_canvas_target_preservation` |
| `runtime_script_not_materialized` | `runtime_script` | `runtime_script_materialization` |
| `runtime_script_target_missing` | `runtime_interactive_behavior` | `runtime_interactive_behavior_restoration` |
| `html_to_blocks_core_slice` (no-loss summary) | `conversion_summary` | `no_repair_needed` |

The runtime-family `repair_bucket` values deliberately match the ones the runtime-dependency report already emitted, so the taxonomy stays consistent across producers. The success summary is honestly classified as a no-loss family rather than forced into a wrong repair code.

## Before / after

Finding paths carrying a complete, non-generic triplet: **0/39 → 39/39** across the contract walk's emission surfaces.

## Verification

- `composer test:canonical` — green (39 findings validated)
- `composer parity` — **152 fixtures, identical** (block OUTPUT unchanged; this is finding metadata only)
- `composer test` — full suite green
- `php -l` — clean on all changed files
- Extended `tests/contract/finding-contract.php` with direct `classify()`/`withClassification()` unit coverage **and** a specificity walk that asserts every emitted finding carries a concrete, non-generic `reason_code`, `repair_bucket`, and `pattern_family` (the exact gap that bucketed 143/173 corpus findings as generic).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Inventorying the diagnostic emission sites, designing the generic classifier taxonomy, implementing the changes, and extending the contract test.

Do not merge yet — for review.