### PR TITLE
Preserve inline SVG artwork instead of stripping it to an empty block

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2986,11 +2986,25 @@ final class HtmlTransformer
      */
     private function inlineSvgBlockFromElement(DOMElement $element): ?array
     {
-        if ( ! $this->isSafeSvgContent($this->outerHtml($element)) ) {
+        // Only preserve when there is actual artwork to keep. An SVG whose only
+        // content is unsafe (e.g. a lone <script>) has nothing left to render
+        // once sanitized, so it defers to the bounded fallback diagnostic.
+        if ( ! $this->svgHasDrawableContent($element) ) {
             return null;
         }
 
-        $html = $this->safeFallbackHtml($element);
+        // Preserve the artwork: sanitize the SVG in place — stripping only the
+        // genuinely-unsafe parts (script/style/foreignObject elements, event
+        // handlers, javascript: URLs) — instead of dropping the entire graphic
+        // the moment one unsafe attribute or element appears. The shape and
+        // structure markup (svg/path/circle/rect/g/text/...) is kept so the
+        // image renders, rather than collapsing to an empty block.
+        $html = $this->sanitizeInlineSvgMarkup($element);
+
+        // Safety gate: only emit raw inline SVG once the sanitized markup is
+        // provably free of script/event-handler/javascript: vectors and still
+        // contains an <svg>. If sanitization could not fully clean it, defer to
+        // the bounded fallback metadata path rather than emit unsafe markup.
         if ( ! $this->isSafeSvgContent($html) ) {
             return null;
         }
@@ -2998,9 +3012,10 @@ final class HtmlTransformer
         // Keep illustrative/decorative inline SVG inline as a core/html block.
         // Externalizing to an `assets/*.svg` file + core/image would be lost in
         // WordPress, which blocks SVG uploads by default. The markup is already
-        // safe-sanitized above (scripts, event handlers, javascript: URLs
-        // stripped via safeFallbackHtml + verified by isSafeSvgContent), and the
-        // original outer SVG preserves viewBox/role/aria-label/class.
+        // safe-sanitized above (scripts, event handlers, foreignObject, and
+        // javascript: URLs stripped via sanitizeInlineSvgMarkup + verified by
+        // isSafeSvgContent), and the original outer SVG preserves
+        // viewBox/role/aria-label/class.
         return $this->createBlock('core/html', array( 'content' => $this->restoreSvgAttributeCasing($html) ), array(), $element);
     }
 

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -357,6 +357,68 @@ trait DomHelpersTrait
     }
 
     /**
+     * Whether an inline SVG carries any drawable artwork worth preserving.
+     *
+     * Returns true when the SVG has at least one shape/structure element
+     * (path/circle/rect/text/g/...) outside of any foreignObject subtree.
+     * Elements that carry no visual artwork on their own — script/style/
+     * foreignObject (all stripped during sanitization) and the metadata-only
+     * title/desc/metadata — do not count. An SVG whose only content is unsafe
+     * has nothing left to render once sanitized, so callers fall back to the
+     * bounded diagnostic instead of emitting an empty graphic.
+     */
+    private function svgHasDrawableContent(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('*') as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            $tag = strtolower($child->tagName);
+            if ( in_array($tag, array( 'script', 'style', 'foreignobject', 'title', 'desc', 'metadata' ), true) ) {
+                continue;
+            }
+            if ( $this->hasAncestorTag($child, array( 'foreignobject' )) ) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Sanitize inline SVG markup for safe inline preservation.
+     *
+     * Strips only the genuinely-unsafe parts of an inline SVG — `<script>` /
+     * `<style>` elements, `<foreignObject>` (which can embed arbitrary HTML and
+     * scripts), event-handler attributes, and `javascript:` URLs — while keeping
+     * the SVG shape and structure markup (`svg`/`path`/`circle`/`rect`/`g`/
+     * `text`/`polygon`/...) intact so the artwork still renders. This preserves
+     * the graphic rather than dropping the whole SVG when a single unsafe
+     * attribute or element is present.
+     */
+    private function sanitizeInlineSvgMarkup(DOMElement $element): string
+    {
+        // safeFallbackHtml() already removes <script>/<style> elements, on*
+        // handlers, javascript: in href/src/xlink:href, and srcdoc.
+        $html = $this->safeFallbackHtml($element);
+
+        // foreignObject can carry arbitrary embedded HTML (iframes, objects,
+        // embeds) that shape markup never needs; drop it entirely (DOMDocument
+        // lowercases the tag name when serializing parsed HTML).
+        $html = preg_replace('@<foreignobject\b[^>]*>.*?</foreignobject>@si', '', $html) ?? $html;
+        $html = preg_replace('@<foreignobject\b[^>]*/?>@si', '', $html) ?? $html;
+
+        // Neutralize any residual javascript: carried in remaining attributes
+        // (e.g. a style attribute), dropping the whole attribute so the shape
+        // it belongs to survives.
+        $html = preg_replace('/\s+[a-zA-Z_:][\w:.-]*\s*=\s*("[^"]*javascript:[^"]*"|\'[^\']*javascript:[^\']*\'|[^\s>]*javascript:[^\s>]*)/i', '', $html) ?? $html;
+
+        return trim($html);
+    }
+
+    /**
      * @param array<int, array<string, mixed>> $rows
      * @return array<int, array<string, mixed>>
      */

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -604,7 +604,11 @@ $assert('core/math' === ($texClassBlocks[1]['blockName'] ?? ''), 'TeX-delimited 
 $assert(str_contains((string) ($texClassBlocks[1]['attrs']['content'] ?? ''), 'a^2 + b^2 = c^2'), 'TeX-delimited math preserves expression content');
 
 $unsafeInlineSvg = ( new HtmlTransformer() )->transform('<main><svg onload="alert(1)"><path d="M0 0h1v1z"></path></svg></main>')->toArray();
-$assert('html_unsafe_inline_svg' === ($unsafeInlineSvg['fallbacks'][0]['diagnostic_code'] ?? ''), 'unsafe inline SVG remains a fallback diagnostic');
+$unsafeInlineSvgContent = (string) ($unsafeInlineSvg['blocks'][0]['attrs']['content'] ?? '');
+$assert('core/html' === ($unsafeInlineSvg['blocks'][0]['blockName'] ?? ''), 'unsafe inline SVG is sanitized and preserved as a core/html block instead of being dropped');
+$assert(array() === ($unsafeInlineSvg['fallbacks'] ?? array()), 'inline SVG with stripped unsafe parts keeps its artwork and emits no fallback diagnostic');
+$assert(str_contains($unsafeInlineSvgContent, '<svg') && str_contains($unsafeInlineSvgContent, '<path'), 'sanitized inline SVG keeps its shape markup');
+$assert(! str_contains($unsafeInlineSvgContent, 'onload'), 'sanitized inline SVG strips event-handler attributes while keeping the shapes');
 
 $asideContainer = ( new HtmlTransformer() )->transform(
     '<main><aside class="sidebar"><h2>Docs</h2><nav><a href="/start">Start</a><a href="/api">API</a></nav></aside><section><h1>Content</h1></section></main>',
@@ -1076,12 +1080,12 @@ $assert(str_contains((string) ($safeDecorativeSvg['serialized_blocks'] ?? ''), '
 $unsafeDecorativeSvg = ( new HtmlTransformer() )->transform(
     '<main><svg aria-hidden="true" viewBox="0 0 10 10"><script>alert(1)</script><circle onclick="alert(1)" cx="5" cy="5" r="5"></circle></svg></main>'
 )->toArray();
-$unsafeDecorativeDiagnostics = $unsafeDecorativeSvg['source_reports']['conversion_report']['fallback_diagnostics'] ?? array();
-$unsafeDecorativeDiagnostic = $unsafeDecorativeDiagnostics[0] ?? array();
-$assert(array() === ($unsafeDecorativeSvg['blocks'] ?? array()), 'unsafe decorative inline SVG does not materialize as a block');
-$assertNormalizedFallbackDiagnostic($unsafeDecorativeDiagnostic, 'html_unsafe_inline_svg', 'warning', 'sanitization_review', 'image_asset');
-$assert(! str_contains((string) ($unsafeDecorativeDiagnostic['html'] ?? ''), '<script'), 'unsafe inline SVG fallback metadata strips scripts');
-$assert(! str_contains((string) ($unsafeDecorativeDiagnostic['html'] ?? ''), 'onclick='), 'unsafe inline SVG fallback metadata strips event attributes');
+$unsafeDecorativeContent = (string) ($unsafeDecorativeSvg['blocks'][0]['attrs']['content'] ?? '');
+$assert('core/html' === ($unsafeDecorativeSvg['blocks'][0]['blockName'] ?? ''), 'unsafe decorative inline SVG is sanitized and preserved as a core/html block rather than dropped');
+$assert(array() === ($unsafeDecorativeSvg['source_reports']['conversion_report']['fallback_diagnostics'] ?? array()), 'sanitized decorative inline SVG keeps its artwork and emits no fallback diagnostic');
+$assert(str_contains($unsafeDecorativeContent, '<circle'), 'unsafe decorative inline SVG keeps its shape markup after sanitization');
+$assert(! str_contains($unsafeDecorativeContent, '<script'), 'unsafe decorative inline SVG strips scripts while keeping the shapes');
+$assert(! str_contains($unsafeDecorativeContent, 'onclick'), 'unsafe decorative inline SVG strips event-handler attributes while keeping the shapes');
 
 $interactions = ( new HtmlTransformer() )->transform(
     '<main><button aria-controls="panel" aria-expanded="false" data-action="toggle">Toggle</button><section id="panel">Panel</section><div role="tablist"><button role="tab" aria-controls="tab-one">One</button></div><div id="tab-one">Tab one</div><dialog id="signup">Join</dialog><div class="hero-carousel"><button class="carousel-next">Next</button></div></main>'

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-artwork-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-artwork-preserved.json
@@ -1,0 +1,39 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-artwork-preserved",
+  "description": "Preserves a full inline SVG illustration (rect/circle/path/g/polygon/text plus a comment) as a faithful core/html block, keeping every shape and the text content. Unsafe parts carried on the same SVG (an inline <script> and an event-handler attribute) are stripped while the artwork survives, so the graphic never collapses to an empty block.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-artwork-preserved.json",
+    "notes": "Product-neutral fixture for inline decorative/illustrative SVG artwork preservation with in-place sanitization."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><section class=\"album-art\"><svg viewBox=\"0 0 600 600\" role=\"img\" aria-label=\"Mara Vale cover\"><!-- Background --><rect width=\"600\" height=\"600\" fill=\"#1a1a2e\"></rect><circle cx=\"300\" cy=\"240\" r=\"160\" fill=\"#e94560\"></circle><path d=\"M100 400 L300 300 L500 400 Z\" fill=\"#0f3460\"></path><g opacity=\"0.8\"><polygon points=\"50,50 100,50 75,90\" fill=\"#fff\"></polygon></g><text x=\"300\" y=\"520\" text-anchor=\"middle\" fill=\"#fff\" onclick=\"steal()\">Between the Fog and the Fire</text><script>track()</script></svg></section></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/html" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<svg viewBox=\"0 0 600 600\"" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "aria-label=\"Mara Vale cover\"" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<rect width=\"600\" height=\"600\" fill=\"#1a1a2e\"></rect>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<circle cx=\"300\" cy=\"240\" r=\"160\" fill=\"#e94560\"></circle>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<path d=\"M100 400 L300 300 L500 400 Z\" fill=\"#0f3460\"></path>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<polygon points=\"50,50 100,50 75,90\" fill=\"#fff\"></polygon>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "Between the Fog and the Fire" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "<script" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "onclick" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "track()" },
+    { "path": "assets", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-unsafe.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-unsafe.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-unsafe",
-  "description": "Diagnoses unsafe inline SVG and exposes only sanitized bounded fallback metadata.",
+  "description": "Sanitizes unsafe inline SVG in place — stripping scripts, event handlers, and javascript: URLs — while preserving the shape markup as a faithful core/html block instead of dropping the whole graphic.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-unsafe.json",
-    "notes": "Product-neutral fixture for script, event handler, and javascript URL stripping from inline SVG fallback metadata."
+    "notes": "Product-neutral fixture proving unsafe parts are removed from inline SVG while the artwork survives."
   },
   "legacy_comparison": {
     "skip": true,
@@ -16,27 +16,21 @@
     "content": "<svg viewBox=\"0 0 20 20\" onclick=\"alert(1)\"><script>alert(2)</script><a xlink:href=\"javascript:alert(3)\"><circle onmouseover=\"alert(4)\" cx=\"10\" cy=\"10\" r=\"8\"></circle></a></svg><p>After</p>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/paragraph", "attrs": { "content": "After" } }
-  ],
-  "expected_fallbacks": [
-    { "type": "inline_svg", "reason": "unsafe_inline_svg", "tag": "svg", "diagnostic_code": "html_unsafe_inline_svg", "selector": "svg:nth-of-type(1)", "child_count": 2 }
+    { "path": "blocks.0", "name": "core/html" },
+    { "path": "blocks.1", "name": "core/paragraph", "attrs": { "content": "After" } }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 1 },
-    { "path": "fallbacks.0.attributes.onclick", "assert": "equals", "value": null },
-    { "path": "fallbacks.0.attributes.viewbox", "assert": "equals", "value": "0 0 20 20" },
-    { "path": "fallbacks.0.html", "assert": "contains", "value": "<svg viewbox=\"0 0 20 20\">" },
-    { "path": "fallbacks.0.html", "assert": "contains", "value": "<circle cx=\"10\" cy=\"10\" r=\"8\"></circle>" },
-    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "<script" },
-    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "onclick" },
-    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "onmouseover" },
-    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "javascript:" },
-    { "path": "fallbacks.0.html", "assert": "not_contains", "value": "alert(" },
-    { "path": "fallbacks.0.html_truncated", "assert": "equals", "value": false },
-    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_unsafe_inline_svg" },
-    { "path": "diagnostics.1.reason", "assert": "equals", "value": "unsafe_inline_svg" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks.0.attrs.content", "assert": "contains", "value": "<svg viewBox=\"0 0 20 20\">" },
+    { "path": "blocks.0.attrs.content", "assert": "contains", "value": "<circle cx=\"10\" cy=\"10\" r=\"8\"></circle>" },
+    { "path": "blocks.0.attrs.content", "assert": "not_contains", "value": "<script" },
+    { "path": "blocks.0.attrs.content", "assert": "not_contains", "value": "onclick" },
+    { "path": "blocks.0.attrs.content", "assert": "not_contains", "value": "onmouseover" },
+    { "path": "blocks.0.attrs.content", "assert": "not_contains", "value": "javascript:" },
+    { "path": "blocks.0.attrs.content", "assert": "not_contains", "value": "alert(" },
+    { "path": "assets", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
+++ b/php-transformer/tests/fixtures/parity/html-provenance-wrapper-safety.json
@@ -13,7 +13,7 @@
   },
   "operation": "html_transformer.transform",
   "input": {
-    "content": "<section class=\"hero-shell\" style=\"padding: 2rem;\" data-layout=\"constrained\" onclick=\"alert(1)\"><h2>Only child</h2></section><svg class=\"badge\"><script>alert(1)</script><circle cx=\"1\" cy=\"1\" r=\"1\"></circle></svg>",
+    "content": "<section class=\"hero-shell\" style=\"padding: 2rem;\" data-layout=\"constrained\" onclick=\"alert(1)\"><h2>Only child</h2></section><svg class=\"badge\"><script>alert(1)</script></svg>",
     "options": {
       "source": "fixture:html-provenance-wrapper-safety",
       "source_scope": "parity"


### PR DESCRIPTION
## Problem

A source inline `<svg>` illustration (album/hero art with `<path>`/`<circle>`/`<rect>`/`<g>`/`<polygon>`/`<text>`) was converted to `core/html` but the SVG elements were stripped, leaving only whitespace, comments, and stray text — the artwork **vanished** into an empty block.

Root cause: `HtmlTransformer::inlineSvgBlockFromElement()` checked `isSafeSvgContent()` against the **raw** outer HTML and bailed to `null` (a bounded fallback diagnostic) the moment a single unsafe attribute or element appeared — *before* `safeFallbackHtml()` ever got a chance to strip the unsafe parts. Any SVG carrying an inline `<script>`, an event handler (`onclick`, `onload`, `onmouseover`, …), or a `javascript:` URL lost its entire graphic.

## Fix

Sanitize the SVG in place and keep the shapes, instead of dropping the whole graphic:

- **`DomHelpersTrait::sanitizeInlineSvgMarkup()`** builds on the existing `safeFallbackHtml()` (which removes `<script>`/`<style>` elements, `on*` handlers, `javascript:` in `href`/`src`/`xlink:href`, and `srcdoc`), then additionally drops `<foreignObject>` subtrees (the main SVG XSS vector) and neutralizes any residual `javascript:` carried in other attributes.
- **`DomHelpersTrait::svgHasDrawableContent()`** gates preservation: an SVG whose only content is unsafe (e.g. a lone `<script>`) has nothing to render once sanitized, so it defers to the bounded fallback diagnostic rather than emitting an empty graphic.
- **`inlineSvgBlockFromElement()`** now sanitizes, re-verifies the cleaned markup with `isSafeSvgContent()` (the safety gate — no `script`/event-handler/`javascript:` vector can ship), and emits the artwork as `core/html`.

### Before / after

| Input | Before | After |
|---|---|---|
| `<svg>` with shapes + inline `<script>` / `onclick` | whole graphic dropped → empty block + fallback diagnostic | shapes kept as `core/html`; script + handler stripped; no fallback |
| `<svg>` whose only content is `<script>` | fallback diagnostic | fallback diagnostic (unchanged — nothing to draw) |
| safe `<svg>` with shapes | preserved | preserved (unchanged) |

Generic: applies to any inline SVG, not fixture-specific. Security preserved — `<script>`, event handlers, `javascript:` URLs, and `<foreignObject>` are removed while the shape/structure markup (`svg`/`path`/`circle`/`rect`/`g`/`text`/…) survives.

## Tests

- New fixture `html-inline-svg-artwork-preserved`: a full illustration (rect/circle/path/g/polygon/text + comment) carrying an inline `<script>` and an `onclick` handler → all shapes and text preserved, unsafe parts stripped, no fallback.
- `html-inline-svg-unsafe` rewritten: proves unsafe parts are stripped while the shape survives as `core/html` (previously asserted the graphic vanished).
- `html-provenance-wrapper-safety`: its incidental badge SVG made script-only so it still exercises the fallback path; fixture intent unchanged.
- Contract assertions in `tests/contract/run.php` updated to the sanitize-and-preserve behavior.
- Full `composer test` green (contract + 157 parity fixtures + packaging); `php -l` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause investigation, implementing the sanitize-and-preserve fix, and authoring/updating fixtures and contract tests.