### PR TITLE
Decode content_base64 when extracting inline styles (fixes empty style.css on real imports)

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -213,7 +213,7 @@ final class ArtifactNormalizer
         foreach ( $files as $file ) {
             $expanded[] = $file;
 
-            $content = is_string($file['content'] ?? null) ? (string) $file['content'] : '';
+            $content = $this->payload($file, (string) ($file['path'] ?? ''))['content'];
             if ( '' === trim($content) || ! $this->isHtmlLikeFile($file) || ! preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $content, $matches) ) {
                 continue;
             }

--- a/php-transformer/tests/fixtures/parity/artifact-inline-style-extraction-base64.json
+++ b/php-transformer/tests/fixtures/parity/artifact-inline-style-extraction-base64.json
@@ -1,0 +1,43 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-inline-style-extraction-base64",
+  "description": "Extracts inline stylesheet rules from base64-encoded full HTML documents into materializable CSS assets, matching the real import CLI which transmits file payloads as content_base64.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-inline-style-extraction-base64.json",
+    "notes": "Real import-theme CLI payloads carry HTML as content_base64; inline <style> extraction must decode the payload before scanning so it does not regress to an empty stylesheet."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream artifact primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "files": [
+        {
+          "path": "index.html",
+          "content_base64": "PCFkb2N0eXBlIGh0bWw+PGh0bWw+PGhlYWQ+PHRpdGxlPlN0eWxlZCBQb3J0Zm9saW88L3RpdGxlPjxzdHlsZT46cm9vdHstLWFjY2VudDojYzRhMzVhOy0taW5rOiMxYTFhMWF9Ym9keXtiYWNrZ3JvdW5kOiNmYWY3ZjA7Y29sb3I6dmFyKC0taW5rKX0uaGVyb3ttaW4taGVpZ2h0OjEwMHZoO2NvbG9yOnZhcigtLWFjY2VudCl9LmNhcmR7Ym9yZGVyOjFweCBzb2xpZCB2YXIoLS1hY2NlbnQpO3BhZGRpbmc6MnJlbX0ud29yay1ncmlke2Rpc3BsYXk6Z3JpZDtncmlkLXRlbXBsYXRlLWNvbHVtbnM6cmVwZWF0KDMsMWZyKX08L3N0eWxlPjwvaGVhZD48Ym9keT48bWFpbj48c2VjdGlvbiBjbGFzcz0iaGVybyI+PGgxPlN0eWxlZCBQb3J0Zm9saW88L2gxPjxwPlZpc3VhbCBjbGFzc2VzIG5lZWQgdGhlaXIgc3R5bGVzaGVldC48L3A+PC9zZWN0aW9uPjxzZWN0aW9uIGNsYXNzPSJ3b3JrLWdyaWQiPjxhcnRpY2xlIGNsYXNzPSJjYXJkIj48aDI+Q2FzZSBTdHVkeTwvaDI+PC9hcnRpY2xlPjwvc2VjdGlvbj48L21haW4+PC9ib2R5PjwvaHRtbD4=",
+          "kind": "html"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "assets", "assert": "count", "count": 1 },
+    { "path": "assets.0.path", "assert": "equals", "value": "index.inline.css" },
+    { "path": "assets.0.kind", "assert": "equals", "value": "css" },
+    { "path": "assets.0.role", "assert": "equals", "value": "stylesheet" },
+    { "path": "assets.0.content", "assert": "contains", "value": ":root{--accent:#c4a35a" },
+    { "path": "assets.0.content", "assert": "contains", "value": "body{background:#faf7f0;color:var(--ink)}" },
+    { "path": "assets.0.content", "assert": "contains", "value": ".card{border:1px solid var(--accent)" },
+    { "path": "source_reports.artifact.files_by_source.inline-style", "assert": "equals", "value": 1 },
+    { "path": "source_reports.artifact.files_by_intent.style", "assert": "equals", "value": 1 },
+    { "path": "source_reports.compiled_site.theme.stylesheets.0", "assert": "equals", "value": "index.inline.css" },
+    { "path": "source_reports.materialization_plan.assets.0.target_path", "assert": "equals", "value": "index.inline.css" },
+    { "path": "source_reports.materialization_plan.assets.0.content", "assert": "contains", "value": ":root{--accent:#c4a35a" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Styled Portfolio" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "hero" }
+  ]
+}


### PR DESCRIPTION
## What
Fixes the dominant cause of unstyled imports. `ArtifactNormalizer::withInlineStyleFiles()` scanned raw `$file['content']` for inline `<style>`, but the real SSI `import-theme` CLI sends every file as `content_base64`. So on a real import the inline `<style>` was never seen → never lifted into a CSS asset → the generated theme shipped an empty `style.css` (~154-byte header only) → the entire site rendered unstyled (white background, no card chrome). This is the verified, dominant ~0.9 visual-mismatch cause.

## Change (1 line, `src/ArtifactCompiler/ArtifactNormalizer.php:215`)
- Before: `$content = is_string($file['content'] ?? null) ? (string) $file['content'] : '';`
- After: `$content = $this->payload($file, (string) ($file['path'] ?? ''))['content'];`
- Reuses the normalizer's existing `payload()` decode helper (already honors `content_base64` everywhere else + emits `content_base64_preferred`). Plain `content` is a superset and unaffected; binary decodes to '' and is correctly skipped.

## Verification
- New parity fixture `artifact-inline-style-extraction-base64.json` (base64 HTML with `:root`/`body`/`.card`) asserts inline CSS is lifted into `materialization_plan.assets`. **Fails on trunk** (`assets: Expected 1 Actual 0`), passes with the fix.
- Real 15-saas, real-CLI base64 encoding: CSS asset **0 bytes → 25,311 bytes** with `:root` present (now identical to the plain path). Plain-content imports unchanged (25,311 → 25,311).
- `composer test` + `composer parity`: **163 fixtures** green.

## Why it hid
The homeboy-rigs fixture matrix built artifacts with plain `content` while the product uses base64 — so the gate tested a path the product never runs. Coverage gap closed in a companion homeboy-rigs PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Root-cause diagnosis (real-import computed-style inspection), the fix, and tests under human review.
