### PR TITLE
Hoist classed/styled span hooks out of paragraph/heading content

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1669,6 +1669,8 @@ final class HtmlTransformer
      */
     private function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array
     {
+        $attrs = $this->hoistContentWrappingSpans($name, $attrs);
+
         if ( $sourceElement instanceof DOMElement ) {
             $provenanceId = $this->nextSourceProvenanceId++;
             $this->recordPresentationProvenance($name, $attrs, $sourceElement);
@@ -1696,6 +1698,177 @@ final class HtmlTransformer
         }
 
         return $block;
+    }
+
+    /**
+     * Lift class/style styling hooks out of a paragraph/heading's RichText
+     * `content` so the stored block round-trips through RichText unchanged.
+     *
+     * core/paragraph and core/heading store `content` as RichText, which only
+     * preserves a fixed set of inline formats (a, strong, em, br, …). A
+     * `<span class="…">` / `<span style="…">` is not a format, so RichText drops
+     * its attributes on parse: the saved markup no longer matches the
+     * re-serialized block ("unexpected or invalid content"), and the class — a
+     * styling hook the materialized CSS targets — would be silently lost.
+     *
+     * The fix keys off STRUCTURE (a content-bearing span carrying only
+     * class/style), never on any specific class name:
+     *   - A SINGLE styling-hook span wrapping the ENTIRE content is UNWRAPPED and
+     *     its class/style are HOISTED onto the block (merged into `className` and
+     *     the canonical `style` object). The hook survives where RichText does
+     *     preserve it and the inner text/inline-format becomes valid content.
+     *     Nested wrappers are peeled across iterations.
+     *   - Remaining sibling/partial styling-hook spans are UNWRAPPED to their
+     *     inner content. Their per-span class styling cannot ride valid RichText
+     *     here, so this is best-effort; the emitted block is always valid.
+     * Genuine inline formats (strong/em/a/br/…) are never touched.
+     *
+     * @param array<string, mixed> $attrs
+     * @return array<string, mixed>
+     */
+    private function hoistContentWrappingSpans(string $name, array $attrs): array
+    {
+        if ( ! in_array($name, array( 'core/paragraph', 'core/heading' ), true) ) {
+            return $attrs;
+        }
+
+        $content = (string) ($attrs['content'] ?? '');
+        if ( '' === $content || ! preg_match('/<span\b/i', $content) ) {
+            return $attrs;
+        }
+
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $content . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
+        if ( ! $body instanceof DOMElement ) {
+            return $attrs;
+        }
+
+        $hoistedClasses      = '';
+        $hoistedDeclarations = array();
+
+        // Peel a single styling-hook span wrapping the whole content, hoisting it
+        // onto the block. Nested wrappers are peeled across iterations.
+        while ( ( $wrapper = $this->soleStylingHookSpan($body) ) instanceof DOMElement ) {
+            $hoistedClasses = trim($hoistedClasses . ' ' . $this->attr($wrapper, 'class'));
+            $wrapperStyle   = trim($this->attr($wrapper, 'style'));
+            if ( '' !== $wrapperStyle ) {
+                $hoistedDeclarations = array_merge($hoistedDeclarations, $this->cssDeclarations($wrapperStyle));
+            }
+            $this->unwrapElement($wrapper);
+        }
+
+        // Unwrap any remaining styling-hook spans (sibling / partial content):
+        // best-effort, the class styling is not representable as valid RichText.
+        foreach ( $this->stylingHookSpans($body) as $span ) {
+            $this->unwrapElement($span);
+        }
+
+        $newContent = $this->innerHtml($body);
+        if ( $newContent === $content && '' === $hoistedClasses && array() === $hoistedDeclarations ) {
+            return $attrs;
+        }
+
+        $attrs['content'] = $newContent;
+
+        if ( '' !== $hoistedClasses ) {
+            $promoted = $this->promotedClassName($hoistedClasses);
+            if ( '' !== trim($promoted) ) {
+                $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $promoted);
+            }
+        }
+
+        if ( array() !== $hoistedDeclarations ) {
+            $mapped = $this->styleAttributeMapper()->map($hoistedDeclarations)['style'];
+            if ( array() !== $mapped ) {
+                $existing       = is_array($attrs['style'] ?? null) ? $attrs['style'] : array();
+                $attrs['style'] = array_replace_recursive($mapped, $existing);
+            }
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * The single styling-hook span that is the container's only significant
+     * child, or null when the content is plain text, inline formats, or sibling
+     * spans (which must not be hoisted as one block-level styling hook).
+     */
+    private function soleStylingHookSpan(DOMElement $container): ?DOMElement
+    {
+        $only = null;
+        foreach ( $container->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+            if ( null !== $only ) {
+                return null;
+            }
+            $only = $child;
+        }
+
+        return $only instanceof DOMElement && $this->isStylingHookSpan($only) ? $only : null;
+    }
+
+    /**
+     * A `<span>` whose only attributes are class and/or style (at least one
+     * non-empty). These are presentational styling hooks RichText cannot store,
+     * not semantic spans (a span carrying id, data-, or role is left intact).
+     */
+    private function isStylingHookSpan(DOMElement $element): bool
+    {
+        if ( 'span' !== strtolower($element->tagName) ) {
+            return false;
+        }
+
+        $hasStyling = false;
+        foreach ( $element->attributes ?? array() as $attribute ) {
+            $attributeName = strtolower($attribute->nodeName);
+            if ( 'class' !== $attributeName && 'style' !== $attributeName ) {
+                return false;
+            }
+            if ( '' !== trim($attribute->nodeValue ?? '') ) {
+                $hasStyling = true;
+            }
+        }
+
+        return $hasStyling;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function stylingHookSpans(DOMElement $container): array
+    {
+        $spans = array();
+        foreach ( $container->getElementsByTagName('span') as $span ) {
+            if ( $span instanceof DOMElement && $this->isStylingHookSpan($span) ) {
+                $spans[] = $span;
+            }
+        }
+
+        return $spans;
+    }
+
+    /**
+     * Replace an element with its children in place, dropping only the wrapper.
+     */
+    private function unwrapElement(DOMElement $element): void
+    {
+        $parent = $element->parentNode;
+        if ( ! $parent instanceof DOMNode ) {
+            return;
+        }
+
+        while ( null !== $element->firstChild ) {
+            $parent->insertBefore($element->firstChild, $element);
+        }
+
+        $parent->removeChild($element);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-strip", "style": { "spacing": { "padding": { "top": "2rem", "right": "2rem", "bottom": "2rem", "left": "2rem" } } } } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Specs", "level": 2, "className": "eyebrow", "style": { "color": { "text": "red" } } } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Use <span class=\"tone\" style=\"font-weight:700\"><mark>inline</mark></span> marks." } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Use <mark>inline</mark> marks." } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/list", "attrs": { "className": "definitions" } },
     { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<strong>Latency</strong> <span class=\"metric\">Low</span> response time" } },
     { "path": "blocks.0.innerBlocks.2.innerBlocks.1", "name": "core/list-item", "attrs": { "content": "<strong>Fallback</strong> Preserved safely" } },

