### PR TITLE
Surface data-entry forms as materializable form findings

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1412,34 +1412,40 @@ final class HtmlTransformer
                 'required_scripts' => $this->requiredScriptsForElement($element),
             ));
 
-            if ( null !== $readableFormBlock ) {
-                return $readableFormBlock;
+            // Surface a form fallback finding so a downstream consumer can map the
+            // preserved control structure onto a working form provider. This fires
+            // when the form has no readable representation (legacy behavior) and
+            // also when the form collects user input, so a standard data-entry
+            // <form> that still renders as readable fallback content is detectable
+            // as a materializable form rather than silently flattened into prose.
+            // Carrying the generic control list (tag/type/name/required/options)
+            // keeps the transformer free of any provider or plugin knowledge.
+            if ( null === $readableFormBlock || $this->formHasDataEntryControls($element) ) {
+                $fallbacks[] = FallbackDiagnostic::build(array(
+                    'type'            => 'html',
+                    'reason'          => 'form_requires_runtime',
+                    'diagnostic_code' => 'html_form_fallback',
+                    'message'         => 'Form HTML requires runtime behavior and was preserved as safe fallback metadata.',
+                    'source_format'   => 'html',
+                    'tag'             => $tagName,
+                    'selector'        => $this->elementSelector($element),
+                    'attributes'      => $this->htmlAttributes($element),
+                    'form'            => $this->formMetadata($element),
+                    'context'         => $this->sourceContext($element),
+                    'classification'  => $this->fallbackEmitter->classifyFallbackSubtree($element),
+                    'events'          => $this->eventMetadata($element),
+                    'readable_blocks' => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
+                    'controls'        => $controls,
+                    'control_count'   => count($controls),
+                    'text_length'     => strlen(trim($element->textContent ?? '')),
+                    'child_count'     => $this->childElementCount($element),
+                    'html'            => $boundedHtml['html'],
+                    'html_bytes'      => $boundedHtml['bytes'],
+                    'html_truncated'  => $boundedHtml['truncated'],
+                ), $this->fallbackProvenance);
             }
 
-            $fallbacks[] = FallbackDiagnostic::build(array(
-                'type'            => 'html',
-                'reason'          => 'form_requires_runtime',
-                'diagnostic_code' => 'html_form_fallback',
-                'message'         => 'Form HTML requires runtime behavior and was preserved as safe fallback metadata.',
-                'source_format'   => 'html',
-                'tag'             => $tagName,
-                'selector'        => $this->elementSelector($element),
-                'attributes'      => $this->htmlAttributes($element),
-                'form'            => $this->formMetadata($element),
-                'context'         => $this->sourceContext($element),
-                'classification'  => $this->fallbackEmitter->classifyFallbackSubtree($element),
-                'events'          => $this->eventMetadata($element),
-                'readable_blocks' => null !== $readableFormBlock ? array( $readableFormBlock ) : array(),
-                'controls'        => $controls,
-                'control_count'   => count($controls),
-                'text_length'     => strlen(trim($element->textContent ?? '')),
-                'child_count'     => $this->childElementCount($element),
-                'html'            => $boundedHtml['html'],
-                'html_bytes'      => $boundedHtml['bytes'],
-                'html_truncated'  => $boundedHtml['truncated'],
-            ), $this->fallbackProvenance);
-
-            return null;
+            return $readableFormBlock;
         }
 
         if ( 'nav' === $tagName ) {
@@ -3615,7 +3621,57 @@ final class HtmlTransformer
     {
         return 0 < $form->getElementsByTagName('script')->length
             || array() !== $this->eventMetadata($form)
-            || array() !== $this->formMetadata($form);
+            || array() !== $this->formMetadata($form)
+            || $this->formHasDataEntryControls($form);
+    }
+
+    /**
+     * Whether a form collects user input through at least one data-entry control.
+     *
+     * A <form> that gathers data (text/email/select/textarea and similar) needs a
+     * real form runtime to submit, validate, and notify — even when it declares no
+     * action/method/script/event handler (common in static exports and design
+     * mockups where submission is wired downstream). Such a form must be preserved
+     * as a runtime island carrying its control structure rather than flattened to
+     * readable prose, so a consumer can materialize it into a working form. Keying
+     * off the control structure keeps this generic: no provider, plugin, or site
+     * knowledge leaks into the transformer.
+     */
+    private function formHasDataEntryControls(DOMElement $form): bool
+    {
+        foreach ( $this->formControlElements($form) as $control ) {
+            if ( $this->isDataEntryControl($control) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether a control collects user input (as opposed to a submit/reset/button,
+     * hidden state, file upload, or image button).
+     *
+     * The excluded set mirrors the controls a form provider cannot map to a data
+     * field, so a form whose only controls are non-data-entry stays a readable
+     * fallback instead of becoming an empty preserved island.
+     */
+    private function isDataEntryControl(DOMElement $control): bool
+    {
+        $tagName = strtolower($control->tagName);
+        if ( in_array($tagName, array( 'select', 'textarea' ), true) ) {
+            return true;
+        }
+
+        if ( 'input' !== $tagName ) {
+            return false;
+        }
+
+        return ! in_array(
+            $this->formControlType($control),
+            array( 'submit', 'reset', 'button', 'image', 'hidden', 'file' ),
+            true
+        );
     }
 
     private function isReadableFormControl(DOMElement $control): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -385,8 +385,12 @@ $formFallback = ( new HtmlTransformer() )->transform(
 )->toArray();
 $formRuntimeIsland = $formFallback['source_reports']['runtime_islands'][0] ?? array();
 $formFallbackBlocks = $formFallback['blocks'][0]['innerBlocks'] ?? array();
-$assert(array() === ($formFallback['fallbacks'] ?? array()), 'readable runtime form converts without unsupported fallback diagnostics');
-$assert(array() === ($formFallback['source_reports']['conversion_report']['fallback_diagnostics'] ?? array()), 'readable runtime form is not projected as a fallback diagnostic');
+$formFallbackDiagnostic = $formFallback['fallbacks'][0] ?? array();
+$assert(1 === count($formFallback['fallbacks'] ?? array()), 'data-entry runtime form surfaces a materializable form fallback finding');
+$assert('html_form_fallback' === ($formFallbackDiagnostic['diagnostic_code'] ?? ''), 'data-entry runtime form fallback carries the form diagnostic code');
+$assert('email' === ($formFallbackDiagnostic['controls'][0]['name'] ?? ''), 'data-entry runtime form fallback carries generic control metadata');
+$assert('/contact' === ($formFallbackDiagnostic['form']['action'] ?? ''), 'data-entry runtime form fallback carries form action metadata');
+$assertNormalizedFallbackDiagnostic($formFallback['source_reports']['conversion_report']['fallback_diagnostics'][0] ?? array(), 'html_form_fallback', 'warning', 'server_or_client_form_handler', 'form');
 $assert('core/group' === ($formFallback['blocks'][0]['blockName'] ?? ''), 'runtime form materializes readable control blocks');
 $assert('core/paragraph' === ($formFallbackBlocks[0]['blockName'] ?? ''), 'runtime form exposes readable input text');
 $assert('core/group' === ($formFallbackBlocks[1]['blockName'] ?? ''), 'runtime form exposes readable select options');

--- a/php-transformer/tests/fixtures/parity/artifact-runtime-target-container-preservation.json
+++ b/php-transformer/tests/fixtures/parity/artifact-runtime-target-container-preservation.json
@@ -30,7 +30,7 @@
     }
   },
   "expect": [
-    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "status", "assert": "equals", "value": "success_with_warnings" },
     { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" },
     { "path": "source_reports.runtime_dependency_parity.dependencies", "assert": "count", "count": 17 },
     { "path": "serialized_blocks", "assert": "contains", "value": "reveal" },

--- a/php-transformer/tests/fixtures/parity/html-actionless-contact-form-materializable.json
+++ b/php-transformer/tests/fixtures/parity/html-actionless-contact-form-materializable.json
@@ -1,0 +1,44 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-actionless-contact-form-materializable",
+  "description": "Surfaces a standard data-entry contact form with no action/method/script as a materializable form finding instead of flattening it to prose.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-actionless-contact-form-materializable.json",
+    "notes": "Static exports and design mockups often omit the form action because submission is wired downstream; the form must still be detectable as a form so a consumer can map it onto a working form provider."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><form class=\"contact-form\"><label for=\"name\">Full Name</label><input type=\"text\" id=\"name\" name=\"name\" placeholder=\"Your name\" required><label for=\"email\">Email Address</label><input type=\"email\" id=\"email\" name=\"email\" placeholder=\"your@email.com\" required><label for=\"subject\">Subject</label><select id=\"subject\" name=\"subject\"><option>Distillery visit</option><option>Wholesale</option><option>Bespoke</option></select><label for=\"message\">Message</label><textarea id=\"message\" name=\"message\" placeholder=\"Your message\" required></textarea><button type=\"submit\">Send Message</button></form></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" }
+  ],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "fallbacks.0.control_count", "assert": "equals", "value": 5 },
+    { "path": "fallbacks.0.controls.0.tag", "assert": "equals", "value": "input" },
+    { "path": "fallbacks.0.controls.0.type", "assert": "equals", "value": "text" },
+    { "path": "fallbacks.0.controls.0.name", "assert": "equals", "value": "name" },
+    { "path": "fallbacks.0.controls.0.required", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.controls.1.type", "assert": "equals", "value": "email" },
+    { "path": "fallbacks.0.controls.2.tag", "assert": "equals", "value": "select" },
+    { "path": "fallbacks.0.controls.2.options.0.label", "assert": "equals", "value": "Distillery visit" },
+    { "path": "fallbacks.0.controls.3.tag", "assert": "equals", "value": "textarea" },
+    { "path": "fallbacks.0.controls.4.type", "assert": "equals", "value": "submit" },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 1 },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "form" },
+    { "path": "source_reports.runtime_islands.0.control_count", "assert": "equals", "value": 5 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Full Name: Your name (required)" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-complex-brand-container.json
+++ b/php-transformer/tests/fixtures/parity/html-complex-brand-container.json
@@ -24,7 +24,9 @@
     { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/paragraph", "attrs": { "className": "success", "content": "You are in." } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "brand", "content": "<span>Simple</span><span>Mark</span>" } }
   ],
-  "expected_fallbacks": [],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback" }
+  ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
@@ -32,7 +34,9 @@
     { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 4 },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },
-    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "fallbacks.0.controls.0.type", "assert": "equals", "value": "email" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"footer-brand\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Dinner plans for busy families." },
     { "path": "serialized_blocks", "assert": "contains", "value": "Email address: you@example.com (required)" }

--- a/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
@@ -39,18 +39,22 @@
     { "path": "blocks.0.innerBlocks.6.innerBlocks.1", "name": "core/code", "attrs": { "className": "language-php", "content": "<?php add_action();" } }
   ],
   "expected_fallbacks": [
+    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback" },
     { "type": "html", "reason": "script_requires_runtime", "tag": "script", "diagnostic_code": "html_script_fallback" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 7 },
-    { "path": "fallbacks", "assert": "count", "count": 1 },
-    { "path": "fallbacks.0.attributes.src", "assert": "equals", "value": "/widget.js" },
-    { "path": "fallbacks.0.context.parent_tag", "assert": "equals", "value": "section" },
-    { "path": "fallbacks.0.html", "assert": "equals", "value": "" },
-    { "path": "fallbacks.0.body", "assert": "equals", "value": "hydrate()" },
-    { "path": "fallbacks.0.body_truncated", "assert": "equals", "value": false },
+    { "path": "fallbacks", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "fallbacks.0.form.action", "assert": "equals", "value": "/signup" },
+    { "path": "fallbacks.0.control_count", "assert": "equals", "value": 2 },
+    { "path": "fallbacks.1.attributes.src", "assert": "equals", "value": "/widget.js" },
+    { "path": "fallbacks.1.context.parent_tag", "assert": "equals", "value": "section" },
+    { "path": "fallbacks.1.html", "assert": "equals", "value": "" },
+    { "path": "fallbacks.1.body", "assert": "equals", "value": "hydrate()" },
+    { "path": "fallbacks.1.body_truncated", "assert": "equals", "value": false },
     { "path": "source_reports.runtime_islands", "assert": "count", "count": 2 },
     { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "form" },
     { "path": "source_reports.runtime_islands.0.preservation_reason", "assert": "equals", "value": "form_requires_runtime" },
@@ -63,9 +67,10 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "<li>Parent<!-- wp:list -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "theme.json" },
     { "path": "serialized_blocks", "assert": "contains", "value": "functions.php" },
-    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_script_fallback" },
-    { "path": "diagnostics.2.code", "assert": "equals", "value": "preserved_runtime_island" },
-    { "path": "diagnostics.2.kind", "assert": "equals", "value": "form" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+    { "path": "diagnostics.1.code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "diagnostics.2.code", "assert": "equals", "value": "html_script_fallback" },
+    { "path": "diagnostics.3.code", "assert": "equals", "value": "preserved_runtime_island" },
+    { "path": "diagnostics.3.kind", "assert": "equals", "value": "form" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-fallback-metadata.json
@@ -20,11 +20,23 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/group" },
     { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "newsletter" } }
   ],
-  "expected_fallbacks": [],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback" },
+    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback" }
+  ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "fallbacks.0.form.action", "assert": "equals", "value": "/contact" },
+    { "path": "fallbacks.0.control_count", "assert": "equals", "value": 4 },
+    { "path": "fallbacks.0.controls.0.name", "assert": "equals", "value": "name" },
+    { "path": "fallbacks.0.controls.0.required", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.controls.2.tag", "assert": "equals", "value": "textarea" },
+    { "path": "fallbacks.1.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "fallbacks.1.form.action", "assert": "equals", "value": "/newsletter" },
+    { "path": "fallbacks.1.control_count", "assert": "equals", "value": 2 },
     { "path": "source_reports.runtime_islands", "assert": "count", "count": 2 },
     { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "form" },
     { "path": "source_reports.runtime_islands.0.form.action", "assert": "equals", "value": "/contact" },
@@ -38,6 +50,6 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "Email: you@example.com" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Subscribe" },
     { "path": "coverage.0.block_count", "assert": "equals", "value": 1 },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-form-readable-controls.json
@@ -23,11 +23,15 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Newsletter", "level": 2 } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/group" }
   ],
-  "expected_fallbacks": [],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback" }
+  ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "fallbacks.0.controls.0.type", "assert": "equals", "value": "email" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0.blockName", "assert": "equals", "value": "core/paragraph" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0.attrs.content", "assert": "equals", "value": "Email address: you@example.com (required)" },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.1.innerBlocks.0.attrs.text", "assert": "equals", "value": "Subscribe" },

--- a/php-transformer/tests/fixtures/parity/html-unsupported-context-required.json
+++ b/php-transformer/tests/fixtures/parity/html-unsupported-context-required.json
@@ -21,14 +21,17 @@
     { "path": "blocks.0.innerBlocks.1", "name": "core/group" }
   ],
   "expected_fallbacks": [
-    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "custom-card", "selector": "main:nth-of-type(1) > custom-card:nth-of-type(1)", "child_count": 1 }
+    { "type": "unsupported_element", "reason": "unsupported_element", "tag": "custom-card", "selector": "main:nth-of-type(1) > custom-card:nth-of-type(1)", "child_count": 1 },
+    { "type": "html", "reason": "form_requires_runtime", "diagnostic_code": "html_form_fallback" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
-    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 2 },
+    { "path": "fallbacks.1.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "fallbacks.1.controls.0.name", "assert": "equals", "value": "email" },
     { "path": "diagnostics.1.selector", "assert": "equals", "value": "main:nth-of-type(1) > custom-card:nth-of-type(1)" },
     { "path": "serialized_blocks", "assert": "contains", "value": "email" },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 1 }
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 2 }
   ]
 }


### PR DESCRIPTION
## Problem

A standard source HTML `<form>` (text/email inputs, a `<select>`, a `<textarea>`, a submit `<button>`) was being imported as flattened paragraph prose instead of a real form. Observed result from an SSI contact-page import:

