### PR TITLE
figma-transformer: support textCase and paragraphSpacing

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -677,6 +677,13 @@ final class StaticHtmlEmitter
         }
         $nodeStyleDiagnostics[] = $this->nodeStyleDiagnostic($node, $type, $className, $tag, $styles, $parentNode);
 
+        if ( 'TEXT' === $type ) {
+            $paragraphSpacingDiagnostic = $this->paragraphSpacingDiagnostic($node);
+            if ( null !== $paragraphSpacingDiagnostic ) {
+                $diagnostics[] = $paragraphSpacingDiagnostic;
+            }
+        }
+
         $attributes = sprintf(' class="%1$s" data-figma-node-id="%2$s" data-figma-node-name="%3$s"', $className, $id, $attributeName);
         if ( 'RECTANGLE' === $type && '' === $content ) {
             $attributes .= ' aria-hidden="true"';
@@ -3808,6 +3815,41 @@ final class StaticHtmlEmitter
     }
 
     /**
+     * Reports a Figma `paragraphSpacing` value that cannot be applied as CSS.
+     *
+     * Multi-paragraph text nodes are emitted as a single element with
+     * `white-space:pre-line`, so there is no per-paragraph box to carry a
+     * `margin-bottom`. When such a node carries paragraph spacing the value is
+     * surfaced as an `info` diagnostic instead of being faked into the CSS.
+     * Single-paragraph nodes are ignored because paragraph spacing has no effect.
+     *
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>|null
+     */
+    private function paragraphSpacingDiagnostic(array $node): ?array
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $style = is_array($text['style'] ?? null) ? $text['style'] : array();
+        if ( ! isset($style['paragraph_spacing']) || ! is_numeric($style['paragraph_spacing']) || 0.0 >= (float) $style['paragraph_spacing'] ) {
+            return null;
+        }
+
+        if ( ! $this->textHasLineBreaks($node) && ! $this->textHasDerivedLineBreaks($node) ) {
+            return null;
+        }
+
+        return array(
+            'severity' => 'info',
+            'code'     => 'paragraph_spacing_not_applied',
+            'message'  => 'Figma paragraphSpacing cannot be applied to a single-element text node rendered with white-space:pre-line; the value is reported but not emitted as CSS.',
+            'context'  => array(
+                'node_id'           => (string) ($node['id'] ?? ''),
+                'paragraph_spacing' => (float) $style['paragraph_spacing'],
+            ),
+        );
+    }
+
+    /**
      * @param array<string, mixed> $node
      */
     private function textHasLineBreaks(array $node): bool
@@ -3991,6 +4033,20 @@ final class StaticHtmlEmitter
         }
         if ( ! empty($decorations) ) {
             $styles[] = 'text-decoration:' . implode(' ', array_values(array_unique($decorations)));
+        }
+
+        if ( isset($style['text_transform']) && is_scalar($style['text_transform']) ) {
+            $transform = strtolower((string) $style['text_transform']);
+            if ( in_array($transform, array('uppercase', 'lowercase', 'capitalize'), true) ) {
+                $styles[] = 'text-transform:' . $transform;
+            }
+        }
+
+        if ( isset($style['font_variant']) && is_scalar($style['font_variant']) ) {
+            $variant = strtolower((string) $style['font_variant']);
+            if ( 'small-caps' === $variant ) {
+                $styles[] = 'font-variant:' . $variant;
+            }
         }
 
         return $styles;

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1612,6 +1612,34 @@ final class ScenegraphNormalizer
             }
         }
 
