### PR TITLE
figma-transformer: per-family font CSS overrides

### DIFF
--- a/figma-transformer/bin/figma-transformer
+++ b/figma-transformer/bin/figma-transformer
@@ -12,7 +12,7 @@ if ( is_readable($autoload) ) {
 
 $path = $argv[1] ?? '';
 if ( '' === $path || '--help' === $path || '-h' === $path ) {
-    fwrite(STDERR, "Usage: figma-transformer <path-to-fig-or-scenegraph-json> [--inspect-frames[=<limit>]] [--multi-page] [--frame-ids=<id,id>] [--entry-frame-id=<id>] [--max-pages=<count>] [--output-dir=<dir>] [--omit-asset-content] [--max-nodes=<count>] [--max-kiwi-message-decode-bytes=<bytes>] [--zstd-command=<path>] [--frame-id=<id>] [--font-css=<css>] [--font-css-file=<path>] [--render-text-glyph-paths] [--parity-status=<status>] [--parity-report-path=<path>] [--parity-source-screenshot-url=<url>] [--parity-source-screenshot-path=<path>] [--parity-generated-screenshot-artifact=<artifact>] [--parity-diff-image-artifact=<artifact>] [--parity-pixel-mismatch-count=<count>] [--parity-pixel-mismatch-ratio=<ratio>] [--parity-threshold=<ratio>] [--parity-viewport=<width>x<height>] [--parity-dom-boxes-path=<path>] [--parity-layout-report-path=<path>] [--parity-render-evidence-path=<path>] [--parity-layout-mismatch-count=<count>]\n");
+    fwrite(STDERR, "Usage: figma-transformer <path-to-fig-or-scenegraph-json> [--inspect-frames[=<limit>]] [--multi-page] [--frame-ids=<id,id>] [--entry-frame-id=<id>] [--max-pages=<count>] [--output-dir=<dir>] [--omit-asset-content] [--max-nodes=<count>] [--max-kiwi-message-decode-bytes=<bytes>] [--zstd-command=<path>] [--frame-id=<id>] [--font-css=<css>] [--font-css-file=<path>] [--font-family-css=<family>:<css>] [--font-family-css-file=<family>:<path>] [--render-text-glyph-paths] [--parity-status=<status>] [--parity-report-path=<path>] [--parity-source-screenshot-url=<url>] [--parity-source-screenshot-path=<path>] [--parity-generated-screenshot-artifact=<artifact>] [--parity-diff-image-artifact=<artifact>] [--parity-pixel-mismatch-count=<count>] [--parity-pixel-mismatch-ratio=<ratio>] [--parity-threshold=<ratio>] [--parity-viewport=<width>x<height>] [--parity-dom-boxes-path=<path>] [--parity-layout-report-path=<path>] [--parity-render-evidence-path=<path>] [--parity-layout-mismatch-count=<count>]\n");
     exit(1);
 }
 
@@ -101,6 +101,33 @@ foreach ( array_slice($argv, 2) as $argument ) {
         $fontCss = is_readable($value) ? file_get_contents($value) : false;
         if ( false !== $fontCss ) {
             $options['font_css'] = $fontCss;
+        }
+        continue;
+    }
+
+    if ( 'font-family-css' === $name ) {
+        $colonPos = strpos($value, ':');
+        if ( false !== $colonPos ) {
+            $familyName = strtolower(trim(substr($value, 0, $colonPos)));
+            $familyCss = trim(substr($value, $colonPos + 1));
+            if ( '' !== $familyName && '' !== $familyCss ) {
+                $options['font_family_overrides'][$familyName] = $familyCss;
+            }
+        }
+        continue;
+    }
+
+    if ( 'font-family-css-file' === $name ) {
+        $colonPos = strpos($value, ':');
+        if ( false !== $colonPos ) {
+            $familyName = strtolower(trim(substr($value, 0, $colonPos)));
+            $filePath = trim(substr($value, $colonPos + 1));
+            if ( '' !== $familyName && '' !== $filePath ) {
+                $familyCss = is_readable($filePath) ? file_get_contents($filePath) : false;
+                if ( false !== $familyCss ) {
+                    $options['font_family_overrides'][$familyName] = $familyCss;
+                }
+            }
         }
         continue;
     }

--- a/figma-transformer/src/Html/FontResolver.php
+++ b/figma-transformer/src/Html/FontResolver.php
@@ -73,13 +73,21 @@ final class FontResolver
      *     coverage: array<int, array<string, mixed>>
      * }
      */
