### PR TITLE
Add 5 dynamic-shop fixtures to the corpus (ecommerce/catalog)

### DIFF
--- a/fixtures/websites/74-lumen-coffee/about.html
+++ b/fixtures/websites/74-lumen-coffee/about.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>About — Lumen Coffee Roasters</title>
+<meta name="description" content="The story behind Lumen Coffee Roasters — our values, our sourcing relationships, and the people who roast your coffee.">
+<link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="wrap site-header__inner">
+    <a class="brand" href="index.html" aria-label="Lumen Coffee Roasters home">
+      <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true">
+        <circle cx="24" cy="24" r="22" fill="#2b1d16"/>
+        <circle cx="24" cy="24" r="11" fill="none" stroke="#c2703d" stroke-width="2.5"/>
+        <g stroke="#f5ece0" stroke-width="2.2" stroke-linecap="round">
+          <path d="M24 9v4M24 35v4M9 24h4M35 24h4M13.4 13.4l2.8 2.8M31.8 31.8l2.8 2.8M13.4 34.6l2.8-2.8M31.8 16.2l2.8-2.8"/>
+        </g>
+        <path d="M24 19c3 2 3 6 0 8-3-2-3-6 0-8z" fill="#c2703d"/>
+      </svg>
+      <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+    </a>
+    <nav class="primary-nav" id="primary-nav" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="shop.html">Shop</a>
+      <a href="about.html" aria-current="page">About</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <button class="icon-btn nav-toggle" id="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-nav">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke-linecap="round"/></svg>
+      </button>
+      <button class="icon-btn" type="button" data-open-drawer aria-label="Open cart">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 6h15l-1.5 9h-12z" stroke-linejoin="round"/><path d="M6 6 5 3H2" stroke-linecap="round"/><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/></svg>
+        <span class="cart-badge" data-cart-badge hidden>0</span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<main>
+  <section class="page-hero">
+    <div class="wrap">
+      <h1>We chase clarity, not trends.</h1>
+      <p>Lumen is a small roastery with a simple obsession: coffee that tastes exactly like where it came from.</p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrap split">
+      <div class="split__art" aria-hidden="true">
+        <svg viewBox="0 0 320 320">
+          <circle cx="160" cy="160" r="150" fill="#ece0cf"/>
+          <!-- roaster drum -->
+          <rect x="70" y="120" width="150" height="90" rx="16" fill="#3a2820"/>
+          <circle cx="145" cy="165" r="32" fill="#2b1d16"/>
+          <circle cx="145" cy="165" r="32" fill="none" stroke="#c2703d" stroke-width="4"/>
+          <circle cx="145" cy="165" r="14" fill="#6f4326"/>
+          <rect x="220" y="150" width="40" height="30" rx="6" fill="#5a3a28"/>
+          <path d="M70 210 h150 v18 a8 8 0 0 1-8 8 H78 a8 8 0 0 1-8-8 z" fill="#2b1d16"/>
+          <circle cx="90" cy="100" r="6" fill="#c2703d"/>
+          <circle cx="110" cy="92" r="5" fill="#c2703d" opacity="0.7"/>
+          <circle cx="128" cy="100" r="4" fill="#c2703d" opacity="0.5"/>
+          <rect x="92" y="236" width="20" height="34" fill="#5a3a28"/>
+          <rect x="178" y="236" width="20" height="34" fill="#5a3a28"/>
+        </svg>
+      </div>
+      <div class="split__copy">
+        <p class="eyebrow">Est. 2014</p>
+        <h2>From one drum roaster to a community.</h2>
+        <p>We started in a borrowed garage with a 5-kilo roaster and a notebook full of curves. A decade later we're still roasting in small batches by taste — because a thermometer can tell you the temperature, but only your palate can tell you when a coffee sings.</p>
+        <p>Today we work with the same families we met in our first year, paying prices that make farming sustainable and reinvesting in the cup quality that started it all.</p>
+        <a class="btn btn--solid" href="shop.html">Taste what we mean</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section--cream">
+    <div class="wrap">
+      <div class="section-head">
+        <p class="eyebrow">What we stand for</p>
+        <h2>Roastery values</h2>
+        <p>Three principles guide every buying trip, every roast, and every bag we ship.</p>
+      </div>
+      <div class="values">
+        <div class="value-card">
+          <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 21s-7-4.5-9.5-9A5.5 5.5 0 0 1 12 6a5.5 5.5 0 0 1 9.5 6c-2.5 4.5-9.5 9-9.5 9z" stroke-linejoin="round"/></svg>
+          <h3>Relationships first</h3>
+          <p>We buy direct and return season after season. Knowing our growers means we can chase quality together, year over year.</p>
+        </div>
+        <div class="value-card">
+          <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3v18M5 8c0 4 14 4 14 0M5 16c0 4 14 4 14 0" stroke-linecap="round"/></svg>
+          <h3>Full traceability</h3>
+          <p>Every bag lists farm, region, altitude and process. If we can't tell you where it grew, we don't sell it.</p>
+        </div>
+        <div class="value-card">
+          <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2a7 7 0 0 0-7 7c0 3 2 5 2 8h10c0-3 2-5 2-8a7 7 0 0 0-7-7zM9 21h6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <h3>Roasted with intent</h3>
+          <p>No dark-and-burnt to hide flaws. We profile each lot to reveal its sweetness, acidity and texture.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrap">
+      <div class="section-head">
+        <p class="eyebrow">The humans behind the beans</p>
+        <h2>Meet the roastery team</h2>
+        <p>A small crew of growers-turned-roasters, baristas and coffee nerds.</p>
+      </div>
+      <div class="team">
+        <div class="member">
+          <div class="member__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6" stroke-linecap="round"/></svg></div>
+          <h3>Mara Vale</h3>
+          <span>Founder &amp; Head Roaster</span>
+          <p>Built the first roast curves and still cups every new lot before it ships.</p>
+        </div>
+        <div class="member">
+          <div class="member__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6" stroke-linecap="round"/></svg></div>
+          <h3>Diego Ramos</h3>
+          <span>Green Buyer</span>
+          <p>Spends harvest season at origin, sourcing the lots that define each year.</p>
+        </div>
+        <div class="member">
+          <div class="member__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6" stroke-linecap="round"/></svg></div>
+          <h3>Priya Nair</h3>
+          <span>Quality &amp; Education</span>
+          <p>Runs the cupping lab and our public brew classes every weekend.</p>
+        </div>
+        <div class="member">
+          <div class="member__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6" stroke-linecap="round"/></svg></div>
+          <h3>Theo Brandt</h3>
+          <span>Roastery &amp; Logistics</span>
+          <p>Keeps the drum turning and your order out the door within 48 hours.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section--espresso">
+    <div class="wrap text-center">
+      <div class="section-head" style="margin-bottom:24px;">
+        <h2>Come taste the difference</h2>
+        <p>Visit the roastery cafe, or have fresh coffee shipped straight to your door.</p>
+      </div>
+      <a class="btn btn--cream btn--lg" href="shop.html">Shop the Roastery</a>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+        <p>Small-batch specialty coffee, roasted to order in the heart of the city since 2014.</p>
+      </div>
+      <div><h4>Shop</h4><ul>
+        <li><a href="shop.html?category=single-origin">Single Origin</a></li>
+        <li><a href="shop.html?category=blend">Blends</a></li>
+        <li><a href="shop.html?category=espresso">Espresso</a></li>
+        <li><a href="shop.html?category=gear">Brew Gear</a></li>
+      </ul></div>
+      <div><h4>Company</h4><ul>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="shop.html">All Products</a></li>
+      </ul></div>
+      <div><h4>Visit</h4><ul>
+        <li>114 Kindling Lane</li>
+        <li>Riverbend, OR 97000</li>
+        <li><a href="contact.html">Store hours</a></li>
+      </ul></div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; <span data-year>2026</span> Lumen Coffee Roasters. All rights reserved.</span>
+      <span>Crafted with care · Brewed with intent</span>
+    </div>
+  </div>
+</footer>
+
+<div class="scrim" id="drawer-scrim" hidden></div>
+<aside class="drawer" id="cart-drawer" aria-label="Shopping cart" aria-hidden="true">
+  <div class="drawer__head">
+    <h2>Your Cart</h2>
+    <button class="drawer__close" type="button" data-close-drawer aria-label="Close cart">&times;</button>
+  </div>
+  <div class="drawer__body">
+    <p class="drawer__empty" data-drawer-empty>Your cart is empty.<br>Time to find your next favorite coffee.</p>
+    <ul class="cart-lines" data-drawer-list></ul>
+  </div>
+  <div class="drawer__foot" data-drawer-foot hidden>
+    <div class="drawer__subtotal"><span>Subtotal</span><strong data-drawer-subtotal>$0.00</strong></div>
+    <a class="btn btn--ghost btn--block" href="cart.html">View Cart</a>
+    <p class="drawer__note">Free shipping on orders over $45.</p>
+  </div>
+</aside>
+
+<div class="modal" id="product-modal" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" hidden>
+  <div class="modal__dialog">
+    <button class="modal__close" type="button" data-close-modal aria-label="Close details">&times;</button>
+    <div id="product-modal-body"></div>
+  </div>
+</div>
+
+<script src="js/products.js"></script>
+<script src="js/cart.js"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/74-lumen-coffee/cart.html
+++ b/fixtures/websites/74-lumen-coffee/cart.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Your Cart — Lumen Coffee Roasters</title>
+<meta name="description" content="Review your Lumen Coffee order — adjust quantities, remove items and check out.">
+<link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="wrap site-header__inner">
+    <a class="brand" href="index.html" aria-label="Lumen Coffee Roasters home">
+      <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true">
+        <circle cx="24" cy="24" r="22" fill="#2b1d16"/>
+        <circle cx="24" cy="24" r="11" fill="none" stroke="#c2703d" stroke-width="2.5"/>
+        <g stroke="#f5ece0" stroke-width="2.2" stroke-linecap="round">
+          <path d="M24 9v4M24 35v4M9 24h4M35 24h4M13.4 13.4l2.8 2.8M31.8 31.8l2.8 2.8M13.4 34.6l2.8-2.8M31.8 16.2l2.8-2.8"/>
+        </g>
+        <path d="M24 19c3 2 3 6 0 8-3-2-3-6 0-8z" fill="#c2703d"/>
+      </svg>
+      <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+    </a>
+    <nav class="primary-nav" id="primary-nav" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="shop.html">Shop</a>
+      <a href="about.html">About</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <button class="icon-btn nav-toggle" id="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-nav">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke-linecap="round"/></svg>
+      </button>
+      <button class="icon-btn" type="button" data-open-drawer aria-label="Open cart">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 6h15l-1.5 9h-12z" stroke-linejoin="round"/><path d="M6 6 5 3H2" stroke-linecap="round"/><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/></svg>
+        <span class="cart-badge" data-cart-badge hidden>0</span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<main>
+  <section class="page-hero">
+    <div class="wrap">
+      <h1>Your cart</h1>
+      <p>Review your order below. Everything ships roasted-to-order within 48 hours.</p>
+    </div>
+  </section>
+
+  <section class="section section--tight" id="cart-page">
+    <div class="wrap">
+      <div class="cart-empty" data-cartpage-empty hidden>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true"><path d="M6 6h15l-1.5 9h-12z" stroke-linejoin="round"/><path d="M6 6 5 3H2" stroke-linecap="round"/><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/></svg>
+        <h2>Your cart is empty</h2>
+        <p>Looks like you haven't added any coffee yet.</p>
+        <a class="btn btn--solid btn--lg" href="shop.html">Start shopping</a>
+      </div>
+
+      <div class="cart-page-layout" data-cartpage-summary hidden>
+        <div>
+          <div class="cart-card">
+            <ul class="cart-lines" data-cartpage-list></ul>
+          </div>
+          <div class="cart-actions">
+            <a class="btn btn--ghost" href="shop.html">&larr; Continue shopping</a>
+            <button class="btn btn--ghost" type="button" data-cart-clear>Clear cart</button>
+          </div>
+        </div>
+        <aside class="cart-summary">
+          <h2>Order summary</h2>
+          <div class="sum-row"><span>Subtotal</span><span data-cartpage-subtotal>$0.00</span></div>
+          <div class="sum-row"><span>Shipping</span><span data-cartpage-shipping>—</span></div>
+          <div class="sum-row sum-row--total"><span>Total</span><span data-cartpage-total>$0.00</span></div>
+          <button class="btn btn--solid btn--block btn--lg mt-32" type="button" data-cart-checkout>Checkout</button>
+          <p class="drawer__note">Free shipping on orders over $45. Taxes calculated at checkout.</p>
+        </aside>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+        <p>Small-batch specialty coffee, roasted to order in the heart of the city since 2014.</p>
+      </div>
+      <div><h4>Shop</h4><ul>
+        <li><a href="shop.html?category=single-origin">Single Origin</a></li>
+        <li><a href="shop.html?category=blend">Blends</a></li>
+        <li><a href="shop.html?category=espresso">Espresso</a></li>
+        <li><a href="shop.html?category=gear">Brew Gear</a></li>
+      </ul></div>
+      <div><h4>Company</h4><ul>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="shop.html">All Products</a></li>
+      </ul></div>
+      <div><h4>Visit</h4><ul>
+        <li>114 Kindling Lane</li>
+        <li>Riverbend, OR 97000</li>
+        <li><a href="contact.html">Store hours</a></li>
+      </ul></div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; <span data-year>2026</span> Lumen Coffee Roasters. All rights reserved.</span>
+      <span>Crafted with care · Brewed with intent</span>
+    </div>
+  </div>
+</footer>
+
+<div class="scrim" id="drawer-scrim" hidden></div>
+<aside class="drawer" id="cart-drawer" aria-label="Shopping cart" aria-hidden="true">
+  <div class="drawer__head">
+    <h2>Your Cart</h2>
+    <button class="drawer__close" type="button" data-close-drawer aria-label="Close cart">&times;</button>
+  </div>
+  <div class="drawer__body">
+    <p class="drawer__empty" data-drawer-empty>Your cart is empty.<br>Time to find your next favorite coffee.</p>
+    <ul class="cart-lines" data-drawer-list></ul>
+  </div>
+  <div class="drawer__foot" data-drawer-foot hidden>
+    <div class="drawer__subtotal"><span>Subtotal</span><strong data-drawer-subtotal>$0.00</strong></div>
+    <a class="btn btn--ghost btn--block" href="cart.html">View Cart</a>
+    <p class="drawer__note">Free shipping on orders over $45.</p>
+  </div>
+</aside>
+
+<div class="modal" id="product-modal" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" hidden>
+  <div class="modal__dialog">
+    <button class="modal__close" type="button" data-close-modal aria-label="Close details">&times;</button>
+    <div id="product-modal-body"></div>
+  </div>
+</div>
+
+<script src="js/products.js"></script>
+<script src="js/cart.js"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/74-lumen-coffee/contact.html
+++ b/fixtures/websites/74-lumen-coffee/contact.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Contact — Lumen Coffee Roasters</title>
+<meta name="description" content="Get in touch with Lumen Coffee Roasters. Store hours, location, and a contact form for wholesale, events and general questions.">
+<link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="wrap site-header__inner">
+    <a class="brand" href="index.html" aria-label="Lumen Coffee Roasters home">
+      <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true">
+        <circle cx="24" cy="24" r="22" fill="#2b1d16"/>
+        <circle cx="24" cy="24" r="11" fill="none" stroke="#c2703d" stroke-width="2.5"/>
+        <g stroke="#f5ece0" stroke-width="2.2" stroke-linecap="round">
+          <path d="M24 9v4M24 35v4M9 24h4M35 24h4M13.4 13.4l2.8 2.8M31.8 31.8l2.8 2.8M13.4 34.6l2.8-2.8M31.8 16.2l2.8-2.8"/>
+        </g>
+        <path d="M24 19c3 2 3 6 0 8-3-2-3-6 0-8z" fill="#c2703d"/>
+      </svg>
+      <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+    </a>
+    <nav class="primary-nav" id="primary-nav" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="shop.html">Shop</a>
+      <a href="about.html">About</a>
+      <a href="contact.html" aria-current="page">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <button class="icon-btn nav-toggle" id="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-nav">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke-linecap="round"/></svg>
+      </button>
+      <button class="icon-btn" type="button" data-open-drawer aria-label="Open cart">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 6h15l-1.5 9h-12z" stroke-linejoin="round"/><path d="M6 6 5 3H2" stroke-linecap="round"/><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/></svg>
+        <span class="cart-badge" data-cart-badge hidden>0</span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<main>
+  <section class="page-hero">
+    <div class="wrap">
+      <h1>Say hello</h1>
+      <p>Questions about a coffee, wholesale, or hosting an event? Drop us a line — we read every message.</p>
+    </div>
+  </section>
+
+  <section class="section section--tight">
+    <div class="wrap contact-layout">
+      <div>
+        <h2 style="margin-top:0;">Send us a message</h2>
+        <form id="contact-form" novalidate>
+          <div class="form-grid">
+            <div class="form-field">
+              <label for="cf-name">Name</label>
+              <input id="cf-name" name="name" type="text" autocomplete="name" required>
+            </div>
+            <div class="form-field">
+              <label for="cf-email">Email</label>
+              <input id="cf-email" name="email" type="email" autocomplete="email" required>
+            </div>
+            <div class="form-field full">
+              <label for="cf-subject">Subject</label>
+              <input id="cf-subject" name="subject" type="text">
+            </div>
+            <div class="form-field full">
+              <label for="cf-message">Message</label>
+              <textarea id="cf-message" name="message" rows="6" required></textarea>
+            </div>
+          </div>
+          <button class="btn btn--solid btn--lg" type="submit">Send message</button>
+          <p class="form-status" id="contact-status" role="status" hidden></p>
+        </form>
+      </div>
+
+      <div>
+        <div class="info-card">
+          <h3>Visit the roastery</h3>
+          <p style="margin:0 0 6px;">114 Kindling Lane<br>Riverbend, OR 97000</p>
+          <p style="margin:0;"><a href="mailto:hello@lumencoffee.example">hello@lumencoffee.example</a><br><a href="tel:+15035550142">(503) 555-0142</a></p>
+        </div>
+        <div class="info-card">
+          <h3>Store hours</h3>
+          <ul class="hours">
+            <li><span>Monday – Friday</span><span>7:00am – 6:00pm</span></li>
+            <li><span>Saturday</span><span>8:00am – 5:00pm</span></li>
+            <li><span>Sunday</span><span>8:00am – 2:00pm</span></li>
+            <li><span>Holidays</span><span>Reduced hours</span></li>
+          </ul>
+        </div>
+        <div class="map-illustration" role="img" aria-label="Stylized map showing the Lumen roastery location near the river and Kindling Lane.">
+          <svg viewBox="0 0 400 240" preserveAspectRatio="xMidYMid meet">
+            <rect width="400" height="240" fill="#ece0cf"/>
+            <!-- river -->
+            <path d="M0 60 C120 40 160 130 280 110 C340 100 380 150 400 140 L400 240 L0 240 Z" fill="#7a8b5a" opacity="0.28"/>
+            <path d="M0 60 C120 40 160 130 280 110 C340 100 380 150 400 140" fill="none" stroke="#7a8b5a" stroke-width="3" opacity="0.5"/>
+            <!-- roads -->
+            <path d="M40 0 L120 240" stroke="#fbf6ee" stroke-width="14"/>
+            <path d="M0 150 L400 120" stroke="#fbf6ee" stroke-width="14"/>
+            <path d="M280 0 L320 240" stroke="#fbf6ee" stroke-width="10"/>
+            <!-- blocks -->
+            <rect x="150" y="40" width="40" height="34" rx="4" fill="#d8c4a8"/>
+            <rect x="210" y="160" width="46" height="36" rx="4" fill="#d8c4a8"/>
+            <rect x="60" y="180" width="34" height="30" rx="4" fill="#d8c4a8"/>
+            <!-- pin -->
+            <g transform="translate(196 96)">
+              <path d="M0 0 C-18 -22 -14 -48 0 -48 C14 -48 18 -22 0 0z" fill="#c2703d"/>
+              <circle cx="0" cy="-30" r="8" fill="#fbf6ee"/>
+            </g>
+            <text x="206" y="70" font-family="Georgia, serif" font-size="12" fill="#3a2418">Kindling Ln</text>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+        <p>Small-batch specialty coffee, roasted to order in the heart of the city since 2014.</p>
+      </div>
+      <div><h4>Shop</h4><ul>
+        <li><a href="shop.html?category=single-origin">Single Origin</a></li>
+        <li><a href="shop.html?category=blend">Blends</a></li>
+        <li><a href="shop.html?category=espresso">Espresso</a></li>
+        <li><a href="shop.html?category=gear">Brew Gear</a></li>
+      </ul></div>
+      <div><h4>Company</h4><ul>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="shop.html">All Products</a></li>
+      </ul></div>
+      <div><h4>Visit</h4><ul>
+        <li>114 Kindling Lane</li>
+        <li>Riverbend, OR 97000</li>
+        <li><a href="contact.html">Store hours</a></li>
+      </ul></div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; <span data-year>2026</span> Lumen Coffee Roasters. All rights reserved.</span>
+      <span>Crafted with care · Brewed with intent</span>
+    </div>
+  </div>
+</footer>
+
+<div class="scrim" id="drawer-scrim" hidden></div>
+<aside class="drawer" id="cart-drawer" aria-label="Shopping cart" aria-hidden="true">
+  <div class="drawer__head">
+    <h2>Your Cart</h2>
+    <button class="drawer__close" type="button" data-close-drawer aria-label="Close cart">&times;</button>
+  </div>
+  <div class="drawer__body">
+    <p class="drawer__empty" data-drawer-empty>Your cart is empty.<br>Time to find your next favorite coffee.</p>
+    <ul class="cart-lines" data-drawer-list></ul>
+  </div>
+  <div class="drawer__foot" data-drawer-foot hidden>
+    <div class="drawer__subtotal"><span>Subtotal</span><strong data-drawer-subtotal>$0.00</strong></div>
+    <a class="btn btn--ghost btn--block" href="cart.html">View Cart</a>
+    <p class="drawer__note">Free shipping on orders over $45.</p>
+  </div>
+</aside>
+
+<div class="modal" id="product-modal" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" hidden>
+  <div class="modal__dialog">
+    <button class="modal__close" type="button" data-close-modal aria-label="Close details">&times;</button>
+    <div id="product-modal-body"></div>
+  </div>
+</div>
+
+<script src="js/products.js"></script>
+<script src="js/cart.js"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/74-lumen-coffee/css/styles.css
+++ b/fixtures/websites/74-lumen-coffee/css/styles.css
@@ -1,0 +1,386 @@
+/* Lumen Coffee Roasters — cohesive stylesheet */
+:root {
+  --espresso: #2b1d16;
+  --espresso-soft: #3a2820;
+  --cream: #f5ece0;
+  --cream-deep: #ece0cf;
+  --parchment: #fbf6ee;
+  --amber: #c2703d;
+  --amber-deep: #a85b2c;
+  --sage: #7a8b5a;
+  --ink: #2b1d16;
+  --muted: #6f5d50;
+  --line: #e2d4c2;
+  --white: #ffffff;
+  --shadow: 0 14px 40px rgba(43, 29, 22, 0.14);
+  --shadow-sm: 0 6px 18px rgba(43, 29, 22, 0.10);
+  --radius: 14px;
+  --radius-sm: 9px;
+  --serif: Georgia, 'Times New Roman', 'Iowan Old Style', serif;
+  --sans: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --wrap: 1180px;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  color: var(--ink);
+  background: var(--parchment);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+body.no-scroll { overflow: hidden; }
+
+h1, h2, h3, h4 { font-family: var(--serif); font-weight: 700; line-height: 1.15; color: var(--espresso); }
+
+a { color: var(--amber-deep); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+img, svg { max-width: 100%; }
+
+.wrap { width: 100%; max-width: var(--wrap); margin: 0 auto; padding: 0 24px; }
+
+.section { padding: 76px 0; }
+.section--tight { padding: 52px 0; }
+.section--cream { background: var(--cream); }
+.section--espresso { background: var(--espresso); color: var(--cream); }
+.section--espresso h1, .section--espresso h2, .section--espresso h3 { color: var(--cream); }
+
+.eyebrow {
+  font-family: var(--sans);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--amber-deep);
+  margin: 0 0 12px;
+}
+.section--espresso .eyebrow { color: var(--amber); }
+
+.section-head { max-width: 640px; margin: 0 auto 44px; text-align: center; }
+.section-head h2 { font-size: clamp(1.8rem, 4vw, 2.6rem); margin: 0 0 12px; }
+.section-head p { color: var(--muted); margin: 0; font-size: 1.05rem; }
+.section--espresso .section-head p { color: rgba(245, 236, 224, 0.8); }
+
+/* ---------------------------------------------------------- buttons */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--sans); font-weight: 600; font-size: 0.92rem;
+  padding: 11px 20px; border-radius: 999px; border: 1.5px solid transparent;
+  cursor: pointer; transition: transform .15s ease, background .15s ease, color .15s ease, box-shadow .15s ease;
+  text-decoration: none; line-height: 1; white-space: nowrap;
+}
+.btn:hover { text-decoration: none; transform: translateY(-1px); }
+.btn:active { transform: translateY(0); }
+.btn--solid { background: var(--amber); color: #fff; border-color: var(--amber); }
+.btn--solid:hover { background: var(--amber-deep); border-color: var(--amber-deep); }
+.btn--ghost { background: transparent; color: var(--espresso); border-color: var(--line); }
+.btn--ghost:hover { border-color: var(--amber); color: var(--amber-deep); }
+.btn--cream { background: var(--cream); color: var(--espresso); border-color: var(--cream); }
+.btn--cream:hover { background: #fff; }
+.btn--lg { padding: 14px 26px; font-size: 1rem; }
+.btn--block { width: 100%; }
+.linklike { background: none; border: 0; padding: 0; font: inherit; color: inherit; cursor: pointer; text-align: left; }
+.linklike:hover { color: var(--amber-deep); }
+
+/* ---------------------------------------------------------- header */
+.site-header {
+  position: sticky; top: 0; z-index: 40;
+  background: rgba(251, 246, 238, 0.92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.site-header__inner { display: flex; align-items: center; justify-content: space-between; gap: 18px; height: 72px; }
+.brand { display: flex; align-items: center; gap: 11px; color: var(--espresso); }
+.brand:hover { text-decoration: none; }
+.brand__mark { width: 38px; height: 38px; flex: none; }
+.brand__name { font-family: var(--serif); font-weight: 700; font-size: 1.32rem; letter-spacing: 0.01em; }
+.brand__name small { display: block; font-family: var(--sans); font-weight: 600; font-size: 0.58rem; letter-spacing: 0.32em; text-transform: uppercase; color: var(--amber-deep); }
+
+.primary-nav { display: flex; align-items: center; gap: 26px; }
+.primary-nav a { color: var(--espresso); font-weight: 600; font-size: 0.95rem; }
+.primary-nav a:hover { color: var(--amber-deep); text-decoration: none; }
+.primary-nav a[aria-current="page"] { color: var(--amber-deep); }
+
+.header-actions { display: flex; align-items: center; gap: 8px; }
+.icon-btn {
+  position: relative; display: inline-flex; align-items: center; justify-content: center;
+  width: 42px; height: 42px; border-radius: 50%; border: 1.5px solid var(--line);
+  background: #fff; cursor: pointer; color: var(--espresso); transition: border-color .15s, color .15s;
+}
+.icon-btn:hover { border-color: var(--amber); color: var(--amber-deep); }
+.icon-btn svg { width: 20px; height: 20px; }
+.cart-badge {
+  position: absolute; top: -5px; right: -5px; min-width: 19px; height: 19px; padding: 0 5px;
+  background: var(--amber); color: #fff; border-radius: 999px; font-size: 0.68rem; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center; font-family: var(--sans);
+}
+.nav-toggle { display: none; }
+
+/* ---------------------------------------------------------- hero */
+.hero { background: linear-gradient(160deg, var(--cream) 0%, var(--parchment) 60%); overflow: hidden; }
+.hero__inner { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 48px; align-items: center; padding: 78px 0 86px; }
+.hero__title { font-size: clamp(2.4rem, 5.2vw, 4rem); margin: 14px 0 18px; }
+.hero__title em { color: var(--amber-deep); font-style: italic; }
+.hero__lead { font-size: 1.15rem; color: var(--muted); max-width: 30em; margin: 0 0 28px; }
+.hero__cta { display: flex; gap: 12px; flex-wrap: wrap; }
+.hero__stats { display: flex; gap: 34px; margin-top: 40px; }
+.hero__stat strong { display: block; font-family: var(--serif); font-size: 1.7rem; color: var(--espresso); }
+.hero__stat span { font-size: 0.82rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.1em; }
+.hero__art { display: flex; justify-content: center; }
+.hero__art svg { width: 100%; max-width: 440px; filter: drop-shadow(0 24px 40px rgba(43,29,22,0.18)); }
+
+/* ---------------------------------------------------------- product grid */
+.product-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(244px, 1fr)); gap: 26px; }
+.featured-grid { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.card {
+  background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
+  overflow: hidden; display: flex; flex-direction: column;
+  transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+}
+.card:hover { transform: translateY(-4px); box-shadow: var(--shadow); border-color: var(--cream-deep); }
+.card__media {
+  border: 0; cursor: pointer; padding: 18px 18px 6px; background: linear-gradient(180deg, var(--cream) 0%, #fff 100%);
+  display: flex; justify-content: center;
+}
+.card__media svg { width: 150px; height: 180px; transition: transform .25s ease; }
+.card:hover .card__media svg { transform: scale(1.05) rotate(-1deg); }
+.card__body { padding: 16px 18px 20px; display: flex; flex-direction: column; flex: 1; }
+.card__cat { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.14em; color: var(--amber-deep); font-weight: 700; }
+.card__title { font-size: 1.18rem; margin: 6px 0 8px; }
+.card__notes { color: var(--muted); font-size: 0.9rem; margin: 0 0 12px; flex: 1; }
+.card__meta { margin-bottom: 14px; }
+.chip {
+  display: inline-block; background: var(--cream); color: var(--espresso-soft);
+  border-radius: 999px; padding: 4px 11px; font-size: 0.74rem; font-weight: 600;
+}
+.card__foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.price { font-family: var(--serif); font-size: 1.25rem; font-weight: 700; color: var(--espresso); }
+.card__actions { display: flex; gap: 6px; }
+.card__actions .btn { padding: 8px 13px; font-size: 0.82rem; }
+
+.empty-note { grid-column: 1 / -1; text-align: center; color: var(--muted); padding: 40px 0; }
+
+/* ---------------------------------------------------------- shop toolbar */
+.shop-layout { display: grid; grid-template-columns: 250px 1fr; gap: 36px; align-items: start; }
+.filters {
+  position: sticky; top: 96px; background: #fff; border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 22px;
+}
+.filters h2 { font-size: 1.1rem; margin: 0 0 16px; }
+.field { margin-bottom: 18px; }
+.field label { display: block; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-bottom: 7px; }
+.field select {
+  width: 100%; padding: 10px 12px; border-radius: var(--radius-sm); border: 1.5px solid var(--line);
+  background: var(--parchment); font: inherit; color: var(--ink); cursor: pointer;
+}
+.field select:focus { outline: 2px solid var(--amber); outline-offset: 1px; border-color: var(--amber); }
+.shop-bar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 24px; flex-wrap: wrap; }
+.result-count { color: var(--muted); font-size: 0.92rem; }
+
+/* ---------------------------------------------------------- process steps */
+.steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 26px; }
+.step { text-align: center; }
+.step__num {
+  width: 54px; height: 54px; margin: 0 auto 16px; border-radius: 50%;
+  background: var(--amber); color: #fff; display: flex; align-items: center; justify-content: center;
+  font-family: var(--serif); font-size: 1.4rem; font-weight: 700;
+}
+.section--espresso .step__num { background: var(--cream); color: var(--espresso); }
+.step h3 { font-size: 1.2rem; margin: 0 0 8px; }
+.step p { color: var(--muted); margin: 0; font-size: 0.94rem; }
+.section--espresso .step p { color: rgba(245,236,224,0.78); }
+
+/* ---------------------------------------------------------- story split */
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: center; }
+.split__art { display: flex; justify-content: center; }
+.split__art svg { width: 100%; max-width: 380px; }
+.split h2 { font-size: clamp(1.7rem, 3.6vw, 2.4rem); margin: 0 0 16px; }
+.split p { color: var(--muted); margin: 0 0 16px; font-size: 1.02rem; }
+.section--espresso .split p { color: rgba(245,236,224,0.82); }
+
+/* ---------------------------------------------------------- values / team */
+.values { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 24px; }
+.value-card { background: #fff; border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; }
+.value-card .ico { width: 44px; height: 44px; color: var(--amber-deep); margin-bottom: 12px; }
+.value-card h3 { font-size: 1.18rem; margin: 0 0 8px; }
+.value-card p { color: var(--muted); margin: 0; font-size: 0.94rem; }
+
+.team { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 26px; }
+.member { text-align: center; }
+.member__avatar { width: 120px; height: 120px; margin: 0 auto 14px; border-radius: 50%; background: var(--cream); display: flex; align-items: center; justify-content: center; border: 2px solid var(--cream-deep); }
+.member__avatar svg { width: 70px; height: 70px; color: var(--amber-deep); }
+.member h3 { font-size: 1.12rem; margin: 0 0 2px; }
+.member span { color: var(--amber-deep); font-size: 0.84rem; font-weight: 600; }
+.member p { color: var(--muted); font-size: 0.9rem; margin: 8px 0 0; }
+
+/* ---------------------------------------------------------- newsletter */
+.newsletter { background: var(--espresso); color: var(--cream); border-radius: var(--radius); padding: 48px; text-align: center; }
+.newsletter h2 { color: var(--cream); font-size: clamp(1.6rem, 3.4vw, 2.2rem); margin: 0 0 10px; }
+.newsletter p { color: rgba(245,236,224,0.8); margin: 0 0 24px; }
+.newsletter__form { display: flex; gap: 10px; max-width: 460px; margin: 0 auto; flex-wrap: wrap; }
+.newsletter__form input {
+  flex: 1; min-width: 200px; padding: 13px 16px; border-radius: 999px; border: 0; font: inherit;
+}
+.newsletter__form input:focus { outline: 2px solid var(--amber); }
+.form-status { margin: 14px 0 0; color: var(--amber); font-size: 0.92rem; font-weight: 600; }
+.section--espresso .form-status, .newsletter .form-status { color: #ffd9b8; }
+
+/* ---------------------------------------------------------- forms (contact) */
+.form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.form-field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
+.form-field.full { grid-column: 1 / -1; }
+.form-field label { font-weight: 600; font-size: 0.9rem; }
+.form-field input, .form-field textarea {
+  padding: 12px 14px; border-radius: var(--radius-sm); border: 1.5px solid var(--line);
+  background: #fff; font: inherit; color: var(--ink); resize: vertical;
+}
+.form-field input:focus, .form-field textarea:focus { outline: 2px solid var(--amber); outline-offset: 1px; border-color: var(--amber); }
+
+.contact-layout { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 44px; align-items: start; }
+.info-card { background: #fff; border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; margin-bottom: 20px; }
+.info-card h3 { font-size: 1.15rem; margin: 0 0 12px; }
+.hours { list-style: none; padding: 0; margin: 0; }
+.hours li { display: flex; justify-content: space-between; padding: 7px 0; border-bottom: 1px solid var(--line); font-size: 0.94rem; }
+.hours li:last-child { border-bottom: 0; }
+.hours span:last-child { color: var(--muted); }
+.map-illustration { width: 100%; border-radius: var(--radius); overflow: hidden; border: 1px solid var(--line); }
+.map-illustration svg { display: block; width: 100%; height: auto; }
+
+/* ---------------------------------------------------------- drawer */
+.scrim { position: fixed; inset: 0; background: rgba(43,29,22,0.5); z-index: 60; }
+.drawer {
+  position: fixed; top: 0; right: 0; height: 100%; width: 400px; max-width: 92vw;
+  background: var(--parchment); z-index: 70; box-shadow: var(--shadow);
+  transform: translateX(100%); transition: transform .28s ease;
+  display: flex; flex-direction: column;
+}
+.drawer.is-open { transform: translateX(0); }
+.drawer__head { display: flex; align-items: center; justify-content: space-between; padding: 20px 22px; border-bottom: 1px solid var(--line); }
+.drawer__head h2 { font-size: 1.3rem; margin: 0; }
+.drawer__close, .modal__close {
+  width: 38px; height: 38px; border-radius: 50%; border: 1.5px solid var(--line); background: #fff;
+  cursor: pointer; font-size: 1.2rem; line-height: 1; color: var(--espresso);
+}
+.drawer__close:hover, .modal__close:hover { border-color: var(--amber); color: var(--amber-deep); }
+.drawer__body { flex: 1; overflow-y: auto; padding: 8px 22px; }
+.drawer__empty { text-align: center; color: var(--muted); padding: 50px 10px; }
+.drawer__foot { padding: 20px 22px; border-top: 1px solid var(--line); background: #fff; }
+.drawer__subtotal { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 14px; }
+.drawer__subtotal strong { font-family: var(--serif); font-size: 1.4rem; }
+.drawer__note { font-size: 0.8rem; color: var(--muted); text-align: center; margin: 12px 0 0; }
+
+.cart-lines { list-style: none; margin: 0; padding: 0; }
+.line { display: grid; grid-template-columns: 60px 1fr auto; gap: 14px; padding: 18px 0; border-bottom: 1px solid var(--line); }
+.line__media { background: var(--cream); border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; }
+.line__media svg { width: 46px; height: 56px; }
+.line__name { font-weight: 600; margin: 0 0 2px; font-size: 0.98rem; }
+.line__opts { color: var(--muted); font-size: 0.78rem; margin: 0 0 4px; }
+.line__price { color: var(--muted); font-size: 0.8rem; margin: 0 0 8px; }
+.line__end { text-align: right; display: flex; flex-direction: column; justify-content: space-between; align-items: flex-end; }
+.line__total { font-family: var(--serif); font-weight: 700; }
+.line__remove { background: none; border: 0; color: var(--amber-deep); cursor: pointer; font-size: 0.8rem; padding: 0; text-decoration: underline; }
+.line__remove:hover { color: var(--espresso); }
+
+/* stepper */
+.stepper { display: inline-flex; align-items: center; border: 1.5px solid var(--line); border-radius: 999px; overflow: hidden; background: #fff; }
+.stepper__btn { width: 34px; height: 34px; border: 0; background: #fff; cursor: pointer; font-size: 1.1rem; line-height: 1; color: var(--espresso); }
+.stepper__btn:hover { background: var(--cream); color: var(--amber-deep); }
+.stepper__val { min-width: 34px; text-align: center; font-weight: 600; }
+.stepper--sm .stepper__btn { width: 28px; height: 28px; font-size: 0.95rem; }
+.stepper--sm .stepper__val { min-width: 28px; font-size: 0.9rem; }
+
+/* ---------------------------------------------------------- modal */
+.modal { position: fixed; inset: 0; z-index: 80; display: flex; align-items: center; justify-content: center; padding: 24px; background: rgba(43,29,22,0.55); }
+.modal__dialog { background: var(--parchment); border-radius: var(--radius); max-width: 760px; width: 100%; max-height: 90vh; overflow-y: auto; position: relative; box-shadow: var(--shadow); }
+.modal__close { position: absolute; top: 16px; right: 16px; z-index: 2; }
+.detail { display: grid; grid-template-columns: 0.9fr 1.1fr; }
+.detail__media { background: linear-gradient(180deg, var(--cream) 0%, var(--cream-deep) 100%); display: flex; align-items: center; justify-content: center; padding: 36px; border-radius: var(--radius) 0 0 var(--radius); }
+.detail__media svg { width: 100%; max-width: 220px; filter: drop-shadow(0 16px 28px rgba(43,29,22,0.2)); }
+.detail__info { padding: 34px 32px; }
+.detail__title { font-size: 1.9rem; margin: 6px 0 6px; }
+.detail__roast { color: var(--amber-deep); font-weight: 600; margin: 0 0 14px; }
+.detail__notes { color: var(--muted); margin: 0 0 22px; }
+.opt-group { margin-bottom: 18px; }
+.opt-group__label { display: block; font-size: 0.76rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-bottom: 8px; }
+.opt-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.opt { padding: 8px 14px; border-radius: 999px; border: 1.5px solid var(--line); background: #fff; cursor: pointer; font: inherit; font-size: 0.86rem; color: var(--espresso); transition: all .15s; }
+.opt:hover { border-color: var(--amber); }
+.opt.is-active { background: var(--espresso); color: var(--cream); border-color: var(--espresso); }
+.detail__buy { display: flex; align-items: center; gap: 14px; margin-top: 26px; flex-wrap: wrap; }
+
+/* ---------------------------------------------------------- cart page */
+.cart-page-layout { display: grid; grid-template-columns: 1.5fr 1fr; gap: 40px; align-items: start; }
+.cart-card { background: #fff; border: 1px solid var(--line); border-radius: var(--radius); padding: 8px 26px; }
+.cart-summary { background: #fff; border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; position: sticky; top: 96px; }
+.cart-summary h2 { font-size: 1.3rem; margin: 0 0 18px; }
+.sum-row { display: flex; justify-content: space-between; padding: 9px 0; color: var(--muted); }
+.sum-row--total { border-top: 1px solid var(--line); margin-top: 8px; padding-top: 16px; color: var(--espresso); font-weight: 700; }
+.sum-row--total span:last-child { font-family: var(--serif); font-size: 1.4rem; }
+.cart-empty { text-align: center; padding: 60px 20px; }
+.cart-empty svg { width: 90px; height: 90px; color: var(--cream-deep); margin-bottom: 16px; }
+.cart-actions { display: flex; justify-content: space-between; align-items: center; padding: 18px 0; flex-wrap: wrap; gap: 10px; }
+
+/* ---------------------------------------------------------- page hero */
+.page-hero { background: var(--cream); padding: 60px 0; text-align: center; }
+.page-hero h1 { font-size: clamp(2rem, 5vw, 3rem); margin: 0 0 12px; }
+.page-hero p { color: var(--muted); max-width: 560px; margin: 0 auto; font-size: 1.08rem; }
+
+/* ---------------------------------------------------------- footer */
+.site-footer { background: var(--espresso); color: rgba(245,236,224,0.8); padding: 60px 0 28px; }
+.footer-grid { display: grid; grid-template-columns: 1.6fr 1fr 1fr 1fr; gap: 36px; margin-bottom: 40px; }
+.footer-grid h4 { color: var(--cream); font-family: var(--sans); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.12em; margin: 0 0 14px; }
+.footer-grid ul { list-style: none; padding: 0; margin: 0; }
+.footer-grid li { margin-bottom: 9px; }
+.footer-grid a { color: rgba(245,236,224,0.8); font-size: 0.92rem; }
+.footer-grid a:hover { color: var(--amber); text-decoration: none; }
+.footer-brand p { font-size: 0.94rem; max-width: 28em; margin: 14px 0 0; }
+.footer-brand .brand__name { color: var(--cream); }
+.footer-bottom { border-top: 1px solid rgba(245,236,224,0.16); padding-top: 22px; display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-size: 0.84rem; }
+
+/* ---------------------------------------------------------- utilities */
+.text-center { text-align: center; }
+.mt-32 { margin-top: 32px; }
+[hidden] { display: none !important; }
+
+/* ---------------------------------------------------------- responsive */
+@media (max-width: 920px) {
+  .hero__inner { grid-template-columns: 1fr; gap: 30px; text-align: center; }
+  .hero__lead { margin-left: auto; margin-right: auto; }
+  .hero__cta, .hero__stats { justify-content: center; }
+  .hero__art { order: -1; }
+  .shop-layout { grid-template-columns: 1fr; }
+  .filters { position: static; }
+  .split, .contact-layout, .cart-page-layout { grid-template-columns: 1fr; gap: 30px; }
+  .cart-summary { position: static; }
+  .detail { grid-template-columns: 1fr; }
+  .detail__media { border-radius: var(--radius) var(--radius) 0 0; padding: 28px; }
+  .footer-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 720px) {
+  .nav-toggle { display: inline-flex; }
+  .primary-nav {
+    display: none; position: absolute; top: 72px; left: 0; right: 0;
+    flex-direction: column; gap: 0; background: var(--parchment);
+    border-bottom: 1px solid var(--line); padding: 8px 24px 16px;
+  }
+  .primary-nav.is-open { display: flex; }
+  .primary-nav a { padding: 12px 0; border-bottom: 1px solid var(--line); width: 100%; }
+  .form-grid { grid-template-columns: 1fr; }
+  .footer-grid { grid-template-columns: 1fr; }
+  .section { padding: 54px 0; }
+  .newsletter { padding: 34px 22px; }
+}
+
+@media (max-width: 420px) {
+  .card__foot { flex-direction: column; align-items: flex-start; }
+  .card__actions { width: 100%; }
+  .card__actions .btn { flex: 1; }
+}

--- a/fixtures/websites/74-lumen-coffee/fixture.json
+++ b/fixtures/websites/74-lumen-coffee/fixture.json
@@ -1,0 +1,16 @@
+{
+  "class": "ecommerce/catalog",
+  "tags": [
+    "ecommerce",
+    "coffee",
+    "has-cart",
+    "add-to-cart",
+    "filters",
+    "sorting",
+    "product-variants",
+    "mini-cart",
+    "multipage",
+    "localstorage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/74-lumen-coffee/index.html
+++ b/fixtures/websites/74-lumen-coffee/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lumen Coffee Roasters — Small-Batch Specialty Coffee</title>
+<meta name="description" content="Lumen Coffee Roasters — small-batch, ethically sourced specialty coffee roasted to order. Single origins, blends, espresso and brew gear.">
+<link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="wrap site-header__inner">
+    <a class="brand" href="index.html" aria-label="Lumen Coffee Roasters home">
+      <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true">
+        <circle cx="24" cy="24" r="22" fill="#2b1d16"/>
+        <circle cx="24" cy="24" r="11" fill="none" stroke="#c2703d" stroke-width="2.5"/>
+        <g stroke="#f5ece0" stroke-width="2.2" stroke-linecap="round">
+          <path d="M24 9v4M24 35v4M9 24h4M35 24h4M13.4 13.4l2.8 2.8M31.8 31.8l2.8 2.8M13.4 34.6l2.8-2.8M31.8 16.2l2.8-2.8"/>
+        </g>
+        <path d="M24 19c3 2 3 6 0 8-3-2-3-6 0-8z" fill="#c2703d"/>
+      </svg>
+      <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+    </a>
+    <nav class="primary-nav" id="primary-nav" aria-label="Primary">
+      <a href="index.html" aria-current="page">Home</a>
+      <a href="shop.html">Shop</a>
+      <a href="about.html">About</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <button class="icon-btn nav-toggle" id="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-nav">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke-linecap="round"/></svg>
+      </button>
+      <button class="icon-btn" type="button" data-open-drawer aria-label="Open cart">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 6h15l-1.5 9h-12z" stroke-linejoin="round"/><path d="M6 6 5 3H2" stroke-linecap="round"/><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/></svg>
+        <span class="cart-badge" data-cart-badge hidden>0</span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<main>
+  <!-- HERO -->
+  <section class="hero">
+    <div class="wrap hero__inner">
+      <div class="hero__copy">
+        <p class="eyebrow">Roasted to order · Shipped fresh</p>
+        <h1 class="hero__title">Coffee with <em>clarity</em>, in every cup.</h1>
+        <p class="hero__lead">We source single-origin lots from growers we know by name, then roast in small batches to let each coffee's true character shine through.</p>
+        <div class="hero__cta">
+          <a class="btn btn--solid btn--lg" href="shop.html">Shop the Roastery</a>
+          <a class="btn btn--ghost btn--lg" href="about.html">Our Story</a>
+        </div>
+        <div class="hero__stats">
+          <div class="hero__stat"><strong>14</strong><span>Origins</span></div>
+          <div class="hero__stat"><strong>48h</strong><span>Roast to ship</span></div>
+          <div class="hero__stat"><strong>100%</strong><span>Traceable</span></div>
+        </div>
+      </div>
+      <div class="hero__art" aria-hidden="true">
+        <svg viewBox="0 0 360 360">
+          <defs>
+            <linearGradient id="cupG" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0" stop-color="#3a2820"/><stop offset="1" stop-color="#2b1d16"/>
+            </linearGradient>
+          </defs>
+          <circle cx="180" cy="180" r="150" fill="#ece0cf"/>
+          <circle cx="180" cy="180" r="150" fill="none" stroke="#c2703d" stroke-width="2" stroke-dasharray="4 8" opacity="0.6"/>
+          <!-- saucer -->
+          <ellipse cx="180" cy="278" rx="120" ry="22" fill="#d8c4a8"/>
+          <ellipse cx="180" cy="274" rx="120" ry="20" fill="#fbf6ee"/>
+          <!-- cup -->
+          <path d="M96 168 L264 168 L246 256 Q243 276 220 276 L140 276 Q117 276 114 256 Z" fill="url(#cupG)"/>
+          <ellipse cx="180" cy="168" rx="84" ry="20" fill="#1c120c"/>
+          <ellipse cx="180" cy="166" rx="72" ry="15" fill="#6f4326"/>
+          <ellipse cx="180" cy="166" rx="44" ry="9" fill="#8c5a34"/>
+          <!-- handle -->
+          <path d="M264 188 Q316 190 312 224 Q308 258 250 252" fill="none" stroke="#2b1d16" stroke-width="16"/>
+          <!-- steam -->
+          <g fill="none" stroke="#c2703d" stroke-width="4" stroke-linecap="round" opacity="0.75">
+            <path d="M150 148 q-14 -22 0 -44 q14 -22 0 -44"/>
+            <path d="M210 148 q-14 -22 0 -44 q14 -22 0 -44"/>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </section>
+
+  <!-- FEATURED -->
+  <section class="section">
+    <div class="wrap">
+      <div class="section-head">
+        <p class="eyebrow">This week at the roastery</p>
+        <h2>Featured coffees &amp; gear</h2>
+        <p>A rotating selection of the lots we're most excited about right now.</p>
+      </div>
+      <div class="product-grid featured-grid" id="featured-grid"></div>
+      <div class="text-center mt-32"><a class="btn btn--ghost btn--lg" href="shop.html">Browse all products</a></div>
+    </div>
+  </section>
+
+  <!-- STORY TEASER -->
+  <section class="section section--cream">
+    <div class="wrap split">
+      <div class="split__art" aria-hidden="true">
+        <svg viewBox="0 0 320 320">
+          <circle cx="160" cy="160" r="150" fill="#fbf6ee"/>
+          <path d="M80 120 Q160 70 240 120 L230 230 Q160 270 90 230 Z" fill="#7a8b5a" opacity="0.25"/>
+          <!-- coffee branch -->
+          <path d="M160 250 C150 200 150 150 160 90" fill="none" stroke="#5a3a28" stroke-width="6" stroke-linecap="round"/>
+          <g fill="#7a8b5a">
+            <path d="M160 200 C130 195 120 175 130 160 C160 165 170 185 160 200z"/>
+            <path d="M160 200 C190 195 200 175 190 160 C160 165 150 185 160 200z"/>
+            <path d="M160 160 C132 156 122 138 132 124 C160 128 169 146 160 160z"/>
+            <path d="M160 160 C188 156 198 138 188 124 C160 128 151 146 160 160z"/>
+          </g>
+          <g fill="#c2703d">
+            <circle cx="138" cy="182" r="11"/><circle cx="182" cy="182" r="11"/>
+            <circle cx="140" cy="144" r="10"/><circle cx="180" cy="144" r="10"/>
+            <circle cx="160" cy="110" r="10"/>
+          </g>
+        </svg>
+      </div>
+      <div class="split__copy">
+        <p class="eyebrow">Our story</p>
+        <h2>A roastery built on relationships.</h2>
+        <p>Lumen began in 2014 with a single drum roaster and a stubborn belief: that great coffee starts long before the beans reach the hopper. We pay above Fair Trade, visit our farms each harvest, and roast every batch by taste, not by timer.</p>
+        <p>The result is coffee that's bright, honest, and unmistakably ours — the kind you'll want to share.</p>
+        <a class="btn btn--solid" href="about.html">Meet the team</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- PROCESS -->
+  <section class="section section--espresso">
+    <div class="wrap">
+      <div class="section-head">
+        <p class="eyebrow">Bean to cup</p>
+        <h2>Our process</h2>
+        <p>Four deliberate steps stand between the cherry on the tree and the cup on your table.</p>
+      </div>
+      <div class="steps">
+        <div class="step"><div class="step__num">1</div><h3>Source</h3><p>We buy direct from farms and co-ops, building long-term partnerships that reward quality.</p></div>
+        <div class="step"><div class="step__num">2</div><h3>Roast</h3><p>Small batches on a vintage drum roaster, profiled to highlight each lot's natural sweetness.</p></div>
+        <div class="step"><div class="step__num">3</div><h3>Rest</h3><p>Beans degas for a few days so the flavors settle and the crema pours thick and stable.</p></div>
+        <div class="step"><div class="step__num">4</div><h3>Ship</h3><p>Packed in valve-sealed bags within 48 hours of roasting and sent straight to your door.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- NEWSLETTER -->
+  <section class="section">
+    <div class="wrap">
+      <div class="newsletter">
+        <h2>Get first dibs on fresh crops</h2>
+        <p>Join the list for new releases, brewing notes, and the occasional subscriber-only lot.</p>
+        <form class="newsletter__form" data-newsletter novalidate>
+          <label class="sr-only" for="nl-home-email" style="position:absolute;left:-9999px;">Email address</label>
+          <input id="nl-home-email" type="email" name="email" placeholder="you@example.com" required>
+          <button class="btn btn--cream" type="submit">Subscribe</button>
+        </form>
+        <p class="form-status" data-newsletter-status hidden></p>
+      </div>
+    </div>
+  </section>
+</main>
+
+<!-- FOOTER (shared) -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+        <p>Small-batch specialty coffee, roasted to order in the heart of the city since 2014.</p>
+      </div>
+      <div><h4>Shop</h4><ul>
+        <li><a href="shop.html?category=single-origin">Single Origin</a></li>
+        <li><a href="shop.html?category=blend">Blends</a></li>
+        <li><a href="shop.html?category=espresso">Espresso</a></li>
+        <li><a href="shop.html?category=gear">Brew Gear</a></li>
+      </ul></div>
+      <div><h4>Company</h4><ul>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="shop.html">All Products</a></li>
+      </ul></div>
+      <div><h4>Visit</h4><ul>
+        <li>114 Kindling Lane</li>
+        <li>Riverbend, OR 97000</li>
+        <li><a href="contact.html">Store hours</a></li>
+      </ul></div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; <span data-year>2026</span> Lumen Coffee Roasters. All rights reserved.</span>
+      <span>Crafted with care · Brewed with intent</span>
+    </div>
+  </div>
+</footer>
+
+<!-- CART DRAWER (shared) -->
+<div class="scrim" id="drawer-scrim" hidden></div>
+<aside class="drawer" id="cart-drawer" aria-label="Shopping cart" aria-hidden="true">
+  <div class="drawer__head">
+    <h2>Your Cart</h2>
+    <button class="drawer__close" type="button" data-close-drawer aria-label="Close cart">&times;</button>
+  </div>
+  <div class="drawer__body">
+    <p class="drawer__empty" data-drawer-empty>Your cart is empty.<br>Time to find your next favorite coffee.</p>
+    <ul class="cart-lines" data-drawer-list></ul>
+  </div>
+  <div class="drawer__foot" data-drawer-foot hidden>
+    <div class="drawer__subtotal"><span>Subtotal</span><strong data-drawer-subtotal>$0.00</strong></div>
+    <a class="btn btn--ghost btn--block" href="cart.html">View Cart</a>
+    <p class="drawer__note">Free shipping on orders over $45.</p>
+  </div>
+</aside>
+
+<!-- PRODUCT MODAL (shared) -->
+<div class="modal" id="product-modal" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" hidden>
+  <div class="modal__dialog">
+    <button class="modal__close" type="button" data-close-modal aria-label="Close details">&times;</button>
+    <div id="product-modal-body"></div>
+  </div>
+</div>
+
+<script src="js/products.js"></script>
+<script src="js/cart.js"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/74-lumen-coffee/js/app.js
+++ b/fixtures/websites/74-lumen-coffee/js/app.js
@@ -1,0 +1,442 @@
+/* Lumen Coffee Roasters — UI: rendering, filter/sort, product modal, cart drawer */
+(function (global) {
+  'use strict';
+
+  var doc = global.document;
+  var L = global.LUMEN || {};
+  var cart = L.cart;
+
+  function $(sel, root) { return (root || doc).querySelector(sel); }
+  function $all(sel, root) { return Array.prototype.slice.call((root || doc).querySelectorAll(sel)); }
+  function el(tag, cls, html) {
+    var n = doc.createElement(tag);
+    if (cls) n.className = cls;
+    if (html != null) n.innerHTML = html;
+    return n;
+  }
+  function money(n) { return cart ? cart.money(n) : '$' + Number(n).toFixed(2); }
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+  function selectionText(sel) {
+    if (!sel) return '';
+    return Object.keys(sel).map(function (k) { return k + ': ' + sel[k]; }).join(' · ');
+  }
+
+  /* ---------------------------------------------------------------- badge */
+  function updateBadge() {
+    var count = cart ? cart.count() : 0;
+    $all('[data-cart-badge]').forEach(function (b) {
+      b.textContent = count;
+      b.hidden = count === 0;
+    });
+  }
+
+  /* ---------------------------------------------------------- product card */
+  function productCard(p) {
+    var card = el('article', 'card');
+    card.innerHTML =
+      '<button class="card__media" type="button" data-detail="' + p.id + '" aria-label="View details for ' + escapeHtml(p.name) + '">' +
+        L.svgFor(p) +
+      '</button>' +
+      '<div class="card__body">' +
+        '<span class="card__cat">' + escapeHtml(categoryLabel(p.category)) + '</span>' +
+        '<h3 class="card__title"><button type="button" class="linklike" data-detail="' + p.id + '">' + escapeHtml(p.name) + '</button></h3>' +
+        '<p class="card__notes">' + escapeHtml(p.notes) + '</p>' +
+        '<div class="card__meta">' +
+          (p.roast !== 'N/A' ? '<span class="chip">' + escapeHtml(p.roast) + ' Roast</span>' : '<span class="chip">Brew Gear</span>') +
+        '</div>' +
+        '<div class="card__foot">' +
+          '<span class="price">' + money(p.price) + '</span>' +
+          '<div class="card__actions">' +
+            '<button class="btn btn--ghost" type="button" data-detail="' + p.id + '">Options</button>' +
+            '<button class="btn btn--solid" type="button" data-quickadd="' + p.id + '">Add</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    return card;
+  }
+
+  function categoryLabel(id) {
+    var c = (L.CATEGORIES || []).filter(function (x) { return x.id === id; })[0];
+    return c ? c.label : id;
+  }
+
+  /* --------------------------------------------------------------- modal */
+  var modal, modalBody, lastFocused;
+  var modalState = { product: null, selection: null, qty: 1 };
+
+  function ensureModal() {
+    modal = $('#product-modal');
+    if (!modal) return false;
+    modalBody = $('#product-modal-body', modal);
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal || e.target.closest('[data-close-modal]')) closeModal();
+    });
+    // Single delegated handler — modalBody is reused across products.
+    modalBody.addEventListener('click', onModalBodyClick);
+    return true;
+  }
+
+  function renderModal() {
+    var p = modalState.product;
+    if (!p) return;
+    var unit = L.priceFor(p, modalState.selection);
+    var optsHtml = Object.keys(p.options || {}).map(function (group) {
+      var choices = p.options[group];
+      var btns = choices.map(function (c) {
+        var label = (typeof c === 'object') ? c.label : c;
+        var active = modalState.selection[group] === label ? ' is-active' : '';
+        return '<button type="button" class="opt' + active + '" data-opt-group="' + escapeHtml(group) + '" data-opt-val="' + escapeHtml(label) + '">' + escapeHtml(label) + '</button>';
+      }).join('');
+      return '<div class="opt-group"><span class="opt-group__label">' + escapeHtml(group) + '</span><div class="opt-row">' + btns + '</div></div>';
+    }).join('');
+
+    modalBody.innerHTML =
+      '<div class="detail">' +
+        '<div class="detail__media">' + L.svgFor(p) + '</div>' +
+        '<div class="detail__info">' +
+          '<span class="card__cat">' + escapeHtml(categoryLabel(p.category)) + '</span>' +
+          '<h2 id="product-modal-title" class="detail__title">' + escapeHtml(p.name) + '</h2>' +
+          (p.roast !== 'N/A' ? '<p class="detail__roast">' + escapeHtml(p.roast) + ' Roast</p>' : '') +
+          '<p class="detail__notes">' + escapeHtml(p.notes) + '</p>' +
+          optsHtml +
+          '<div class="detail__buy">' +
+            '<div class="stepper" role="group" aria-label="Quantity">' +
+              '<button type="button" class="stepper__btn" data-qty="-1" aria-label="Decrease quantity">&minus;</button>' +
+              '<span class="stepper__val" data-qty-val aria-live="polite">' + modalState.qty + '</span>' +
+              '<button type="button" class="stepper__btn" data-qty="1" aria-label="Increase quantity">+</button>' +
+            '</div>' +
+            '<button type="button" class="btn btn--solid btn--lg" data-add-detail>Add to Cart · <span data-detail-price>' + money(unit) + '</span></button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+  }
+
+  function onModalBodyClick(e) {
+    if (!modalState.product) return;
+    var opt = e.target.closest('[data-opt-group]');
+    if (opt) {
+      modalState.selection[opt.getAttribute('data-opt-group')] = opt.getAttribute('data-opt-val');
+      renderModal();
+      return;
+    }
+    var step = e.target.closest('[data-qty]');
+    if (step) {
+      modalState.qty = Math.max(1, modalState.qty + parseInt(step.getAttribute('data-qty'), 10));
+      renderModal();
+      return;
+    }
+    if (e.target.closest('[data-add-detail]')) {
+      cart.add(modalState.product, modalState.selection, modalState.qty);
+      closeModal();
+      openDrawer();
+    }
+  }
+
+  function openModal(productId) {
+    if (!modal) return;
+    var p = L.productById(productId);
+    if (!p) return;
+    modalState.product = p;
+    modalState.selection = L.defaultSelection(p);
+    modalState.qty = 1;
+    renderModal();
+
+    lastFocused = doc.activeElement;
+    modal.hidden = false;
+    doc.body.classList.add('no-scroll');
+    var closeBtn = $('[data-close-modal]', modal);
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeModal() {
+    if (!modal || modal.hidden) return;
+    modal.hidden = true;
+    modalState.product = null;
+    if (modalBody) modalBody.innerHTML = '';
+    if (!drawerOpen()) doc.body.classList.remove('no-scroll');
+    if (lastFocused && lastFocused.focus) lastFocused.focus();
+  }
+
+  /* --------------------------------------------------------------- drawer */
+  var drawer, drawerScrim;
+
+  function ensureDrawer() {
+    drawer = $('#cart-drawer');
+    drawerScrim = $('#drawer-scrim');
+    if (!drawer) return false;
+    if (drawerScrim) drawerScrim.addEventListener('click', closeDrawer);
+    drawer.addEventListener('click', function (e) {
+      if (e.target.closest('[data-close-drawer]')) closeDrawer();
+    });
+    $all('[data-open-drawer]').forEach(function (b) {
+      b.addEventListener('click', function (e) { e.preventDefault(); openDrawer(); });
+    });
+    drawer.addEventListener('click', onLineAction);
+    return true;
+  }
+
+  function drawerOpen() { return drawer && drawer.classList.contains('is-open'); }
+
+  function openDrawer() {
+    if (!drawer) return;
+    renderDrawer();
+    drawer.classList.add('is-open');
+    drawer.setAttribute('aria-hidden', 'false');
+    if (drawerScrim) drawerScrim.hidden = false;
+    doc.body.classList.add('no-scroll');
+    var c = $('[data-close-drawer]', drawer);
+    if (c) c.focus();
+  }
+
+  function closeDrawer() {
+    if (!drawer) return;
+    drawer.classList.remove('is-open');
+    drawer.setAttribute('aria-hidden', 'true');
+    if (drawerScrim) drawerScrim.hidden = true;
+    if (!modal || modal.hidden) doc.body.classList.remove('no-scroll');
+  }
+
+  function lineRow(line) {
+    var p = L.productById(line.id);
+    return '' +
+      '<li class="line">' +
+        '<div class="line__media">' + (p ? L.svgFor(p) : '') + '</div>' +
+        '<div class="line__main">' +
+          '<p class="line__name">' + escapeHtml(line.name) + '</p>' +
+          (selectionText(line.selection) ? '<p class="line__opts">' + escapeHtml(selectionText(line.selection)) + '</p>' : '') +
+          '<p class="line__price">' + money(line.price) + ' each</p>' +
+          '<div class="stepper stepper--sm" role="group" aria-label="Quantity for ' + escapeHtml(line.name) + '">' +
+            '<button type="button" class="stepper__btn" data-line-dec="' + line.key + '" aria-label="Decrease quantity">&minus;</button>' +
+            '<span class="stepper__val">' + line.qty + '</span>' +
+            '<button type="button" class="stepper__btn" data-line-inc="' + line.key + '" aria-label="Increase quantity">+</button>' +
+          '</div>' +
+        '</div>' +
+        '<div class="line__end">' +
+          '<span class="line__total">' + money(line.price * line.qty) + '</span>' +
+          '<button type="button" class="line__remove" data-line-remove="' + line.key + '" aria-label="Remove ' + escapeHtml(line.name) + '">Remove</button>' +
+        '</div>' +
+      '</li>';
+  }
+
+  function renderDrawer() {
+    if (!drawer) return;
+    var items = cart.get();
+    var listEl = $('[data-drawer-list]', drawer);
+    var emptyEl = $('[data-drawer-empty]', drawer);
+    var footEl = $('[data-drawer-foot]', drawer);
+    var subEl = $('[data-drawer-subtotal]', drawer);
+    if (items.length === 0) {
+      if (listEl) listEl.innerHTML = '';
+      if (emptyEl) emptyEl.hidden = false;
+      if (footEl) footEl.hidden = true;
+      return;
+    }
+    if (emptyEl) emptyEl.hidden = true;
+    if (footEl) footEl.hidden = false;
+    if (listEl) listEl.innerHTML = items.map(lineRow).join('');
+    if (subEl) subEl.textContent = money(cart.subtotal());
+  }
+
+  function onLineAction(e) {
+    var inc = e.target.closest('[data-line-inc]');
+    var dec = e.target.closest('[data-line-dec]');
+    var rem = e.target.closest('[data-line-remove]');
+    if (inc) cart.changeQty(inc.getAttribute('data-line-inc'), 1);
+    else if (dec) cart.changeQty(dec.getAttribute('data-line-dec'), -1);
+    else if (rem) cart.remove(rem.getAttribute('data-line-remove'));
+  }
+
+  /* ------------------------------------------------------- shop catalog */
+  function initShop() {
+    var grid = $('#product-grid');
+    if (!grid) return;
+
+    var state = { category: 'all', maxPrice: null, sort: 'newest' };
+    var catSel = $('#filter-category');
+    var priceSel = $('#filter-price');
+    var sortSel = $('#sort-by');
+    var countEl = $('#result-count');
+
+    function apply() {
+      var list = (L.products || []).slice();
+      if (state.category !== 'all') {
+        list = list.filter(function (p) { return p.category === state.category; });
+      }
+      if (state.maxPrice != null) {
+        list = list.filter(function (p) { return p.price <= state.maxPrice; });
+      }
+      switch (state.sort) {
+        case 'price-asc': list.sort(function (a, b) { return a.price - b.price; }); break;
+        case 'price-desc': list.sort(function (a, b) { return b.price - a.price; }); break;
+        case 'name-asc': list.sort(function (a, b) { return a.name.localeCompare(b.name); }); break;
+        default: list.sort(function (a, b) { return b.date - a.date; }); break;
+      }
+      grid.innerHTML = '';
+      if (list.length === 0) {
+        grid.appendChild(el('p', 'empty-note', 'No coffees match those filters. Try widening your search.'));
+      } else {
+        list.forEach(function (p) { grid.appendChild(productCard(p)); });
+      }
+      if (countEl) countEl.textContent = list.length + (list.length === 1 ? ' product' : ' products');
+    }
+
+    if (catSel) catSel.addEventListener('change', function () { state.category = catSel.value; apply(); });
+    if (priceSel) priceSel.addEventListener('change', function () {
+      state.maxPrice = priceSel.value === 'all' ? null : Number(priceSel.value);
+      apply();
+    });
+    if (sortSel) sortSel.addEventListener('change', function () { state.sort = sortSel.value; apply(); });
+
+    // Honor ?category= deep link from the home page.
+    try {
+      var q = new global.URLSearchParams(global.location.search).get('category');
+      if (q && catSel) {
+        var has = $all('option', catSel).some(function (o) { return o.value === q; });
+        if (has) { catSel.value = q; state.category = q; }
+      }
+    } catch (e) { /* no-op */ }
+
+    apply();
+  }
+
+  /* --------------------------------------------------- featured (home) */
+  function initFeatured() {
+    var row = $('#featured-grid');
+    if (!row) return;
+    var ids = ['ethiopia-yirgacheffe', 'lumen-house-blend', 'aurora-espresso', 'pour-over-dripper'];
+    ids.forEach(function (id) {
+      var p = L.productById(id);
+      if (p) row.appendChild(productCard(p));
+    });
+  }
+
+  /* ------------------------------------------------------- cart page */
+  function initCartPage() {
+    var wrap = $('#cart-page');
+    if (!wrap) return;
+
+    function render() {
+      var items = cart.get();
+      var listEl = $('[data-cartpage-list]', wrap);
+      var emptyEl = $('[data-cartpage-empty]', wrap);
+      var summaryEl = $('[data-cartpage-summary]', wrap);
+      var subEl = $('[data-cartpage-subtotal]', wrap);
+      var shipEl = $('[data-cartpage-shipping]', wrap);
+      var totalEl = $('[data-cartpage-total]', wrap);
+
+      if (items.length === 0) {
+        if (listEl) listEl.innerHTML = '';
+        if (emptyEl) emptyEl.hidden = false;
+        if (summaryEl) summaryEl.hidden = true;
+        return;
+      }
+      if (emptyEl) emptyEl.hidden = true;
+      if (summaryEl) summaryEl.hidden = false;
+      if (listEl) listEl.innerHTML = items.map(lineRow).join('');
+      var sub = cart.subtotal();
+      var ship = sub >= 45 || sub === 0 ? 0 : 6;
+      if (subEl) subEl.textContent = money(sub);
+      if (shipEl) shipEl.textContent = ship === 0 ? 'Free' : money(ship);
+      if (totalEl) totalEl.textContent = money(sub + ship);
+    }
+
+    wrap.addEventListener('click', function (e) {
+      onLineAction(e);
+      if (e.target.closest('[data-cart-clear]')) cart.clear();
+      if (e.target.closest('[data-cart-checkout]')) {
+        e.preventDefault();
+        global.alert('This is a demo storefront — checkout is not connected to a payment processor.');
+      }
+    });
+
+    global.addEventListener(cart.EVENT, render);
+    render();
+  }
+
+  /* ----------------------------------------------------- contact form */
+  function initContactForm() {
+    var form = $('#contact-form');
+    if (!form) return;
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var status = $('#contact-status', form);
+      if (status) {
+        status.hidden = false;
+        status.textContent = 'Thanks — your message has been received. We’ll be in touch within two business days.';
+      }
+      form.reset();
+    });
+  }
+
+  function initNewsletter() {
+    $all('[data-newsletter]').forEach(function (form) {
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var status = form.querySelector('[data-newsletter-status]');
+        if (status) {
+          status.hidden = false;
+          status.textContent = 'You’re on the list. Watch your inbox for fresh-crop releases.';
+        }
+        form.reset();
+      });
+    });
+  }
+
+  /* ------------------------------------------------ global delegation */
+  function initGlobalClicks() {
+    doc.addEventListener('click', function (e) {
+      var detail = e.target.closest('[data-detail]');
+      if (detail) { openModal(detail.getAttribute('data-detail')); return; }
+      var quick = e.target.closest('[data-quickadd]');
+      if (quick) {
+        var p = L.productById(quick.getAttribute('data-quickadd'));
+        if (p) { cart.add(p, L.defaultSelection(p), 1); openDrawer(); }
+      }
+    });
+    doc.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') { closeModal(); closeDrawer(); }
+    });
+  }
+
+  /* ------------------------------------------------------------- boot */
+  function boot() {
+    if (!L.products || !cart) return; // products/cart scripts not loaded on this page
+    updateBadge();
+    ensureModal();
+    ensureDrawer();
+    initGlobalClicks();
+    initFeatured();
+    initShop();
+    initCartPage();
+    initContactForm();
+    initNewsletter();
+
+    global.addEventListener(cart.EVENT, function () {
+      updateBadge();
+      if (drawerOpen()) renderDrawer();
+    });
+
+    // mobile nav toggle
+    var navToggle = $('#nav-toggle');
+    var nav = $('#primary-nav');
+    if (navToggle && nav) {
+      navToggle.addEventListener('click', function () {
+        var open = nav.classList.toggle('is-open');
+        navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      });
+    }
+
+    // footer year
+    $all('[data-year]').forEach(function (n) { n.textContent = new Date().getFullYear(); });
+  }
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+})(window);

--- a/fixtures/websites/74-lumen-coffee/js/cart.js
+++ b/fixtures/websites/74-lumen-coffee/js/cart.js
@@ -1,0 +1,125 @@
+/* Lumen Coffee Roasters — cart state, localStorage persistence, shared across pages */
+(function (global) {
+  'use strict';
+
+  var KEY = 'lumen_cart';
+  var EVENT = 'lumen:cart-updated';
+
+  function read() {
+    try {
+      var raw = global.localStorage.getItem(KEY);
+      var data = raw ? JSON.parse(raw) : [];
+      return Array.isArray(data) ? data : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function write(items) {
+    try {
+      global.localStorage.setItem(KEY, JSON.stringify(items));
+    } catch (e) { /* storage unavailable — operate in-memory */ }
+    notify();
+  }
+
+  function notify() {
+    try {
+      global.dispatchEvent(new CustomEvent(EVENT));
+    } catch (e) {
+      var ev = global.document.createEvent('Event');
+      ev.initEvent(EVENT, true, true);
+      global.dispatchEvent(ev);
+    }
+  }
+
+  // A stable line key merges identical product + option selections.
+  function lineKey(productId, selection) {
+    var parts = [productId];
+    if (selection) {
+      Object.keys(selection).sort().forEach(function (k) {
+        parts.push(k + ':' + selection[k]);
+      });
+    }
+    return parts.join('|');
+  }
+
+  function getCart() { return read(); }
+
+  function getCount() {
+    return read().reduce(function (n, l) { return n + l.qty; }, 0);
+  }
+
+  function getSubtotal() {
+    return read().reduce(function (s, l) { return s + l.price * l.qty; }, 0);
+  }
+
+  function add(product, selection, qty) {
+    qty = Math.max(1, parseInt(qty, 10) || 1);
+    var price = (global.LUMEN && global.LUMEN.priceFor)
+      ? global.LUMEN.priceFor(product, selection)
+      : product.price;
+    var key = lineKey(product.id, selection);
+    var items = read();
+    var existing = items.filter(function (l) { return l.key === key; })[0];
+    if (existing) {
+      existing.qty += qty;
+    } else {
+      items.push({
+        key: key,
+        id: product.id,
+        name: product.name,
+        category: product.category,
+        selection: selection || {},
+        price: price,
+        qty: qty
+      });
+    }
+    write(items);
+  }
+
+  function setQty(key, qty) {
+    qty = parseInt(qty, 10) || 0;
+    var items = read();
+    if (qty <= 0) {
+      items = items.filter(function (l) { return l.key !== key; });
+    } else {
+      items.forEach(function (l) { if (l.key === key) l.qty = qty; });
+    }
+    write(items);
+  }
+
+  function changeQty(key, delta) {
+    var items = read();
+    var line = items.filter(function (l) { return l.key === key; })[0];
+    if (line) setQty(key, line.qty + delta);
+  }
+
+  function remove(key) {
+    write(read().filter(function (l) { return l.key !== key; }));
+  }
+
+  function clear() { write([]); }
+
+  function money(n) {
+    return '$' + Number(n).toFixed(2);
+  }
+
+  global.LUMEN = global.LUMEN || {};
+  global.LUMEN.cart = {
+    EVENT: EVENT,
+    get: getCart,
+    count: getCount,
+    subtotal: getSubtotal,
+    add: add,
+    setQty: setQty,
+    changeQty: changeQty,
+    remove: remove,
+    clear: clear,
+    money: money
+  };
+
+  // Sync across browser tabs.
+  global.addEventListener('storage', function (e) {
+    if (e.key === KEY) notify();
+  });
+})(window);

--- a/fixtures/websites/74-lumen-coffee/js/products.js
+++ b/fixtures/websites/74-lumen-coffee/js/products.js
@@ -1,0 +1,203 @@
+/* Lumen Coffee Roasters — product catalog data + inline SVG illustrations */
+(function (global) {
+  'use strict';
+
+  // Category color schemes for SVG bag illustrations.
+  var SCHEMES = {
+    'single-origin': { bag: '#c2703d', band: '#8c4a25', tag: '#f5ece0', ink: '#3a2418' },
+    'blend':         { bag: '#5a3a28', band: '#3a2418', tag: '#f5ece0', ink: '#3a2418' },
+    'espresso':      { bag: '#2b1d16', band: '#120b07', tag: '#e7c9a0', ink: '#2b1d16' },
+    'decaf':         { bag: '#7a8b5a', band: '#566234', tag: '#f5ece0', ink: '#33401d' },
+    'gear':          { bag: '#d8c4a8', band: '#b69a72', tag: '#3a2418', ink: '#3a2418' }
+  };
+
+  // Coffee bag illustration (used for all bean products).
+  function bagSVG(scheme, initials) {
+    return '' +
+      '<svg viewBox="0 0 200 240" role="img" aria-hidden="true" preserveAspectRatio="xMidYMid meet">' +
+        '<rect width="200" height="240" fill="none"/>' +
+        // bag body
+        '<path d="M50 60 Q50 50 60 50 L140 50 Q150 50 150 60 L156 210 Q157 222 145 222 L55 222 Q43 222 44 210 Z" fill="' + scheme.bag + '"/>' +
+        // side shadow
+        '<path d="M120 50 L150 60 L156 210 Q157 222 145 222 L122 222 Z" fill="rgba(0,0,0,0.12)"/>' +
+        // top folded seam
+        '<rect x="52" y="44" width="96" height="14" rx="4" fill="' + scheme.band + '"/>' +
+        '<rect x="52" y="44" width="96" height="5" rx="2" fill="rgba(255,255,255,0.12)"/>' +
+        // label
+        '<rect x="66" y="92" width="68" height="92" rx="6" fill="' + scheme.tag + '"/>' +
+        // steam / lumen mark
+        '<circle cx="100" cy="120" r="15" fill="none" stroke="' + scheme.ink + '" stroke-width="3"/>' +
+        '<path d="M100 105 L100 99 M115 120 L121 120 M100 135 L100 141 M85 120 L79 120 M110.6 109.4 L114.9 105.1 M110.6 130.6 L114.9 134.9 M89.4 130.6 L85.1 134.9 M89.4 109.4 L85.1 105.1" stroke="' + scheme.ink + '" stroke-width="2.5" stroke-linecap="round"/>' +
+        '<text x="100" y="125" text-anchor="middle" font-family="Georgia, serif" font-size="13" font-weight="700" fill="' + scheme.ink + '">' + initials + '</text>' +
+        '<rect x="74" y="158" width="52" height="4" rx="2" fill="' + scheme.ink + '" opacity="0.5"/>' +
+        '<rect x="80" y="168" width="40" height="4" rx="2" fill="' + scheme.ink + '" opacity="0.3"/>' +
+      '</svg>';
+  }
+
+  // Pour-over dripper illustration.
+  function dripperSVG(scheme) {
+    return '' +
+      '<svg viewBox="0 0 200 240" role="img" aria-hidden="true" preserveAspectRatio="xMidYMid meet">' +
+        '<path d="M55 70 L145 70 L112 150 L88 150 Z" fill="' + scheme.bag + '"/>' +
+        '<path d="M100 70 L145 70 L112 150 L100 150 Z" fill="rgba(0,0,0,0.12)"/>' +
+        '<rect x="50" y="62" width="100" height="12" rx="6" fill="' + scheme.band + '"/>' +
+        '<rect x="84" y="150" width="32" height="10" fill="' + scheme.band + '"/>' +
+        // ridges
+        '<path d="M70 78 L96 140 M86 74 L100 142 M114 78 L104 140 M130 78 L108 138" stroke="rgba(0,0,0,0.18)" stroke-width="2" fill="none"/>' +
+        // carafe
+        '<path d="M70 162 L130 162 L138 214 Q139 224 128 224 L72 224 Q61 224 62 214 Z" fill="none" stroke="' + scheme.band + '" stroke-width="4"/>' +
+        // drip
+        '<circle cx="100" cy="172" r="3" fill="' + scheme.band + '"/>' +
+        '<circle cx="100" cy="186" r="2.4" fill="' + scheme.band + '" opacity="0.7"/>' +
+      '</svg>';
+  }
+
+  // Ceramic mug illustration.
+  function mugSVG(scheme) {
+    return '' +
+      '<svg viewBox="0 0 200 240" role="img" aria-hidden="true" preserveAspectRatio="xMidYMid meet">' +
+        '<path d="M62 90 L138 90 L132 196 Q131 208 119 208 L81 208 Q69 208 68 196 Z" fill="' + scheme.bag + '"/>' +
+        '<path d="M100 90 L138 90 L132 196 Q131 208 119 208 L100 208 Z" fill="rgba(0,0,0,0.10)"/>' +
+        '<ellipse cx="100" cy="90" rx="38" ry="9" fill="' + scheme.band + '"/>' +
+        '<ellipse cx="100" cy="90" rx="30" ry="6" fill="rgba(0,0,0,0.25)"/>' +
+        '<path d="M138 110 Q172 112 170 140 Q168 168 134 166" fill="none" stroke="' + scheme.band + '" stroke-width="10"/>' +
+        // steam
+        '<path d="M88 76 q-6 -10 0 -20 q6 -10 0 -20" fill="none" stroke="' + scheme.band + '" stroke-width="3" stroke-linecap="round" opacity="0.6"/>' +
+        '<path d="M112 76 q-6 -10 0 -20 q6 -10 0 -20" fill="none" stroke="' + scheme.band + '" stroke-width="3" stroke-linecap="round" opacity="0.6"/>' +
+      '</svg>';
+  }
+
+  function svgFor(p) {
+    var scheme = SCHEMES[p.category] || SCHEMES.blend;
+    if (p.id === 'pour-over-dripper') return dripperSVG(scheme);
+    if (p.id === 'stoneware-mug') return mugSVG(scheme);
+    return bagSVG(scheme, p.initials || p.name.slice(0, 2).toUpperCase());
+  }
+
+  var BEAN_SIZE = [
+    { label: '250g', delta: 0 },
+    { label: '500g', delta: 14 },
+    { label: '1kg', delta: 30 }
+  ];
+  var GRIND = ['Whole Bean', 'Filter', 'Pour Over', 'Espresso'];
+
+  // `date` is a monotonically increasing release index used for "newest" sorting.
+  var PRODUCTS = [
+    {
+      id: 'ethiopia-yirgacheffe', name: 'Ethiopia Yirgacheffe', category: 'single-origin',
+      price: 21, roast: 'Light', date: 12, initials: 'ET',
+      notes: 'Jasmine and bergamot lift into a syrupy stone-fruit body with a clean, tea-like finish.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'colombia-huila', name: 'Colombia Huila', category: 'single-origin',
+      price: 19, roast: 'Medium', date: 9, initials: 'CO',
+      notes: 'Red apple and caramel sweetness with a rounded milk-chocolate finish. An everyday favorite.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'kenya-nyeri', name: 'Kenya Nyeri AA', category: 'single-origin',
+      price: 23, roast: 'Light', date: 11, initials: 'KE',
+      notes: 'Blackcurrant and tomato vine acidity, dense and juicy with a brown-sugar sweetness.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'guatemala-antigua', name: 'Guatemala Antigua', category: 'single-origin',
+      price: 20, roast: 'Medium', date: 7, initials: 'GU',
+      notes: 'Cocoa nib and toasted almond with a gentle orange-zest brightness and full body.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'lumen-house-blend', name: 'Lumen House Blend', category: 'blend',
+      price: 17, roast: 'Medium', date: 6, initials: 'HB',
+      notes: 'Our flagship: balanced cocoa, hazelnut and dried cherry. Forgiving across every brew method.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'midnight-blend', name: 'Midnight Blend', category: 'blend',
+      price: 18, roast: 'Dark', date: 8, initials: 'MN',
+      notes: 'Deep and smoky with dark-chocolate, molasses and a lingering pipe-tobacco richness.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'sunrise-blend', name: 'Sunrise Breakfast Blend', category: 'blend',
+      price: 17, roast: 'Medium', date: 5, initials: 'SR',
+      notes: 'Bright and easy-drinking: honey, toasted oat and a soft citrus lift to start the day.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'gravita-espresso', name: 'Gravita Espresso', category: 'espresso',
+      price: 22, roast: 'Dark', date: 10, initials: 'GR',
+      notes: 'Built for the machine: thick crema, dark chocolate and dried fig with a clean caramel tail.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'aurora-espresso', name: 'Aurora Espresso', category: 'espresso',
+      price: 24, roast: 'Medium-Dark', date: 13, initials: 'AU',
+      notes: 'A modern espresso — red berries and brown sugar that blooms beautifully in milk.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'twilight-decaf', name: 'Twilight Decaf', category: 'decaf',
+      price: 19, roast: 'Medium', date: 4, initials: 'TW',
+      notes: 'Swiss Water processed. Smooth cocoa and roasted hazelnut with none of the caffeine.',
+      options: { Size: BEAN_SIZE, Grind: GRIND }
+    },
+    {
+      id: 'pour-over-dripper', name: 'Ceramic Pour-Over Dripper', category: 'gear',
+      price: 32, roast: 'N/A', date: 3, initials: 'PD',
+      notes: 'Hand-glazed stoneware dripper with a single large hole for full control over your brew.',
+      options: { Color: ['Espresso Brown', 'Parchment Cream', 'Terracotta'] }
+    },
+    {
+      id: 'stoneware-mug', name: 'Stoneware Mug 350ml', category: 'gear',
+      price: 18, roast: 'N/A', date: 2, initials: 'SM',
+      notes: 'A weighty, comfortable 350ml mug with a reactive glaze — no two are exactly alike.',
+      options: { Color: ['Espresso Brown', 'Sage Green', 'Amber'] }
+    }
+  ];
+
+  // Compute unit price for a chosen set of options.
+  function priceFor(product, selection) {
+    var price = product.price;
+    var opts = product.options || {};
+    Object.keys(opts).forEach(function (group) {
+      var choices = opts[group];
+      var chosen = selection && selection[group];
+      if (Array.isArray(choices) && choices.length && typeof choices[0] === 'object') {
+        var match = choices.filter(function (c) { return c.label === chosen; })[0] || choices[0];
+        price += (match.delta || 0);
+      }
+    });
+    return price;
+  }
+
+  // Default selection (first option of every group).
+  function defaultSelection(product) {
+    var sel = {};
+    var opts = product.options || {};
+    Object.keys(opts).forEach(function (group) {
+      var c = opts[group][0];
+      sel[group] = (typeof c === 'object') ? c.label : c;
+    });
+    return sel;
+  }
+
+  function byId(id) {
+    return PRODUCTS.filter(function (p) { return p.id === id; })[0] || null;
+  }
+
+  global.LUMEN = global.LUMEN || {};
+  global.LUMEN.products = PRODUCTS;
+  global.LUMEN.svgFor = svgFor;
+  global.LUMEN.priceFor = priceFor;
+  global.LUMEN.defaultSelection = defaultSelection;
+  global.LUMEN.productById = byId;
+  global.LUMEN.CATEGORIES = [
+    { id: 'single-origin', label: 'Single Origin' },
+    { id: 'blend', label: 'Blends' },
+    { id: 'espresso', label: 'Espresso' },
+    { id: 'decaf', label: 'Decaf' },
+    { id: 'gear', label: 'Gear' }
+  ];
+})(window);

--- a/fixtures/websites/74-lumen-coffee/shop.html
+++ b/fixtures/websites/74-lumen-coffee/shop.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Shop — Lumen Coffee Roasters</title>
+<meta name="description" content="Browse the full Lumen Coffee catalog: single-origin beans, signature blends, espresso, decaf and brew gear. Filter and sort to find your perfect cup.">
+<link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="wrap site-header__inner">
+    <a class="brand" href="index.html" aria-label="Lumen Coffee Roasters home">
+      <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true">
+        <circle cx="24" cy="24" r="22" fill="#2b1d16"/>
+        <circle cx="24" cy="24" r="11" fill="none" stroke="#c2703d" stroke-width="2.5"/>
+        <g stroke="#f5ece0" stroke-width="2.2" stroke-linecap="round">
+          <path d="M24 9v4M24 35v4M9 24h4M35 24h4M13.4 13.4l2.8 2.8M31.8 31.8l2.8 2.8M13.4 34.6l2.8-2.8M31.8 16.2l2.8-2.8"/>
+        </g>
+        <path d="M24 19c3 2 3 6 0 8-3-2-3-6 0-8z" fill="#c2703d"/>
+      </svg>
+      <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+    </a>
+    <nav class="primary-nav" id="primary-nav" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="shop.html" aria-current="page">Shop</a>
+      <a href="about.html">About</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <div class="header-actions">
+      <button class="icon-btn nav-toggle" id="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-nav">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke-linecap="round"/></svg>
+      </button>
+      <button class="icon-btn" type="button" data-open-drawer aria-label="Open cart">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 6h15l-1.5 9h-12z" stroke-linejoin="round"/><path d="M6 6 5 3H2" stroke-linecap="round"/><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/></svg>
+        <span class="cart-badge" data-cart-badge hidden>0</span>
+      </button>
+    </div>
+  </div>
+</header>
+
+<main>
+  <section class="page-hero">
+    <div class="wrap">
+      <h1>The Roastery Shop</h1>
+      <p>Every coffee is roasted to order and shipped within 48 hours. Filter and sort to find exactly what you're after.</p>
+    </div>
+  </section>
+
+  <section class="section section--tight">
+    <div class="wrap">
+      <div class="shop-layout">
+        <aside class="filters" aria-label="Product filters">
+          <h2>Filter &amp; Sort</h2>
+          <div class="field">
+            <label for="filter-category">Category</label>
+            <select id="filter-category">
+              <option value="all">All products</option>
+              <option value="single-origin">Single Origin</option>
+              <option value="blend">Blends</option>
+              <option value="espresso">Espresso</option>
+              <option value="decaf">Decaf</option>
+              <option value="gear">Gear</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="filter-price">Max price</label>
+            <select id="filter-price">
+              <option value="all">Any price</option>
+              <option value="18">Under $18</option>
+              <option value="20">Under $20</option>
+              <option value="22">Under $22</option>
+              <option value="25">Under $25</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="sort-by">Sort by</label>
+            <select id="sort-by">
+              <option value="newest">Newest</option>
+              <option value="price-asc">Price: Low to High</option>
+              <option value="price-desc">Price: High to Low</option>
+              <option value="name-asc">Name: A to Z</option>
+            </select>
+          </div>
+        </aside>
+
+        <div>
+          <div class="shop-bar">
+            <span class="result-count" id="result-count" aria-live="polite"></span>
+          </div>
+          <div class="product-grid" id="product-grid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <span class="brand__name">Lumen<small>Coffee Roasters</small></span>
+        <p>Small-batch specialty coffee, roasted to order in the heart of the city since 2014.</p>
+      </div>
+      <div><h4>Shop</h4><ul>
+        <li><a href="shop.html?category=single-origin">Single Origin</a></li>
+        <li><a href="shop.html?category=blend">Blends</a></li>
+        <li><a href="shop.html?category=espresso">Espresso</a></li>
+        <li><a href="shop.html?category=gear">Brew Gear</a></li>
+      </ul></div>
+      <div><h4>Company</h4><ul>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="shop.html">All Products</a></li>
+      </ul></div>
+      <div><h4>Visit</h4><ul>
+        <li>114 Kindling Lane</li>
+        <li>Riverbend, OR 97000</li>
+        <li><a href="contact.html">Store hours</a></li>
+      </ul></div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; <span data-year>2026</span> Lumen Coffee Roasters. All rights reserved.</span>
+      <span>Crafted with care · Brewed with intent</span>
+    </div>
+  </div>
+</footer>
+
+<div class="scrim" id="drawer-scrim" hidden></div>
+<aside class="drawer" id="cart-drawer" aria-label="Shopping cart" aria-hidden="true">
+  <div class="drawer__head">
+    <h2>Your Cart</h2>
+    <button class="drawer__close" type="button" data-close-drawer aria-label="Close cart">&times;</button>
+  </div>
+  <div class="drawer__body">
+    <p class="drawer__empty" data-drawer-empty>Your cart is empty.<br>Time to find your next favorite coffee.</p>
+    <ul class="cart-lines" data-drawer-list></ul>
+  </div>
+  <div class="drawer__foot" data-drawer-foot hidden>
+    <div class="drawer__subtotal"><span>Subtotal</span><strong data-drawer-subtotal>$0.00</strong></div>
+    <a class="btn btn--ghost btn--block" href="cart.html">View Cart</a>
+    <p class="drawer__note">Free shipping on orders over $45.</p>
+  </div>
+</aside>
+
+<div class="modal" id="product-modal" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" hidden>
+  <div class="modal__dialog">
+    <button class="modal__close" type="button" data-close-modal aria-label="Close details">&times;</button>
+    <div id="product-modal-body"></div>
+  </div>
+</div>
+
+<script src="js/products.js"></script>
+<script src="js/cart.js"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/75-inkwell-books/about.html
+++ b/fixtures/websites/75-inkwell-books/about.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About — Inkwell &amp; Quill Booksellers</title>
+  <meta name="description" content="The story of Inkwell & Quill: our history, our booksellers, and the community events that fill our shop." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__bar">
+      <a class="brand" href="index.html">
+        <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="44" height="44" rx="8" fill="#16223d" stroke="#b8923f" stroke-width="1.5"/>
+          <path d="M24 12 C18 9, 10 9, 8 11 V35 C10 33, 18 33, 24 36 C30 33, 38 33, 40 35 V11 C38 9, 30 9, 24 12 Z" fill="none" stroke="#d8c08a" stroke-width="1.6"/>
+          <line x1="24" y1="12" x2="24" y2="36" stroke="#d8c08a" stroke-width="1.6"/>
+          <path d="M32 8 L36 12 L24 24 L20 24 L20 20 Z" fill="#8c2b27" stroke="#d8c08a" stroke-width="1"/>
+        </svg>
+        <span class="brand__text">
+          <span class="brand__name">Inkwell &amp; Quill</span>
+          <span class="brand__tag">Independent Booksellers</span>
+        </span>
+      </a>
+      <nav class="site-nav" data-nav aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html" aria-current="page">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="icon-btn" href="cart.html" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.4"/><circle cx="18" cy="20" r="1.4"/>
+            <path d="M2 3h2.2l2.1 12.2a1.5 1.5 0 0 0 1.5 1.3h8.9a1.5 1.5 0 0 0 1.5-1.2L21 7H6"/>
+          </svg>
+          <span class="cart-count is-empty" data-cart-count>0</span>
+        </a>
+        <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <section class="page-hero">
+    <div class="container">
+      <p class="breadcrumb"><a href="index.html">Home</a> / About</p>
+      <h1>Our Story</h1>
+      <p>A little shop with a long memory, run by people who believe the right book at the right time can change everything.</p>
+    </div>
+  </section>
+
+  <main>
+    <section class="section">
+      <div class="container two-col">
+        <div class="prose">
+          <h2>From a single shelf to a neighborhood landmark</h2>
+          <p>Inkwell &amp; Quill opened its doors in the autumn of 1998 with one creaky shelf, a secondhand till, and a hand-lettered sign in the window. Our founder, Margaret Quill, had spent twenty years recommending books to friends and finally decided to make a vocation of it.</p>
+          <p>A quarter century later, those shelves now climb to the ceiling, the rolling ladder squeaks just so, and there is always a pot of coffee on in the back. We have stayed stubbornly independent because we believe a bookstore should be shaped by the people who run it and the readers who fill it — not an algorithm.</p>
+          <p>Every title in the shop has been chosen by a human who wanted it here. That is the whole philosophy, and it has never let us down.</p>
+        </div>
+        <div class="storefront-art" aria-hidden="true">
+          <svg viewBox="0 0 400 320" xmlns="http://www.w3.org/2000/svg">
+            <rect width="400" height="320" fill="#efe5cf"/>
+            <rect x="30" y="60" width="340" height="210" fill="#25345a"/>
+            <rect x="30" y="44" width="340" height="26" fill="#16223d"/>
+            <text x="200" y="63" text-anchor="middle" font-family="Georgia, serif" font-size="16" fill="#d8c08a">INKWELL &amp; QUILL · BOOKS</text>
+            <!-- awning -->
+            <g>
+              <path d="M30 78 H370 L356 104 H44 Z" fill="#8c2b27"/>
+              <g fill="#6f201d"><rect x="44" y="78" width="24" height="26"/><rect x="92" y="78" width="24" height="26"/><rect x="140" y="78" width="24" height="26"/><rect x="188" y="78" width="24" height="26"/><rect x="236" y="78" width="24" height="26"/><rect x="284" y="78" width="24" height="26"/><rect x="332" y="78" width="24" height="26"/></g>
+            </g>
+            <!-- windows with books -->
+            <rect x="56" y="128" width="120" height="110" fill="#f6efdf" stroke="#b8923f" stroke-width="3"/>
+            <rect x="224" y="128" width="120" height="110" fill="#f6efdf" stroke="#b8923f" stroke-width="3"/>
+            <g fill="#25345a"><rect x="66" y="150" width="14" height="78"/><rect x="84" y="160" width="14" height="68"/><rect x="102" y="146" width="14" height="82"/><rect x="120" y="158" width="14" height="70"/><rect x="138" y="150" width="14" height="78"/><rect x="156" y="162" width="12" height="66"/></g>
+            <g fill="#8c2b27"><rect x="234" y="156" width="14" height="72"/><rect x="252" y="148" width="14" height="80"/><rect x="270" y="160" width="14" height="68"/></g>
+            <g fill="#b8923f"><rect x="290" y="150" width="14" height="78"/><rect x="308" y="158" width="14" height="70"/><rect x="326" y="152" width="12" height="76"/></g>
+            <!-- door -->
+            <rect x="184" y="170" width="48" height="100" fill="#16223d" stroke="#b8923f" stroke-width="3"/>
+            <circle cx="222" cy="222" r="3" fill="#d8c08a"/>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <section class="section feature-band">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-head__titles">
+            <span class="section-head__eyebrow" style="color:var(--gold-soft)">The people behind the counter</span>
+            <h2>Meet the Booksellers</h2>
+          </div>
+        </div>
+        <div class="bookseller-grid">
+          <article class="bio-card">
+            <svg viewBox="0 0 100 100" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="48" fill="#25345a"/><circle cx="50" cy="40" r="18" fill="#d8c08a"/><path d="M22 84 a28 24 0 0 1 56 0 Z" fill="#d8c08a"/></svg>
+            <h3>Margaret Quill</h3>
+            <p class="bio-card__role">Founder &amp; Fiction</p>
+            <p>Started it all in 1998. Will press a Russian novel into your hands if you give her half a chance.</p>
+          </article>
+          <article class="bio-card">
+            <svg viewBox="0 0 100 100" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="48" fill="#8c2b27"/><circle cx="50" cy="40" r="18" fill="#f6efdf"/><path d="M22 84 a28 24 0 0 1 56 0 Z" fill="#f6efdf"/></svg>
+            <h3>Devin Okoro</h3>
+            <p class="bio-card__role">Mystery &amp; Sci-Fi</p>
+            <p>Our resident genre obsessive. If it has a twist or a spaceship, Devin has already read it twice.</p>
+          </article>
+          <article class="bio-card">
+            <svg viewBox="0 0 100 100" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="48" fill="#0f5c63"/><circle cx="50" cy="40" r="18" fill="#fff7e6"/><path d="M22 84 a28 24 0 0 1 56 0 Z" fill="#fff7e6"/></svg>
+            <h3>Lucia Bramble</h3>
+            <p class="bio-card__role">Children's &amp; Events</p>
+            <p>Runs Saturday Storytime and never met a picture book she couldn't perform with full voices.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-head__titles">
+            <span class="section-head__eyebrow">There's always something happening</span>
+            <h2>Community Events</h2>
+          </div>
+          <a class="section-head__link" href="contact.html">Get directions &rarr;</a>
+        </div>
+        <ul class="events-list">
+          <li class="event-item">
+            <div class="event-date"><span class="day">12</span><span class="mon">Jul</span></div>
+            <div><h3>Author Evening: Marguerite Ellison</h3><p>A reading from <em>The Lantern Keepers</em>, followed by Q&amp;A and signing. 7:00pm · Free.</p></div>
+          </li>
+          <li class="event-item">
+            <div class="event-date"><span class="day">19</span><span class="mon">Jul</span></div>
+            <div><h3>Mystery Book Club</h3><p>This month: <em>Midnight at the Ledger</em>. New readers always welcome. 6:30pm · Back room.</p></div>
+          </li>
+          <li class="event-item">
+            <div class="event-date"><span class="day">26</span><span class="mon">Jul</span></div>
+            <div><h3>Saturday Storytime</h3><p>Picture books and puppets for ages 3–7 with bookseller Lucia. 10:30am · Children's nook.</p></div>
+          </li>
+          <li class="event-item">
+            <div class="event-date"><span class="day">02</span><span class="mon">Aug</span></div>
+            <div><h3>Poetry Open Mic</h3><p>Bring a poem or just your ears. Tea and cider provided. 7:30pm · Free.</p></div>
+          </li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <h4>Inkwell &amp; Quill</h4>
+          <p>An independent bookshop on the corner of Maple &amp; 3rd, serving readers since 1998.</p>
+        </div>
+        <div>
+          <h4>Shop</h4>
+          <ul>
+            <li><a href="shop.html">All Books</a></li>
+            <li><a href="shop.html?genre=Fiction">Fiction</a></li>
+            <li><a href="shop.html?genre=Mystery">Mystery</a></li>
+            <li><a href="shop.html?genre=Poetry">Poetry</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <ul>
+            <li><a href="about.html">Our Story</a></li>
+            <li><a href="contact.html">Hours &amp; Location</a></li>
+            <li><a href="contact.html">Events</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Hours</h4>
+          <ul>
+            <li>Mon–Fri: 9am – 8pm</li>
+            <li>Saturday: 10am – 8pm</li>
+            <li>Sunday: 11am – 6pm</li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Inkwell &amp; Quill Booksellers. All rights reserved.</span>
+        <span>Made with care for readers everywhere.</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/75-inkwell-books/cart.html
+++ b/fixtures/websites/75-inkwell-books/cart.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your Cart — Inkwell &amp; Quill Booksellers</title>
+  <meta name="description" content="Review the books in your cart, adjust quantities, and check out." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__bar">
+      <a class="brand" href="index.html">
+        <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="44" height="44" rx="8" fill="#16223d" stroke="#b8923f" stroke-width="1.5"/>
+          <path d="M24 12 C18 9, 10 9, 8 11 V35 C10 33, 18 33, 24 36 C30 33, 38 33, 40 35 V11 C38 9, 30 9, 24 12 Z" fill="none" stroke="#d8c08a" stroke-width="1.6"/>
+          <line x1="24" y1="12" x2="24" y2="36" stroke="#d8c08a" stroke-width="1.6"/>
+          <path d="M32 8 L36 12 L24 24 L20 24 L20 20 Z" fill="#8c2b27" stroke="#d8c08a" stroke-width="1"/>
+        </svg>
+        <span class="brand__text">
+          <span class="brand__name">Inkwell &amp; Quill</span>
+          <span class="brand__tag">Independent Booksellers</span>
+        </span>
+      </a>
+      <nav class="site-nav" data-nav aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="icon-btn" href="cart.html" aria-label="Cart" aria-current="page">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.4"/><circle cx="18" cy="20" r="1.4"/>
+            <path d="M2 3h2.2l2.1 12.2a1.5 1.5 0 0 0 1.5 1.3h8.9a1.5 1.5 0 0 0 1.5-1.2L21 7H6"/>
+          </svg>
+          <span class="cart-count is-empty" data-cart-count>0</span>
+        </a>
+        <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <section class="page-hero">
+    <div class="container">
+      <p class="breadcrumb"><a href="index.html">Home</a> / Cart</p>
+      <h1>Your Cart</h1>
+      <p>Review your selection, adjust quantities, and you're a few clicks from your next great read.</p>
+    </div>
+  </section>
+
+  <main class="section">
+    <div class="container" data-cart-page>
+      <div class="cart-empty" data-cart-empty hidden>
+        <svg viewBox="0 0 120 120" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="14" y="20" width="92" height="80" rx="6" fill="#efe5cf" stroke="#b8923f" stroke-width="2"/>
+          <path d="M60 30 C48 24, 28 24, 22 28 V86 C28 82, 48 82, 60 88 C72 82, 92 82, 98 86 V28 C92 24, 72 24, 60 30 Z" fill="#f6efdf" stroke="#25345a" stroke-width="2"/>
+          <line x1="60" y1="30" x2="60" y2="88" stroke="#25345a" stroke-width="2"/>
+        </svg>
+        <h2>Your cart is empty</h2>
+        <p>No books yet — but the shelves are waiting.</p>
+        <a class="btn btn--primary" href="shop.html">Browse the Shop</a>
+      </div>
+
+      <div class="cart-page">
+        <section aria-label="Cart items">
+          <div data-cart-lines></div>
+        </section>
+        <aside class="cart-summary" data-cart-summary hidden>
+          <h2>Order Summary</h2>
+          <div class="summary-row"><span>Subtotal</span><span data-cart-subtotal>$0.00</span></div>
+          <div class="summary-row"><span>Shipping</span><span>$4.95</span></div>
+          <div class="summary-row summary-row--total"><span>Total</span><span data-cart-total>$0.00</span></div>
+          <button class="btn btn--primary" data-cart-checkout>Proceed to Checkout</button>
+          <a class="btn btn--outline" href="shop.html">Continue Shopping</a>
+        </aside>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <h4>Inkwell &amp; Quill</h4>
+          <p>An independent bookshop on the corner of Maple &amp; 3rd, serving readers since 1998.</p>
+        </div>
+        <div>
+          <h4>Shop</h4>
+          <ul>
+            <li><a href="shop.html">All Books</a></li>
+            <li><a href="shop.html?genre=Fiction">Fiction</a></li>
+            <li><a href="shop.html?genre=Mystery">Mystery</a></li>
+            <li><a href="shop.html?genre=Poetry">Poetry</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <ul>
+            <li><a href="about.html">Our Story</a></li>
+            <li><a href="contact.html">Hours &amp; Location</a></li>
+            <li><a href="contact.html">Events</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Hours</h4>
+          <ul>
+            <li>Mon–Fri: 9am – 8pm</li>
+            <li>Saturday: 10am – 8pm</li>
+            <li>Sunday: 11am – 6pm</li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Inkwell &amp; Quill Booksellers. All rights reserved.</span>
+        <span>Made with care for readers everywhere.</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/75-inkwell-books/contact.html
+++ b/fixtures/websites/75-inkwell-books/contact.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact &amp; Visit — Inkwell &amp; Quill Booksellers</title>
+  <meta name="description" content="Visit Inkwell & Quill on the corner of Maple & 3rd. Store hours, location, and a contact form for any question." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__bar">
+      <a class="brand" href="index.html">
+        <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="44" height="44" rx="8" fill="#16223d" stroke="#b8923f" stroke-width="1.5"/>
+          <path d="M24 12 C18 9, 10 9, 8 11 V35 C10 33, 18 33, 24 36 C30 33, 38 33, 40 35 V11 C38 9, 30 9, 24 12 Z" fill="none" stroke="#d8c08a" stroke-width="1.6"/>
+          <line x1="24" y1="12" x2="24" y2="36" stroke="#d8c08a" stroke-width="1.6"/>
+          <path d="M32 8 L36 12 L24 24 L20 24 L20 20 Z" fill="#8c2b27" stroke="#d8c08a" stroke-width="1"/>
+        </svg>
+        <span class="brand__text">
+          <span class="brand__name">Inkwell &amp; Quill</span>
+          <span class="brand__tag">Independent Booksellers</span>
+        </span>
+      </a>
+      <nav class="site-nav" data-nav aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html" aria-current="page">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="icon-btn" href="cart.html" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.4"/><circle cx="18" cy="20" r="1.4"/>
+            <path d="M2 3h2.2l2.1 12.2a1.5 1.5 0 0 0 1.5 1.3h8.9a1.5 1.5 0 0 0 1.5-1.2L21 7H6"/>
+          </svg>
+          <span class="cart-count is-empty" data-cart-count>0</span>
+        </a>
+        <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <section class="page-hero">
+    <div class="container">
+      <p class="breadcrumb"><a href="index.html">Home</a> / Contact</p>
+      <h1>Come Visit Us</h1>
+      <p>Questions about an order, a special request, or just want to say hello? Drop us a line, or stop by the shop.</p>
+    </div>
+  </section>
+
+  <main class="section">
+    <div class="container contact-layout">
+      <div>
+        <h2>Send a Message</h2>
+        <form class="contact-form" data-contact-form novalidate>
+          <div class="row2">
+            <label class="field">
+              <span class="field__label">Name</span>
+              <input type="text" name="name" autocomplete="name" required />
+            </label>
+            <label class="field">
+              <span class="field__label">Email</span>
+              <input type="email" name="email" autocomplete="email" required />
+            </label>
+          </div>
+          <label class="field">
+            <span class="field__label">Subject</span>
+            <input type="text" name="subject" required />
+          </label>
+          <label class="field">
+            <span class="field__label">Message</span>
+            <textarea name="message" rows="6" required></textarea>
+          </label>
+          <div>
+            <button class="btn btn--primary" type="submit">Send Message</button>
+          </div>
+          <p class="form-note" data-form-note hidden style="color:var(--oxblood)"></p>
+        </form>
+      </div>
+
+      <aside>
+        <div class="info-card">
+          <h3>Find the Shop</h3>
+          <p>142 Maple Street (corner of 3rd)<br />Rivertown, OR 97000</p>
+          <p><strong>Phone:</strong> (555) 014-2030<br /><strong>Email:</strong> hello@inkwellquill.example</p>
+        </div>
+        <div class="info-card">
+          <h3>Store Hours</h3>
+          <table class="hours-table">
+            <tbody>
+              <tr><td>Monday – Friday</td><td>9:00am – 8:00pm</td></tr>
+              <tr><td>Saturday</td><td>10:00am – 8:00pm</td></tr>
+              <tr><td>Sunday</td><td>11:00am – 6:00pm</td></tr>
+              <tr><td>Holidays</td><td>Reduced hours</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="storefront-art" aria-hidden="true">
+          <svg viewBox="0 0 400 240" xmlns="http://www.w3.org/2000/svg">
+            <rect width="400" height="240" fill="#e8ddc2"/>
+            <!-- streets -->
+            <rect x="0" y="150" width="400" height="34" fill="#d2c39e"/>
+            <rect x="170" y="0" width="34" height="240" fill="#d2c39e"/>
+            <g stroke="#f6efdf" stroke-width="2" stroke-dasharray="10 10"><line x1="0" y1="167" x2="400" y2="167"/><line x1="187" y1="0" x2="187" y2="240"/></g>
+            <!-- blocks -->
+            <rect x="20" y="20" width="130" height="110" fill="#cbbb95"/>
+            <rect x="224" y="20" width="156" height="110" fill="#cbbb95"/>
+            <rect x="20" y="200" width="130" height="30" fill="#cbbb95"/>
+            <rect x="224" y="200" width="156" height="30" fill="#cbbb95"/>
+            <!-- river -->
+            <path d="M224 20 q60 40 0 90 q-50 40 30 20" fill="none" stroke="#5fb0c9" stroke-width="10" opacity="0.6"/>
+            <!-- pin marking the shop -->
+            <g transform="translate(187 150)">
+              <path d="M0 -44 C20 -44 28 -28 28 -16 C28 2 0 24 0 24 C0 24 -28 2 -28 -16 C-28 -28 -20 -44 0 -44 Z" fill="#8c2b27" stroke="#6f201d" stroke-width="2"/>
+              <circle cx="0" cy="-16" r="10" fill="#f6efdf"/>
+            </g>
+            <text x="187" y="200" text-anchor="middle" font-family="Georgia, serif" font-size="13" fill="#16223d">Maple &amp; 3rd</text>
+          </svg>
+        </div>
+      </aside>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <h4>Inkwell &amp; Quill</h4>
+          <p>An independent bookshop on the corner of Maple &amp; 3rd, serving readers since 1998.</p>
+        </div>
+        <div>
+          <h4>Shop</h4>
+          <ul>
+            <li><a href="shop.html">All Books</a></li>
+            <li><a href="shop.html?genre=Fiction">Fiction</a></li>
+            <li><a href="shop.html?genre=Mystery">Mystery</a></li>
+            <li><a href="shop.html?genre=Poetry">Poetry</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <ul>
+            <li><a href="about.html">Our Story</a></li>
+            <li><a href="contact.html">Hours &amp; Location</a></li>
+            <li><a href="contact.html">Events</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Hours</h4>
+          <ul>
+            <li>Mon–Fri: 9am – 8pm</li>
+            <li>Saturday: 10am – 8pm</li>
+            <li>Sunday: 11am – 6pm</li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Inkwell &amp; Quill Booksellers. All rights reserved.</span>
+        <span>Made with care for readers everywhere.</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/75-inkwell-books/css/styles.css
+++ b/fixtures/websites/75-inkwell-books/css/styles.css
@@ -1,0 +1,470 @@
+/* =====================================================================
+   Inkwell & Quill — Independent Booksellers
+   Classic / literary / cozy. Ink navy, warm paper cream, oxblood, gold.
+   ===================================================================== */
+
+:root {
+  --ink: #16223d;          /* deep navy / ink */
+  --ink-soft: #25345a;
+  --paper: #f6efdf;        /* warm cream */
+  --paper-deep: #efe5cf;
+  --paper-card: #fbf6ea;
+  --oxblood: #8c2b27;      /* accent */
+  --oxblood-deep: #6f201d;
+  --gold: #b8923f;         /* hairline gold */
+  --gold-soft: #d8c08a;
+  --text: #1d2336;
+  --text-soft: #4a5169;
+  --muted: #767c92;
+  --line: #d9ccae;
+  --shadow: 0 10px 30px rgba(22, 34, 61, 0.14);
+  --shadow-soft: 0 4px 14px rgba(22, 34, 61, 0.10);
+  --serif: Georgia, 'Times New Roman', 'Iowan Old Style', serif;
+  --sans: 'Helvetica Neue', Helvetica, Arial, system-ui, sans-serif;
+  --radius: 6px;
+  --maxw: 1180px;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  color: var(--text);
+  line-height: 1.6;
+  background-color: var(--paper);
+  /* subtle paper grain via layered gradients */
+  background-image:
+    radial-gradient(circle at 20% 15%, rgba(184, 146, 63, 0.05), transparent 40%),
+    radial-gradient(circle at 80% 60%, rgba(140, 43, 39, 0.04), transparent 45%),
+    repeating-linear-gradient(0deg, rgba(22, 34, 61, 0.018) 0 1px, transparent 1px 3px);
+}
+
+body.no-scroll { overflow: hidden; }
+
+h1, h2, h3, h4 { font-family: var(--serif); color: var(--ink); line-height: 1.2; margin: 0 0 0.4em; }
+p { margin: 0 0 1em; }
+a { color: var(--oxblood); text-decoration: none; }
+a:hover { color: var(--oxblood-deep); text-decoration: underline; }
+img, svg { max-width: 100%; }
+
+.container { max-width: var(--maxw); margin: 0 auto; padding: 0 1.25rem; }
+.section { padding: 3.5rem 0; }
+.section--tight { padding: 2.25rem 0; }
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+
+/* ---------- buttons ---------- */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 0.4rem;
+  font-family: var(--sans); font-size: 0.9rem; font-weight: 600; letter-spacing: 0.02em;
+  padding: 0.7rem 1.2rem; border-radius: var(--radius); border: 1px solid transparent;
+  cursor: pointer; transition: transform 0.12s ease, background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  background: var(--ink); color: var(--paper); text-decoration: none;
+}
+.btn:hover { background: var(--ink-soft); color: #fff; text-decoration: none; transform: translateY(-1px); }
+.btn--primary { background: var(--oxblood); }
+.btn--primary:hover { background: var(--oxblood-deep); }
+.btn--outline { background: transparent; color: var(--ink); border-color: var(--ink); }
+.btn--outline:hover { background: var(--ink); color: var(--paper); }
+.btn--small { padding: 0.45rem 0.8rem; font-size: 0.8rem; }
+.btn--ghost { background: transparent; color: var(--paper); border-color: rgba(255,255,255,0.4); }
+.btn--ghost:hover { background: rgba(255,255,255,0.12); color: #fff; }
+
+.linkish {
+  background: none; border: 0; padding: 0; cursor: pointer; font: inherit;
+  color: inherit; text-align: left;
+}
+.linkish:hover { color: var(--oxblood); }
+
+/* ---------- header ---------- */
+.site-header {
+  position: sticky; top: 0; z-index: 40;
+  background: var(--ink);
+  color: var(--paper);
+  border-bottom: 2px solid var(--gold);
+}
+.site-header__bar {
+  display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+  padding: 0.65rem 1.25rem; max-width: var(--maxw); margin: 0 auto;
+}
+.brand { display: flex; align-items: center; gap: 0.7rem; color: var(--paper); text-decoration: none; }
+.brand:hover { color: #fff; text-decoration: none; }
+.brand__mark { width: 40px; height: 40px; flex: 0 0 auto; }
+.brand__text { display: flex; flex-direction: column; line-height: 1.05; }
+.brand__name { font-family: var(--serif); font-size: 1.2rem; font-weight: 700; letter-spacing: 0.01em; }
+.brand__tag { font-family: var(--sans); font-size: 0.62rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--gold-soft); }
+
+.site-nav { display: flex; align-items: center; gap: 1.4rem; }
+.site-nav a {
+  color: var(--paper); font-size: 0.92rem; letter-spacing: 0.02em; text-decoration: none;
+  padding: 0.2rem 0; border-bottom: 2px solid transparent;
+}
+.site-nav a:hover, .site-nav a[aria-current="page"] { color: #fff; border-bottom-color: var(--gold); }
+
+.header-actions { display: flex; align-items: center; gap: 0.4rem; }
+.icon-btn {
+  position: relative; display: inline-flex; align-items: center; justify-content: center;
+  width: 42px; height: 42px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.18);
+  background: transparent; color: var(--paper); cursor: pointer; transition: background 0.18s ease;
+}
+.icon-btn:hover { background: rgba(255,255,255,0.12); }
+.icon-btn svg { width: 20px; height: 20px; }
+.cart-count {
+  position: absolute; top: -4px; right: -4px; min-width: 20px; height: 20px; padding: 0 5px;
+  border-radius: 10px; background: var(--oxblood); color: #fff; font-family: var(--sans);
+  font-size: 0.7rem; font-weight: 700; display: flex; align-items: center; justify-content: center;
+  border: 2px solid var(--ink);
+}
+.cart-count.is-empty { display: none; }
+
+.nav-toggle { display: none; }
+
+/* ---------- hero ---------- */
+.hero {
+  background:
+    radial-gradient(circle at 85% 20%, rgba(184, 146, 63, 0.16), transparent 45%),
+    linear-gradient(160deg, var(--ink) 0%, var(--ink-soft) 100%);
+  color: var(--paper); position: relative; overflow: hidden;
+  border-bottom: 1px solid var(--gold);
+}
+.hero__inner {
+  display: grid; grid-template-columns: 1.1fr 0.9fr; align-items: center; gap: 2.5rem;
+  max-width: var(--maxw); margin: 0 auto; padding: 3.75rem 1.25rem;
+}
+.hero__kicker {
+  font-size: 0.72rem; letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--gold-soft); margin-bottom: 0.8rem;
+}
+.hero h1 { color: var(--paper); font-size: clamp(2.1rem, 4.5vw, 3.4rem); margin-bottom: 0.6rem; }
+.hero__lead { color: rgba(246, 239, 223, 0.85); font-size: 1.08rem; max-width: 32ch; }
+.hero__cta { display: flex; gap: 0.8rem; margin-top: 1.6rem; flex-wrap: wrap; }
+.hero__art { display: flex; justify-content: center; }
+.hero__art svg { width: 100%; max-width: 380px; filter: drop-shadow(0 18px 30px rgba(0,0,0,0.35)); }
+
+/* ---------- section headings ---------- */
+.section-head {
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 1rem;
+  margin-bottom: 1.8rem; border-bottom: 1px solid var(--line); padding-bottom: 0.7rem;
+}
+.section-head__titles { display: flex; flex-direction: column; }
+.section-head__eyebrow {
+  font-family: var(--sans); font-size: 0.7rem; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--oxblood); margin-bottom: 0.35rem;
+}
+.section-head h2 { font-size: 1.7rem; margin: 0; }
+.section-head__link { font-size: 0.88rem; font-weight: 600; white-space: nowrap; }
+
+/* ---------- book grid + cards ---------- */
+.book-grid {
+  display: grid; gap: 1.6rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+.book-row {
+  display: grid; gap: 1.6rem;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.book-card {
+  background: var(--paper-card); border: 1px solid var(--line); border-radius: var(--radius);
+  overflow: hidden; display: flex; flex-direction: column;
+  box-shadow: var(--shadow-soft); transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+.book-card:hover { transform: translateY(-4px); box-shadow: var(--shadow); }
+.book-card__cover {
+  position: relative; display: block; width: 100%; padding: 1.3rem 1.3rem 0; border: 0;
+  background: transparent; cursor: pointer;
+}
+.book-card__cover .cover-svg {
+  width: 100%; height: auto; display: block; border-radius: 4px;
+  box-shadow: 0 8px 18px rgba(22, 34, 61, 0.22);
+  transition: transform 0.18s ease;
+}
+.book-card__cover:hover .cover-svg { transform: scale(1.02); }
+.card-flag {
+  position: absolute; top: 1.55rem; left: 0; z-index: 2;
+  font-family: var(--sans); font-size: 0.62rem; font-weight: 700; letter-spacing: 0.12em;
+  text-transform: uppercase; color: #fff; padding: 0.28rem 0.6rem;
+}
+.card-flag--best { background: var(--oxblood); }
+.card-flag--pick { background: var(--gold); color: var(--ink); }
+
+.book-card__body { padding: 1rem 1.3rem 1.3rem; display: flex; flex-direction: column; flex: 1; }
+.book-card__genre {
+  font-family: var(--sans); font-size: 0.65rem; letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--muted); margin: 0 0 0.3rem;
+}
+.book-card__title { font-size: 1.08rem; margin: 0 0 0.2rem; }
+.book-card__author { font-style: italic; color: var(--text-soft); margin: 0 0 0.9rem; font-size: 0.92rem; }
+.book-card__foot { margin-top: auto; display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; }
+.book-card__price { font-family: var(--serif); font-size: 1.2rem; font-weight: 700; color: var(--ink); }
+
+.empty-note { color: var(--text-soft); font-style: italic; grid-column: 1 / -1; padding: 1.5rem 0; }
+
+/* ---------- shop layout ---------- */
+.shop-layout { display: grid; grid-template-columns: 250px 1fr; gap: 2rem; align-items: start; }
+.filters {
+  background: var(--paper-card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 1.3rem; position: sticky; top: 84px;
+}
+.filters h2 { font-size: 1.1rem; border-bottom: 1px solid var(--line); padding-bottom: 0.5rem; margin-bottom: 1rem; }
+.field { display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 1.1rem; }
+.field__label {
+  font-family: var(--sans); font-size: 0.72rem; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--text-soft); font-weight: 600;
+}
+select, input[type="text"], input[type="email"], input[type="tel"], textarea {
+  font-family: var(--sans); font-size: 0.92rem; color: var(--text);
+  padding: 0.6rem 0.7rem; border: 1px solid var(--line); border-radius: var(--radius);
+  background: #fff; width: 100%;
+}
+select:focus, input:focus, textarea:focus {
+  outline: 2px solid var(--gold); outline-offset: 1px; border-color: var(--gold);
+}
+
+.shop-toolbar {
+  display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+  margin-bottom: 1.4rem; flex-wrap: wrap;
+}
+.shop-toolbar .field { flex-direction: row; align-items: center; gap: 0.6rem; margin: 0; }
+.result-count { font-size: 0.85rem; color: var(--text-soft); }
+
+/* ---------- modal ---------- */
+.modal { position: fixed; inset: 0; z-index: 80; display: flex; align-items: center; justify-content: center; }
+.modal[hidden] { display: none; }
+.modal__overlay { position: absolute; inset: 0; background: rgba(13, 20, 38, 0.6); backdrop-filter: blur(2px); }
+.modal__dialog {
+  position: relative; z-index: 1; width: min(820px, 92vw); max-height: 90vh; overflow: auto;
+  background: var(--paper-card); border: 1px solid var(--gold); border-radius: 10px; box-shadow: var(--shadow);
+}
+.modal__close, .drawer__close {
+  position: absolute; top: 0.8rem; right: 0.9rem; width: 38px; height: 38px;
+  border-radius: 50%; border: 1px solid var(--line); background: #fff; color: var(--ink);
+  font-size: 1.5rem; line-height: 1; cursor: pointer; z-index: 2;
+}
+.modal__close:hover, .drawer__close:hover { background: var(--paper-deep); }
+.modal__grid { display: grid; grid-template-columns: 0.85fr 1.15fr; gap: 1.8rem; padding: 2rem; }
+.modal__cover svg { width: 100%; border-radius: 4px; box-shadow: 0 12px 26px rgba(22,34,61,0.28); }
+.modal__genre {
+  font-size: 0.68rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--oxblood); margin: 0 0 0.4rem;
+}
+.modal__title { font-size: 1.8rem; margin-bottom: 0.2rem; }
+.modal__author { font-style: italic; color: var(--text-soft); margin-bottom: 1rem; }
+.modal__desc { color: var(--text); margin-bottom: 1.4rem; }
+.modal__controls { display: flex; gap: 1.4rem; flex-wrap: wrap; align-items: flex-end; margin-bottom: 1.4rem; }
+.modal__buy { display: flex; align-items: center; gap: 1.2rem; border-top: 1px solid var(--line); padding-top: 1.2rem; }
+.modal__price { font-family: var(--serif); font-size: 1.6rem; font-weight: 700; color: var(--ink); }
+
+/* ---------- stepper ---------- */
+.stepper { display: inline-flex; align-items: center; border: 1px solid var(--line); border-radius: var(--radius); background: #fff; }
+.stepper__btn {
+  width: 38px; height: 38px; border: 0; background: transparent; cursor: pointer;
+  font-size: 1.15rem; color: var(--ink); line-height: 1;
+}
+.stepper__btn:hover { background: var(--paper-deep); }
+.stepper__val { min-width: 34px; text-align: center; font-weight: 600; }
+.stepper--sm .stepper__btn { width: 30px; height: 30px; font-size: 1rem; }
+.stepper--sm .stepper__val { min-width: 26px; font-size: 0.9rem; }
+
+/* ---------- drawer ---------- */
+.drawer { position: fixed; inset: 0; z-index: 80; }
+.drawer[hidden] { display: none; }
+.drawer__overlay { position: absolute; inset: 0; background: rgba(13, 20, 38, 0.55); }
+.drawer__panel {
+  position: absolute; top: 0; right: 0; height: 100%; width: min(420px, 92vw);
+  background: var(--paper-card); border-left: 2px solid var(--gold);
+  display: flex; flex-direction: column; box-shadow: var(--shadow);
+  animation: slideIn 0.22s ease;
+}
+@keyframes slideIn { from { transform: translateX(100%); } to { transform: translateX(0); } }
+.drawer__head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.2rem 1.3rem; border-bottom: 1px solid var(--line); position: relative;
+}
+.drawer__title { margin: 0; font-size: 1.3rem; }
+.drawer__close { position: static; }
+.drawer__body { flex: 1; overflow-y: auto; padding: 1rem 1.3rem; }
+.drawer__foot { border-top: 1px solid var(--line); padding: 1.2rem 1.3rem; display: grid; gap: 0.6rem; }
+.drawer__subtotal { display: flex; justify-content: space-between; font-size: 1.05rem; margin-bottom: 0.4rem; }
+.drawer__subtotal strong { font-family: var(--serif); font-size: 1.25rem; }
+
+/* ---------- cart line items ---------- */
+.line {
+  display: grid; grid-template-columns: 64px 1fr auto; gap: 1rem; align-items: start;
+  padding: 1rem 0; border-bottom: 1px solid var(--line);
+}
+.line__cover svg { width: 64px; height: auto; border-radius: 3px; box-shadow: var(--shadow-soft); }
+.line__title { font-family: var(--serif); font-weight: 700; margin: 0 0 0.15rem; color: var(--ink); }
+.line__meta { font-size: 0.82rem; color: var(--text-soft); margin: 0 0 0.15rem; }
+.line__unit { font-size: 0.8rem; color: var(--muted); margin: 0 0 0.55rem; }
+.line__controls { display: flex; align-items: center; gap: 0.8rem; }
+.line__remove {
+  background: none; border: 0; color: var(--oxblood); cursor: pointer; font-size: 0.82rem;
+  text-decoration: underline; padding: 0;
+}
+.line__remove:hover { color: var(--oxblood-deep); }
+.line__total { font-family: var(--serif); font-weight: 700; color: var(--ink); white-space: nowrap; }
+
+/* full cart page */
+.cart-page { display: grid; grid-template-columns: 1fr 320px; gap: 2.5rem; align-items: start; }
+.cart-summary {
+  background: var(--paper-card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 1.5rem; position: sticky; top: 84px;
+}
+.cart-summary h2 { font-size: 1.25rem; border-bottom: 1px solid var(--line); padding-bottom: 0.6rem; margin-bottom: 1rem; }
+.summary-row { display: flex; justify-content: space-between; margin-bottom: 0.7rem; font-size: 0.95rem; }
+.summary-row--total {
+  border-top: 1px solid var(--line); margin-top: 1rem; padding-top: 1rem;
+  font-family: var(--serif); font-size: 1.3rem; font-weight: 700; color: var(--ink);
+}
+.cart-summary .btn { width: 100%; margin-top: 0.8rem; }
+.cart-empty { text-align: center; padding: 3rem 1rem; }
+.cart-empty svg { width: 120px; margin-bottom: 1rem; opacity: 0.8; }
+
+/* ---------- editorial / content blocks ---------- */
+.lead { font-size: 1.15rem; color: var(--text-soft); max-width: 60ch; }
+.prose { max-width: 70ch; }
+.prose p { font-size: 1.02rem; }
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 2.5rem; align-items: center; }
+
+.feature-band { background: var(--ink); color: var(--paper); }
+.feature-band h2, .feature-band h3 { color: var(--paper); }
+.feature-band .lead { color: rgba(246,239,223,0.82); }
+
+.bookseller-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.6rem; }
+.bio-card {
+  background: var(--paper-card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 1.5rem; text-align: center;
+}
+.bio-card svg { width: 90px; height: 90px; margin: 0 auto 1rem; }
+.bio-card h3 { font-size: 1.2rem; margin-bottom: 0.2rem; }
+.bio-card__role { font-size: 0.75rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--oxblood); margin-bottom: 0.7rem; }
+
+.events-list { list-style: none; padding: 0; margin: 0; }
+.event-item {
+  display: grid; grid-template-columns: 84px 1fr; gap: 1.2rem; align-items: center;
+  padding: 1.1rem 0; border-bottom: 1px solid var(--line);
+}
+.event-date {
+  text-align: center; background: var(--ink); color: var(--paper); border-radius: var(--radius);
+  padding: 0.5rem; line-height: 1.1;
+}
+.event-date .day { font-family: var(--serif); font-size: 1.6rem; font-weight: 700; display: block; }
+.event-date .mon { font-size: 0.68rem; letter-spacing: 0.16em; text-transform: uppercase; }
+.event-item h3 { font-size: 1.1rem; margin-bottom: 0.15rem; }
+.event-item p { margin: 0; color: var(--text-soft); font-size: 0.9rem; }
+
+/* reading list teaser */
+.reading-list { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.6rem; }
+.post-card {
+  background: var(--paper-card); border: 1px solid var(--line); border-radius: var(--radius);
+  overflow: hidden; display: flex; flex-direction: column;
+}
+.post-card__art { height: 150px; }
+.post-card__art svg { width: 100%; height: 100%; display: block; }
+.post-card__body { padding: 1.2rem; display: flex; flex-direction: column; flex: 1; }
+.post-card__tag { font-size: 0.66rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--oxblood); margin-bottom: 0.4rem; }
+.post-card h3 { font-size: 1.15rem; }
+.post-card__excerpt { color: var(--text-soft); font-size: 0.92rem; }
+.post-card__more { margin-top: auto; font-weight: 600; font-size: 0.85rem; }
+
+/* newsletter */
+.newsletter {
+  background:
+    radial-gradient(circle at 12% 20%, rgba(184,146,63,0.18), transparent 40%),
+    linear-gradient(150deg, var(--oxblood-deep), var(--oxblood));
+  color: #fff; border-radius: 10px; padding: 2.6rem; text-align: center;
+}
+.newsletter h2 { color: #fff; font-size: 1.8rem; }
+.newsletter p { color: rgba(255,255,255,0.88); max-width: 46ch; margin: 0 auto 1.4rem; }
+.newsletter__form { display: flex; gap: 0.6rem; max-width: 440px; margin: 0 auto; flex-wrap: wrap; }
+.newsletter__form input {
+  flex: 1; min-width: 200px; border: 0; padding: 0.8rem 1rem; border-radius: var(--radius);
+}
+.newsletter__form .btn { background: var(--ink); }
+.newsletter__form .btn:hover { background: #0d1426; }
+.form-note { margin-top: 1rem; font-size: 0.9rem; color: #fff; font-style: italic; }
+
+/* contact */
+.contact-layout { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 2.5rem; align-items: start; }
+.contact-form { display: grid; gap: 1.1rem; }
+.contact-form .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1.1rem; }
+.info-card {
+  background: var(--paper-card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 1.5rem; margin-bottom: 1.5rem;
+}
+.info-card h3 { font-size: 1.2rem; border-bottom: 1px solid var(--line); padding-bottom: 0.5rem; margin-bottom: 0.9rem; }
+.hours-table { width: 100%; border-collapse: collapse; }
+.hours-table td { padding: 0.35rem 0; font-size: 0.92rem; }
+.hours-table td:last-child { text-align: right; color: var(--text-soft); }
+.storefront-art svg { width: 100%; border-radius: var(--radius); border: 1px solid var(--line); }
+
+.page-hero {
+  background: linear-gradient(160deg, var(--ink), var(--ink-soft));
+  color: var(--paper); padding: 3rem 0; border-bottom: 2px solid var(--gold);
+}
+.page-hero h1 { color: var(--paper); font-size: clamp(2rem, 4vw, 3rem); }
+.page-hero p { color: rgba(246,239,223,0.85); max-width: 56ch; margin: 0; }
+.breadcrumb { font-size: 0.8rem; color: var(--gold-soft); margin-bottom: 0.6rem; letter-spacing: 0.04em; }
+.breadcrumb a { color: var(--gold-soft); }
+
+/* ---------- footer ---------- */
+.site-footer { background: var(--ink); color: rgba(246,239,223,0.8); padding: 3rem 0 1.5rem; border-top: 2px solid var(--gold); }
+.footer-grid { display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; gap: 2rem; }
+.site-footer h4 { color: var(--paper); font-size: 1rem; margin-bottom: 0.9rem; }
+.site-footer ul { list-style: none; padding: 0; margin: 0; }
+.site-footer li { margin-bottom: 0.5rem; }
+.site-footer a { color: rgba(246,239,223,0.8); font-size: 0.9rem; }
+.site-footer a:hover { color: #fff; }
+.footer-brand p { font-size: 0.9rem; max-width: 36ch; }
+.footer-bottom {
+  border-top: 1px solid rgba(255,255,255,0.12); margin-top: 2rem; padding-top: 1.2rem;
+  display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;
+  font-size: 0.82rem; color: rgba(246,239,223,0.6);
+}
+
+/* ---------- responsive ---------- */
+@media (max-width: 940px) {
+  .hero__inner { grid-template-columns: 1fr; text-align: center; }
+  .hero__cta { justify-content: center; }
+  .hero__lead { margin: 0 auto; }
+  .hero__art { order: -1; }
+  .shop-layout { grid-template-columns: 1fr; }
+  .filters { position: static; }
+  .cart-page { grid-template-columns: 1fr; }
+  .cart-summary { position: static; }
+  .two-col, .contact-layout { grid-template-columns: 1fr; }
+  .bookseller-grid, .reading-list { grid-template-columns: 1fr 1fr; }
+  .book-row { grid-template-columns: 1fr 1fr; }
+  .footer-grid { grid-template-columns: 1fr 1fr; }
+  .modal__grid { grid-template-columns: 1fr; }
+  .modal__cover { max-width: 220px; margin: 0 auto; }
+}
+
+@media (max-width: 680px) {
+  .nav-toggle {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 42px; height: 42px; border-radius: var(--radius);
+    background: transparent; border: 1px solid rgba(255,255,255,0.25); color: var(--paper); cursor: pointer;
+  }
+  .nav-toggle svg { width: 22px; height: 22px; }
+  .site-nav {
+    position: absolute; top: 100%; left: 0; right: 0; flex-direction: column; align-items: stretch;
+    gap: 0; background: var(--ink); border-bottom: 2px solid var(--gold);
+    max-height: 0; overflow: hidden; transition: max-height 0.25s ease;
+  }
+  .site-nav.is-open { max-height: 360px; }
+  .site-nav a { padding: 0.9rem 1.25rem; border-bottom: 1px solid rgba(255,255,255,0.08); }
+  .site-nav a:hover, .site-nav a[aria-current="page"] { border-bottom-color: rgba(255,255,255,0.08); background: var(--ink-soft); }
+  .bookseller-grid, .reading-list, .book-row, .footer-grid { grid-template-columns: 1fr; }
+  .contact-form .row2 { grid-template-columns: 1fr; }
+  .section { padding: 2.5rem 0; }
+  .newsletter { padding: 1.8rem 1.2rem; }
+  .line { grid-template-columns: 52px 1fr; }
+  .line__cover svg { width: 52px; }
+  .line__total { grid-column: 2; text-align: right; }
+}

--- a/fixtures/websites/75-inkwell-books/fixture.json
+++ b/fixtures/websites/75-inkwell-books/fixture.json
@@ -1,0 +1,16 @@
+{
+  "class": "ecommerce/catalog",
+  "tags": [
+    "ecommerce",
+    "bookstore",
+    "has-cart",
+    "add-to-cart",
+    "filters",
+    "sorting",
+    "format-variants",
+    "mini-cart",
+    "multipage",
+    "localstorage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/75-inkwell-books/index.html
+++ b/fixtures/websites/75-inkwell-books/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inkwell &amp; Quill — Independent Booksellers</title>
+  <meta name="description" content="Inkwell & Quill is a cozy independent bookstore. Discover staff picks, new arrivals, and bestsellers across fiction, mystery, poetry, and more." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__bar">
+      <a class="brand" href="index.html">
+        <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="44" height="44" rx="8" fill="#16223d" stroke="#b8923f" stroke-width="1.5"/>
+          <path d="M24 12 C18 9, 10 9, 8 11 V35 C10 33, 18 33, 24 36 C30 33, 38 33, 40 35 V11 C38 9, 30 9, 24 12 Z" fill="none" stroke="#d8c08a" stroke-width="1.6"/>
+          <line x1="24" y1="12" x2="24" y2="36" stroke="#d8c08a" stroke-width="1.6"/>
+          <path d="M32 8 L36 12 L24 24 L20 24 L20 20 Z" fill="#8c2b27" stroke="#d8c08a" stroke-width="1"/>
+        </svg>
+        <span class="brand__text">
+          <span class="brand__name">Inkwell &amp; Quill</span>
+          <span class="brand__tag">Independent Booksellers</span>
+        </span>
+      </a>
+      <nav class="site-nav" data-nav aria-label="Primary">
+        <a href="index.html" aria-current="page">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="icon-btn" href="cart.html" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.4"/><circle cx="18" cy="20" r="1.4"/>
+            <path d="M2 3h2.2l2.1 12.2a1.5 1.5 0 0 0 1.5 1.3h8.9a1.5 1.5 0 0 0 1.5-1.2L21 7H6"/>
+          </svg>
+          <span class="cart-count is-empty" data-cart-count>0</span>
+        </a>
+        <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <!-- HERO -->
+    <section class="hero">
+      <div class="hero__inner">
+        <div class="hero__copy">
+          <p class="hero__kicker">Est. 1998 &middot; On the corner of Maple &amp; 3rd</p>
+          <h1>Where every story finds its reader.</h1>
+          <p class="hero__lead">A cozy corner bookshop stacked floor-to-ceiling with hand-picked titles, curated by booksellers who actually read them.</p>
+          <div class="hero__cta">
+            <a class="btn btn--primary" href="shop.html">Browse the Shelves</a>
+            <a class="btn btn--ghost" href="#staff-picks">See Staff Picks</a>
+          </div>
+        </div>
+        <div class="hero__art" aria-hidden="true">
+          <svg viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="hb1" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#8c2b27"/><stop offset="1" stop-color="#6f201d"/></linearGradient>
+              <linearGradient id="hb2" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#25345a"/><stop offset="1" stop-color="#16223d"/></linearGradient>
+              <linearGradient id="hb3" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#b8923f"/><stop offset="1" stop-color="#8c6f2c"/></linearGradient>
+            </defs>
+            <!-- open book on top -->
+            <g transform="translate(40 40)">
+              <path d="M140 30 C100 12, 50 12, 30 24 V70 C50 58, 100 58, 140 76 C180 58, 230 58, 250 70 V24 C230 12, 180 12, 140 30 Z" fill="#f6efdf" stroke="#b8923f" stroke-width="2"/>
+              <line x1="140" y1="30" x2="140" y2="76" stroke="#b8923f" stroke-width="2"/>
+              <g stroke="#c9b48a" stroke-width="1.4">
+                <line x1="46" y1="36" x2="120" y2="40"/><line x1="46" y1="46" x2="120" y2="50"/>
+                <line x1="160" y1="40" x2="234" y2="36"/><line x1="160" y1="50" x2="234" y2="46"/>
+              </g>
+            </g>
+            <!-- stacked books -->
+            <g transform="translate(70 150)">
+              <rect x="0" y="0" width="220" height="34" rx="4" fill="url(#hb2)" stroke="#0d1426" stroke-width="1"/>
+              <rect x="10" y="6" width="200" height="3" fill="#d8c08a" opacity="0.6"/>
+              <rect x="14" y="40" width="200" height="34" rx="4" fill="url(#hb1)" stroke="#561917" stroke-width="1"/>
+              <rect x="24" y="46" width="180" height="3" fill="#f6efdf" opacity="0.5"/>
+              <rect x="4" y="80" width="214" height="34" rx="4" fill="url(#hb3)" stroke="#6c531f" stroke-width="1"/>
+              <rect x="14" y="86" width="194" height="3" fill="#16223d" opacity="0.4"/>
+            </g>
+            <!-- quill -->
+            <g transform="translate(232 30) rotate(20)">
+              <path d="M0 120 C30 60, 60 20, 96 0 C84 40, 60 90, 22 124 Z" fill="#f6efdf" stroke="#b8923f" stroke-width="1.4"/>
+              <line x1="14" y1="120" x2="60" y2="44" stroke="#b8923f" stroke-width="1.2"/>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <!-- STAFF PICKS -->
+    <section class="section" id="staff-picks">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-head__titles">
+            <span class="section-head__eyebrow">Hand-selected by our booksellers</span>
+            <h2>Staff Picks</h2>
+          </div>
+          <a class="section-head__link" href="shop.html">Shop all &rarr;</a>
+        </div>
+        <div class="book-row" data-row="staff"></div>
+      </div>
+    </section>
+
+    <!-- NEW ARRIVALS -->
+    <section class="section section--tight">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-head__titles">
+            <span class="section-head__eyebrow">Fresh off the delivery truck</span>
+            <h2>New Arrivals</h2>
+          </div>
+          <a class="section-head__link" href="shop.html?sort=newest">Newest first &rarr;</a>
+        </div>
+        <div class="book-row" data-row="arrivals"></div>
+      </div>
+    </section>
+
+    <!-- BESTSELLERS -->
+    <section class="section section--tight">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-head__titles">
+            <span class="section-head__eyebrow">What the neighborhood is reading</span>
+            <h2>Bestsellers</h2>
+          </div>
+          <a class="section-head__link" href="shop.html">Shop all &rarr;</a>
+        </div>
+        <div class="book-row" data-row="bestsellers"></div>
+      </div>
+    </section>
+
+    <!-- READING LIST / BLOG TEASER -->
+    <section class="section feature-band">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-head__titles">
+            <span class="section-head__eyebrow" style="color:var(--gold-soft)">From the reading room</span>
+            <h2>The Reading List</h2>
+          </div>
+        </div>
+        <div class="reading-list">
+          <article class="post-card">
+            <div class="post-card__art" aria-hidden="true">
+              <svg viewBox="0 0 300 150" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><rect width="300" height="150" fill="#25345a"/><circle cx="60" cy="75" r="40" fill="#8c2b27" opacity="0.7"/><circle cx="220" cy="60" r="55" fill="#b8923f" opacity="0.45"/></svg>
+            </div>
+            <div class="post-card__body">
+              <span class="post-card__tag">Booklists</span>
+              <h3>10 Cozy Reads for a Rainy Weekend</h3>
+              <p class="post-card__excerpt">Kettle on, blanket out — these are the slow, warm novels we reach for when the sky turns gray.</p>
+              <a class="post-card__more" href="#">Read more &rarr;</a>
+            </div>
+          </article>
+          <article class="post-card">
+            <div class="post-card__art" aria-hidden="true">
+              <svg viewBox="0 0 300 150" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><rect width="300" height="150" fill="#16223d"/><path d="M0 110 Q75 60 150 100 T300 90 V150 H0 Z" fill="#0f5c63" opacity="0.7"/><circle cx="240" cy="45" r="26" fill="#d8c08a"/></svg>
+            </div>
+            <div class="post-card__body">
+              <span class="post-card__tag">Bookseller Diary</span>
+              <h3>How We Choose the Window Display</h3>
+              <p class="post-card__excerpt">A peek behind the glass at the small, opinionated ritual that greets you every morning.</p>
+              <a class="post-card__more" href="#">Read more &rarr;</a>
+            </div>
+          </article>
+          <article class="post-card">
+            <div class="post-card__art" aria-hidden="true">
+              <svg viewBox="0 0 300 150" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><rect width="300" height="150" fill="#2e2440"/><g stroke="#caa15a" stroke-width="2" opacity="0.7" fill="none"><circle cx="150" cy="75" r="30"/><circle cx="150" cy="75" r="55"/></g></svg>
+            </div>
+            <div class="post-card__body">
+              <span class="post-card__tag">Author Events</span>
+              <h3>Spring Author Series: The Lineup</h3>
+              <p class="post-card__excerpt">Five evenings, five voices. Wine, readings, and Q&amp;A with the writers we love most.</p>
+              <a class="post-card__more" href="about.html">See events &rarr;</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- NEWSLETTER -->
+    <section class="section">
+      <div class="container">
+        <div class="newsletter">
+          <h2>The Monthly Dispatch</h2>
+          <p>New releases, staff picks, and event invitations — one tasteful email a month. No spam, ever.</p>
+          <form class="newsletter__form" data-newsletter novalidate>
+            <label class="visually-hidden" for="nl-home">Email address</label>
+            <input type="email" id="nl-home" name="email" placeholder="you@example.com" required />
+            <button class="btn" type="submit">Subscribe</button>
+          </form>
+          <p class="form-note" data-newsletter-note hidden></p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <h4>Inkwell &amp; Quill</h4>
+          <p>An independent bookshop on the corner of Maple &amp; 3rd, serving readers since 1998.</p>
+        </div>
+        <div>
+          <h4>Shop</h4>
+          <ul>
+            <li><a href="shop.html">All Books</a></li>
+            <li><a href="shop.html?genre=Fiction">Fiction</a></li>
+            <li><a href="shop.html?genre=Mystery">Mystery</a></li>
+            <li><a href="shop.html?genre=Poetry">Poetry</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <ul>
+            <li><a href="about.html">Our Story</a></li>
+            <li><a href="contact.html">Hours &amp; Location</a></li>
+            <li><a href="contact.html">Events</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Hours</h4>
+          <ul>
+            <li>Mon–Fri: 9am – 8pm</li>
+            <li>Saturday: 10am – 8pm</li>
+            <li>Sunday: 11am – 6pm</li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Inkwell &amp; Quill Booksellers. All rights reserved.</span>
+        <span>Made with care for readers everywhere.</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/75-inkwell-books/js/app.js
+++ b/fixtures/websites/75-inkwell-books/js/app.js
@@ -1,0 +1,657 @@
+/* Inkwell & Quill — UI behavior (render / filter / sort / modal / drawer / cart page)
+ * Vanilla JS, no dependencies. Every page-specific feature guards for missing
+ * DOM nodes, so this one file powers all five pages safely.
+ */
+(function () {
+  'use strict';
+
+  var DATA = window.INKWELL_DATA;
+  var Cart = window.InkwellCart;
+
+  /* ---------- small helpers ---------- */
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $all(sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); }
+  function money(n) { return '$' + (Math.round(n * 100) / 100).toFixed(2); }
+  function esc(str) {
+    return String(str).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+  function hashHue(str) {
+    var h = 0;
+    for (var i = 0; i < str.length; i++) { h = (h * 31 + str.charCodeAt(i)) % 360; }
+    return h;
+  }
+
+  /* ---------- inline SVG book cover generator ---------- */
+  // Produces a distinct cover per book using genre theme + coverStyle + title hash.
+  function buildCoverSVG(product, opts) {
+    opts = opts || {};
+    var theme = (window.INKWELL_GENRE_THEMES && window.INKWELL_GENRE_THEMES[product.genre]) ||
+      { bg: '#1f2d4a', panel: '#27406b', ink: '#f4ecd8', accent: '#9b2226' };
+    var uid = product.id.replace(/[^a-z0-9]/gi, '');
+    var hue = hashHue(product.title);
+    var initials = product.title.replace(/[^A-Za-z ]/g, '').split(/\s+/)
+      .slice(0, 2).map(function (w) { return w.charAt(0).toUpperCase(); }).join('');
+    var w = 300, h = 440;
+
+    var motif = '';
+    switch (product.coverStyle) {
+      case 'stripe':
+        motif =
+          '<rect x="40" y="120" width="220" height="6" fill="' + theme.accent + '"/>' +
+          '<rect x="40" y="300" width="220" height="6" fill="' + theme.accent + '"/>';
+        break;
+      case 'arch':
+        motif =
+          '<path d="M60 360 V200 a90 90 0 0 1 180 0 V360 Z" fill="none" stroke="' + theme.accent + '" stroke-width="4" opacity="0.85"/>';
+        break;
+      case 'grid':
+        motif =
+          '<g stroke="' + theme.accent + '" stroke-width="1.5" opacity="0.5">' +
+          '<line x1="40" y1="170" x2="260" y2="170"/><line x1="40" y1="220" x2="260" y2="220"/>' +
+          '<line x1="40" y1="270" x2="260" y2="270"/><line x1="110" y1="150" x2="110" y2="300"/>' +
+          '<line x1="190" y1="150" x2="190" y2="300"/></g>';
+        break;
+      case 'banner':
+        motif =
+          '<path d="M150 110 l70 40 v120 l-70 -34 -70 34 V150 Z" fill="' + theme.accent + '" opacity="0.85"/>';
+        break;
+      case 'noir':
+        motif =
+          '<circle cx="150" cy="210" r="78" fill="none" stroke="' + theme.accent + '" stroke-width="3"/>' +
+          '<circle cx="150" cy="210" r="48" fill="' + theme.accent + '" opacity="0.18"/>' +
+          '<line x1="150" y1="210" x2="206" y2="166" stroke="' + theme.accent + '" stroke-width="3"/>';
+        break;
+      case 'orbit':
+        motif =
+          '<g fill="none" stroke="' + theme.accent + '" stroke-width="2.5" opacity="0.9">' +
+          '<ellipse cx="150" cy="210" rx="100" ry="42"/>' +
+          '<ellipse cx="150" cy="210" rx="60" ry="92" transform="rotate(35 150 210)"/></g>' +
+          '<circle cx="150" cy="210" r="16" fill="' + theme.accent + '"/>';
+        break;
+      case 'minimal':
+        motif =
+          '<line x1="90" y1="250" x2="210" y2="250" stroke="' + theme.accent + '" stroke-width="2"/>';
+        break;
+      case 'playful':
+        motif =
+          '<circle cx="95" cy="180" r="26" fill="' + theme.accent + '"/>' +
+          '<circle cx="160" cy="230" r="18" fill="hsl(' + hue + ',70%,60%)"/>' +
+          '<circle cx="215" cy="170" r="22" fill="' + theme.ink + '" opacity="0.85"/>';
+        break;
+      default:
+        motif = '';
+    }
+
+    return '' +
+      '<svg class="cover-svg" viewBox="0 0 ' + w + ' ' + h + '" role="img" ' +
+      'aria-label="Cover of ' + esc(product.title) + ' by ' + esc(product.author) + '" ' +
+      'preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">' +
+        '<defs>' +
+          '<linearGradient id="bg' + uid + '" x1="0" y1="0" x2="1" y2="1">' +
+            '<stop offset="0" stop-color="' + theme.bg + '"/>' +
+            '<stop offset="1" stop-color="' + theme.panel + '"/>' +
+          '</linearGradient>' +
+        '</defs>' +
+        '<rect width="' + w + '" height="' + h + '" rx="6" fill="url(#bg' + uid + ')"/>' +
+        // spine + paper edge
+        '<rect x="0" y="0" width="14" height="' + h + '" rx="6" fill="#00000033"/>' +
+        '<rect x="14" y="0" width="3" height="' + h + '" fill="' + theme.accent + '" opacity="0.7"/>' +
+        // gold hairline frame
+        '<rect x="24" y="24" width="' + (w - 48) + '" height="' + (h - 48) + '" rx="3" ' +
+          'fill="none" stroke="' + theme.accent + '" stroke-width="1" opacity="0.55"/>' +
+        motif +
+        // big initial watermark
+        '<text x="150" y="240" text-anchor="middle" font-family="Georgia, serif" ' +
+          'font-size="120" fill="' + theme.ink + '" opacity="0.07" font-weight="700">' + esc(initials) + '</text>' +
+        // title
+        wrapTitle(product.title, theme.ink) +
+        // author
+        '<text x="150" y="404" text-anchor="middle" font-family="Georgia, serif" ' +
+          'font-size="15" fill="' + theme.ink + '" opacity="0.85" font-style="italic">' +
+          esc(product.author) + '</text>' +
+        // genre kicker
+        '<text x="150" y="64" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" ' +
+          'font-size="11" letter-spacing="3" fill="' + theme.accent + '">' +
+          esc(product.genre.toUpperCase()) + '</text>' +
+      '</svg>';
+  }
+
+  // crude word-wrap into up to 3 tspans for the cover title
+  function wrapTitle(title, ink) {
+    var words = title.split(' ');
+    var lines = [];
+    var current = '';
+    var max = 14;
+    words.forEach(function (word) {
+      if ((current + ' ' + word).trim().length > max && current) {
+        lines.push(current.trim());
+        current = word;
+      } else {
+        current = (current + ' ' + word).trim();
+      }
+    });
+    if (current) { lines.push(current); }
+    lines = lines.slice(0, 3);
+    var startY = 348 - (lines.length - 1) * 26;
+    return '<g font-family="Georgia, serif" font-weight="700" font-size="26" fill="' + ink + '" text-anchor="middle">' +
+      lines.map(function (line, i) {
+        return '<text x="150" y="' + (startY + i * 30) + '">' + esc(line) + '</text>';
+      }).join('') + '</g>';
+  }
+
+  /* ---------- header badge (every page) ---------- */
+  function initBadge() {
+    var badges = $all('[data-cart-count]');
+    if (!badges.length) { return; }
+    Cart.subscribe(function (snap) {
+      badges.forEach(function (b) {
+        b.textContent = snap.count;
+        b.classList.toggle('is-empty', snap.count === 0);
+        b.setAttribute('aria-label', snap.count + ' items in cart');
+      });
+    });
+  }
+
+  /* ---------- mobile nav toggle ---------- */
+  function initNavToggle() {
+    var toggle = $('[data-nav-toggle]');
+    var nav = $('[data-nav]');
+    if (!toggle || !nav) { return; }
+    toggle.addEventListener('click', function () {
+      var open = nav.classList.toggle('is-open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
+
+  /* ---------- product card markup ---------- */
+  function cardHTML(product) {
+    var badge = product.bestseller ? '<span class="card-flag card-flag--best">Bestseller</span>' :
+      (product.staffPick ? '<span class="card-flag card-flag--pick">Staff Pick</span>' : '');
+    return '' +
+      '<article class="book-card" data-id="' + esc(product.id) + '">' +
+        '<button class="book-card__cover" data-open="' + esc(product.id) + '" ' +
+          'aria-label="View details for ' + esc(product.title) + '">' +
+          badge + buildCoverSVG(product) +
+        '</button>' +
+        '<div class="book-card__body">' +
+          '<p class="book-card__genre">' + esc(product.genre) + '</p>' +
+          '<h3 class="book-card__title">' +
+            '<button class="linkish" data-open="' + esc(product.id) + '">' + esc(product.title) + '</button>' +
+          '</h3>' +
+          '<p class="book-card__author">' + esc(product.author) + '</p>' +
+          '<div class="book-card__foot">' +
+            '<span class="book-card__price">' + money(product.price) + '</span>' +
+            '<button class="btn btn--small" data-add="' + esc(product.id) + '">Add to Cart</button>' +
+          '</div>' +
+        '</div>' +
+      '</article>';
+  }
+
+  function renderInto(node, list) {
+    if (!node) { return; }
+    if (!list.length) {
+      node.innerHTML = '<p class="empty-note">No books match these filters. Try widening your search.</p>';
+      return;
+    }
+    node.innerHTML = list.map(cardHTML).join('');
+  }
+
+  /* ---------- home page rows ---------- */
+  function initHomeRows() {
+    var staff = $('[data-row="staff"]');
+    var arrivals = $('[data-row="arrivals"]');
+    var best = $('[data-row="bestsellers"]');
+    if (!staff && !arrivals && !best) { return; }
+    var all = DATA.products;
+
+    if (staff) {
+      renderInto(staff, all.filter(function (p) { return p.staffPick; }).slice(0, 4));
+    }
+    if (arrivals) {
+      renderInto(arrivals, all.slice().sort(function (a, b) {
+        return new Date(b.added) - new Date(a.added);
+      }).slice(0, 4));
+    }
+    if (best) {
+      renderInto(best, all.filter(function (p) { return p.bestseller; }).slice(0, 4));
+    }
+  }
+
+  /* ---------- shop page filter + sort ---------- */
+  function initShop() {
+    var grid = $('[data-shop-grid]');
+    if (!grid) { return; }
+    var genreSel = $('[data-filter-genre]');
+    var priceSel = $('[data-filter-price]');
+    var sortSel = $('[data-sort]');
+    var countOut = $('[data-result-count]');
+
+    // populate genre options
+    if (genreSel) {
+      var genres = DATA.products.map(function (p) { return p.genre; })
+        .filter(function (g, i, arr) { return arr.indexOf(g) === i; }).sort();
+      genres.forEach(function (g) {
+        var opt = document.createElement('option');
+        opt.value = g; opt.textContent = g;
+        genreSel.appendChild(opt);
+      });
+    }
+
+    // honor ?genre= and ?sort= from query string (links from home)
+    var qs = new URLSearchParams(window.location.search);
+    if (genreSel && qs.get('genre')) { genreSel.value = qs.get('genre'); }
+    if (sortSel && qs.get('sort')) {
+      var wanted = qs.get('sort');
+      if ($all('option', sortSel).some(function (o) { return o.value === wanted; })) {
+        sortSel.value = wanted;
+      }
+    }
+
+    function priceBand(val, product) {
+      if (val === 'all' || !val) { return true; }
+      if (val === 'under20') { return product.price < 20; }
+      if (val === '20to28') { return product.price >= 20 && product.price <= 28; }
+      if (val === 'over28') { return product.price > 28; }
+      return true;
+    }
+
+    function apply() {
+      var g = genreSel ? genreSel.value : 'all';
+      var pb = priceSel ? priceSel.value : 'all';
+      var sort = sortSel ? sortSel.value : 'featured';
+
+      var list = DATA.products.filter(function (p) {
+        return (g === 'all' || !g || p.genre === g) && priceBand(pb, p);
+      });
+
+      list.sort(function (a, b) {
+        switch (sort) {
+          case 'price-asc': return a.price - b.price;
+          case 'price-desc': return b.price - a.price;
+          case 'title-asc': return a.title.localeCompare(b.title);
+          case 'newest': return new Date(b.added) - new Date(a.added);
+          default:
+            // featured: staff picks then bestsellers then title
+            var sa = (a.staffPick ? 0 : 1) - 0, sb = (b.staffPick ? 0 : 1) - 0;
+            if (sa !== sb) { return sa - sb; }
+            var ba = a.bestseller ? 0 : 1, bb = b.bestseller ? 0 : 1;
+            if (ba !== bb) { return ba - bb; }
+            return a.title.localeCompare(b.title);
+        }
+      });
+
+      renderInto(grid, list);
+      if (countOut) {
+        countOut.textContent = list.length + (list.length === 1 ? ' book' : ' books');
+      }
+    }
+
+    [genreSel, priceSel, sortSel].forEach(function (el) {
+      if (el) { el.addEventListener('change', apply); }
+    });
+    apply();
+  }
+
+  /* ---------- product detail modal ---------- */
+  var modal = {
+    root: null, lastFocus: null, currentId: null, qty: 1, formatId: null
+  };
+
+  function buildModalShell() {
+    if (modal.root) { return modal.root; }
+    var el = document.createElement('div');
+    el.className = 'modal';
+    el.setAttribute('hidden', '');
+    el.innerHTML =
+      '<div class="modal__overlay" data-close></div>' +
+      '<div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modalTitle">' +
+        '<button class="modal__close" data-close aria-label="Close details">&times;</button>' +
+        '<div class="modal__grid">' +
+          '<div class="modal__cover" data-modal-cover></div>' +
+          '<div class="modal__info">' +
+            '<p class="modal__genre" data-modal-genre></p>' +
+            '<h2 class="modal__title" id="modalTitle" data-modal-title></h2>' +
+            '<p class="modal__author" data-modal-author></p>' +
+            '<p class="modal__desc" data-modal-desc></p>' +
+            '<div class="modal__controls">' +
+              '<label class="field">' +
+                '<span class="field__label">Format</span>' +
+                '<select data-modal-format></select>' +
+              '</label>' +
+              '<div class="field">' +
+                '<span class="field__label">Quantity</span>' +
+                '<div class="stepper" role="group" aria-label="Quantity">' +
+                  '<button class="stepper__btn" data-qty-dec aria-label="Decrease quantity">&minus;</button>' +
+                  '<span class="stepper__val" data-qty-val aria-live="polite">1</span>' +
+                  '<button class="stepper__btn" data-qty-inc aria-label="Increase quantity">+</button>' +
+                '</div>' +
+              '</div>' +
+            '</div>' +
+            '<div class="modal__buy">' +
+              '<span class="modal__price" data-modal-price></span>' +
+              '<button class="btn btn--primary" data-modal-add>Add to Cart</button>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(el);
+    modal.root = el;
+
+    el.addEventListener('click', function (e) {
+      if (e.target.hasAttribute('data-close')) { closeModal(); }
+    });
+    $('[data-qty-dec]', el).addEventListener('click', function () { setModalQty(modal.qty - 1); });
+    $('[data-qty-inc]', el).addEventListener('click', function () { setModalQty(modal.qty + 1); });
+    $('[data-modal-format]', el).addEventListener('change', function (e) {
+      modal.formatId = e.target.value;
+      updateModalPrice();
+    });
+    $('[data-modal-add]', el).addEventListener('click', function () {
+      Cart.add(modal.currentId, modal.formatId, modal.qty);
+      closeModal();
+      openDrawer();
+    });
+    return el;
+  }
+
+  function setModalQty(n) {
+    modal.qty = Math.max(1, n);
+    var out = $('[data-qty-val]', modal.root);
+    if (out) { out.textContent = modal.qty; }
+    updateModalPrice();
+  }
+
+  function updateModalPrice() {
+    var product = DATA.getProduct(modal.currentId);
+    if (!product) { return; }
+    var unit = DATA.priceFor(product, modal.formatId);
+    var out = $('[data-modal-price]', modal.root);
+    if (out) { out.textContent = money(unit * modal.qty); }
+  }
+
+  function openModal(id) {
+    var product = DATA.getProduct(id);
+    if (!product) { return; }
+    buildModalShell();
+    modal.currentId = id;
+    modal.qty = 1;
+    modal.formatId = DATA.formats[0].id;
+    modal.lastFocus = document.activeElement;
+
+    $('[data-modal-cover]', modal.root).innerHTML = buildCoverSVG(product);
+    $('[data-modal-genre]', modal.root).textContent = product.genre;
+    $('[data-modal-title]', modal.root).textContent = product.title;
+    $('[data-modal-author]', modal.root).textContent = 'by ' + product.author;
+    $('[data-modal-desc]', modal.root).textContent = product.description;
+
+    var fmtSel = $('[data-modal-format]', modal.root);
+    fmtSel.innerHTML = DATA.formats.map(function (f) {
+      return '<option value="' + f.id + '">' + esc(f.label) + ' — ' +
+        money(DATA.priceFor(product, f.id)) + '</option>';
+    }).join('');
+    fmtSel.value = modal.formatId;
+
+    setModalQty(1);
+    modal.root.removeAttribute('hidden');
+    document.body.classList.add('no-scroll');
+    var closeBtn = $('.modal__close', modal.root);
+    if (closeBtn) { closeBtn.focus(); }
+  }
+
+  function closeModal() {
+    if (!modal.root || modal.root.hasAttribute('hidden')) { return; }
+    modal.root.setAttribute('hidden', '');
+    document.body.classList.remove('no-scroll');
+    if (modal.lastFocus && modal.lastFocus.focus) { modal.lastFocus.focus(); }
+  }
+
+  /* ---------- mini-cart drawer ---------- */
+  var drawer = { root: null, lastFocus: null };
+
+  function buildDrawerShell() {
+    if (drawer.root) { return drawer.root; }
+    var el = document.createElement('div');
+    el.className = 'drawer';
+    el.setAttribute('hidden', '');
+    el.innerHTML =
+      '<div class="drawer__overlay" data-close></div>' +
+      '<aside class="drawer__panel" role="dialog" aria-modal="true" aria-label="Shopping cart">' +
+        '<header class="drawer__head">' +
+          '<h2 class="drawer__title">Your Cart</h2>' +
+          '<button class="drawer__close" data-close aria-label="Close cart">&times;</button>' +
+        '</header>' +
+        '<div class="drawer__body" data-drawer-lines></div>' +
+        '<footer class="drawer__foot">' +
+          '<div class="drawer__subtotal"><span>Subtotal</span><strong data-drawer-subtotal>$0.00</strong></div>' +
+          '<a class="btn btn--outline" href="cart.html">View Cart</a>' +
+          '<button class="btn btn--primary" data-checkout>Checkout</button>' +
+        '</footer>' +
+      '</aside>';
+    document.body.appendChild(el);
+    drawer.root = el;
+
+    el.addEventListener('click', function (e) {
+      if (e.target.hasAttribute('data-close')) { closeDrawer(); }
+    });
+    var checkout = $('[data-checkout]', el);
+    if (checkout) {
+      checkout.addEventListener('click', function () {
+        var snap = Cart.snapshot();
+        if (!snap.count) { return; }
+        alert('Thank you! This is a demo store — your order of ' + snap.count +
+          ' book(s) totaling ' + money(snap.subtotal) + ' would be placed here.');
+        Cart.clear();
+        closeDrawer();
+      });
+    }
+
+    // delegate qty/remove inside drawer
+    $('[data-drawer-lines]', el).addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-line-action]');
+      if (!btn) { return; }
+      var id = btn.getAttribute('data-id');
+      var fmt = btn.getAttribute('data-format');
+      var action = btn.getAttribute('data-line-action');
+      if (action === 'inc') { Cart.increment(id, fmt, 1); }
+      else if (action === 'dec') { Cart.increment(id, fmt, -1); }
+      else if (action === 'remove') { Cart.remove(id, fmt); }
+    });
+    return el;
+  }
+
+  function lineRowHTML(line, compact) {
+    var product = line.product;
+    var coverMini = product ?
+      '<div class="line__cover">' + buildCoverSVG(product) + '</div>' : '';
+    return '' +
+      '<div class="line' + (compact ? ' line--compact' : '') + '">' +
+        coverMini +
+        '<div class="line__main">' +
+          '<p class="line__title">' + esc(line.title) + '</p>' +
+          '<p class="line__meta">' + esc(line.author) + ' &middot; ' + esc(line.formatLabel) + '</p>' +
+          '<p class="line__unit">' + money(line.unitPrice) + ' each</p>' +
+          '<div class="line__controls">' +
+            '<div class="stepper stepper--sm" role="group" aria-label="Quantity for ' + esc(line.title) + '">' +
+              '<button class="stepper__btn" data-line-action="dec" data-id="' + esc(line.id) + '" data-format="' + esc(line.formatId) + '" aria-label="Decrease quantity">&minus;</button>' +
+              '<span class="stepper__val">' + line.qty + '</span>' +
+              '<button class="stepper__btn" data-line-action="inc" data-id="' + esc(line.id) + '" data-format="' + esc(line.formatId) + '" aria-label="Increase quantity">+</button>' +
+            '</div>' +
+            '<button class="line__remove" data-line-action="remove" data-id="' + esc(line.id) + '" data-format="' + esc(line.formatId) + '" aria-label="Remove ' + esc(line.title) + '">Remove</button>' +
+          '</div>' +
+        '</div>' +
+        '<div class="line__total">' + money(line.lineTotal) + '</div>' +
+      '</div>';
+  }
+
+  function renderDrawer(snap) {
+    if (!drawer.root) { return; }
+    var body = $('[data-drawer-lines]', drawer.root);
+    var sub = $('[data-drawer-subtotal]', drawer.root);
+    if (!snap.lines.length) {
+      body.innerHTML = '<p class="empty-note">Your cart is empty. Find your next great read in the shop.</p>';
+    } else {
+      body.innerHTML = snap.lines.map(function (l) { return lineRowHTML(l, true); }).join('');
+    }
+    if (sub) { sub.textContent = money(snap.subtotal); }
+  }
+
+  function openDrawer() {
+    buildDrawerShell();
+    renderDrawer(Cart.snapshot());
+    drawer.lastFocus = document.activeElement;
+    drawer.root.removeAttribute('hidden');
+    document.body.classList.add('no-scroll');
+    var closeBtn = $('.drawer__close', drawer.root);
+    if (closeBtn) { closeBtn.focus(); }
+  }
+
+  function closeDrawer() {
+    if (!drawer.root || drawer.root.hasAttribute('hidden')) { return; }
+    drawer.root.setAttribute('hidden', '');
+    document.body.classList.remove('no-scroll');
+    if (drawer.lastFocus && drawer.lastFocus.focus) { drawer.lastFocus.focus(); }
+  }
+
+  function initDrawer() {
+    // keep drawer contents fresh whenever cart changes
+    Cart.subscribe(function (snap) {
+      if (drawer.root && !drawer.root.hasAttribute('hidden')) { renderDrawer(snap); }
+    });
+    var trigger = $('[data-open-cart]');
+    if (trigger) {
+      trigger.addEventListener('click', function (e) {
+        e.preventDefault();
+        openDrawer();
+      });
+    }
+  }
+
+  /* ---------- full cart page ---------- */
+  function initCartPage() {
+    var wrap = $('[data-cart-page]');
+    if (!wrap) { return; }
+    var linesNode = $('[data-cart-lines]', wrap);
+    var subNode = $('[data-cart-subtotal]', wrap);
+    var totalNode = $('[data-cart-total]', wrap);
+    var summary = $('[data-cart-summary]', wrap);
+    var emptyNode = $('[data-cart-empty]', wrap);
+    var SHIP = 4.95;
+
+    function render(snap) {
+      if (!snap.lines.length) {
+        if (linesNode) { linesNode.innerHTML = ''; }
+        if (summary) { summary.hidden = true; }
+        if (emptyNode) { emptyNode.hidden = false; }
+        return;
+      }
+      if (emptyNode) { emptyNode.hidden = true; }
+      if (summary) { summary.hidden = false; }
+      if (linesNode) {
+        linesNode.innerHTML = snap.lines.map(function (l) { return lineRowHTML(l, false); }).join('');
+      }
+      if (subNode) { subNode.textContent = money(snap.subtotal); }
+      if (totalNode) { totalNode.textContent = money(snap.subtotal + SHIP); }
+    }
+
+    if (linesNode) {
+      linesNode.addEventListener('click', function (e) {
+        var btn = e.target.closest('[data-line-action]');
+        if (!btn) { return; }
+        var id = btn.getAttribute('data-id');
+        var fmt = btn.getAttribute('data-format');
+        var action = btn.getAttribute('data-line-action');
+        if (action === 'inc') { Cart.increment(id, fmt, 1); }
+        else if (action === 'dec') { Cart.increment(id, fmt, -1); }
+        else if (action === 'remove') { Cart.remove(id, fmt); }
+      });
+    }
+
+    var checkoutBtn = $('[data-cart-checkout]', wrap);
+    if (checkoutBtn) {
+      checkoutBtn.addEventListener('click', function () {
+        var snap = Cart.snapshot();
+        if (!snap.count) { return; }
+        alert('Thank you! This is a demo store — your order of ' + snap.count +
+          ' book(s) totaling ' + money(snap.subtotal + SHIP) + ' would be placed here.');
+        Cart.clear();
+      });
+    }
+
+    Cart.subscribe(render);
+  }
+
+  /* ---------- contact form (demo, no backend) ---------- */
+  function initContactForm() {
+    var form = $('[data-contact-form]');
+    if (!form) { return; }
+    var note = $('[data-form-note]', form);
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      if (!form.checkValidity()) { form.reportValidity(); return; }
+      if (note) {
+        note.hidden = false;
+        note.textContent = 'Thank you — your message has been received. We’ll reply within two business days.';
+      }
+      form.reset();
+    });
+  }
+
+  /* ---------- newsletter (demo) ---------- */
+  function initNewsletter() {
+    $all('[data-newsletter]').forEach(function (form) {
+      var note = $('[data-newsletter-note]', form);
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        if (!form.checkValidity()) { form.reportValidity(); return; }
+        if (note) {
+          note.hidden = false;
+          note.textContent = 'You’re on the list! Watch your inbox for our monthly reading dispatch.';
+        }
+        form.reset();
+      });
+    });
+  }
+
+  /* ---------- global click + keyboard wiring ---------- */
+  function initGlobalEvents() {
+    document.addEventListener('click', function (e) {
+      var openBtn = e.target.closest('[data-open]');
+      if (openBtn) { e.preventDefault(); openModal(openBtn.getAttribute('data-open')); return; }
+      var addBtn = e.target.closest('[data-add]');
+      if (addBtn) {
+        e.preventDefault();
+        var product = DATA.getProduct(addBtn.getAttribute('data-add'));
+        if (product) {
+          Cart.add(product.id, DATA.formats[0].id, 1);
+          openDrawer();
+        }
+      }
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        closeModal();
+        closeDrawer();
+      }
+    });
+  }
+
+  /* ---------- boot ---------- */
+  document.addEventListener('DOMContentLoaded', function () {
+    if (!DATA || !Cart) { return; }
+    initBadge();
+    initNavToggle();
+    initDrawer();
+    initGlobalEvents();
+    initHomeRows();
+    initShop();
+    initCartPage();
+    initContactForm();
+    initNewsletter();
+
+    // stamp current year in footers
+    $all('[data-year]').forEach(function (n) { n.textContent = new Date().getFullYear(); });
+  });
+})();

--- a/fixtures/websites/75-inkwell-books/js/cart.js
+++ b/fixtures/websites/75-inkwell-books/js/cart.js
@@ -1,0 +1,152 @@
+/* Inkwell & Quill — cart + localStorage (shared across every page)
+ * Exposes window.InkwellCart with a small, framework-free API and a
+ * change-notification system so app.js can re-render badges/drawers/pages.
+ */
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'inkwell_cart';
+  var listeners = [];
+  var items = load();
+
+  function load() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) { return []; }
+      var parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter(isValidLine) : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function isValidLine(line) {
+    return line && typeof line.id === 'string' &&
+      typeof line.formatId === 'string' &&
+      typeof line.qty === 'number' && line.qty > 0;
+  }
+
+  function persist() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    } catch (e) { /* storage may be unavailable; degrade silently */ }
+  }
+
+  function lineKey(id, formatId) {
+    return id + '::' + formatId;
+  }
+
+  function find(id, formatId) {
+    for (var i = 0; i < items.length; i++) {
+      if (items[i].id === id && items[i].formatId === formatId) { return items[i]; }
+    }
+    return null;
+  }
+
+  function notify() {
+    persist();
+    for (var i = 0; i < listeners.length; i++) {
+      try { listeners[i](publicSnapshot()); } catch (e) { /* keep going */ }
+    }
+  }
+
+  // Enrich raw lines with live product data + computed prices for consumers.
+  function publicSnapshot() {
+    var data = window.INKWELL_DATA;
+    var lines = items.map(function (line) {
+      var product = data ? data.getProduct(line.id) : null;
+      var unit = product ? data.priceFor(product, line.formatId) : 0;
+      return {
+        key: lineKey(line.id, line.formatId),
+        id: line.id,
+        formatId: line.formatId,
+        formatLabel: data ? data.formatLabel(line.formatId) : line.formatId,
+        qty: line.qty,
+        title: product ? product.title : line.id,
+        author: product ? product.author : '',
+        genre: product ? product.genre : '',
+        product: product,
+        unitPrice: unit,
+        lineTotal: unit * line.qty
+      };
+    });
+    return {
+      lines: lines,
+      count: count(),
+      subtotal: lines.reduce(function (sum, l) { return sum + l.lineTotal; }, 0)
+    };
+  }
+
+  function count() {
+    return items.reduce(function (sum, l) { return sum + l.qty; }, 0);
+  }
+
+  function add(id, formatId, qty) {
+    qty = Math.max(1, parseInt(qty, 10) || 1);
+    var existing = find(id, formatId);
+    if (existing) {
+      existing.qty += qty;
+    } else {
+      items.push({ id: id, formatId: formatId, qty: qty });
+    }
+    notify();
+  }
+
+  function setQty(id, formatId, qty) {
+    qty = parseInt(qty, 10) || 0;
+    var existing = find(id, formatId);
+    if (!existing) { return; }
+    if (qty <= 0) {
+      remove(id, formatId);
+      return;
+    }
+    existing.qty = qty;
+    notify();
+  }
+
+  function increment(id, formatId, delta) {
+    var existing = find(id, formatId);
+    if (!existing) { return; }
+    setQty(id, formatId, existing.qty + (delta || 1));
+  }
+
+  function remove(id, formatId) {
+    items = items.filter(function (l) {
+      return !(l.id === id && l.formatId === formatId);
+    });
+    notify();
+  }
+
+  function clear() {
+    items = [];
+    notify();
+  }
+
+  function subscribe(fn) {
+    if (typeof fn === 'function') {
+      listeners.push(fn);
+      fn(publicSnapshot()); // emit current state immediately
+    }
+  }
+
+  // Keep multiple open tabs/pages in sync.
+  window.addEventListener('storage', function (e) {
+    if (e.key === STORAGE_KEY) {
+      items = load();
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](publicSnapshot()); } catch (err) { /* noop */ }
+      }
+    }
+  });
+
+  window.InkwellCart = {
+    add: add,
+    setQty: setQty,
+    increment: increment,
+    remove: remove,
+    clear: clear,
+    count: count,
+    snapshot: publicSnapshot,
+    subscribe: subscribe
+  };
+})();

--- a/fixtures/websites/75-inkwell-books/js/products.js
+++ b/fixtures/websites/75-inkwell-books/js/products.js
@@ -1,0 +1,224 @@
+/* Inkwell & Quill — product catalog data
+ * Shared across all pages. Exposes window.INKWELL_PRODUCTS and helpers.
+ * Each product carries a "cover" descriptor used by buildCoverSVG() in app.js
+ * so every book renders a unique inline SVG "cover".
+ */
+(function () {
+  'use strict';
+
+  // Genre palettes — drive the SVG cover colors so each genre reads distinctly.
+  var GENRE_THEMES = {
+    'Fiction':            { bg: '#1f2d4a', panel: '#27406b', ink: '#f4ecd8', accent: '#9b2226' },
+    'Non-Fiction':        { bg: '#3a3226', panel: '#574a36', ink: '#f4ecd8', accent: '#c9a227' },
+    'Mystery':            { bg: '#14181f', panel: '#222a36', ink: '#e8e2d0', accent: '#8c1c13' },
+    'Sci-Fi & Fantasy':   { bg: '#1b2a3a', panel: '#123047', ink: '#d8f0ff', accent: '#5fb0c9' },
+    'Poetry':             { bg: '#2e2440', panel: '#3f315a', ink: '#f3e9ff', accent: '#caa15a' },
+    "Children's":         { bg: '#0f5c63', panel: '#147a82', ink: '#fff7e6', accent: '#f4a259' },
+    'History':            { bg: '#3d2c20', panel: '#5a4130', ink: '#f0e3cf', accent: '#a86a3d' }
+  };
+
+  // Standard format variants. Price is computed as a delta on the base price.
+  var FORMATS = [
+    { id: 'hardcover', label: 'Hardcover', delta: 0 },
+    { id: 'paperback', label: 'Paperback', delta: -6 },
+    { id: 'ebook',     label: 'eBook',     delta: -9 }
+  ];
+
+  var PRODUCTS = [
+    {
+      id: 'the-lantern-keepers',
+      title: 'The Lantern Keepers',
+      author: 'Marguerite Ellison',
+      genre: 'Fiction',
+      price: 27.0,
+      added: '2026-06-20',
+      bestseller: true,
+      staffPick: true,
+      coverStyle: 'stripe',
+      description: 'On a windswept island where the lighthouse never sleeps, three generations of women guard a secret the sea keeps trying to reclaim. A luminous, character-driven novel about inheritance, grief, and the small mercies that keep us tethered to one another.'
+    },
+    {
+      id: 'salt-and-cedar',
+      title: 'Salt & Cedar',
+      author: 'Tomas Reyes',
+      genre: 'Fiction',
+      price: 24.0,
+      added: '2026-05-02',
+      bestseller: false,
+      staffPick: true,
+      coverStyle: 'arch',
+      description: 'A sweeping family saga that follows a fishing community across four decades of boom, bust, and stubborn love. Reyes writes the ordinary with such tenderness that you will swear you can smell the harbor.'
+    },
+    {
+      id: 'the-quiet-algorithm',
+      title: 'The Quiet Algorithm',
+      author: 'Dr. Priya Nandakumar',
+      genre: 'Non-Fiction',
+      price: 29.0,
+      added: '2026-06-12',
+      bestseller: true,
+      staffPick: false,
+      coverStyle: 'grid',
+      description: 'A clear-eyed field guide to the invisible systems shaping modern life — from credit scores to recommendation engines. Nandakumar trades hype for humanity, asking not what machines can do, but what we should let them.'
+    },
+    {
+      id: 'breadcrumbs-and-empires',
+      title: 'Breadcrumbs & Empires',
+      author: 'Helena Brandt',
+      genre: 'History',
+      price: 32.0,
+      added: '2026-03-18',
+      bestseller: false,
+      staffPick: false,
+      coverStyle: 'banner',
+      description: 'A surprising history of the world told through bread — the loaf as currency, weapon, ritual, and revolution. Meticulously researched and impossible to put down on an empty stomach.'
+    },
+    {
+      id: 'midnight-at-the-ledger',
+      title: 'Midnight at the Ledger',
+      author: 'Cormac Vane',
+      genre: 'Mystery',
+      price: 25.0,
+      added: '2026-06-25',
+      bestseller: true,
+      staffPick: true,
+      coverStyle: 'noir',
+      description: 'When a reclusive accountant is found dead among his immaculate books, the only clue is a single balanced column that should not balance. A twisting, atmospheric whodunit for fans of slow-burning dread.'
+    },
+    {
+      id: 'the-hollow-tide',
+      title: 'The Hollow Tide',
+      author: 'Imani Okafor',
+      genre: 'Mystery',
+      price: 26.0,
+      added: '2026-04-09',
+      bestseller: false,
+      staffPick: false,
+      coverStyle: 'noir',
+      description: 'A detective returns to her drowned hometown to solve a cold case that the rising water keeps unburying. Taut, lyrical, and laced with secrets that refuse to stay submerged.'
+    },
+    {
+      id: 'starlight-cartographers',
+      title: 'Starlight Cartographers',
+      author: 'Wren Adekoya',
+      genre: 'Sci-Fi & Fantasy',
+      price: 28.0,
+      added: '2026-06-22',
+      bestseller: true,
+      staffPick: true,
+      coverStyle: 'orbit',
+      description: 'In a galaxy where maps are illegal and memory is the only reliable navigation, a disgraced cartographer is hired to chart a route no one has survived. Grand, inventive space opera with a beating human heart.'
+    },
+    {
+      id: 'the-glass-thicket',
+      title: 'The Glass Thicket',
+      author: 'Solveig Marsh',
+      genre: 'Sci-Fi & Fantasy',
+      price: 27.0,
+      added: '2026-02-14',
+      bestseller: false,
+      staffPick: false,
+      coverStyle: 'orbit',
+      description: 'A young hedge-witch discovers that the forest swallowing her village is not growing but remembering. Lush, eerie fantasy about the price of forgetting and the courage of staying soft.'
+    },
+    {
+      id: 'small-gods-of-the-kitchen',
+      title: 'Small Gods of the Kitchen',
+      author: 'Beatriz Llanos',
+      genre: 'Poetry',
+      price: 19.0,
+      added: '2026-05-30',
+      bestseller: false,
+      staffPick: true,
+      coverStyle: 'minimal',
+      description: 'A debut collection that finds the sacred in chopped onions, chipped mugs, and Sunday rice. Llanos writes domestic life as devotion — tender, funny, and quietly devastating.'
+    },
+    {
+      id: 'field-notes-on-longing',
+      title: 'Field Notes on Longing',
+      author: 'Aria Petrov',
+      genre: 'Poetry',
+      price: 18.0,
+      added: '2026-01-21',
+      bestseller: false,
+      staffPick: false,
+      coverStyle: 'minimal',
+      description: 'Spare, aching poems mapping the geography of want — for places, for people, for versions of ourselves we never became. A collection to keep on the nightstand and return to often.'
+    },
+    {
+      id: 'the-button-moon-express',
+      title: 'The Button-Moon Express',
+      author: 'Daisy Whitlock',
+      genre: "Children's",
+      price: 17.0,
+      added: '2026-06-18',
+      bestseller: true,
+      staffPick: false,
+      coverStyle: 'playful',
+      description: 'All aboard the train that runs on bedtime! A rhyming, riotously illustrated adventure where a brave conductor cat collects yawns to fuel the journey to the Button-Moon. For ages 3 to 7.'
+    },
+    {
+      id: 'how-to-befriend-a-dragon',
+      title: 'How to Befriend a Dragon',
+      author: 'Oliver Finch',
+      genre: "Children's",
+      price: 16.0,
+      added: '2026-04-27',
+      bestseller: false,
+      staffPick: true,
+      coverStyle: 'playful',
+      description: 'Step one: do not scream. A warm, witty picture book about friendship, courage, and sharing your sandwiches with very large reptiles. For ages 4 to 8.'
+    },
+    {
+      id: 'the-cartographers-daughter',
+      title: "The Cartographer's Daughter",
+      author: 'Noor Hassan',
+      genre: 'Non-Fiction',
+      price: 30.0,
+      added: '2026-06-05',
+      bestseller: false,
+      staffPick: false,
+      coverStyle: 'grid',
+      description: 'Part memoir, part travelogue, this is the story of growing up between borders, languages, and the maps her father drew by hand. A moving meditation on belonging and the places that make us.'
+    },
+    {
+      id: 'an-honest-history-of-fire',
+      title: 'An Honest History of Fire',
+      author: 'Gregor Adamou',
+      genre: 'History',
+      price: 31.0,
+      added: '2026-06-28',
+      bestseller: true,
+      staffPick: true,
+      coverStyle: 'banner',
+      description: 'From the first spark to the combustion engine, a vivid history of humanity told through our oldest, most dangerous tool. Adamou makes the past crackle with life — and warning.'
+    }
+  ];
+
+  // Compute the price for a given product + format id.
+  function priceFor(product, formatId) {
+    var fmt = FORMATS.filter(function (f) { return f.id === formatId; })[0] || FORMATS[0];
+    return Math.max(0, product.price + fmt.delta);
+  }
+
+  function getProduct(id) {
+    return PRODUCTS.filter(function (p) { return p.id === id; })[0] || null;
+  }
+
+  function formatLabel(formatId) {
+    var fmt = FORMATS.filter(function (f) { return f.id === formatId; })[0];
+    return fmt ? fmt.label : formatId;
+  }
+
+  window.INKWELL_PRODUCTS = PRODUCTS;
+  window.INKWELL_FORMATS = FORMATS;
+  window.INKWELL_GENRE_THEMES = GENRE_THEMES;
+  window.INKWELL_DATA = {
+    products: PRODUCTS,
+    formats: FORMATS,
+    genreThemes: GENRE_THEMES,
+    priceFor: priceFor,
+    getProduct: getProduct,
+    formatLabel: formatLabel
+  };
+})();

--- a/fixtures/websites/75-inkwell-books/shop.html
+++ b/fixtures/websites/75-inkwell-books/shop.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shop — Inkwell &amp; Quill Booksellers</title>
+  <meta name="description" content="Browse the full Inkwell & Quill catalog. Filter by genre and price, sort by price, title, or newest arrivals." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__bar">
+      <a class="brand" href="index.html">
+        <svg class="brand__mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="44" height="44" rx="8" fill="#16223d" stroke="#b8923f" stroke-width="1.5"/>
+          <path d="M24 12 C18 9, 10 9, 8 11 V35 C10 33, 18 33, 24 36 C30 33, 38 33, 40 35 V11 C38 9, 30 9, 24 12 Z" fill="none" stroke="#d8c08a" stroke-width="1.6"/>
+          <line x1="24" y1="12" x2="24" y2="36" stroke="#d8c08a" stroke-width="1.6"/>
+          <path d="M32 8 L36 12 L24 24 L20 24 L20 20 Z" fill="#8c2b27" stroke="#d8c08a" stroke-width="1"/>
+        </svg>
+        <span class="brand__text">
+          <span class="brand__name">Inkwell &amp; Quill</span>
+          <span class="brand__tag">Independent Booksellers</span>
+        </span>
+      </a>
+      <nav class="site-nav" data-nav aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html" aria-current="page">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="icon-btn" href="cart.html" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.4"/><circle cx="18" cy="20" r="1.4"/>
+            <path d="M2 3h2.2l2.1 12.2a1.5 1.5 0 0 0 1.5 1.3h8.9a1.5 1.5 0 0 0 1.5-1.2L21 7H6"/>
+          </svg>
+          <span class="cart-count is-empty" data-cart-count>0</span>
+        </a>
+        <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <section class="page-hero">
+    <div class="container">
+      <p class="breadcrumb"><a href="index.html">Home</a> / Shop</p>
+      <h1>The Shelves</h1>
+      <p>Every title in the shop, curated and ready to read. Filter by genre and price, then sort to taste.</p>
+    </div>
+  </section>
+
+  <main class="section">
+    <div class="container">
+      <div class="shop-layout">
+        <aside class="filters" aria-label="Filter books">
+          <h2>Filter</h2>
+          <label class="field">
+            <span class="field__label">Genre</span>
+            <select data-filter-genre>
+              <option value="all">All Genres</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field__label">Price</span>
+            <select data-filter-price>
+              <option value="all">Any Price</option>
+              <option value="under20">Under $20</option>
+              <option value="20to28">$20 – $28</option>
+              <option value="over28">Over $28</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field__label">Sort By</span>
+            <select data-sort>
+              <option value="featured">Featured</option>
+              <option value="newest">Newest Arrivals</option>
+              <option value="price-asc">Price: Low to High</option>
+              <option value="price-desc">Price: High to Low</option>
+              <option value="title-asc">Title: A to Z</option>
+            </select>
+          </label>
+        </aside>
+
+        <div class="shop-main">
+          <div class="shop-toolbar">
+            <p class="result-count" data-result-count>—</p>
+          </div>
+          <div class="book-grid" data-shop-grid></div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <h4>Inkwell &amp; Quill</h4>
+          <p>An independent bookshop on the corner of Maple &amp; 3rd, serving readers since 1998.</p>
+        </div>
+        <div>
+          <h4>Shop</h4>
+          <ul>
+            <li><a href="shop.html">All Books</a></li>
+            <li><a href="shop.html?genre=Fiction">Fiction</a></li>
+            <li><a href="shop.html?genre=Mystery">Mystery</a></li>
+            <li><a href="shop.html?genre=Poetry">Poetry</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <ul>
+            <li><a href="about.html">Our Story</a></li>
+            <li><a href="contact.html">Hours &amp; Location</a></li>
+            <li><a href="contact.html">Events</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Hours</h4>
+          <ul>
+            <li>Mon–Fri: 9am – 8pm</li>
+            <li>Saturday: 10am – 8pm</li>
+            <li>Sunday: 11am – 6pm</li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Inkwell &amp; Quill Booksellers. All rights reserved.</span>
+        <span>Made with care for readers everywhere.</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/76-sole-society/about.html
+++ b/fixtures/websites/76-sole-society/about.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Our Story — SOLE SOCIETY</title>
+  <meta name="description" content="The SOLE SOCIETY story: built by sneakerheads for drop culture. Learn about our authenticity guarantee and the culture behind the boutique." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="SOLE SOCIETY home">
+        <svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/><path d="M9 31 L40 28" stroke="#c6ff00" stroke-width="2" fill="none"/></svg>
+        <span class="brand-text">SOLE<b>SOCIETY</b></span>
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">
+        <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html" class="is-current">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-cart-toggle aria-label="Open cart">
+          <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1 13H7L6 7Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="wrap">
+        <p class="eyebrow">Since day one</p>
+        <h1>Built By Heads,<br>For The Culture</h1>
+        <p>SOLE SOCIETY started in a back room with three pairs and a waitlist. We do not chase hype — we curate it.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="wrap" style="display:grid;grid-template-columns:1.3fr 1fr;gap:40px;align-items:center">
+        <div class="prose">
+          <p class="eyebrow">The story</p>
+          <h2>From a Waitlist to a Boutique</h2>
+          <p>We grew up in line. Camping releases, refreshing carts at 9:59am, trading on forums before "resell" was a business. SOLE SOCIETY is what we wished existed back then: a boutique that treats every customer like an insider and every pair like a grail.</p>
+          <p>Today we stock verified-authentic sneakers across running, lifestyle, basketball, skate, and our own limited house drops. Every pair is inspected, photographed, and shipped with the care a collector expects.</p>
+          <p>No bots. No bait-and-switch. No fakes. Just the heat, delivered fast.</p>
+        </div>
+        <div>
+          <svg viewBox="0 0 400 300" role="img" aria-label="Stylized sneaker on a pedestal" xmlns="http://www.w3.org/2000/svg" style="width:100%;background:#0c0d10;border-radius:16px;padding:18px">
+            <rect x="60" y="210" width="280" height="40" rx="8" fill="#16181d"/>
+            <rect x="90" y="250" width="220" height="14" rx="6" fill="#20232a"/>
+            <path d="M52 168 Q44 148 70 142 L350 130 Q382 130 378 156 L374 176 Q372 186 358 186 L82 186 Q56 186 52 168 Z" fill="#f3f3f3" stroke="#000" stroke-width="2"/>
+            <path d="M60 158 L370 147" stroke="#c6ff00" stroke-width="5" fill="none" stroke-linecap="round"/>
+            <path d="M74 142 Q74 100 122 90 L180 84 Q206 58 244 64 L280 90 Q330 96 360 116 L70 144 Z" fill="#1b1d22" stroke="#000" stroke-width="2.5"/>
+            <path d="M180 136 Q240 100 320 110 Q270 130 198 138 Z" fill="#c6ff00" stroke="#7fa600" stroke-width="1.5"/>
+            <g stroke="#c6ff00" stroke-width="4" stroke-linecap="round"><line x1="188" y1="96" x2="216" y2="104"/><line x1="192" y1="106" x2="220" y2="114"/><line x1="198" y1="116" x2="226" y2="124"/></g>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-dark">
+      <div class="wrap">
+        <div class="stat-band">
+          <div class="stat"><b>50K+</b><span>Pairs shipped</span></div>
+          <div class="stat"><b>100%</b><span>Authenticated</span></div>
+          <div class="stat"><b>4.9★</b><span>Member rating</span></div>
+          <div class="stat"><b>14</b><span>Live drops</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="authenticity">
+      <div class="wrap">
+        <div class="section-head"><div><p class="eyebrow">No fakes, ever</p><h2>The Authenticity Guarantee</h2></div></div>
+        <div class="feature-grid">
+          <article class="feature">
+            <div class="feature-ico"><svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M8.5 12l2.5 2.5L16 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
+            <h3>Multi-Point Inspection</h3>
+            <p>Every pair is checked by hand against verified references — stitching, materials, box, and tags — before it ships.</p>
+          </article>
+          <article class="feature">
+            <div class="feature-ico"><svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" fill="none" stroke="currentColor" stroke-width="2"/><path d="M16 16l5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
+            <h3>Traceable Provenance</h3>
+            <p>Each order ships with a verification card and digital record so you always know exactly what you're getting.</p>
+          </article>
+          <article class="feature">
+            <div class="feature-ico"><svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12l4 4 12-12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
+            <h3>Money-Back Promise</h3>
+            <p>If a pair ever fails authentication, you get a full refund — no questions, no hassle, no exceptions.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-alt">
+      <div class="wrap" style="text-align:center">
+        <p class="eyebrow">Ready when you are</p>
+        <h2>Join the Society</h2>
+        <p class="lead" style="margin:0 auto 24px">Thousands of members get first access to every drop. Start your collection today.</p>
+        <a class="btn btn-accent" href="shop.html">Shop the boutique</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html" aria-label="SOLE SOCIETY home" style="margin-bottom:14px"><svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/></svg><span class="brand-text">SOLE<b>SOCIETY</b></span></a>
+          <p class="footer-blurb">The streetwear sneaker boutique built for drop culture. Verified authentic, shipped fast, no fakes ever.</p>
+        </div>
+        <div><h4>Shop</h4><ul><li><a href="shop.html?category=Running">Running</a></li><li><a href="shop.html?category=Lifestyle">Lifestyle</a></li><li><a href="shop.html?category=Basketball">Basketball</a></li><li><a href="shop.html?category=Skate">Skate</a></li><li><a href="shop.html?category=Limited">Limited</a></li></ul></div>
+        <div><h4>Society</h4><ul><li><a href="about.html">Our story</a></li><li><a href="about.html#authenticity">Authenticity</a></li><li><a href="contact.html">Contact</a></li><li><a href="cart.html">Cart</a></li></ul></div>
+        <div><h4>Support</h4><ul><li><a href="contact.html">Shipping</a></li><li><a href="contact.html">Returns</a></li><li><a href="contact.html">Size guide</a></li><li><a href="contact.html">FAQ</a></li></ul></div>
+      </div>
+      <div class="footer-bottom"><span>&copy; <span data-year>2026</span> SOLE SOCIETY. All rights reserved.</span><span>Demo boutique — not a real store.</span></div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/76-sole-society/cart.html
+++ b/fixtures/websites/76-sole-society/cart.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your Cart — SOLE SOCIETY</title>
+  <meta name="description" content="Review your SOLE SOCIETY cart, adjust quantities, and check out your verified-authentic sneakers." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="SOLE SOCIETY home">
+        <svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/><path d="M9 31 L40 28" stroke="#c6ff00" stroke-width="2" fill="none"/></svg>
+        <span class="brand-text">SOLE<b>SOCIETY</b></span>
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">
+        <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-cart-toggle aria-label="Open cart">
+          <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1 13H7L6 7Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="cart-page" class="cart-page">
+    <div class="wrap">
+      <p class="eyebrow">Almost yours</p>
+      <h1 style="font-size:clamp(2rem,6vw,3.4rem);margin-bottom:24px">Your Cart</h1>
+
+      <div id="cart-empty" class="cart-empty" hidden>
+        <h2>Your cart is empty</h2>
+        <p>No heat in the bag yet. Let's fix that.</p>
+        <a class="btn btn-accent" href="shop.html">Shop the boutique</a>
+      </div>
+
+      <div class="cart-layout">
+        <div id="cart-lines"><!-- JS injects cart rows --></div>
+        <aside class="cart-summary" id="cart-summary" hidden><!-- JS injects summary --></aside>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html" aria-label="SOLE SOCIETY home" style="margin-bottom:14px"><svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/></svg><span class="brand-text">SOLE<b>SOCIETY</b></span></a>
+          <p class="footer-blurb">The streetwear sneaker boutique built for drop culture. Verified authentic, shipped fast, no fakes ever.</p>
+        </div>
+        <div><h4>Shop</h4><ul><li><a href="shop.html?category=Running">Running</a></li><li><a href="shop.html?category=Lifestyle">Lifestyle</a></li><li><a href="shop.html?category=Basketball">Basketball</a></li><li><a href="shop.html?category=Skate">Skate</a></li><li><a href="shop.html?category=Limited">Limited</a></li></ul></div>
+        <div><h4>Society</h4><ul><li><a href="about.html">Our story</a></li><li><a href="about.html#authenticity">Authenticity</a></li><li><a href="contact.html">Contact</a></li><li><a href="cart.html">Cart</a></li></ul></div>
+        <div><h4>Support</h4><ul><li><a href="contact.html">Shipping</a></li><li><a href="contact.html">Returns</a></li><li><a href="contact.html">Size guide</a></li><li><a href="contact.html">FAQ</a></li></ul></div>
+      </div>
+      <div class="footer-bottom"><span>&copy; <span data-year>2026</span> SOLE SOCIETY. All rights reserved.</span><span>Demo boutique — not a real store.</span></div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/76-sole-society/contact.html
+++ b/fixtures/websites/76-sole-society/contact.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact &amp; Flagship — SOLE SOCIETY</title>
+  <meta name="description" content="Get in touch with SOLE SOCIETY. Contact form, store hours, and our flagship boutique location." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="SOLE SOCIETY home">
+        <svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/><path d="M9 31 L40 28" stroke="#c6ff00" stroke-width="2" fill="none"/></svg>
+        <span class="brand-text">SOLE<b>SOCIETY</b></span>
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">
+        <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html" class="is-current">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-cart-toggle aria-label="Open cart">
+          <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1 13H7L6 7Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="wrap">
+        <p class="eyebrow">Talk to us</p>
+        <h1>Get In Touch</h1>
+        <p>Questions about a drop, an order, or authentication? We're quick to reply. Or swing by the flagship.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="wrap">
+        <div class="contact-layout">
+          <div>
+            <h2>Send a Message</h2>
+            <form id="contact-form" class="form-grid" novalidate>
+              <div class="form-row two">
+                <div class="form-row">
+                  <label for="c-name">Full name</label>
+                  <input id="c-name" name="name" type="text" autocomplete="name" required />
+                </div>
+                <div class="form-row">
+                  <label for="c-email">Email</label>
+                  <input id="c-email" name="email" type="email" autocomplete="email" required />
+                </div>
+              </div>
+              <div class="form-row">
+                <label for="c-topic">Topic</label>
+                <select id="c-topic" name="topic">
+                  <option>Order help</option>
+                  <option>Authentication question</option>
+                  <option>Returns &amp; exchanges</option>
+                  <option>Wholesale / collab</option>
+                  <option>Something else</option>
+                </select>
+              </div>
+              <div class="form-row">
+                <label for="c-order">Order number (optional)</label>
+                <input id="c-order" name="order" type="text" placeholder="SS-000000" />
+              </div>
+              <div class="form-row">
+                <label for="c-message">Message</label>
+                <textarea id="c-message" name="message" rows="5" required></textarea>
+              </div>
+              <button class="btn btn-accent" type="submit">Send message</button>
+              <p class="form-note" id="contact-note" hidden>Thanks — your message is in. We reply within one business day.</p>
+            </form>
+          </div>
+
+          <aside>
+            <div class="info-card">
+              <h3>Flagship Boutique</h3>
+              <p style="margin:0 0 4px;font-weight:700">SOLE SOCIETY HQ</p>
+              <p style="margin:0;color:var(--muted)">412 Concrete Ave, Suite 7<br>Brooklyn, NY 11201</p>
+            </div>
+            <div class="info-card">
+              <h3>Store Hours</h3>
+              <ul class="hours-list">
+                <li><span>Mon – Thu</span><b>11am – 8pm</b></li>
+                <li><span>Friday</span><b>11am – 9pm</b></li>
+                <li><span>Saturday</span><b>10am – 9pm</b></li>
+                <li><span>Sunday</span><b>12pm – 6pm</b></li>
+              </ul>
+            </div>
+            <div class="info-card">
+              <h3>Direct</h3>
+              <p style="margin:0;color:var(--muted)">hello@solesociety.demo<br>+1 (555) 010-2674</p>
+            </div>
+            <div class="map-frame">
+              <svg viewBox="0 0 400 240" role="img" aria-label="Stylized map showing the SOLE SOCIETY flagship location" xmlns="http://www.w3.org/2000/svg" style="width:100%;display:block">
+                <rect width="400" height="240" fill="#0c0d10"/>
+                <g stroke="#20232a" stroke-width="2">
+                  <line x1="0" y1="60" x2="400" y2="60"/><line x1="0" y1="120" x2="400" y2="120"/><line x1="0" y1="180" x2="400" y2="180"/>
+                  <line x1="80" y1="0" x2="80" y2="240"/><line x1="180" y1="0" x2="180" y2="240"/><line x1="280" y1="0" x2="280" y2="240"/>
+                </g>
+                <path d="M0 150 L160 150 L160 90 L400 90" fill="none" stroke="#c6ff00" stroke-width="4" stroke-linecap="round"/>
+                <path d="M40 0 L40 200 L240 200" fill="none" stroke="#2c2f37" stroke-width="6"/>
+                <rect x="120" y="40" width="90" height="46" rx="6" fill="#16181d" stroke="#2c2f37"/>
+                <circle cx="160" cy="90" r="9" fill="#ff2d78"/>
+                <circle cx="160" cy="90" r="16" fill="none" stroke="#ff2d78" stroke-width="2" opacity="0.5"/>
+                <path d="M160 78 a8 8 0 0 1 8 8 c0 6 -8 14 -8 14 c0 0 -8 -8 -8 -14 a8 8 0 0 1 8 -8 Z" fill="#ff2d78"/>
+                <text x="172" y="116" fill="#c6ff00" font-family="Arial" font-size="11" font-weight="bold">412 Concrete Ave</text>
+              </svg>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html" aria-label="SOLE SOCIETY home" style="margin-bottom:14px"><svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/></svg><span class="brand-text">SOLE<b>SOCIETY</b></span></a>
+          <p class="footer-blurb">The streetwear sneaker boutique built for drop culture. Verified authentic, shipped fast, no fakes ever.</p>
+        </div>
+        <div><h4>Shop</h4><ul><li><a href="shop.html?category=Running">Running</a></li><li><a href="shop.html?category=Lifestyle">Lifestyle</a></li><li><a href="shop.html?category=Basketball">Basketball</a></li><li><a href="shop.html?category=Skate">Skate</a></li><li><a href="shop.html?category=Limited">Limited</a></li></ul></div>
+        <div><h4>Society</h4><ul><li><a href="about.html">Our story</a></li><li><a href="about.html#authenticity">Authenticity</a></li><li><a href="contact.html">Contact</a></li><li><a href="cart.html">Cart</a></li></ul></div>
+        <div><h4>Support</h4><ul><li><a href="contact.html">Shipping</a></li><li><a href="contact.html">Returns</a></li><li><a href="contact.html">Size guide</a></li><li><a href="contact.html">FAQ</a></li></ul></div>
+      </div>
+      <div class="footer-bottom"><span>&copy; <span data-year>2026</span> SOLE SOCIETY. All rights reserved.</span><span>Demo boutique — not a real store.</span></div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/76-sole-society/css/styles.css
+++ b/fixtures/websites/76-sole-society/css/styles.css
@@ -1,0 +1,426 @@
+/* ============================================================
+   SOLE SOCIETY — streetwear sneaker boutique
+   ============================================================ */
+:root {
+  --ink: #0c0d10;
+  --ink-2: #16181d;
+  --ink-3: #20232a;
+  --line: #2c2f37;
+  --paper: #ffffff;
+  --paper-2: #f4f4f2;
+  --text: #14151a;
+  --muted: #6b7080;
+  --muted-dark: #9aa0b0;
+  --volt: #c6ff00;
+  --volt-dim: #a8da00;
+  --magenta: #ff2d78;
+  --radius: 14px;
+  --radius-sm: 9px;
+  --shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+  --shadow-sm: 0 8px 22px rgba(0, 0, 0, 0.10);
+  --maxw: 1200px;
+  --head-stack: "Arial Black", "Arial Narrow Bold", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --body-stack: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: var(--body-stack);
+  color: var(--text);
+  background: var(--paper);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+body.no-scroll { overflow: hidden; }
+img, svg { max-width: 100%; display: block; }
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+h1, h2, h3 {
+  font-family: var(--head-stack);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  line-height: 0.98;
+  text-transform: uppercase;
+  margin: 0 0 0.4em;
+}
+
+.wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 22px; }
+.section { padding: 72px 0; }
+.section-dark { background: var(--ink); color: #fff; }
+.section-alt { background: var(--paper-2); }
+.eyebrow {
+  font-family: var(--head-stack);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.72rem;
+  color: var(--volt-dim);
+  margin: 0 0 12px;
+  font-weight: 800;
+}
+.section-dark .eyebrow { color: var(--volt); }
+.section-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 34px; flex-wrap: wrap; }
+.section-head h2 { font-size: clamp(1.8rem, 4vw, 3rem); margin: 0; }
+.lead { color: var(--muted); font-size: 1.05rem; max-width: 60ch; }
+.section-dark .lead { color: var(--muted-dark); }
+
+/* -------- Buttons -------- */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  border: 2px solid transparent; border-radius: 999px;
+  padding: 13px 26px; font-weight: 800; font-size: 0.92rem;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  transition: transform .12s ease, box-shadow .15s ease, background .15s ease, color .15s ease;
+  background: var(--ink); color: #fff;
+}
+.btn:hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); }
+.btn:active { transform: translateY(0) scale(0.98); }
+.btn-accent { background: var(--volt); color: var(--ink); }
+.btn-accent:hover { background: var(--volt-dim); }
+.btn-outline { background: transparent; color: var(--ink); border-color: var(--ink); }
+.section-dark .btn-outline { color: #fff; border-color: #fff; }
+.btn-ghost { background: transparent; color: var(--muted); border-color: var(--line); }
+.btn-sm { padding: 9px 16px; font-size: 0.78rem; }
+.btn-block { width: 100%; }
+.linkish { background: none; border: 0; padding: 0; font: inherit; color: inherit; text-align: left; cursor: pointer; }
+.linkish:hover { color: var(--magenta); }
+
+/* -------- Header -------- */
+.site-header {
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(12, 13, 16, 0.96);
+  backdrop-filter: blur(10px);
+  color: #fff; border-bottom: 1px solid var(--line);
+}
+.header-inner { display: flex; align-items: center; gap: 20px; height: 66px; }
+.brand { display: flex; align-items: center; gap: 10px; font-family: var(--head-stack); font-weight: 900; letter-spacing: -0.03em; color: #fff; }
+.brand .brand-mark { width: 34px; height: 34px; }
+.brand .brand-text { font-size: 1.18rem; text-transform: uppercase; }
+.brand .brand-text b { color: var(--volt); }
+.site-nav { margin-left: auto; display: flex; align-items: center; gap: 4px; }
+.site-nav a {
+  padding: 8px 14px; font-weight: 700; font-size: 0.86rem; text-transform: uppercase; letter-spacing: 0.04em;
+  color: #d7dae2; border-radius: 999px; transition: color .15s, background .15s;
+}
+.site-nav a:hover, .site-nav a.is-current { color: var(--volt); }
+.header-actions { display: flex; align-items: center; gap: 6px; }
+.icon-btn {
+  position: relative; width: 42px; height: 42px; border-radius: 999px;
+  background: transparent; border: 1px solid var(--line); color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: transform .12s, background .15s, border-color .15s;
+}
+.icon-btn:hover { background: var(--ink-3); border-color: var(--volt); }
+.icon-btn.pulse { animation: pulse .45s ease; }
+@keyframes pulse { 0% { transform: scale(1);} 40% { transform: scale(1.18);} 100% { transform: scale(1);} }
+.cart-badge {
+  position: absolute; top: -5px; right: -5px; min-width: 19px; height: 19px; padding: 0 5px;
+  background: var(--volt); color: var(--ink); border-radius: 999px;
+  font-size: 0.68rem; font-weight: 900; display: flex; align-items: center; justify-content: center;
+}
+.cart-badge[data-empty="true"] { background: var(--ink-3); color: var(--muted-dark); }
+.nav-toggle { display: none; }
+
+/* -------- Hero -------- */
+.hero {
+  position: relative; overflow: hidden;
+  background:
+    radial-gradient(1100px 500px at 80% -10%, rgba(198,255,0,0.16), transparent 60%),
+    radial-gradient(800px 500px at 0% 120%, rgba(255,45,120,0.12), transparent 55%),
+    var(--ink);
+  color: #fff;
+}
+.hero::before {
+  content: ""; position: absolute; inset: 0;
+  background: repeating-linear-gradient(135deg, rgba(255,255,255,0.04) 0 2px, transparent 2px 26px);
+  pointer-events: none;
+}
+.hero-inner { position: relative; display: grid; grid-template-columns: 1.05fr 1fr; gap: 40px; align-items: center; padding: 86px 0 96px; }
+.hero-kicker {
+  display: inline-flex; align-items: center; gap: 8px; padding: 7px 14px; border-radius: 999px;
+  background: rgba(198,255,0,0.12); color: var(--volt); border: 1px solid rgba(198,255,0,0.35);
+  font-family: var(--head-stack); text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.68rem; margin-bottom: 22px;
+}
+.hero h1 { font-size: clamp(2.8rem, 8vw, 6rem); margin: 0 0 18px; }
+.hero h1 .hl { color: var(--volt); }
+.hero p { color: var(--muted-dark); font-size: 1.12rem; max-width: 46ch; margin: 0 0 30px; }
+.hero-cta { display: flex; gap: 14px; flex-wrap: wrap; }
+.hero-stats { display: flex; gap: 28px; margin-top: 38px; flex-wrap: wrap; }
+.hero-stats .stat b { font-family: var(--head-stack); font-size: 1.7rem; display: block; color: #fff; }
+.hero-stats .stat span { color: var(--muted-dark); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.1em; }
+.hero-art { position: relative; }
+.hero-art .hero-blob {
+  position: absolute; inset: 4% 0 0 0; margin: auto; width: 96%; aspect-ratio: 1.5/1;
+  background: linear-gradient(135deg, var(--volt), transparent 70%);
+  filter: blur(2px); opacity: 0.16; border-radius: 40% 60% 55% 45%; transform: rotate(-8deg);
+}
+.hero-art .shoe-svg { position: relative; transform: rotate(-7deg) scale(1.12); filter: drop-shadow(0 30px 40px rgba(0,0,0,0.5)); }
+
+/* -------- Marquee strip -------- */
+.strip { background: var(--volt); color: var(--ink); overflow: hidden; }
+.strip-inner { display: flex; gap: 40px; padding: 12px 0; font-family: var(--head-stack); text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.82rem; white-space: nowrap; animation: marquee 26s linear infinite; }
+.strip-inner span { display: inline-flex; align-items: center; gap: 40px; }
+@keyframes marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* -------- Product grid + cards -------- */
+.product-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 22px; }
+.card {
+  background: var(--paper); border: 1px solid #e9e9e6; border-radius: var(--radius); overflow: hidden;
+  display: flex; flex-direction: column; transition: transform .15s ease, box-shadow .2s ease, border-color .2s;
+}
+.card:hover { transform: translateY(-4px); box-shadow: var(--shadow); border-color: #ddd; }
+.card-media {
+  position: relative; border: 0; width: 100%; padding: 26px 18px 12px;
+  background: linear-gradient(160deg, #fafafa, #ececeb); display: block;
+}
+.card:hover .card-media .shoe-svg { transform: rotate(-5deg) scale(1.05); }
+.card-media .shoe-svg { transition: transform .25s ease; }
+.card-tag {
+  position: absolute; top: 12px; left: 12px; background: var(--ink); color: #fff;
+  font-family: var(--head-stack); text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.62rem;
+  padding: 5px 9px; border-radius: 6px;
+}
+.card-body { padding: 16px 16px 18px; display: flex; flex-direction: column; gap: 4px; flex: 1; }
+.card-maker { color: var(--muted); font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.1em; margin: 0; font-weight: 700; }
+.card-name { font-size: 1rem; line-height: 1.1; margin: 0; }
+.card-foot { margin-top: auto; padding-top: 12px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.card-price { font-family: var(--head-stack); font-size: 1.25rem; }
+.shoe-svg { width: 100%; height: auto; }
+
+/* -------- Category tiles -------- */
+.tiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+.tile {
+  position: relative; border-radius: var(--radius); overflow: hidden; min-height: 180px;
+  display: flex; align-items: flex-end; padding: 20px; color: #fff;
+  background: var(--ink-2); border: 1px solid var(--line); transition: transform .15s, box-shadow .2s;
+}
+.tile:hover { transform: translateY(-4px); box-shadow: var(--shadow); }
+.tile::after { content: ""; position: absolute; inset: 0; background: repeating-linear-gradient(135deg, rgba(255,255,255,0.05) 0 2px, transparent 2px 22px); }
+.tile .tile-svg { position: absolute; right: -10px; top: 18px; width: 62%; opacity: 0.9; transform: rotate(-8deg); }
+.tile h3 { position: relative; z-index: 1; font-size: 1.3rem; margin: 0; }
+.tile span { position: relative; z-index: 1; color: var(--volt); font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.1em; font-weight: 800; }
+.tile-text { position: relative; z-index: 1; }
+.tile-running { background: linear-gradient(150deg, #102a2f, #0c0d10); }
+.tile-lifestyle { background: linear-gradient(150deg, #2a210f, #0c0d10); }
+.tile-basketball { background: linear-gradient(150deg, #2a0f1c, #0c0d10); }
+.tile-skate { background: linear-gradient(150deg, #1a1030, #0c0d10); }
+
+/* -------- Collabs -------- */
+.collab-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.collab {
+  border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; background: var(--ink-2);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.collab .collab-mark { width: 46px; height: 46px; border-radius: 12px; background: var(--ink-3); display: flex; align-items: center; justify-content: center; color: var(--volt); font-family: var(--head-stack); font-size: 1.2rem; }
+.collab h3 { font-size: 1.1rem; margin: 4px 0 0; }
+.collab p { color: var(--muted-dark); margin: 0; font-size: 0.92rem; }
+
+/* -------- Newsletter / hype -------- */
+.hype { background: var(--volt); color: var(--ink); border-radius: 20px; padding: 48px; text-align: center; position: relative; overflow: hidden; }
+.hype::before { content: ""; position: absolute; inset: 0; background: repeating-linear-gradient(135deg, rgba(0,0,0,0.05) 0 2px, transparent 2px 24px); }
+.hype > * { position: relative; }
+.hype h2 { font-size: clamp(1.8rem, 5vw, 3.2rem); margin: 0 0 10px; }
+.hype p { max-width: 50ch; margin: 0 auto 24px; font-weight: 600; }
+.signup { display: flex; gap: 10px; max-width: 460px; margin: 0 auto; }
+.signup input {
+  flex: 1; border: 2px solid var(--ink); border-radius: 999px; padding: 13px 18px; font-size: 0.95rem; background: #fff; color: var(--ink);
+}
+.signup input:focus { outline: 3px solid rgba(0,0,0,0.25); }
+.signup-note { margin: 14px 0 0; font-weight: 800; text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.82rem; }
+
+/* -------- Footer -------- */
+.site-footer { background: var(--ink); color: #fff; padding: 60px 0 28px; }
+.footer-grid { display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 30px; }
+.footer-grid h4 { font-family: var(--head-stack); text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.82rem; color: var(--volt); margin: 0 0 14px; }
+.footer-grid ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 9px; }
+.footer-grid a { color: var(--muted-dark); font-size: 0.92rem; }
+.footer-grid a:hover { color: #fff; }
+.footer-blurb { color: var(--muted-dark); font-size: 0.92rem; max-width: 36ch; }
+.footer-bottom { margin-top: 40px; padding-top: 22px; border-top: 1px solid var(--line); display: flex; justify-content: space-between; gap: 14px; flex-wrap: wrap; color: var(--muted-dark); font-size: 0.82rem; }
+
+/* -------- Catalog toolbar -------- */
+.shop-head { background: var(--ink); color: #fff; padding: 54px 0 40px; }
+.shop-head h1 { font-size: clamp(2.2rem, 6vw, 4rem); margin: 0 0 8px; }
+.shop-head p { color: var(--muted-dark); margin: 0; }
+.toolbar {
+  display: flex; gap: 14px; align-items: center; flex-wrap: wrap;
+  padding: 18px 0; position: sticky; top: 66px; z-index: 20;
+  background: var(--paper); border-bottom: 1px solid #eee;
+}
+.toolbar .field-inline { display: flex; align-items: center; gap: 8px; }
+.toolbar label { font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 800; color: var(--muted); }
+.toolbar select {
+  border: 1px solid #d8d8d4; border-radius: 999px; padding: 9px 14px; font-size: 0.88rem; font-weight: 600;
+  background: #fff; color: var(--text);
+}
+.toolbar select:focus { outline: 2px solid var(--ink); }
+.toolbar .result-count { margin-left: auto; font-weight: 800; font-size: 0.84rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+.empty-note { color: var(--muted); grid-column: 1 / -1; padding: 40px 0; text-align: center; }
+
+/* -------- Modal -------- */
+.modal { position: fixed; inset: 0; z-index: 100; display: none; }
+.modal[aria-hidden="false"] { display: block; }
+.modal-backdrop { position: absolute; inset: 0; background: rgba(8,9,12,0.7); backdrop-filter: blur(3px); }
+.modal-dialog {
+  position: relative; max-width: 880px; margin: 5vh auto; background: #fff; border-radius: 18px; overflow: hidden;
+  box-shadow: var(--shadow); animation: pop .2s ease;
+}
+@keyframes pop { from { transform: translateY(14px) scale(0.98); opacity: 0; } to { transform: none; opacity: 1; } }
+.modal-close { position: absolute; top: 12px; right: 14px; z-index: 2; width: 40px; height: 40px; border-radius: 999px; border: 0; background: rgba(0,0,0,0.06); font-size: 1.5rem; line-height: 1; color: var(--ink); }
+.modal-close:hover { background: var(--volt); }
+.modal-grid { display: grid; grid-template-columns: 1fr 1fr; }
+.modal-media { background: linear-gradient(160deg, #f7f7f6, #e9e9e7); padding: 40px 30px; display: flex; align-items: center; }
+.modal-info { padding: 34px 32px; max-height: 90vh; overflow-y: auto; }
+.modal-maker { color: var(--muted); text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.74rem; font-weight: 800; margin: 0 0 6px; }
+.modal-title { font-size: 1.6rem; margin: 0 0 8px; }
+.modal-price { font-family: var(--head-stack); font-size: 1.6rem; margin: 0 0 14px; }
+.modal-desc { color: var(--muted); margin: 0 0 22px; }
+.field { margin-bottom: 20px; }
+.field-label { display: block; font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 800; color: var(--text); margin-bottom: 9px; }
+.field-label .req { color: var(--muted); font-weight: 700; }
+.chip-row { display: flex; gap: 8px; flex-wrap: wrap; }
+.chip {
+  border: 1.5px solid #d8d8d4; background: #fff; border-radius: 999px; padding: 8px 14px; font-size: 0.82rem; font-weight: 700; color: var(--text);
+  transition: border-color .12s, background .12s, color .12s;
+}
+.chip:hover { border-color: var(--ink); }
+.chip.is-active { background: var(--ink); color: #fff; border-color: var(--ink); }
+.size-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 7px; }
+.size-btn {
+  border: 1.5px solid #d8d8d4; background: #fff; border-radius: 9px; padding: 9px 0; font-size: 0.82rem; font-weight: 800; color: var(--text);
+  transition: border-color .12s, background .12s, color .12s, transform .1s;
+}
+.size-btn:hover { border-color: var(--ink); transform: translateY(-1px); }
+.size-btn.is-active { background: var(--volt); border-color: var(--ink); color: var(--ink); }
+.size-grid.shake { animation: shake .4s ease; }
+@keyframes shake { 0%,100%{ transform: translateX(0);} 20%,60%{ transform: translateX(-6px);} 40%,80%{ transform: translateX(6px);} }
+.size-prompt { color: var(--magenta); font-weight: 800; font-size: 0.82rem; margin: 10px 0 0; }
+.qty-field .field-label { margin-bottom: 9px; }
+
+/* -------- Steppers -------- */
+.stepper { display: inline-flex; align-items: center; border: 1.5px solid #d8d8d4; border-radius: 999px; overflow: hidden; }
+.step-btn { width: 38px; height: 38px; border: 0; background: #fff; font-size: 1.2rem; line-height: 1; color: var(--ink); transition: background .12s; }
+.step-btn:hover { background: var(--volt); }
+.step-val { min-width: 38px; text-align: center; font-weight: 800; }
+.stepper-sm .step-btn { width: 30px; height: 30px; font-size: 1rem; }
+.stepper-sm .step-val { min-width: 30px; }
+
+/* -------- Drawer -------- */
+.drawer { position: fixed; inset: 0; z-index: 90; display: none; }
+.drawer[aria-hidden="false"] { display: block; }
+.drawer-backdrop { position: absolute; inset: 0; background: rgba(8,9,12,0.55); }
+.drawer-panel {
+  position: absolute; top: 0; right: 0; height: 100%; width: min(420px, 92vw);
+  background: #fff; display: flex; flex-direction: column; box-shadow: var(--shadow);
+  animation: slidein .22s ease;
+}
+@keyframes slidein { from { transform: translateX(100%); } to { transform: translateX(0); } }
+.drawer-head { display: flex; align-items: center; justify-content: space-between; padding: 20px 22px; border-bottom: 1px solid #eee; }
+.drawer-title { margin: 0; font-size: 1.2rem; }
+.drawer-close { width: 38px; height: 38px; border: 0; border-radius: 999px; background: #f1f1ef; font-size: 1.4rem; line-height: 1; }
+.drawer-close:hover { background: var(--volt); }
+.drawer-items { flex: 1; overflow-y: auto; padding: 14px 22px; }
+.line { display: grid; grid-template-columns: 72px 1fr auto; gap: 12px; padding: 14px 0; border-bottom: 1px solid #f0f0ee; align-items: center; }
+.line-media { background: #f4f4f2; border-radius: 10px; padding: 6px; }
+.line-name { margin: 0; font-weight: 800; font-size: 0.9rem; line-height: 1.15; }
+.line-meta { margin: 2px 0 8px; color: var(--muted); font-size: 0.78rem; }
+.line-controls { display: flex; align-items: center; gap: 12px; }
+.line-remove { background: none; border: 0; color: var(--muted); font-size: 0.76rem; font-weight: 700; text-decoration: underline; padding: 0; }
+.line-remove:hover { color: var(--magenta); }
+.line-price { font-family: var(--head-stack); font-size: 0.98rem; }
+.drawer-foot { border-top: 1px solid #eee; padding: 18px 22px; display: flex; flex-direction: column; gap: 10px; }
+.drawer-subtotal { display: flex; justify-content: space-between; font-weight: 800; font-size: 1.05rem; margin-bottom: 4px; }
+
+/* -------- Cart page -------- */
+.cart-page { padding: 50px 0 80px; }
+.cart-layout { display: grid; grid-template-columns: 1.7fr 1fr; gap: 34px; align-items: start; }
+.cart-row { display: grid; grid-template-columns: 110px 1fr auto auto; gap: 18px; align-items: center; padding: 20px 0; border-bottom: 1px solid #eee; }
+.cart-row-media { background: #f4f4f2; border-radius: 12px; padding: 10px; }
+.cart-row-maker { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 700; margin: 0; }
+.cart-row-name { font-size: 1.05rem; margin: 2px 0 4px; }
+.cart-row-meta { color: var(--muted); font-size: 0.85rem; margin: 0 0 8px; }
+.cart-row-price { font-family: var(--head-stack); font-size: 1.15rem; }
+.cart-summary { background: var(--paper-2); border: 1px solid #e8e8e4; border-radius: var(--radius); padding: 26px; position: sticky; top: 90px; }
+.summary-title { font-size: 1.3rem; margin: 0 0 16px; }
+.summary-row { display: flex; justify-content: space-between; padding: 8px 0; color: var(--muted); font-size: 0.95rem; }
+.summary-total { border-top: 2px solid var(--ink); margin-top: 8px; padding-top: 14px; color: var(--text); font-weight: 900; font-size: 1.2rem; font-family: var(--head-stack); }
+.summary-note { font-size: 0.82rem; color: var(--muted); margin: 6px 0 16px; }
+.cart-empty { text-align: center; padding: 80px 20px; }
+.cart-empty h2 { font-size: 2rem; }
+.cart-empty p { color: var(--muted); margin-bottom: 22px; }
+
+/* -------- About / content -------- */
+.page-hero { background: var(--ink); color: #fff; padding: 70px 0; }
+.page-hero h1 { font-size: clamp(2.4rem, 7vw, 4.6rem); margin: 0 0 12px; }
+.page-hero p { color: var(--muted-dark); max-width: 56ch; font-size: 1.08rem; }
+.prose { max-width: 70ch; }
+.prose p { color: #33363f; margin: 0 0 18px; font-size: 1.04rem; }
+.feature-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.feature { border: 1px solid #ececea; border-radius: var(--radius); padding: 26px; background: #fff; }
+.feature .feature-ico { width: 46px; height: 46px; border-radius: 12px; background: var(--ink); color: var(--volt); display: flex; align-items: center; justify-content: center; margin-bottom: 14px; }
+.feature h3 { font-size: 1.1rem; margin: 0 0 8px; }
+.feature p { color: var(--muted); margin: 0; font-size: 0.94rem; }
+.stat-band { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; text-align: center; }
+.stat-band .stat b { font-family: var(--head-stack); font-size: clamp(2rem, 5vw, 3.2rem); display: block; color: var(--volt); }
+.stat-band .stat span { color: var(--muted-dark); text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.78rem; }
+
+/* -------- Contact -------- */
+.contact-layout { display: grid; grid-template-columns: 1.2fr 1fr; gap: 38px; align-items: start; }
+.form-grid { display: grid; gap: 16px; }
+.form-row { display: grid; gap: 6px; }
+.form-row.two { grid-template-columns: 1fr 1fr; gap: 16px; }
+.form-row label { font-size: 0.76rem; text-transform: uppercase; letter-spacing: 0.07em; font-weight: 800; color: var(--text); }
+.form-row input, .form-row textarea, .form-row select {
+  border: 1.5px solid #d8d8d4; border-radius: var(--radius-sm); padding: 12px 14px; font-size: 0.95rem; font-family: inherit; background: #fff; color: var(--text); width: 100%;
+}
+.form-row input:focus, .form-row textarea:focus, .form-row select:focus { outline: 2px solid var(--ink); border-color: var(--ink); }
+.form-note { color: var(--volt-dim); font-weight: 800; font-size: 0.88rem; background: var(--ink); padding: 12px 16px; border-radius: var(--radius-sm); }
+.info-card { border: 1px solid #ececea; border-radius: var(--radius); padding: 24px; background: var(--paper-2); margin-bottom: 18px; }
+.info-card h3 { font-size: 1.05rem; margin: 0 0 12px; }
+.hours-list { list-style: none; margin: 0; padding: 0; }
+.hours-list li { display: flex; justify-content: space-between; padding: 6px 0; border-bottom: 1px dashed #ddd; font-size: 0.92rem; }
+.hours-list li:last-child { border-bottom: 0; }
+.hours-list b { font-weight: 800; }
+.map-frame { border-radius: var(--radius); overflow: hidden; border: 1px solid var(--line); background: var(--ink); }
+
+/* -------- Responsive -------- */
+@media (max-width: 980px) {
+  .hero-inner { grid-template-columns: 1fr; padding: 60px 0 70px; }
+  .hero-art { order: -1; }
+  .product-grid, .tiles { grid-template-columns: repeat(2, 1fr); }
+  .collab-grid, .feature-grid, .stat-band { grid-template-columns: repeat(2, 1fr); }
+  .modal-grid { grid-template-columns: 1fr; }
+  .modal-media { padding: 26px; }
+  .cart-layout, .contact-layout { grid-template-columns: 1fr; }
+  .cart-summary { position: static; }
+  .footer-grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 760px) {
+  .nav-toggle {
+    display: inline-flex; margin-left: auto; width: 42px; height: 42px; border-radius: 10px;
+    background: transparent; border: 1px solid var(--line); color: #fff; align-items: center; justify-content: center;
+  }
+  .site-nav {
+    position: absolute; top: 66px; left: 0; right: 0; flex-direction: column; align-items: stretch; gap: 0;
+    background: var(--ink); border-bottom: 1px solid var(--line); padding: 8px 16px 16px; margin-left: 0; display: none;
+  }
+  .site-nav.is-open { display: flex; }
+  .header-actions { margin-left: 8px; }
+  .section { padding: 52px 0; }
+  .cart-row { grid-template-columns: 80px 1fr; grid-template-areas: "media main" "qty price"; }
+  .cart-row-media { grid-area: media; } .cart-row-main { grid-area: main; }
+  .cart-row-qty { grid-area: qty; } .cart-row-price { grid-area: price; text-align: right; align-self: center; }
+}
+@media (max-width: 480px) {
+  .product-grid, .tiles, .collab-grid, .feature-grid, .stat-band { grid-template-columns: 1fr; }
+  .signup { flex-direction: column; }
+  .form-row.two { grid-template-columns: 1fr; }
+  .hype { padding: 34px 22px; }
+}
+
+/* accessibility helpers */
+.visually-hidden { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+:focus-visible { outline: 3px solid var(--magenta); outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; scroll-behavior: auto; } }

--- a/fixtures/websites/76-sole-society/fixture.json
+++ b/fixtures/websites/76-sole-society/fixture.json
@@ -1,0 +1,17 @@
+{
+  "class": "ecommerce/catalog",
+  "tags": [
+    "ecommerce",
+    "sneakers",
+    "has-cart",
+    "add-to-cart",
+    "size-selector",
+    "filters",
+    "sorting",
+    "mini-cart",
+    "multipage",
+    "localstorage",
+    "marquee"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/76-sole-society/index.html
+++ b/fixtures/websites/76-sole-society/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SOLE SOCIETY — Sneaker Boutique &amp; Drop Culture</title>
+  <meta name="description" content="SOLE SOCIETY is a streetwear sneaker boutique. Shop the latest drops, exclusive collabs, and verified-authentic kicks across running, lifestyle, basketball and skate." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="SOLE SOCIETY home">
+        <svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect width="48" height="48" rx="11" fill="#c6ff00"/>
+          <path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/>
+          <path d="M9 31 L40 28" stroke="#c6ff00" stroke-width="2" fill="none"/>
+        </svg>
+        <span class="brand-text">SOLE<b>SOCIETY</b></span>
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">
+        <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Primary">
+        <a href="index.html" class="is-current">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-cart-toggle aria-label="Open cart">
+          <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1 13H7L6 7Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <!-- HERO -->
+    <section class="hero">
+      <div class="wrap hero-inner">
+        <div class="hero-copy">
+          <span class="hero-kicker">New Season // FW Drop 14</span>
+          <h1>Lace Up.<br>Stand <span class="hl">Out.</span></h1>
+          <p>The boutique for drop-culture obsessives. Verified-authentic sneakers, exclusive collabs, and the heat that sells out everywhere else.</p>
+          <div class="hero-cta">
+            <a class="btn btn-accent" href="shop.html">Shop the drop</a>
+            <a class="btn btn-outline" href="#drops">Latest releases</a>
+          </div>
+          <div class="hero-stats">
+            <div class="stat"><b>14</b><span>Live drops</span></div>
+            <div class="stat"><b>100%</b><span>Verified pairs</span></div>
+            <div class="stat"><b>48hr</b><span>Express ship</span></div>
+          </div>
+        </div>
+        <div class="hero-art">
+          <div class="hero-blob"></div>
+          <svg class="shoe-svg" viewBox="0 0 400 240" role="img" aria-label="Featured volt-green sneaker" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+            <defs>
+              <linearGradient id="heroU" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1b1d22"/><stop offset="1" stop-color="#0c0d10"/></linearGradient>
+              <linearGradient id="heroS" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#f3f3f3"/><stop offset="1" stop-color="#c9c9c9"/></linearGradient>
+            </defs>
+            <path d="M22 188 Q14 168 40 162 L360 150 Q392 150 388 176 L384 196 Q382 206 368 206 L52 206 Q26 206 22 188 Z" fill="url(#heroS)" stroke="#000" stroke-width="2"/>
+            <path d="M30 178 L380 167" fill="none" stroke="#c6ff00" stroke-width="5" stroke-linecap="round"/>
+            <path d="M44 162 Q44 120 92 110 L150 104 Q176 78 214 84 L250 110 Q300 116 340 126 Q372 132 360 152 L40 164 Q40 163 44 162 Z" fill="url(#heroU)" stroke="#000" stroke-width="2.5"/>
+            <path d="M150 156 Q210 120 300 130 Q250 150 168 158 Z" fill="#c6ff00" stroke="#7fa600" stroke-width="1.5"/>
+            <path d="M150 104 L162 132 L150 138 L138 118 Z" fill="#2a2d33" stroke="#000" stroke-width="1.5"/>
+            <g stroke="#c6ff00" stroke-width="4" stroke-linecap="round"><line x1="158" y1="116" x2="186" y2="124"/><line x1="162" y1="126" x2="190" y2="134"/><line x1="168" y1="136" x2="196" y2="144"/></g>
+            <g fill="#000"><circle cx="186" cy="124" r="2.6"/><circle cx="190" cy="134" r="2.6"/><circle cx="196" cy="144" r="2.6"/></g>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <!-- MARQUEE -->
+    <div class="strip" aria-hidden="true">
+      <div class="strip-inner">
+        <span>FREE EXPRESS SHIPPING OVER $150 ★ VERIFIED AUTHENTIC ★ NEW DROPS WEEKLY ★ HOUSE COLLABS ★ NO FAKES, EVER ★&nbsp;</span>
+        <span>FREE EXPRESS SHIPPING OVER $150 ★ VERIFIED AUTHENTIC ★ NEW DROPS WEEKLY ★ HOUSE COLLABS ★ NO FAKES, EVER ★&nbsp;</span>
+      </div>
+    </div>
+
+    <!-- LATEST DROPS -->
+    <section class="section" id="drops">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Just landed</p>
+            <h2>Latest Drops</h2>
+          </div>
+          <a class="btn btn-outline btn-sm" href="shop.html">View all</a>
+        </div>
+        <div class="product-grid" id="latest-drops"><!-- JS injects featured cards --></div>
+      </div>
+    </section>
+
+    <!-- CATEGORY TILES -->
+    <section class="section section-alt">
+      <div class="wrap">
+        <div class="section-head"><div><p class="eyebrow">Find your lane</p><h2>Shop by Category</h2></div></div>
+        <div class="tiles">
+          <a class="tile tile-running" href="shop.html?category=Running">
+            <svg class="tile-svg" viewBox="0 0 400 240" aria-hidden="true"><path d="M40 170 Q34 158 52 154 L350 144 Q374 144 370 164 L367 178 Q365 186 354 186 L60 186 Q42 186 40 170Z" fill="#19c3e6" opacity="0.85"/><path d="M60 156 Q60 128 100 120 L160 114 Q190 96 220 104 L300 124 Q330 130 320 148 L58 158Z" fill="#0c2b30"/></svg>
+            <div class="tile-text"><span>Built for speed</span><h3>Running</h3></div>
+          </a>
+          <a class="tile tile-lifestyle" href="shop.html?category=Lifestyle">
+            <svg class="tile-svg" viewBox="0 0 400 240" aria-hidden="true"><path d="M40 170 Q34 158 52 154 L350 144 Q374 144 370 164 L367 178 Q365 186 354 186 L60 186 Q42 186 40 170Z" fill="#d8b48a" opacity="0.85"/><path d="M60 156 Q60 128 100 120 L160 114 Q190 96 220 104 L300 124 Q330 130 320 148 L58 158Z" fill="#3a2c14"/></svg>
+            <div class="tile-text"><span>Everyday icons</span><h3>Lifestyle</h3></div>
+          </a>
+          <a class="tile tile-basketball" href="shop.html?category=Basketball">
+            <svg class="tile-svg" viewBox="0 0 400 240" aria-hidden="true"><path d="M40 170 Q34 158 52 154 L350 144 Q374 144 370 164 L367 178 Q365 186 354 186 L60 186 Q42 186 40 170Z" fill="#ff3b30" opacity="0.85"/><path d="M60 156 Q60 128 100 120 L160 114 Q190 96 220 104 L300 124 Q330 130 320 148 L58 158Z" fill="#2a0f12"/></svg>
+            <div class="tile-text"><span>Own the rim</span><h3>Basketball</h3></div>
+          </a>
+          <a class="tile tile-skate" href="shop.html?category=Skate">
+            <svg class="tile-svg" viewBox="0 0 400 240" aria-hidden="true"><path d="M40 170 Q34 158 52 154 L350 144 Q374 144 370 164 L367 178 Q365 186 354 186 L60 186 Q42 186 40 170Z" fill="#b39cff" opacity="0.85"/><path d="M60 156 Q60 128 100 120 L160 114 Q190 96 220 104 L300 124 Q330 130 320 148 L58 158Z" fill="#1c1340"/></svg>
+            <div class="tile-text"><span>Board feel</span><h3>Skate</h3></div>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- COLLABS -->
+    <section class="section section-dark">
+      <div class="wrap">
+        <div class="section-head"><div><p class="eyebrow">Exclusive to the society</p><h2>Brand Collabs</h2></div>
+          <a class="btn btn-accent btn-sm" href="shop.html?category=Limited">Shop limited</a>
+        </div>
+        <div class="collab-grid">
+          <article class="collab"><div class="collab-mark">SS</div><h3>SOLE SOCIETY × Apex Labs</h3><p>The "Eclipse" Phantom — a numbered blackout build with reflective ghost detailing. Strictly limited.</p></article>
+          <article class="collab"><div class="collab-mark">★</div><h3>Heritage Court Archive</h3><p>Vault reissues dressed in metallic 24K detailing. Premium materials, collector packaging.</p></article>
+          <article class="collab"><div class="collab-mark">⚡</div><h3>Curbside Co. Pro Series</h3><p>Pro-model durability meets boutique colorways. Built with the riders who actually skate them.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <!-- HYPE / NEWSLETTER -->
+    <section class="section">
+      <div class="wrap">
+        <div class="hype">
+          <p class="eyebrow" style="color:#0c0d10">Join the list</p>
+          <h2>Get the Drop First</h2>
+          <p>Early access to releases, restock alerts, and members-only colorways. No spam — just heat.</p>
+          <form class="signup" data-signup>
+            <label class="visually-hidden" for="hype-email">Email address</label>
+            <input id="hype-email" type="email" name="email" placeholder="you@email.com" required />
+            <button class="btn" type="submit">Notify me</button>
+          </form>
+          <p class="signup-note" data-signup-note hidden>You're on the list. Check your inbox.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html" aria-label="SOLE SOCIETY home" style="margin-bottom:14px">
+            <svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/></svg>
+            <span class="brand-text">SOLE<b>SOCIETY</b></span>
+          </a>
+          <p class="footer-blurb">The streetwear sneaker boutique built for drop culture. Verified authentic, shipped fast, no fakes ever.</p>
+        </div>
+        <div><h4>Shop</h4><ul><li><a href="shop.html?category=Running">Running</a></li><li><a href="shop.html?category=Lifestyle">Lifestyle</a></li><li><a href="shop.html?category=Basketball">Basketball</a></li><li><a href="shop.html?category=Skate">Skate</a></li><li><a href="shop.html?category=Limited">Limited</a></li></ul></div>
+        <div><h4>Society</h4><ul><li><a href="about.html">Our story</a></li><li><a href="about.html#authenticity">Authenticity</a></li><li><a href="contact.html">Contact</a></li><li><a href="cart.html">Cart</a></li></ul></div>
+        <div><h4>Support</h4><ul><li><a href="contact.html">Shipping</a></li><li><a href="contact.html">Returns</a></li><li><a href="contact.html">Size guide</a></li><li><a href="contact.html">FAQ</a></li></ul></div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> SOLE SOCIETY. All rights reserved.</span>
+        <span>Demo boutique — not a real store.</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/76-sole-society/js/app.js
+++ b/fixtures/websites/76-sole-society/js/app.js
@@ -1,0 +1,595 @@
+/* SOLE SOCIETY — app.js
+ * Rendering, SVG sneaker generator, catalog filter/sort, product modal,
+ * mini-cart drawer, and full cart-page rendering. All page-guarded.
+ */
+(function () {
+  'use strict';
+
+  var SIZES = ['7', '7.5', '8', '8.5', '9', '9.5', '10', '10.5', '11', '11.5', '12', '12.5', '13'];
+
+  function money(n) {
+    return '$' + Number(n).toFixed(2);
+  }
+  function moneyShort(n) {
+    return '$' + Number(n).toFixed(0);
+  }
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+  function byId(id) {
+    var list = window.SOLE_PRODUCTS || [];
+    for (var i = 0; i < list.length; i++) if (list[i].id === id) return list[i];
+    return null;
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Inline SVG sneaker — a stylized side profile driven by a colorway palette.
+   * Returns markup for a 400x240 viewBox; scales to any container.
+   * ------------------------------------------------------------------------ */
+  function sneakerSVG(colorway, opts) {
+    opts = opts || {};
+    var c = colorway || {};
+    var upper = c.upper || '#222';
+    var accent = c.accent || '#c6ff00';
+    var sole = c.sole || '#eee';
+    var midsole = c.midsole || upper;
+    var lace = c.lace || accent;
+    var detail = c.detail || '#111';
+    var uid = 'g' + Math.random().toString(36).slice(2, 8);
+    var title = opts.title ? '<title>' + esc(opts.title) + '</title>' : '';
+
+    return (
+      '<svg class="shoe-svg" viewBox="0 0 400 240" role="img" aria-hidden="' +
+      (opts.title ? 'false' : 'true') +
+      '" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">' +
+      title +
+      '<defs>' +
+      '<linearGradient id="' + uid + 'u" x1="0" y1="0" x2="0" y2="1">' +
+      '<stop offset="0" stop-color="' + upper + '"/>' +
+      '<stop offset="1" stop-color="' + shade(upper, -18) + '"/>' +
+      '</linearGradient>' +
+      '<linearGradient id="' + uid + 's" x1="0" y1="0" x2="0" y2="1">' +
+      '<stop offset="0" stop-color="' + sole + '"/>' +
+      '<stop offset="1" stop-color="' + shade(sole, -22) + '"/>' +
+      '</linearGradient>' +
+      '</defs>' +
+      /* sole */
+      '<path d="M22 188 Q14 168 40 162 L360 150 Q392 150 388 176 L384 196 Q382 206 368 206 L52 206 Q26 206 22 188 Z" fill="url(#' + uid + 's)" stroke="' + detail + '" stroke-width="2"/>' +
+      /* midsole stripe */
+      '<path d="M30 178 L380 167" fill="none" stroke="' + accent + '" stroke-width="4" stroke-linecap="round" opacity="0.85"/>' +
+      /* main upper body */
+      '<path d="M44 162 Q44 120 92 110 L150 104 Q176 78 214 84 L250 110 Q300 116 340 126 Q372 132 360 152 L40 164 Q40 163 44 162 Z" fill="url(#' + uid + 'u)" stroke="' + detail + '" stroke-width="2.5"/>' +
+      /* toe cap */
+      '<path d="M44 162 Q44 130 86 120 L118 116 Q120 150 116 160 L46 163 Q44 163 44 162 Z" fill="' + shade(upper, -10) + '" stroke="' + detail + '" stroke-width="1.5" opacity="0.9"/>' +
+      /* heel counter */
+      '<path d="M312 130 Q352 132 358 150 L334 154 Q322 140 308 136 Z" fill="' + midsole + '" stroke="' + detail + '" stroke-width="1.5"/>' +
+      /* accent swoosh-style side panel */
+      '<path d="M150 156 Q210 120 300 130 Q250 150 168 158 Z" fill="' + accent + '" stroke="' + shade(accent, -25) + '" stroke-width="1.5"/>' +
+      /* collar / ankle padding */
+      '<path d="M214 84 Q236 86 250 110 L236 120 Q220 100 206 100 Z" fill="' + shade(upper, 14) + '" stroke="' + detail + '" stroke-width="1.5"/>' +
+      /* tongue */
+      '<path d="M150 104 L162 132 L150 138 L138 118 Z" fill="' + shade(upper, 18) + '" stroke="' + detail + '" stroke-width="1.5"/>' +
+      /* laces */
+      lacePath(150, 118, accent === lace ? lace : lace, 5) +
+      '<g stroke="' + lace + '" stroke-width="3.5" stroke-linecap="round">' +
+      '<line x1="158" y1="116" x2="186" y2="124"/>' +
+      '<line x1="162" y1="126" x2="190" y2="134"/>' +
+      '<line x1="168" y1="136" x2="196" y2="144"/>' +
+      '</g>' +
+      /* eyelets */
+      '<g fill="' + detail + '">' +
+      '<circle cx="186" cy="124" r="2.4"/><circle cx="190" cy="134" r="2.4"/><circle cx="196" cy="144" r="2.4"/>' +
+      '<circle cx="158" cy="116" r="2.4"/><circle cx="162" cy="126" r="2.4"/><circle cx="168" cy="136" r="2.4"/>' +
+      '</g>' +
+      /* outsole tread ticks */
+      treadTicks(detail) +
+      '</svg>'
+    );
+  }
+
+  function lacePath() {
+    return '';
+  }
+
+  function treadTicks(color) {
+    var s = '<g stroke="' + color + '" stroke-width="1.6" opacity="0.55">';
+    for (var x = 60; x < 360; x += 26) {
+      s += '<line x1="' + x + '" y1="198" x2="' + (x + 2) + '" y2="206"/>';
+    }
+    return s + '</g>';
+  }
+
+  /* Lighten/darken a hex color by a percent (-100..100). */
+  function shade(hex, percent) {
+    var h = String(hex).replace('#', '');
+    if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    var r = parseInt(h.substring(0, 2), 16);
+    var g = parseInt(h.substring(2, 4), 16);
+    var b = parseInt(h.substring(4, 6), 16);
+    var t = percent < 0 ? 0 : 255;
+    var p = Math.abs(percent) / 100;
+    r = Math.round((t - r) * p) + r;
+    g = Math.round((t - g) * p) + g;
+    b = Math.round((t - b) * p) + b;
+    return '#' + [r, g, b].map(function (v) {
+      var s = Math.max(0, Math.min(255, v)).toString(16);
+      return s.length === 1 ? '0' + s : s;
+    }).join('');
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Product card markup
+   * ------------------------------------------------------------------------ */
+  function cardHTML(p) {
+    return (
+      '<article class="card" data-id="' + p.id + '">' +
+      '<button class="card-media" data-open="' + p.id + '" aria-label="View ' + esc(p.name) + '">' +
+      '<span class="card-tag">' + esc(p.category) + '</span>' +
+      sneakerSVG(p.colorway) +
+      '</button>' +
+      '<div class="card-body">' +
+      '<p class="card-maker">' + esc(p.maker) + '</p>' +
+      '<h3 class="card-name"><button class="linkish" data-open="' + p.id + '">' + esc(p.name) + '</button></h3>' +
+      '<div class="card-foot">' +
+      '<span class="card-price">' + money(p.price) + '</span>' +
+      '<button class="btn btn-sm btn-accent" data-quickadd="' + p.id + '">Add</button>' +
+      '</div>' +
+      '</div>' +
+      '</article>'
+    );
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Catalog (shop.html) — filter + sort + live render
+   * ------------------------------------------------------------------------ */
+  function initCatalog() {
+    var grid = document.getElementById('catalog-grid');
+    if (!grid) return;
+    var all = (window.SOLE_PRODUCTS || []).slice();
+
+    var catSel = document.getElementById('filter-category');
+    var priceSel = document.getElementById('filter-price');
+    var sortSel = document.getElementById('sort-by');
+    var countEl = document.getElementById('result-count');
+
+    /* Optionally seed category from ?category= */
+    var qs = new URLSearchParams(window.location.search);
+    var preCat = qs.get('category');
+    if (preCat && catSel) {
+      for (var i = 0; i < catSel.options.length; i++) {
+        if (catSel.options[i].value.toLowerCase() === preCat.toLowerCase()) {
+          catSel.value = catSel.options[i].value;
+        }
+      }
+    }
+
+    function priceMatch(p, band) {
+      if (band === 'all' || !band) return true;
+      if (band === 'under100') return p.price < 100;
+      if (band === '100-175') return p.price >= 100 && p.price <= 175;
+      if (band === 'over175') return p.price > 175;
+      return true;
+    }
+
+    function apply() {
+      var cat = catSel ? catSel.value : 'all';
+      var band = priceSel ? priceSel.value : 'all';
+      var sort = sortSel ? sortSel.value : 'newest';
+
+      var rows = all.filter(function (p) {
+        var catOk = cat === 'all' || p.category === cat;
+        return catOk && priceMatch(p, band);
+      });
+
+      rows.sort(function (a, b) {
+        switch (sort) {
+          case 'price-asc': return a.price - b.price;
+          case 'price-desc': return b.price - a.price;
+          case 'name-asc': return a.name.localeCompare(b.name);
+          case 'newest':
+          default: return b.drop - a.drop;
+        }
+      });
+
+      grid.innerHTML = rows.length
+        ? rows.map(cardHTML).join('')
+        : '<p class="empty-note">No kicks match those filters. Try widening your search.</p>';
+
+      if (countEl) {
+        countEl.textContent = rows.length + (rows.length === 1 ? ' pair' : ' pairs');
+      }
+    }
+
+    [catSel, priceSel, sortSel].forEach(function (el) {
+      if (el) el.addEventListener('change', apply);
+    });
+
+    apply();
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Featured rows (index.html)
+   * ------------------------------------------------------------------------ */
+  function initFeatured() {
+    var dropsEl = document.getElementById('latest-drops');
+    if (dropsEl) {
+      var byDrop = (window.SOLE_PRODUCTS || []).slice().sort(function (a, b) {
+        return b.drop - a.drop;
+      }).slice(0, 4);
+      dropsEl.innerHTML = byDrop.map(cardHTML).join('');
+    }
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Product detail modal
+   * ------------------------------------------------------------------------ */
+  var modal = {
+    el: null, product: null, size: null, color: null, qty: 1, lastFocus: null
+  };
+
+  function buildModalShell() {
+    if (document.getElementById('product-modal')) return;
+    var wrap = document.createElement('div');
+    wrap.id = 'product-modal';
+    wrap.className = 'modal';
+    wrap.setAttribute('aria-hidden', 'true');
+    wrap.innerHTML =
+      '<div class="modal-backdrop" data-close-modal></div>' +
+      '<div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title">' +
+      '<button class="modal-close" data-close-modal aria-label="Close product details">&times;</button>' +
+      '<div class="modal-grid">' +
+      '<div class="modal-media" id="modal-media"></div>' +
+      '<div class="modal-info">' +
+      '<p class="modal-maker" id="modal-maker"></p>' +
+      '<h2 class="modal-title" id="modal-title"></h2>' +
+      '<p class="modal-price" id="modal-price"></p>' +
+      '<p class="modal-desc" id="modal-desc"></p>' +
+      '<div class="field"><span class="field-label">Color</span><div class="chip-row" id="modal-colors"></div></div>' +
+      '<div class="field"><span class="field-label">Size <span class="req">US</span></span><div class="size-grid" id="modal-sizes"></div>' +
+      '<p class="size-prompt" id="size-prompt" hidden>Pick your size to continue.</p></div>' +
+      '<div class="field qty-field"><span class="field-label">Quantity</span>' +
+      '<div class="stepper">' +
+      '<button class="step-btn" id="modal-qminus" aria-label="Decrease quantity">&minus;</button>' +
+      '<span class="step-val" id="modal-qty" aria-live="polite">1</span>' +
+      '<button class="step-btn" id="modal-qplus" aria-label="Increase quantity">+</button>' +
+      '</div></div>' +
+      '<button class="btn btn-accent btn-block" id="modal-add">Add to cart</button>' +
+      '</div></div></div>';
+    document.body.appendChild(wrap);
+    modal.el = wrap;
+
+    wrap.addEventListener('click', function (e) {
+      if (e.target.hasAttribute('data-close-modal')) closeModal();
+    });
+    document.getElementById('modal-qminus').addEventListener('click', function () { setQty(modal.qty - 1); });
+    document.getElementById('modal-qplus').addEventListener('click', function () { setQty(modal.qty + 1); });
+    document.getElementById('modal-add').addEventListener('click', addFromModal);
+  }
+
+  function setQty(n) {
+    modal.qty = Math.max(1, Math.min(20, n));
+    var el = document.getElementById('modal-qty');
+    if (el) el.textContent = modal.qty;
+  }
+
+  function openModal(id) {
+    var p = byId(id);
+    if (!p) return;
+    buildModalShell();
+    modal.product = p;
+    modal.size = null;
+    modal.color = (p.colors && p.colors[0]) || '';
+    modal.qty = 1;
+    modal.lastFocus = document.activeElement;
+
+    document.getElementById('modal-media').innerHTML = sneakerSVG(p.colorway, { title: p.name });
+    document.getElementById('modal-maker').textContent = p.maker;
+    document.getElementById('modal-title').textContent = p.name;
+    document.getElementById('modal-price').textContent = money(p.price);
+    document.getElementById('modal-desc').textContent = p.description;
+    document.getElementById('modal-qty').textContent = '1';
+
+    /* colors */
+    var colorsEl = document.getElementById('modal-colors');
+    colorsEl.innerHTML = (p.colors || []).map(function (col, i) {
+      return '<button class="chip' + (i === 0 ? ' is-active' : '') + '" data-color="' + esc(col) + '">' + esc(col) + '</button>';
+    }).join('');
+    colorsEl.querySelectorAll('.chip').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        modal.color = btn.getAttribute('data-color');
+        colorsEl.querySelectorAll('.chip').forEach(function (b) { b.classList.remove('is-active'); });
+        btn.classList.add('is-active');
+      });
+    });
+
+    /* sizes */
+    var sizesEl = document.getElementById('modal-sizes');
+    sizesEl.innerHTML = SIZES.map(function (s) {
+      return '<button class="size-btn" data-size="' + s + '">' + s + '</button>';
+    }).join('');
+    sizesEl.querySelectorAll('.size-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        modal.size = btn.getAttribute('data-size');
+        sizesEl.querySelectorAll('.size-btn').forEach(function (b) { b.classList.remove('is-active'); });
+        btn.classList.add('is-active');
+        document.getElementById('size-prompt').hidden = true;
+      });
+    });
+    document.getElementById('size-prompt').hidden = true;
+
+    modal.el.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('no-scroll');
+    var closeBtn = modal.el.querySelector('.modal-close');
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeModal() {
+    if (!modal.el) return;
+    modal.el.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('no-scroll');
+    if (modal.lastFocus && modal.lastFocus.focus) modal.lastFocus.focus();
+  }
+
+  function addFromModal() {
+    if (!modal.product) return;
+    if (!modal.size) {
+      var prompt = document.getElementById('size-prompt');
+      if (prompt) prompt.hidden = false;
+      var grid = document.getElementById('modal-sizes');
+      if (grid) {
+        grid.classList.remove('shake');
+        void grid.offsetWidth; /* reflow to restart animation */
+        grid.classList.add('shake');
+      }
+      return;
+    }
+    window.SoleCart.add(modal.product.id, modal.size, modal.color, modal.qty);
+    closeModal();
+    openDrawer();
+    flashAdded();
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Mini-cart drawer
+   * ------------------------------------------------------------------------ */
+  function buildDrawerShell() {
+    if (document.getElementById('cart-drawer')) return;
+    var wrap = document.createElement('div');
+    wrap.id = 'cart-drawer';
+    wrap.className = 'drawer';
+    wrap.setAttribute('aria-hidden', 'true');
+    wrap.innerHTML =
+      '<div class="drawer-backdrop" data-close-drawer></div>' +
+      '<aside class="drawer-panel" role="dialog" aria-modal="true" aria-label="Shopping cart">' +
+      '<header class="drawer-head">' +
+      '<h2 class="drawer-title">Your Bag</h2>' +
+      '<button class="drawer-close" data-close-drawer aria-label="Close cart">&times;</button>' +
+      '</header>' +
+      '<div class="drawer-items" id="drawer-items"></div>' +
+      '<footer class="drawer-foot">' +
+      '<div class="drawer-subtotal"><span>Subtotal</span><span id="drawer-subtotal">$0.00</span></div>' +
+      '<a class="btn btn-block btn-outline" href="cart.html">View full cart</a>' +
+      '<button class="btn btn-block btn-accent" id="drawer-checkout">Checkout</button>' +
+      '</footer>' +
+      '</aside>';
+    document.body.appendChild(wrap);
+
+    wrap.addEventListener('click', function (e) {
+      if (e.target.hasAttribute('data-close-drawer')) closeDrawer();
+    });
+    document.getElementById('drawer-checkout').addEventListener('click', function () {
+      alert('This is a demo store — checkout is not wired to a payment provider.');
+    });
+  }
+
+  function renderDrawer() {
+    var box = document.getElementById('drawer-items');
+    if (!box) return;
+    var items = window.SoleCart.items();
+    if (!items.length) {
+      box.innerHTML = '<p class="empty-note">Your bag is empty. Go cop something.</p>';
+    } else {
+      box.innerHTML = items.map(function (it) {
+        var p = byId(it.id);
+        var key = window.SoleCart.keyFor(it);
+        return (
+          '<div class="line">' +
+          '<div class="line-media">' + (p ? sneakerSVG(p.colorway) : '') + '</div>' +
+          '<div class="line-info">' +
+          '<p class="line-name">' + esc(it.name) + '</p>' +
+          '<p class="line-meta">Size ' + esc(it.size) + ' &middot; ' + esc(it.color) + '</p>' +
+          '<div class="line-controls">' +
+          '<div class="stepper stepper-sm">' +
+          '<button class="step-btn" data-dec="' + key + '" aria-label="Decrease quantity">&minus;</button>' +
+          '<span class="step-val">' + it.qty + '</span>' +
+          '<button class="step-btn" data-inc="' + key + '" aria-label="Increase quantity">+</button>' +
+          '</div>' +
+          '<button class="line-remove" data-remove="' + key + '" aria-label="Remove ' + esc(it.name) + '">Remove</button>' +
+          '</div>' +
+          '</div>' +
+          '<div class="line-price">' + money(it.price * it.qty) + '</div>' +
+          '</div>'
+        );
+      }).join('');
+    }
+    var sub = document.getElementById('drawer-subtotal');
+    if (sub) sub.textContent = money(window.SoleCart.subtotal());
+  }
+
+  function openDrawer() {
+    buildDrawerShell();
+    renderDrawer();
+    var d = document.getElementById('cart-drawer');
+    d.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('no-scroll');
+    var c = d.querySelector('.drawer-close');
+    if (c) c.focus();
+  }
+  function closeDrawer() {
+    var d = document.getElementById('cart-drawer');
+    if (!d) return;
+    d.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('no-scroll');
+  }
+
+  function flashAdded() {
+    var btns = document.querySelectorAll('[data-cart-toggle]');
+    btns.forEach(function (b) {
+      b.classList.remove('pulse');
+      void b.offsetWidth;
+      b.classList.add('pulse');
+    });
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Full cart page (cart.html)
+   * ------------------------------------------------------------------------ */
+  function renderCartPage() {
+    var root = document.getElementById('cart-page');
+    if (!root) return;
+    var items = window.SoleCart.items();
+    var listEl = document.getElementById('cart-lines');
+    var summaryEl = document.getElementById('cart-summary');
+    var emptyEl = document.getElementById('cart-empty');
+
+    if (!items.length) {
+      if (listEl) listEl.innerHTML = '';
+      if (summaryEl) summaryEl.hidden = true;
+      if (emptyEl) emptyEl.hidden = false;
+      return;
+    }
+    if (emptyEl) emptyEl.hidden = true;
+    if (summaryEl) summaryEl.hidden = false;
+
+    listEl.innerHTML = items.map(function (it) {
+      var p = byId(it.id);
+      var key = window.SoleCart.keyFor(it);
+      return (
+        '<div class="cart-row">' +
+        '<div class="cart-row-media">' + (p ? sneakerSVG(p.colorway) : '') + '</div>' +
+        '<div class="cart-row-main">' +
+        '<p class="cart-row-maker">' + esc(it.maker) + '</p>' +
+        '<h3 class="cart-row-name">' + esc(it.name) + '</h3>' +
+        '<p class="cart-row-meta">Size US ' + esc(it.size) + ' &middot; ' + esc(it.color) + '</p>' +
+        '<button class="line-remove" data-remove="' + key + '">Remove</button>' +
+        '</div>' +
+        '<div class="cart-row-qty">' +
+        '<div class="stepper">' +
+        '<button class="step-btn" data-dec="' + key + '" aria-label="Decrease quantity">&minus;</button>' +
+        '<span class="step-val">' + it.qty + '</span>' +
+        '<button class="step-btn" data-inc="' + key + '" aria-label="Increase quantity">+</button>' +
+        '</div>' +
+        '</div>' +
+        '<div class="cart-row-price">' + money(it.price * it.qty) + '</div>' +
+        '</div>'
+      );
+    }).join('');
+
+    var sub = window.SoleCart.subtotal();
+    var ship = sub >= 150 || sub === 0 ? 0 : 12;
+    var tax = +(sub * 0.08).toFixed(2);
+    var total = +(sub + ship + tax).toFixed(2);
+    summaryEl.innerHTML =
+      '<h2 class="summary-title">Order Summary</h2>' +
+      '<div class="summary-row"><span>Subtotal</span><span>' + money(sub) + '</span></div>' +
+      '<div class="summary-row"><span>Shipping</span><span>' + (ship === 0 ? 'FREE' : money(ship)) + '</span></div>' +
+      '<div class="summary-row"><span>Estimated tax</span><span>' + money(tax) + '</span></div>' +
+      '<div class="summary-row summary-total"><span>Total</span><span>' + money(total) + '</span></div>' +
+      (sub < 150 ? '<p class="summary-note">Add ' + money(150 - sub) + ' more for free shipping.</p>' : '<p class="summary-note">You unlocked free shipping.</p>') +
+      '<button class="btn btn-block btn-accent" id="cart-checkout">Checkout</button>' +
+      '<button class="btn btn-block btn-ghost" id="cart-clear">Clear cart</button>';
+
+    var co = document.getElementById('cart-checkout');
+    if (co) co.addEventListener('click', function () {
+      alert('This is a demo store — checkout is not wired to a payment provider.');
+    });
+    var cl = document.getElementById('cart-clear');
+    if (cl) cl.addEventListener('click', function () {
+      if (confirm('Remove all items from your cart?')) window.SoleCart.clear();
+    });
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Global delegated events
+   * ------------------------------------------------------------------------ */
+  function initGlobalEvents() {
+    document.addEventListener('click', function (e) {
+      var t = e.target.closest('[data-open]');
+      if (t) { openModal(t.getAttribute('data-open')); return; }
+
+      var qa = e.target.closest('[data-quickadd]');
+      if (qa) { openModal(qa.getAttribute('data-quickadd')); return; }
+
+      var toggle = e.target.closest('[data-cart-toggle]');
+      if (toggle) { e.preventDefault(); openDrawer(); return; }
+
+      var dec = e.target.closest('[data-dec]');
+      if (dec) { window.SoleCart.changeQty(dec.getAttribute('data-dec'), -1); return; }
+      var inc = e.target.closest('[data-inc]');
+      if (inc) { window.SoleCart.changeQty(inc.getAttribute('data-inc'), 1); return; }
+      var rm = e.target.closest('[data-remove]');
+      if (rm) { window.SoleCart.remove(rm.getAttribute('data-remove')); return; }
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        var m = document.getElementById('product-modal');
+        if (m && m.getAttribute('aria-hidden') === 'false') { closeModal(); return; }
+        var d = document.getElementById('cart-drawer');
+        if (d && d.getAttribute('aria-hidden') === 'false') { closeDrawer(); return; }
+      }
+    });
+
+    /* Re-render live surfaces whenever the cart changes. */
+    document.addEventListener('sole-cart:change', function () {
+      renderDrawer();
+      renderCartPage();
+    });
+
+    /* Mobile nav toggle */
+    var navToggle = document.querySelector('[data-nav-toggle]');
+    var nav = document.getElementById('site-nav');
+    if (navToggle && nav) {
+      navToggle.addEventListener('click', function () {
+        var open = nav.classList.toggle('is-open');
+        navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      });
+    }
+
+    /* Newsletter / signup forms */
+    document.querySelectorAll('[data-signup]').forEach(function (form) {
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var note = form.querySelector('[data-signup-note]');
+        if (note) { note.hidden = false; }
+        form.reset();
+      });
+    });
+
+    /* Contact form */
+    var contact = document.getElementById('contact-form');
+    if (contact) {
+      contact.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var note = document.getElementById('contact-note');
+        if (note) note.hidden = false;
+        contact.reset();
+      });
+    }
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Boot
+   * ------------------------------------------------------------------------ */
+  document.addEventListener('DOMContentLoaded', function () {
+    initGlobalEvents();
+    initFeatured();
+    initCatalog();
+    renderCartPage();
+    /* footer year */
+    var y = document.querySelectorAll('[data-year]');
+    for (var i = 0; i < y.length; i++) y[i].textContent = new Date().getFullYear();
+  });
+})();

--- a/fixtures/websites/76-sole-society/js/cart.js
+++ b/fixtures/websites/76-sole-society/js/cart.js
@@ -1,0 +1,168 @@
+/* SOLE SOCIETY — cart module (shared across all pages)
+ * Persists to localStorage under "sole_cart".
+ * A line item is keyed by productId + size + color, so the SAME shoe in a
+ * different size (or colorway) is a DISTINCT line item.
+ */
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'sole_cart';
+
+  function lookupProduct(id) {
+    var list = window.SOLE_PRODUCTS || [];
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].id === id) return list[i];
+    }
+    return null;
+  }
+
+  function read() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      var parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function write(items) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    } catch (e) {
+      /* storage may be unavailable; fail quietly */
+    }
+    emitChange();
+  }
+
+  function emitChange() {
+    document.dispatchEvent(new CustomEvent('sole-cart:change', { detail: { items: read() } }));
+  }
+
+  function lineKey(id, size, color) {
+    return id + '::' + (size || '') + '::' + (color || '');
+  }
+
+  var Cart = {
+    STORAGE_KEY: STORAGE_KEY,
+
+    items: function () {
+      return read();
+    },
+
+    /* Add a quantity of a product/size/color. Merges with matching line. */
+    add: function (productId, size, color, qty) {
+      qty = parseInt(qty, 10) || 1;
+      if (qty < 1) qty = 1;
+      var product = lookupProduct(productId);
+      if (!product) return;
+      var items = read();
+      var key = lineKey(productId, size, color);
+      var found = null;
+      for (var i = 0; i < items.length; i++) {
+        if (lineKey(items[i].id, items[i].size, items[i].color) === key) {
+          found = items[i];
+          break;
+        }
+      }
+      if (found) {
+        found.qty += qty;
+      } else {
+        items.push({
+          id: productId,
+          name: product.name,
+          maker: product.maker,
+          price: product.price,
+          size: size || '',
+          color: color || (product.colors && product.colors[0]) || '',
+          qty: qty
+        });
+      }
+      write(items);
+    },
+
+    /* Set absolute quantity for a line; removes line if qty <= 0. */
+    setQty: function (key, qty) {
+      qty = parseInt(qty, 10) || 0;
+      var items = read();
+      var next = [];
+      for (var i = 0; i < items.length; i++) {
+        var it = items[i];
+        if (lineKey(it.id, it.size, it.color) === key) {
+          if (qty > 0) {
+            it.qty = qty;
+            next.push(it);
+          }
+          /* qty <= 0 drops the line */
+        } else {
+          next.push(it);
+        }
+      }
+      write(next);
+    },
+
+    changeQty: function (key, delta) {
+      var items = read();
+      for (var i = 0; i < items.length; i++) {
+        if (lineKey(items[i].id, items[i].size, items[i].color) === key) {
+          Cart.setQty(key, items[i].qty + delta);
+          return;
+        }
+      }
+    },
+
+    remove: function (key) {
+      var items = read();
+      var next = [];
+      for (var i = 0; i < items.length; i++) {
+        if (lineKey(items[i].id, items[i].size, items[i].color) !== key) {
+          next.push(items[i]);
+        }
+      }
+      write(next);
+    },
+
+    clear: function () {
+      write([]);
+    },
+
+    keyFor: function (item) {
+      return lineKey(item.id, item.size, item.color);
+    },
+
+    count: function () {
+      var items = read();
+      var n = 0;
+      for (var i = 0; i < items.length; i++) n += items[i].qty;
+      return n;
+    },
+
+    subtotal: function () {
+      var items = read();
+      var t = 0;
+      for (var i = 0; i < items.length; i++) t += items[i].price * items[i].qty;
+      return t;
+    }
+  };
+
+  window.SoleCart = Cart;
+
+  /* Keep the header badge in sync everywhere. */
+  function updateBadges() {
+    var count = Cart.count();
+    var badges = document.querySelectorAll('[data-cart-count]');
+    for (var i = 0; i < badges.length; i++) {
+      badges[i].textContent = count;
+      badges[i].setAttribute('data-empty', count === 0 ? 'true' : 'false');
+    }
+  }
+
+  document.addEventListener('sole-cart:change', updateBadges);
+  document.addEventListener('DOMContentLoaded', updateBadges);
+
+  /* Reflect cart edits made in another tab/page. */
+  window.addEventListener('storage', function (e) {
+    if (e.key === STORAGE_KEY) emitChange();
+  });
+})();

--- a/fixtures/websites/76-sole-society/js/products.js
+++ b/fixtures/websites/76-sole-society/js/products.js
@@ -1,0 +1,175 @@
+/* SOLE SOCIETY — product catalog
+ * Each product carries a `colorway` palette consumed by the inline-SVG
+ * sneaker renderer in app.js so every card renders a distinct shoe.
+ * `drop` is an integer release index used for "newest" sorting (higher = newer).
+ */
+window.SOLE_PRODUCTS = [
+  {
+    id: 'velocity-volt',
+    name: 'Velocity Pro "Volt Strike"',
+    maker: 'Apex Athletics',
+    price: 165,
+    category: 'Running',
+    drop: 14,
+    description:
+      'A featherweight daily trainer built for speed. Energy-return foam, breathable engineered mesh, and a no-nonsense volt hit that lights up the pavement.',
+    colors: ['Volt Strike', 'Triple Black', 'Storm Grey'],
+    colorway: { upper: '#15161a', accent: '#c6ff00', sole: '#f3f3f3', midsole: '#23252b', lace: '#c6ff00', detail: '#0c0d10' }
+  },
+  {
+    id: 'court-classic-cream',
+    name: 'Court Classic "Vintage Cream"',
+    maker: 'Heritage Court',
+    price: 110,
+    category: 'Lifestyle',
+    drop: 6,
+    description:
+      'The everyday icon. Premium tumbled leather, a timeless silhouette, and an aged cream sole that only looks better with wear.',
+    colors: ['Vintage Cream', 'White/Green', 'Panda'],
+    colorway: { upper: '#f4efe2', accent: '#2f6f4f', sole: '#e8dcc0', midsole: '#f4efe2', lace: '#ffffff', detail: '#cfc4a8' }
+  },
+  {
+    id: 'skyhook-magenta',
+    name: 'SkyHook 2 "Hyper Magenta"',
+    maker: 'Vertical Sports',
+    price: 185,
+    category: 'Basketball',
+    drop: 13,
+    description:
+      'Built for the rim. Full-length cushioning plate, lockdown midfoot strap geometry, and a hyper magenta blast that demands the spotlight.',
+    colors: ['Hyper Magenta', 'Court Purple', 'Blackout'],
+    colorway: { upper: '#1a1014', accent: '#ff2d78', sole: '#0e0a0c', midsole: '#2a1620', lace: '#ff2d78', detail: '#3a1f2c' }
+  },
+  {
+    id: 'grip-tape-skate',
+    name: 'GripTape Low "Asphalt"',
+    maker: 'Curbside Co.',
+    price: 85,
+    category: 'Skate',
+    drop: 8,
+    description:
+      'Vulcanized for board feel, reinforced for ollies. A padded collar and gum outsole that bites the deck and shrugs off curbs.',
+    colors: ['Asphalt', 'Bone', 'Oxblood'],
+    colorway: { upper: '#3a3f47', accent: '#d9a441', sole: '#caa472', midsole: '#2b2f35', lace: '#e7e3da', detail: '#23272c' }
+  },
+  {
+    id: 'phantom-limited',
+    name: 'Phantom "Eclipse" (Limited)',
+    maker: 'SOLE SOCIETY Labs',
+    price: 320,
+    category: 'Limited',
+    drop: 15,
+    description:
+      'A numbered house drop. Tonal blackout build, reflective ghost detailing, and a sculpted sole unit. Strictly limited — when it is gone, it is gone.',
+    colors: ['Eclipse', 'Phantom White'],
+    colorway: { upper: '#0c0c0f', accent: '#6f7bff', sole: '#161620', midsole: '#1d1d27', lace: '#2a2a35', detail: '#3a3aff' }
+  },
+  {
+    id: 'aero-glide-ice',
+    name: 'AeroGlide "Ice Cyan"',
+    maker: 'Apex Athletics',
+    price: 145,
+    category: 'Running',
+    drop: 11,
+    description:
+      'Long-run comfort with a plush rocker geometry and a cooling ice cyan upper. Your half-marathon weapon of choice.',
+    colors: ['Ice Cyan', 'Pure Platinum', 'Black/Volt'],
+    colorway: { upper: '#e9f6fb', accent: '#19c3e6', sole: '#ffffff', midsole: '#d8eef6', lace: '#19c3e6', detail: '#bfe2ee' }
+  },
+  {
+    id: 'metro-lux-mocha',
+    name: 'Metro Lux "Mocha"',
+    maker: 'Heritage Court',
+    price: 135,
+    category: 'Lifestyle',
+    drop: 9,
+    description:
+      'Luxe streetwear staple. Suede overlays, a quilted heel, and a rich mocha tone that pairs with everything in the rotation.',
+    colors: ['Mocha', 'Sail', 'Slate'],
+    colorway: { upper: '#6e4a33', accent: '#d8b48a', sole: '#efe6d6', midsole: '#7d5640', lace: '#e9dcc6', detail: '#553622' }
+  },
+  {
+    id: 'rim-rocker-fire',
+    name: 'RimRocker "Fire Red"',
+    maker: 'Vertical Sports',
+    price: 175,
+    category: 'Basketball',
+    drop: 10,
+    description:
+      'A bully on the blacktop. Herringbone traction, a stiff TPU shank, and a fire red colorway loud enough to talk trash for you.',
+    colors: ['Fire Red', 'Bred', 'University Blue'],
+    colorway: { upper: '#1c1416', accent: '#ff3b30', sole: '#f2f2f2', midsole: '#2a1c1f', lace: '#ff3b30', detail: '#0f0a0b' }
+  },
+  {
+    id: 'kickflip-teal',
+    name: 'Kickflip Pro "Teal Fade"',
+    maker: 'Curbside Co.',
+    price: 95,
+    category: 'Skate',
+    drop: 12,
+    description:
+      'Pro-model durability with a suede toe box that survives flip tricks. A teal fade that pops under any streetlight.',
+    colors: ['Teal Fade', 'Black/Gum', 'Washed Denim'],
+    colorway: { upper: '#1f6f74', accent: '#f4d35e', sole: '#caa472', midsole: '#175357', lace: '#fefae0', detail: '#0f3c40' }
+  },
+  {
+    id: 'nova-burst-coral',
+    name: 'NovaBurst "Coral Pulse"',
+    maker: 'Apex Athletics',
+    price: 155,
+    category: 'Running',
+    drop: 13,
+    description:
+      'Tempo-day responsiveness with a snappy carbon-ish plate feel and a coral pulse upper that screams negative splits.',
+    colors: ['Coral Pulse', 'Solar Yellow', 'Mono Black'],
+    colorway: { upper: '#15161a', accent: '#ff6f61', sole: '#ffffff', midsole: '#23252b', lace: '#ff6f61', detail: '#0c0d10' }
+  },
+  {
+    id: 'boulevard-onyx',
+    name: 'Boulevard "Onyx Panda"',
+    maker: 'Heritage Court',
+    price: 120,
+    category: 'Lifestyle',
+    drop: 7,
+    description:
+      'The clean two-tone everyone reaches for. Crisp leather panels, an onyx-and-white split, and an everyday-comfort footbed.',
+    colors: ['Onyx Panda', 'All White', 'Sail/Gum'],
+    colorway: { upper: '#101114', accent: '#ffffff', sole: '#ffffff', midsole: '#f3f3f3', lace: '#ffffff', detail: '#0a0b0d' }
+  },
+  {
+    id: 'tip-off-amber',
+    name: 'Tip-Off "Amber Glow"',
+    maker: 'Vertical Sports',
+    price: 160,
+    category: 'Basketball',
+    drop: 11,
+    description:
+      'Quick-guard cushioning with a low, locked-in ride. An amber glow upper that heats up from the opening tip.',
+    colors: ['Amber Glow', 'Court Green', 'Triple White'],
+    colorway: { upper: '#2a1c0e', accent: '#ffb000', sole: '#1a1106', midsole: '#3a2913', lace: '#ffb000', detail: '#4a3518' }
+  },
+  {
+    id: 'halfpipe-violet',
+    name: 'Halfpipe "Ultra Violet"',
+    maker: 'Curbside Co.',
+    price: 90,
+    category: 'Skate',
+    drop: 9,
+    description:
+      'Cupsole support meets vulcanized flex. Abrasion-tough sidewalls and an ultra violet hit for the bowl sessions.',
+    colors: ['Ultra Violet', 'Black/White', 'Forest'],
+    colorway: { upper: '#3b2a6b', accent: '#b39cff', sole: '#caa472', midsole: '#2c1f52', lace: '#ece6ff', detail: '#1f1640' }
+  },
+  {
+    id: 'archive-gold-limited',
+    name: 'Archive "24K" (Limited)',
+    maker: 'SOLE SOCIETY Labs',
+    price: 280,
+    category: 'Limited',
+    drop: 15,
+    description:
+      'A vault reissue dressed in metallic gold detailing on a deep black base. Premium materials, numbered tongue, collector packaging.',
+    colors: ['24K Gold', 'Midnight'],
+    colorway: { upper: '#121013', accent: '#e6b422', sole: '#1a1a1a', midsole: '#23202a', lace: '#e6b422', detail: '#caa11a' }
+  }
+];

--- a/fixtures/websites/76-sole-society/shop.html
+++ b/fixtures/websites/76-sole-society/shop.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shop All Sneakers — SOLE SOCIETY</title>
+  <meta name="description" content="Browse every drop at SOLE SOCIETY. Filter by category and price, sort by price, name or newest. Verified-authentic running, lifestyle, basketball, skate and limited sneakers." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="SOLE SOCIETY home">
+        <svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/><path d="M9 31 L40 28" stroke="#c6ff00" stroke-width="2" fill="none"/></svg>
+        <span class="brand-text">SOLE<b>SOCIETY</b></span>
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">
+        <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="shop.html" class="is-current">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-cart-toggle aria-label="Open cart">
+          <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1 13H7L6 7Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="shop-head">
+      <div class="wrap">
+        <p class="eyebrow">The full lineup</p>
+        <h1>Shop All Kicks</h1>
+        <p>Every verified pair in the boutique. Filter, sort, and find your heat.</p>
+      </div>
+    </section>
+
+    <div class="wrap">
+      <div class="toolbar" role="region" aria-label="Filter and sort">
+        <div class="field-inline">
+          <label for="filter-category">Category</label>
+          <select id="filter-category">
+            <option value="all">All</option>
+            <option value="Running">Running</option>
+            <option value="Lifestyle">Lifestyle</option>
+            <option value="Basketball">Basketball</option>
+            <option value="Skate">Skate</option>
+            <option value="Limited">Limited</option>
+          </select>
+        </div>
+        <div class="field-inline">
+          <label for="filter-price">Price</label>
+          <select id="filter-price">
+            <option value="all">Any</option>
+            <option value="under100">Under $100</option>
+            <option value="100-175">$100 – $175</option>
+            <option value="over175">Over $175</option>
+          </select>
+        </div>
+        <div class="field-inline">
+          <label for="sort-by">Sort</label>
+          <select id="sort-by">
+            <option value="newest">Newest</option>
+            <option value="price-asc">Price: Low to High</option>
+            <option value="price-desc">Price: High to Low</option>
+            <option value="name-asc">Name: A → Z</option>
+          </select>
+        </div>
+        <span class="result-count" id="result-count" aria-live="polite"></span>
+      </div>
+    </div>
+
+    <section class="section" style="padding-top:30px">
+      <div class="wrap">
+        <div class="product-grid" id="catalog-grid"><!-- JS injects cards --></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <a class="brand" href="index.html" aria-label="SOLE SOCIETY home" style="margin-bottom:14px"><svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true"><rect width="48" height="48" rx="11" fill="#c6ff00"/><path d="M8 30 Q8 22 16 21 L24 19 Q28 14 33 16 L38 22 Q43 23 41 28 L40 31 Q39 33 36 33 L11 33 Q8 33 8 30 Z" fill="#0c0d10"/></svg><span class="brand-text">SOLE<b>SOCIETY</b></span></a>
+          <p class="footer-blurb">The streetwear sneaker boutique built for drop culture. Verified authentic, shipped fast, no fakes ever.</p>
+        </div>
+        <div><h4>Shop</h4><ul><li><a href="shop.html?category=Running">Running</a></li><li><a href="shop.html?category=Lifestyle">Lifestyle</a></li><li><a href="shop.html?category=Basketball">Basketball</a></li><li><a href="shop.html?category=Skate">Skate</a></li><li><a href="shop.html?category=Limited">Limited</a></li></ul></div>
+        <div><h4>Society</h4><ul><li><a href="about.html">Our story</a></li><li><a href="about.html#authenticity">Authenticity</a></li><li><a href="contact.html">Contact</a></li><li><a href="cart.html">Cart</a></li></ul></div>
+        <div><h4>Support</h4><ul><li><a href="contact.html">Shipping</a></li><li><a href="contact.html">Returns</a></li><li><a href="contact.html">Size guide</a></li><li><a href="contact.html">FAQ</a></li></ul></div>
+      </div>
+      <div class="footer-bottom"><span>&copy; <span data-year>2026</span> SOLE SOCIETY. All rights reserved.</span><span>Demo boutique — not a real store.</span></div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/77-fernwood-plants/about.html
+++ b/fixtures/websites/77-fernwood-plants/about.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About — Fernwood Botanicals</title>
+  <meta name="description" content="The Fernwood Botanicals story: three decades of family growing, peat-free sustainability, and the growers who raise every plant by hand." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="Fernwood Botanicals home">
+        <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#2f4a2c" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+        Fernwood
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+      <nav class="nav" data-nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html" class="active">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/><path d="M2 3h2.2l2.3 12.3a2 2 0 0 0 2 1.7h8.7a2 2 0 0 0 2-1.6L21 7H6"/></svg>
+          <span class="cart-badge is-empty" data-cart-count>0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="wrap">
+        <span class="eyebrow">Our roots</span>
+        <h1>Three decades of growing green</h1>
+        <p>Fernwood Botanicals started as a single backyard greenhouse and a stubborn belief that everyone can keep a plant alive with the right start.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="wrap about-split">
+        <div class="about-copy">
+          <span class="eyebrow">Est. 1994</span>
+          <h2>From one greenhouse to a thriving nursery</h2>
+          <p>What began in 1994 as Marisol Fern's backyard hobby — a lean-to greenhouse and a dozen propagation trays — has grown into a beloved neighborhood nursery on the edge of Mossvale. We still grow the way Marisol did: slowly, by hand, and with a deep respect for each plant's natural rhythm.</p>
+          <p>We don't flood our benches with mass-grown stock. Every plant that leaves Fernwood is acclimated, root-checked, and matched to the home it's heading to. If a plant isn't ready, it doesn't ship.</p>
+        </div>
+        <div class="about-art">
+          <svg viewBox="0 0 400 300" role="img" aria-label="A small glasshouse surrounded by plants">
+            <rect x="0" y="0" width="400" height="300" fill="none"/>
+            <path d="M60 250V150l140-70 140 70v100Z" fill="#dde7d0"/>
+            <path d="M60 150 200 80 340 150" fill="none" stroke="#2f4a2c" stroke-width="4" stroke-linejoin="round"/>
+            <rect x="60" y="150" width="280" height="100" fill="none" stroke="#3f6b3a" stroke-width="4"/>
+            <line x1="130" y1="115" x2="130" y2="250" stroke="#9caf88" stroke-width="3"/>
+            <line x1="200" y1="80" x2="200" y2="250" stroke="#9caf88" stroke-width="3"/>
+            <line x1="270" y1="115" x2="270" y2="250" stroke="#9caf88" stroke-width="3"/>
+            <line x1="60" y1="200" x2="340" y2="200" stroke="#9caf88" stroke-width="3"/>
+            <circle cx="100" cy="225" r="14" fill="#5a9050"/>
+            <circle cx="300" cy="225" r="14" fill="#6fae5a"/>
+            <rect x="180" y="210" width="40" height="40" fill="#c97a54"/>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-tight" id="sustainability" style="background:#fff;">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">How we grow</span>
+          <h2>Sustainability, all the way down</h2>
+          <p>Good for your home, gentler on the planet. These aren't add-ons — they're how Fernwood has always worked.</p>
+        </div>
+        <div class="values">
+          <div class="value">
+            <svg class="v-ico" viewBox="0 0 52 52" aria-hidden="true"><circle cx="26" cy="26" r="24" fill="#dce4d2"/><path d="M26 38V20m0 0c-6-2-10-7-10-13 6 0 11 4 13 9 2-5 7-9 13-9 0 6-4 11-10 13" fill="#3f6b3a"/></svg>
+            <h3>100% peat-free</h3>
+            <p>We grow in renewable coir and composted bark blends — never peat, protecting precious carbon-rich bogs.</p>
+          </div>
+          <div class="value">
+            <svg class="v-ico" viewBox="0 0 52 52" aria-hidden="true"><circle cx="26" cy="26" r="24" fill="#d6e6e0"/><path d="M16 30c0-8 4-14 10-14s10 6 10 14" fill="none" stroke="#2f4a2c" stroke-width="3"/><path d="M26 16v22" stroke="#2f4a2c" stroke-width="3"/><circle cx="26" cy="40" r="3" fill="#3f6b3a"/></svg>
+            <h3>Rainwater recovery</h3>
+            <p>Our greenhouse roof feeds a 10,000L cistern, so nearly every drop your plants drink fell from our own sky.</p>
+          </div>
+          <div class="value">
+            <svg class="v-ico" viewBox="0 0 52 52" aria-hidden="true"><circle cx="26" cy="26" r="24" fill="#f5dcc4"/><path d="M18 34h16l-3 8H21Z" fill="#c97a54"/><rect x="16" y="28" width="20" height="6" rx="3" fill="#b15f3c"/></svg>
+            <h3>Plastic-light packing</h3>
+            <p>Plants ship in compostable nursery pots and recycled, molded-pulp cradles. Return your pots for store credit.</p>
+          </div>
+          <div class="value">
+            <svg class="v-ico" viewBox="0 0 52 52" aria-hidden="true"><circle cx="26" cy="26" r="24" fill="#ece0c4"/><circle cx="26" cy="24" r="7" fill="#e0a23a"/><path d="M26 12v-4M26 44v-4M14 24h-4M42 24h-4" stroke="#b15f3c" stroke-width="3" stroke-linecap="round"/></svg>
+            <h3>Solar greenhouse</h3>
+            <p>Our benches and propagation mats run on rooftop solar, with battery backup for those long Oregon winters.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">Say hello</span>
+          <h2>Meet the growers</h2>
+          <p>The small, dirt-under-the-nails team who raise every plant on our benches.</p>
+        </div>
+        <div class="growers">
+          <div class="grower">
+            <div class="avatar"><svg viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="38" r="20" fill="#9caf88"/><path d="M20 92c0-18 13-30 30-30s30 12 30 30Z" fill="#3f6b3a"/></svg></div>
+            <h3>Marisol Fern</h3><span>Founder &amp; head grower</span>
+            <p>Started it all in 1994. Can diagnose a sad plant from across the room.</p>
+          </div>
+          <div class="grower">
+            <div class="avatar"><svg viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="38" r="20" fill="#c97a54"/><path d="M20 92c0-18 13-30 30-30s30 12 30 30Z" fill="#56864f"/></svg></div>
+            <h3>Theo Fern</h3><span>Propagation lead</span>
+            <p>Turns one plant into a hundred. Keeps the misting schedule sacred.</p>
+          </div>
+          <div class="grower">
+            <div class="avatar"><svg viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="38" r="20" fill="#6fae5a"/><path d="M20 92c0-18 13-30 30-30s30 12 30 30Z" fill="#2f4a2c"/></svg></div>
+            <h3>Priya Anand</h3><span>Greenhouse manager</span>
+            <p>Runs the cistern, the solar, and the soil lab. Our sustainability conscience.</p>
+          </div>
+          <div class="grower">
+            <div class="avatar"><svg viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="38" r="20" fill="#849a6d"/><path d="M20 92c0-18 13-30 30-30s30 12 30 30Z" fill="#b15f3c"/></svg></div>
+            <h3>Wren Okafor</h3><span>Care &amp; deliveries</span>
+            <p>Hand-checks every order and writes the care cards tucked in each box.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-tight">
+      <div class="wrap">
+        <div class="newsletter">
+          <span class="eyebrow">Come grow with us</span>
+          <h2>Ready to start your jungle?</h2>
+          <p style="color:var(--muted);max-width:46ch;margin:6px auto 18px;">Browse the collection or stop by the greenhouse — we love talking plants.</p>
+          <div class="hero-cta" style="justify-content:center;">
+            <a class="btn btn-primary" href="shop.html">Shop plants</a>
+            <a class="btn btn-outline" href="contact.html">Visit us</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <div class="footer-brand">
+            <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#1f3320" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+            Fernwood Botanicals
+          </div>
+          <p>A family nursery growing happy, healthy plants — and the people who care for them — since 1994.</p>
+        </div>
+        <div><h4>Shop</h4><ul>
+          <li><a href="shop.html?category=Indoor">Indoor plants</a></li>
+          <li><a href="shop.html?category=Outdoor">Outdoor plants</a></li>
+          <li><a href="shop.html?category=Succulents &amp; Cacti">Succulents &amp; cacti</a></li>
+          <li><a href="shop.html?category=Pots &amp; Planters">Pots &amp; planters</a></li>
+        </ul></div>
+        <div><h4>Company</h4><ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#sustainability">Sustainability</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="contact.html#hours">Greenhouse hours</a></li>
+        </ul></div>
+        <div><h4>Visit</h4><ul>
+          <li>14 Fernwood Lane</li><li>Mossvale, OR 97000</li>
+          <li><a href="tel:+15035550142">(503) 555-0142</a></li>
+          <li><a href="mailto:hello@fernwood.example">hello@fernwood.example</a></li>
+        </ul></div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Fernwood Botanicals. Grown with care.</span>
+        <span>Peat-free · Plastic-light · Locally rooted</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/77-fernwood-plants/cart.html
+++ b/fixtures/websites/77-fernwood-plants/cart.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your Cart — Fernwood Botanicals</title>
+  <meta name="description" content="Review your Fernwood Botanicals cart, adjust quantities, and check out." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="Fernwood Botanicals home">
+        <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#2f4a2c" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+        Fernwood
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+      <nav class="nav" data-nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/><path d="M2 3h2.2l2.3 12.3a2 2 0 0 0 2 1.7h8.7a2 2 0 0 0 2-1.6L21 7H6"/></svg>
+          <span class="cart-badge is-empty" data-cart-count>0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="wrap">
+        <span class="eyebrow">Almost there</span>
+        <h1>Your cart</h1>
+        <p>Review your selection, adjust quantities, and check out. Free shipping on orders over $75.</p>
+      </div>
+    </section>
+
+    <section class="section section-tight" data-cart-page>
+      <div class="wrap">
+        <div class="cart-empty" data-cart-empty hidden>
+          <svg viewBox="0 0 120 120" width="120" height="120" aria-hidden="true" style="margin:0 auto 12px;">
+            <path d="M30 50h60l-8 50a8 8 0 0 1-8 7H46a8 8 0 0 1-8-7Z" fill="#cdd8bf"/>
+            <rect x="24" y="40" width="72" height="14" rx="7" fill="#9caf88"/>
+            <path d="M60 40V22m0 0c-6-2-10-7-10-12 6 0 11 4 13 9 2-5 7-9 13-9 0 5-4 10-10 12" fill="#3f6b3a"/>
+          </svg>
+          <h2>Your cart is empty</h2>
+          <p style="margin-bottom:18px;">Looks like you haven't added any greenery yet.</p>
+          <a class="btn btn-primary" href="shop.html">Start shopping</a>
+        </div>
+
+        <div class="cart-grid">
+          <div class="cart-lines" data-cart-lines></div>
+
+          <aside class="cart-summary" data-cart-summary hidden>
+            <h3>Order summary</h3>
+            <div class="summary-row"><span>Subtotal</span><span data-sum-subtotal>$0.00</span></div>
+            <div class="summary-row"><span>Shipping</span><span data-sum-shipping>Free</span></div>
+            <div class="summary-row total"><span>Total</span><span data-sum-total>$0.00</span></div>
+            <p class="summary-note">Taxes calculated at checkout. Free shipping over $75.</p>
+            <button class="btn btn-primary btn-block" data-c-checkout>Proceed to checkout</button>
+            <p style="text-align:center;margin:14px 0 0;"><a href="shop.html">← Continue shopping</a></p>
+          </aside>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <div class="footer-brand">
+            <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#1f3320" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+            Fernwood Botanicals
+          </div>
+          <p>A family nursery growing happy, healthy plants — and the people who care for them — since 1994.</p>
+        </div>
+        <div><h4>Shop</h4><ul>
+          <li><a href="shop.html?category=Indoor">Indoor plants</a></li>
+          <li><a href="shop.html?category=Outdoor">Outdoor plants</a></li>
+          <li><a href="shop.html?category=Succulents &amp; Cacti">Succulents &amp; cacti</a></li>
+          <li><a href="shop.html?category=Pots &amp; Planters">Pots &amp; planters</a></li>
+        </ul></div>
+        <div><h4>Company</h4><ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#sustainability">Sustainability</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="contact.html#hours">Greenhouse hours</a></li>
+        </ul></div>
+        <div><h4>Visit</h4><ul>
+          <li>14 Fernwood Lane</li><li>Mossvale, OR 97000</li>
+          <li><a href="tel:+15035550142">(503) 555-0142</a></li>
+          <li><a href="mailto:hello@fernwood.example">hello@fernwood.example</a></li>
+        </ul></div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Fernwood Botanicals. Grown with care.</span>
+        <span>Peat-free · Plastic-light · Locally rooted</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/77-fernwood-plants/contact.html
+++ b/fixtures/websites/77-fernwood-plants/contact.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact &amp; Visit — Fernwood Botanicals</title>
+  <meta name="description" content="Get in touch with Fernwood Botanicals. Greenhouse hours, location, and a message form to reach our growers." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="Fernwood Botanicals home">
+        <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#2f4a2c" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+        Fernwood
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+      <nav class="nav" data-nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html" class="active">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/><path d="M2 3h2.2l2.3 12.3a2 2 0 0 0 2 1.7h8.7a2 2 0 0 0 2-1.6L21 7H6"/></svg>
+          <span class="cart-badge is-empty" data-cart-count>0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="wrap">
+        <span class="eyebrow">We'd love to hear from you</span>
+        <h1>Contact &amp; visit</h1>
+        <p>Questions about a plant, an order, or just need some care advice? Reach out, or come wander the greenhouse in person.</p>
+      </div>
+    </section>
+
+    <section class="section section-tight">
+      <div class="wrap contact-grid">
+        <!-- FORM -->
+        <div>
+          <h2>Send us a message</h2>
+          <form data-contact-form novalidate>
+            <div class="field">
+              <label for="cf-name">Your name</label>
+              <input id="cf-name" name="name" type="text" autocomplete="name" required />
+            </div>
+            <div class="field">
+              <label for="cf-email">Email address</label>
+              <input id="cf-email" name="email" type="email" autocomplete="email" required />
+            </div>
+            <div class="field">
+              <label for="cf-topic">What's this about?</label>
+              <select id="cf-topic" name="topic">
+                <option>Plant care advice</option>
+                <option>An existing order</option>
+                <option>Wholesale &amp; events</option>
+                <option>Something else</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="cf-message">Message</label>
+              <textarea id="cf-message" name="message" required placeholder="Tell us what's growing on…"></textarea>
+            </div>
+            <button class="btn btn-primary btn-block" type="submit">Send message</button>
+            <p class="form-note" data-form-note hidden></p>
+          </form>
+        </div>
+
+        <!-- INFO -->
+        <div>
+          <div class="info-card" id="hours">
+            <h3>Greenhouse hours</h3>
+            <div class="hours-row"><span>Monday – Friday</span><span>9:00 – 18:00</span></div>
+            <div class="hours-row"><span>Saturday</span><span>9:00 – 17:00</span></div>
+            <div class="hours-row"><span>Sunday</span><span>10:00 – 16:00</span></div>
+            <div class="hours-row"><span>Public holidays</span><span>Closed</span></div>
+          </div>
+
+          <div class="info-card">
+            <h3>Find us</h3>
+            <p style="color:var(--muted);margin-top:0;">14 Fernwood Lane<br>Mossvale, OR 97000</p>
+            <p style="margin:0;"><a href="tel:+15035550142">(503) 555-0142</a> · <a href="mailto:hello@fernwood.example">hello@fernwood.example</a></p>
+          </div>
+
+          <div class="map-art" role="img" aria-label="Stylized map showing Fernwood Botanicals just off Mossvale's main road">
+            <svg viewBox="0 0 400 240" xmlns="http://www.w3.org/2000/svg">
+              <rect x="0" y="0" width="400" height="240" rx="16" fill="#eef3e6"/>
+              <path d="M0 150 Q120 120 220 160 T400 150" fill="none" stroke="#cdd8bf" stroke-width="16"/>
+              <path d="M120 0 L150 240" fill="none" stroke="#cdd8bf" stroke-width="12"/>
+              <path d="M0 60 L400 90" fill="none" stroke="#dde7d0" stroke-width="8"/>
+              <circle cx="80" cy="60" r="10" fill="#9caf88"/>
+              <circle cx="320" cy="180" r="12" fill="#9caf88"/>
+              <rect x="250" y="50" width="40" height="34" rx="4" fill="#c4d4b2"/>
+              <!-- marker -->
+              <g transform="translate(196 96)">
+                <path d="M0 60 C-22 32 -22 12 0 0 C22 12 22 32 0 60Z" fill="#c97a54"/>
+                <circle cx="0" cy="22" r="10" fill="#fff"/>
+                <path d="M0 28V14m0 0c-3-1-5-3-5-6 3 0 5 2 6 4 1-2 3-4 6-4 0 3-2 5-5 6" fill="#3f6b3a"/>
+              </g>
+              <text x="210" y="190" font-family="sans-serif" font-size="13" fill="#6a7563">Mossvale</text>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <div class="footer-brand">
+            <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#1f3320" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+            Fernwood Botanicals
+          </div>
+          <p>A family nursery growing happy, healthy plants — and the people who care for them — since 1994.</p>
+        </div>
+        <div><h4>Shop</h4><ul>
+          <li><a href="shop.html?category=Indoor">Indoor plants</a></li>
+          <li><a href="shop.html?category=Outdoor">Outdoor plants</a></li>
+          <li><a href="shop.html?category=Succulents &amp; Cacti">Succulents &amp; cacti</a></li>
+          <li><a href="shop.html?category=Pots &amp; Planters">Pots &amp; planters</a></li>
+        </ul></div>
+        <div><h4>Company</h4><ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#sustainability">Sustainability</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="contact.html#hours">Greenhouse hours</a></li>
+        </ul></div>
+        <div><h4>Visit</h4><ul>
+          <li>14 Fernwood Lane</li><li>Mossvale, OR 97000</li>
+          <li><a href="tel:+15035550142">(503) 555-0142</a></li>
+          <li><a href="mailto:hello@fernwood.example">hello@fernwood.example</a></li>
+        </ul></div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Fernwood Botanicals. Grown with care.</span>
+        <span>Peat-free · Plastic-light · Locally rooted</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/77-fernwood-plants/css/styles.css
+++ b/fixtures/websites/77-fernwood-plants/css/styles.css
@@ -1,0 +1,448 @@
+/* Fernwood Botanicals — fresh, organic, calming design system.
+ * Pure CSS. Forest green / sage / clay / terracotta. Soft rounded geometry. */
+
+:root {
+  --forest: #2f4a2c;
+  --forest-deep: #1f3320;
+  --green: #3f6b3a;
+  --sage: #9caf88;
+  --sage-soft: #cdd8bf;
+  --offwhite: #f7f5ee;
+  --clay: #e7ddcd;
+  --clay-deep: #d9c9b2;
+  --terracotta: #c97a54;
+  --terracotta-deep: #b15f3c;
+  --ink: #283526;
+  --muted: #6a7563;
+  --line: #e2ddd0;
+  --white: #ffffff;
+
+  --radius: 18px;
+  --radius-lg: 28px;
+  --radius-pill: 999px;
+  --shadow-sm: 0 4px 14px rgba(47, 74, 44, 0.08);
+  --shadow: 0 14px 34px rgba(47, 74, 44, 0.12);
+  --shadow-lg: 0 24px 60px rgba(31, 51, 32, 0.22);
+
+  --sans: "Avenir Next", "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  --display: "Cooper BT", "Marker Felt", "Hiragino Maru Gothic ProN", "Quicksand",
+    ui-rounded, "Segoe UI", system-ui, sans-serif;
+
+  --maxw: 1180px;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  color: var(--ink);
+  background: var(--offwhite);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+body.no-scroll { overflow: hidden; }
+
+h1, h2, h3, h4 {
+  font-family: var(--display);
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--forest);
+  margin: 0 0 0.5em;
+  letter-spacing: 0.2px;
+}
+
+a { color: var(--green); text-decoration: none; }
+a:hover { color: var(--terracotta-deep); }
+
+img, svg { max-width: 100%; display: block; }
+
+.wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 22px; }
+
+.section { padding: 72px 0; }
+.section-tight { padding: 48px 0; }
+.section-head { text-align: center; max-width: 640px; margin: 0 auto 40px; }
+.section-head h2 { font-size: clamp(1.7rem, 3.5vw, 2.6rem); }
+.section-head p { color: var(--muted); font-size: 1.05rem; }
+.eyebrow {
+  display: inline-block; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.72rem; font-weight: 700; color: var(--terracotta-deep);
+  font-family: var(--sans); margin-bottom: 10px;
+}
+
+/* ---------------------------------------------------------------- buttons */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--sans); font-weight: 600; font-size: 0.95rem;
+  padding: 12px 22px; border-radius: var(--radius-pill); border: 1.5px solid transparent;
+  cursor: pointer; transition: transform .18s ease, box-shadow .18s ease, background .18s ease, color .18s ease;
+  background: var(--sage-soft); color: var(--forest);
+}
+.btn:hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); }
+.btn:active { transform: translateY(0); }
+.btn-primary { background: var(--forest); color: var(--offwhite); }
+.btn-primary:hover { background: var(--forest-deep); color: #fff; }
+.btn-accent { background: var(--terracotta); color: #fff; }
+.btn-accent:hover { background: var(--terracotta-deep); color: #fff; }
+.btn-outline { background: transparent; border-color: var(--forest); color: var(--forest); }
+.btn-outline:hover { background: var(--forest); color: var(--offwhite); }
+.btn-add {
+  background: var(--clay); color: var(--forest); padding: 9px 16px; font-size: 0.85rem;
+}
+.btn-add:hover { background: var(--terracotta); color: #fff; }
+.btn-block { width: 100%; }
+
+/* ---------------------------------------------------------------- header */
+.site-header {
+  position: sticky; top: 0; z-index: 40;
+  background: rgba(247, 245, 238, 0.86);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.header-inner { display: flex; align-items: center; gap: 18px; height: 72px; }
+.brand { display: flex; align-items: center; gap: 10px; font-family: var(--display);
+  font-size: 1.35rem; font-weight: 700; color: var(--forest); }
+.brand svg { width: 38px; height: 38px; }
+.brand:hover { color: var(--forest); }
+
+.nav { margin-left: auto; display: flex; align-items: center; gap: 6px; }
+.nav a { padding: 8px 14px; border-radius: var(--radius-pill); font-weight: 600; color: var(--ink); }
+.nav a:hover, .nav a.active { background: var(--sage-soft); color: var(--forest); }
+
+.header-actions { display: flex; align-items: center; gap: 6px; }
+.icon-btn {
+  position: relative; display: inline-flex; align-items: center; justify-content: center;
+  width: 44px; height: 44px; border-radius: 50%; border: none; background: transparent;
+  color: var(--forest); cursor: pointer; transition: background .18s ease;
+}
+.icon-btn:hover { background: var(--sage-soft); }
+.icon-btn svg { width: 22px; height: 22px; }
+.cart-badge {
+  position: absolute; top: 4px; right: 2px; min-width: 19px; height: 19px; padding: 0 5px;
+  border-radius: var(--radius-pill); background: var(--terracotta); color: #fff;
+  font-size: 0.7rem; font-weight: 700; display: flex; align-items: center; justify-content: center;
+  font-family: var(--sans);
+}
+.cart-badge.is-empty { display: none; }
+
+.nav-toggle { display: none; }
+
+/* ---------------------------------------------------------------- hero */
+.hero { position: relative; overflow: hidden; background:
+  radial-gradient(120% 120% at 80% 0%, #e9efdd 0%, var(--offwhite) 55%); }
+.hero-inner { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 36px; align-items: center;
+  padding: 70px 0 80px; }
+.hero h1 { font-size: clamp(2.3rem, 5vw, 3.8rem); margin-bottom: 18px; }
+.hero p.lead { font-size: 1.18rem; color: var(--muted); max-width: 30ch; margin-bottom: 28px; }
+.hero-cta { display: flex; gap: 14px; flex-wrap: wrap; }
+.hero-stats { display: flex; gap: 28px; margin-top: 34px; }
+.hero-stats .stat strong { font-family: var(--display); font-size: 1.5rem; color: var(--forest); display: block; }
+.hero-stats .stat span { font-size: 0.85rem; color: var(--muted); }
+.hero-art { position: relative; display: flex; justify-content: center; }
+.hero-art svg { width: min(440px, 100%); height: auto; filter: drop-shadow(0 24px 40px rgba(47,74,44,0.18)); }
+.blob-bg { position: absolute; inset: 0; z-index: 0; }
+
+/* ---------------------------------------------------------------- product grid */
+.grid {
+  display: grid; gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(238px, 1fr));
+}
+.empty-grid { grid-column: 1 / -1; text-align: center; color: var(--muted); padding: 50px 0; }
+
+.card {
+  background: var(--white); border-radius: var(--radius-lg); overflow: hidden;
+  box-shadow: var(--shadow-sm); border: 1px solid var(--line);
+  display: flex; flex-direction: column; transition: transform .2s ease, box-shadow .2s ease;
+}
+.card:hover { transform: translateY(-6px); box-shadow: var(--shadow); }
+.card-media {
+  position: relative; border: none; cursor: pointer; padding: 14px; background:
+  linear-gradient(180deg, #eef3e6 0%, #e3ecd7 100%); width: 100%;
+}
+.card-media .plant-svg { width: 100%; height: auto; transition: transform .25s ease; }
+.card:hover .card-media .plant-svg { transform: scale(1.04) rotate(-1deg); }
+.card-cat {
+  position: absolute; top: 12px; left: 12px; background: rgba(255,255,255,0.85);
+  color: var(--forest); font-size: 0.68rem; font-weight: 700; padding: 4px 10px;
+  border-radius: var(--radius-pill); text-transform: uppercase; letter-spacing: 0.06em;
+}
+.card-body { padding: 16px 18px 18px; display: flex; flex-direction: column; flex: 1; }
+.card-title { font-size: 1.12rem; margin-bottom: 2px; }
+.card-botanical { font-style: italic; color: var(--muted); font-size: 0.82rem; margin: 0 0 10px; }
+.card-meta { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 14px; }
+.chip {
+  font-size: 0.7rem; padding: 3px 9px; border-radius: var(--radius-pill);
+  background: var(--clay); color: var(--ink); font-weight: 600;
+}
+.chip.light-low { background: #dce4d2; }
+.chip.light-medium { background: #ece0c4; }
+.chip.light-high { background: #f5dcc4; }
+.chip.water { background: #d6e6e0; }
+.card-foot { display: flex; align-items: center; justify-content: space-between; margin-top: auto; gap: 10px; }
+.price { font-family: var(--display); font-weight: 700; font-size: 1.2rem; color: var(--forest); }
+
+/* ---------------------------------------------------------------- categories */
+.cat-grid { display: grid; gap: 20px; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.cat-tile {
+  position: relative; border-radius: var(--radius-lg); padding: 26px 22px; min-height: 170px;
+  display: flex; flex-direction: column; justify-content: flex-end; overflow: hidden;
+  color: var(--forest); box-shadow: var(--shadow-sm); transition: transform .2s ease, box-shadow .2s ease;
+  border: 1px solid var(--line);
+}
+.cat-tile:hover { transform: translateY(-5px); box-shadow: var(--shadow); color: var(--forest); }
+.cat-tile h3 { margin: 0; font-size: 1.25rem; position: relative; z-index: 2; }
+.cat-tile span { font-size: 0.85rem; color: var(--muted); position: relative; z-index: 2; }
+.cat-tile .cat-ico { position: absolute; top: -10px; right: -6px; width: 110px; height: 110px; opacity: 0.9; z-index: 1; }
+.cat-tile.c1 { background: linear-gradient(160deg, #e9efdd, #d7e3c6); }
+.cat-tile.c2 { background: linear-gradient(160deg, #f0e6d6, #e3d2ba); }
+.cat-tile.c3 { background: linear-gradient(160deg, #f5e2d3, #ecc9b1); }
+.cat-tile.c4 { background: linear-gradient(160deg, #dde7e1, #c6d8cf); }
+.cat-tile.c5 { background: linear-gradient(160deg, #e6e3da, #d3cdbd); }
+
+/* ---------------------------------------------------------------- care tips */
+.tips-band { background: var(--forest); color: var(--offwhite); border-radius: var(--radius-lg); padding: 48px; }
+.tips-band h2 { color: var(--offwhite); }
+.tips-grid { display: grid; gap: 22px; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.tip { background: rgba(255,255,255,0.07); border-radius: var(--radius); padding: 22px; }
+.tip .tip-ico { font-size: 1.6rem; margin-bottom: 8px; }
+.tip h3 { color: #eef3e6; font-size: 1.1rem; }
+.tip p { color: #cdd8bf; font-size: 0.92rem; margin: 0; }
+
+/* ---------------------------------------------------------------- newsletter */
+.newsletter { background: var(--clay); border-radius: var(--radius-lg); padding: 48px; text-align: center; }
+.newsletter form { display: flex; gap: 10px; max-width: 440px; margin: 18px auto 0; flex-wrap: wrap; }
+.newsletter input[type="email"] {
+  flex: 1; min-width: 200px; padding: 13px 18px; border-radius: var(--radius-pill);
+  border: 1.5px solid var(--clay-deep); font-family: var(--sans); font-size: 0.95rem; background: #fff;
+}
+.newsletter input:focus { outline: none; border-color: var(--green); }
+.form-note { margin: 12px 0 0; color: var(--green); font-weight: 600; }
+
+/* ---------------------------------------------------------------- shop layout */
+.shop-layout { display: grid; grid-template-columns: 260px 1fr; gap: 32px; align-items: start; }
+.filters {
+  position: sticky; top: 88px; background: var(--white); border: 1px solid var(--line);
+  border-radius: var(--radius-lg); padding: 22px; box-shadow: var(--shadow-sm);
+}
+.filters h3 { font-size: 1.05rem; }
+.filter-group { margin-bottom: 22px; }
+.filter-group > label { display: block; font-weight: 700; font-size: 0.85rem; margin-bottom: 10px; color: var(--forest); }
+.cat-filters { display: flex; flex-direction: column; gap: 6px; }
+.cat-btn {
+  text-align: left; padding: 9px 14px; border-radius: var(--radius-pill); border: 1px solid transparent;
+  background: var(--offwhite); cursor: pointer; font-family: var(--sans); font-size: 0.9rem;
+  color: var(--ink); transition: background .15s ease, color .15s ease;
+}
+.cat-btn:hover { background: var(--sage-soft); }
+.cat-btn.active { background: var(--forest); color: var(--offwhite); }
+.range { width: 100%; accent-color: var(--green); }
+.price-row { display: flex; justify-content: space-between; font-size: 0.85rem; color: var(--muted); margin-top: 4px; }
+select {
+  width: 100%; padding: 10px 14px; border-radius: var(--radius); border: 1.5px solid var(--line);
+  background: var(--offwhite); font-family: var(--sans); font-size: 0.9rem; color: var(--ink); cursor: pointer;
+}
+select:focus { outline: none; border-color: var(--green); }
+
+.shop-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 22px; flex-wrap: wrap; }
+.shop-toolbar .result-count { color: var(--muted); font-weight: 600; }
+.shop-toolbar .sort-wrap { display: flex; align-items: center; gap: 10px; }
+.shop-toolbar .sort-wrap label { font-size: 0.85rem; font-weight: 600; color: var(--muted); }
+.shop-toolbar .sort-wrap select { width: auto; min-width: 170px; }
+
+/* ---------------------------------------------------------------- page hero */
+.page-hero { background: radial-gradient(120% 120% at 50% 0%, #e9efdd, var(--offwhite) 60%); padding: 56px 0 36px; text-align: center; }
+.page-hero h1 { font-size: clamp(2rem, 4.5vw, 3rem); }
+.page-hero p { color: var(--muted); max-width: 56ch; margin: 0 auto; font-size: 1.05rem; }
+
+/* ---------------------------------------------------------------- modal */
+.modal-overlay {
+  position: fixed; inset: 0; z-index: 60; background: rgba(31, 51, 32, 0.5);
+  display: flex; align-items: center; justify-content: center; padding: 20px;
+  backdrop-filter: blur(3px);
+}
+.modal-overlay[hidden] { display: none; }
+.modal {
+  position: relative; background: var(--offwhite); border-radius: var(--radius-lg);
+  width: min(820px, 100%); max-height: 92vh; overflow: auto; box-shadow: var(--shadow-lg);
+  animation: pop .25s ease;
+}
+@keyframes pop { from { transform: translateY(14px) scale(.98); opacity: 0; } to { transform: none; opacity: 1; } }
+.modal-close {
+  position: absolute; top: 14px; right: 14px; z-index: 2; width: 40px; height: 40px; border: none;
+  border-radius: 50%; background: rgba(255,255,255,0.8); font-size: 1.6rem; line-height: 1; cursor: pointer;
+  color: var(--forest);
+}
+.modal-close:hover { background: var(--terracotta); color: #fff; }
+.modal-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0; }
+.modal-media { background: linear-gradient(180deg, #eef3e6, #dde7d0); padding: 30px; display: flex; align-items: center; }
+.modal-info { padding: 34px 32px; }
+.modal-cat { display: inline-block; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em;
+  font-weight: 700; color: var(--terracotta-deep); margin-bottom: 6px; }
+.modal-info h2 { font-size: 1.7rem; margin-bottom: 2px; }
+.modal-botanical { font-style: italic; color: var(--muted); margin: 0 0 14px; }
+.modal-desc { color: var(--ink); margin-bottom: 18px; }
+.modal-care { display: flex; gap: 14px; margin-bottom: 20px; flex-wrap: wrap; }
+.care-item { display: flex; gap: 8px; align-items: center; background: #fff; border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 8px 12px; }
+.care-item .care-ico { font-size: 1.2rem; }
+.care-item strong { display: block; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); }
+.care-item span { font-size: 0.88rem; color: var(--forest); font-weight: 600; }
+.modal-variant { margin-bottom: 18px; }
+.modal-variant label { display: block; font-weight: 700; font-size: 0.85rem; margin-bottom: 6px; }
+.modal-buy { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+.modal-addbtn { flex: 1; min-width: 180px; }
+
+/* stepper */
+.stepper { display: inline-flex; align-items: center; gap: 0; border: 1.5px solid var(--line);
+  border-radius: var(--radius-pill); background: #fff; overflow: hidden; }
+.stepper .step {
+  width: 38px; height: 40px; border: none; background: transparent; font-size: 1.2rem; cursor: pointer;
+  color: var(--forest); transition: background .15s ease;
+}
+.stepper .step:hover { background: var(--sage-soft); }
+.stepper .step-val { min-width: 34px; text-align: center; font-weight: 700; }
+.stepper.sm .step { width: 30px; height: 32px; font-size: 1rem; }
+.stepper.sm .step-val { min-width: 26px; font-size: 0.9rem; }
+
+/* ---------------------------------------------------------------- drawer */
+.drawer-overlay { position: fixed; inset: 0; z-index: 70; background: rgba(31,51,32,0.45); }
+.drawer-overlay[hidden] { display: none; }
+.drawer {
+  position: absolute; top: 0; right: 0; height: 100%; width: min(420px, 100%);
+  background: var(--offwhite); display: flex; flex-direction: column; box-shadow: var(--shadow-lg);
+  animation: slideIn .26s ease;
+}
+@keyframes slideIn { from { transform: translateX(100%); } to { transform: none; } }
+.drawer-head { display: flex; align-items: center; justify-content: space-between; padding: 20px 22px;
+  border-bottom: 1px solid var(--line); }
+.drawer-head h2 { margin: 0; font-size: 1.3rem; }
+.drawer-close { width: 38px; height: 38px; border: none; background: transparent; font-size: 1.6rem;
+  cursor: pointer; color: var(--forest); border-radius: 50%; }
+.drawer-close:hover { background: var(--sage-soft); }
+.drawer-body { flex: 1; overflow: auto; padding: 16px 22px; }
+.drawer-empty { text-align: center; color: var(--muted); padding: 50px 10px; }
+.drawer-line { display: grid; grid-template-columns: 60px 1fr auto; gap: 12px; padding: 14px 0;
+  border-bottom: 1px solid var(--line); }
+.drawer-thumb { background: #eef3e6; border-radius: var(--radius); overflow: hidden; }
+.drawer-thumb svg { width: 100%; height: 100%; }
+.drawer-line-info strong { display: block; font-size: 0.95rem; }
+.drawer-variant { font-size: 0.78rem; color: var(--muted); display: block; margin-bottom: 6px; }
+.drawer-line-end { text-align: right; display: flex; flex-direction: column; gap: 6px; align-items: flex-end; }
+.link-remove { background: none; border: none; color: var(--terracotta-deep); cursor: pointer;
+  font-size: 0.78rem; font-family: var(--sans); padding: 0; }
+.link-remove:hover { text-decoration: underline; }
+.drawer-foot { padding: 18px 22px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 10px; }
+.drawer-subtotal { display: flex; justify-content: space-between; font-weight: 700; font-size: 1.1rem; color: var(--forest); }
+
+/* ---------------------------------------------------------------- cart page */
+.cart-grid { display: grid; grid-template-columns: 1fr 330px; gap: 30px; align-items: start; }
+.cart-lines { display: flex; flex-direction: column; }
+.cartrow { display: grid; grid-template-columns: 90px 1fr auto auto; gap: 18px; align-items: center;
+  padding: 18px 0; border-bottom: 1px solid var(--line); }
+.cartrow-media { background: #eef3e6; border-radius: var(--radius); overflow: hidden; }
+.cartrow-main h3 { margin: 0 0 2px; font-size: 1.1rem; }
+.cartrow-variant { color: var(--muted); font-size: 0.85rem; margin: 0 0 6px; }
+.cartrow-price { font-family: var(--display); font-weight: 700; color: var(--forest); font-size: 1.1rem; min-width: 70px; text-align: right; }
+.cart-empty { text-align: center; padding: 60px 0; color: var(--muted); }
+.cart-summary { background: var(--white); border: 1px solid var(--line); border-radius: var(--radius-lg);
+  padding: 26px; box-shadow: var(--shadow-sm); position: sticky; top: 88px; }
+.cart-summary h3 { font-size: 1.25rem; }
+.summary-row { display: flex; justify-content: space-between; padding: 8px 0; color: var(--muted); }
+.summary-row.total { border-top: 1px solid var(--line); margin-top: 10px; padding-top: 16px;
+  font-family: var(--display); font-size: 1.3rem; color: var(--forest); font-weight: 700; }
+.summary-note { font-size: 0.8rem; color: var(--muted); margin: 14px 0; text-align: center; }
+
+/* ---------------------------------------------------------------- about */
+.about-split { display: grid; grid-template-columns: 1fr 1fr; gap: 44px; align-items: center; }
+.about-split.reverse .about-art { order: -1; }
+.about-art { background: linear-gradient(160deg, #eef3e6, #dde7d0); border-radius: var(--radius-lg); padding: 36px; }
+.values { display: grid; gap: 20px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.value { background: var(--white); border: 1px solid var(--line); border-radius: var(--radius-lg);
+  padding: 26px; box-shadow: var(--shadow-sm); }
+.value .v-ico { width: 52px; height: 52px; margin-bottom: 12px; }
+.growers { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.grower { text-align: center; }
+.grower .avatar { width: 120px; height: 120px; margin: 0 auto 12px; border-radius: 50%;
+  background: linear-gradient(160deg, #eef3e6, #dde7d0); overflow: hidden; display: flex; align-items: center; justify-content: center; }
+.grower h3 { margin: 0; font-size: 1.1rem; }
+.grower span { color: var(--terracotta-deep); font-size: 0.85rem; font-weight: 600; }
+.grower p { color: var(--muted); font-size: 0.9rem; }
+
+/* ---------------------------------------------------------------- contact */
+.contact-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: start; }
+.field { margin-bottom: 18px; }
+.field label { display: block; font-weight: 700; font-size: 0.85rem; margin-bottom: 6px; color: var(--forest); }
+.field input, .field textarea, .field select {
+  width: 100%; padding: 12px 16px; border-radius: var(--radius); border: 1.5px solid var(--line);
+  font-family: var(--sans); font-size: 0.95rem; background: #fff; color: var(--ink);
+}
+.field textarea { resize: vertical; min-height: 130px; }
+.field input:focus, .field textarea:focus, .field select:focus { outline: none; border-color: var(--green); }
+.info-card { background: var(--white); border: 1px solid var(--line); border-radius: var(--radius-lg);
+  padding: 28px; box-shadow: var(--shadow-sm); margin-bottom: 22px; }
+.info-card h3 { font-size: 1.15rem; }
+.hours-row { display: flex; justify-content: space-between; padding: 6px 0; border-bottom: 1px dashed var(--line); }
+.hours-row:last-child { border-bottom: none; }
+.hours-row span:last-child { color: var(--muted); }
+.map-art { background: linear-gradient(160deg, #dde7d0, #cdd8bf); border-radius: var(--radius-lg); padding: 20px; }
+
+/* ---------------------------------------------------------------- footer */
+.site-footer { background: var(--forest-deep); color: #cdd8bf; padding: 56px 0 28px; margin-top: 80px; }
+.footer-grid { display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; gap: 32px; }
+.footer-brand { display: flex; align-items: center; gap: 10px; color: var(--offwhite);
+  font-family: var(--display); font-size: 1.3rem; font-weight: 700; margin-bottom: 12px; }
+.footer-brand svg { width: 34px; height: 34px; }
+.site-footer p { color: #a9b89c; font-size: 0.9rem; max-width: 32ch; }
+.site-footer h4 { color: var(--offwhite); font-family: var(--sans); font-size: 0.95rem; text-transform: uppercase;
+  letter-spacing: 0.06em; margin-bottom: 14px; }
+.site-footer ul { list-style: none; padding: 0; margin: 0; }
+.site-footer ul li { margin-bottom: 8px; }
+.site-footer ul a { color: #cdd8bf; font-size: 0.92rem; }
+.site-footer ul a:hover { color: var(--terracotta); }
+.footer-bottom { border-top: 1px solid rgba(255,255,255,0.12); margin-top: 36px; padding-top: 20px;
+  display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; font-size: 0.82rem; color: #8ea07f; }
+
+/* ---------------------------------------------------------------- responsive */
+@media (max-width: 940px) {
+  .hero-inner { grid-template-columns: 1fr; text-align: center; }
+  .hero p.lead { margin-left: auto; margin-right: auto; }
+  .hero-cta, .hero-stats { justify-content: center; }
+  .hero-art { order: -1; }
+  .shop-layout { grid-template-columns: 1fr; }
+  .filters { position: static; }
+  .cart-grid { grid-template-columns: 1fr; }
+  .cart-summary { position: static; }
+  .about-split, .contact-grid { grid-template-columns: 1fr; }
+  .about-split.reverse .about-art { order: 0; }
+  .footer-grid { grid-template-columns: 1fr 1fr; }
+  .modal-grid { grid-template-columns: 1fr; }
+  .modal-media { padding: 24px; }
+}
+
+@media (max-width: 720px) {
+  .nav {
+    position: fixed; top: 72px; left: 0; right: 0; flex-direction: column; align-items: stretch;
+    background: var(--offwhite); padding: 14px 22px; gap: 4px; border-bottom: 1px solid var(--line);
+    transform: translateY(-130%); transition: transform .25s ease; box-shadow: var(--shadow);
+    margin-left: 0;
+  }
+  .nav.open { transform: translateY(0); }
+  .nav-toggle {
+    display: inline-flex; margin-left: auto; align-items: center; justify-content: center;
+    width: 44px; height: 44px; border: none; background: transparent; cursor: pointer; color: var(--forest);
+  }
+  .nav-toggle svg { width: 24px; height: 24px; }
+  .tips-band, .newsletter { padding: 32px 22px; }
+  .footer-grid { grid-template-columns: 1fr; }
+  .cartrow { grid-template-columns: 70px 1fr; grid-template-areas: "media main" "qty price"; row-gap: 12px; }
+  .cartrow-media { grid-area: media; }
+  .cartrow-main { grid-area: main; }
+  .cartrow-qty { grid-area: qty; }
+  .cartrow-price { grid-area: price; }
+}
+
+/* focus visibility for accessibility */
+:focus-visible { outline: 3px solid var(--sage); outline-offset: 2px; border-radius: 6px; }

--- a/fixtures/websites/77-fernwood-plants/fixture.json
+++ b/fixtures/websites/77-fernwood-plants/fixture.json
@@ -1,0 +1,16 @@
+{
+  "class": "ecommerce/catalog",
+  "tags": [
+    "ecommerce",
+    "plants",
+    "has-cart",
+    "add-to-cart",
+    "filters",
+    "sorting",
+    "product-variants",
+    "mini-cart",
+    "multipage",
+    "localstorage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/77-fernwood-plants/index.html
+++ b/fixtures/websites/77-fernwood-plants/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fernwood Botanicals — Plants &amp; Garden Shop</title>
+  <meta name="description" content="Fernwood Botanicals: a family nursery for happy, healthy houseplants, garden greenery, succulents, pots and tools. Easy-care picks and expert care tips." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="Fernwood Botanicals home">
+        <svg viewBox="0 0 48 48" aria-hidden="true">
+          <path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/>
+          <path d="M24 42V16" stroke="#2f4a2c" stroke-width="2.4" stroke-linecap="round"/>
+          <path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/>
+        </svg>
+        Fernwood
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+      <nav class="nav" data-nav>
+        <a href="index.html" class="active">Home</a>
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/><path d="M2 3h2.2l2.3 12.3a2 2 0 0 0 2 1.7h8.7a2 2 0 0 0 2-1.6L21 7H6"/></svg>
+          <span class="cart-badge is-empty" data-cart-count>0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <!-- HERO -->
+    <section class="hero">
+      <div class="wrap hero-inner">
+        <div class="hero-copy">
+          <span class="eyebrow">Grown with care since 1994</span>
+          <h1>Bring the<br>outside in.</h1>
+          <p class="lead">Hand-raised houseplants, garden greenery and the tools to help them thrive — delivered happy and healthy to your door.</p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="shop.html">Shop all plants</a>
+            <a class="btn btn-outline" href="#easy-care">Easy-care picks</a>
+          </div>
+          <div class="hero-stats">
+            <div class="stat"><strong>20+</strong><span>plants &amp; goods</span></div>
+            <div class="stat"><strong>30yr</strong><span>family nursery</span></div>
+            <div class="stat"><strong>100%</strong><span>peat-free soil</span></div>
+          </div>
+        </div>
+        <div class="hero-art">
+          <svg viewBox="0 0 400 400" role="img" aria-label="A lush potted plant with broad leaves">
+            <defs>
+              <radialGradient id="hg" cx="50%" cy="38%" r="70%">
+                <stop offset="0%" stop-color="#eef3e6"/><stop offset="100%" stop-color="#d7e3c6"/>
+              </radialGradient>
+            </defs>
+            <path d="M70 250C30 180 100 70 200 78c110 9 150 110 110 188-32 62-180 76-240-16Z" fill="url(#hg)"/>
+            <!-- leaves -->
+            <g stroke="#1f3320" stroke-width="2" fill="none" opacity="0.25">
+              <path d="M200 250V120"/>
+            </g>
+            <path d="M200 250C140 230 110 170 120 120c52 4 78 44 80 96" fill="#3f6b3a"/>
+            <path d="M200 250C260 230 290 170 280 120c-52 4-78 44-80 96" fill="#4a7a45"/>
+            <path d="M200 240C160 200 150 140 175 96c40 22 48 78 25 130" fill="#56864f"/>
+            <path d="M200 240C240 200 250 140 225 96c-40 22-48 78-25 130" fill="#5a9050"/>
+            <path d="M200 235C200 175 215 130 250 104c14 44-6 96-50 118" fill="#6fae5a"/>
+            <path d="M200 235C200 175 185 130 150 104c-14 44 6 96 50 118" fill="#6fae5a"/>
+            <!-- pot -->
+            <path d="M150 250h100l-14 96a8 8 0 0 1-8 7h-48a8 8 0 0 1-8-7Z" fill="#c97a54"/>
+            <path d="M200 250h50l-14 96a8 8 0 0 1-8 7h-28Z" fill="#b15f3c" opacity="0.55"/>
+            <rect x="142" y="234" width="116" height="24" rx="12" fill="#dd9270"/>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <!-- EASY CARE PICKS -->
+    <section class="section" id="easy-care">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">Beginner friendly</span>
+          <h2>Easy-care picks</h2>
+          <p>Forgiving, near-unkillable favorites that thrive on a little neglect. The perfect place to start your jungle.</p>
+        </div>
+        <div class="grid" data-featured-grid></div>
+        <div style="text-align:center; margin-top:34px;">
+          <a class="btn btn-outline" href="shop.html">Browse the full shop</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- SHOP BY CATEGORY -->
+    <section class="section section-tight" style="background:#fff;">
+      <div class="wrap">
+        <div class="section-head">
+          <span class="eyebrow">Find your fit</span>
+          <h2>Shop by category</h2>
+        </div>
+        <div class="cat-grid">
+          <a class="cat-tile c1" href="shop.html?category=Indoor">
+            <svg class="cat-ico" viewBox="0 0 100 100" aria-hidden="true"><path d="M50 80V40" stroke="#2f4a2c" stroke-width="3"/><path d="M50 50C36 46 28 34 30 22c14 0 24 9 26 22 2-13 12-22 26-22 2 12-6 24-20 28" fill="#3f6b3a"/></svg>
+            <h3>Indoor</h3><span>Leafy houseplants</span>
+          </a>
+          <a class="cat-tile c2" href="shop.html?category=Outdoor">
+            <svg class="cat-ico" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="40" r="22" fill="#5a9050"/><path d="M50 62v22" stroke="#2f4a2c" stroke-width="3"/></svg>
+            <h3>Outdoor</h3><span>Garden &amp; patio</span>
+          </a>
+          <a class="cat-tile c3" href="shop.html?category=Succulents &amp; Cacti">
+            <svg class="cat-ico" viewBox="0 0 100 100" aria-hidden="true"><rect x="42" y="30" width="16" height="46" rx="8" fill="#6f9a4a"/><rect x="26" y="44" width="12" height="28" rx="6" fill="#5a8a3f"/><rect x="62" y="40" width="12" height="32" rx="6" fill="#5a8a3f"/></svg>
+            <h3>Succulents</h3><span>&amp; cacti</span>
+          </a>
+          <a class="cat-tile c4" href="shop.html?category=Pots &amp; Planters">
+            <svg class="cat-ico" viewBox="0 0 100 100" aria-hidden="true"><path d="M28 38h44l-7 38a6 6 0 0 1-6 5H41a6 6 0 0 1-6-5Z" fill="#9caf88"/><rect x="24" y="30" width="52" height="12" rx="6" fill="#b3c4a2"/></svg>
+            <h3>Pots &amp; Planters</h3><span>Ceramic &amp; clay</span>
+          </a>
+          <a class="cat-tile c5" href="shop.html?category=Tools">
+            <svg class="cat-ico" viewBox="0 0 100 100" aria-hidden="true"><rect x="46" y="24" width="8" height="30" rx="4" fill="#9caf88"/><path d="M38 54q12 32 24 0Z" fill="#b9b3a7"/></svg>
+            <h3>Tools</h3><span>For green thumbs</span>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- CARE TIPS TEASER -->
+    <section class="section">
+      <div class="wrap">
+        <div class="tips-band">
+          <div class="section-head" style="margin-bottom:30px;">
+            <span class="eyebrow" style="color:#e7b79a;">From the greenhouse</span>
+            <h2>Plant-care tips</h2>
+          </div>
+          <div class="tips-grid">
+            <div class="tip"><div class="tip-ico">💧</div><h3>Water less than you think</h3><p>Most houseplants die from overwatering. Let the top inch of soil dry out before reaching for the can.</p></div>
+            <div class="tip"><div class="tip-ico">☀️</div><h3>Read the light</h3><p>Match each plant to its spot. Bright indirect means near a window but out of harsh direct rays.</p></div>
+            <div class="tip"><div class="tip-ico">🪴</div><h3>Repot in spring</h3><p>Roots circling the pot? Size up by one pot and refresh with peat-free soil as growth wakes up.</p></div>
+            <div class="tip"><div class="tip-ico">🍃</div><h3>Dust the leaves</h3><p>Clean leaves photosynthesize better. Wipe broad foliage monthly with a damp cloth.</p></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- NEWSLETTER -->
+    <section class="section section-tight">
+      <div class="wrap">
+        <div class="newsletter">
+          <span class="eyebrow">Join the Fernwood family</span>
+          <h2>Care tips &amp; new arrivals</h2>
+          <p style="color:var(--muted);max-width:46ch;margin:6px auto 0;">Monthly seasonal advice and first dibs on fresh stock. No spam, just greenery.</p>
+          <form data-newsletter novalidate>
+            <label for="news-email" class="sr-only" style="position:absolute;left:-9999px;">Email address</label>
+            <input id="news-email" type="email" placeholder="you@example.com" required />
+            <button class="btn btn-accent" type="submit">Subscribe</button>
+          </form>
+          <p class="form-note" data-news-note hidden></p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <div class="footer-brand">
+            <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#1f3320" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+            Fernwood Botanicals
+          </div>
+          <p>A family nursery growing happy, healthy plants — and the people who care for them — since 1994.</p>
+        </div>
+        <div>
+          <h4>Shop</h4>
+          <ul>
+            <li><a href="shop.html?category=Indoor">Indoor plants</a></li>
+            <li><a href="shop.html?category=Outdoor">Outdoor plants</a></li>
+            <li><a href="shop.html?category=Succulents &amp; Cacti">Succulents &amp; cacti</a></li>
+            <li><a href="shop.html?category=Pots &amp; Planters">Pots &amp; planters</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Company</h4>
+          <ul>
+            <li><a href="about.html">Our story</a></li>
+            <li><a href="about.html#sustainability">Sustainability</a></li>
+            <li><a href="contact.html">Contact</a></li>
+            <li><a href="contact.html#hours">Greenhouse hours</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <ul>
+            <li>14 Fernwood Lane</li>
+            <li>Mossvale, OR 97000</li>
+            <li><a href="tel:+15035550142">(503) 555-0142</a></li>
+            <li><a href="mailto:hello@fernwood.example">hello@fernwood.example</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Fernwood Botanicals. Grown with care.</span>
+        <span>Peat-free · Plastic-light · Locally rooted</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/77-fernwood-plants/js/app.js
+++ b/fixtures/websites/77-fernwood-plants/js/app.js
@@ -1,0 +1,511 @@
+/* Fernwood Botanicals — UI controller.
+ * Renders product grids, runs filter/sort, builds the detail modal, the
+ * mini-cart drawer, the cart page, and wires up the header badge.
+ * All DOM access is guarded so each page only runs what it has. */
+
+(function () {
+  'use strict';
+
+  var Data = window.FernwoodData;
+  var Cart = window.FernwoodCart;
+
+  function $(sel, ctx) { return (ctx || document).querySelector(sel); }
+  function $all(sel, ctx) { return Array.prototype.slice.call((ctx || document).querySelectorAll(sel)); }
+
+  function productById(id) {
+    return Data.products.filter(function (p) { return p.id === id; })[0];
+  }
+
+  function variantPrice(product, label) {
+    var base = product.price;
+    for (var i = 0; i < product.variants.length; i++) {
+      if (product.variants[i].label === label) return base + product.variants[i].delta;
+    }
+    return base;
+  }
+
+  function lightClass(light) {
+    var l = (light || '').toLowerCase();
+    if (l.indexOf('low') !== -1) return 'low';
+    if (l.indexOf('full') !== -1 || l.indexOf('direct') !== -1) return 'high';
+    return 'medium';
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Header badge (every page)
+   * ------------------------------------------------------------------------- */
+  function refreshBadges() {
+    var n = Cart.count();
+    $all('[data-cart-count]').forEach(function (el) {
+      el.textContent = n;
+      el.classList.toggle('is-empty', n === 0);
+    });
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Product card
+   * ------------------------------------------------------------------------- */
+  function cardHTML(p) {
+    return (
+      '<article class="card" data-id="' + p.id + '">' +
+      '<button class="card-media" data-detail="' + p.id + '" aria-label="View details for ' + p.name + '">' +
+      Data.renderArt(p) +
+      '<span class="card-cat">' + p.category + '</span>' +
+      '</button>' +
+      '<div class="card-body">' +
+      '<h3 class="card-title">' + p.name + '</h3>' +
+      '<p class="card-botanical">' + p.botanical + '</p>' +
+      '<div class="card-meta">' +
+      (p.light !== '—' ? '<span class="chip light-' + lightClass(p.light) + '">&#9728; ' + p.light + '</span>' : '') +
+      (p.water !== '—' ? '<span class="chip water">&#128167; ' + p.water + '</span>' : '') +
+      '</div>' +
+      '<div class="card-foot">' +
+      '<span class="price">' + Cart.money(p.price) + '</span>' +
+      '<button class="btn btn-add" data-add="' + p.id + '">Add to cart</button>' +
+      '</div>' +
+      '</div>' +
+      '</article>'
+    );
+  }
+
+  function renderGrid(target, list) {
+    if (!target) return;
+    if (!list.length) {
+      target.innerHTML = '<p class="empty-grid">No plants match your filters. Try widening your search.</p>';
+      return;
+    }
+    target.innerHTML = list.map(cardHTML).join('');
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Detail modal
+   * ------------------------------------------------------------------------- */
+  var modal, modalState = { id: null, variant: null, qty: 1 };
+
+  function ensureModal() {
+    if (modal) return modal;
+    modal = document.createElement('div');
+    modal.className = 'modal-overlay';
+    modal.setAttribute('hidden', '');
+    modal.innerHTML =
+      '<div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">' +
+      '<button class="modal-close" data-close aria-label="Close details">&times;</button>' +
+      '<div class="modal-grid">' +
+      '<div class="modal-media" data-modal-media></div>' +
+      '<div class="modal-info">' +
+      '<span class="modal-cat" data-modal-cat></span>' +
+      '<h2 id="modal-title" data-modal-title></h2>' +
+      '<p class="modal-botanical" data-modal-botanical></p>' +
+      '<p class="modal-desc" data-modal-desc></p>' +
+      '<div class="modal-care" data-modal-care></div>' +
+      '<div class="modal-variant">' +
+      '<label for="variant-select" data-modal-variant-label>Size</label>' +
+      '<select id="variant-select" data-modal-variant></select>' +
+      '</div>' +
+      '<div class="modal-buy">' +
+      '<div class="stepper" role="group" aria-label="Quantity">' +
+      '<button class="step" data-step="-1" aria-label="Decrease quantity">&minus;</button>' +
+      '<span class="step-val" data-modal-qty aria-live="polite">1</span>' +
+      '<button class="step" data-step="1" aria-label="Increase quantity">+</button>' +
+      '</div>' +
+      '<button class="btn btn-primary modal-addbtn" data-modal-add>Add to cart &middot; <span data-modal-price></span></button>' +
+      '</div>' +
+      '</div>' +
+      '</div>' +
+      '</div>';
+    document.body.appendChild(modal);
+
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal || e.target.hasAttribute('data-close')) closeModal();
+      var step = e.target.closest('[data-step]');
+      if (step) {
+        modalState.qty = Math.max(1, modalState.qty + parseInt(step.getAttribute('data-step'), 10));
+        $('[data-modal-qty]', modal).textContent = modalState.qty;
+        updateModalPrice();
+      }
+      if (e.target.closest('[data-modal-add]')) {
+        var p = productById(modalState.id);
+        Cart.add(p, modalState.variant, variantPrice(p, modalState.variant), modalState.qty);
+        closeModal();
+        openDrawer();
+      }
+    });
+
+    $('[data-modal-variant]', modal).addEventListener('change', function (e) {
+      modalState.variant = e.target.value;
+      updateModalPrice();
+    });
+
+    return modal;
+  }
+
+  function updateModalPrice() {
+    var p = productById(modalState.id);
+    var unit = variantPrice(p, modalState.variant);
+    $('[data-modal-price]', modal).textContent = Cart.money(unit * modalState.qty);
+  }
+
+  function openModal(id) {
+    ensureModal();
+    var p = productById(id);
+    if (!p) return;
+    modalState = { id: id, variant: p.variants[0].label, qty: 1 };
+    $('[data-modal-media]', modal).innerHTML = Data.renderArt(p);
+    $('[data-modal-cat]', modal).textContent = p.category;
+    $('[data-modal-title]', modal).textContent = p.name;
+    $('[data-modal-botanical]', modal).textContent = p.botanical;
+    $('[data-modal-desc]', modal).textContent = p.desc;
+
+    var care = '';
+    if (p.light !== '—') care += '<div class="care-item"><span class="care-ico">&#9728;</span><div><strong>Light</strong><span>' + p.light + '</span></div></div>';
+    if (p.water !== '—') care += '<div class="care-item"><span class="care-ico">&#128167;</span><div><strong>Water</strong><span>' + p.water + '</span></div></div>';
+    $('[data-modal-care]', modal).innerHTML = care;
+
+    $('[data-modal-variant-label]', modal).textContent = p.variantType === 'color' ? 'Pot color' : 'Pot size';
+    $('[data-modal-variant]', modal).innerHTML = p.variants.map(function (v) {
+      var extra = v.delta ? ' (+' + Cart.money(v.delta).replace('$', '$') + ')' : '';
+      return '<option value="' + v.label + '">' + v.label + extra + '</option>';
+    }).join('');
+    $('[data-modal-qty]', modal).textContent = '1';
+    updateModalPrice();
+
+    modal.removeAttribute('hidden');
+    document.body.classList.add('no-scroll');
+    var closeBtn = $('[data-close]', modal);
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeModal() {
+    if (modal) modal.setAttribute('hidden', '');
+    if (!drawerOpen()) document.body.classList.remove('no-scroll');
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Mini-cart drawer
+   * ------------------------------------------------------------------------- */
+  var drawer;
+
+  function ensureDrawer() {
+    if (drawer) return drawer;
+    drawer = document.createElement('div');
+    drawer.className = 'drawer-overlay';
+    drawer.setAttribute('hidden', '');
+    drawer.innerHTML =
+      '<aside class="drawer" role="dialog" aria-modal="true" aria-label="Shopping cart">' +
+      '<header class="drawer-head">' +
+      '<h2>Your Cart</h2>' +
+      '<button class="drawer-close" data-drawer-close aria-label="Close cart">&times;</button>' +
+      '</header>' +
+      '<div class="drawer-body" data-drawer-body></div>' +
+      '<footer class="drawer-foot">' +
+      '<div class="drawer-subtotal"><span>Subtotal</span><span data-drawer-subtotal>$0.00</span></div>' +
+      '<a class="btn btn-outline" href="cart.html">View cart</a>' +
+      '<button class="btn btn-primary" data-checkout>Checkout</button>' +
+      '</footer>' +
+      '</aside>';
+    document.body.appendChild(drawer);
+
+    drawer.addEventListener('click', function (e) {
+      if (e.target === drawer || e.target.hasAttribute('data-drawer-close')) closeDrawer();
+      var dec = e.target.closest('[data-d-dec]');
+      var inc = e.target.closest('[data-d-inc]');
+      var rem = e.target.closest('[data-d-remove]');
+      if (dec) Cart.changeQty(dec.dataset.id, dec.dataset.variant, -1);
+      if (inc) Cart.changeQty(inc.dataset.id, inc.dataset.variant, 1);
+      if (rem) Cart.remove(rem.dataset.id, rem.dataset.variant);
+      if (e.target.closest('[data-checkout]')) {
+        alert('Checkout is a demo in this static shop. Thanks for browsing Fernwood Botanicals!');
+      }
+    });
+    return drawer;
+  }
+
+  function drawerOpen() { return drawer && !drawer.hasAttribute('hidden'); }
+
+  function renderDrawer() {
+    if (!drawer) return;
+    var body = $('[data-drawer-body]', drawer);
+    var list = Cart.items();
+    if (!list.length) {
+      body.innerHTML = '<p class="drawer-empty">Your cart is empty.<br>Time to add some green.</p>';
+    } else {
+      body.innerHTML = list.map(function (it) {
+        var p = productById(it.id);
+        return (
+          '<div class="drawer-line">' +
+          '<div class="drawer-thumb">' + (p ? Data.renderArt(p) : '') + '</div>' +
+          '<div class="drawer-line-info">' +
+          '<strong>' + it.name + '</strong>' +
+          (it.variant ? '<span class="drawer-variant">' + it.variant + '</span>' : '') +
+          '<div class="stepper sm" role="group" aria-label="Quantity for ' + it.name + '">' +
+          '<button class="step" data-d-dec data-id="' + it.id + '" data-variant="' + it.variant + '" aria-label="Decrease">&minus;</button>' +
+          '<span class="step-val">' + it.qty + '</span>' +
+          '<button class="step" data-d-inc data-id="' + it.id + '" data-variant="' + it.variant + '" aria-label="Increase">+</button>' +
+          '</div>' +
+          '</div>' +
+          '<div class="drawer-line-end">' +
+          '<span class="price">' + Cart.money(it.price * it.qty) + '</span>' +
+          '<button class="link-remove" data-d-remove data-id="' + it.id + '" data-variant="' + it.variant + '" aria-label="Remove ' + it.name + '">Remove</button>' +
+          '</div>' +
+          '</div>'
+        );
+      }).join('');
+    }
+    $('[data-drawer-subtotal]', drawer).textContent = Cart.money(Cart.subtotal());
+  }
+
+  function openDrawer() {
+    ensureDrawer();
+    renderDrawer();
+    drawer.removeAttribute('hidden');
+    document.body.classList.add('no-scroll');
+    var c = $('[data-drawer-close]', drawer);
+    if (c) c.focus();
+  }
+
+  function closeDrawer() {
+    if (drawer) drawer.setAttribute('hidden', '');
+    if (!modal || modal.hasAttribute('hidden')) document.body.classList.remove('no-scroll');
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Global delegated clicks (add buttons, detail buttons, cart toggle)
+   * ------------------------------------------------------------------------- */
+  function wireGlobal() {
+    document.addEventListener('click', function (e) {
+      var add = e.target.closest('[data-add]');
+      if (add) {
+        var p = productById(add.getAttribute('data-add'));
+        if (p) {
+          Cart.add(p, p.variants[0].label, p.price, 1);
+          openDrawer();
+        }
+        return;
+      }
+      var det = e.target.closest('[data-detail]');
+      if (det) { openModal(det.getAttribute('data-detail')); return; }
+
+      if (e.target.closest('[data-open-cart]')) { openDrawer(); }
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        if (drawerOpen()) closeDrawer();
+        else if (modal && !modal.hasAttribute('hidden')) closeModal();
+      }
+    });
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Mobile nav toggle
+   * ------------------------------------------------------------------------- */
+  function wireNav() {
+    var toggle = $('[data-nav-toggle]');
+    var nav = $('[data-nav]');
+    if (!toggle || !nav) return;
+    toggle.addEventListener('click', function () {
+      var open = nav.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Shop page: filters + sort
+   * ------------------------------------------------------------------------- */
+  function initShop() {
+    var grid = $('[data-shop-grid]');
+    if (!grid) return;
+
+    var state = { category: 'all', light: 'all', maxPrice: 100, sort: 'featured' };
+    var countEl = $('[data-result-count]');
+    var priceOut = $('[data-price-out]');
+
+    // populate category chips
+    var catWrap = $('[data-cat-filters]');
+    if (catWrap) {
+      // preselect from ?category=
+      var params = new URLSearchParams(window.location.search);
+      var pre = params.get('category');
+      if (pre && Data.categories.indexOf(pre) !== -1) state.category = pre;
+      catWrap.addEventListener('click', function (e) {
+        var b = e.target.closest('[data-cat]');
+        if (!b) return;
+        state.category = b.getAttribute('data-cat');
+        $all('[data-cat]', catWrap).forEach(function (x) { x.classList.toggle('active', x === b); });
+        apply();
+      });
+      $all('[data-cat]', catWrap).forEach(function (x) {
+        x.classList.toggle('active', x.getAttribute('data-cat') === state.category);
+      });
+    }
+
+    var lightSel = $('[data-light-filter]');
+    if (lightSel) lightSel.addEventListener('change', function () { state.light = lightSel.value; apply(); });
+
+    var priceInput = $('[data-price-filter]');
+    if (priceInput) {
+      priceInput.addEventListener('input', function () {
+        state.maxPrice = parseInt(priceInput.value, 10);
+        if (priceOut) priceOut.textContent = '$' + state.maxPrice;
+        apply();
+      });
+    }
+
+    var sortSel = $('[data-sort]');
+    if (sortSel) sortSel.addEventListener('change', function () { state.sort = sortSel.value; apply(); });
+
+    function apply() {
+      var list = Data.products.filter(function (p) {
+        if (state.category !== 'all' && p.category !== state.category) return false;
+        if (p.price > state.maxPrice) return false;
+        if (state.light !== 'all') {
+          if (p.light === '—') return false;
+          if (lightClass(p.light) !== state.light) return false;
+        }
+        return true;
+      });
+
+      switch (state.sort) {
+        case 'price-asc': list.sort(function (a, b) { return a.price - b.price; }); break;
+        case 'price-desc': list.sort(function (a, b) { return b.price - a.price; }); break;
+        case 'name': list.sort(function (a, b) { return a.name.localeCompare(b.name); }); break;
+        case 'newest': list.sort(function (a, b) { return b.added - a.added; }); break;
+        default: break; // featured = data order
+      }
+
+      renderGrid(grid, list);
+      if (countEl) countEl.textContent = list.length + (list.length === 1 ? ' plant' : ' plants');
+    }
+
+    apply();
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Home page featured rows
+   * ------------------------------------------------------------------------- */
+  function initHome() {
+    var featured = $('[data-featured-grid]');
+    if (featured) {
+      // "easy-care picks" = low/medium maintenance favorites
+      var picks = ['snake', 'pothos', 'zz', 'echeveria'].map(productById).filter(Boolean);
+      renderGrid(featured, picks);
+    }
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Cart page
+   * ------------------------------------------------------------------------- */
+  function initCartPage() {
+    var wrap = $('[data-cart-page]');
+    if (!wrap) return;
+
+    function render() {
+      var list = Cart.items();
+      var linesEl = $('[data-cart-lines]', wrap);
+      var emptyEl = $('[data-cart-empty]', wrap);
+      var summaryEl = $('[data-cart-summary]', wrap);
+
+      if (!list.length) {
+        if (linesEl) linesEl.innerHTML = '';
+        if (emptyEl) emptyEl.hidden = false;
+        if (summaryEl) summaryEl.hidden = true;
+        return;
+      }
+      if (emptyEl) emptyEl.hidden = true;
+      if (summaryEl) summaryEl.hidden = false;
+
+      linesEl.innerHTML = list.map(function (it) {
+        var p = productById(it.id);
+        return (
+          '<div class="cartrow">' +
+          '<div class="cartrow-media">' + (p ? Data.renderArt(p) : '') + '</div>' +
+          '<div class="cartrow-main">' +
+          '<h3>' + it.name + '</h3>' +
+          (it.variant ? '<p class="cartrow-variant">' + it.variant + '</p>' : '') +
+          '<button class="link-remove" data-c-remove data-id="' + it.id + '" data-variant="' + it.variant + '">Remove</button>' +
+          '</div>' +
+          '<div class="cartrow-qty">' +
+          '<div class="stepper" role="group" aria-label="Quantity for ' + it.name + '">' +
+          '<button class="step" data-c-dec data-id="' + it.id + '" data-variant="' + it.variant + '" aria-label="Decrease">&minus;</button>' +
+          '<span class="step-val">' + it.qty + '</span>' +
+          '<button class="step" data-c-inc data-id="' + it.id + '" data-variant="' + it.variant + '" aria-label="Increase">+</button>' +
+          '</div>' +
+          '</div>' +
+          '<div class="cartrow-price">' + Cart.money(it.price * it.qty) + '</div>' +
+          '</div>'
+        );
+      }).join('');
+
+      var sub = Cart.subtotal();
+      var shipping = sub >= 75 || sub === 0 ? 0 : 8.5;
+      $('[data-sum-subtotal]', wrap).textContent = Cart.money(sub);
+      $('[data-sum-shipping]', wrap).textContent = shipping === 0 ? 'Free' : Cart.money(shipping);
+      $('[data-sum-total]', wrap).textContent = Cart.money(sub + shipping);
+    }
+
+    wrap.addEventListener('click', function (e) {
+      var dec = e.target.closest('[data-c-dec]');
+      var inc = e.target.closest('[data-c-inc]');
+      var rem = e.target.closest('[data-c-remove]');
+      if (dec) Cart.changeQty(dec.dataset.id, dec.dataset.variant, -1);
+      if (inc) Cart.changeQty(inc.dataset.id, inc.dataset.variant, 1);
+      if (rem) Cart.remove(rem.dataset.id, rem.dataset.variant);
+      if (e.target.closest('[data-c-checkout]')) {
+        alert('Checkout is a demo in this static shop. Thanks for browsing Fernwood Botanicals!');
+      }
+    });
+
+    Cart.subscribe(render);
+    render();
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Contact form (demo)
+   * ------------------------------------------------------------------------- */
+  function initContact() {
+    var form = $('[data-contact-form]');
+    if (!form) return;
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var note = $('[data-form-note]', form);
+      if (note) {
+        note.hidden = false;
+        note.textContent = 'Thanks for reaching out! A grower will reply within two business days.';
+      }
+      form.reset();
+    });
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Newsletter (demo)
+   * ------------------------------------------------------------------------- */
+  function initNewsletter() {
+    $all('[data-newsletter]').forEach(function (form) {
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var note = $('[data-news-note]', form);
+        if (note) { note.hidden = false; note.textContent = 'You’re on the list — welcome to the greenhouse!'; }
+        form.reset();
+      });
+    });
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Boot
+   * ------------------------------------------------------------------------- */
+  document.addEventListener('DOMContentLoaded', function () {
+    wireGlobal();
+    wireNav();
+    Cart.subscribe(function () { refreshBadges(); renderDrawer(); });
+    refreshBadges();
+
+    initHome();
+    initShop();
+    initCartPage();
+    initContact();
+    initNewsletter();
+
+    // stamp footer year
+    $all('[data-year]').forEach(function (el) { el.textContent = new Date().getFullYear(); });
+  });
+})();

--- a/fixtures/websites/77-fernwood-plants/js/cart.js
+++ b/fixtures/websites/77-fernwood-plants/js/cart.js
@@ -1,0 +1,131 @@
+/* Fernwood Botanicals — shared cart module.
+ * Owns localStorage persistence (key "fernwood_cart"), totals, and the
+ * header badge + mini-cart drawer. Shared across every page. */
+
+(function (global) {
+  'use strict';
+
+  var STORAGE_KEY = 'fernwood_cart';
+  var listeners = [];
+
+  function load() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      var parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function save(items) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    } catch (e) { /* storage may be unavailable */ }
+  }
+
+  var items = load();
+
+  function emit() {
+    save(items);
+    for (var i = 0; i < listeners.length; i++) {
+      try { listeners[i](items); } catch (e) { /* keep others alive */ }
+    }
+  }
+
+  function lineKey(id, variant) {
+    return id + '::' + (variant || '');
+  }
+
+  function money(n) {
+    return '$' + Number(n).toFixed(2);
+  }
+
+  var Cart = {
+    money: money,
+
+    items: function () { return items.slice(); },
+
+    count: function () {
+      return items.reduce(function (sum, it) { return sum + it.qty; }, 0);
+    },
+
+    subtotal: function () {
+      return items.reduce(function (sum, it) { return sum + it.price * it.qty; }, 0);
+    },
+
+    add: function (product, variantLabel, unitPrice, qty) {
+      qty = qty || 1;
+      var key = lineKey(product.id, variantLabel);
+      var existing = null;
+      for (var i = 0; i < items.length; i++) {
+        if (lineKey(items[i].id, items[i].variant) === key) { existing = items[i]; break; }
+      }
+      if (existing) {
+        existing.qty += qty;
+      } else {
+        items.push({
+          id: product.id,
+          name: product.name,
+          variant: variantLabel || '',
+          price: unitPrice,
+          qty: qty
+        });
+      }
+      emit();
+    },
+
+    setQty: function (id, variant, qty) {
+      var key = lineKey(id, variant);
+      for (var i = 0; i < items.length; i++) {
+        if (lineKey(items[i].id, items[i].variant) === key) {
+          items[i].qty = Math.max(1, qty);
+          break;
+        }
+      }
+      emit();
+    },
+
+    changeQty: function (id, variant, delta) {
+      var key = lineKey(id, variant);
+      for (var i = 0; i < items.length; i++) {
+        if (lineKey(items[i].id, items[i].variant) === key) {
+          items[i].qty = Math.max(1, items[i].qty + delta);
+          break;
+        }
+      }
+      emit();
+    },
+
+    remove: function (id, variant) {
+      var key = lineKey(id, variant);
+      items = items.filter(function (it) { return lineKey(it.id, it.variant) !== key; });
+      emit();
+    },
+
+    clear: function () {
+      items = [];
+      emit();
+    },
+
+    subscribe: function (fn) {
+      listeners.push(fn);
+      return fn;
+    },
+
+    /* Sync when another tab/page mutates localStorage. */
+    _externalReload: function () {
+      items = load();
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](items); } catch (e) {}
+      }
+    }
+  };
+
+  global.addEventListener('storage', function (e) {
+    if (e.key === STORAGE_KEY) Cart._externalReload();
+  });
+
+  global.FernwoodCart = Cart;
+})(window);

--- a/fixtures/websites/77-fernwood-plants/js/products.js
+++ b/fixtures/websites/77-fernwood-plants/js/products.js
@@ -1,0 +1,551 @@
+/* Fernwood Botanicals — product catalog data + inline SVG plant renderer.
+ * Pure data + presentation helpers. No frameworks, no external assets. */
+
+(function (global) {
+  'use strict';
+
+  /* ---------------------------------------------------------------------------
+   * SVG art helpers
+   * Each plant/product renders a varied inline SVG built from parameters so the
+   * grid looks lush and no two cards are identical. Returns an SVG string.
+   * ------------------------------------------------------------------------- */
+
+  var POT_COLORS = {
+    terracotta: { body: '#c97a54', shade: '#b15f3c', rim: '#dd9270' },
+    clay: { body: '#d9b08c', shade: '#c4955f', rim: '#e7c6a6' },
+    sage: { body: '#9caf88', shade: '#849a6d', rim: '#b3c4a2' },
+    stone: { body: '#b9b3a7', shade: '#a39c8d', rim: '#cdc8bd' },
+    forest: { body: '#3f5e3a', shade: '#314a2d', rim: '#56784f' },
+    charcoal: { body: '#4a4f4d', shade: '#393d3b', rim: '#626966' }
+  };
+
+  function pot(potKey, cx, topY, w, h) {
+    var c = POT_COLORS[potKey] || POT_COLORS.terracotta;
+    var halfTop = w / 2;
+    var halfBottom = w * 0.36;
+    var rimH = h * 0.16;
+    var lx = cx - halfTop, rx = cx + halfTop;
+    var blx = cx - halfBottom, brx = cx + halfBottom;
+    var bottomY = topY + h;
+    return (
+      '<path d="M' + lx + ' ' + topY + ' L' + rx + ' ' + topY +
+      ' L' + brx + ' ' + bottomY + ' L' + blx + ' ' + bottomY + ' Z" fill="' + c.body + '"/>' +
+      '<path d="M' + cx + ' ' + topY + ' L' + rx + ' ' + topY +
+      ' L' + brx + ' ' + bottomY + ' L' + cx + ' ' + bottomY + ' Z" fill="' + c.shade + '" opacity="0.5"/>' +
+      '<rect x="' + (lx - 3) + '" y="' + (topY - rimH) + '" width="' + (w + 6) + '" height="' + rimH +
+      '" rx="' + (rimH / 2) + '" fill="' + c.rim + '"/>'
+    );
+  }
+
+  function leaf(cx, cy, len, wide, angle, color, vein) {
+    var t = 'rotate(' + angle + ' ' + cx + ' ' + cy + ')';
+    var tipY = cy - len;
+    var midY = cy - len * 0.5;
+    var path =
+      'M' + cx + ' ' + cy +
+      ' C' + (cx - wide) + ' ' + midY + ' ' + (cx - wide * 0.4) + ' ' + tipY + ' ' + cx + ' ' + tipY +
+      ' C' + (cx + wide * 0.4) + ' ' + tipY + ' ' + (cx + wide) + ' ' + midY + ' ' + cx + ' ' + cy + ' Z';
+    var out = '<g transform="' + t + '">' +
+      '<path d="' + path + '" fill="' + color + '"/>';
+    if (vein) {
+      out += '<path d="M' + cx + ' ' + cy + ' L' + cx + ' ' + tipY + '" stroke="' + vein +
+        '" stroke-width="1.2" opacity="0.5" fill="none"/>';
+    }
+    out += '</g>';
+    return out;
+  }
+
+  function frond(cx, cy, len, angle, color) {
+    var t = 'rotate(' + angle + ' ' + cx + ' ' + cy + ')';
+    var out = '<g transform="' + t + '">';
+    out += '<path d="M' + cx + ' ' + cy + ' L' + cx + ' ' + (cy - len) +
+      '" stroke="' + color + '" stroke-width="3" stroke-linecap="round"/>';
+    var segs = 7;
+    for (var i = 1; i <= segs; i++) {
+      var fy = cy - (len * i) / (segs + 1);
+      var fl = 14 * (1 - i / (segs + 2));
+      out += '<path d="M' + cx + ' ' + fy + ' q' + (-fl) + ' ' + (-fl * 0.5) + ' ' + (-fl * 1.1) + ' ' + (fl * 0.2) +
+        '" stroke="' + color + '" stroke-width="2.4" fill="none" stroke-linecap="round"/>';
+      out += '<path d="M' + cx + ' ' + fy + ' q' + fl + ' ' + (-fl * 0.5) + ' ' + (fl * 1.1) + ' ' + (fl * 0.2) +
+        '" stroke="' + color + '" stroke-width="2.4" fill="none" stroke-linecap="round"/>';
+    }
+    out += '</g>';
+    return out;
+  }
+
+  function svgWrap(inner, label) {
+    return (
+      '<svg class="plant-svg" viewBox="0 0 200 200" role="img" aria-label="' +
+      (label || 'plant illustration') +
+      '" xmlns="http://www.w3.org/2000/svg">' +
+      '<defs><radialGradient id="blobg" cx="50%" cy="40%" r="70%">' +
+      '<stop offset="0%" stop-color="#eef3e6"/><stop offset="100%" stop-color="#dde7d0"/>' +
+      '</radialGradient></defs>' +
+      '<path d="M40 120 C20 80 60 30 110 36 C168 42 192 96 168 138 C150 170 70 178 40 120 Z" fill="url(#blobg)"/>' +
+      inner +
+      '</svg>'
+    );
+  }
+
+  /* ---- Per-style plant builders ---- */
+
+  function artUpright(g1, g2, potKey) {
+    var s = '';
+    s += leaf(100, 120, 78, 30, -22, g1, g2);
+    s += leaf(100, 120, 88, 30, 0, g2, g1);
+    s += leaf(100, 120, 78, 30, 22, g1, g2);
+    s += leaf(100, 120, 60, 24, -42, g2, g1);
+    s += leaf(100, 120, 60, 24, 42, g2, g1);
+    s += pot(potKey, 100, 120, 56, 56);
+    return s;
+  }
+
+  function artBushy(g1, g2, potKey) {
+    var s = '';
+    var angles = [-55, -35, -15, 0, 15, 35, 55];
+    for (var i = 0; i < angles.length; i++) {
+      var col = i % 2 === 0 ? g1 : g2;
+      s += leaf(100, 124, 56 + (i % 3) * 8, 26, angles[i], col, g1);
+    }
+    s += pot(potKey, 100, 124, 58, 52);
+    return s;
+  }
+
+  function artPalm(g1, g2, potKey) {
+    var s = '';
+    s += frond(100, 124, 80, -34, g1);
+    s += frond(100, 124, 92, 0, g2);
+    s += frond(100, 124, 80, 34, g1);
+    s += frond(100, 124, 66, -60, g2);
+    s += frond(100, 124, 66, 60, g2);
+    s += pot(potKey, 100, 124, 52, 52);
+    return s;
+  }
+
+  function artTrailing(g1, g2, potKey) {
+    var s = '';
+    s += pot(potKey, 100, 108, 60, 50);
+    // vines spilling over the rim
+    for (var d = -1; d <= 1; d += 2) {
+      var x0 = 100 + d * 26;
+      s += '<path d="M' + x0 + ' 108 q' + (d * 26) + ' 30 ' + (d * 10) + ' 70" stroke="' + g1 +
+        '" stroke-width="3" fill="none" stroke-linecap="round"/>';
+      for (var k = 0; k < 5; k++) {
+        var ly = 116 + k * 13;
+        var lx = x0 + d * (6 + k * 3);
+        s += '<ellipse cx="' + lx + '" cy="' + ly + '" rx="7" ry="5" fill="' + (k % 2 ? g2 : g1) + '"/>';
+      }
+    }
+    s += leaf(100, 108, 40, 18, 0, g2, g1);
+    s += leaf(100, 108, 36, 16, -28, g1, g2);
+    s += leaf(100, 108, 36, 16, 28, g1, g2);
+    return s;
+  }
+
+  function artSucculent(g1, g2, potKey) {
+    var s = '';
+    var rings = [
+      { r: 8, n: 0, len: 26 },
+      { r: 0, n: 6, len: 30 },
+      { r: 0, n: 8, len: 22 }
+    ];
+    s += pot(potKey, 100, 132, 64, 44);
+    // rosette
+    var layers = [{ n: 8, len: 34, w: 13, c: g1 }, { n: 6, len: 24, w: 11, c: g2 }, { n: 4, len: 14, w: 9, c: g1 }];
+    for (var li = 0; li < layers.length; li++) {
+      var L = layers[li];
+      for (var j = 0; j < L.n; j++) {
+        var a = (360 / L.n) * j + (li * 22);
+        s += leaf(100, 130, L.len, L.w, a, L.c, '');
+      }
+    }
+    s += '<circle cx="100" cy="128" r="6" fill="' + g2 + '"/>';
+    return s;
+  }
+
+  function artCactus(g1, g2, potKey) {
+    var s = '';
+    s += pot(potKey, 100, 136, 60, 40);
+    s += '<rect x="86" y="74" width="28" height="66" rx="14" fill="' + g1 + '"/>';
+    s += '<rect x="62" y="96" width="20" height="40" rx="10" fill="' + g2 + '"/>';
+    s += '<rect x="118" y="88" width="20" height="48" rx="10" fill="' + g2 + '"/>';
+    s += '<path d="M62 116 q-8 -16 0 -24" stroke="' + g1 + '" stroke-width="8" fill="none" stroke-linecap="round"/>';
+    s += '<path d="M138 108 q8 -16 0 -24" stroke="' + g1 + '" stroke-width="8" fill="none" stroke-linecap="round"/>';
+    // spine dots
+    for (var sp = 0; sp < 6; sp++) {
+      s += '<circle cx="100" cy="' + (84 + sp * 9) + '" r="1.6" fill="#eef3e6"/>';
+    }
+    s += '<circle cx="100" cy="72" r="6" fill="#e88aa6"/>'; // little bloom
+    return s;
+  }
+
+  function artFern(g1, g2, potKey) {
+    var s = '';
+    var angles = [-50, -28, -10, 10, 28, 50];
+    for (var i = 0; i < angles.length; i++) {
+      s += frond(100, 126, 70 + (i % 2) * 12, angles[i], i % 2 ? g2 : g1);
+    }
+    s += pot(potKey, 100, 126, 52, 50);
+    return s;
+  }
+
+  /* ---- Non-plant product art ---- */
+
+  function artPlanter(g1, g2, potKey) {
+    var c = POT_COLORS[potKey] || POT_COLORS.terracotta;
+    var s = '';
+    s += pot(potKey, 100, 92, 84, 78);
+    s += '<ellipse cx="100" cy="92" rx="46" ry="12" fill="' + c.shade + '" opacity="0.6"/>';
+    s += '<ellipse cx="100" cy="90" rx="40" ry="9" fill="#1f2a1c" opacity="0.35"/>';
+    return s;
+  }
+
+  function artTool(kind, g1, g2) {
+    var s = '';
+    if (kind === 'trowel') {
+      s += '<rect x="92" y="40" width="16" height="56" rx="8" fill="#9caf88"/>';
+      s += '<path d="M78 96 q22 60 44 0 Z" fill="#b9b3a7"/>';
+      s += '<path d="M78 96 q22 60 44 0" fill="none" stroke="#8a857a" stroke-width="2"/>';
+    } else if (kind === 'shears') {
+      s += '<path d="M70 60 L110 120" stroke="#62696e" stroke-width="7" stroke-linecap="round"/>';
+      s += '<path d="M130 60 L90 120" stroke="#62696e" stroke-width="7" stroke-linecap="round"/>';
+      s += '<circle cx="84" cy="138" r="12" fill="none" stroke="#c97a54" stroke-width="7"/>';
+      s += '<circle cx="116" cy="138" r="12" fill="none" stroke="#c97a54" stroke-width="7"/>';
+    } else if (kind === 'can') {
+      s += '<rect x="64" y="86" width="56" height="46" rx="10" fill="#9caf88"/>';
+      s += '<path d="M120 96 L160 70 L162 78 L126 110 Z" fill="#849a6d"/>';
+      s += '<rect x="78" y="66" width="22" height="24" rx="8" fill="#849a6d"/>';
+      s += '<path d="M158 66 q8 0 8 8" stroke="#849a6d" stroke-width="4" fill="none"/>';
+      s += '<circle cx="166" cy="66" r="6" fill="#b3c4a2"/>';
+    }
+    return s;
+  }
+
+  /* renderArt: dispatch by style key, return full SVG string. */
+  function renderArt(style, p1, p2, potKey, label) {
+    var inner;
+    switch (style) {
+      case 'upright': inner = artUpright(p1, p2, potKey); break;
+      case 'bushy': inner = artBushy(p1, p2, potKey); break;
+      case 'palm': inner = artPalm(p1, p2, potKey); break;
+      case 'trailing': inner = artTrailing(p1, p2, potKey); break;
+      case 'succulent': inner = artSucculent(p1, p2, potKey); break;
+      case 'cactus': inner = artCactus(p1, p2, potKey); break;
+      case 'fern': inner = artFern(p1, p2, potKey); break;
+      case 'planter': inner = artPlanter(p1, p2, potKey); break;
+      case 'trowel': inner = artTool('trowel'); break;
+      case 'shears': inner = artTool('shears'); break;
+      case 'can': inner = artTool('can'); break;
+      default: inner = artUpright(p1, p2, potKey);
+    }
+    return svgWrap(inner, label);
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Product catalog
+   * ------------------------------------------------------------------------- */
+
+  var SIZE_VARIANTS = [
+    { label: 'Small (4")', delta: 0 },
+    { label: 'Medium (6")', delta: 14 },
+    { label: 'Large (10")', delta: 38 }
+  ];
+
+  var PRODUCTS = [
+    {
+      id: 'monstera',
+      name: 'Monstera Deliciosa',
+      botanical: 'Monstera deliciosa',
+      price: 38,
+      category: 'Indoor',
+      light: 'Bright indirect',
+      water: 'Weekly',
+      added: 14,
+      desc: 'The iconic Swiss cheese plant. Dramatic split leaves that grow larger and more fenestrated with age. Wipe leaves monthly and give it a moss pole to climb.',
+      art: { style: 'upright', p1: '#3f6b3a', p2: '#56864f', pot: 'terracotta' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'snake',
+      name: 'Snake Plant',
+      botanical: 'Dracaena trifasciata',
+      price: 26,
+      category: 'Indoor',
+      light: 'Low to bright',
+      water: 'Every 2-3 weeks',
+      added: 12,
+      desc: 'Nearly indestructible upright sword-like leaves. Tolerates neglect, low light, and irregular watering. A top air-purifier and perfect for beginners.',
+      art: { style: 'upright', p1: '#4a7a45', p2: '#cdd98a', pot: 'charcoal' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'pothos',
+      name: 'Golden Pothos',
+      botanical: 'Epipremnum aureum',
+      price: 18,
+      category: 'Indoor',
+      light: 'Low to bright indirect',
+      water: 'Weekly',
+      added: 9,
+      desc: 'Fast-growing trailing vine with heart-shaped, marbled leaves. Forgiving and lush — drape it from a shelf or train it up a wall.',
+      art: { style: 'trailing', p1: '#5a8a3f', p2: '#bcd06a', pot: 'clay' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'zz',
+      name: 'ZZ Plant',
+      botanical: 'Zamioculcas zamiifolia',
+      price: 30,
+      category: 'Indoor',
+      light: 'Low to medium',
+      water: 'Every 2-3 weeks',
+      added: 7,
+      desc: 'Glossy, waxy leaflets on arching stems. Thrives on neglect and low light thanks to water-storing rhizomes. The ultimate low-effort statement plant.',
+      art: { style: 'bushy', p1: '#2f5a2c', p2: '#447a3f', pot: 'stone' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'fiddle',
+      name: 'Fiddle Leaf Fig',
+      botanical: 'Ficus lyrata',
+      price: 52,
+      category: 'Indoor',
+      light: 'Bright indirect',
+      water: 'Weekly',
+      added: 13,
+      desc: 'Bold violin-shaped leaves on a sculptural trunk. A designer favorite that rewards consistency — keep it in one bright spot and avoid drafts.',
+      art: { style: 'bushy', p1: '#37662f', p2: '#5a9050', pot: 'sage' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'calathea',
+      name: 'Calathea Orbifolia',
+      botanical: 'Goeppertia orbifolia',
+      price: 34,
+      category: 'Indoor',
+      light: 'Medium indirect',
+      water: 'Keep evenly moist',
+      added: 6,
+      desc: 'Large round leaves striped silver-green that fold up at night. Loves humidity — perfect for bathrooms or grouped with other plants.',
+      art: { style: 'bushy', p1: '#3d6b4a', p2: '#9fc7a0', pot: 'sage' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'parlor-palm',
+      name: 'Parlor Palm',
+      botanical: 'Chamaedorea elegans',
+      price: 28,
+      category: 'Indoor',
+      light: 'Low to medium',
+      water: 'Weekly',
+      added: 4,
+      desc: 'Delicate feathery fronds that bring a soft tropical feel to low-light corners. Pet-friendly and slow-growing.',
+      art: { style: 'palm', p1: '#3f6b3a', p2: '#5a8a4a', pot: 'clay' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'boston-fern',
+      name: 'Boston Fern',
+      botanical: 'Nephrolepis exaltata',
+      price: 24,
+      category: 'Indoor',
+      light: 'Medium indirect',
+      water: 'Keep moist',
+      added: 5,
+      desc: 'Lush arching fronds that thrive in humidity. A classic hanging plant — mist often and never let it dry out completely.',
+      art: { style: 'fern', p1: '#3a7a3a', p2: '#6fae5a', pot: 'forest' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'lavender',
+      name: 'English Lavender',
+      botanical: 'Lavandula angustifolia',
+      price: 16,
+      category: 'Outdoor',
+      light: 'Full sun',
+      water: 'Low, drought-tolerant',
+      added: 8,
+      desc: 'Fragrant silvery foliage topped with purple blooms. Pollinator magnet that loves sun and well-drained soil. Drought-tolerant once established.',
+      art: { style: 'bushy', p1: '#7f8f6a', p2: '#9c84c4', pot: 'stone' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'japanese-maple',
+      name: 'Japanese Maple',
+      botanical: 'Acer palmatum',
+      price: 68,
+      category: 'Outdoor',
+      light: 'Part shade',
+      water: 'Regular',
+      added: 11,
+      desc: 'Elegant lacy foliage that turns fiery red in autumn. A slow-growing ornamental for patios and shaded borders. Shelter from harsh afternoon sun.',
+      art: { style: 'bushy', p1: '#a64b3a', p2: '#c97a54', pot: 'charcoal' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'rosemary',
+      name: 'Rosemary',
+      botanical: 'Salvia rosmarinus',
+      price: 14,
+      category: 'Outdoor',
+      light: 'Full sun',
+      water: 'Low',
+      added: 3,
+      desc: 'Aromatic evergreen herb with needle-like leaves. Equally at home in the kitchen garden and the flower border. Loves sun and dry feet.',
+      art: { style: 'upright', p1: '#4a6b48', p2: '#6f8f5a', pot: 'terracotta' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'echeveria',
+      name: 'Echeveria Rosette',
+      botanical: 'Echeveria elegans',
+      price: 12,
+      category: 'Succulents & Cacti',
+      light: 'Bright direct',
+      water: 'Every 2-3 weeks',
+      added: 10,
+      desc: 'Symmetrical pale-blue rosette that blushes pink in bright light. Store water in plump leaves — let soil dry fully between drinks.',
+      art: { style: 'succulent', p1: '#8fb9a0', p2: '#c8d8c0', pot: 'clay' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'aloe',
+      name: 'Aloe Vera',
+      botanical: 'Aloe barbadensis',
+      price: 18,
+      category: 'Succulents & Cacti',
+      light: 'Bright direct',
+      water: 'Every 2-3 weeks',
+      added: 6,
+      desc: 'Architectural fleshy spears with soothing gel inside. A practical windowsill succulent — water deeply but infrequently in gritty soil.',
+      art: { style: 'succulent', p1: '#5a8a5a', p2: '#9fc78a', pot: 'sage' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'golden-barrel',
+      name: 'Golden Barrel Cactus',
+      botanical: 'Echinocactus grusonii',
+      price: 22,
+      category: 'Succulents & Cacti',
+      light: 'Full sun',
+      water: 'Monthly',
+      added: 2,
+      desc: 'A round, ribbed cactus crowned with golden spines. Slow and sculptural — give it the sunniest spot and barely any water in winter.',
+      art: { style: 'cactus', p1: '#6f9a4a', p2: '#5a8a3f', pot: 'terracotta' },
+      variantType: 'size',
+      variants: SIZE_VARIANTS
+    },
+    {
+      id: 'terracotta-pot',
+      name: 'Hand-Thrown Terracotta Pot',
+      botanical: 'Glazed stoneware',
+      price: 24,
+      category: 'Pots & Planters',
+      light: '—',
+      water: '—',
+      added: 7,
+      desc: 'Breathable hand-thrown terracotta with a drainage hole and matching saucer. Develops a beautiful patina over time. Sold empty.',
+      art: { style: 'planter', p1: '#c97a54', p2: '#b15f3c', pot: 'terracotta' },
+      variantType: 'color',
+      variants: [
+        { label: 'Terracotta', delta: 0 },
+        { label: 'Sage', delta: 0 },
+        { label: 'Charcoal', delta: 4 }
+      ]
+    },
+    {
+      id: 'stoneware-planter',
+      name: 'Glazed Stoneware Planter',
+      botanical: 'Reactive glaze ceramic',
+      price: 36,
+      category: 'Pots & Planters',
+      light: '—',
+      water: '—',
+      added: 9,
+      desc: 'A weighty reactive-glaze planter with a self-watering insert. Modern rounded silhouette that suits trailing and upright plants alike.',
+      art: { style: 'planter', p1: '#9caf88', p2: '#849a6d', pot: 'sage' },
+      variantType: 'color',
+      variants: [
+        { label: 'Sage', delta: 0 },
+        { label: 'Stone', delta: 0 },
+        { label: 'Forest', delta: 6 }
+      ]
+    },
+    {
+      id: 'trowel',
+      name: 'Forged Hand Trowel',
+      botanical: 'Stainless & ash wood',
+      price: 19,
+      category: 'Tools',
+      light: '—',
+      water: '—',
+      added: 4,
+      desc: 'A balanced stainless trowel with an oiled ash handle and leather hanging loop. Built to last a lifetime of repotting and bedding.',
+      art: { style: 'trowel' },
+      variantType: 'size',
+      variants: [
+        { label: 'Standard', delta: 0 },
+        { label: 'Narrow', delta: 0 }
+      ]
+    },
+    {
+      id: 'shears',
+      name: 'Bypass Pruning Shears',
+      botanical: 'Carbon steel blade',
+      price: 28,
+      category: 'Tools',
+      light: '—',
+      water: '—',
+      added: 5,
+      desc: 'Razor-sharp bypass blades for clean cuts that heal fast. Spring-loaded action and a safety lock. Keep them sharp and they will reward you.',
+      art: { style: 'shears' },
+      variantType: 'size',
+      variants: [
+        { label: 'Standard', delta: 0 },
+        { label: 'Compact', delta: 0 }
+      ]
+    },
+    {
+      id: 'watering-can',
+      name: 'Long-Spout Watering Can',
+      botanical: 'Powder-coated steel',
+      price: 32,
+      category: 'Tools',
+      light: '—',
+      water: '—',
+      added: 8,
+      desc: 'A 1.5L powder-coated can with a long precision spout to reach the soil without splashing leaves. Balanced for one-handed pouring.',
+      art: { style: 'can' },
+      variantType: 'color',
+      variants: [
+        { label: 'Sage', delta: 0 },
+        { label: 'Clay', delta: 0 },
+        { label: 'Charcoal', delta: 3 }
+      ]
+    }
+  ];
+
+  var CATEGORIES = ['Indoor', 'Outdoor', 'Succulents & Cacti', 'Pots & Planters', 'Tools'];
+
+  global.FernwoodData = {
+    products: PRODUCTS,
+    categories: CATEGORIES,
+    renderArt: function (p) {
+      return renderArt(p.art.style, p.art.p1, p.art.p2, p.art.pot, p.name);
+    },
+    renderArtRaw: renderArt
+  };
+})(window);

--- a/fixtures/websites/77-fernwood-plants/shop.html
+++ b/fixtures/websites/77-fernwood-plants/shop.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shop — Fernwood Botanicals</title>
+  <meta name="description" content="Browse Fernwood Botanicals: indoor plants, outdoor greenery, succulents, cacti, pots and tools. Filter by category, price and light, then sort to taste." />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap header-inner">
+      <a class="brand" href="index.html" aria-label="Fernwood Botanicals home">
+        <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#2f4a2c" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+        Fernwood
+      </a>
+      <button class="nav-toggle" data-nav-toggle aria-label="Toggle menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+      <nav class="nav" data-nav>
+        <a href="index.html">Home</a>
+        <a href="shop.html" class="active">Shop</a>
+        <a href="about.html">About</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn" data-open-cart aria-label="Open cart">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="20" r="1.6"/><circle cx="18" cy="20" r="1.6"/><path d="M2 3h2.2l2.3 12.3a2 2 0 0 0 2 1.7h8.7a2 2 0 0 0 2-1.6L21 7H6"/></svg>
+          <span class="cart-badge is-empty" data-cart-count>0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="wrap">
+        <span class="eyebrow">The full collection</span>
+        <h1>Shop our greenery</h1>
+        <p>From near-unkillable starters to statement foliage and the pots and tools to match. Filter, sort, and build your jungle.</p>
+      </div>
+    </section>
+
+    <section class="section section-tight">
+      <div class="wrap shop-layout">
+        <!-- FILTERS -->
+        <aside class="filters" aria-label="Product filters">
+          <h3>Filter</h3>
+          <div class="filter-group">
+            <label id="catlabel">Category</label>
+            <div class="cat-filters" data-cat-filters role="group" aria-labelledby="catlabel">
+              <button class="cat-btn" data-cat="all">All plants &amp; goods</button>
+              <button class="cat-btn" data-cat="Indoor">Indoor</button>
+              <button class="cat-btn" data-cat="Outdoor">Outdoor</button>
+              <button class="cat-btn" data-cat="Succulents &amp; Cacti">Succulents &amp; Cacti</button>
+              <button class="cat-btn" data-cat="Pots &amp; Planters">Pots &amp; Planters</button>
+              <button class="cat-btn" data-cat="Tools">Tools</button>
+            </div>
+          </div>
+          <div class="filter-group">
+            <label for="price-filter">Max price</label>
+            <input id="price-filter" class="range" type="range" min="10" max="100" value="100" step="2" data-price-filter />
+            <div class="price-row"><span>$10</span><span data-price-out>$100</span></div>
+          </div>
+          <div class="filter-group">
+            <label for="light-filter">Light level</label>
+            <select id="light-filter" data-light-filter>
+              <option value="all">Any light</option>
+              <option value="low">Low light</option>
+              <option value="medium">Medium / indirect</option>
+              <option value="high">Bright / full sun</option>
+            </select>
+          </div>
+        </aside>
+
+        <!-- RESULTS -->
+        <div>
+          <div class="shop-toolbar">
+            <span class="result-count" data-result-count aria-live="polite">All plants</span>
+            <div class="sort-wrap">
+              <label for="sort">Sort by</label>
+              <select id="sort" data-sort>
+                <option value="featured">Featured</option>
+                <option value="newest">Newest</option>
+                <option value="price-asc">Price: low to high</option>
+                <option value="price-desc">Price: high to low</option>
+                <option value="name">Name: A → Z</option>
+              </select>
+            </div>
+          </div>
+          <div class="grid" data-shop-grid></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-grid">
+        <div>
+          <div class="footer-brand">
+            <svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 44C16 40 7 36 7 22 7 13 14 6 24 6s17 7 17 16c0 14-9 18-17 22Z" fill="#9caf88"/><path d="M24 42V16" stroke="#1f3320" stroke-width="2.4" stroke-linecap="round"/><path d="M24 24C18 22 13 17 13 11c6 0 11 4 13 9 2-6 7-9 13-9 0 6-5 11-11 13" fill="#3f6b3a"/></svg>
+            Fernwood Botanicals
+          </div>
+          <p>A family nursery growing happy, healthy plants — and the people who care for them — since 1994.</p>
+        </div>
+        <div><h4>Shop</h4><ul>
+          <li><a href="shop.html?category=Indoor">Indoor plants</a></li>
+          <li><a href="shop.html?category=Outdoor">Outdoor plants</a></li>
+          <li><a href="shop.html?category=Succulents &amp; Cacti">Succulents &amp; cacti</a></li>
+          <li><a href="shop.html?category=Pots &amp; Planters">Pots &amp; planters</a></li>
+        </ul></div>
+        <div><h4>Company</h4><ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#sustainability">Sustainability</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="contact.html#hours">Greenhouse hours</a></li>
+        </ul></div>
+        <div><h4>Visit</h4><ul>
+          <li>14 Fernwood Lane</li><li>Mossvale, OR 97000</li>
+          <li><a href="tel:+15035550142">(503) 555-0142</a></li>
+          <li><a href="mailto:hello@fernwood.example">hello@fernwood.example</a></li>
+        </ul></div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; <span data-year>2026</span> Fernwood Botanicals. Grown with care.</span>
+        <span>Peat-free · Plastic-light · Locally rooted</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/78-terra-ceramics/about.html
+++ b/fixtures/websites/78-terra-ceramics/about.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About — Terra &amp; Form</title>
+  <meta name="description" content="The story of Terra &amp; Form — a small ceramics studio, the materials and process behind each hand-thrown piece, and the ethos that guides the work.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap site-header__inner">
+      <a class="brand" href="index.html" aria-label="Terra and Form, home">
+        <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+          <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+          <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+          <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+        </svg>
+        <span class="brand__name">Terra &amp; Form<small>Handmade Ceramics</small></span>
+      </a>
+      <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="siteNav">
+        <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="#2c2c29" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="siteNav" aria-label="Primary">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="about.html" aria-current="page">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="header__tools">
+        <button class="icon-btn" id="cartButton" aria-label="Open cart">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1.2 11a2 2 0 0 1-2 1.8H9.2a2 2 0 0 1-2-1.8L6 7Z" fill="none" stroke="#2c2c29" stroke-width="1.3"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="#2c2c29" stroke-width="1.3"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section">
+      <div class="wrap lede-block">
+        <div class="lede-block__copy">
+          <p class="eyebrow">The studio</p>
+          <h1 class="section__title" style="font-size:clamp(2.2rem,5vw,3.4rem);">Made slowly, by <em>two hands</em>.</h1>
+          <div class="prose" style="margin-top:1.4rem;">
+            <p>Terra &amp; Form began as a single wheel in a corner of a shared workshop. What started as evenings spent learning to centre clay turned into a small studio devoted to one idea: that the objects we use every day should be made with care, and should get better the more we use them.</p>
+            <p>Everything is thrown, trimmed, and glazed by hand in small batches. We are not interested in perfect symmetry or endless uniformity — we are interested in pots that feel good to hold and earn a place on your shelf for years.</p>
+          </div>
+        </div>
+        <div class="lede-block__art">
+          <svg viewBox="0 0 200 200" role="img" aria-label="A potter's hands cradling a thrown bowl on the wheel">
+            <ellipse cx="100" cy="150" rx="74" ry="14" fill="#cbbda4"/>
+            <path d="M48 120 Q100 116 152 120 Q140 150 100 150 Q60 150 48 120 Z" fill="#a7b09a" stroke="#2c2c29" stroke-width="1.2"/>
+            <ellipse cx="100" cy="120" rx="52" ry="13" fill="#67735a" opacity="0.5"/>
+            <ellipse cx="100" cy="120" rx="52" ry="11" fill="#b3bba6"/>
+            <path d="M40 118 Q34 100 44 96 Q52 110 60 116 Z" fill="#c08a6a" stroke="#2c2c29" stroke-width="1"/>
+            <path d="M160 118 Q166 100 156 96 Q148 110 140 116 Z" fill="#c08a6a" stroke="#2c2c29" stroke-width="1"/>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--tint" id="process">
+      <div class="wrap">
+        <div class="section__head">
+          <div>
+            <p class="eyebrow">Materials &amp; process</p>
+            <h2 class="section__title">What goes into a <em>pot</em></h2>
+            <p class="section__intro">A piece can spend three to five weeks moving through the studio before it reaches your table.</p>
+          </div>
+        </div>
+        <div class="process">
+          <div class="process__step">
+            <span class="process__num">01</span>
+            <h3>Stoneware clay</h3>
+            <p>We work with a speckled, mid-fire stoneware that fires to a warm toasty body. It is durable enough for daily use and takes our glazes beautifully.</p>
+          </div>
+          <div class="process__step">
+            <span class="process__num">02</span>
+            <h3>Hand-mixed glazes</h3>
+            <p>Our glazes are mixed in the studio from raw materials — no commercial pre-mixes. The muted oatmeal, sage, charcoal, and rust palette is tuned over many test tiles.</p>
+          </div>
+          <div class="process__step">
+            <span class="process__num">03</span>
+            <h3>Two firings</h3>
+            <p>Each piece is bisque-fired, glazed, then fired again to 1240&deg;C in an electric kiln. The second firing vitrifies the clay and melts the glaze into its final surface.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="ethos">
+      <div class="wrap">
+        <div class="section__head">
+          <div>
+            <p class="eyebrow">Our ethos</p>
+            <h2 class="section__title">How we like to <em>work</em></h2>
+          </div>
+        </div>
+        <div class="values">
+          <div class="value">
+            <svg class="value__mark" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v18M5 8q7-5 14 0M5 16q7-5 14 0" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
+            <h3>Made to order</h3>
+            <p>Most pieces are thrown when you order them, which keeps waste low and means each piece is genuinely yours. Lead times run three to five weeks.</p>
+          </div>
+          <div class="value">
+            <svg class="value__mark" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.4"/><path d="M8 12l3 3 5-6" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <h3>Built to last</h3>
+            <p>Functional ware is food-safe, microwave- and dishwasher-friendly, and made to take the knocks of daily life rather than sit behind glass.</p>
+          </div>
+          <div class="value">
+            <svg class="value__mark" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21s-7-4.5-9-9a4.5 4.5 0 0 1 9-1 4.5 4.5 0 0 1 9 1c-2 4.5-9 9-9 9Z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>
+            <h3>Small &amp; local</h3>
+            <p>We stay small on purpose. Working in small batches lets us keep our hands on every piece and our standards exactly where we want them.</p>
+          </div>
+        </div>
+        <div style="margin-top:clamp(2.5rem,5vw,3.5rem); text-align:center;">
+          <a class="btn btn--solid btn--lg" href="shop.html">Browse the studio</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer__grid">
+      <div class="footer__brand">
+        <a class="brand" href="index.html" aria-label="Terra and Form, home">
+          <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+            <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+            <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+            <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+          </svg>
+          <span class="brand__name">Terra &amp; Form</span>
+        </a>
+        <p class="footer__about">A small ceramics studio making hand-thrown stoneware for the table and the home. Made to order, made to last.</p>
+      </div>
+      <div class="footer__col">
+        <h4>Shop</h4>
+        <ul>
+          <li><a href="shop.html?category=Tableware">Tableware</a></li>
+          <li><a href="shop.html?category=Mugs &amp; Cups">Mugs &amp; Cups</a></li>
+          <li><a href="shop.html?category=Vases">Vases</a></li>
+          <li><a href="shop.html?category=Bowls">Bowls</a></li>
+          <li><a href="shop.html?category=Decor">Decor</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Studio</h4>
+        <ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#process">Materials &amp; process</a></li>
+          <li><a href="contact.html">Visit the studio</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Care</h4>
+        <ul>
+          <li><a href="about.html#ethos">Made to order</a></li>
+          <li><a href="contact.html">Lead times</a></li>
+          <li><a href="contact.html">Wholesale</a></li>
+          <li><a href="cart.html">Your cart</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="wrap footer__bottom">
+      <span>&copy; <span data-year>2026</span> Terra &amp; Form. Hand-thrown in the studio.</span>
+      <span>Free shipping on orders over $150</span>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/78-terra-ceramics/cart.html
+++ b/fixtures/websites/78-terra-ceramics/cart.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Cart — Terra &amp; Form</title>
+  <meta name="description" content="Review the hand-thrown pieces in your cart, adjust quantities, and head to checkout.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap site-header__inner">
+      <a class="brand" href="index.html" aria-label="Terra and Form, home">
+        <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+          <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+          <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+          <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+        </svg>
+        <span class="brand__name">Terra &amp; Form<small>Handmade Ceramics</small></span>
+      </a>
+      <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="siteNav">
+        <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="#2c2c29" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="siteNav" aria-label="Primary">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="header__tools">
+        <button class="icon-btn" id="cartButton" aria-label="Open cart">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1.2 11a2 2 0 0 1-2 1.8H9.2a2 2 0 0 1-2-1.8L6 7Z" fill="none" stroke="#2c2c29" stroke-width="1.3"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="#2c2c29" stroke-width="1.3"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="wrap cartpage">
+      <div id="cartPage"><!-- cart contents injected --></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer__grid">
+      <div class="footer__brand">
+        <a class="brand" href="index.html" aria-label="Terra and Form, home">
+          <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+            <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+            <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+            <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+          </svg>
+          <span class="brand__name">Terra &amp; Form</span>
+        </a>
+        <p class="footer__about">A small ceramics studio making hand-thrown stoneware for the table and the home. Made to order, made to last.</p>
+      </div>
+      <div class="footer__col">
+        <h4>Shop</h4>
+        <ul>
+          <li><a href="shop.html?category=Tableware">Tableware</a></li>
+          <li><a href="shop.html?category=Mugs &amp; Cups">Mugs &amp; Cups</a></li>
+          <li><a href="shop.html?category=Vases">Vases</a></li>
+          <li><a href="shop.html?category=Bowls">Bowls</a></li>
+          <li><a href="shop.html?category=Decor">Decor</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Studio</h4>
+        <ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#process">Materials &amp; process</a></li>
+          <li><a href="contact.html">Visit the studio</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Care</h4>
+        <ul>
+          <li><a href="about.html#ethos">Made to order</a></li>
+          <li><a href="contact.html">Lead times</a></li>
+          <li><a href="contact.html">Wholesale</a></li>
+          <li><a href="cart.html">Your cart</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="wrap footer__bottom">
+      <span>&copy; <span data-year>2026</span> Terra &amp; Form. Hand-thrown in the studio.</span>
+      <span>Free shipping on orders over $150</span>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/78-terra-ceramics/contact.html
+++ b/fixtures/websites/78-terra-ceramics/contact.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact &amp; Studio Visits — Terra &amp; Form</title>
+  <meta name="description" content="Get in touch with Terra &amp; Form, find our studio hours and location, and read about made-to-order lead times.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap site-header__inner">
+      <a class="brand" href="index.html" aria-label="Terra and Form, home">
+        <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+          <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+          <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+          <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+        </svg>
+        <span class="brand__name">Terra &amp; Form<small>Handmade Ceramics</small></span>
+      </a>
+      <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="siteNav">
+        <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="#2c2c29" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="siteNav" aria-label="Primary">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html" aria-current="page">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="header__tools">
+        <button class="icon-btn" id="cartButton" aria-label="Open cart">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1.2 11a2 2 0 0 1-2 1.8H9.2a2 2 0 0 1-2-1.8L6 7Z" fill="none" stroke="#2c2c29" stroke-width="1.3"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="#2c2c29" stroke-width="1.3"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section">
+      <div class="wrap">
+        <p class="eyebrow">Say hello</p>
+        <h1 class="section__title" style="font-size:clamp(2.2rem,5vw,3.4rem);">Get in touch &amp; <em>visit the studio</em></h1>
+        <p class="section__intro">Questions about a piece, a custom order, or wholesale? Send a note. We read everything ourselves and usually reply within two working days.</p>
+
+        <div class="contact-grid" style="margin-top:clamp(2.5rem,5vw,3.5rem);">
+          <form class="form" id="contactForm" novalidate>
+            <div class="form-row">
+              <div class="field">
+                <label class="field__label" for="cfName">Name</label>
+                <input type="text" id="cfName" name="name" autocomplete="name" required>
+              </div>
+              <div class="field">
+                <label class="field__label" for="cfEmail">Email</label>
+                <input type="email" id="cfEmail" name="email" autocomplete="email" required>
+              </div>
+            </div>
+            <div class="field">
+              <label class="field__label" for="cfSubject">Subject</label>
+              <select id="cfSubject" name="subject">
+                <option>General enquiry</option>
+                <option>Custom order</option>
+                <option>Wholesale</option>
+                <option>Studio visit</option>
+                <option>Press</option>
+              </select>
+            </div>
+            <div class="field field--full">
+              <label class="field__label" for="cfMessage">Message</label>
+              <textarea id="cfMessage" name="message" placeholder="Tell us a little about what you're after…" required></textarea>
+            </div>
+            <button type="submit" class="btn btn--solid btn--lg">Send message</button>
+            <p class="form-status" id="contactStatus" role="status" aria-live="polite"></p>
+          </form>
+
+          <aside class="studio-card">
+            <svg class="studio-card__map" viewBox="0 0 320 200" role="img" aria-label="A simplified map showing the studio location near the river and the old mill quarter">
+              <rect width="320" height="200" fill="#f4ece0"/>
+              <path d="M0 150 Q80 130 160 150 Q240 170 320 150 L320 200 L0 200 Z" fill="#a7b09a" opacity="0.35"/>
+              <path d="M0 70 L120 70 L120 0" fill="none" stroke="#cbbda4" stroke-width="6"/>
+              <path d="M120 110 L320 110" fill="none" stroke="#cbbda4" stroke-width="6"/>
+              <path d="M200 0 L200 200" fill="none" stroke="#e0d8c9" stroke-width="4"/>
+              <rect x="60" y="40" width="40" height="26" fill="#d6c3a5" stroke="#2c2c29" stroke-width="1"/>
+              <rect x="150" y="120" width="34" height="24" fill="#d6c3a5" stroke="#2c2c29" stroke-width="1"/>
+              <rect x="230" y="60" width="46" height="30" fill="#d6c3a5" stroke="#2c2c29" stroke-width="1"/>
+              <circle cx="138" cy="96" r="9" fill="#a9613f"/>
+              <path d="M138 96 L138 116" stroke="#a9613f" stroke-width="3"/>
+              <circle cx="138" cy="93" r="3" fill="#f4ece0"/>
+              <text x="150" y="92" font-family="Georgia, serif" font-size="11" fill="#2c2c29">The Studio</text>
+            </svg>
+
+            <h3>Visit the studio</h3>
+            <p class="muted">Unit 7, The Old Mill Yard<br>Riverside Lane, Clayton CL4 2RT</p>
+
+            <ul class="hours">
+              <li><span>Thursday</span><span>10:00 – 17:00</span></li>
+              <li><span>Friday</span><span>10:00 – 17:00</span></li>
+              <li><span>Saturday</span><span>11:00 – 16:00</span></li>
+              <li><span>Sun – Wed</span><span>By appointment</span></li>
+            </ul>
+
+            <p class="lead-note">A note on lead times: most pieces are made to order and ship in 3–5 weeks. If something is in stock it ships within a few days — we will always confirm timing by email before your piece is fired.</p>
+          </aside>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer__grid">
+      <div class="footer__brand">
+        <a class="brand" href="index.html" aria-label="Terra and Form, home">
+          <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+            <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+            <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+            <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+          </svg>
+          <span class="brand__name">Terra &amp; Form</span>
+        </a>
+        <p class="footer__about">A small ceramics studio making hand-thrown stoneware for the table and the home. Made to order, made to last.</p>
+      </div>
+      <div class="footer__col">
+        <h4>Shop</h4>
+        <ul>
+          <li><a href="shop.html?category=Tableware">Tableware</a></li>
+          <li><a href="shop.html?category=Mugs &amp; Cups">Mugs &amp; Cups</a></li>
+          <li><a href="shop.html?category=Vases">Vases</a></li>
+          <li><a href="shop.html?category=Bowls">Bowls</a></li>
+          <li><a href="shop.html?category=Decor">Decor</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Studio</h4>
+        <ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#process">Materials &amp; process</a></li>
+          <li><a href="contact.html">Visit the studio</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Care</h4>
+        <ul>
+          <li><a href="about.html#ethos">Made to order</a></li>
+          <li><a href="contact.html">Lead times</a></li>
+          <li><a href="contact.html">Wholesale</a></li>
+          <li><a href="cart.html">Your cart</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="wrap footer__bottom">
+      <span>&copy; <span data-year>2026</span> Terra &amp; Form. Hand-thrown in the studio.</span>
+      <span>Free shipping on orders over $150</span>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/78-terra-ceramics/css/styles.css
+++ b/fixtures/websites/78-terra-ceramics/css/styles.css
@@ -1,0 +1,444 @@
+/* ==========================================================================
+   Terra & Form — Handmade Ceramics
+   Minimal, gallery-like. Muted earthtones, hairline rules, serif display +
+   clean sans UI. Asymmetric editorial spacing.
+   ========================================================================== */
+
+:root {
+  /* palette */
+  --clay:      #b07a5c;   /* warm clay */
+  --oatmeal:   #e3d8c5;
+  --sand:      #d6c3a5;
+  --warm-white:#f7f3ec;
+  --paper:     #fbf8f2;
+  --charcoal:  #2c2c29;
+  --ink:       #38362f;
+  --muted:     #8a857a;
+  --line:      #e0d8c9;   /* hairline */
+  --line-strong:#cfc6b4;
+  --accent:    #7e8a6f;   /* dusty sage */
+  --accent-deep:#67735a;
+  --rust:      #a9613f;
+
+  /* type */
+  --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+  --sans:  "Helvetica Neue", "Inter", system-ui, -apple-system, "Segoe UI", Arial, sans-serif;
+
+  --maxw: 1180px;
+  --gutter: clamp(1.25rem, 4vw, 3.5rem);
+  --radius: 2px;
+}
+
+/* ---------- reset ---------- */
+*, *::before, *::after { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+img, svg { display: block; max-width: 100%; }
+button { font: inherit; cursor: pointer; color: inherit; }
+a { color: inherit; text-decoration: none; }
+h1, h2, h3, h4 { font-family: var(--serif); font-weight: 500; line-height: 1.15; letter-spacing: 0.01em; margin: 0; }
+p { margin: 0; }
+ul { margin: 0; padding: 0; list-style: none; }
+.no-scroll { overflow: hidden; }
+
+/* ---------- layout helpers ---------- */
+.wrap { width: 100%; max-width: var(--maxw); margin-inline: auto; padding-inline: var(--gutter); }
+.muted { color: var(--muted); }
+.linklike {
+  background: none; border: none; padding: 0;
+  color: var(--accent-deep); text-decoration: underline; text-underline-offset: 3px;
+  text-decoration-color: var(--line-strong); font-size: inherit;
+}
+.linklike:hover { text-decoration-color: var(--accent-deep); }
+.eyebrow {
+  font-size: 0.72rem; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--clay); margin-bottom: 0.9rem;
+}
+
+/* ---------- buttons ---------- */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem;
+  font-size: 0.82rem; letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 0.7rem 1.4rem; border-radius: var(--radius);
+  border: 1px solid transparent; transition: background .2s, color .2s, border-color .2s, transform .12s;
+}
+.btn:active { transform: translateY(1px); }
+.btn--solid { background: var(--charcoal); color: var(--warm-white); }
+.btn--solid:hover { background: #000; }
+.btn--quiet { background: transparent; color: var(--ink); border-color: var(--line-strong); }
+.btn--quiet:hover { border-color: var(--charcoal); }
+.btn--lg { padding: 0.85rem 1.8rem; }
+.btn--block { width: 100%; }
+
+/* ---------- header ---------- */
+.site-header {
+  position: sticky; top: 0; z-index: 40;
+  background: rgba(251,248,242,0.9);
+  backdrop-filter: saturate(120%) blur(8px);
+  border-bottom: 1px solid var(--line);
+}
+.site-header__inner {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 1.5rem; height: 76px;
+}
+.brand { display: flex; align-items: center; gap: 0.65rem; }
+.brand__mark { width: 34px; height: 34px; flex: none; }
+.brand__name {
+  font-family: var(--serif); font-size: 1.22rem; letter-spacing: 0.02em; line-height: 1.05;
+}
+.brand__name small { display: block; font-family: var(--sans); font-size: 0.6rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--muted); margin-top: 2px; }
+
+.site-nav ul { display: flex; gap: 2rem; }
+.site-nav a {
+  font-size: 0.8rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink);
+  padding: 0.4rem 0; position: relative;
+}
+.site-nav a::after {
+  content: ""; position: absolute; left: 0; bottom: 0; height: 1px; width: 0;
+  background: var(--charcoal); transition: width .25s;
+}
+.site-nav a:hover::after, .site-nav a[aria-current="page"]::after { width: 100%; }
+.site-nav a[aria-current="page"] { color: var(--charcoal); }
+
+.header__tools { display: flex; align-items: center; gap: 0.5rem; }
+.icon-btn {
+  position: relative; width: 42px; height: 42px; border: none; background: transparent;
+  display: inline-flex; align-items: center; justify-content: center; border-radius: 50%;
+  transition: background .2s;
+}
+.icon-btn:hover { background: var(--oatmeal); }
+.icon-btn svg { width: 21px; height: 21px; }
+.cart-badge {
+  position: absolute; top: 4px; right: 2px; min-width: 18px; height: 18px; padding: 0 5px;
+  background: var(--accent); color: #fff; border-radius: 10px;
+  font-family: var(--sans); font-size: 0.68rem; line-height: 18px; text-align: center;
+}
+.cart-badge[data-empty="true"] { background: var(--line-strong); color: var(--ink); }
+
+.nav-toggle { display: none; }
+
+/* ---------- hero ---------- */
+.hero { border-bottom: 1px solid var(--line); }
+.hero__inner {
+  display: grid; grid-template-columns: 1.05fr 0.95fr; gap: clamp(2rem, 5vw, 5rem);
+  align-items: center; padding-block: clamp(3rem, 8vw, 6.5rem);
+}
+.hero__title { font-size: clamp(2.6rem, 6vw, 4.4rem); line-height: 1.04; letter-spacing: -0.01em; }
+.hero__title em { font-style: italic; color: var(--clay); }
+.hero__lede { margin-top: 1.6rem; max-width: 42ch; font-size: 1.08rem; color: var(--ink); }
+.hero__actions { margin-top: 2.2rem; display: flex; gap: 0.9rem; flex-wrap: wrap; }
+.hero__stage {
+  position: relative; aspect-ratio: 1/1; max-width: 460px; margin-inline: auto; width: 100%;
+  display: grid; place-items: center;
+  background:
+    radial-gradient(120% 90% at 50% 12%, var(--warm-white), transparent 60%),
+    linear-gradient(180deg, var(--oatmeal), var(--sand));
+  border-radius: 50% 50% 4px 4px / 60% 60% 4px 4px;
+}
+.hero__stage svg { width: 72%; filter: drop-shadow(0 22px 30px rgba(44,44,41,0.18)); }
+.hero__pedestal {
+  position: absolute; bottom: 8%; left: 50%; transform: translateX(-50%);
+  width: 58%; height: 10px; background: var(--charcoal); border-radius: 2px; opacity: 0.85;
+}
+
+/* ---------- sections ---------- */
+.section { padding-block: clamp(3.5rem, 8vw, 6rem); }
+.section--tint { background: var(--warm-white); border-block: 1px solid var(--line); }
+.section__head {
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 1.5rem;
+  margin-bottom: 2.5rem; flex-wrap: wrap;
+}
+.section__title { font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.section__title em { font-style: italic; color: var(--clay); }
+.section__intro { max-width: 52ch; margin-top: 0.8rem; color: var(--muted); }
+
+/* ---------- product grid + cards ---------- */
+.grid {
+  display: grid; gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+.card { display: flex; flex-direction: column; }
+.card__media {
+  position: relative; border: 1px solid var(--line); background: var(--warm-white);
+  aspect-ratio: 4/3.4; display: grid; place-items: center; padding: 1.5rem;
+  width: 100%; transition: border-color .25s, background .25s;
+  border-radius: var(--radius); overflow: hidden;
+}
+.card__media:hover { border-color: var(--line-strong); background: #fff; }
+.card__vessel { width: 78%; display: grid; place-items: center; transition: transform .35s ease; }
+.card__media:hover .card__vessel { transform: translateY(-4px) scale(1.02); }
+.card__vessel svg { width: 100%; }
+.card__tag {
+  position: absolute; top: 12px; left: 12px;
+  font-size: 0.62rem; letter-spacing: 0.18em; text-transform: uppercase;
+  background: var(--accent); color: #fff; padding: 0.25rem 0.55rem; border-radius: 2px;
+}
+.card__body { padding-top: 1rem; }
+.card__cat { font-size: 0.68rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); }
+.card__name { font-size: 1.18rem; margin-top: 0.25rem; }
+.card__name .linklike { text-decoration: none; color: var(--ink); }
+.card__name .linklike:hover { color: var(--clay); }
+.card__price { font-family: var(--serif); font-size: 1.05rem; margin-top: 0.3rem; color: var(--charcoal); }
+.card__actions { display: flex; gap: 0.6rem; margin-top: 1rem; }
+.card__actions .btn { flex: 1; padding-inline: 0.6rem; }
+
+.empty { grid-column: 1 / -1; text-align: center; color: var(--muted); padding: 3rem 0; }
+
+/* ---------- collections ---------- */
+.collections { display: grid; grid-template-columns: repeat(4, 1fr); gap: clamp(1rem, 2.5vw, 1.8rem); }
+.collection {
+  display: block; border: 1px solid var(--line); padding: 1.8rem 1.5rem; border-radius: var(--radius);
+  background: var(--paper); transition: background .25s, border-color .25s, transform .25s;
+}
+.collection:hover { background: #fff; border-color: var(--line-strong); transform: translateY(-3px); }
+.collection__art { height: 110px; display: grid; place-items: center; margin-bottom: 1rem; }
+.collection__art svg { height: 100%; }
+.collection__name { font-size: 1.15rem; }
+.collection__count { font-size: 0.78rem; color: var(--muted); margin-top: 0.2rem; }
+
+/* ---------- process ---------- */
+.process { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(1.5rem, 4vw, 3rem); }
+.process__step { position: relative; padding-top: 2.2rem; border-top: 1px solid var(--line); }
+.process__num {
+  position: absolute; top: -0.9rem; left: 0; font-family: var(--serif); font-style: italic;
+  font-size: 1rem; color: var(--clay); background: var(--paper); padding-right: 0.6rem;
+}
+.section--tint .process__num { background: var(--warm-white); }
+.process__step h3 { font-size: 1.25rem; margin-bottom: 0.6rem; }
+.process__step p { color: var(--ink); }
+
+/* ---------- newsletter ---------- */
+.newsletter { text-align: center; }
+.newsletter__form {
+  display: flex; gap: 0.6rem; max-width: 460px; margin: 1.8rem auto 0; flex-wrap: wrap;
+}
+.newsletter__form input[type="email"] {
+  flex: 1; min-width: 200px; padding: 0.8rem 1rem; border: 1px solid var(--line-strong);
+  background: var(--paper); border-radius: var(--radius); font: inherit;
+}
+.newsletter__form input:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+/* ---------- shop toolbar ---------- */
+.shop-head { padding-top: clamp(2.5rem, 6vw, 4rem); padding-bottom: 1.5rem; }
+.toolbar {
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 1.5rem;
+  flex-wrap: wrap; padding-block: 1.2rem; border-block: 1px solid var(--line); margin-bottom: 2.5rem;
+}
+.toolbar__filters { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+.field { display: flex; flex-direction: column; gap: 0.35rem; }
+.field__label { font-size: 0.68rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+.field select {
+  appearance: none; -webkit-appearance: none;
+  padding: 0.5rem 2.2rem 0.5rem 0.8rem; border: 1px solid var(--line-strong);
+  background: var(--paper) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%238a857a' stroke-width='1.4'/%3E%3C/svg%3E") no-repeat right 0.8rem center;
+  border-radius: var(--radius); font: inherit; color: var(--ink); min-width: 150px;
+}
+.field select:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+.toolbar__meta { font-size: 0.85rem; color: var(--muted); }
+
+/* ---------- modal ---------- */
+.modal { position: fixed; inset: 0; z-index: 60; }
+.modal[hidden] { display: none; }
+.modal__backdrop { position: absolute; inset: 0; background: rgba(44,44,41,0.42); opacity: 0; transition: opacity .2s; }
+.modal.is-open .modal__backdrop { opacity: 1; }
+.modal__panel {
+  position: absolute; inset: 0; margin: auto; width: min(880px, calc(100% - 2rem));
+  max-height: calc(100% - 2rem); height: max-content; overflow: auto;
+  background: var(--paper); border-radius: var(--radius); box-shadow: 0 30px 80px rgba(44,44,41,0.28);
+  transform: translateY(12px) scale(0.98); opacity: 0; transition: transform .22s, opacity .22s;
+}
+.modal.is-open .modal__panel { transform: none; opacity: 1; }
+.modal__close {
+  position: absolute; top: 0.8rem; right: 1rem; z-index: 2; border: none; background: transparent;
+  font-size: 1.8rem; line-height: 1; color: var(--muted); width: 40px; height: 40px; border-radius: 50%;
+}
+.modal__close:hover { color: var(--charcoal); background: var(--oatmeal); }
+.modal__grid { display: grid; grid-template-columns: 1fr 1fr; }
+.modal__media {
+  display: grid; place-items: center; padding: 2.5rem; background: var(--warm-white);
+  border-right: 1px solid var(--line);
+}
+.modal__media svg { width: 78%; filter: drop-shadow(0 16px 22px rgba(44,44,41,0.16)); }
+.modal__info { padding: clamp(1.8rem, 4vw, 2.8rem); }
+.modal__cat { font-size: 0.68rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); }
+.modal__name { font-size: 1.9rem; margin-top: 0.3rem; }
+.modal__price { font-family: var(--serif); font-size: 1.3rem; color: var(--charcoal); margin-top: 0.5rem; }
+.modal__desc { margin-top: 1.1rem; color: var(--ink); }
+.modal__meta { margin-top: 1.2rem; display: flex; gap: 0.6rem; align-items: baseline; }
+.modal__meta dt { font-size: 0.68rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+.modal__meta dd { margin: 0; font-size: 0.92rem; }
+.modal__variant { margin-top: 1.5rem; }
+.swatches { display: flex; gap: 0.6rem; flex-wrap: wrap; margin-top: 0.6rem; }
+.swatch {
+  display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.7rem 0.4rem 0.45rem;
+  border: 1px solid var(--line-strong); background: var(--paper); border-radius: 20px;
+  font-size: 0.82rem; transition: border-color .2s, background .2s;
+}
+.swatch__dot { width: 16px; height: 16px; border-radius: 50%; border: 1px solid rgba(44,44,41,0.18); }
+.swatch[aria-pressed="true"] { border-color: var(--charcoal); background: #fff; }
+.swatch--text { padding: 0.45rem 0.9rem; }
+.modal__buy { display: flex; align-items: center; gap: 1rem; margin-top: 1.8rem; flex-wrap: wrap; }
+.modal__note { margin-top: 1.3rem; font-size: 0.84rem; color: var(--muted); font-style: italic; border-top: 1px solid var(--line); padding-top: 1.1rem; }
+
+/* ---------- stepper ---------- */
+.stepper { display: inline-flex; align-items: center; border: 1px solid var(--line-strong); border-radius: var(--radius); }
+.stepper__btn {
+  width: 40px; height: 42px; border: none; background: transparent; font-size: 1.1rem; color: var(--ink);
+  display: grid; place-items: center; transition: background .2s;
+}
+.stepper__btn:hover { background: var(--oatmeal); }
+.stepper__val { min-width: 38px; text-align: center; font-variant-numeric: tabular-nums; }
+.stepper--sm .stepper__btn { width: 32px; height: 34px; font-size: 1rem; }
+.stepper--sm .stepper__val { min-width: 30px; }
+
+/* ---------- drawer ---------- */
+.drawer { position: fixed; inset: 0; z-index: 70; }
+.drawer[hidden] { display: none; }
+.drawer__backdrop { position: absolute; inset: 0; background: rgba(44,44,41,0.42); opacity: 0; transition: opacity .25s; }
+.drawer.is-open .drawer__backdrop { opacity: 1; }
+.drawer__panel {
+  position: absolute; top: 0; right: 0; height: 100%; width: min(420px, 100%);
+  background: var(--paper); display: flex; flex-direction: column;
+  box-shadow: -20px 0 60px rgba(44,44,41,0.22);
+  transform: translateX(100%); transition: transform .28s ease;
+}
+.drawer.is-open .drawer__panel { transform: none; }
+.drawer__head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.3rem var(--gutter); border-bottom: 1px solid var(--line);
+}
+.drawer__title { font-size: 1.25rem; }
+.drawer__close { border: none; background: transparent; font-size: 1.7rem; line-height: 1; color: var(--muted); width: 38px; height: 38px; border-radius: 50%; }
+.drawer__close:hover { color: var(--charcoal); background: var(--oatmeal); }
+.drawer__body { flex: 1; overflow: auto; padding: 0.5rem var(--gutter); }
+.drawer__foot { border-top: 1px solid var(--line); padding: 1.3rem var(--gutter); }
+.drawer__total { display: flex; justify-content: space-between; font-family: var(--serif); font-size: 1.15rem; margin-bottom: 0.4rem; }
+.drawer__ship { font-size: 0.78rem; margin-bottom: 1rem; }
+.drawer__empty { text-align: center; padding: 3rem 1rem; }
+.drawer__empty .muted { margin-top: 0.4rem; font-size: 0.9rem; }
+
+/* ---------- line item (drawer + cart) ---------- */
+.line {
+  display: grid; grid-template-columns: 64px 1fr auto; gap: 1rem; align-items: start;
+  padding: 1.1rem 0; border-bottom: 1px solid var(--line);
+}
+.line__media { width: 64px; height: 64px; background: var(--warm-white); border: 1px solid var(--line); border-radius: var(--radius); display: grid; place-items: center; padding: 6px; }
+.line__media svg { width: 100%; }
+.line__name { font-family: var(--serif); font-size: 1.02rem; }
+.line__variant { display: inline-block; font-size: 0.74rem; color: var(--muted); letter-spacing: 0.06em; text-transform: uppercase; margin-top: 0.1rem; }
+.line__price { font-size: 0.86rem; color: var(--muted); margin-top: 0.25rem; }
+.line__controls { grid-column: 2; display: flex; align-items: center; gap: 1rem; margin-top: 0.6rem; }
+.line__remove { background: none; border: none; padding: 0; font-size: 0.76rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); text-decoration: underline; text-underline-offset: 3px; }
+.line__remove:hover { color: var(--rust); }
+.line__subtotal { grid-column: 3; grid-row: 1; font-family: var(--serif); font-size: 1.02rem; color: var(--charcoal); }
+
+/* ---------- cart page ---------- */
+.cartpage { padding-block: clamp(2.5rem, 6vw, 4.5rem); }
+.cartpage__grid { display: grid; grid-template-columns: 1.6fr 0.9fr; gap: clamp(2rem, 5vw, 4rem); align-items: start; }
+.cartpage__lines-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 0.5rem; }
+.cartpage__summary { border: 1px solid var(--line); background: var(--warm-white); padding: clamp(1.5rem, 3vw, 2rem); border-radius: var(--radius); position: sticky; top: 96px; }
+.summary__title { font-size: 1.4rem; margin-bottom: 1.2rem; }
+.summary__row { display: flex; justify-content: space-between; padding: 0.55rem 0; font-size: 0.95rem; }
+.summary__row--total { border-top: 1px solid var(--line-strong); margin-top: 0.4rem; padding-top: 0.9rem; font-family: var(--serif); font-size: 1.25rem; color: var(--charcoal); }
+.cartpage__summary .btn { margin-top: 1rem; }
+.summary__note { font-size: 0.8rem; margin-top: 1rem; }
+.cartpage__empty { text-align: center; padding: 4rem 1rem; }
+.cartpage__empty .btn { margin-top: 1.5rem; }
+.cartpage__empty .muted { margin-top: 0.6rem; }
+
+/* ---------- editorial / about ---------- */
+.lede-block { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(2rem, 5vw, 4rem); align-items: center; }
+.lede-block__art { aspect-ratio: 4/4.4; background: linear-gradient(180deg, var(--oatmeal), var(--sand)); border-radius: var(--radius); display: grid; place-items: center; padding: 2rem; }
+.lede-block__art svg { width: 70%; filter: drop-shadow(0 18px 26px rgba(44,44,41,0.16)); }
+.prose { max-width: 60ch; }
+.prose p + p { margin-top: 1.1rem; }
+.prose h3 { font-size: 1.5rem; margin: 2rem 0 0.7rem; }
+.values { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(1.5rem, 4vw, 3rem); }
+.value h3 { font-size: 1.2rem; margin-bottom: 0.5rem; }
+.value__mark { width: 40px; height: 40px; margin-bottom: 1rem; color: var(--accent); }
+
+/* ---------- contact ---------- */
+.contact-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(2rem, 5vw, 4rem); align-items: start; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1.2rem; }
+.field--full { grid-column: 1 / -1; }
+.form .field { margin-bottom: 1.2rem; }
+.form input, .form textarea, .form select {
+  padding: 0.75rem 0.9rem; border: 1px solid var(--line-strong); background: var(--paper);
+  border-radius: var(--radius); font: inherit; color: var(--ink); width: 100%;
+}
+.form input:focus, .form textarea:focus, .form select:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+.form textarea { resize: vertical; min-height: 130px; }
+.form .field__label { font-size: 0.78rem; letter-spacing: 0.06em; text-transform: none; color: var(--ink); margin-bottom: 0.4rem; }
+.form-status { margin-top: 1rem; padding: 0.9rem 1.1rem; border: 1px solid var(--accent); background: rgba(126,138,111,0.1); border-radius: var(--radius); font-size: 0.9rem; display: none; }
+.form-status.is-visible { display: block; }
+.studio-card { border: 1px solid var(--line); background: var(--warm-white); padding: clamp(1.5rem, 3vw, 2rem); border-radius: var(--radius); }
+.studio-card__map { background: var(--paper); border: 1px solid var(--line); border-radius: var(--radius); margin-bottom: 1.5rem; }
+.studio-card h3 { font-size: 1.25rem; margin-bottom: 0.4rem; }
+.hours { margin-top: 1.2rem; }
+.hours li { display: flex; justify-content: space-between; padding: 0.45rem 0; border-bottom: 1px solid var(--line); font-size: 0.92rem; }
+.hours li span:last-child { color: var(--muted); }
+.lead-note { margin-top: 1.3rem; font-size: 0.88rem; color: var(--muted); font-style: italic; }
+
+/* ---------- footer ---------- */
+.site-footer { border-top: 1px solid var(--line); background: var(--warm-white); margin-top: 2rem; }
+.footer__grid { display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; gap: 2rem; padding-block: clamp(3rem, 6vw, 4.5rem); }
+.footer__brand .brand__name { font-size: 1.3rem; }
+.footer__about { margin-top: 1rem; max-width: 34ch; color: var(--muted); font-size: 0.92rem; }
+.footer__col h4 { font-size: 0.72rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--charcoal); margin-bottom: 1rem; font-family: var(--sans); font-weight: 600; }
+.footer__col li { margin-bottom: 0.6rem; }
+.footer__col a { font-size: 0.92rem; color: var(--ink); }
+.footer__col a:hover { color: var(--clay); }
+.footer__bottom { border-top: 1px solid var(--line); padding-block: 1.4rem; display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap; font-size: 0.82rem; color: var(--muted); }
+
+/* ---------- responsive ---------- */
+@media (max-width: 900px) {
+  .hero__inner { grid-template-columns: 1fr; }
+  .hero__stage { order: -1; max-width: 360px; }
+  .collections { grid-template-columns: repeat(2, 1fr); }
+  .process, .values { grid-template-columns: 1fr; gap: 2rem; }
+  .modal__grid { grid-template-columns: 1fr; }
+  .modal__media { border-right: none; border-bottom: 1px solid var(--line); }
+  .lede-block, .contact-grid, .cartpage__grid { grid-template-columns: 1fr; }
+  .cartpage__summary { position: static; }
+  .footer__grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 720px) {
+  .nav-toggle {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 42px; height: 42px; border: none; background: transparent; border-radius: 50%;
+  }
+  .nav-toggle:hover { background: var(--oatmeal); }
+  .site-nav {
+    position: absolute; top: 76px; left: 0; right: 0; background: var(--paper);
+    border-bottom: 1px solid var(--line); padding: 0.5rem var(--gutter) 1.2rem;
+    display: none; box-shadow: 0 20px 40px rgba(44,44,41,0.1);
+  }
+  .site-nav.is-open { display: block; }
+  .site-nav ul { flex-direction: column; gap: 0; }
+  .site-nav li { border-bottom: 1px solid var(--line); }
+  .site-nav a { display: block; padding: 0.9rem 0; }
+  .form-row { grid-template-columns: 1fr; }
+  .footer__grid { grid-template-columns: 1fr; }
+  .toolbar { align-items: stretch; }
+  .toolbar__filters { width: 100%; }
+  .field { flex: 1; }
+}
+@media (max-width: 460px) {
+  .card__actions { flex-direction: column; }
+  .line { grid-template-columns: 52px 1fr; }
+  .line__subtotal { grid-column: 2; grid-row: auto; margin-top: 0.4rem; }
+  .line__media { width: 52px; height: 52px; }
+}
+
+/* ---------- motion preference ---------- */
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; scroll-behavior: auto !important; }
+}

--- a/fixtures/websites/78-terra-ceramics/fixture.json
+++ b/fixtures/websites/78-terra-ceramics/fixture.json
@@ -1,0 +1,16 @@
+{
+  "class": "ecommerce/catalog",
+  "tags": [
+    "ecommerce",
+    "ceramics",
+    "has-cart",
+    "add-to-cart",
+    "glaze-variants",
+    "filters",
+    "sorting",
+    "mini-cart",
+    "multipage",
+    "localstorage"
+  ],
+  "complexity": 3
+}

--- a/fixtures/websites/78-terra-ceramics/index.html
+++ b/fixtures/websites/78-terra-ceramics/index.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terra &amp; Form — Handmade Ceramics</title>
+  <meta name="description" content="Terra &amp; Form is a small studio making hand-thrown stoneware for everyday rituals — tableware, mugs, vases, bowls and quiet decorative objects.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main" style="position:absolute;left:-999px;">Skip to content</a>
+
+  <header class="site-header">
+    <div class="wrap site-header__inner">
+      <a class="brand" href="index.html" aria-label="Terra and Form, home">
+        <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+          <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+          <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+          <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+        </svg>
+        <span class="brand__name">Terra &amp; Form<small>Handmade Ceramics</small></span>
+      </a>
+
+      <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="siteNav">
+        <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="#2c2c29" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>
+      </button>
+
+      <nav class="site-nav" id="siteNav" aria-label="Primary">
+        <ul>
+          <li><a href="index.html" aria-current="page">Home</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+
+      <div class="header__tools">
+        <button class="icon-btn" id="cartButton" aria-label="Open cart">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1.2 11a2 2 0 0 1-2 1.8H9.2a2 2 0 0 1-2-1.8L6 7Z" fill="none" stroke="#2c2c29" stroke-width="1.3"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="#2c2c29" stroke-width="1.3"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- HERO -->
+    <section class="hero">
+      <div class="wrap hero__inner">
+        <div class="hero__copy">
+          <p class="eyebrow">Small-batch stoneware</p>
+          <h1 class="hero__title">Objects made <em>by hand</em>, for everyday rituals.</h1>
+          <p class="hero__lede">Each piece is thrown on the wheel in our studio, glazed in muted earthtones, and made to be used — morning coffee, an evening meal, a single stem on the sill.</p>
+          <div class="hero__actions">
+            <a class="btn btn--solid btn--lg" href="shop.html">Shop the studio</a>
+            <a class="btn btn--quiet btn--lg" href="about.html">Our process</a>
+          </div>
+        </div>
+        <div class="hero__stage">
+          <svg viewBox="0 0 200 220" role="img" aria-label="A hand-thrown pedestal vase on a plinth">
+            <path d="M70 44 L66 70 Q44 92 44 124 Q44 158 100 160 Q156 158 156 124 Q156 92 134 70 L130 44 Z" fill="#efe7d8" stroke="#2c2c29" stroke-width="1.2"/>
+            <rect x="92" y="160" width="16" height="10" fill="#cbbda4"/>
+            <path d="M78 172 L122 172 L132 186 L68 186 Z" fill="#f7f3ec" stroke="#2c2c29" stroke-width="1.1"/>
+            <ellipse cx="100" cy="44" rx="30" ry="8" fill="#cbbda4"/>
+            <ellipse cx="100" cy="44" rx="30" ry="6.5" fill="#f4ece0"/>
+            <path d="M62 118 Q100 126 138 118" fill="none" stroke="#cbbda4" stroke-width="1.4" opacity="0.7"/>
+          </svg>
+          <span class="hero__pedestal" aria-hidden="true"></span>
+        </div>
+      </div>
+    </section>
+
+    <!-- FEATURED -->
+    <section class="section">
+      <div class="wrap">
+        <div class="section__head">
+          <div>
+            <p class="eyebrow">New in the studio</p>
+            <h2 class="section__title">Latest <em>pieces</em></h2>
+          </div>
+          <a class="linklike" href="shop.html">View all pieces &rarr;</a>
+        </div>
+        <div class="grid" id="featuredGrid"><!-- featured cards injected --></div>
+      </div>
+    </section>
+
+    <!-- COLLECTIONS -->
+    <section class="section section--tint">
+      <div class="wrap">
+        <div class="section__head">
+          <div>
+            <p class="eyebrow">Browse by form</p>
+            <h2 class="section__title">Collections</h2>
+          </div>
+        </div>
+        <div class="collections">
+          <a class="collection" href="shop.html?category=Tableware">
+            <span class="collection__art"><svg viewBox="0 0 120 90" aria-hidden="true"><ellipse cx="60" cy="55" rx="46" ry="15" fill="#e3d8c5" stroke="#2c2c29" stroke-width="1"/><ellipse cx="60" cy="51" rx="46" ry="13" fill="#efe7d8"/><ellipse cx="60" cy="51" rx="28" ry="8" fill="#d6c3a5" opacity="0.6"/></svg></span>
+            <h3 class="collection__name">Tableware</h3>
+            <p class="collection__count">Plates &amp; platters</p>
+          </a>
+          <a class="collection" href="shop.html?category=Mugs &amp; Cups">
+            <span class="collection__art"><svg viewBox="0 0 120 90" aria-hidden="true"><path d="M44 24 L44 70 Q44 76 50 76 L78 76 Q84 76 84 70 L84 24 Z" fill="#a7b09a" stroke="#2c2c29" stroke-width="1"/><path d="M84 36 Q104 38 104 52 Q104 66 84 64" fill="none" stroke="#2c2c29" stroke-width="4" stroke-linecap="round"/></svg></span>
+            <h3 class="collection__name">Mugs &amp; Cups</h3>
+            <p class="collection__count">For coffee &amp; tea</p>
+          </a>
+          <a class="collection" href="shop.html?category=Vases">
+            <span class="collection__art"><svg viewBox="0 0 120 90" aria-hidden="true"><path d="M52 12 L50 34 Q36 46 36 62 Q36 80 60 82 Q84 80 84 62 Q84 46 70 34 L68 12 Z" fill="#b07a5c" stroke="#2c2c29" stroke-width="1"/><ellipse cx="60" cy="12" rx="8" ry="2.5" fill="#8a5a40"/></svg></span>
+            <h3 class="collection__name">Vases</h3>
+            <p class="collection__count">For stems &amp; branches</p>
+          </a>
+          <a class="collection" href="shop.html?category=Decor">
+            <span class="collection__art"><svg viewBox="0 0 120 90" aria-hidden="true"><path d="M48 18 L40 56 Q38 80 60 84 Q82 80 80 56 L70 18 Q60 12 48 18 Z" fill="#b9b6ad" stroke="#2c2c29" stroke-width="1"/><path d="M60 14 L60 84" stroke="#8a857a" stroke-width="1" opacity="0.5"/></svg></span>
+            <h3 class="collection__name">Decor</h3>
+            <p class="collection__count">Objects for the shelf</p>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- PROCESS -->
+    <section class="section">
+      <div class="wrap">
+        <div class="section__head">
+          <div>
+            <p class="eyebrow">From the wheel</p>
+            <h2 class="section__title">The maker's <em>process</em></h2>
+            <p class="section__intro">Nothing here is mass-produced. Every piece passes through the same slow sequence of hands, heat, and time.</p>
+          </div>
+        </div>
+        <div class="process">
+          <div class="process__step">
+            <span class="process__num">i.</span>
+            <h3>Throwing</h3>
+            <p>We wedge local stoneware and throw each form on the wheel — centring, opening, and pulling the walls until the shape feels right in the hand.</p>
+          </div>
+          <div class="process__step">
+            <span class="process__num">ii.</span>
+            <h3>Trimming &amp; drying</h3>
+            <p>Once leather-hard, each piece is trimmed, footed, and left to dry slowly before its first bisque firing to a stable, porous state.</p>
+          </div>
+          <div class="process__step">
+            <span class="process__num">iii.</span>
+            <h3>Glaze &amp; fire</h3>
+            <p>We mix our own muted glazes and fire to 1240&deg;C. The kiln has the final word — small variations are kept, not corrected.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- NEWSLETTER -->
+    <section class="section section--tint">
+      <div class="wrap newsletter">
+        <p class="eyebrow">Studio letter</p>
+        <h2 class="section__title">First look at new <em>kiln loads</em></h2>
+        <p class="section__intro" style="margin-inline:auto;">Small batches sell quickly. Join the list for early access, restock notes, and the occasional studio second.</p>
+        <form class="newsletter__form" id="newsletterForm" onsubmit="event.preventDefault(); this.reset(); this.querySelector('button').textContent='Subscribed';">
+          <label class="field__label" for="newsletterEmail" style="position:absolute;left:-999px;">Email address</label>
+          <input type="email" id="newsletterEmail" name="email" placeholder="you@example.com" required>
+          <button type="submit" class="btn btn--solid">Subscribe</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer__grid">
+      <div class="footer__brand">
+        <a class="brand" href="index.html" aria-label="Terra and Form, home">
+          <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+            <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+            <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+            <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+          </svg>
+          <span class="brand__name">Terra &amp; Form</span>
+        </a>
+        <p class="footer__about">A small ceramics studio making hand-thrown stoneware for the table and the home. Made to order, made to last.</p>
+      </div>
+      <div class="footer__col">
+        <h4>Shop</h4>
+        <ul>
+          <li><a href="shop.html?category=Tableware">Tableware</a></li>
+          <li><a href="shop.html?category=Mugs &amp; Cups">Mugs &amp; Cups</a></li>
+          <li><a href="shop.html?category=Vases">Vases</a></li>
+          <li><a href="shop.html?category=Bowls">Bowls</a></li>
+          <li><a href="shop.html?category=Decor">Decor</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Studio</h4>
+        <ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#process">Materials &amp; process</a></li>
+          <li><a href="contact.html">Visit the studio</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Care</h4>
+        <ul>
+          <li><a href="about.html#ethos">Made to order</a></li>
+          <li><a href="contact.html">Lead times</a></li>
+          <li><a href="contact.html">Wholesale</a></li>
+          <li><a href="cart.html">Your cart</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="wrap footer__bottom">
+      <span>&copy; <span data-year>2026</span> Terra &amp; Form. Hand-thrown in the studio.</span>
+      <span>Free shipping on orders over $150</span>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/fixtures/websites/78-terra-ceramics/js/app.js
+++ b/fixtures/websites/78-terra-ceramics/js/app.js
@@ -1,0 +1,613 @@
+/* Terra & Form — UI logic: vessel SVGs, catalog render/filter/sort,
+ * product modal, mini-cart drawer, and full cart page.
+ * Everything is guarded for per-page DOM and wired on DOMContentLoaded.
+ */
+(function (window, document) {
+  'use strict';
+
+  /* ---------- utilities ---------- */
+
+  function money(n) {
+    return '$' + Number(n).toFixed(2);
+  }
+
+  function glazeFill(name) {
+    return (window.GLAZES && window.GLAZES[name]) || '#d6c3a5';
+  }
+
+  // Slightly darker tone for shading/pooling, derived from the glaze hex.
+  function shade(hex, amt) {
+    var h = hex.replace('#', '');
+    var r = parseInt(h.substring(0, 2), 16);
+    var g = parseInt(h.substring(2, 4), 16);
+    var b = parseInt(h.substring(4, 6), 16);
+    r = Math.max(0, Math.min(255, Math.round(r + amt)));
+    g = Math.max(0, Math.min(255, Math.round(g + amt)));
+    b = Math.max(0, Math.min(255, Math.round(b + amt)));
+    function p(v) { return ('0' + v.toString(16)).slice(-2); }
+    return '#' + p(r) + p(g) + p(b);
+  }
+
+  function byId(id) { return document.getElementById(id); }
+
+  function findProduct(id) {
+    var list = window.PRODUCTS || [];
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].id === id) return list[i];
+    }
+    return null;
+  }
+
+  /* ---------- vessel SVG generator ----------
+   * Returns an <svg> string. Each `shape` draws a distinct silhouette so the
+   * grid reads like a gallery. `glaze` picks the fill; shade() adds pooling.
+   */
+  function renderVessel(shape, glazeName) {
+    var fill = glazeFill(glazeName);
+    var deep = shade(fill, -28);
+    var light = shade(fill, 22);
+    var line = '#2c2c29';
+    var s = '';
+    var shadow = '<ellipse cx="100" cy="178" rx="58" ry="9" fill="rgba(44,44,41,0.10)"/>';
+
+    switch (shape) {
+      case 'plate':
+        s = shadow +
+          '<ellipse cx="100" cy="120" rx="78" ry="26" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<ellipse cx="100" cy="116" rx="78" ry="24" fill="' + light + '"/>' +
+          '<ellipse cx="100" cy="116" rx="52" ry="15" fill="' + deep + '" opacity="0.55"/>' +
+          '<ellipse cx="100" cy="114" rx="52" ry="14" fill="' + fill + '"/>';
+        break;
+      case 'platter':
+        s = shadow +
+          '<ellipse cx="100" cy="124" rx="86" ry="30" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<ellipse cx="100" cy="119" rx="86" ry="27" fill="' + light + '"/>' +
+          '<ellipse cx="100" cy="120" rx="58" ry="17" fill="' + deep + '" opacity="0.5"/>';
+        break;
+      case 'bowl':
+        s = shadow +
+          '<path d="M40 92 Q100 96 160 92 Q150 156 100 158 Q50 156 40 92 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<ellipse cx="100" cy="92" rx="60" ry="16" fill="' + deep + '" opacity="0.55"/>' +
+          '<ellipse cx="100" cy="92" rx="60" ry="14" fill="' + light + '"/>';
+        break;
+      case 'tumbler':
+        s = shadow +
+          '<path d="M64 64 Q60 110 70 158 L130 158 Q140 110 136 64 Q100 56 64 64 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<ellipse cx="100" cy="64" rx="36" ry="9" fill="' + deep + '" opacity="0.55"/>' +
+          '<ellipse cx="100" cy="64" rx="36" ry="8" fill="' + light + '"/>' +
+          '<path d="M74 100 Q100 104 126 100" fill="none" stroke="' + deep + '" stroke-width="1" opacity="0.4"/>';
+        break;
+      case 'mug':
+        s = shadow +
+          '<path d="M62 60 L62 152 Q62 160 70 160 L122 160 Q130 160 130 152 L130 60 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<path d="M130 78 Q166 80 166 108 Q166 136 130 134" fill="none" stroke="' + line + '" stroke-width="7" stroke-linecap="round"/>' +
+          '<ellipse cx="96" cy="60" rx="34" ry="9" fill="' + deep + '" opacity="0.55"/>' +
+          '<ellipse cx="96" cy="60" rx="34" ry="8" fill="' + light + '"/>';
+        break;
+      case 'espresso':
+        s = shadow +
+          '<ellipse cx="100" cy="150" rx="50" ry="12" fill="' + light + '" stroke="' + line + '" stroke-width="1.1"/>' +
+          '<path d="M76 96 L80 138 Q80 144 88 144 L112 144 Q120 144 120 138 L124 96 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<path d="M124 104 Q150 106 150 122 Q150 136 124 134" fill="none" stroke="' + line + '" stroke-width="5" stroke-linecap="round"/>' +
+          '<ellipse cx="100" cy="96" rx="24" ry="6" fill="' + deep + '" opacity="0.55"/>';
+        break;
+      case 'budvase':
+        s = shadow +
+          '<path d="M86 50 L84 78 Q66 96 66 124 Q66 160 100 162 Q134 160 134 124 Q134 96 116 78 L114 50 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<ellipse cx="100" cy="50" rx="14" ry="5" fill="' + deep + '" opacity="0.6"/>' +
+          '<path d="M70 132 Q100 138 130 132" fill="none" stroke="' + light + '" stroke-width="2" opacity="0.6"/>';
+        break;
+      case 'pedestal':
+        s = shadow +
+          '<path d="M70 44 L66 70 Q44 92 44 124 Q44 158 100 160 Q156 158 156 124 Q156 92 134 70 L130 44 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<rect x="92" y="160" width="16" height="10" fill="' + deep + '"/>' +
+          '<path d="M78 172 L122 172 L132 184 L68 184 Z" fill="' + light + '" stroke="' + line + '" stroke-width="1.1"/>' +
+          '<ellipse cx="100" cy="44" rx="30" ry="8" fill="' + deep + '" opacity="0.55"/>' +
+          '<ellipse cx="100" cy="44" rx="30" ry="7" fill="' + light + '"/>';
+        break;
+      case 'ikebana':
+        s = shadow +
+          '<path d="M44 110 Q100 96 156 110 Q150 150 100 152 Q50 150 44 110 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<ellipse cx="100" cy="110" rx="56" ry="14" fill="' + deep + '" opacity="0.6"/>' +
+          '<ellipse cx="100" cy="110" rx="56" ry="12" fill="' + shade(fill, -10) + '"/>';
+        break;
+      case 'nesting':
+        s = shadow +
+          '<path d="M52 118 Q100 122 148 118 Q140 158 100 160 Q60 158 52 118 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<path d="M64 96 Q100 100 136 96 Q130 124 100 126 Q70 124 64 96 Z" fill="' + light + '" stroke="' + line + '" stroke-width="1.1"/>' +
+          '<path d="M76 76 Q100 80 124 76 Q120 96 100 98 Q80 96 76 76 Z" fill="' + shade(fill, 10) + '" stroke="' + line + '" stroke-width="1"/>';
+        break;
+      case 'dish':
+        s = shadow +
+          '<ellipse cx="100" cy="128" rx="64" ry="20" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<ellipse cx="100" cy="124" rx="64" ry="18" fill="' + light + '"/>' +
+          '<ellipse cx="100" cy="124" rx="40" ry="10" fill="' + deep + '" opacity="0.5"/>' +
+          '<circle cx="100" cy="124" r="3" fill="' + line + '"/>';
+        break;
+      case 'sculpture':
+        s = shadow +
+          '<path d="M74 52 L62 110 Q58 150 100 158 Q142 150 138 110 L120 52 Q100 44 74 52 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<path d="M100 50 L100 158" stroke="' + deep + '" stroke-width="1" opacity="0.4"/>' +
+          '<path d="M74 52 L80 156" stroke="' + light + '" stroke-width="1.5" opacity="0.6"/>' +
+          '<path d="M120 52 L122 156" stroke="' + deep + '" stroke-width="1.5" opacity="0.45"/>';
+        break;
+      case 'teapot':
+        s = shadow +
+          '<path d="M52 110 Q52 70 100 70 Q148 70 148 110 Q148 150 100 152 Q52 150 52 110 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>' +
+          '<path d="M148 100 Q176 96 182 72" fill="none" stroke="' + line + '" stroke-width="7" stroke-linecap="round"/>' +
+          '<path d="M52 96 Q26 92 24 116" fill="none" stroke="' + line + '" stroke-width="6" stroke-linecap="round"/>' +
+          '<path d="M82 70 Q100 62 118 70 L112 58 Q100 54 88 58 Z" fill="' + light + '" stroke="' + line + '" stroke-width="1.1"/>' +
+          '<circle cx="100" cy="56" r="4" fill="' + deep + '"/>';
+        break;
+      default:
+        s = shadow +
+          '<path d="M64 64 Q60 110 70 158 L130 158 Q140 110 136 64 Q100 56 64 64 Z" fill="' + fill + '" stroke="' + line + '" stroke-width="1.2"/>';
+    }
+
+    return '<svg viewBox="0 0 200 200" role="img" aria-hidden="true" preserveAspectRatio="xMidYMid meet">' + s + '</svg>';
+  }
+  window.renderVessel = renderVessel;
+
+  /* ---------- header / badge / mobile nav ---------- */
+
+  function initHeader() {
+    var badges = document.querySelectorAll('[data-cart-count]');
+    if (badges.length && window.Cart) {
+      window.Cart.onChange(function () {
+        var c = window.Cart.count();
+        for (var i = 0; i < badges.length; i++) {
+          badges[i].textContent = c;
+          badges[i].setAttribute('data-empty', c === 0 ? 'true' : 'false');
+        }
+      });
+    }
+
+    var toggle = byId('navToggle');
+    var nav = byId('siteNav');
+    if (toggle && nav) {
+      toggle.addEventListener('click', function () {
+        var open = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      });
+    }
+
+    var cartBtn = byId('cartButton');
+    if (cartBtn) {
+      cartBtn.addEventListener('click', function () { openDrawer(); });
+    }
+  }
+
+  /* ---------- product card ---------- */
+
+  function cardHTML(p) {
+    return '' +
+      '<article class="card" data-id="' + p.id + '">' +
+        '<button class="card__media" data-open="' + p.id + '" aria-label="View ' + p.name + '">' +
+          '<span class="card__vessel">' + renderVessel(p.shape, p.glaze) + '</span>' +
+          (p.featured ? '<span class="card__tag">New</span>' : '') +
+        '</button>' +
+        '<div class="card__body">' +
+          '<p class="card__cat">' + p.category + '</p>' +
+          '<h3 class="card__name"><button class="linklike" data-open="' + p.id + '">' + p.name + '</button></h3>' +
+          '<p class="card__price">' + money(p.price) + '</p>' +
+          '<div class="card__actions">' +
+            '<button class="btn btn--quiet" data-open="' + p.id + '">Details</button>' +
+            '<button class="btn btn--solid" data-add="' + p.id + '">Add to cart</button>' +
+          '</div>' +
+        '</div>' +
+      '</article>';
+  }
+
+  function bindGrid(container) {
+    container.addEventListener('click', function (e) {
+      var openEl = e.target.closest('[data-open]');
+      if (openEl) { openModal(openEl.getAttribute('data-open')); return; }
+      var addEl = e.target.closest('[data-add]');
+      if (addEl) {
+        var p = findProduct(addEl.getAttribute('data-add'));
+        if (p && window.Cart) {
+          var defVariant = p.variants ? p.variants.options[0] : '';
+          window.Cart.add(p, defVariant, 1);
+          openDrawer();
+        }
+      }
+    });
+  }
+
+  /* ---------- home: featured row + collections ---------- */
+
+  function initHome() {
+    var feat = byId('featuredGrid');
+    if (feat) {
+      var featured = (window.PRODUCTS || []).filter(function (p) { return p.featured; }).slice(0, 4);
+      feat.innerHTML = featured.map(cardHTML).join('');
+      bindGrid(feat);
+    }
+  }
+
+  /* ---------- shop: filter + sort ---------- */
+
+  function initShop() {
+    var grid = byId('shopGrid');
+    if (!grid) return;
+
+    var catSel = byId('filterCategory');
+    var priceSel = byId('filterPrice');
+    var sortSel = byId('sortBy');
+    var countEl = byId('resultCount');
+
+    bindGrid(grid);
+
+    function priceMatch(p, token) {
+      if (token === 'all') return true;
+      if (token === 'u30') return p.price < 30;
+      if (token === '30-60') return p.price >= 30 && p.price <= 60;
+      if (token === '60-90') return p.price > 60 && p.price <= 90;
+      if (token === 'o90') return p.price > 90;
+      return true;
+    }
+
+    function apply() {
+      var cat = catSel ? catSel.value : 'all';
+      var priceTok = priceSel ? priceSel.value : 'all';
+      var sort = sortSel ? sortSel.value : 'newest';
+
+      var list = (window.PRODUCTS || []).filter(function (p) {
+        return (cat === 'all' || p.category === cat) && priceMatch(p, priceTok);
+      });
+
+      list.sort(function (a, b) {
+        switch (sort) {
+          case 'price-asc':  return a.price - b.price;
+          case 'price-desc': return b.price - a.price;
+          case 'name':       return a.name.localeCompare(b.name);
+          case 'newest':
+          default:           return b.added - a.added;
+        }
+      });
+
+      grid.innerHTML = list.length
+        ? list.map(cardHTML).join('')
+        : '<p class="empty">No pieces match these filters. Try widening your search.</p>';
+
+      if (countEl) {
+        countEl.textContent = list.length + (list.length === 1 ? ' piece' : ' pieces');
+      }
+    }
+
+    [catSel, priceSel, sortSel].forEach(function (el) {
+      if (el) el.addEventListener('change', apply);
+    });
+
+    // Optional category deep-link via ?category=Vases
+    var params = new URLSearchParams(window.location.search);
+    var qc = params.get('category');
+    if (qc && catSel) {
+      for (var i = 0; i < catSel.options.length; i++) {
+        if (catSel.options[i].value === qc) { catSel.value = qc; break; }
+      }
+    }
+
+    apply();
+  }
+
+  /* ---------- product modal ---------- */
+
+  var modalState = { id: null, variant: null, qty: 1, lastFocus: null };
+
+  function ensureModal() {
+    var modal = byId('productModal');
+    if (modal) return modal;
+    modal = document.createElement('div');
+    modal.id = 'productModal';
+    modal.className = 'modal';
+    modal.setAttribute('hidden', '');
+    modal.innerHTML =
+      '<div class="modal__backdrop" data-close-modal></div>' +
+      '<div class="modal__panel" role="dialog" aria-modal="true" aria-labelledby="modalName">' +
+        '<button class="modal__close" data-close-modal aria-label="Close details">&times;</button>' +
+        '<div class="modal__grid">' +
+          '<div class="modal__media" id="modalMedia"></div>' +
+          '<div class="modal__info">' +
+            '<p class="modal__cat" id="modalCat"></p>' +
+            '<h2 class="modal__name" id="modalName"></h2>' +
+            '<p class="modal__price" id="modalPrice"></p>' +
+            '<p class="modal__desc" id="modalDesc"></p>' +
+            '<dl class="modal__meta"><dt>Dimensions</dt><dd id="modalDims"></dd></dl>' +
+            '<div class="modal__variant" id="modalVariantWrap">' +
+              '<label class="field__label" id="modalVariantLabel" for="modalVariant"></label>' +
+              '<div class="swatches" id="modalSwatches"></div>' +
+            '</div>' +
+            '<div class="modal__buy">' +
+              '<div class="stepper" role="group" aria-label="Quantity">' +
+                '<button class="stepper__btn" data-qty="-1" aria-label="Decrease quantity">&minus;</button>' +
+                '<span class="stepper__val" id="modalQty" aria-live="polite">1</span>' +
+                '<button class="stepper__btn" data-qty="1" aria-label="Increase quantity">+</button>' +
+              '</div>' +
+              '<button class="btn btn--solid btn--lg" id="modalAdd">Add to cart</button>' +
+            '</div>' +
+            '<p class="modal__note">Each piece is thrown by hand and made to order — slight variations in form and glaze are part of the work.</p>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(modal);
+
+    modal.addEventListener('click', function (e) {
+      if (e.target.closest('[data-close-modal]')) closeModal();
+      var q = e.target.closest('[data-qty]');
+      if (q) {
+        modalState.qty = Math.max(1, modalState.qty + parseInt(q.getAttribute('data-qty'), 10));
+        byId('modalQty').textContent = modalState.qty;
+      }
+      var sw = e.target.closest('[data-swatch]');
+      if (sw) {
+        modalState.variant = sw.getAttribute('data-swatch');
+        var all = modal.querySelectorAll('[data-swatch]');
+        for (var i = 0; i < all.length; i++) {
+          all[i].setAttribute('aria-pressed', all[i] === sw ? 'true' : 'false');
+        }
+        var p = findProduct(modalState.id);
+        if (p) byId('modalMedia').innerHTML = renderVessel(p.shape, GLAZES[modalState.variant] ? modalState.variant : p.glaze);
+      }
+    });
+
+    byId('modalAdd').addEventListener('click', function () {
+      var p = findProduct(modalState.id);
+      if (p && window.Cart) {
+        window.Cart.add(p, modalState.variant || '', modalState.qty);
+        closeModal();
+        openDrawer();
+      }
+    });
+
+    return modal;
+  }
+
+  function openModal(id) {
+    var p = findProduct(id);
+    if (!p) return;
+    var modal = ensureModal();
+    modalState.id = id;
+    modalState.qty = 1;
+    modalState.variant = p.variants ? p.variants.options[0] : '';
+    modalState.lastFocus = document.activeElement;
+
+    byId('modalCat').textContent = p.category;
+    byId('modalName').textContent = p.name;
+    byId('modalPrice').textContent = money(p.price);
+    byId('modalDesc').textContent = p.description;
+    byId('modalDims').textContent = p.dimensions;
+    byId('modalQty').textContent = '1';
+    byId('modalMedia').innerHTML = renderVessel(p.shape, p.glaze);
+
+    var wrap = byId('modalVariantWrap');
+    if (p.variants) {
+      wrap.removeAttribute('hidden');
+      byId('modalVariantLabel').textContent = p.variants.label;
+      var isGlaze = p.variants.label === 'Glaze';
+      byId('modalSwatches').innerHTML = p.variants.options.map(function (opt, idx) {
+        var pressed = idx === 0 ? 'true' : 'false';
+        if (isGlaze) {
+          return '<button class="swatch" data-swatch="' + opt + '" aria-pressed="' + pressed + '" title="' + opt + '">' +
+            '<span class="swatch__dot" style="background:' + glazeFill(opt) + '"></span>' +
+            '<span class="swatch__name">' + opt + '</span></button>';
+        }
+        return '<button class="swatch swatch--text" data-swatch="' + opt + '" aria-pressed="' + pressed + '">' + opt + '</button>';
+      }).join('');
+    } else {
+      wrap.setAttribute('hidden', '');
+    }
+
+    modal.removeAttribute('hidden');
+    document.body.classList.add('no-scroll');
+    requestAnimationFrame(function () { modal.classList.add('is-open'); });
+    var closeBtn = modal.querySelector('.modal__close');
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeModal() {
+    var modal = byId('productModal');
+    if (!modal || modal.hasAttribute('hidden')) return;
+    modal.classList.remove('is-open');
+    document.body.classList.remove('no-scroll');
+    window.setTimeout(function () { modal.setAttribute('hidden', ''); }, 200);
+    if (modalState.lastFocus && modalState.lastFocus.focus) modalState.lastFocus.focus();
+  }
+
+  /* ---------- mini-cart drawer ---------- */
+
+  function ensureDrawer() {
+    var drawer = byId('cartDrawer');
+    if (drawer) return drawer;
+    drawer = document.createElement('div');
+    drawer.id = 'cartDrawer';
+    drawer.className = 'drawer';
+    drawer.setAttribute('hidden', '');
+    drawer.innerHTML =
+      '<div class="drawer__backdrop" data-close-drawer></div>' +
+      '<aside class="drawer__panel" role="dialog" aria-modal="true" aria-label="Shopping cart">' +
+        '<header class="drawer__head">' +
+          '<h2 class="drawer__title">Your cart</h2>' +
+          '<button class="drawer__close" data-close-drawer aria-label="Close cart">&times;</button>' +
+        '</header>' +
+        '<div class="drawer__body" id="drawerBody"></div>' +
+        '<footer class="drawer__foot" id="drawerFoot"></footer>' +
+      '</aside>';
+    document.body.appendChild(drawer);
+
+    drawer.addEventListener('click', function (e) {
+      if (e.target.closest('[data-close-drawer]')) { closeDrawer(); return; }
+      var inc = e.target.closest('[data-inc]');
+      if (inc) { window.Cart.increment(inc.getAttribute('data-inc'), parseInt(inc.getAttribute('data-step'), 10)); return; }
+      var rm = e.target.closest('[data-remove]');
+      if (rm) { window.Cart.remove(rm.getAttribute('data-remove')); return; }
+    });
+
+    if (window.Cart) {
+      window.Cart.onChange(function () {
+        if (!drawer.hasAttribute('hidden')) renderDrawer();
+      });
+    }
+    return drawer;
+  }
+
+  function lineRowHTML(it, opts) {
+    opts = opts || {};
+    var variant = it.variant ? '<span class="line__variant">' + it.variant + '</span>' : '';
+    return '' +
+      '<div class="line">' +
+        '<span class="line__media">' + renderVessel(it.shape, it.glaze) + '</span>' +
+        '<div class="line__main">' +
+          '<p class="line__name">' + it.name + '</p>' +
+          variant +
+          '<p class="line__price">' + money(it.price) + '</p>' +
+        '</div>' +
+        '<div class="line__controls">' +
+          '<div class="stepper stepper--sm" role="group" aria-label="Quantity for ' + it.name + '">' +
+            '<button class="stepper__btn" data-inc="' + it.key + '" data-step="-1" aria-label="Decrease quantity">&minus;</button>' +
+            '<span class="stepper__val">' + it.qty + '</span>' +
+            '<button class="stepper__btn" data-inc="' + it.key + '" data-step="1" aria-label="Increase quantity">+</button>' +
+          '</div>' +
+          '<button class="line__remove" data-remove="' + it.key + '" aria-label="Remove ' + it.name + '">Remove</button>' +
+        '</div>' +
+        '<p class="line__subtotal">' + money(it.price * it.qty) + '</p>' +
+      '</div>';
+  }
+
+  function renderDrawer() {
+    var body = byId('drawerBody');
+    var foot = byId('drawerFoot');
+    if (!body || !foot) return;
+    var items = window.Cart.items();
+    if (!items.length) {
+      body.innerHTML = '<div class="drawer__empty"><p>Your cart is empty.</p><p class="muted">Pieces you add will appear here.</p></div>';
+      foot.innerHTML = '<a class="btn btn--solid btn--block" href="shop.html">Browse the shop</a>';
+      return;
+    }
+    body.innerHTML = items.map(function (it) { return lineRowHTML(it); }).join('');
+    foot.innerHTML =
+      '<div class="drawer__total"><span>Subtotal</span><span>' + money(window.Cart.total()) + '</span></div>' +
+      '<p class="drawer__ship muted">Shipping &amp; made-to-order lead times calculated at checkout.</p>' +
+      '<a class="btn btn--solid btn--block" href="cart.html">View cart</a>';
+  }
+
+  function openDrawer() {
+    var drawer = ensureDrawer();
+    renderDrawer();
+    drawer.removeAttribute('hidden');
+    document.body.classList.add('no-scroll');
+    requestAnimationFrame(function () { drawer.classList.add('is-open'); });
+    var closeBtn = drawer.querySelector('.drawer__close');
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeDrawer() {
+    var drawer = byId('cartDrawer');
+    if (!drawer || drawer.hasAttribute('hidden')) return;
+    drawer.classList.remove('is-open');
+    document.body.classList.remove('no-scroll');
+    window.setTimeout(function () { drawer.setAttribute('hidden', ''); }, 200);
+  }
+
+  /* ---------- full cart page ---------- */
+
+  function initCartPage() {
+    var root = byId('cartPage');
+    if (!root) return;
+
+    root.addEventListener('click', function (e) {
+      var inc = e.target.closest('[data-inc]');
+      if (inc) { window.Cart.increment(inc.getAttribute('data-inc'), parseInt(inc.getAttribute('data-step'), 10)); return; }
+      var rm = e.target.closest('[data-remove]');
+      if (rm) { window.Cart.remove(rm.getAttribute('data-remove')); return; }
+      if (e.target.closest('[data-clear]')) { window.Cart.clear(); return; }
+    });
+
+    function render() {
+      var items = window.Cart.items();
+      if (!items.length) {
+        root.innerHTML =
+          '<div class="cartpage__empty">' +
+            '<h1 class="section__title">Your cart is empty</h1>' +
+            '<p class="muted">Nothing here yet — find a piece for your table.</p>' +
+            '<a class="btn btn--solid" href="shop.html">Browse the shop</a>' +
+          '</div>';
+        return;
+      }
+      var lines = items.map(function (it) { return lineRowHTML(it); }).join('');
+      root.innerHTML =
+        '<div class="cartpage__grid">' +
+          '<div class="cartpage__lines">' +
+            '<div class="cartpage__lines-head"><h1 class="section__title">Your cart</h1>' +
+              '<button class="linklike" data-clear>Clear cart</button></div>' +
+            lines +
+          '</div>' +
+          '<aside class="cartpage__summary">' +
+            '<h2 class="summary__title">Order summary</h2>' +
+            '<div class="summary__row"><span>Subtotal</span><span>' + money(window.Cart.total()) + '</span></div>' +
+            '<div class="summary__row muted"><span>Shipping</span><span>Calculated at checkout</span></div>' +
+            '<div class="summary__row summary__row--total"><span>Total</span><span>' + money(window.Cart.total()) + '</span></div>' +
+            '<button class="btn btn--solid btn--block" id="checkoutBtn">Proceed to checkout</button>' +
+            '<a class="btn btn--quiet btn--block" href="shop.html">Continue shopping</a>' +
+            '<p class="muted summary__note">Made-to-order pieces ship in 3–5 weeks. We will confirm your lead time by email.</p>' +
+          '</aside>' +
+        '</div>';
+      var co = byId('checkoutBtn');
+      if (co) co.addEventListener('click', function () {
+        co.textContent = 'Thank you — this is a demo';
+        co.disabled = true;
+      });
+    }
+
+    window.Cart.onChange(render);
+  }
+
+  /* ---------- contact form (demo) ---------- */
+
+  function initContact() {
+    var form = byId('contactForm');
+    if (!form) return;
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var status = byId('contactStatus');
+      if (status) {
+        status.textContent = 'Thank you — your message has been noted. This is a demo form, so nothing was sent.';
+        status.classList.add('is-visible');
+      }
+      form.reset();
+    });
+  }
+
+  /* ---------- global key handling ---------- */
+
+  function initKeys() {
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        closeModal();
+        closeDrawer();
+      }
+    });
+  }
+
+  /* ---------- footer year ---------- */
+
+  function initYear() {
+    var els = document.querySelectorAll('[data-year]');
+    var y = new Date().getFullYear();
+    for (var i = 0; i < els.length; i++) els[i].textContent = y;
+  }
+
+  /* ---------- boot ---------- */
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initHeader();
+    initHome();
+    initShop();
+    initCartPage();
+    initContact();
+    initKeys();
+    initYear();
+    ensureDrawer(); // pre-build so badge-driven open is instant
+  });
+
+})(window, document);

--- a/fixtures/websites/78-terra-ceramics/js/cart.js
+++ b/fixtures/websites/78-terra-ceramics/js/cart.js
@@ -1,0 +1,130 @@
+/* Terra & Form — cart state, shared across all pages.
+ * Persists to localStorage under "terra_cart". Other scripts subscribe to
+ * Cart.onChange() to keep the header badge, drawer, and cart page in sync.
+ */
+(function (window) {
+  'use strict';
+
+  var STORAGE_KEY = 'terra_cart';
+  var listeners = [];
+
+  // A line item is keyed by product id + chosen variant so different glazes
+  // of the same piece stack separately.
+  function lineKey(id, variant) {
+    return id + '::' + (variant || '');
+  }
+
+  function read() {
+    try {
+      var raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      var parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function write(items) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    } catch (e) {
+      /* storage unavailable — keep working in-memory for this page */
+    }
+    emit();
+  }
+
+  function emit() {
+    var snapshot = read();
+    for (var i = 0; i < listeners.length; i++) {
+      try { listeners[i](snapshot); } catch (e) { /* keep others alive */ }
+    }
+  }
+
+  var Cart = {
+    STORAGE_KEY: STORAGE_KEY,
+
+    items: function () {
+      return read();
+    },
+
+    count: function () {
+      return read().reduce(function (sum, it) { return sum + it.qty; }, 0);
+    },
+
+    total: function () {
+      return read().reduce(function (sum, it) { return sum + it.price * it.qty; }, 0);
+    },
+
+    add: function (product, variant, qty) {
+      qty = Math.max(1, parseInt(qty, 10) || 1);
+      var items = read();
+      var key = lineKey(product.id, variant);
+      var existing = null;
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].key === key) { existing = items[i]; break; }
+      }
+      if (existing) {
+        existing.qty += qty;
+      } else {
+        items.push({
+          key: key,
+          id: product.id,
+          name: product.name,
+          price: product.price,
+          category: product.category,
+          shape: product.shape,
+          glaze: variant && window.GLAZES && window.GLAZES[variant] ? variant : product.glaze,
+          variant: variant || '',
+          qty: qty
+        });
+      }
+      write(items);
+    },
+
+    setQty: function (key, qty) {
+      qty = parseInt(qty, 10) || 0;
+      var items = read();
+      if (qty <= 0) {
+        items = items.filter(function (it) { return it.key !== key; });
+      } else {
+        for (var i = 0; i < items.length; i++) {
+          if (items[i].key === key) { items[i].qty = qty; break; }
+        }
+      }
+      write(items);
+    },
+
+    increment: function (key, delta) {
+      var items = read();
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].key === key) {
+          Cart.setQty(key, items[i].qty + delta);
+          return;
+        }
+      }
+    },
+
+    remove: function (key) {
+      write(read().filter(function (it) { return it.key !== key; }));
+    },
+
+    clear: function () {
+      write([]);
+    },
+
+    onChange: function (fn) {
+      if (typeof fn === 'function') {
+        listeners.push(fn);
+        fn(read()); // fire immediately with current state
+      }
+    }
+  };
+
+  // Sync across tabs/pages.
+  window.addEventListener('storage', function (e) {
+    if (e.key === STORAGE_KEY) emit();
+  });
+
+  window.Cart = Cart;
+})(window);

--- a/fixtures/websites/78-terra-ceramics/js/products.js
+++ b/fixtures/websites/78-terra-ceramics/js/products.js
@@ -1,0 +1,196 @@
+/* Terra & Form — product catalog data
+ * Each product renders as a varied inline SVG vessel. The `shape` + `glaze`
+ * fields drive the SVG generator in app.js so the grid reads like a gallery.
+ * Glaze palette tokens map to fills in renderVessel().
+ */
+
+// Glaze swatch tokens -> hex. Muted, dusty earthtone glazes.
+const GLAZES = {
+  Oatmeal:  '#e3d8c5',
+  Sage:     '#a7b09a',
+  Charcoal: '#3f3f3c',
+  Rust:     '#b07a5c',
+  Sand:     '#d6c3a5',
+  Ash:      '#b9b6ad',
+  Cream:    '#efe7d8',
+  Clay:     '#c08a6a'
+};
+
+// `added` is a sortable index — higher = newer in the studio.
+const PRODUCTS = [
+  {
+    id: 'tf-01',
+    name: 'Oatmeal Dinner Plate',
+    category: 'Tableware',
+    price: 48,
+    added: 13,
+    featured: true,
+    shape: 'plate',
+    glaze: 'Oatmeal',
+    dimensions: '27 cm diameter · 2.5 cm high',
+    description: 'A generous hand-thrown dinner plate finished in a soft matte oatmeal glaze. Subtle throwing rings catch the light at the rim. Lead-free, food-safe, dishwasher friendly.',
+    variants: { label: 'Glaze', options: ['Oatmeal', 'Sage', 'Charcoal'] }
+  },
+  {
+    id: 'tf-02',
+    name: 'Sage Breakfast Bowl',
+    category: 'Bowls',
+    price: 36,
+    added: 12,
+    featured: true,
+    shape: 'bowl',
+    glaze: 'Sage',
+    dimensions: '15 cm diameter · 7 cm deep',
+    description: 'A deep everyday bowl glazed in dusty sage that pools darker toward the foot. Thrown on the wheel and trimmed by hand for a comfortable lifted base.',
+    variants: { label: 'Glaze', options: ['Sage', 'Oatmeal', 'Rust'] }
+  },
+  {
+    id: 'tf-03',
+    name: 'Stoneware Tumbler',
+    category: 'Mugs & Cups',
+    price: 28,
+    added: 11,
+    featured: false,
+    shape: 'tumbler',
+    glaze: 'Sand',
+    dimensions: '8 cm diameter · 10 cm high · 300 ml',
+    description: 'A handleless tumbler with a gently tapered waist that sits easily in the hand. Speckled stoneware body under a translucent sand glaze.',
+    variants: { label: 'Glaze', options: ['Sand', 'Charcoal', 'Sage'] }
+  },
+  {
+    id: 'tf-04',
+    name: 'Charcoal Coffee Mug',
+    category: 'Mugs & Cups',
+    price: 34,
+    added: 10,
+    featured: true,
+    shape: 'mug',
+    glaze: 'Charcoal',
+    dimensions: '9 cm diameter · 9 cm high · 350 ml',
+    description: 'A morning mug with a full pulled handle and a satin charcoal glaze that breaks to warm brown over the throwing marks. Holds a proper cup of coffee.',
+    variants: { label: 'Glaze', options: ['Charcoal', 'Rust', 'Oatmeal'] }
+  },
+  {
+    id: 'tf-05',
+    name: 'Bud Vase',
+    category: 'Vases',
+    price: 42,
+    added: 9,
+    featured: false,
+    shape: 'budvase',
+    glaze: 'Rust',
+    dimensions: '7 cm diameter · 14 cm high',
+    description: 'A slim bud vase for a single stem or a small foraged sprig. Narrow neck, rounded belly, soft rust glaze with a wax-resist line at the foot.',
+    variants: { label: 'Glaze', options: ['Rust', 'Sage', 'Charcoal'] }
+  },
+  {
+    id: 'tf-06',
+    name: 'Pedestal Vase',
+    category: 'Vases',
+    price: 96,
+    added: 8,
+    featured: true,
+    shape: 'pedestal',
+    glaze: 'Cream',
+    dimensions: '16 cm diameter · 28 cm high',
+    description: 'A statement vase thrown in two sections and joined at the waist, raised on a turned pedestal foot. A quiet cream glaze keeps the focus on the form.',
+    variants: { label: 'Size', options: ['Medium', 'Large'] }
+  },
+  {
+    id: 'tf-07',
+    name: 'Serving Platter',
+    category: 'Tableware',
+    price: 72,
+    added: 7,
+    featured: false,
+    shape: 'platter',
+    glaze: 'Ash',
+    dimensions: '34 cm diameter · 3 cm high',
+    description: 'A wide low platter for sharing — bread, fruit, or a roast at the centre of the table. Hand-trimmed rim with a soft ash glaze that pools into the well.',
+    variants: { label: 'Glaze', options: ['Ash', 'Oatmeal', 'Sage'] }
+  },
+  {
+    id: 'tf-08',
+    name: 'Nesting Prep Bowls',
+    category: 'Bowls',
+    price: 64,
+    added: 6,
+    featured: false,
+    shape: 'nesting',
+    glaze: 'Clay',
+    dimensions: 'Set of three · 11 / 14 / 17 cm',
+    description: 'A set of three nesting prep bowls thrown to stack neatly on the shelf. Warm clay glaze with bare unglazed rims that show the speckled body.',
+    variants: { label: 'Glaze', options: ['Clay', 'Sage', 'Charcoal'] }
+  },
+  {
+    id: 'tf-09',
+    name: 'Espresso Cup & Saucer',
+    category: 'Mugs & Cups',
+    price: 30,
+    added: 5,
+    featured: false,
+    shape: 'espresso',
+    glaze: 'Oatmeal',
+    dimensions: '6 cm cup · 11 cm saucer · 90 ml',
+    description: 'A small thrown espresso cup with a matching saucer, finished in a creamy oatmeal glaze. The handle is pulled thin to keep the cup feeling delicate.',
+    variants: { label: 'Glaze', options: ['Oatmeal', 'Charcoal', 'Rust'] }
+  },
+  {
+    id: 'tf-10',
+    name: 'Ikebana Vessel',
+    category: 'Vases',
+    price: 58,
+    added: 4,
+    featured: false,
+    shape: 'ikebana',
+    glaze: 'Sage',
+    dimensions: '18 cm wide · 9 cm high',
+    description: 'A low wide-mouthed vessel made for minimal ikebana arrangements. Matte sage glaze outside, glossy pooled glaze inside the shallow well.',
+    variants: { label: 'Glaze', options: ['Sage', 'Ash', 'Rust'] }
+  },
+  {
+    id: 'tf-11',
+    name: 'Incense Holder',
+    category: 'Decor',
+    price: 24,
+    added: 3,
+    featured: false,
+    shape: 'dish',
+    glaze: 'Rust',
+    dimensions: '10 cm diameter · 2 cm high',
+    description: 'A small round dish with a hand-pierced centre to hold a single incense stick, with a raised lip to catch the ash. Warm rust glaze, unglazed foot.',
+    variants: { label: 'Glaze', options: ['Rust', 'Charcoal', 'Sage'] }
+  },
+  {
+    id: 'tf-12',
+    name: 'Sculptural Object',
+    category: 'Decor',
+    price: 88,
+    added: 2,
+    featured: false,
+    shape: 'sculpture',
+    glaze: 'Ash',
+    dimensions: '12 cm wide · 20 cm high',
+    description: 'A purely sculptural thrown-and-altered form for the shelf or mantel. No two are alike — each is pushed and faceted by hand while the clay is soft.',
+    variants: { label: 'Size', options: ['Small', 'Large'] }
+  },
+  {
+    id: 'tf-13',
+    name: 'Tea Pot',
+    category: 'Tableware',
+    price: 110,
+    added: 1,
+    featured: true,
+    shape: 'teapot',
+    glaze: 'Charcoal',
+    dimensions: '18 cm wide · 14 cm high · 700 ml',
+    description: 'A round-bodied teapot with a pulled handle, thrown spout, and fitted lid. Satin charcoal glaze. Pours cleanly and keeps two cups hot.',
+    variants: { label: 'Glaze', options: ['Charcoal', 'Sage', 'Clay'] }
+  }
+];
+
+// Expose for non-module scripts.
+if (typeof window !== 'undefined') {
+  window.PRODUCTS = PRODUCTS;
+  window.GLAZES = GLAZES;
+}

--- a/fixtures/websites/78-terra-ceramics/shop.html
+++ b/fixtures/websites/78-terra-ceramics/shop.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shop — Terra &amp; Form</title>
+  <meta name="description" content="Browse hand-thrown stoneware tableware, mugs, vases, bowls and decor. Filter by category and price, sort by what suits you.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap site-header__inner">
+      <a class="brand" href="index.html" aria-label="Terra and Form, home">
+        <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+          <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+          <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+          <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+        </svg>
+        <span class="brand__name">Terra &amp; Form<small>Handmade Ceramics</small></span>
+      </a>
+      <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="siteNav">
+        <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="#2c2c29" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>
+      </button>
+      <nav class="site-nav" id="siteNav" aria-label="Primary">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="shop.html" aria-current="page">Shop</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="header__tools">
+        <button class="icon-btn" id="cartButton" aria-label="Open cart">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1.2 11a2 2 0 0 1-2 1.8H9.2a2 2 0 0 1-2-1.8L6 7Z" fill="none" stroke="#2c2c29" stroke-width="1.3"/><path d="M9 7a3 3 0 0 1 6 0" fill="none" stroke="#2c2c29" stroke-width="1.3"/></svg>
+          <span class="cart-badge" data-cart-count data-empty="true">0</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="wrap shop-head">
+      <p class="eyebrow">The shop</p>
+      <h1 class="section__title">Every piece in the <em>studio</em></h1>
+      <p class="section__intro">Hand-thrown stoneware, glazed in muted earthtones. Filter and sort to find your piece — each one is made to order.</p>
+    </section>
+
+    <section class="wrap">
+      <div class="toolbar">
+        <div class="toolbar__filters">
+          <div class="field">
+            <label class="field__label" for="filterCategory">Category</label>
+            <select id="filterCategory">
+              <option value="all">All categories</option>
+              <option value="Tableware">Tableware</option>
+              <option value="Mugs &amp; Cups">Mugs &amp; Cups</option>
+              <option value="Vases">Vases</option>
+              <option value="Bowls">Bowls</option>
+              <option value="Decor">Decor</option>
+            </select>
+          </div>
+          <div class="field">
+            <label class="field__label" for="filterPrice">Price</label>
+            <select id="filterPrice">
+              <option value="all">Any price</option>
+              <option value="u30">Under $30</option>
+              <option value="30-60">$30 – $60</option>
+              <option value="60-90">$60 – $90</option>
+              <option value="o90">Over $90</option>
+            </select>
+          </div>
+          <div class="field">
+            <label class="field__label" for="sortBy">Sort by</label>
+            <select id="sortBy">
+              <option value="newest">Newest</option>
+              <option value="price-asc">Price: low to high</option>
+              <option value="price-desc">Price: high to low</option>
+              <option value="name">Name: A to Z</option>
+            </select>
+          </div>
+        </div>
+        <p class="toolbar__meta"><span id="resultCount">0 pieces</span></p>
+      </div>
+
+      <div class="grid" id="shopGrid" style="padding-bottom: clamp(3.5rem, 8vw, 6rem);"><!-- product cards injected --></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer__grid">
+      <div class="footer__brand">
+        <a class="brand" href="index.html" aria-label="Terra and Form, home">
+          <svg class="brand__mark" viewBox="0 0 40 40" aria-hidden="true">
+            <circle cx="20" cy="20" r="19" fill="none" stroke="#2c2c29" stroke-width="1.2"/>
+            <path d="M14 13 Q12 24 17 30 L23 30 Q28 24 26 13 Q20 10 14 13 Z" fill="#b07a5c"/>
+            <ellipse cx="20" cy="13" rx="6" ry="1.8" fill="#7e8a6f"/>
+          </svg>
+          <span class="brand__name">Terra &amp; Form</span>
+        </a>
+        <p class="footer__about">A small ceramics studio making hand-thrown stoneware for the table and the home. Made to order, made to last.</p>
+      </div>
+      <div class="footer__col">
+        <h4>Shop</h4>
+        <ul>
+          <li><a href="shop.html?category=Tableware">Tableware</a></li>
+          <li><a href="shop.html?category=Mugs &amp; Cups">Mugs &amp; Cups</a></li>
+          <li><a href="shop.html?category=Vases">Vases</a></li>
+          <li><a href="shop.html?category=Bowls">Bowls</a></li>
+          <li><a href="shop.html?category=Decor">Decor</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Studio</h4>
+        <ul>
+          <li><a href="about.html">Our story</a></li>
+          <li><a href="about.html#process">Materials &amp; process</a></li>
+          <li><a href="contact.html">Visit the studio</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer__col">
+        <h4>Care</h4>
+        <ul>
+          <li><a href="about.html#ethos">Made to order</a></li>
+          <li><a href="contact.html">Lead times</a></li>
+          <li><a href="contact.html">Wholesale</a></li>
+          <li><a href="cart.html">Your cart</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="wrap footer__bottom">
+      <span>&copy; <span data-year>2026</span> Terra &amp; Form. Hand-thrown in the studio.</span>
+      <span>Free shipping on orders over $150</span>
+    </div>
+  </footer>
+
+  <script src="js/products.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds 5 realistic static e-commerce shops (coffee, books, sneakers, plants, ceramics) to `fixtures/websites/` to strengthen the thin `ecommerce/catalog` lane and exercise dynamic store features (cart, qty steppers, live filter/sort, variant/size selectors, mini-cart drawer, localStorage cart).

Generated by a WordPress-blind design agent (no transformer/blocks context) so the markup is authentic real-world commerce HTML, not transformer-friendly. Each carries a `fixture.json` (`class: ecommerce/catalog` + feature tags). Data only — no source changes.