+        // Figma `textCase` enum → CSS text-transform / font-variant. ORIGINAL and
+        // absent values keep the native font casing. SMALL_CAPS_FORCED uppercases
+        // before rendering small caps, matching Figma's render behaviour.
+        if ( isset($source['textCase']) && is_scalar($source['textCase']) && '' !== (string) $source['textCase'] ) {
+            $textCase = strtoupper((string) $source['textCase']);
+            $textTransform = match ( $textCase ) {
+                'UPPER'             => 'uppercase',
+                'LOWER'             => 'lowercase',
+                'TITLE'             => 'capitalize',
+                'SMALL_CAPS_FORCED' => 'uppercase',
+                default             => null,
+            };
+            if ( null !== $textTransform ) {
+                $style['text_transform'] = $textTransform;
+            }
+            if ( 'SMALL_CAPS' === $textCase || 'SMALL_CAPS_FORCED' === $textCase ) {
+                $style['font_variant'] = 'small-caps';
+            }
+        }
+
+        // Figma `paragraphSpacing` (px between paragraphs). The emitter renders a
+        // multi-paragraph text node as a single white-space:pre-line element, so
+        // this is captured for downstream consumers and a diagnostic rather than
+        // emitted as CSS that would not apply.
+        if ( isset($source['paragraphSpacing']) && is_numeric($source['paragraphSpacing']) ) {
+            $style['paragraph_spacing'] = (float) $source['paragraphSpacing'];
+        }
+
         return $style;
     }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4106,9 +4106,113 @@ $kiwiRadiusResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         ),
     ),
 ));