-    public function resolve(array $fontUsage, string $operatorFontCss = ''): array
+    public function resolve(array $fontUsage, string $operatorFontCss = '', array $familyOverrides = []): array
     {
         $operatorSupplied = '' !== trim($operatorFontCss);
         $coverage = array();
         $resolved = array();
         $unresolved = array();
         $cdnFamilies = array();
+        $familyOverridesApplied = array();
+        $familyOverridesCss = array();
+
+        // Normalize override keys to lowercase for safe lookups.
+        $normalizedOverrides = array();
+        foreach ( $familyOverrides as $overrideKey => $overrideCss ) {
+            $normalizedOverrides[strtolower((string) $overrideKey)] = (string) $overrideCss;
+        }
 
         foreach ( $fontUsage as $usage ) {
             if ( ! is_array($usage) ) {
@@ -96,6 +104,12 @@ final class FontResolver
 
             if ( $operatorSupplied ) {
                 $resolution = 'operator_supplied';
+            } elseif ( isset($normalizedOverrides[$key]) ) {
+                $resolution = 'operator_supplied_family';
+                if ( ! isset($familyOverridesCss[$key]) ) {
+                    $familyOverridesCss[$key] = $normalizedOverrides[$key];
+                    $familyOverridesApplied[] = $family;
+                }
             } elseif ( isset(self::WEB_SAFE[$key]) ) {
                 $resolution = 'web_safe';
             } elseif ( isset(self::googleFonts()[$key]) ) {
@@ -128,15 +142,29 @@ final class FontResolver
             $coverage[] = $entry;
         }
 
-        $css = $operatorSupplied ? trim($operatorFontCss) : $this->cdnImportCss($cdnFamilies);
+        if ( $operatorSupplied ) {
+            $css = trim($operatorFontCss);
+        } else {
+            $parts = array();
+            $cdnCss = $this->cdnImportCss($cdnFamilies);
+            if ( '' !== $cdnCss ) {
+                $parts[] = $cdnCss;
+            }
+            ksort($familyOverridesCss, SORT_NATURAL | SORT_FLAG_CASE);
+            foreach ( $familyOverridesCss as $overrideCss ) {
+                $parts[] = $overrideCss;
+            }
+            $css = implode("\n", $parts);
+        }
 
         return array(
-            'css'                 => $css,
-            'operator_supplied'   => $operatorSupplied,
-            'resolved_families'   => array_values(array_unique($resolved)),
-            'unresolved_families' => array_values(array_unique($unresolved)),
-            'cdn_families'        => array_keys($cdnFamilies),
-            'coverage'            => $coverage,
+            'css'                      => $css,
+            'operator_supplied'        => $operatorSupplied,
+            'resolved_families'        => array_values(array_unique($resolved)),
+            'unresolved_families'      => array_values(array_unique($unresolved)),
+            'cdn_families'             => array_keys($cdnFamilies),
+            'family_overrides_applied' => array_values(array_unique($familyOverridesApplied)),
+            'coverage'                 => $coverage,
         );
     }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -146,6 +146,7 @@ final class StaticHtmlEmitter
             $cssRules[] = '.figma-text-glyphs{display:block;width:100%;height:100%;overflow:visible}';
         }
         $operatorFontCss = $this->fontCss($options);
+        $familyOverrides = $this->fontFamilyOverrides($options);
 
         foreach ( $nodes as $node ) {
             if ( ! is_array($node) ) {
@@ -162,7 +163,7 @@ final class StaticHtmlEmitter
 
         $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
         $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
-        $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
+        $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss, $familyOverrides);
         $fontCss = (string) $fontResolution['css'];
 
         $designSystem = $this->designSystemExtractor()->extract($scenegraph);
@@ -266,6 +267,7 @@ final class StaticHtmlEmitter
             $cssRules[] = '.figma-text-glyphs{display:block;width:100%;height:100%;overflow:visible}';
         }
         $operatorFontCss = $this->fontCss($options);
+        $familyOverrides = $this->fontFamilyOverrides($options);
         $files = array();
         $pages = array();
         $renderedNodes = array();
@@ -362,7 +364,7 @@ final class StaticHtmlEmitter
 
         $fontFamilies = $this->fontFamilies($nodeStyleDiagnostics);
         $fontUsage = $this->fontUsage($nodeStyleDiagnostics);
-        $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss);
+        $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss, $familyOverrides);
         $fontCss = (string) $fontResolution['css'];
         $designSystem = $this->designSystemExtractor()->extract($scenegraph);
         foreach ( $this->designSystemDiagnostics($designSystem) as $diagnostic ) {
@@ -1403,6 +1405,25 @@ final class StaticHtmlEmitter
     }
 
     /**
+     * @param array<string, mixed> $options
+     * @return array<string, string>
+     */
+    private function fontFamilyOverrides(array $options): array
+    {
+        $overrides = $options['font_family_overrides'] ?? array();
+        if ( ! is_array($overrides) ) {
+            return array();
+        }
+        $result = array();
+        foreach ( $overrides as $family => $css ) {
+            if ( is_string($family) && '' !== $family && is_string($css) ) {
+                $result[strtolower($family)] = $css;
+            }
+        }
+        return $result;
+    }
+
+    /**
      * @param array<string, mixed> $node
      * @param array<int, string> $styles
      * @return array<string, mixed>
@@ -1921,15 +1942,16 @@ final class StaticHtmlEmitter
         );
         $fontCss = (string) ($fontResolution['css'] ?? '');
         $fonts = array(
-            'families'      => $fontFamilies,
-            'usage'         => $fontUsage,
-            'count'         => count($fontFamilies),
-            'css_supplied'  => (bool) ($fontResolution['operator_supplied'] ?? false),
-            'materialized'  => '' !== $fontCss,
-            'missing_css'   => array_values($fontResolution['unresolved_families'] ?? array()),
-            'resolved_css'  => array_values($fontResolution['resolved_families'] ?? array()),
-            'cdn_families'  => array_values($fontResolution['cdn_families'] ?? array()),
-            'coverage'      => array_values($fontResolution['coverage'] ?? array()),
+            'families'                => $fontFamilies,
+            'usage'                   => $fontUsage,
+            'count'                   => count($fontFamilies),
+            'css_supplied'            => (bool) ($fontResolution['operator_supplied'] ?? false),
+            'materialized'            => '' !== $fontCss,
+            'missing_css'             => array_values($fontResolution['unresolved_families'] ?? array()),
+            'resolved_css'            => array_values($fontResolution['resolved_families'] ?? array()),
+            'cdn_families'            => array_values($fontResolution['cdn_families'] ?? array()),
+            'family_overrides_applied' => array_values($fontResolution['family_overrides_applied'] ?? array()),
+            'coverage'                => array_values($fontResolution['coverage'] ?? array()),
         );
 
         $links = $this->linkDiagnostics();

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6360,6 +6360,64 @@ $assert(0 === ($plainCoverage['frame_count'] ?? -1), 'design-system-plain-site-z
 $designSystemRerun = blocks_engine_figma_transformer_transform_scenegraph($designSystemScenegraph);
 $assert($designSystemCss === $fileContent($designSystemRerun, 'style.css'), 'design-system-css-deterministic');
 
+// PER-FAMILY FONT OVERRIDES — verify that $familyOverrides fills in gaps
+// without displacing the GF auto-import for other families. The design uses
+// two font families: Inter (resolvable via Google Fonts CDN) and Brand Sans
+// (not in GF, supplied via font_family_overrides). Expectations:
+//   1. Emitted CSS contains the GF @import for Inter.
+//   2. Emitted CSS contains the operator-supplied Brand Sans CSS.
+//   3. family_overrides_applied in transform_diagnostics.fonts = ['Brand Sans'].
+//   4. Inter is not in missing_css (unresolved_families).
+//   5. Brand Sans is not in missing_css (unresolved_families).
+$fontFamilyOverridesResult = blocks_engine_figma_transformer_transform_scenegraph(
+    array(
+        'name'  => 'Per-Family Font Override Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'pffo:frame',
+                'type'     => 'FRAME',
+                'name'     => 'Hero',
+                'width'    => 1200,
+                'height'   => 600,
+                'children' => array(
+                    array(
+                        'id'         => 'pffo:text-inter',
+                        'type'       => 'TEXT',
+                        'name'       => 'Inter Heading',
+                        'characters' => 'Hello World',
+                        'fontName'   => array('family' => 'Inter', 'style' => 'Regular'),
+                        'fontSize'   => 32,
+                        'fontWeight' => 400,
+                    ),
+                    array(
+                        'id'         => 'pffo:text-brand',
+                        'type'       => 'TEXT',
+                        'name'       => 'Brand Heading',
+                        'characters' => 'Brand Copy',
+                        'fontName'   => array('family' => 'Brand Sans', 'style' => 'Regular'),
+                        'fontSize'   => 24,
+                        'fontWeight' => 400,
+                    ),
+                ),
+            ),
+        ),
+    ),
+    array(
+        'font_family_overrides' => array(
+            'brand sans' => "@import url('https://api.fontshare.com/v2/css?f[]=brand-sans@400&display=swap');",
+        ),
+    )
+);
+$fontFamilyOverridesCss = $fileContent($fontFamilyOverridesResult, 'style.css');
+$fontFamilyOverridesFonts = $fontFamilyOverridesResult['source_reports']['figma']['html']['transform_diagnostics']['fonts'] ?? array();
+$assert('success' === ($fontFamilyOverridesResult['status'] ?? null), 'per-family-override-transform-success');
+$assert(str_contains($fontFamilyOverridesCss, 'fonts.googleapis.com'), 'per-family-override-css-contains-gf-import');
+$assert(str_contains($fontFamilyOverridesCss, 'Inter'), 'per-family-override-css-gf-import-includes-inter');
+$assert(str_contains($fontFamilyOverridesCss, "api.fontshare.com"), 'per-family-override-css-contains-operator-css');
+$assert(array('Brand Sans') === ($fontFamilyOverridesFonts['family_overrides_applied'] ?? null), 'per-family-override-family-overrides-applied');
+$assert(! in_array('Inter', $fontFamilyOverridesFonts['missing_css'] ?? array(), true), 'per-family-override-inter-not-unresolved');
+$assert(! in_array('Brand Sans', $fontFamilyOverridesFonts['missing_css'] ?? array(), true), 'per-family-override-brand-sans-not-unresolved');
+
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");
     exit(1);


### PR DESCRIPTION
## Summary

- `FontResolver::resolve()` gains a `$familyOverrides` third param (`array<lowercased-family => css-string>`). Matched families resolve as `operator_supplied_family` while unmatched families continue through the GF auto-resolve path.
- Emitted CSS combines the GF `@import` (for CDN-resolved families) with the per-family operator CSS strings, joined by newlines.
- `family_overrides_applied` added to resolver return value and surfaced in `transform_diagnostics.fonts`.
- CLI gains `--font-family-css="Family Name:<css>"` and `--font-family-css-file="Family Name:<path>"` (both repeatable), populating `font_family_overrides` without touching `--font-css` backwards compat.
- Contract test added: Inter (GF-resolvable) + Brand Sans (operator override) — verifies GF import present, operator CSS present, `family_overrides_applied` correct, neither family unresolved.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation