### PR TITLE
figma-transformer: wire Kiwi per-corner radius field names

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -3157,19 +3157,44 @@ final class ScenegraphNormalizer
             }
         }
 
+        $uniformRadius = null;
         if ( isset($node['cornerRadius']) && is_numeric($node['cornerRadius']) ) {
-            $box['corner_radius'] = (float) $node['cornerRadius'];
+            $uniformRadius = (float) $node['cornerRadius'];
         }
 
+        // Per-corner radii arrive under REST API names (`topLeftRadius`) from
+        // remote scenegraphs and under Kiwi names (`rectangleTopLeftCornerRadius`)
+        // from decoded `.fig` archives. Read the REST name first and fall back to
+        // the Kiwi name so mixed-radius nodes survive both ingestion paths.
+        $perCorner = array();
         foreach ( array(
-            'topLeftRadius' => 'top_left_radius',
-            'topRightRadius' => 'top_right_radius',
-            'bottomRightRadius' => 'bottom_right_radius',
-            'bottomLeftRadius' => 'bottom_left_radius',
-        ) as $sourceKey => $targetKey ) {
-            if ( isset($node[$sourceKey]) && is_numeric($node[$sourceKey]) ) {
-                $box[$targetKey] = (float) $node[$sourceKey];
+            'top_left_radius'     => array('topLeftRadius', 'rectangleTopLeftCornerRadius'),
+            'top_right_radius'    => array('topRightRadius', 'rectangleTopRightCornerRadius'),
+            'bottom_right_radius' => array('bottomRightRadius', 'rectangleBottomRightCornerRadius'),
+            'bottom_left_radius'  => array('bottomLeftRadius', 'rectangleBottomLeftCornerRadius'),
+        ) as $targetKey => $sourceKeys ) {
+            foreach ( $sourceKeys as $sourceKey ) {
+                if ( isset($node[$sourceKey]) && is_numeric($node[$sourceKey]) ) {
+                    $perCorner[$targetKey] = (float) $node[$sourceKey];
+                    break;
+                }
             }
+        }
+
+        if ( ! empty($perCorner) ) {
+            // Per-corner values override the uniform radius when present. Fill any
+            // corner the source left unset from the uniform radius so partial
+            // per-corner data still describes the full shape.
+            foreach ( array('top_left_radius', 'top_right_radius', 'bottom_right_radius', 'bottom_left_radius') as $targetKey ) {
+                if ( ! isset($perCorner[$targetKey]) && null !== $uniformRadius ) {
+                    $perCorner[$targetKey] = $uniformRadius;
+                }
+                if ( isset($perCorner[$targetKey]) ) {
+                    $box[$targetKey] = $perCorner[$targetKey];
+                }
+            }
+        } elseif ( null !== $uniformRadius ) {
+            $box['corner_radius'] = $uniformRadius;
         }
 
         return $box;

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4027,6 +4027,43 @@ $assert(null !== $frameStyleDiagnostic, 'node-style-diagnostics-frame-node-prese
 $assert('rgba(51,102,153,0.5)' === ($frameStyleDiagnostic['expected']['background'] ?? null), 'node-style-diagnostics-expected-background');
 $assert('rgba(51,102,153,0.5)' === ($frameStyleDiagnostic['emitted']['background'] ?? null), 'node-style-diagnostics-emitted-background');
 
+// Kiwi-format per-corner radii (the `.fig` ingestion path). Decoded archives carry
+// the Kiwi field names (`rectangleTopLeftCornerRadius`) alongside a uniform
+// `cornerRadius`, where the REST scenegraph would carry `topLeftRadius`. The
+// normalizer must read the Kiwi names and let per-corner values win over the
+// uniform radius so a mixed node (top rounded, bottom square) keeps its shape
+// instead of collapsing to a uniform radius or a square.
+$kiwiRadiusResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Kiwi Corner Radius',
+    'nodes' => array(
+        array(
+            'id'       => '5:1',
+            'type'     => 'FRAME',
+            'name'     => 'Kiwi radius frame',
+            'width'    => 200,
+            'height'   => 200,
+            'children' => array(
+                array(
+                    'id'                               => '5:2',
+                    'type'                             => 'RECTANGLE',
+                    'name'                             => 'Kiwi corner radius',
+                    'width'                            => 160,
+                    'height'                           => 90,
+                    // Uniform value is intentionally wrong; per-corner must override it.
+                    'cornerRadius'                     => 99,
+                    'rectangleTopLeftCornerRadius'     => 8,
+                    'rectangleTopRightCornerRadius'    => 8,
+                    'rectangleBottomRightCornerRadius' => 0,
+                    'rectangleBottomLeftCornerRadius'  => 0,
+                ),
+            ),
+        ),
+    ),
+));
+$kiwiRadiusCss = $fileContent($kiwiRadiusResult, 'style.css');
+$assert(str_contains($kiwiRadiusCss, '.figma-node-5-2-kiwi-corner-radius{width:160px;height:90px;border-top-left-radius:8px;border-top-right-radius:8px;border-bottom-right-radius:0px;border-bottom-left-radius:0px}'), 'kiwi-per-corner-radius-style');
+$assert(! str_contains($kiwiRadiusCss, 'border-radius:99px'), 'kiwi-per-corner-radius-overrides-uniform');
+
 // Inline character-level style overrides (characterStyleOverrides + styleOverrideTable).
 //
 // The Figma API encodes per-character style overrides as a parallel array of integer


### PR DESCRIPTION
## Summary

`figma-transformer` dropped per-corner border radius for `.fig` input. Decoded `.fig` (Kiwi) archives carry per-corner radii under Kiwi field names (`rectangleTopLeftCornerRadius`, etc.), but `ScenegraphNormalizer::normalizeVisualBox()` only read the Figma REST API names (`topLeftRadius`, etc.). As a result, mixed-radius nodes ingested from `.fig` files lost their per-corner values and rendered as a uniform radius or a square.

## What changed

`normalizeVisualBox()` now:

- Reads each corner from the REST name first (existing behavior preserved) and falls back to the Kiwi name:
  | Target | REST name | Kiwi fallback |
  |---|---|---|
  | `top_left_radius` | `topLeftRadius` | `rectangleTopLeftCornerRadius` |
  | `top_right_radius` | `topRightRadius` | `rectangleTopRightCornerRadius` |
  | `bottom_right_radius` | `bottomRightRadius` | `rectangleBottomRightCornerRadius` |
  | `bottom_left_radius` | `bottomLeftRadius` | `rectangleBottomLeftCornerRadius` |
- Lets per-corner values override the uniform `cornerRadius` when present. The HTML emitter's `radiusStyles()` returns the uniform `border-radius` first when `corner_radius` is set, so the normalizer now omits the uniform value whenever any per-corner radius is present, and backfills any unset corner from the uniform value so partial per-corner data still describes the full shape.

Kiwi field names verified against the `NodeChange` field policy in `FigKiwiDecoder.php`.

## Tests

Added a contract fixture in `tests/contract/run.php`: a Kiwi-format node with top corners rounded (8px) and bottom corners square (0px), plus an intentionally wrong uniform `cornerRadius: 99`. Asserts the emitted CSS carries the per-corner `border-*-radius` values and never emits `border-radius:99px`, proving both Kiwi field reading and per-corner precedence over uniform.

```
cd figma-transformer && php tests/contract/run.php
# Figma Transformer contract tests passed.
```

Existing REST-name per-corner and uniform-only fixtures are unchanged and still pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation
