### PR TITLE
Fix responsive normalize path skipping instance resolution on variant frames

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -489,9 +489,14 @@ final class FigmaTransformer
         $pageName = isset($options['page_name']) && is_scalar($options['page_name']) ? (string) $options['page_name'] : '';
 
         // Normalize the FULL scenegraph (drop the single-frame selection) so
-        // every variant frame is present in the emitter node map.
+        // every variant frame is present in the emitter node map. render_document
+        // prevents the normalizer from auto-selecting a single frame when no
+        // frame_id is passed — the full document render tree is needed so that
+        // appendNodeMap can overwrite the flat node_map's stale embedded children
+        // with refreshed, instance-resolved versions for all variant frames.
         $normalizeOptions = $options;
         unset($normalizeOptions['frame_id'], $normalizeOptions['responsive_variants'], $normalizeOptions['page_name']);
+        $normalizeOptions['render_document'] = true;
         $normalized = $this->scenegraphNormalizer->normalize($scenegraph, $normalizeOptions);
 
         $pagePlan = array(

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -47,7 +47,8 @@ final class ScenegraphNormalizer
         }
 
         $renderIds = $topLevelIds;
-        if ( null !== $selectedFrameId && 1 === count($topLevelIds) && $selectedFrameId !== $topLevelIds[0] ) {
+        $renderDocument = ! empty($options['render_document']);
+        if ( ! $renderDocument && null !== $selectedFrameId && 1 === count($topLevelIds) && $selectedFrameId !== $topLevelIds[0] ) {
             $renderIds = array($selectedFrameId);
         }
         $renderNodes = array();


### PR DESCRIPTION
## Summary

Fixes a bug where resolved INSTANCE children (with namespaced IDs like `11320:3030/4177:10488`) were absent from the emitted HTML when using the responsive multi-page transform path. The `<header>` and other INSTANCE elements emitted as empty containers even though `resolveInstances` reported 338/338 resolved.

**Root cause**: `transformResponsivePage` calls `normalize(scenegraph, opts)` with `frame_id` removed to allow all variant frames to be accessible in the emitter's nodeMap. However, the normalizer's `selectTopLevelFrameIds` + frame-narrowing logic treats this call identically to a single-frame call: it auto-selects `frameIds[0]` as the render root (e.g., `4166:11483 "Header"` — the first frame in the first canvas), and `refreshResolvedTree` is only applied to that one frame's subtree. The emitter's `appendNodeMap` then traverses only 81 nodes from that wrong frame, leaving all variant frames (`11320:3027`, `3468:1038`, `4197:4735`) to be served from the flat `node_map` with stale pre-resolution embedded children. `emitNode(11320:3027)` walks the embedded children tree and finds `11320:3030` with 0 children — empty.

**Fix**: Add a `render_document` option to `ScenegraphNormalizer::normalize()`. When set, the frame-narrowing step is skipped and `renderIds` stays as `topLevelIds` (`['0:0']`). `refreshResolvedTree` is applied to the full document root, producing a complete resolved render tree. `appendNodeMap` then traverses the entire document and overwrites all flat `node_map` entries with their resolved render-tree versions — including correctly populated embedded children for every frame.

`transformResponsivePage` now passes `render_document: true` to get the intended behavior the code comment already described: "Normalize the FULL scenegraph so every variant frame is present in the emitter node map."

## Verification

Before fix: `<header class="figma-node-11320-3030-header" ...></header>` — empty.

After fix: `<header>` contains Logo SVG, Navigation, Menu Items, Button — the full resolved component tree with namespaced child IDs.

All 917 contract tests pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Root cause diagnosis (traced the normalize → refreshResolvedTree → emitter nodeMap data flow), fix design, and implementation