### PR TITLE
figma-transformer: wire Kiwi-format layout field names in normalizer

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2714,6 +2714,19 @@ final class StaticHtmlEmitter
             }
         }
 
+        // Auto Layout min/max constraints (Kiwi minSize/maxSize). Skip a property
+        // the width/height pass already emitted (e.g. the fluid root max-width).
+        foreach ( array(
+            'min_width'  => 'min-width',
+            'max_width'  => 'max-width',
+            'min_height' => 'min-height',
+            'max_height' => 'max-height',
+        ) as $layoutKey => $property ) {
+            if ( isset($layout[$layoutKey]) && is_numeric($layout[$layoutKey]) && ! $this->stylesDeclareProperty($styles, $property) ) {
+                $styles[] = $property . ':' . $this->number((float) $layout[$layoutKey]) . 'px';
+            }
+        }
+
         if ( true === ($layout['clips_content'] ?? false) ) {
             $styles[] = 'overflow:hidden';
         }
@@ -2923,6 +2936,20 @@ final class StaticHtmlEmitter
     }
 
     /**
+     * @param array<int, string> $styles
+     */
+    private function stylesDeclareProperty(array $styles, string $property): bool
+    {
+        foreach ( $styles as $style ) {
+            if ( is_string($style) && str_starts_with($style, $property . ':') ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param array<string, mixed> $box
      * @param array<string, mixed> $layout
      * @return array<int, string>
@@ -2935,17 +2962,66 @@ final class StaticHtmlEmitter
         $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
         $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
 
-        if ( null !== $left ) {
-            $styles[] = 'left:' . $this->number($left) . 'px';
+        foreach ( $this->axisConstraintStyles('horizontal', is_scalar($constraints['horizontal'] ?? null) ? (string) $constraints['horizontal'] : null, $left, $parentBox, $box) as $style ) {
+            $styles[] = $style;
         }
-        if ( isset($constraints['horizontal'], $parentBox['width'], $box['width']) && 'LEFT_RIGHT' === $constraints['horizontal'] && null !== $left ) {
-            $styles[] = 'right:' . $this->number((float) $parentBox['width'] - $left - (float) $box['width']) . 'px';
+        foreach ( $this->axisConstraintStyles('vertical', is_scalar($constraints['vertical'] ?? null) ? (string) $constraints['vertical'] : null, $top, $parentBox, $box) as $style ) {
+            $styles[] = $style;
         }
-        if ( null !== $top ) {
-            $styles[] = 'top:' . $this->number($top) . 'px';
+
+        return $styles;
+    }
+
+    /**
+     * Resolve the absolute-position CSS for a single axis from its Figma pin
+     * constraint. The near edge (left/top) is the default; LEFT_RIGHT/TOP_BOTTOM
+     * pin both edges, RIGHT/BOTTOM pin only the far edge, and CENTER holds a fixed
+     * offset from the parent center without relying on `transform` (which the
+     * emitter reserves for the node's own matrix). SCALE is percentage-based and
+     * has no clean pixel translation, so it falls back to the deterministic near
+     * pin instead of emitting a wrong guess.
+     *
+     * @param array<string, mixed> $parentBox
+     * @param array<string, mixed> $box
+     * @return array<int, string>
+     */
+    private function axisConstraintStyles(string $axis, ?string $constraint, ?float $offset, array $parentBox, array $box): array
+    {
+        $isHorizontal = 'horizontal' === $axis;
+        $startProp = $isHorizontal ? 'left' : 'top';
+        $endProp = $isHorizontal ? 'right' : 'bottom';
+        $sizeKey = $isHorizontal ? 'width' : 'height';
+        $bothPin = $isHorizontal ? 'LEFT_RIGHT' : 'TOP_BOTTOM';
+        $farPin = $isHorizontal ? 'RIGHT' : 'BOTTOM';
+        $parentSize = isset($parentBox[$sizeKey]) && is_numeric($parentBox[$sizeKey]) ? (float) $parentBox[$sizeKey] : null;
+        $boxSize = isset($box[$sizeKey]) && is_numeric($box[$sizeKey]) ? (float) $box[$sizeKey] : null;
+        $constraint = null === $constraint ? null : strtoupper($constraint);
+
+        $styles = array();
+
+        // Far-edge-only pin (REST RIGHT/BOTTOM, Kiwi MAX): anchor to the trailing
+        // edge and drop the leading offset so the node stays glued on resize.
+        if ( $farPin === $constraint && null !== $offset && null !== $parentSize && null !== $boxSize ) {
+            $styles[] = $endProp . ':' . $this->number($parentSize - $offset - $boxSize) . 'px';
+            return $styles;
         }
-        if ( isset($constraints['vertical'], $parentBox['height'], $box['height']) && 'TOP_BOTTOM' === $constraints['vertical'] && null !== $top ) {
-            $styles[] = 'bottom:' . $this->number((float) $parentBox['height'] - $top - (float) $box['height']) . 'px';
+
+        // Center pin: keep a constant offset from the parent center. Using calc()
+        // off the leading edge avoids touching transform.
+        if ( 'CENTER' === $constraint && null !== $offset && null !== $parentSize ) {
+            $delta = $offset - ( $parentSize / 2.0 );
+            $sign = $delta < 0 ? '-' : '+';
+            $styles[] = $startProp . ':calc(50% ' . $sign . ' ' . $this->number(abs($delta)) . 'px)';
+            return $styles;
+        }
+
+        // Near-edge pin (LEFT/TOP/default, also SCALE fallback) plus an optional
+        // far-edge pin for the both-side stretch constraint.
+        if ( null !== $offset ) {
+            $styles[] = $startProp . ':' . $this->number($offset) . 'px';
+        }
+        if ( $bothPin === $constraint && null !== $offset && null !== $parentSize && null !== $boxSize ) {
+            $styles[] = $endProp . ':' . $this->number($parentSize - $offset - $boxSize) . 'px';
         }
 
         return $styles;

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -3443,12 +3443,38 @@ final class ScenegraphNormalizer
             }
         }
 
+        // REST exposes `primaryAxisSizingMode`/`counterAxisSizingMode`; the .fig
+        // Kiwi schema carries the same intent as flat `stackPrimarySizing`/
+        // `stackCounterSizing` enums. Read REST first, fall back to Kiwi, and
+        // normalize both vocabularies to canonical HUG/FIXED tokens.
         foreach ( array(
-            'primaryAxisSizingMode' => 'primary_axis_sizing',
-            'counterAxisSizingMode' => 'counter_axis_sizing',
-        ) as $source => $target ) {
-            if ( isset($node[$source]) && is_scalar($node[$source]) ) {
-                $layout[$target] = strtoupper((string) $node[$source]);
+            'primary_axis_sizing' => array('rest' => 'primaryAxisSizingMode', 'kiwi' => 'stackPrimarySizing'),
+            'counter_axis_sizing' => array('rest' => 'counterAxisSizingMode', 'kiwi' => 'stackCounterSizing'),
+        ) as $target => $sources ) {
+            $raw = null;
+            if ( isset($node[$sources['rest']]) && is_scalar($node[$sources['rest']]) ) {
+                $raw = (string) $node[$sources['rest']];
+            } elseif ( isset($node[$sources['kiwi']]) && is_scalar($node[$sources['kiwi']]) ) {
+                $raw = (string) $node[$sources['kiwi']];
+            }
+            if ( null !== $raw ) {
+                $layout[$target] = $this->normalizeAxisSizingValue($raw);
+            }
+        }
+
+        // Bridge axis sizing onto the horizontal/vertical sizing fields the HTML
+        // emitter consumes, mapping primary/counter to physical axes by stack
+        // orientation. .fig input never sets `layoutSizingHorizontal`, so without
+        // this bridge HUG/FIXED intent from the Kiwi stack enums is pure data loss.
+        $flexDirection = $layout['flex_direction'] ?? null;
+        if ( 'row' === $flexDirection || 'column' === $flexDirection ) {
+            $primaryAxisKey = 'row' === $flexDirection ? 'sizing_horizontal' : 'sizing_vertical';
+            $counterAxisKey = 'row' === $flexDirection ? 'sizing_vertical' : 'sizing_horizontal';
+            if ( isset($layout['primary_axis_sizing']) && ! isset($layout[$primaryAxisKey]) ) {
+                $layout[$primaryAxisKey] = $layout['primary_axis_sizing'];
+            }
+            if ( isset($layout['counter_axis_sizing']) && ! isset($layout[$counterAxisKey]) ) {
+                $layout[$counterAxisKey] = $layout['counter_axis_sizing'];
             }
         }
 
@@ -3523,12 +3549,23 @@ final class ScenegraphNormalizer
             }
         }
 
-        if ( isset($node['layoutPositioning']) && 'ABSOLUTE' === strtoupper((string) $node['layoutPositioning']) ) {
+        // REST `layoutPositioning`; Kiwi `stackPositioning`. Both encode the
+        // absolute-in-auto-layout escape with an `ABSOLUTE` enum token.
+        $positioning = null;
+        if ( isset($node['layoutPositioning']) && is_scalar($node['layoutPositioning']) ) {
+            $positioning = strtoupper((string) $node['layoutPositioning']);
+        } elseif ( isset($node['stackPositioning']) && is_scalar($node['stackPositioning']) ) {
+            $positioning = strtoupper((string) $node['stackPositioning']);
+        }
+        if ( 'ABSOLUTE' === $positioning ) {
             $layout['positioning'] = 'absolute';
         }
 
+        // REST `layoutGrow`; Kiwi `stackChildPrimaryGrow`. Flex-grow factor.
         if ( isset($node['layoutGrow']) && is_numeric($node['layoutGrow']) ) {
             $layout['grow'] = (float) $node['layoutGrow'];
+        } elseif ( isset($node['stackChildPrimaryGrow']) && is_numeric($node['stackChildPrimaryGrow']) ) {
+            $layout['grow'] = (float) $node['stackChildPrimaryGrow'];
         }
 
         if ( isset($node['layoutAlign']) && is_scalar($node['layoutAlign']) ) {
@@ -3541,15 +3578,48 @@ final class ScenegraphNormalizer
             $layout['clips_content'] = true;
         }
 
+        // REST exposes a nested `constraints` object with LEFT/RIGHT/LEFT_RIGHT/
+        // CENTER/SCALE (and TOP/BOTTOM/TOP_BOTTOM) tokens. The .fig Kiwi schema
+        // instead carries flat `horizontalConstraint`/`verticalConstraint` enums
+        // whose token vocabulary is MIN/CENTER/MAX/STRETCH/SCALE. Read the REST
+        // shape first, then fall back to the Kiwi scalars, translating the Kiwi
+        // enum onto the REST vocabulary so the emitter sees a single language.
+        $constraints = array();
         if ( is_array($node['constraints'] ?? null) ) {
-            $constraints = array();
             foreach ( array('horizontal', 'vertical') as $axis ) {
                 if ( isset($node['constraints'][$axis]) && is_scalar($node['constraints'][$axis]) ) {
                     $constraints[$axis] = strtoupper((string) $node['constraints'][$axis]);
                 }
             }
-            if ( ! empty($constraints) ) {
-                $layout['constraints'] = $constraints;
+        }
+        foreach ( array('horizontal' => 'horizontalConstraint', 'vertical' => 'verticalConstraint') as $axis => $kiwiKey ) {
+            if ( isset($constraints[$axis]) || ! isset($node[$kiwiKey]) || ! is_scalar($node[$kiwiKey]) ) {
+                continue;
+            }
+            $translated = $this->normalizeKiwiConstraint(strtoupper((string) $node[$kiwiKey]), $axis);
+            if ( null !== $translated ) {
+                $constraints[$axis] = $translated;
+            }
+        }
+        if ( ! empty($constraints) ) {
+            $layout['constraints'] = $constraints;
+        }
+
+        // Auto Layout min/max width/height. Kiwi decodes `minSize`/`maxSize` as
+        // OptionalVector {x, y} objects (x = width, y = height) but nothing ever
+        // referenced them, so they were decoded-and-dropped for .fig input.
+        foreach ( array('minSize' => 'min', 'maxSize' => 'max') as $source => $prefix ) {
+            if ( ! is_array($node[$source] ?? null) ) {
+                continue;
+            }
+            foreach ( array('x' => 'width', 'y' => 'height') as $axis => $dimension ) {
+                if ( ! isset($node[$source][$axis]) || ! is_numeric($node[$source][$axis]) ) {
+                    continue;
+                }
+                $value = (float) $node[$source][$axis];
+                if ( is_finite($value) && $value >= 0.0 ) {
+                    $layout[$prefix . '_' . $dimension] = $value;
+                }
             }
         }
 
@@ -3561,6 +3631,42 @@ final class ScenegraphNormalizer
         }
 
         return $layout;
+    }
+
+    /**
+     * Normalize REST `*AxisSizingMode` and Kiwi `stack*Sizing` enum tokens onto a
+     * single HUG/FILL/FIXED vocabulary the HTML emitter understands. REST uses
+     * FIXED/AUTO, the .fig Kiwi `StackSize` enum uses FIXED/RESIZE_TO_FIT
+     * (RESIZE_TO_FIT == HUG / resize-to-fit-content).
+     */
+    private function normalizeAxisSizingValue(string $value): string
+    {
+        return match ( strtoupper($value) ) {
+            'AUTO', 'HUG', 'RESIZE_TO_FIT', 'RESIZE_TO_FIT_WITH_IMPLICIT_SIZE' => 'HUG',
+            'FILL', 'STRETCH' => 'FILL',
+            default => 'FIXED',
+        };
+    }
+
+    /**
+     * Translate a Kiwi `horizontalConstraint`/`verticalConstraint` enum token onto
+     * the REST `constraints` vocabulary the emitter pins against. The Kiwi
+     * `ConstraintType` enum is MIN/CENTER/MAX/STRETCH/SCALE; STRETCH is the
+     * both-side pin (REST LEFT_RIGHT/TOP_BOTTOM), MIN is the near edge (LEFT/TOP),
+     * MAX is the far edge (RIGHT/BOTTOM).
+     */
+    private function normalizeKiwiConstraint(string $value, string $axis): ?string
+    {
+        $isHorizontal = 'horizontal' === $axis;
+
+        return match ( strtoupper($value) ) {
+            'MIN' => $isHorizontal ? 'LEFT' : 'TOP',
+            'MAX' => $isHorizontal ? 'RIGHT' : 'BOTTOM',
+            'STRETCH' => $isHorizontal ? 'LEFT_RIGHT' : 'TOP_BOTTOM',
+            'CENTER' => 'CENTER',
+            'SCALE' => 'SCALE',
+            default => null,
+        };
     }
 
     private function cssAxisAlignment(string $alignment): ?string

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4555,6 +4555,101 @@ $kiwiStackLayoutCss = $fileContent($kiwiStackLayoutResult, 'style.css');
 $assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-frame-kiwi-stack-frame{width:300px;height:200px;overflow:hidden;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;flex-wrap:wrap;align-content:flex-start;padding-top:8px;padding-right:20px;padding-bottom:30px;padding-left:8px;gap:24px}'), 'kiwi-stack-layout-emits-flex-padding-gap');
 $assert(str_contains($kiwiStackLayoutCss, '.figma-node-stack-child-a-child-a{width:50px;height:40px;flex-shrink:0}'), 'kiwi-stack-child-not-absolute');
 
+// .fig (Kiwi) input carries layout intent under flat Kiwi field names the
+// normalizer historically ignored in favor of the REST vocabulary, so the
+// constraints, stack sizing, child grow, min/max, and absolute-positioning
+// signals were pure data loss. This fixture feeds the Kiwi field names with
+// their real decoded enum values (ConstraintType MIN/MAX/STRETCH/CENTER,
+// StackSize RESIZE_TO_FIT/FIXED, OptionalVector min/maxSize) and proves they
+// reach CSS: constraints become pins, stack sizing becomes flex sizing, grow
+// becomes flex-grow, and min/maxSize become min/max width/height.
+$kiwiLayoutFieldsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Kiwi Layout Fields Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'kiwi-layout:frame',
+            'type'                => 'FRAME',
+            'name'                => 'Kiwi layout frame',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 400, 'height' => 300),
+            'children'            => array(
+                array(
+                    'id'                   => 'kiwi-layout:stretch-badge',
+                    'type'                 => 'RECTANGLE',
+                    'name'                 => 'Stretch badge',
+                    'absoluteBoundingBox'  => array('x' => 20, 'y' => 30, 'width' => 50, 'height' => 20),
+                    'stackPositioning'     => 'ABSOLUTE',
+                    'horizontalConstraint' => 'STRETCH',
+                    'verticalConstraint'   => 'STRETCH',
+                    'fill'                 => array('r' => 0, 'g' => 0, 'b' => 0),
+                ),
+                array(
+                    'id'                   => 'kiwi-layout:far-badge',
+                    'type'                 => 'RECTANGLE',
+                    'name'                 => 'Far badge',
+                    'absoluteBoundingBox'  => array('x' => 300, 'y' => 10, 'width' => 60, 'height' => 40),
+                    'stackPositioning'     => 'ABSOLUTE',
+                    'horizontalConstraint' => 'MAX',
+                    'verticalConstraint'   => 'MIN',
+                ),
+                array(
+                    'id'                   => 'kiwi-layout:center-badge',
+                    'type'                 => 'RECTANGLE',
+                    'name'                 => 'Center badge',
+                    'absoluteBoundingBox'  => array('x' => 175, 'y' => 140, 'width' => 50, 'height' => 20),
+                    'stackPositioning'     => 'ABSOLUTE',
+                    'horizontalConstraint' => 'CENTER',
+                    'verticalConstraint'   => 'CENTER',
+                ),
+            ),
+        ),
+        array(
+            'id'        => 'kiwi-layout:flexframe',
+            'type'      => 'FRAME',
+            'name'      => 'Kiwi flex frame',
+            'width'     => 300,
+            'height'    => 100,
+            'stackMode' => 'HORIZONTAL',
+            'children'  => array(
+                array(
+                    'id'                    => 'kiwi-layout:fill-item',
+                    'type'                  => 'RECTANGLE',
+                    'name'                  => 'Fill item',
+                    'width'                 => 80,
+                    'height'                => 40,
+                    'stackChildPrimaryGrow' => 1,
+                    'minSize'               => array('x' => 100, 'y' => 20),
+                    'maxSize'               => array('x' => 200, 'y' => 60),
+                ),
+                array(
+                    'id'                 => 'kiwi-layout:hug-frame',
+                    'type'               => 'FRAME',
+                    'name'               => 'Hug frame',
+                    'width'              => 50,
+                    'height'             => 40,
+                    'stackMode'          => 'HORIZONTAL',
+                    'stackPrimarySizing' => 'RESIZE_TO_FIT',
+                    'stackCounterSizing' => 'FIXED',
+                    'children'           => array(
+                        array('id' => 'kiwi-layout:hug-a', 'type' => 'RECTANGLE', 'name' => 'Hug A', 'width' => 30, 'height' => 20),
+                        array('id' => 'kiwi-layout:hug-b', 'type' => 'RECTANGLE', 'name' => 'Hug B', 'width' => 40, 'height' => 20),
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$kiwiLayoutFieldsCss = $fileContent($kiwiLayoutFieldsResult, 'style.css');
+// Kiwi STRETCH constraint == REST LEFT_RIGHT/TOP_BOTTOM both-side pin.
+$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-stretch-badge-stretch-badge{width:50px;height:20px;position:absolute;left:20px;right:330px;top:30px;bottom:250px;background:#000000}'), 'kiwi-constraint-stretch-pins-both-edges');
+// Kiwi MAX (horizontal) == far-edge pin only; Kiwi MIN (vertical) == near pin.
+$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-far-badge-far-badge{width:60px;height:40px;position:absolute;right:40px;top:10px}'), 'kiwi-constraint-max-pins-far-edge-only');
+// Kiwi CENTER == fixed offset from parent center via calc(), no transform.
+$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-center-badge-center-badge{width:50px;height:20px;position:absolute;left:calc(50% - 25px);top:calc(50% - 10px)}'), 'kiwi-constraint-center-uses-calc-offset');
+// stackChildPrimaryGrow -> flex-grow; minSize/maxSize -> min/max width/height.
+$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-fill-item-fill-item{width:80px;height:40px;min-width:100px;max-width:200px;min-height:20px;max-height:60px;flex-grow:1}'), 'kiwi-grow-and-min-max-size');
+// stackPrimarySizing RESIZE_TO_FIT -> HUG main axis; stackCounterSizing FIXED -> fixed cross axis.
+$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-hug-frame-hug-frame{width:max-content;height:40px;display:flex;flex-direction:row;flex-shrink:0}'), 'kiwi-stack-sizing-bridges-to-flex-sizing');
+
 $plainFrameLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Plain Frame Layout Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary

`ScenegraphNormalizer::normalizeLayout()` only read **REST API** layout field names. The same layout properties decode out of the `.fig` binary under different **flat Kiwi field names**, so the normalizer never read them — for `.fig` input these were decoded-and-dropped, i.e. pure data loss.

This adds a Kiwi fallback for each field (REST is still read first; existing behavior unchanged):

| REST name (read first) | Kiwi fallback | Maps to |
|---|---|---|
| `constraints.horizontal/vertical` (nested) | `horizontalConstraint` / `verticalConstraint` (flat) | left/right + top/bottom pinning |
| `primaryAxisSizingMode` / `counterAxisSizingMode` | `stackPrimarySizing` / `stackCounterSizing` | HUG/FILL/FIXED sizing |
| `layoutGrow` | `stackChildPrimaryGrow` | flex-grow |
| `layoutPositioning` | `stackPositioning` | absolute-in-auto-layout |
| — | `minSize` / `maxSize` (`OptionalVector {x,y}`) | `min/max` width/height |

### The enum-vocabulary gap (the important bit)

The Kiwi `horizontalConstraint`/`verticalConstraint` enum is **not** the REST string. The decoder reads token names straight from the schema embedded in each `.fig`, and Figma's `ConstraintType` enum is `MIN` / `CENTER` / `MAX` / `STRETCH` / `SCALE`, whereas the REST `constraints` object uses `LEFT` / `RIGHT` / `LEFT_RIGHT` / `CENTER` / `SCALE` (and the vertical equivalents). The normalizer translates the Kiwi vocabulary onto the REST one so the emitter speaks a single language:

- Kiwi `MIN` → `LEFT` / `TOP` (near-edge pin)
- Kiwi `MAX` → `RIGHT` / `BOTTOM` (far-edge pin)
- Kiwi `STRETCH` → `LEFT_RIGHT` / `TOP_BOTTOM` (both-side pin)
- Kiwi `CENTER` / `SCALE` → passthrough

Stack sizing uses the Kiwi `StackSize` enum (`FIXED` / `RESIZE_TO_FIT`); `RESIZE_TO_FIT` is normalized to HUG. `minSize`/`maxSize` decode as `OptionalVector {x, y}` (x = width, y = height), confirmed against the `FigKiwiDecoder` field policy.

### Emitter changes (`StaticHtmlEmitter`)

- Emit `min-width` / `max-width` / `min-height` / `max-height` from the new `layout.min/max_*` fields (guarded against duplicating the fluid-root `max-width`).
- **Constraint completeness.** Previously only `LEFT_RIGHT`/`TOP_BOTTOM` produced both-side pins; `RIGHT`-only, `CENTER`, `SCALE`, `STRETCH` produced nothing. Now:
  - `RIGHT` / `BOTTOM` (Kiwi `MAX`) → far-edge pin only
  - `CENTER` → fixed offset from parent center via `left/top: calc(50% ± Npx)` (avoids clobbering the node's own `transform`)
  - `SCALE` → keeps the deterministic near-edge pixel pin instead of emitting a percentage wrong-guess

### Tests

Adds a contract fixture to `tests/contract/run.php` that feeds the Kiwi field names with their real decoded enum values and asserts the resulting CSS: constraints → pins (both-side / far-edge / center-calc), stack sizing → flex sizing (`width:max-content` HUG + fixed cross axis), `stackChildPrimaryGrow` → `flex-grow:1`, and `minSize`/`maxSize` → `min/max-width`/`min/max-height`. Full suite passes (`php tests/contract/run.php`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation