### PR TITLE
Preserve imported inline SVGs faithfully instead of empty core/icon

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1321,11 +1321,14 @@ final class HtmlTransformer
         }
 
         if ( 'svg' === $tagName ) {
-            $iconBlock = $this->iconBlockFromSvgElement($element);
-            if ( null !== $iconBlock ) {
-                return $iconBlock;
-            }
-
+            // Imported inline SVGs are preserved faithfully as raw markup
+            // (core/html via inlineSvgBlockFromElement). They are never routed
+            // through core/icon: that block is a dynamic block keyed on a
+            // registry slug (its `icon` attribute) and discards arbitrary inline
+            // SVG markup, so render_block_core_icon() returns empty output for
+            // imported SVGs. Faithful passthrough keeps the original element,
+            // its sizing class(es), and correct-case viewBox so the
+            // materialized source CSS can size it.
             if ( $this->isSafeDecorativeSvgElement($element) ) {
                 if ( $this->hasIconLikeContext($element) ) {
                     return $this->inlineSvgBlockFromElement($element);
@@ -3003,118 +3006,6 @@ final class HtmlTransformer
     }
 
     /**
-     * @return array<string, mixed>|null
-     */
-    private function iconBlockFromSvgElement(DOMElement $element): ?array
-    {
-        if ( ! $this->isSafeSvgContent($this->outerHtml($element)) || ! $this->isPassiveSvgMarkup($element) || ! $this->isIconSvgElement($element) ) {
-            return null;
-        }
-
-        $html = $this->safeFallbackHtml($element);
-        if ( ! $this->isSafeSvgContent($html) ) {
-            return null;
-        }
-
-        $label = $this->inlineSvgAltText($element);
-        $attrs = array_filter(array_merge($this->presentationAttributes($element), array(
-            'svg'        => $html,
-            'label'      => $label,
-            'ariaHidden' => '' === $label && ( 'true' === strtolower($this->attr($element, 'aria-hidden')) || in_array(strtolower($this->attr($element, 'role')), array( 'presentation', 'none' ), true) ),
-        )), static fn (mixed $value): bool => is_bool($value) ? $value : '' !== $value);
-
-        return $this->createBlock('core/icon', $attrs, array(), $element);
-    }
-
-    private function isIconSvgElement(DOMElement $element): bool
-    {
-        if ( $this->hasLogoLikeContext($element) || $this->hasImageLikeContext($element) || ! $this->hasSimpleSvgShape($element) ) {
-            return false;
-        }
-
-        $role = strtolower(trim($this->attr($element, 'role')));
-        if ( 'true' === strtolower(trim($this->attr($element, 'aria-hidden'))) || in_array($role, array( 'presentation', 'none' ), true) || $this->hasAriaHiddenAncestor($element) ) {
-            return $this->hasIconLikeContext($element);
-        }
-
-        return 'img' === $role && '' !== $this->inlineSvgAltText($element);
-    }
-
-    private function hasAriaHiddenAncestor(DOMElement $element): bool
-    {
-        for ( $parent = $element->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode instanceof DOMElement ? $parent->parentNode : null ) {
-            if ( 'true' === strtolower(trim($this->attr($parent, 'aria-hidden'))) ) {
-                return true;
-            }
-            if ( in_array(strtolower($parent->tagName), array( 'body', 'main', 'article', 'section' ), true) ) {
-                return false;
-            }
-        }
-
-        return false;
-    }
-
-    private function hasSimpleSvgShape(DOMElement $element): bool
-    {
-        $shapeCount = 0;
-        foreach ( $element->getElementsByTagName('*') as $child ) {
-            if ( ! $child instanceof DOMElement ) {
-                continue;
-            }
-            if ( in_array(strtolower($child->tagName), array( 'circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect' ), true) ) {
-                ++$shapeCount;
-            }
-        }
-
-        return 0 < $shapeCount && $shapeCount <= 8 && $this->hasSmallSvgViewport($element);
-    }
-
-    private function hasSmallSvgViewport(DOMElement $element): bool
-    {
-        $viewBox = trim($this->attr($element, 'viewBox'));
-        if ( '' === $viewBox ) {
-            $viewBox = trim($this->attr($element, 'viewbox'));
-        }
-        if ( preg_match('/^-?\d+(?:\.\d+)?\s+-?\d+(?:\.\d+)?\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)/', $viewBox, $matches) ) {
-            return (float) $matches[1] <= 128 && (float) $matches[2] <= 128;
-        }
-
-        $width = $this->numericSvgLength($this->attr($element, 'width'));
-        $height = $this->numericSvgLength($this->attr($element, 'height'));
-        return null !== $width && null !== $height && $width <= 128 && $height <= 128;
-    }
-
-    private function numericSvgLength(string $value): ?float
-    {
-        return preg_match('/^\s*(\d+(?:\.\d+)?)(?:px)?\s*$/i', $value, $matches) ? (float) $matches[1] : null;
-    }
-
-    private function inlineSvgAltText(DOMElement $element): string
-    {
-        if ( 'true' === strtolower($this->attr($element, 'aria-hidden')) || 'presentation' === strtolower($this->attr($element, 'role')) ) {
-            return '';
-        }
-
-        $ariaLabel = trim($this->attr($element, 'aria-label'));
-        if ( '' !== $ariaLabel ) {
-            return $ariaLabel;
-        }
-
-        return $this->inlineSvgTitleText($element);
-    }
-
-    private function inlineSvgTitleText(DOMElement $element): string
-    {
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement && 'title' === strtolower($child->tagName) ) {
-                return trim($child->textContent ?? '');
-            }
-        }
-
-        return '';
-    }
-
-    /**
      * @param array<int, array<string, mixed>> $fallbacks
      */
     private function captureInlineSvgFallback(DOMElement $element, array &$fallbacks): void
@@ -3284,40 +3175,6 @@ final class HtmlTransformer
         }
 
         return false;
-    }
-
-    private function hasLogoLikeContext(DOMElement $element): bool
-    {
-        for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null ) {
-            $context = strtolower(trim(implode(' ', array(
-                $this->attr($current, 'class'),
-                $this->attr($current, 'id'),
-                $this->attr($current, 'aria-label'),
-                $this->attr($current, 'title'),
-            ))));
-
-            if ( preg_match('/(?:^|[\s_-])(?:brand|diagram|illustration|logo|logomark|wordmark)(?:$|[\s_-])/', $context) ) {
-                return true;
-            }
-
-            if ( in_array(strtolower($current->tagName), array( 'body', 'main', 'article', 'section' ), true) ) {
-                return false;
-            }
-        }
-
-        return false;
-    }
-
-    private function hasImageLikeContext(DOMElement $element): bool
-    {
-        $context = strtolower(trim(implode(' ', array(
-            $this->attr($element, 'class'),
-            $this->attr($element, 'id'),
-            $this->attr($element, 'aria-label'),
-            $this->attr($element, 'title'),
-        ))));
-
-        return (bool) preg_match('/(?:^|[\s_-])(?:image|photo|picture)(?:$|[\s_-])/', $context);
     }
 
     private function isPassiveSvgMarkup(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -568,16 +568,17 @@ $safeInlineSvgSerialized = (string) ($safeInlineSvg['serialized_blocks'] ?? '');
 $assert('success' === ($safeInlineSvg['status'] ?? ''), 'safe inline SVG does not trip strict fallback gates', (string) ($safeInlineSvg['status'] ?? ''));
 $assert(array() === ($safeInlineSvg['fallbacks'] ?? array()), 'safe decorative inline SVG is consumed instead of recorded as fallback metadata');
 $assert('core/group' === ($safeInlineSvg['blocks'][0]['blockName'] ?? ''), 'decorative inline SVG preserves its CSS-addressable wrapper when present');
-$assert('core/icon' === ($safeInlineSvg['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? ''), 'icon-context decorative SVG converts to a core icon block');
-$assert(! str_contains($safeInlineSvgSerialized, '<!-- wp:html'), 'safe inline SVG conversion avoids raw HTML blocks');
+$assert('core/html' === ($safeInlineSvg['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? ''), 'icon-context decorative SVG is preserved faithfully as a core/html block, not a dynamic core/icon (which discards inline SVG markup and renders empty)');
+$assert(str_contains($safeInlineSvgSerialized, '<!-- wp:html'), 'icon-context inline SVG is preserved through a faithful core/html block so the verbatim <svg> element survives rendering');
 $assert(! str_contains($safeInlineSvgSerialized, 'data:image/svg+xml,'), 'decorative inline SVG avoids image data URI noise');
-$assert(str_contains(rawurldecode($safeInlineSvgSerialized), '<svg'), 'decorative icon SVG markup is preserved in the core icon block');
+$assert(str_contains($safeInlineSvgSerialized, '<svg viewBox="0 0 16 16"'), 'decorative icon SVG markup is preserved verbatim with correct-case viewBox');
 
 $safeInlineSvgAsset = ( new HtmlTransformer() )->transform(
     '<svg role="img" aria-label="Status badge" viewBox="0 0 10 10"><title>Status badge</title><circle cx="5" cy="5" r="4"></circle></svg>'
 )->toArray();
-$assert('core/icon' === ($safeInlineSvgAsset['blocks'][0]['blockName'] ?? ''), 'simple accessible inline SVG converts to a core icon block');
-$assert('Status badge' === ($safeInlineSvgAsset['blocks'][0]['attrs']['label'] ?? ''), 'safe accessible inline SVG icon preserves accessible label');
+$safeInlineSvgAssetContent = (string) ($safeInlineSvgAsset['blocks'][0]['attrs']['content'] ?? '');
+$assert('core/html' === ($safeInlineSvgAsset['blocks'][0]['blockName'] ?? ''), 'simple accessible inline SVG is preserved faithfully as a core/html block, not a dynamic core/icon');
+$assert(str_contains($safeInlineSvgAssetContent, 'aria-label="Status badge"') && str_contains($safeInlineSvgAssetContent, 'viewBox="0 0 10 10"'), 'safe accessible inline SVG preserves its accessible label and correct-case viewBox in faithful markup');
 $assert(array() === ($safeInlineSvgAsset['assets'] ?? array()), 'safe accessible inline SVG icon does not generate an image asset');
 $assert(! str_contains((string) ($safeInlineSvgAsset['serialized_blocks'] ?? ''), 'data:image/svg+xml,'), 'safe accessible inline SVG avoids data URI serialization');
 
@@ -1226,8 +1227,8 @@ $artifactNonEntryInlineSvg = $compiler->compile(
     )
 )->toArray();
 $artifactNonEntryInlineSvgPage = $artifactNonEntryInlineSvg['source_reports']['materialization_plan']['pages'][1] ?? array();
-$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), '<!-- wp:icon'), 'non-entry artifact simple icon SVG converts to a core icon block');
-$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), 'About icon'), 'non-entry artifact core icon preserves safe SVG accessible label');
+$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), '<!-- wp:html'), 'non-entry artifact simple icon SVG is preserved faithfully as a core/html block, not a dynamic core/icon');
+$assert(str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), 'aria-label="About icon"') && str_contains((string) ($artifactNonEntryInlineSvgPage['block_markup'] ?? ''), 'viewBox="0 0 8 8"'), 'non-entry artifact faithful SVG preserves its accessible label and correct-case viewBox');
 $assert(array() === ($artifactNonEntryInlineSvg['source_reports']['materialization_plan']['assets'] ?? array()), 'non-entry artifact simple icon SVG does not materialize a generated image asset');
 $assert(1 === ($simple['source_reports']['materialization_plan']['totals']['pages'] ?? null), 'materialization plan counts pages');
 $assert('index' === ($simple['source_reports']['materialization_plan']['pages'][0]['slug'] ?? ''), 'materialization plan exposes page slug');

