### PR TITLE
figma-transformer: skip invisible (visible:false) nodes during emission

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -622,6 +622,15 @@ final class StaticHtmlEmitter
      */
     private function emitNode(array $node, array &$cssRules, array &$diagnostics, array &$nodeStyleDiagnostics, int $depth, ?array $parentNode): string
     {
+        // Designer-hidden layers carry an explicit `visible: false` from Figma.
+        // Skip emitting them and their entire subtree. Absent/null `visible`
+        // means visible, so only an explicit false is honored. A hidden node
+        // emitted as a top-level render root (depth 0, e.g. an explicitly
+        // selected frame) still renders; hidden descendants never do.
+        if ( $depth > 0 && false === ($node['visible'] ?? null) ) {
+            return '';
+        }
+
         $id = $this->sanitizeAttribute((string) ($node['id'] ?? ''));
         $name = (string) ($node['name'] ?? '');
         $attributeName = $this->sanitizeAttribute($name);

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -935,6 +935,11 @@ final class ScenegraphNormalizer
         $resolved['id'] = (string) ($instance['id'] ?? $resolved['id'] ?? '');
         $resolved['type'] = 'INSTANCE';
         $resolved['name'] = (string) ($instance['name'] ?? $resolved['name'] ?? '');
+        // The resolved node stands in for the instance placement, so its
+        // visibility is governed by the instance, not the component definition.
+        // Without this, a designer-hidden (visible:false) instance would inherit
+        // the definition's visibility and incorrectly emit to HTML.
+        $resolved['visible'] = $instance['visible'] ?? true;
 
         foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd') as $key ) {
             if ( array_key_exists($key, $instance) ) {

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6418,6 +6418,43 @@ $assert(array('Brand Sans') === ($fontFamilyOverridesFonts['family_overrides_app
 $assert(! in_array('Inter', $fontFamilyOverridesFonts['missing_css'] ?? array(), true), 'per-family-override-inter-not-unresolved');
 $assert(! in_array('Brand Sans', $fontFamilyOverridesFonts['missing_css'] ?? array(), true), 'per-family-override-brand-sans-not-unresolved');
 
+// HIDDEN LAYER SKIP: a designer-hidden child (node-level visible:false) must
+// not emit to HTML, while a sibling without an explicit visible:false renders.
+$hiddenLayerResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Hidden Layer Skip Fixture',
+    'nodes' => array(
+        array(
+            'id'         => 'vis:frame',
+            'type'       => 'FRAME',
+            'name'       => 'Visibility frame',
+            'width'      => 400,
+            'height'     => 200,
+            'layoutMode' => 'VERTICAL',
+            'children'   => array(
+                array(
+                    'id'         => 'vis:visible-child',
+                    'type'       => 'TEXT',
+                    'name'       => 'Shown copy',
+                    'characters' => 'Visible content stays',
+                ),
+                array(
+                    'id'         => 'vis:hidden-child',
+                    'type'       => 'TEXT',
+                    'name'       => 'Hidden copy',
+                    'visible'    => false,
+                    'characters' => 'Hidden content must vanish',
+                ),
+            ),
+        ),
+    ),
+));
+$hiddenLayerHtml = $fileContent($hiddenLayerResult, 'index.html');
+$assert('success' === ($hiddenLayerResult['status'] ?? null), 'hidden-layer-skip-transform-success');
+$assert(str_contains($hiddenLayerHtml, 'data-figma-node-id="vis:visible-child"'), 'visible-sibling-emitted');
+$assert(str_contains($hiddenLayerHtml, 'Visible content stays'), 'visible-sibling-text-emitted');
+$assert(! str_contains($hiddenLayerHtml, 'data-figma-node-id="vis:hidden-child"'), 'hidden-node-id-not-emitted');
+$assert(! str_contains($hiddenLayerHtml, 'Hidden content must vanish'), 'hidden-node-text-not-emitted');
+
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");
     exit(1);


### PR DESCRIPTION
## Problem

The figma-transformer decoded each node's `visible` flag (`FigKiwiDecoder` whitelists `visible` on `NodeChange`) and the `ScenegraphNormalizer` carried it through to the normalized node map, but `StaticHtmlEmitter` never consumed it for nodes. The emitter already skipped invisible *paints* and *effects*, yet a designer-hidden layer (node-level `visible: false`) still emitted to HTML — so hidden layers showed up in the output.

## Fix

- **`StaticHtmlEmitter::emitNode`** returns early — skipping the node and its entire subtree — when the node carries an explicit `visible === false`. Absent/null `visible` still means visible (only an explicit `false` is honored). The guard is scoped to `depth > 0`, so an explicitly selected / top-level hidden frame still renders (edge case), while every hidden descendant and instance child is skipped.
- **`ScenegraphNormalizer::cloneComponentForInstance`** now sets the resolved instance's `visible` from the instance placement (defaulting to `true`). Previously the resolved node was cloned from the component definition and never carried the instance's `visible`, so a hidden instance would have leaked through (and a definition's visibility could have leaked into the resolved node). Now a designer-hidden instance is correctly skipped.

## Tests

Added a contract fixture (a frame with one visible child and one `visible: false` child) asserting the hidden child's id and text are absent from emitted HTML while the visible sibling renders. Verified the new assertions fail without the emitter guard and pass with it. All existing contract tests still pass (`php tests/contract/run.php`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation