### PR TITLE
Make CSS value/shorthand parsing parenthesis-depth aware

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -51,7 +51,8 @@
     ],
     "test:unit": [
       "php tests/unit/subtree-classifier.php",
-      "php tests/unit/custom-block-generator.php"
+      "php tests/unit/custom-block-generator.php",
+      "php tests/unit/css-value-splitter.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/Style/CssValueSplitter.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssValueSplitter.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/**
+ * Parenthesis-depth-aware splitting for CSS declaration lists and values.
+ *
+ * Naive `explode(';', ...)`, `explode(',', ...)`, and `preg_split('/\s+/', ...)`
+ * over CSS values break apart the inside of functional notation —
+ * `rgba(251, 247, 241, .95)`, `clamp(3.5rem, 8vw, 6.5rem)`, `var(--x, 0)`, and
+ * `linear-gradient(90deg, red, blue)` all carry commas and spaces that are NOT
+ * top-level delimiters. Splitting them mid-function yields truncated, invalid
+ * tokens (`rgba(251,`) that no longer round-trip through the block style object,
+ * which is what produces "unexpected or invalid content" and mangled spacing.
+ *
+ * Every method here only treats a delimiter as a separator when it appears at
+ * paren depth 0, so functional values stay whole.
+ */
+final class CssValueSplitter
+{
+    /**
+     * Split on any of the given single-character delimiters, but only when the
+     * delimiter occurs outside of `(...)`. Empty/whitespace-only segments are
+     * dropped and remaining segments are trimmed.
+     *
+     * @param array<int, string> $delimiters
+     * @return array<int, string>
+     */
+    public static function splitTopLevel(string $input, array $delimiters): array
+    {
+        $parts  = array();
+        $buffer = '';
+        $depth  = 0;
+        $length = strlen($input);
+
+        for ( $index = 0; $index < $length; ++$index ) {
+            $char = $input[ $index ];
+            if ( '(' === $char ) {
+                ++$depth;
+            } elseif ( ')' === $char && $depth > 0 ) {
+                --$depth;
+            }
+
+            if ( 0 === $depth && in_array($char, $delimiters, true) ) {
+                $parts[] = $buffer;
+                $buffer  = '';
+                continue;
+            }
+
+            $buffer .= $char;
+        }
+
+        $parts[] = $buffer;
+
+        $trimmed = array();
+        foreach ( $parts as $part ) {
+            $part = trim($part);
+            if ( '' !== $part ) {
+                $trimmed[] = $part;
+            }
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * Split on top-level whitespace runs, keeping functional values whole. This
+     * is the paren-aware replacement for `preg_split('/\s+/', ...)` over CSS
+     * shorthand values such as `padding: clamp(3.5rem, 8vw, 6.5rem) 0` or
+     * `border: 1px solid rgba(0, 0, 0, .1)`.
+     *
+     * @return array<int, string>
+     */
+    public static function splitTopLevelWhitespace(string $input): array
+    {
+        $parts  = array();
+        $buffer = '';
+        $depth  = 0;
+        $length = strlen($input);
+
+        for ( $index = 0; $index < $length; ++$index ) {
+            $char = $input[ $index ];
+            if ( '(' === $char ) {
+                ++$depth;
+            } elseif ( ')' === $char && $depth > 0 ) {
+                --$depth;
+            }
+
+            if ( 0 === $depth && '' === trim($char) ) {
+                if ( '' !== $buffer ) {
+                    $parts[] = $buffer;
+                    $buffer  = '';
+                }
+                continue;
+            }
+
+            $buffer .= $char;
+        }
+
+        if ( '' !== $buffer ) {
+            $parts[] = $buffer;
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Whether every `(` in the value has a matching `)` and no `)` closes more
+     * than has been opened. A value that contains `(` but is unbalanced is a
+     * truncated/malformed functional value (e.g. `rgba(251,`) and must not be
+     * stored as a resolved CSS value.
+     */
+    public static function hasBalancedParens(string $value): bool
+    {
+        $depth  = 0;
+        $length = strlen($value);
+
+        for ( $index = 0; $index < $length; ++$index ) {
+            $char = $value[ $index ];
+            if ( '(' === $char ) {
+                ++$depth;
+            } elseif ( ')' === $char ) {
+                --$depth;
+                if ( $depth < 0 ) {
+                    return false;
+                }
+            }
+        }
+
+        return 0 === $depth;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
@@ -266,7 +266,7 @@ final class StyleAttributeMapper
         }
 
         $consumed['background'] = true;
-        return $this->cssColor(preg_split('/\s+/', $value)[0] ?? '');
+        return $this->cssColor(CssValueSplitter::splitTopLevelWhitespace($value)[0] ?? '');
     }
 
     /**
@@ -277,7 +277,7 @@ final class StyleAttributeMapper
     {
         foreach ( array( 'background', 'background-image' ) as $name ) {
             $value = trim((string) ($declarations[ $name ] ?? ''));
-            if ( '' !== $value && preg_match('/\bgradient\s*\(/i', $value) ) {
+            if ( '' !== $value && preg_match('/\bgradient\s*\(/i', $value) && CssValueSplitter::hasBalancedParens($value) ) {
                 $consumed[ $name ] = true;
                 return $value;
             }
@@ -298,7 +298,7 @@ final class StyleAttributeMapper
         $shorthand = trim((string) ($declarations[ $property ] ?? ''));
         if ( '' !== $shorthand ) {
             $consumed[ $property ] = true;
-            $parts = preg_split('/\s+/', $shorthand) ?: array();
+            $parts = CssValueSplitter::splitTopLevelWhitespace($shorthand);
             $count = count($parts);
             if ( 1 === $count ) {
                 $sides = array( 'top' => $parts[0], 'right' => $parts[0], 'bottom' => $parts[0], 'left' => $parts[0] );
@@ -377,7 +377,7 @@ final class StyleAttributeMapper
         }
 
         $parsed = array();
-        foreach ( preg_split('/\s+/', $value) ?: array() as $token ) {
+        foreach ( CssValueSplitter::splitTopLevelWhitespace($value) as $token ) {
             $lower = strtolower($token);
             if ( in_array($lower, array( 'none', 'hidden', 'solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset' ), true) ) {
                 $parsed['style'] = $lower;
@@ -413,6 +413,20 @@ final class StyleAttributeMapper
         if ( preg_match('/^#[0-9a-f]{3,8}$/i', $value) ) {
             return $value;
         }
+
+        // Functional color notation must be syntactically complete: a truncated
+        // value such as `rgba(251,` (produced by a non-paren-aware split) still
+        // matches the `rgb(`/`var(` prefix but is invalid CSS. WordPress drops
+        // the inline style for it while keeping the has-* support class, so the
+        // saved markup diverges from the block attributes ("unexpected or invalid
+        // content"). Require balanced parentheses and a closing `)` so only
+        // values WordPress will actually render are stored.
+        if ( str_contains($value, '(') ) {
+            if ( ! str_ends_with($value, ')') || ! CssValueSplitter::hasBalancedParens($value) ) {
+                return '';
+            }
+        }
+
         if ( preg_match('/^(?:rgb|rgba|hsl|hsla)\s*\(/i', $value) ) {
             return $value;
         }

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -269,7 +269,7 @@ trait StyleResolutionTrait
     private function cssDeclarations(string $style): array
     {
         $declarations = array();
-        foreach ( explode(';', $style) as $declaration ) {
+        foreach ( CssValueSplitter::splitTopLevel($style, array( ';' )) as $declaration ) {
             if ( ! str_contains($declaration, ':') ) {
                 continue;
             }

--- a/php-transformer/tests/fixtures/parity/html-style-function-values-rgba-clamp-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-style-function-values-rgba-clamp-preserved.json
@@ -1,0 +1,33 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-style-function-values-rgba-clamp-preserved",
+  "description": "Parses CSS values with parenthesis-depth awareness so an rgba() background and a clamp()-led box shorthand keep their internal commas/spaces, and the resulting block stays valid (has-* class only with a matching renderable style).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-style-function-values-rgba-clamp-preserved.json",
+    "notes": "Generic CSS-syntax coverage: functional notation (rgba/clamp) must not be split mid-function by the declaration/value/shorthand parsers."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New paren-aware CSS value parsing behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section style=\"background: rgba(251, 247, 241, .95); padding: clamp(3.5rem, 8vw, 6.5rem) 0; color: rgb(20, 20, 20)\"><h2>Hello</h2><p>World</p></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "style": { "color": { "text": "rgb(20, 20, 20)", "background": "rgba(251, 247, 241, .95)" }, "spacing": { "padding": { "top": "clamp(3.5rem, 8vw, 6.5rem)", "right": "0", "bottom": "clamp(3.5rem, 8vw, 6.5rem)", "left": "0" } } }, "tagName": "section" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"background\":\"rgba(251, 247, 241, .95)\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"top\":\"clamp(3.5rem, 8vw, 6.5rem)\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background-color:rgba(251, 247, 241, .95)" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "padding-top:clamp(3.5rem, 8vw, 6.5rem)" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-group has-text-color has-background\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"background\":\"rgba(251,\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color:rgba(251,;" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "padding-right:8vw" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-style-function-values-var-gradient-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-style-function-values-var-gradient-preserved.json
@@ -1,0 +1,30 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-style-function-values-var-gradient-preserved",
+  "description": "Keeps a var() custom-property color and a multi-stop linear-gradient (with a nested rgba()) whole through paren-aware value parsing, emitting a valid block whose has-background class matches the rendered gradient style.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-style-function-values-var-gradient-preserved.json",
+    "notes": "Generic CSS-syntax coverage: var() defaults and gradient color stops carry commas/spaces that are not top-level delimiters."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New paren-aware CSS value parsing behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section style=\"color: var(--accent, #c4a35a); background: linear-gradient(90deg, rgba(0,0,0,.5), #fff)\"><h2>Grad</h2></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "style": { "color": { "text": "var(--accent, #c4a35a)", "gradient": "linear-gradient(90deg, rgba(0,0,0,.5), #fff)" } }, "tagName": "section" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"text\":\"var(--accent, #c4a35a)\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"gradient\":\"linear-gradient(90deg, rgba(0,0,0,.5), #fff)\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "background:linear-gradient(90deg, rgba(0,0,0,.5), #fff)" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-group has-text-color has-background\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"text\":\"var(--accent,\"" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-style-invalid-function-value-dropped-no-orphan-class.json
+++ b/php-transformer/tests/fixtures/parity/html-style-invalid-function-value-dropped-no-orphan-class.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-style-invalid-function-value-dropped-no-orphan-class",
+  "description": "A genuinely invalid/truncated functional color value is dropped cleanly so the block never carries a has-background support class without a matching renderable style; the valid padding alongside it is preserved.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-style-invalid-function-value-dropped-no-orphan-class.json",
+    "notes": "Generic editor-validity invariant: block attributes must always match the rendered has-* classes + inline style."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New validity-guard behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section style=\"padding: 2rem; background: rgba(1, 2\"><h2>Guard</h2></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "style": { "spacing": { "padding": { "top": "2rem", "right": "2rem", "bottom": "2rem", "left": "2rem" } } }, "tagName": "section" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-group\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "padding-top:2rem" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "has-background" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "background" }
+  ]
+}

--- a/php-transformer/tests/unit/css-value-splitter.php
+++ b/php-transformer/tests/unit/css-value-splitter.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the parenthesis-depth-aware CSS value splitter and the
+ * StyleAttributeMapper validity guard that depends on it.
+ *
+ * Plain-PHP test script in the style of tests/unit/subtree-classifier.php — no
+ * PHPUnit. The splitter must only treat `;`, `,`, and whitespace as delimiters
+ * at paren depth 0 so functional notation (rgba(), clamp(), var(), gradients)
+ * stays whole. The mapper must never store a truncated/unbalanced functional
+ * value, so a block never carries a has-* support class without a matching,
+ * renderable style.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+// ---------------------------------------------------------------------------
+// 1. Top-level comma split keeps commas inside rgba()/clamp()/var() intact.
+// ---------------------------------------------------------------------------
+$assert(
+    CssValueSplitter::splitTopLevel('rgba(251, 247, 241, .95)', array( ',' )) === array( 'rgba(251, 247, 241, .95)' ),
+    '1: rgba() is not split on its internal commas'
+);
+$assert(
+    CssValueSplitter::splitTopLevel('clamp(3.5rem, 8vw, 6.5rem), 0', array( ',' )) === array( 'clamp(3.5rem, 8vw, 6.5rem)', '0' ),
+    '1b: only the top-level comma after clamp() splits'
+);
+$assert(
+    CssValueSplitter::splitTopLevel('var(--x, 0), var(--y, 1)', array( ',' )) === array( 'var(--x, 0)', 'var(--y, 1)' ),
+    '1c: nested var() defaults stay whole, top-level comma splits'
+);
+
+// ---------------------------------------------------------------------------
+// 2. Top-level whitespace split keeps function-internal spaces intact — the
+//    box-shorthand expansion bug (`clamp(3.5rem, 8vw, 6.5rem) 0`).
+// ---------------------------------------------------------------------------
+$assert(
+    CssValueSplitter::splitTopLevelWhitespace('clamp(3.5rem, 8vw, 6.5rem) 0') === array( 'clamp(3.5rem, 8vw, 6.5rem)', '0' ),
+    '2: padding shorthand splits into clamp() + 0, clamp() stays whole'
+);
+$assert(
+    CssValueSplitter::splitTopLevelWhitespace('1px solid rgba(0, 0, 0, .1)') === array( '1px', 'solid', 'rgba(0, 0, 0, .1)' ),
+    '2b: border shorthand keeps rgba() whole'
+);
+$assert(
+    CssValueSplitter::splitTopLevelWhitespace('  10px   20px  ') === array( '10px', '20px' ),
+    '2c: collapses leading/trailing/repeated whitespace'
+);
+
+// ---------------------------------------------------------------------------
+// 3. Top-level declaration split keeps `;` inside functions intact.
+// ---------------------------------------------------------------------------
+$assert(
+    CssValueSplitter::splitTopLevel('color: red; background: rgba(1, 2, 3, .4)', array( ';' )) === array( 'color: red', 'background: rgba(1, 2, 3, .4)' ),
+    '3: declaration list splits on top-level semicolons only'
+);
+
+// ---------------------------------------------------------------------------
+// 4. Balanced-paren detection (validity guard primitive).
+// ---------------------------------------------------------------------------
+$assert(CssValueSplitter::hasBalancedParens('rgba(251, 247, 241, .95)'), '4: complete rgba() is balanced');
+$assert(! CssValueSplitter::hasBalancedParens('rgba(251,'), '4b: truncated rgba() is unbalanced');
+$assert(! CssValueSplitter::hasBalancedParens('foo)bar'), '4c: stray close paren is unbalanced');
+$assert(CssValueSplitter::hasBalancedParens('linear-gradient(90deg, rgba(0,0,0,.5), #fff)'), '4d: nested functions are balanced');
+
+// ---------------------------------------------------------------------------
+// 5. Mapper: function values survive end-to-end and stay whole.
+// ---------------------------------------------------------------------------
+$mapper = new StyleAttributeMapper();
+$mapped = $mapper->map(array(
+    'background' => 'rgba(251, 247, 241, .95)',
+    'padding'    => 'clamp(3.5rem, 8vw, 6.5rem) 0',
+    'color'      => 'var(--accent, #c4a35a)',
+));
+$assert(($mapped['style']['color']['background'] ?? '') === 'rgba(251, 247, 241, .95)', '5: rgba() background preserved whole');
+$assert(($mapped['style']['color']['text'] ?? '') === 'var(--accent, #c4a35a)', '5b: var() color preserved whole');
+$padding = $mapped['style']['spacing']['padding'] ?? array();
+$assert(
+    ($padding['top'] ?? '') === 'clamp(3.5rem, 8vw, 6.5rem)' && ($padding['right'] ?? '') === '0'
+        && ($padding['bottom'] ?? '') === 'clamp(3.5rem, 8vw, 6.5rem)' && ($padding['left'] ?? '') === '0',
+    '5c: clamp()/0 two-value shorthand maps to correct sides',
+    json_encode($padding)
+);
+
+// ---------------------------------------------------------------------------
+// 6. Validity guard: a genuinely invalid/truncated value is dropped, and the
+//    has-* class is NEVER emitted without a matching renderable style.
+// ---------------------------------------------------------------------------
+$invalid = $mapper->map(array( 'background' => 'rgba(251,' ));
+$assert(! isset($invalid['style']['color']['background']), '6: truncated background is not stored');
+$serialized = $mapper->serialize($invalid['style']);
+$assert(! str_contains($serialized['classes'], 'has-background'), '6b: no has-background class without a valid style');
+$assert('' === $serialized['style'], '6c: no inline style emitted for the invalid value');
+
+// A valid value still pairs class + declaration.
+$valid = $mapper->serialize($mapper->map(array( 'background' => 'rgba(1, 2, 3, .4)' ))['style']);
+$assert(str_contains($valid['classes'], 'has-background') && str_contains($valid['style'], 'background-color:rgba(1, 2, 3, .4)'), '6d: valid background pairs class + style');
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "CssValueSplitter unit tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "CssValueSplitter unit tests: {$passes} passed\n");


### PR DESCRIPTION
## Problem

The PHP transformer's CSS declaration, value, and box-shorthand splitters split on commas / spaces / semicolons **without respecting function parentheses**, truncating functional notation mid-function. This is the root cause of two distinct import defects.

### 1. `rgba()` → invalid block ("unexpected or invalid content")

`background: rgba(251, 247, 241, .95)` was split at the first comma:

```
"style":{"color":{"background":"rgba(251,"}}
```

A truncated color is invalid CSS. WordPress drops the inline `style` but **still emits the `has-background` support class**, so the saved HTML no longer matches the block attributes:

```
<div class="wp-block-group has-background ..."> (no style attribute)
```

The editor then flags *"this block contains unexpected or invalid content."*

### 2. `clamp()` box shorthand → mangled spacing

`padding: clamp(3.5rem, 8vw, 6.5rem) 0` was split on every space:

```
top:"clamp(3.5rem,"  right:"8vw,"  bottom:"6.5rem)"  left:"0"
-> padding-right:8vw,;padding-bottom:6.5rem)
```

## Fix

**Paren-aware splitting** — new `CssValueSplitter` (in `Style/`) walks the string tracking `(` depth and only splits at **top-level (depth 0)** delimiters. All naive splits feeding `StyleAttributeMapper` are routed through it:

- declaration-list split — top-level `;` only (`StyleResolutionTrait::cssDeclarations`)
- box-shorthand expansion — top-level whitespace only (`boxSides`), with correct 1/2/3/4-value → top/right/bottom/left mapping
- background first-token color resolution (`backgroundColor`)
- border shorthand tokenizer (`parseBorderShorthand`)

This keeps `rgba()`, `var()`, `clamp()`, `calc()`, and gradients whole.

**Validity guard** (editor-validity invariant) — when a resolved value is still genuinely invalid/unmappable, it is dropped cleanly so a block **never** carries a `has-*` presentation class without a matching renderable style:

- `cssColor()` now rejects functional values that are not syntactically complete (unbalanced or missing closing `)`), so a truncated `rgba(251,` resolves to nothing instead of a false-positive color.
- the gradient resolver requires balanced parens.

Dropped declarations ride on the preserved `className`; block attributes always match the rendered `has-*` classes + inline style.

### Before / after

| Input | Before | After |
|---|---|---|
| `background: rgba(251, 247, 241, .95)` | `background:"rgba(251,"` + orphan `has-background` → invalid block | `background:"rgba(251, 247, 241, .95)"` + matching `has-background` → valid |
| `padding: clamp(3.5rem, 8vw, 6.5rem) 0` | `right:"8vw,"` `bottom:"6.5rem)"` → mangled | `top/bottom:"clamp(3.5rem, 8vw, 6.5rem)"`, `right/left:"0"` |
| `background: rgba(1, 2` (genuinely invalid) | orphan `has-background`, no style | dropped, no `has-background` |

## Tests

- Baseline `composer test:canonical` + `composer parity` were green first; no existing fixture's output changed.
- Focused unit test `tests/unit/css-value-splitter.php` — commas/spaces/semicolons inside `rgba()`/`clamp()`/`var()`/gradients are not split, balanced-paren detection, and the mapper guard (invalid value dropped, no orphan class).
- New parity fixtures: rgba()/clamp(), var()/gradient (values intact, valid blocks), and the invalid-value guard (no `has-*` without matching style).
- Full `composer test` green (159 parity fixtures, +3); `php -l` clean.

Scope: `Style/` and the CSS declaration/value parsing it calls. No changes to pattern/anchor/link handling.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause analysis, implementing the paren-aware splitter + validity guard, and writing the unit/parity tests.