--- a/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
+++ b/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-background-icon-media-patterns",
-  "description": "Converts generic background-image heroes and icon-like SVG card media into core media/icon blocks without fallbacks.",
+  "description": "Converts generic background-image heroes into core media blocks and preserves icon-like SVG card media faithfully as core/html (verbatim svg with correct-case viewBox), without fallbacks.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-background-icon-media-patterns.json",
@@ -21,7 +21,7 @@
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Care that meets you", "level": 1 } },
     { "path": "blocks.1", "name": "core/group", "attrs": { "className": "feature-card" } },
     { "path": "blocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature-icon" } },
-    { "path": "blocks.1.innerBlocks.0.innerBlocks.0", "name": "core/icon" },
+    { "path": "blocks.1.innerBlocks.0.innerBlocks.0", "name": "core/html" },
     { "path": "blocks.1.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Fast booking", "level": 3 } }
   ],
   "expected_fallbacks": [],
@@ -30,7 +30,8 @@
     { "path": "blocks", "assert": "count", "count": 2 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:icon" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:html" },
+    { "path": "blocks.1.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<svg viewBox=\"0 0 24 24\"" },
     { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-benefit-icon-faithful.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-benefit-icon-faithful.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-benefit-icon-faithful",
+  "description": "Imported feature/benefit inline SVGs are preserved faithfully as core/html so the verbatim <svg> element, its sizing class (e.g. benefit-icon), and its correct-case viewBox survive rendering. They are never routed through the dynamic core/icon block, which is keyed on a registry slug and discards inline SVG markup (rendering empty).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-benefit-icon-faithful.json",
+    "notes": "Regression guard: core/icon discards arbitrary inline SVG (render_block_core_icon returns empty without a registry slug), so imported feature icons must use faithful core/html passthrough that keeps element + class + viewBox case."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><section class=\"features\"><div class=\"feature\"><svg class=\"benefit-icon\" viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 12l5 5L20 6\"></path></svg><h3>Fast</h3><p>Quick care.</p></div></section></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "features" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/html" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Fast", "level": 3 } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "assets", "assert": "count", "count": 0 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "class=\"benefit-icon\"" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "viewBox=\"0 0 24 24\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<svg class=\"benefit-icon\" viewBox=\"0 0 24 24\"" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-decorative",
-  "description": "Consumes safe decorative inline SVG separators and converts simple accessible icon SVGs without fallback noise.",
+  "description": "Consumes safe decorative inline SVG separators and preserves simple accessible icon SVGs faithfully as core/html (verbatim svg element, class, and correct-case viewBox) without fallback noise.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-decorative.json",
@@ -18,13 +18,14 @@
   "expected_blocks": [
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Before", "level": 2 } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "After" } },
-    { "path": "blocks.0.innerBlocks.2", "name": "core/icon", "attrs": { "label": "Acme integration" } }
+    { "path": "blocks.0.innerBlocks.2", "name": "core/html" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
-    { "path": "blocks.0.innerBlocks.2.attrs.svg", "assert": "contains", "value": "aria-label=\"Acme integration\"" },
+    { "path": "blocks.0.innerBlocks.2.attrs.content", "assert": "contains", "value": "<svg viewBox=\"0 0 32 32\"" },
+    { "path": "blocks.0.innerBlocks.2.attrs.content", "assert": "contains", "value": "aria-label=\"Acme integration\"" },
     { "path": "assets", "assert": "count", "count": 0 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-fallback",
-  "description": "Represents simple accessible inline SVG as a core icon block while preserving supported siblings.",
+  "description": "Preserves simple accessible inline SVG faithfully as a core/html block (verbatim svg, accessible label, correct-case viewBox) while preserving supported siblings.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-fallback.json",
@@ -17,13 +17,14 @@
   },
   "expected_blocks": [
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Icon row", "level": 2 } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/icon", "attrs": { "label": "Status" } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/html" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "blocks.0.innerBlocks.1.attrs.svg", "assert": "contains", "value": "aria-label=\"Status\"" },
+    { "path": "blocks.0.innerBlocks.1.attrs.content", "assert": "contains", "value": "<svg viewBox=\"0 0 10 10\"" },
+    { "path": "blocks.0.innerBlocks.1.attrs.content", "assert": "contains", "value": "aria-label=\"Status\"" },
     { "path": "assets", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]


### PR DESCRIPTION
## What
Verified visual-parity fix: imported inline SVGs were emitted as `core/icon`, which is a DYNAMIC block keyed on a registry slug — it discards our inline `svg` and renders EMPTY (0 bytes). On 15-saas, 5 of 6 feature icons vanished; corpus-wide **212 `core/icon` blocks rendered empty**. SVGs on that path also got `viewBox` lowercased to `viewbox` (invalid).

## Change
- `HtmlTransformer.php`: removed the `iconBlockFromSvgElement` dispatch from the `<svg>` branch; imported inline SVGs now flow to faithful `core/html` (the same path the integration logos already used successfully), which preserves the verbatim `<svg>`, its class (e.g. `benefit-icon`), and correct-case `viewBox` via `restoreSvgAttributeCasing`. Removed 10 now-dead icon-classification helpers (151 lines).
- `core/icon` stays a recognized core block for a future real-registry-slug recognizer; it's simply never synthesized from arbitrary imported SVG.

## Verification (real render)
- Live `do_blocks`: BEFORE `wp:icon` → 0 bytes, no svg; AFTER `core/html` → 246 bytes, `<svg viewBox="0 0 24 24" class="benefit-icon">` intact.
- Corpus: `core/icon` 212 → 0; SVGs now render faithfully (17 on 15-saas, 0 empty).
- `composer test` + `composer parity`: **154 fixtures** green; contract + 3 fixtures corrected to assert faithful output (strengthened), + a new regression fixture.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and live-render verification under human review.