### PR TITLE
Fix whole-element links emitting core/group with unsupported href (#260)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -125,6 +125,16 @@ final class HtmlTransformer
     private array $frozenHiddenStateFindings = array();
 
     /**
+     * Whole-element link wrappers (an <a> wrapping block-level content) whose
+     * link was dropped because the resulting core/group has no native link
+     * attribute (#260). Surfaced for diagnostics so navigation loss is
+     * detectable rather than emitted as an unsupported attribute.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $droppedLinkWrapperFindings = array();
+
+    /**
      * @var array<int, array<string, mixed>>
      */
     private array $sourceProvenance = array();
@@ -265,6 +275,7 @@ final class HtmlTransformer
         $this->fallbackProvenance = TransformationOptions::provenance($options);
         $this->presentationProvenance = array();
         $this->frozenHiddenStateFindings = array();
+        $this->droppedLinkWrapperFindings = array();
         $this->sourceProvenance = array();
         $this->structureProvenance = array();
         $this->scriptMetadata = array();
@@ -378,6 +389,7 @@ final class HtmlTransformer
             'html' => array(
                 'presentation_signals' => $this->presentationProvenance,
                 'frozen_hidden_state'  => $this->frozenHiddenStateFindings,
+                'dropped_link_wrappers' => $this->droppedLinkWrapperFindings,
                 'source_provenance'    => $sourceProvenance,
                 'structure_signals'    => $this->structureProvenance,
                 'script_metadata'      => $this->scriptMetadata,
@@ -1303,7 +1315,13 @@ final class HtmlTransformer
             if ( $this->hasBlockContentChildren($element) ) {
                 $children = $this->convertChildren($element, $fallbacks, true);
                 if ( array() !== $children ) {
-                    return $this->createBlock('core/group', array_merge($this->presentationAttributes($element), $this->cardLinkAttributes($element)), $children, $element);
+                    // core/group has no native link attribute, so the wrapping
+                    // anchor's href/target/rel cannot live on the group without
+                    // becoming an unsupported attribute WordPress silently drops
+                    // (#260). Preserve the children as a valid group and surface
+                    // the dropped link wrapper for diagnostics instead.
+                    $this->recordDroppedLinkWrapper($element);
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
                 }
             }
 
@@ -4356,6 +4374,28 @@ final class HtmlTransformer
             'rel'       => $this->attr($anchor, 'rel'),
             'ariaLabel' => $this->attr($anchor, 'aria-label'),
         ), static fn (string $value): bool => '' !== trim($value));
+    }
+
+    /**
+     * Record a content-wrapping anchor whose link was dropped because the
+     * resulting core/group exposes no native link attribute (#260). The link
+     * details are captured for diagnostics so the navigation loss is detectable
+     * rather than silently emitted as an unsupported attribute on the group.
+     */
+    private function recordDroppedLinkWrapper(DOMElement $anchor): void
+    {
+        $link = $this->cardLinkAttributes($anchor);
+        if ( array() === $link ) {
+            return;
+        }
+
+        $this->droppedLinkWrapperFindings[] = array_merge(
+            array(
+                'tag'      => strtolower($anchor->tagName),
+                'selector' => $this->elementSelector($anchor),
+            ),
+            $link
+        );
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-linked-overlay-category-card.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-overlay-category-card.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-linked-overlay-category-card",
-  "description": "Preserves linked overlay/category card hrefs when anchors wrap background and content regions.",
+  "description": "Whole-card overlay/category anchors wrapping background and content regions become valid core/group blocks with children preserved and no unsupported href attribute on the group (#260).",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-linked-overlay-category-card.json",
@@ -17,10 +17,10 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "category-grid", "layout": { "type": "grid" } } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "category-card overlay-card", "href": "/category/design", "ariaLabel": "Read design category" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "category-card overlay-card" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "card__bg" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "overlay" } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "category-card overlay-card", "href": "/category/build" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "category-card overlay-card" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "card__bg" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/group", "attrs": { "className": "content" } }
   ],