+
+// Figma `textCase` enum → CSS text-transform / font-variant, and `paragraphSpacing`
+// surfaced as an info diagnostic because a single-element text node cannot carry
+// per-paragraph margins.
+$textCaseResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Text Case And Paragraph Spacing',
+    'nodes' => array(
+        array(
+            'id'       => 'tc:1',
+            'type'     => 'FRAME',
+            'name'     => 'Text case frame',
+            'children' => array(
+                array(
+                    'id'         => 'tc:2',
+                    'type'       => 'TEXT',
+                    'name'       => 'Upper text',
+                    'characters' => 'shout this',
+                    'style'      => array(
+                        'fontFamily' => 'Example Sans',
+                        'fontSize'   => 18,
+                        'textCase'   => 'UPPER',
+                    ),
+                ),
+                array(
+                    'id'         => 'tc:3',
+                    'type'       => 'TEXT',
+                    'name'       => 'Lower text',
+                    'characters' => 'QUIET This',
+                    'style'      => array(
+                        'fontFamily' => 'Example Sans',
+                        'fontSize'   => 18,
+                        'textCase'   => 'LOWER',
+                    ),
+                ),
+                array(
+                    'id'         => 'tc:4',
+                    'type'       => 'TEXT',
+                    'name'       => 'Title text',
+                    'characters' => 'a nice heading',
+                    'style'      => array(
+                        'fontFamily' => 'Example Sans',
+                        'fontSize'   => 18,
+                        'textCase'   => 'TITLE',
+                    ),
+                ),
+                array(
+                    'id'         => 'tc:5',
+                    'type'       => 'TEXT',
+                    'name'       => 'Small caps forced text',
+                    'characters' => 'small caps forced',
+                    'style'      => array(
+                        'fontFamily' => 'Example Sans',
+                        'fontSize'   => 18,
+                        'textCase'   => 'SMALL_CAPS_FORCED',
+                    ),
+                ),
+                array(
+                    'id'         => 'tc:6',
+                    'type'       => 'TEXT',
+                    'name'       => 'Original case text',
+                    'characters' => 'Leave Me Alone',
+                    'style'      => array(
+                        'fontFamily' => 'Example Sans',
+                        'fontSize'   => 18,
+                        'textCase'   => 'ORIGINAL',
+                    ),
+                ),
+                array(
+                    'id'         => 'tc:7',
+                    'type'       => 'TEXT',
+                    'name'       => 'Multi paragraph text',
+                    'characters' => "First paragraph.\nSecond paragraph.",
+                    'style'      => array(
+                        'fontFamily'        => 'Example Sans',
+                        'fontSize'          => 18,
+                        'paragraphSpacing'  => 24,
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
 $kiwiRadiusCss = $fileContent($kiwiRadiusResult, 'style.css');
 $assert(str_contains($kiwiRadiusCss, '.figma-node-5-2-kiwi-corner-radius{width:160px;height:90px;border-top-left-radius:8px;border-top-right-radius:8px;border-bottom-right-radius:0px;border-bottom-left-radius:0px}'), 'kiwi-per-corner-radius-style');
 $assert(! str_contains($kiwiRadiusCss, 'border-radius:99px'), 'kiwi-per-corner-radius-overrides-uniform');
+
+$textCaseCss = $fileContent($textCaseResult, 'style.css');
+$textCaseDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $textCaseResult['diagnostics'] ?? array()
+);
+$assert(str_contains($textCaseCss, '.figma-node-tc-2-upper-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px;text-transform:uppercase}'), 'text-case-upper-text-transform');
+$assert(str_contains($textCaseCss, 'text-transform:lowercase'), 'text-case-lower-text-transform');
+$assert(str_contains($textCaseCss, 'text-transform:capitalize'), 'text-case-title-text-transform');
+$assert(str_contains($textCaseCss, '.figma-node-tc-5-small-caps-forced-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px;text-transform:uppercase;font-variant:small-caps}'), 'text-case-small-caps-forced');
+$assert(str_contains($textCaseCss, '.figma-node-tc-6-original-case-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px}'), 'text-case-original-no-transform');
+$textCaseParagraphDiagnostic = null;
+foreach ( $textCaseResult['diagnostics'] ?? array() as $diagnostic ) {
+    if ( 'paragraph_spacing_not_applied' === ($diagnostic['code'] ?? null) ) {
+        $textCaseParagraphDiagnostic = $diagnostic;
+        break;
+    }
+}
+$assert(null !== $textCaseParagraphDiagnostic, 'paragraph-spacing-diagnostic-present');
+$assert('tc:7' === ($textCaseParagraphDiagnostic['context']['node_id'] ?? null), 'paragraph-spacing-diagnostic-node-id');
+$assert(24.0 === ($textCaseParagraphDiagnostic['context']['paragraph_spacing'] ?? null), 'paragraph-spacing-diagnostic-value');
+$assert(! str_contains($textCaseCss, 'paragraph-spacing') && ! str_contains($textCaseCss, 'paragraph_spacing'), 'paragraph-spacing-not-emitted-as-css');
 
 // Inline character-level style overrides (characterStyleOverrides + styleOverrideTable).
 //


### PR DESCRIPTION
## Summary

`figma-transformer`'s `ScenegraphNormalizer::normalizeTextStyle()` decoded `textCase` and `paragraphSpacing` from Kiwi (both are whitelisted on `NodeChange` in `FigKiwiDecoder`) but never read them. As a result ALL CAPS / lowercase / title-case designs rendered in the native font casing, and multi-paragraph text lost its inter-paragraph spacing.

### textCase → CSS text-transform / font-variant

`normalizeTextStyle()` now reads `textCase` and maps the Figma enum:

| `textCase` | CSS |
|------------|-----|
| `UPPER` | `text-transform: uppercase` |
| `LOWER` | `text-transform: lowercase` |
| `TITLE` | `text-transform: capitalize` |
| `SMALL_CAPS` | `font-variant: small-caps` |
| `SMALL_CAPS_FORCED` | `text-transform: uppercase` + `font-variant: small-caps` |
| `ORIGINAL` / absent | no transform (native casing) |

The CSS is emitted in `StaticHtmlEmitter::textStyleDeclarations()` next to the other text-style declarations, so it flows through both whole-node text styles and per-segment `<span>` styles.

### paragraphSpacing → normalized field + diagnostic

`paragraphSpacing` is normalized to `text_style.paragraph_spacing`. The emitter renders a multi-paragraph text node as a **single element** with `white-space: pre-line` (newlines preserved literally; see `derivedLineBreakText()` / `textStyles()`) — there is no per-paragraph box to hang a `margin-bottom` on. Rather than fake CSS that would not apply, the value is surfaced as an `info` diagnostic `paragraph_spacing_not_applied` (with `node_id` + `paragraph_spacing` context) when a text node carries paragraph spacing **and** has multiple paragraphs. Single-paragraph nodes are ignored because the value has no visual effect there.

This is the honest wiring: the emitter does not split paragraphs into separate elements, so there is no clean CSS path. If paragraph splitting is added later, the normalized field is ready to drive `margin-bottom`.

## Tests

Added a contract fixture in `tests/contract/run.php` proving:
- `textCase: UPPER` → `text-transform:uppercase` in emitted CSS (exact-match)
- `LOWER`/`TITLE`/`SMALL_CAPS_FORCED`/`ORIGINAL` mappings
- `paragraphSpacing` emits the `paragraph_spacing_not_applied` diagnostic with the right node id and value, and no paragraph-spacing CSS is emitted

`php tests/contract/run.php` → all pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation
