### PR TITLE
Drop redundant bar-stack hamburger nav toggles (no ARIA wiring)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -792,11 +792,63 @@ final class HtmlTransformer
             return false;
         }
 
-        if ( ! $element->hasAttribute('aria-controls') && ! $element->hasAttribute('aria-expanded') ) {
+        if ( '' !== $this->visibleMenuToggleLabel($element) ) {
             return false;
         }
 
-        return '' === $this->visibleMenuToggleLabel($element);
+        // ARIA-toggle shape: a labelless control that opens a menu via ARIA
+        // state (aria-controls/aria-expanded), regardless of its icon markup.
+        if ( $element->hasAttribute('aria-controls') || $element->hasAttribute('aria-expanded') ) {
+            return true;
+        }
+
+        // Icon-bars shape: a labelless control whose only content is the stacked
+        // empty <span> bars that draw a hamburger glyph, with no ARIA toggle
+        // wiring. Many themes draw the bars with CSS on empty spans and bind the
+        // open/close behavior in JS the importer cannot carry, so the control
+        // arrives with no aria-* hooks at all — only its bar-stack shape betrays
+        // it. Recognizing that shape (never a class string) lets these toggles be
+        // dropped too, instead of surfacing as an empty, always-visible button.
+        return $this->isHamburgerBarStackControl($element);
+    }
+
+    /**
+     * Whether the control's only content is a stack of two or more empty <span>
+     * bars: the framework-agnostic shape of a CSS-drawn hamburger glyph. A real
+     * button carries a text label, an image, or other meaningful content, so it
+     * is never matched. Genuinely empty controls (no bars) are not matched
+     * either; only the deliberate multi-bar stack qualifies.
+     */
+    private function isHamburgerBarStackControl(DOMElement $element): bool
+    {
+        $emptyBars = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_COMMENT_NODE === $child->nodeType ) {
+                continue;
+            }
+
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                if ( '' !== trim($child->textContent ?? '') ) {
+                    return false;
+                }
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement ) {
+                return false;
+            }
+
+            if ( 'span' !== strtolower($child->tagName)
+                || '' !== trim($child->textContent ?? '')
+                || 0 !== $child->getElementsByTagName('img')->length
+                || 0 !== $child->getElementsByTagName('svg')->length ) {
+                return false;
+            }
+
+            ++$emptyBars;
+        }
+
+        return $emptyBars >= 2;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-nav-hamburger-bar-stack-drop.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-hamburger-bar-stack-drop.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-hamburger-bar-stack-drop",
+  "description": "A site header holds a converting core/navigation menu (overlayMenu='mobile') beside a mobile hamburger toggle that carries NO aria-controls/aria-expanded — only an aria-label and the stacked empty <span> bars themes draw with CSS. The open/close behavior lived in JS the importer cannot carry, so the bare bar-stack shape is the only signal. The toggle is dropped as redundant chrome (the navigation already supplies its own responsive overlay hamburger) instead of surfacing as an empty, always-visible core/button. Detection is structural — a labelless control whose only content is two or more empty <span> bars, associated with a navigation menu in its header landmark — never the class string (the source class 'nav-toggle' is ignored).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-hamburger-bar-stack-drop.json",
+    "notes": "Generalizes redundant-toggle dropping to hamburgers with no ARIA toggle wiring. Mirrors the recurring runtime_target_gap:...:class:nav-toggle matrix finding where the toggle became a broken empty button and shifted header layout."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"site-header\"><a class=\"logo\" href=\"/\">Acme</a><nav class=\"main-nav\" aria-label=\"Main\"><ul><li><a href=\"/about\">About</a></li><li><a href=\"/blog\">Blog</a></li></ul></nav><button class=\"nav-toggle is-style-outline\" aria-label=\"Toggle menu\"><span></span><span></span><span></span></button></header>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "main-nav", "overlayMenu": "mobile" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "About", "url": "/about", "kind": "custom" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:button" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:buttons" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "Toggle menu" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"overlayMenu\":\"mobile\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"About\",\"url\":\"/about\",\"kind\":\"custom\"} -->" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nav-real-button-near-nav-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-real-button-near-nav-preserved.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-real-button-near-nav-preserved",
+  "description": "Negative-case guard for the generalized hamburger-drop: a real labeled action button sitting in a header beside a converting core/navigation menu is NOT a nav toggle and must be preserved as a core/button. The bar-stack hamburger drop only removes labelless controls whose sole content is stacked empty <span> bars; a button carrying visible text ('Get Started') keeps its content and converts normally, so legitimate header CTAs survive next to the navigation.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-real-button-near-nav-preserved.json",
+    "notes": "Proves the conservative boundary of redundant nav-toggle detection: presence beside a nav does not cause real buttons to be dropped."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"site-header\"><nav class=\"main-nav\" aria-label=\"Main\"><ul><li><a href=\"/about\">About</a></li><li><a href=\"/blog\">Blog</a></li></ul></nav><button class=\"cta\">Get Started</button></header>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation", "attrs": { "className": "main-nav", "overlayMenu": "mobile" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "className": "cta", "tagName": "button", "text": "Get Started" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:button" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Get Started" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"overlayMenu\":\"mobile\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Problem

A source mobile nav toggle (hamburger) repeatedly surfaced in real imports as a broken, empty `core/button`:

```
wp:button {"className":"nav-toggle is-style-outline","aria-label":"Toggle menu","tagName":"button","text":"<span></span><span></span><span></span>"}
```

The three empty `<span>` bars are the CSS-drawn hamburger glyph; emitted as a button they become empty/garbage text. This is redundant: the adjacent nav already converts to `core/navigation` with `overlayMenu:"mobile"`, which supplies WordPress's own responsive toggle. It also shifted page layout (the "menu in a different location per page" symptom) and recurred in the corpus matrix as `runtime_target_gap:...:class:nav-toggle` (the source JS targeting `.nav-toggle` is moot once the toggle is dropped).

The transformer already dropped hamburger toggles that carry `aria-controls`/`aria-expanded` (`isHamburgerMenuToggleControl` + `hasAssociatedNavigationMenu`). The gap: many themes draw the hamburger as empty `<span>` bars and bind open/close in JS the importer cannot carry, so the control arrives with **no ARIA toggle wiring at all** — only its bar-stack shape. Those fell through to `core/button`.

## Fix (generic, structural)

`isHamburgerMenuToggleControl()` now recognizes two structural shapes for a labelless `<button>` / `<a role="button">`:

1. **ARIA-toggle shape** (existing): has `aria-controls` or `aria-expanded`.
2. **Bar-stack shape** (new): its only content is two or more empty `<span>` bars (the hamburger glyph), with no ARIA wiring — detected by `isHamburgerBarStackControl()`.

Both shapes still require an associated navigation menu (`hasAssociatedNavigationMenu`: opens a nav via `aria-controls`, lives inside a nav/header landmark, or sits beside a nav menu in its enclosing landmark) before the control is dropped. The converted `core/navigation` already ships its own responsive overlay hamburger, so nothing is lost.

Detection is purely structural — the source class string (e.g. `nav-toggle`) is **never** consulted, so any framework's hamburger generalizes.

### Negative-case guard (conservative by construction)
`isHamburgerBarStackControl()` matches only a control whose sole content is >= 2 empty `<span>` bars. A control with visible text, an image, an svg, a single span, or no associated navigation is preserved as a normal `core/button`. Verified:
- Real labeled button (`Get Started`) beside a nav -> preserved.
- Single empty `<span>` (not a bar stack) -> preserved.
- Bar-stack button with no associated nav (plain section) -> preserved.

## Before / After

Source: `<header>` with `<a class="logo">`, `<nav>` menu, and `<button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>`.

**Before:**
```
core/group (site-header)
  core/paragraph (logo)
  core/navigation {overlayMenu: mobile}
    core/navigation-link x2
  core/buttons
    core/button {className: "nav-toggle ...", text: "<span></span><span></span><span></span>"}   <-- broken
```

**After:**
```
core/group (site-header)
  core/paragraph (logo)
  core/navigation {overlayMenu: mobile}
    core/navigation-link x2
```
Toggle dropped, navigation intact.

## Tests

- Baseline green first: `composer test:canonical` + `composer parity` (165 fixtures).
- Added 2 parity fixtures: `html-nav-hamburger-bar-stack-drop` (toggle dropped, nav intact) and `html-nav-real-button-near-nav-preserved` (real button preserved).
- Full `composer test` green: canonical + 167 parity fixtures + packaging. `php -l` clean. No existing fixtures changed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (claude-opus-4-8) via Data Machine Code agent
- **Used for:** Diagnosing the gap, implementing the structural detection, and authoring fixtures.

DO NOT MERGE without review.