--- a/php-transformer/tests/fixtures/parity/html-inline-content-wrapper.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-content-wrapper.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-content-wrapper",
-  "description": "Converts generic block wrappers containing only phrasing content into one paragraph while preserving inline markup and line breaks.",
+  "description": "Converts generic block wrappers containing only phrasing content into one paragraph, preserving genuine inline formats and line breaks while unwrapping presentational class-only sibling spans whose class RichText cannot store.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-content-wrapper.json",
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "hours-row", "content": "<span class=\"hours-day\">Tuesday</span><span class=\"hours-time\">5:00 pm</span>" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "hours-row", "content": "Tuesday5:00 pm" } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "address", "content": "<strong>412 Coalyard Lane</strong> Pearl District<br>Portland, OR" } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/buttons" }
   ],

--- a/php-transformer/tests/fixtures/parity/html-paragraph-heading-classed-span-hoist.json
+++ b/php-transformer/tests/fixtures/parity/html-paragraph-heading-classed-span-hoist.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-paragraph-heading-classed-span-hoist",
+  "description": "Hoists a single content-wrapping class/style span out of paragraph and heading RichText content onto the block, and unwraps sibling/partial styling-hook spans, so the stored block round-trips through RichText (saved == regenerated) while genuine inline formats are preserved.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-paragraph-heading-classed-span-hoist.json",
+    "notes": "Covers the dominant invalid-block cause in real imports: classed/styled <span> styling hooks inside paragraph/heading content, which RichText strips on parse."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers WordPress block-validity normalization beyond the legacy converter behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"card\"><p><span class=\"section-label\">Our Kitchen</span></p><p><span class=\"badge\" style=\"color:#ffffff\">New</span></p><h2><span class=\"ht-line\">Ember</span> <span class=\"ht-amp\">&amp;</span> <span class=\"ht-line-2\">Rye</span></h2><p><span class=\"lead\"><strong>Bold</strong> and <a href=\"/x\">link</a></span></p><p>Plain <strong>bold</strong> text</p></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "card" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "section-label", "content": "Our Kitchen" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "badge", "content": "New", "style": { "color": { "text": "#ffffff" } } } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/heading", "attrs": { "level": 2, "content": "Ember &amp; Rye" } },
+    { "path": "blocks.0.innerBlocks.3", "name": "core/paragraph", "attrs": { "className": "lead", "content": "<strong>Bold</strong> and <a href=\"/x\">link</a>" } },
+    { "path": "blocks.0.innerBlocks.4", "name": "core/paragraph", "attrs": { "content": "Plain <strong>bold</strong> text" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 5 },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"section-label\">Our Kitchen</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"has-text-color badge\" style=\"color:#ffffff\">New</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<h2>Ember &amp; Rye</h2>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"lead\"><strong>Bold</strong> and <a href=\"/x\">link</a></p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p>Plain <strong>bold</strong> text</p>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "class=\"section-label\">Our Kitchen</span>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "ht-line" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<span" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/wordpress-is-dead-hero.json
+++ b/php-transformer/tests/fixtures/parity/wordpress-is-dead-hero.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "<span class=\"eyebrow\">A Public Service Announcement</span>" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "eyebrow", "content": "A Public Service Announcement" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "level": 1 } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Generated from a <em>single sentence</em>. No <code>wp-admin</code>." } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/buttons" },


### PR DESCRIPTION
## Problem

Real imports leave invalid `core/paragraph` / `core/heading` blocks whose `content` carries classed/styled `<span>` styling hooks:

```
wp:paragraph {"content":"<span class=\"section-label\">Our Kitchen</span>"}
wp:paragraph {"className":"chef-caption","content":"<span class=\"chef-name\">Nora Westfield</span>\n <span class=\"chef-role\">Executive Chef</span>"}
wp:heading   {"content":"<span class=\"ht-line\">Ember</span> <span class=\"ht-amp\">&amp;</span> <span class=\"ht-line-2\">Rye</span>"}
```

Paragraph/heading `content` is RichText, which only preserves a fixed set of inline formats. A `<span class>`/`<span style>` is not a format, so RichText strips its attributes on parse: saved HTML no longer matches the regenerated HTML and the editor flags "unexpected or invalid content". The class is also a styling hook the materialized CSS targets, so naively dropping it loses the styling intent — this is the dominant remaining invalid-block cause.

## Fix

`createBlock` now normalizes `core/paragraph` and `core/heading` content, keying off **structure** (a content-bearing span carrying only class/style), never on fixture names or specific class strings:

- **Single wrapping span (the clean, common case):** when the entire content is one styling-hook `<span>`, it is **unwrapped** and its class/style are **hoisted onto the block** (merged into `className` and the canonical `style` object). The styling hook survives where RichText preserves it, and the inner text/inline-format becomes valid content. Nested wrappers are peeled across iterations.
- **Multiple sibling / partial styling-hook spans:** each span is **unwrapped to its inner content**. A per-span class is not representable as valid RichText here, so this is best-effort; the hard requirement met is that the emitted block is VALID and round-trips (saved == regenerated).
- **Genuine inline formats** (`<strong>`, `<em>`, `<a>`, `<br>`, `<mark>`, …) are never touched.

It stays in the paragraph/heading content lane — nav-toggle handling and CSS/theme materialization are untouched.

## Before / after

| Source | Before (invalid) | After (valid) |
|---|---|---|
| `<p><span class="section-label">Our Kitchen</span></p>` | `paragraph {content:"<span class=\"section-label\">Our Kitchen</span>"}` | `paragraph {className:"section-label", content:"Our Kitchen"}` |
| `<p><span class="badge" style="color:#fff">New</span></p>` | `paragraph {content:"<span class=\"badge\" style=\"color:#fff\">New</span>"}` | `paragraph {className:"badge", style:{color:{text:"#fff"}}, content:"New"}` → `<p class="has-text-color badge" style="color:#fff">New</p>` |
| `<h2><span class="ht-line">Ember</span> <span class="ht-amp">&amp;</span> <span class="ht-line-2">Rye</span></h2>` | heading content keeps three classed spans | `heading {content:"Ember &amp; Rye"}` |
| `<p><span class="lead"><strong>Bold</strong> and <a href="/x">link</a></span></p>` | wrapping span kept | `paragraph {className:"lead", content:"<strong>Bold</strong> and <a href=\"/x\">link</a>"}` |

## Tests / parity

- Baseline `composer test:canonical` + `composer parity` were green before the change.
- New fixture `html-paragraph-heading-classed-span-hoist` covers single-span hoist, style hoist, multi-span heading unwrap, inline-format preservation, and asserts `source_reports.wp_block_validity.status == pass`.
- Updated three fixtures whose prior expectations encoded the invalid classed-span-in-content output: `html-expanded-primitives`, `html-inline-content-wrapper`, `wordpress-is-dead-hero`.
- Full `composer test` green: 166 parity fixtures, canonical contracts, unit tests, packaging install-proof. `php -l` clean. `wp_block_validity` reports `pass` with 0 findings on the new cases.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigating the invalid-block cause, implementing the unwrap+hoist in the PHP transformer, and writing/updating parity fixtures.