### PR TITLE
Fix core/button label span wrapping and unsupported layout attr

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -105,7 +105,47 @@ final class ButtonsPattern
     {
         $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>\s*<\/\1>/i', '', $html) ?? $html;
         $html = preg_replace('/<\/?(?:' . self::BLOCK_LEVEL_LABEL_TAGS . ')\b[^>]*>/i', '', $html) ?? $html;
-        return trim($html);
+        return $this->unwrapPresentationalSpan(trim($html));
+    }
+
+    /**
+     * Strip a presentational <span> that wraps the entire button label.
+     *
+     * core/button stores its label as RichText, which only recognizes a fixed
+     * set of inline formats (e.g. <strong>, <em>). A bare wrapping <span> is not
+     * a format, so RichText drops it on parse: the saved markup no longer matches
+     * the re-serialized block ("unexpected or invalid content") and the label is
+     * captured as literal `<span>…</span>` markup instead of text. Removing the
+     * non-format wrapper keeps the label as valid RichText that round-trips, while
+     * genuine inline formats inside the span are preserved.
+     */
+    private function unwrapPresentationalSpan(string $html): string
+    {
+        while ( preg_match('/^<span\b[^>]*>(.*)<\/span>$/is', $html, $matches) === 1 && $this->spanWrapsEntireContent($matches[1]) ) {
+            $html = trim($matches[1]);
+        }
+
+        return $html;
+    }
+
+    /**
+     * True when the outer span's matching close is the final </span>, i.e. a
+     * single span wraps the whole label rather than two sibling spans
+     * (`<span>A</span> <span>B</span>`), which must not be unwrapped.
+     */
+    private function spanWrapsEntireContent(string $inner): bool
+    {
+        $depth = 0;
+        if ( preg_match_all('/<(\/?)span\b[^>]*>/i', $inner, $matches) ) {
+            foreach ( $matches[1] as $slash ) {
+                $depth += '' === $slash ? 1 : -1;
+                if ( $depth < 0 ) {
+                    return false;
+                }
+            }
+        }
+
+        return 0 === $depth;
     }
 
     /**
@@ -120,6 +160,10 @@ final class ButtonsPattern
         // block style object, so the (now object-shaped) presentation `style` is
         // dropped and re-derived via ButtonStyleResolver below.
         unset($attrs['style']);
+        // core/button does not support a `layout` attribute (a flex/grid layout
+        // belongs on the parent core/buttons, not each button). Emitting it here
+        // produces an unsupported attribute and invalid block markup, so drop it.
+        unset($attrs['layout']);
         $resolvedStyle = (string) $resolvedStyle($element);
         if ( $this->hasOutlineSignal($element, $resolvedStyle) ) {
             $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' is-style-outline');

--- a/php-transformer/tests/fixtures/parity/html-button-label-presentational-span-unwrapped.json
+++ b/php-transformer/tests/fixtures/parity/html-button-label-presentational-span-unwrapped.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-label-presentational-span-unwrapped",
+  "description": "Unwraps a single presentational <span> wrapping a button label so core/button stores valid RichText text and drops the unsupported flex layout attribute.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-label-presentational-span-unwrapped.json",
+    "notes": "Covers buttons whose anchor wraps the label in a non-format <span> and carries display:flex, which previously yielded text=\"<span>…</span>\" plus an unsupported layout attribute."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers WordPress block-validity normalization beyond the legacy converter behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"btn\" href=\"/listen\" style=\"display:flex\"><span>Listen Now</span></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn", "text": "Listen Now", "url": "/listen" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-button__link wp-element-button\" href=\"/listen\">Listen Now</a>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<span>Listen Now</span>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"layout\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-button-label-preserves-inline-format.json
+++ b/php-transformer/tests/fixtures/parity/html-button-label-preserves-inline-format.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-label-preserves-inline-format",
+  "description": "Keeps genuine inline RichText formats (e.g. <strong>) in a button label while still unwrapping a non-format presentational <span>.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-label-preserves-inline-format.json",
+    "notes": "Ensures the wrapping-span unwrap is structural and never strips formats core/button's RichText supports."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers WordPress block-validity normalization beyond the legacy converter behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"btn\" href=\"/go\"><span><strong>Go</strong> now</span></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn", "text": "<strong>Go</strong> now", "url": "/go" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-button__link wp-element-button\" href=\"/go\"><strong>Go</strong> now</a>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes two `core/button` defects observed in a real import, both in the PHP transformer's `ButtonsPattern`.

### 1. Button label captured as wrapping markup, not text
A source button `<a class="btn"><span>Listen Now</span></a>` became:

```
wp:button {"text":"<span>Listen Now</span>"} → <a ...><span>Listen Now</span></a>
```

`core/button` stores its label as RichText, which only recognizes a fixed set of inline formats. A bare wrapping `<span>` is not a format, so RichText drops it on parse: the saved markup no longer matches the re-serialized block ("unexpected or invalid content") and the label is wrong.

`buttonText()` now unwraps a **single presentational `<span>` that wraps the entire label**, using its inner content as the `text`. The unwrap is structural:
- Genuine inline formats RichText supports (`<strong>`, `<em>`, …) are preserved — only the non-format wrapping span is stripped.
- Nested wrapping spans are unwrapped iteratively.
- Sibling spans (`<span>A</span> <span>B</span>`) are never merged — `spanWrapsEntireContent()` confirms the opening span's matching close is the final `</span>` before unwrapping.

### 2. Unsupported `layout` attribute on core/button
Buttons were emitted as `wp:button {...,"layout":{"type":"flex"}}` (derived from the anchor's `display:flex`). `core/button` has no `layout` attribute, so this produced invalid/unsupported markup. `buttonPresentationAttributes()` now drops `layout` (it already drops `style` for the same re-derivation reason). A flex/grid layout, if meaningful, belongs on the parent `core/buttons`, not each button.

Both fixes are **generic** and key off structure (a presentational wrapping span; an unsupported attr), not any fixture/class specifics.

## Before / after

Input: `<a class="btn" href="/listen" style="display:flex"><span>Listen Now</span></a>`

Before:
```
<!-- wp:button {"className":"btn","layout":{"type":"flex"},"text":"<span>Listen Now</span>","url":"/listen"} -->
<div class="wp-block-button btn"><a class="wp-block-button__link wp-element-button" href="/listen"><span>Listen Now</span></a></div>
<!-- /wp:button -->
```

After:
```
<!-- wp:button {"className":"btn","text":"Listen Now","url":"/listen"} -->
<div class="wp-block-button btn"><a class="wp-block-button__link wp-element-button" href="/listen">Listen Now</a></div>
<!-- /wp:button -->
```

`wp_block_validity` now passes (no "unexpected or invalid content").

## Tests
- Baseline `composer test:canonical` + `composer parity` green before changes.
- Added two parity fixtures:
  - `html-button-label-presentational-span-unwrapped` — `<a class="btn"><span>Listen Now</span></a>` (+ `display:flex`) → `text":"Listen Now"`, no `<span>`, no `layout`, valid block.
  - `html-button-label-preserves-inline-format` — `<span><strong>Go</strong> now</span>` → `text":"<strong>Go</strong> now"` (strong preserved).
- Full `composer test` green (158 parity fixtures, all contracts/unit, packaging proof).
- `php -l` clean.

Scope stayed in `Patterns/ButtonsPattern.php`. No changes to `StyleAttributeMapper`/CSS parsing or the anchor→group link handling.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Diagnosing both defects, implementing the span-unwrap + layout-drop fixes, and authoring the parity fixtures.