@@ -29,9 +29,12 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
-    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/category/design\"" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/category/build\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Sharp Visual Systems" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Production Workflows" },
     { "path": "serialized_blocks", "assert": "contains", "value": "card__bg" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/category/design\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/category/build\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"ariaLabel\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-linked-resource-card-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-resource-card-grid.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-linked-resource-card-grid",
-  "description": "Preserves card-level hrefs when anchors wrap resource-card content in a grid.",
+  "description": "Whole-card anchors wrapping resource-card content become valid core/group blocks with their children preserved and no unsupported href attribute on the group (#260).",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-linked-resource-card-grid.json",
-    "notes": "Product-neutral coverage for resource/card grids where the whole card is an anchor."
+    "notes": "Product-neutral coverage for resource/card grids where the whole card is an anchor. core/group has no native link attribute, so the wrapping anchor's href/target/rel are not emitted on the group; the card children are preserved as valid blocks."
   },
   "legacy_comparison": {
     "skip": true,
@@ -17,18 +17,22 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "resource-grid", "layout": { "type": "grid" } } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "resource-card", "href": "/resources/block-patterns" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "resource-card" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "resource-card__media" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "resource-card__content" } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "resource-card", "href": "/resources/site-launch", "target": "_blank", "rel": "noopener" } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "resource-card" } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
-    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/resources/block-patterns\"" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "\"href\":\"/resources/site-launch\"" },
+    { "path": "blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.innerBlocks.1.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Block Pattern Basics" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Launch Review" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/resources/block-patterns\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/resources/site-launch\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<p><a class=\"resource-card\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }

--- a/php-transformer/tests/fixtures/parity/html-whole-element-link-group-no-href.json
+++ b/php-transformer/tests/fixtures/parity/html-whole-element-link-group-no-href.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-whole-element-link-group-no-href",
+  "description": "A whole-element link (an <a> wrapping block-level content) converts to a valid core/group with its children preserved and no unsupported href/target/rel/ariaLabel attribute on the group (#260).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-whole-element-link-group-no-href.json",
+    "notes": "Generic structural coverage: any anchor wrapping block-level content. core/group has no native link attribute, so the link wrapper's href/target/rel are not emitted on the group; the children are kept as valid, editable blocks."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"panel-link\" href=\"https://example.com/details/\" target=\"_blank\" rel=\"noopener\" aria-label=\"Open details\"><h2>Quarterly Review</h2><p>A summary of the latest reporting period.</p></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "panel-link" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Quarterly Review", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "A summary of the latest reporting period." } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Quarterly Review" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "A summary of the latest reporting period." },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"target\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"rel\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"ariaLabel\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
Refs #260

## Problem
A whole-element link — an `<a href>` whose children are block-level content (a clickable card/tile/panel) — was converted to a `core/group` whose attributes included the anchor's `href`/`target`/`rel`/`ariaLabel`:

```
<!-- wp:group {"className":"feature-card", ... ,"href":"https://.../details/"} -->
```

`core/group` has no native link attribute, so WordPress silently ignores it. The result is unsupported/unexpected block content (a dead attribute the editor drops) and the card is no longer clickable, with the link loss undetected.

## Fix
Generic and structural — keys off the shape (an `<a>` containing block-level content), never fixture/class/URL specifics. In `HtmlTransformer`'s anchor branch, when an anchor wraps block-level content the group is now emitted with only its supported presentation attributes (`className`, `style`, `layout`, `anchor`) and the children are preserved as valid, editable blocks. The anchor's link attributes are no longer placed on the group.

The hard requirement holds: **no block is emitted with an attribute its block type does not support.**

Because `core/group` has no native whole-container link in WordPress, the link wrapper cannot be preserved natively without emitting an unsupported attribute. To keep the navigation loss detectable rather than silent, the dropped link wrapper (tag, selector, href/target/rel/ariaLabel) is recorded as a diagnostic finding, surfaced under `sourceReports['html']['dropped_link_wrappers']`.

### Before / After (representative card grid)
Before:
```
<!-- wp:group {"className":"resource-card","href":"/resources/block-patterns"} -->
  ... card children ...
<!-- /wp:group -->
```
After:
```
<!-- wp:group {"className":"resource-card"} -->
  ... card children (heading, paragraphs, image) preserved as valid blocks ...
<!-- /wp:group -->
```

## How a whole-element link is now represented
As a valid `core/group` containing the converted children (headings, paragraphs, images, nested groups) with no unsupported link attribute. The link target is reported via the `dropped_link_wrappers` diagnostic.

## Tests
- New parity fixture `html-whole-element-link-group-no-href`: an `<a>` (with `href`/`target`/`rel`/`aria-label`) wrapping a heading + paragraph -> valid `core/group`, children preserved, asserts no `href`/`target`/`rel`/`ariaLabel` on the group.
- Updated `html-linked-resource-card-grid` and `html-linked-overlay-category-card`, which previously blessed the buggy `href`-on-group output; they now assert the children are preserved and no unsupported link attribute is emitted.
- `composer parity`: 157 fixtures pass. Full `composer test` green. `php -l` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigating issue #260, implementing the structural fix, updating/adding parity fixtures, and drafting this PR.