```
<p id="cf-name">Name: Your name (required)</p>          (was an <input>)
<p id="cf-email">Email: your@email.com (required)</p>    (was an <input>)
<div id="cf-subject"><p>What's this about?</p><ul>…</ul></div>  (was a <select>)
<p id="cf-message">Message: … (required)</p>            (was a <textarea>)
<a class="wp-block-button__link …">Send Message</a>     (was <button type=submit>)
```

The form structure was destroyed before the consumer (static-site-importer, via PR #490's Jetpack form materializer) ever saw a form to materialize.

## Breakpoint diagnosis (this layer)

PR #490's SSI form materializer consumes `fallbacks` rows with `diagnostic_code === 'html_form_fallback'` (carrying the generic control list) and maps them onto `jetpack/contact-form` + `jetpack/field-*`. The transformer never produced that finding for a standard contact form, for two reasons:

1. **`formRequiresRuntimePreservation()` only matched forms with a script, inline event handler, or `action`/`method`/`enctype`.** A standard static contact form declares none of these (submission is wired downstream), so it took the readable-flatten path with **no runtime island and no fallback at all** — its control structure was lost entirely. This is the literal flattening in the evidence.

2. **`html_form_fallback` was emitted only when a form had no readable representation.** A readable data form recorded a `preserved_runtime_island` (a different collection SSI does not scan for forms) but no `html_form_fallback` finding — so even action-bearing readable contact forms were invisible to the materializer.

## Fix (generic, structure-only)

Keyed entirely off form/control structure so blocks-engine stays free of any Jetpack/SSI/provider knowledge:

- `formHasDataEntryControls()` / `isDataEntryControl()` recognize a form that collects user input: a `<input>` whose type is not `submit`/`reset`/`button`/`image`/`hidden`/`file`, a `<select>`, or a `<textarea>`. Such a form now requires runtime preservation even with no `action`/`method`/script/event handler.
- The form handler emits the `html_form_fallback` finding — carrying the generic controls (`tag`/`type`/`name`/`required`/`options`) and form metadata — whenever the form has no readable representation (unchanged) **or** collects user input, while still returning the readable block as visible fallback content.

Search forms (`core/search`) and single-button action forms keep their prior behavior. The field-type → provider mapping stays downstream in SSI's form adapter, where Jetpack knowledge belongs.

## Field mapping (downstream, unchanged in SSI)

The generic controls this PR surfaces map to: text→`jetpack/field-text`, email→`jetpack/field-email`, select(+options)→`jetpack/field-select`, textarea→`jetpack/field-textarea`, submit→the contact-form submit (`jetpack/button`). Verified end-to-end: feeding this transformer's `html_form_fallback` output through SSI's `materialize_form_findings` yields a real `jetpack/contact-form` with `field-text`/`field-email`/`field-select`/`field-textarea` + submit.

## Tests

- New parity fixture `html-actionless-contact-form-materializable` (the standard action-less contact form → `html_form_fallback` carrying text/email/select/textarea/submit controls).
- Updated the canonical contract test and existing form/runtime parity fixtures to assert the new materializable findings (readable blocks + runtime islands still preserved).
- `composer test` green: 163 parity fixtures + all contract/unit suites. `php -l` clean.

## Known downstream follow-up (separate, not in this PR)

SSI's `materialize_form_findings` records the seeded `jetpack/contact-form` block markup into the import report and marks the finding `runtime_mapped`, but does not yet graft that markup into the page's `post_content` (the page keeps the readable fallback). That page-graft is a pre-existing SSI-side limitation independent of this transformer fix; this PR makes the form detectable and materializable, which is the prerequisite.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (claude-opus-4-8) via Claude Code
- **Used for:** Investigation across blocks-engine + static-site-importer, the transformer fix, and test/fixture updates.