### PR TITLE
figma-transformer: apply gradient transform to compute real CSS gradient angle

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -5430,10 +5430,78 @@ final class StaticHtmlEmitter
         }
 
         if ( 'GRADIENT_RADIAL' === ($paint['type'] ?? null) ) {
+            // Radial center/radius are encoded in the gradientTransform too, but
+            // recovering them faithfully is more involved; emit a centered circle
+            // as the supported baseline.
             return 'radial-gradient(circle,' . implode(',', $cssStops) . ')';
         }
 
-        return 'linear-gradient(180deg,' . implode(',', $cssStops) . ')';
+        return 'linear-gradient(' . $this->number($this->linearGradientAngle($paint)) . 'deg,' . implode(',', $cssStops) . ')';
+    }
+
+    /**
+     * Computes the CSS linear-gradient angle (degrees) for a Figma linear paint
+     * from its gradientTransform matrix.
+     *
+     * Figma encodes gradient direction with a 2x3 affine matrix that maps the
+     * shape's normalized bounding-box space (0..1, y-down) into the gradient's
+     * canonical parameter space, where the gradient runs along x from 0 (start)
+     * to 1 (end) at any y. To recover the start->end direction in the shape's own
+     * space we map the canonical points (0, 0.5) and (1, 0.5) back through the
+     * INVERSE matrix. Their difference equals the first column of the inverse
+     * linear part, (d/det, -c/det), where the linear part is [[a, b], [c, d]] and
+     * det = a*d - b*c.
+     *
+     * CSS linear-gradient angles run clockwise from "to top": 0deg points up,
+     * 90deg right, 180deg down, 270deg left. For a direction vector (dx, dy) in
+     * y-down space the matching angle is atan2(dx, -dy), normalized to [0, 360).
+     * A left-to-right vector (1, 0) yields 90deg; a top-to-bottom vector (0, 1)
+     * yields 180deg.
+     *
+     * Returns 180.0 (top-to-bottom) when no usable transform is present, so paints
+     * without geometry keep the historical default.
+     *
+     * @param array<string, mixed> $paint
+     */
+    private function linearGradientAngle(array $paint): float
+    {
+        $matrix = $paint['gradientTransform'] ?? null;
+        if ( ! is_array($matrix) || ! is_array($matrix[0] ?? null) || ! is_array($matrix[1] ?? null) ) {
+            return 180.0;
+        }
+
+        $a = $this->numericOrNull($matrix[0][0] ?? null);
+        $b = $this->numericOrNull($matrix[0][1] ?? null);
+        $c = $this->numericOrNull($matrix[1][0] ?? null);
+        $d = $this->numericOrNull($matrix[1][1] ?? null);
+        if ( null === $a || null === $b || null === $c || null === $d ) {
+            return 180.0;
+        }
+
+        $det = $a * $d - $b * $c;
+        if ( abs($det) < 1e-9 ) {
+            return 180.0;
+        }
+
+        // First column of the inverse linear part: the start->end direction in
+        // the shape's normalized (y-down) coordinate space.
+        $dx = $d / $det;
+        $dy = -$c / $det;
+        if ( abs($dx) < 1e-9 && abs($dy) < 1e-9 ) {
+            return 180.0;
+        }
+
+        $angle = fmod(rad2deg(atan2($dx, -$dy)), 360.0);
+        if ( $angle < 0.0 ) {
+            $angle += 360.0;
+        }
+
+        return $angle;
+    }
+
+    private function numericOrNull(mixed $value): ?float
+    {
+        return is_numeric($value) ? (float) $value : null;
     }
 
     private function color(mixed $value, mixed $opacity = null): ?string

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3791,6 +3791,50 @@ $gradientPaintResult = blocks_engine_figma_transformer_transform_scenegraph(arra
             ),
         ),
         array(
+            'id'     => 'gradient:linear-h',
+            'type'   => 'RECTANGLE',
+            'name'   => 'Horizontal gradient',
+            'width'  => 120,
+            'height' => 80,
+            'fills'  => array(
+                array(
+                    'type'              => 'GRADIENT_LINEAR',
+                    // Identity gradientTransform: the gradient runs along the
+                    // shape's x-axis, i.e. left-to-right => CSS 90deg.
+                    'gradientTransform' => array(
+                        array(1, 0, 0),
+                        array(0, 1, 0),
+                    ),
+                    'gradientStops'     => array(
+                        array('position' => 0, 'color' => array('r' => 1, 'g' => 0, 'b' => 0, 'a' => 1)),
+                        array('position' => 1, 'color' => array('r' => 0, 'g' => 0, 'b' => 1, 'a' => 1)),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'     => 'gradient:linear-v',
+            'type'   => 'RECTANGLE',
+            'name'   => 'Vertical gradient',
+            'width'  => 110,
+            'height' => 80,
+            'fills'  => array(
+                array(
+                    'type'              => 'GRADIENT_LINEAR',
+                    // A real top-to-bottom Figma transform; the formula must
+                    // still resolve this to CSS 180deg.
+                    'gradientTransform' => array(
+                        array(0, 1, 0),
+                        array(-1, 0, 1),
+                    ),
+                    'gradientStops'     => array(
+                        array('position' => 0, 'color' => array('r' => 1, 'g' => 0, 'b' => 0, 'a' => 1)),
+                        array('position' => 1, 'color' => array('r' => 0, 'g' => 0, 'b' => 1, 'a' => 1)),
+                    ),
+                ),
+            ),
+        ),
+        array(
             'id'     => 'gradient:radial',
             'type'   => 'RECTANGLE',
             'name'   => 'Radial gradient',
@@ -3842,6 +3886,8 @@ $gradientDiagnosticCodes = array_map(
     $gradientPaintResult['diagnostics'] ?? array()
 );
 $assert(str_contains($gradientPaintCss, '.figma-node-gradient-linear-linear-gradient{width:100px;height:80px;background:linear-gradient(180deg,#ff0000 0%,#0000ff 100%)}'), 'linear-gradient-background-emits');
+$assert(str_contains($gradientPaintCss, '.figma-node-gradient-linear-h-horizontal-gradient{width:120px;height:80px;background:linear-gradient(90deg,#ff0000 0%,#0000ff 100%)}'), 'linear-gradient-horizontal-transform-emits-90deg');
+$assert(str_contains($gradientPaintCss, '.figma-node-gradient-linear-v-vertical-gradient{width:110px;height:80px;background:linear-gradient(180deg,#ff0000 0%,#0000ff 100%)}'), 'linear-gradient-vertical-transform-emits-180deg');
 $assert(str_contains($gradientPaintCss, '.figma-node-gradient-radial-radial-gradient{width:90px;height:70px;background:radial-gradient(circle,rgba(0,255,0,0.5) 25%,rgba(0,0,0,0.5) 100%)}'), 'radial-gradient-background-emits');
 $assert(str_contains($gradientPaintCss, '.figma-node-gradient-stroke-gradient-stroke{width:70px;height:60px;border:3px solid transparent;border-image:linear-gradient(180deg,#ffff00 0%,#ff00ff 100%) 1}'), 'linear-gradient-stroke-emits-border-image');
 $assert(in_array('unsupported_figma_paint_type', $gradientDiagnosticCodes, true), 'unsupported-malformed-gradient-diagnostic');


### PR DESCRIPTION
## Problem

The figma-transformer emitted every linear gradient as `linear-gradient(180deg, ...)` regardless of the design's actual direction. The `ScenegraphNormalizer` already preserves the Figma `gradientTransform` (a 2x3 affine matrix) on each gradient paint, but `StaticHtmlEmitter::gradientPaint()` hardcoded `180deg`.

## Fix

`gradientPaint()` now derives the CSS angle from the matrix via a new `linearGradientAngle()` helper.

### Matrix -> angle derivation

Figma's `gradientTransform` maps the shape's normalized bounding-box space (0..1, **y-down**) into the gradient's canonical parameter space, where the gradient runs along x from 0 (start) to 1 (end) at any y. To recover the start->end direction in the shape's own space, map the canonical points `(0, 0.5)` and `(1, 0.5)` back through the **inverse** matrix. Their difference is the first column of the inverse linear part:

```
det = a*d - b*c
dx  =  d / det
dy  = -c / det
```

where the linear part is `[[a, b], [c, d]]`.

CSS `linear-gradient` angles run clockwise from "to top" (`0deg` up, `90deg` right, `180deg` down, `270deg` left). For a y-down direction vector `(dx, dy)` the matching angle is `atan2(dx, -dy)`, normalized to `[0, 360)`.

Verified cases:
- left-to-right `(1, 0)` -> `90deg`
- top-to-bottom `(0, 1)` -> `180deg`
- identity transform -> `90deg` (gradient along the shape's x-axis)

Paints with no usable / degenerate transform fall back to the historical `180deg`, so existing fixtures without geometry are unchanged.

### Radial gradients

Radial gradients still emit a centered `radial-gradient(circle, ...)`. Recovering the radial center/radius from the transform is more involved and is left as a follow-up (noted in code).

## Tests

`figma-transformer/tests/contract/run.php` — added fixtures that run through the full normalize + emit pipeline:
- horizontal gradient with an identity `gradientTransform` asserts `linear-gradient(90deg, ...)`
- vertical gradient with a real top-to-bottom transform asserts `linear-gradient(180deg, ...)`

All existing contract assertions (including the existing `180deg` gradient/stroke cases that carry no transform) still pass.

```
cd figma-transformer && php tests/contract/run.php
# Figma Transformer contract tests passed.
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation