### PR TITLE
Emit additive html_product_grid_fallback finding for product grids

### DIFF
--- a/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
+++ b/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
@@ -66,6 +66,19 @@ final class FallbackDiagnostic
                 'suggested_primitive'   => 'form',
                 'materialization_hint'  => 'preserve_form_markup_or_replace_with_form_block_integration',
             ),
+            'html_product_grid_fallback' => array(
+                'severity'              => 'info',
+                'conversion_classification' => 'editable_approximation',
+                'loss_class'            => 'native_conversion',
+                'diagnostic_class'      => 'commerce_structure_detected',
+                'preservation_strategy' => 'layout_blocks_with_structured_product_metadata',
+                'runtime_requirement'   => 'none',
+                'recoverability'        => 'recoverable_with_commerce_product_materialization',
+                'actionability'         => 'materialize_detected_products_in_a_commerce_provider',
+                'suggested_repair_class' => 'materialize_commerce_products',
+                'suggested_primitive'   => 'product_grid',
+                'materialization_hint'  => 'layout_blocks_are_emitted_as_is; map_each_detected_product_name_price_and_cart_control_onto_a_commerce_provider',
+            ),
             'html_script_fallback' => array(
                 'severity'              => 'warning',
                 'conversion_classification' => 'runtime_island_preserved',
@@ -204,6 +217,7 @@ final class FallbackDiagnostic
 
         return match ( $code ) {
             'html_form_fallback' => 'interactive_form',
+            'html_product_grid_fallback' => 'commerce_product_grid',
             'html_script_fallback' => 'runtime_script',
             'interactive_control_behavior_lost' => 'interactive_control',
             'html_iframe_embed_fallback' => 'external_embed',

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -362,6 +362,7 @@ final class HtmlTransformer
         $this->collectSupersededNavToggleSelectors($body);
         $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));
         $this->appendInteractiveControlBehaviorLossFallbacks($body, $fallbacks);
+        $this->appendProductGridFallbacks($body, $fallbacks);
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
@@ -2531,6 +2532,433 @@ final class HtmlTransformer
             ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->fallbackProvenance);
             ++$emitted;
         }
+    }
+
+    /**
+     * Surface a generic product-grid finding so a downstream consumer can
+     * materialize the recognized products (e.g. as commerce products) without the
+     * transformer carrying any provider or plugin knowledge.
+     *
+     * This is purely ADDITIVE: the layout block output (grid -> group/columns) is
+     * unchanged; this only appends an `html_product_grid_fallback` diagnostic that
+     * a consumer may act on or ignore.
+     *
+     * Detection composes the existing commerce-recognition primitives
+     * (grid_like / repeated card children / price + name tokens) with schema.org
+     * microdata (`itemtype` Product / `itemprop` name|price|Offer). A product card
+     * is a repeated sibling (>= 2 under a grid_like or list container) that either
+     * declares schema.org Product/Offer structure OR carries the full structural
+     * triad: a name (heading or name token), a currency-formatted price, and an
+     * add-to-cart/buy control. Detection reads only structural/semantic signals
+     * and schema.org vocabulary — never fixture names or specific class strings.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    private function appendProductGridFallbacks(DOMElement $body, array &$fallbacks): void
+    {
+        $emitted = 0;
+        $coveredPaths = array();
+        foreach ( $body->getElementsByTagName('*') as $element ) {
+            if ( ! $element instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( $emitted >= self::MAX_INTERACTION_CANDIDATES ) {
+                return;
+            }
+
+            if ( ! $this->isProductGridContainer($element) ) {
+                continue;
+            }
+
+            // Prefer the innermost qualifying container: skip a grid whose products
+            // were already attributed to a nested grid emitted earlier in the walk.
+            $path = $element->getNodePath() ?? '';
+            foreach ( $coveredPaths as $coveredPath ) {
+                if ( '' !== $path && '' !== $coveredPath && str_starts_with($coveredPath, $path . '/') ) {
+                    continue 2;
+                }
+            }
+
+            $products = $this->productCardsForContainer($element);
+            if ( count($products) < 2 ) {
+                continue;
+            }
+
+            $coveredPaths[] = $path;
+
+            $fallbacks[] = FallbackDiagnostic::build(array_filter(array(
+                'type'              => 'html',
+                'reason'            => 'commerce_product_grid_detected',
+                'diagnostic_code'   => 'html_product_grid_fallback',
+                'kind'              => 'html_product_grid_fallback',
+                'message'           => 'A product grid was detected; per-card commerce structure was extracted so a consumer can materialize the products.',
+                'source_format'     => 'html',
+                'tag'               => strtolower($element->tagName),
+                'selector'          => $this->elementSelector($element),
+                'container_selector' => $this->elementSelector($element),
+                'context'           => $this->sourceContext($element),
+                'products'          => $products,
+                'product_count'     => count($products),
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->fallbackProvenance);
+            ++$emitted;
+        }
+    }
+
+    /**
+     * Whether an element is a plausible product-grid container: a list (ul/ol) or
+     * an element the structure classifier already flags as grid_like.
+     */
+    private function isProductGridContainer(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( in_array($tagName, array( 'ul', 'ol' ), true) ) {
+            return true;
+        }
+
+        $signals = $this->structureSignals($element, array());
+        return true === ($signals['grid_like'] ?? false);
+    }
+
+    /**
+     * Extract the qualifying product cards directly under a grid container. A card
+     * is a direct child element that declares schema.org Product/Offer structure or
+     * carries the full structural commerce triad (name + price + cart control).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function productCardsForContainer(DOMElement $container): array
+    {
+        $products = array();
+        foreach ( $container->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $product = $this->productCardData($child);
+            if ( null !== $product ) {
+                $products[] = $product;
+            }
+        }
+
+        return $products;
+    }
+
+    /**
+     * Build the per-card product payload when a card qualifies, else null.
+     *
+     * A card qualifies when it declares schema.org Product/Offer structure
+     * (microdata `itemtype` Product or both `itemprop` name and price), OR carries
+     * the structural triad: a name, a currency-formatted price, and an
+     * add-to-cart/buy control.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function productCardData(DOMElement $card): ?array
+    {
+        $name = $this->productNameText($card);
+        $prices = $this->productPriceTexts($card);
+        $hasCart = $this->hasCartControl($card);
+        $isSchemaProduct = $this->isSchemaProductCard($card);
+
+        if ( '' === $name || array() === $prices ) {
+            return null;
+        }
+
+        // schema.org Product/Offer is an authoritative commerce signal, so it
+        // qualifies a card on its own. Otherwise require the full structural triad
+        // (name + price + cart control) to avoid flagging generic content grids.
+        if ( ! $isSchemaProduct && ! $hasCart ) {
+            return null;
+        }
+
+        return array_filter(array(
+            'name'             => $name,
+            'price'            => $prices['price'],
+            'sale_price'       => $prices['sale_price'] ?? null,
+            'description'      => $this->productDescriptionText($card, $name),
+            'image'            => $this->productImage($card),
+            'has_cart_control' => $hasCart,
+            'source_selector'  => $this->elementSelector($card),
+        ), static fn (mixed $value, string $key): bool => in_array($key, array( 'sale_price', 'description', 'image' ), true) || ( null !== $value && '' !== $value ), ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Whether the card declares schema.org Product/Offer structure via microdata.
+     */
+    private function isSchemaProductCard(DOMElement $card): bool
+    {
+        $itemtype = strtolower($this->attr($card, 'itemtype'));
+        if ( str_contains($itemtype, 'schema.org/product') ) {
+            return true;
+        }
+
+        $hasName = null !== $this->firstDescendantWithItemprop($card, array( 'name' ));
+        $hasPrice = null !== $this->firstDescendantWithItemprop($card, array( 'price' ));
+        if ( $hasName && $hasPrice ) {
+            return true;
+        }
+
+        foreach ( $card->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && str_contains(strtolower($this->attr($descendant, 'itemtype')), 'schema.org/offer') ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The product name text: schema.org `itemprop="name"`, else the first heading,
+     * else the first element carrying a name token.
+     */
+    private function productNameText(DOMElement $card): string
+    {
+        $schemaName = $this->firstDescendantWithItemprop($card, array( 'name' ));
+        if ( null !== $schemaName ) {
+            $text = $this->collapsedText($schemaName);
+            if ( '' !== $text ) {
+                return $text;
+            }
+        }
+
+        foreach ( $card->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && preg_match('/^h[1-6]$/', strtolower($descendant->tagName)) ) {
+                $text = $this->collapsedText($descendant);
+                if ( '' !== $text ) {
+                    return $text;
+                }
+            }
+        }
+
+        foreach ( $card->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && $this->hasCommerceToken($descendant, array( 'name', 'title', 'product' )) ) {
+                $text = $this->collapsedText($descendant);
+                if ( '' !== $text ) {
+                    return $text;
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Currency-formatted price text for the card, returning the regular price and
+     * an optional sale price. schema.org `itemprop="price"` is preferred; otherwise
+     * elements whose text is currency-formatted or carry a price token are used.
+     * A price element marked with a sale/discount token is treated as the sale
+     * price and the other as the regular price.
+     *
+     * @return array{price: string, sale_price?: string}
+     */
+    private function productPriceTexts(DOMElement $card): array
+    {
+        $regular = '';
+        $sale = '';
+        $fallback = '';
+
+        $schemaPrice = $this->firstDescendantWithItemprop($card, array( 'price' ));
+        if ( null !== $schemaPrice ) {
+            $content = trim($this->attr($schemaPrice, 'content'));
+            $regular = $this->currencyFormattedText('' !== $content ? $content : ($schemaPrice->textContent ?? ''), $schemaPrice);
+        }
+
+        foreach ( $card->getElementsByTagName('*') as $descendant ) {
+            if ( ! $descendant instanceof DOMElement ) {
+                continue;
+            }
+
+            $text = $this->collapsedText($descendant);
+            if ( '' === $text || ! $this->isPriceElement($descendant) ) {
+                continue;
+            }
+            // Only consider leaf-ish price elements so a wrapper's concatenated
+            // text does not shadow the individual regular/sale amounts.
+            if ( $this->childElementCount($descendant) > 0 ) {
+                continue;
+            }
+
+            $formatted = $this->currencyFormattedText($text, $descendant);
+            if ( '' === $formatted ) {
+                continue;
+            }
+
+            if ( $this->hasCommerceToken($descendant, array( 'sale', 'discount', 'special', 'reduced', 'now' )) ) {
+                $sale = '' === $sale ? $formatted : $sale;
+                continue;
+            }
+
+            if ( '' === $regular ) {
+                $regular = $formatted;
+            } elseif ( '' === $fallback ) {
+                $fallback = $formatted;
+            }
+        }
+
+        if ( '' === $regular ) {
+            $regular = '' !== $fallback ? $fallback : $sale;
+            $sale = '' !== $fallback ? $sale : '';
+        }
+
+        if ( '' === $regular ) {
+            return array();
+        }
+
+        $result = array( 'price' => $regular );
+        if ( '' !== $sale && $sale !== $regular ) {
+            $result['sale_price'] = $sale;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reduce raw text to its currency-formatted price token (e.g. "$24"), keeping
+     * the trimmed source when no currency token is present but the element is a
+     * declared price (schema.org / price token).
+     */
+    private function currencyFormattedText(string $text, DOMElement $element): string
+    {
+        $text = trim(preg_replace('/\s+/', ' ', $text) ?? '');
+        if ( '' === $text ) {
+            return '';
+        }
+
+        if ( preg_match('/\p{Sc}\s?\d[\d.,]*|\d[\d.,]*\s?(?:usd|eur|gbp|cad|aud)\b/iu', $text, $matches) ) {
+            return trim($matches[0]);
+        }
+
+        // A schema.org price content attribute is bare numeric (e.g. "24.00");
+        // keep it as-is when the element is a declared price.
+        if ( $this->hasCommerceToken($element, array( 'price', 'amount', 'cost' )) && preg_match('/\d/', $text) ) {
+            return $text;
+        }
+
+        return '';
+    }
+
+    /**
+     * Whether the card contains an add-to-cart / buy / purchase control. Detection
+     * is semantic: a button/link/input whose text, class, id, name, aria-label, or
+     * data-* carries cart/buy/add/purchase/checkout/order semantics.
+     */
+    private function hasCartControl(DOMElement $card): bool
+    {
+        $tokens = array( 'cart', 'buy', 'purchase', 'checkout', 'order', 'addtocart', 'add-to-cart' );
+        foreach ( $card->getElementsByTagName('*') as $descendant ) {
+            if ( ! $descendant instanceof DOMElement ) {
+                continue;
+            }
+
+            $tagName = strtolower($descendant->tagName);
+            $role = strtolower($this->attr($descendant, 'role'));
+            $isControl = in_array($tagName, array( 'button', 'a', 'input' ), true) || 'button' === $role;
+            if ( ! $isControl ) {
+                continue;
+            }
+
+            $haystack = strtolower(implode(' ', array(
+                $this->attr($descendant, 'class'),
+                $this->attr($descendant, 'id'),
+                $this->attr($descendant, 'name'),
+                $this->attr($descendant, 'aria-label'),
+                $this->attr($descendant, 'value'),
+                implode(' ', $this->safeDataAttributes($descendant)),
+                $this->collapsedText($descendant),
+            )));
+
+            foreach ( $tokens as $token ) {
+                if ( str_contains($haystack, $token) ) {
+                    return true;
+                }
+            }
+
+            // "add" alone is ambiguous, so require it to co-occur with a commerce
+            // context word ("cart"/"bag"/"basket") to count as a cart control.
+            if ( preg_match('/\badd\b/', $haystack) && preg_match('/\b(?:cart|bag|basket)\b/', $haystack) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * An optional short product description: the first paragraph in the card whose
+     * text is neither the name nor a price. Returns null when none is present.
+     */
+    private function productDescriptionText(DOMElement $card, string $name): ?string
+    {
+        foreach ( $card->getElementsByTagName('p') as $paragraph ) {
+            if ( ! $paragraph instanceof DOMElement ) {
+                continue;
+            }
+
+            $text = $this->collapsedText($paragraph);
+            if ( '' === $text || $text === $name || $this->looksLikePriceText($text) ) {
+                continue;
+            }
+
+            return mb_strlen($text) > 280 ? mb_substr($text, 0, 277) . '...' : $text;
+        }
+
+        return null;
+    }
+
+    /**
+     * The card's primary image as a generic { src, alt } pair, or null.
+     *
+     * @return array<string, string>|null
+     */
+    private function productImage(DOMElement $card): ?array
+    {
+        foreach ( $card->getElementsByTagName('img') as $image ) {
+            if ( ! $image instanceof DOMElement ) {
+                continue;
+            }
+
+            $src = trim($this->attr($image, 'src'));
+            if ( '' === $src && '' !== trim($this->attr($image, 'data-src')) ) {
+                $src = trim($this->attr($image, 'data-src'));
+            }
+            if ( '' === $src || preg_match('/^\s*javascript\s*:/i', $src) ) {
+                continue;
+            }
+
+            return array_filter(array(
+                'src' => $src,
+                'alt' => trim($this->attr($image, 'alt')),
+            ), static fn (mixed $value): bool => '' !== $value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the nearest descendant (or the element itself) declaring one of the
+     * given schema.org `itemprop` values.
+     *
+     * @param array<int, string> $itemprops
+     */
+    private function firstDescendantWithItemprop(DOMElement $element, array $itemprops): ?DOMElement
+    {
+        if ( in_array(strtolower($this->attr($element, 'itemprop')), $itemprops, true) ) {
+            return $element;
+        }
+
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && in_array(strtolower($this->attr($descendant, 'itemprop')), $itemprops, true) ) {
+                return $descendant;
+            }
+        }
+
+        return null;
+    }
+
+    private function collapsedText(DOMElement $element): string
+    {
+        return trim(preg_replace('/\s+/', ' ', $element->textContent ?? '') ?? '');
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/generated-store-inferred-html.json
+++ b/php-transformer/tests/fixtures/parity/generated-store-inferred-html.json
@@ -25,13 +25,31 @@
     { "path": "blocks.0.innerBlocks.2", "name": "core/group" },
     { "path": "blocks.0.innerBlocks.2.innerBlocks.2", "name": "core/buttons" }
   ],
-  "expected_fallbacks": [],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "commerce_product_grid_detected", "tag": "section", "diagnostic_code": "html_product_grid_fallback", "kind": "html_product_grid_fallback", "product_count": 2 }
+  ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
     { "path": "serialized_blocks", "assert": "contains", "value": "Signal Hoodie" },
     { "path": "serialized_blocks", "assert": "contains", "value": "#signal-hoodie" },
-    { "path": "fallbacks", "assert": "count", "count": 0 }
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_product_grid_fallback" },
+    { "path": "fallbacks.0.kind", "assert": "equals", "value": "html_product_grid_fallback" },
+    { "path": "fallbacks.0.reason_code", "assert": "equals", "value": "html_product_grid_fallback" },
+    { "path": "fallbacks.0.pattern_family", "assert": "equals", "value": "commerce_product_grid" },
+    { "path": "fallbacks.0.repair_bucket", "assert": "equals", "value": "materialize_commerce_products" },
+    { "path": "fallbacks.0.container_selector", "assert": "equals", "value": "section:nth-of-type(1)" },
+    { "path": "fallbacks.0.products", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.products.0.name", "assert": "equals", "value": "Signal Hoodie" },
+    { "path": "fallbacks.0.products.0.price", "assert": "equals", "value": "$64.00" },
+    { "path": "fallbacks.0.products.0.has_cart_control", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.products.0.image.src", "assert": "equals", "value": "assets/signal-hoodie.jpg" },
+    { "path": "fallbacks.0.products.0.image.alt", "assert": "equals", "value": "Signal Hoodie" },
+    { "path": "fallbacks.0.products.0.source_selector", "assert": "equals", "value": "section:nth-of-type(1) > article:nth-of-type(1)" },
+    { "path": "fallbacks.0.products.1.name", "assert": "equals", "value": "Field Notes" },
+    { "path": "fallbacks.0.products.1.price", "assert": "equals", "value": "$12" },
+    { "path": "fallbacks.0.products.1.has_cart_control", "assert": "equals", "value": true }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
@@ -24,7 +24,9 @@
     { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/buttons" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.3.innerBlocks.0", "name": "core/button", "attrs": { "className": "product-cta", "text": "Buy now", "url": "/products/bowl" } }
   ],
-  "expected_fallbacks": [],
+  "expected_fallbacks": [
+    { "type": "html", "reason": "commerce_product_grid_detected", "tag": "div", "diagnostic_code": "html_product_grid_fallback", "kind": "html_product_grid_fallback", "product_count": 2 }
+  ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
@@ -32,6 +34,16 @@
     { "path": "assets", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "product-price" },
     { "path": "source_reports.html.structure_signals.3.signals.price_like", "assert": "equals", "value": true },
-    { "path": "source_reports.html.structure_signals.14.signals.grid_like", "assert": "equals", "value": true }
+    { "path": "source_reports.html.structure_signals.14.signals.grid_like", "assert": "equals", "value": true },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_product_grid_fallback" },
+    { "path": "fallbacks.0.container_selector", "assert": "equals", "value": "div:nth-of-type(1)" },
+    { "path": "fallbacks.0.products", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.products.0.name", "assert": "equals", "value": "Ceramic Bowl" },
+    { "path": "fallbacks.0.products.0.price", "assert": "equals", "value": "$42" },
+    { "path": "fallbacks.0.products.0.has_cart_control", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.products.1.name", "assert": "equals", "value": "Linen Towel" },
+    { "path": "fallbacks.0.products.1.price", "assert": "equals", "value": "$18" },
+    { "path": "fallbacks.0.products.1.has_cart_control", "assert": "equals", "value": true }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-product-grid-schema-and-structural.json
+++ b/php-transformer/tests/fixtures/parity/html-product-grid-schema-and-structural.json
@@ -1,0 +1,44 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-product-grid-schema-and-structural",
+  "description": "Emits an additive html_product_grid_fallback finding for a schema.org Product grid (name/price/sale_price/image/cart control) while leaving a generic services grid and a price-only pricing table unflagged.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-product-grid-schema-and-structural.json",
+    "notes": "Product-neutral fixture: detection is driven by schema.org microdata and the structural commerce triad (name + currency price + add-to-cart control), never by fixture class names. Proves genericity by leaving the services/pricing grids silent."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream commerce-recognition fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><ul class=\"product-grid\"><li class=\"card\" itemscope itemtype=\"https://schema.org/Product\"><img src=\"/img/lamp.jpg\" alt=\"Desk Lamp\"><h3 itemprop=\"name\">Desk Lamp</h3><p class=\"desc\">Warm focused light for any desk.</p><span class=\"price\" itemprop=\"price\">$48</span><span class=\"price sale\">$36</span><a class=\"add-to-cart\" href=\"/cart/add/lamp\">Add to cart</a></li><li class=\"card\" itemscope itemtype=\"https://schema.org/Product\"><h3 itemprop=\"name\">Wall Clock</h3><span class=\"price\" itemprop=\"price\">$29</span><button class=\"buy-now\">Buy now</button></li></ul><div class=\"services grid\"><div class=\"service card\"><h3>Consulting</h3><p>We help you grow.</p><a href=\"/contact\">Learn more</a></div><div class=\"service card\"><h3>Design</h3><p>Beautiful interfaces.</p><a href=\"/contact\">Learn more</a></div></div><section class=\"pricing grid\"><div class=\"tier card\"><h3>Basic</h3><span class=\"price\">$9/mo</span><a href=\"/signup\">Get started</a></div><div class=\"tier card\"><h3>Pro</h3><span class=\"price\">$29/mo</span><a href=\"/signup\">Get started</a></div></section></main>"
+  },
+  "expected_fallbacks": [
+    { "type": "html", "reason": "commerce_product_grid_detected", "tag": "ul", "diagnostic_code": "html_product_grid_fallback", "kind": "html_product_grid_fallback", "product_count": 2 }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 1 },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_product_grid_fallback" },
+    { "path": "fallbacks.0.kind", "assert": "equals", "value": "html_product_grid_fallback" },
+    { "path": "fallbacks.0.reason_code", "assert": "equals", "value": "html_product_grid_fallback" },
+    { "path": "fallbacks.0.pattern_family", "assert": "equals", "value": "commerce_product_grid" },
+    { "path": "fallbacks.0.repair_bucket", "assert": "equals", "value": "materialize_commerce_products" },
+    { "path": "fallbacks.0.container_selector", "assert": "equals", "value": "main:nth-of-type(1) > ul:nth-of-type(1)" },
+    { "path": "fallbacks.0.products", "assert": "count", "count": 2 },
+    { "path": "fallbacks.0.products.0.name", "assert": "equals", "value": "Desk Lamp" },
+    { "path": "fallbacks.0.products.0.price", "assert": "equals", "value": "$48" },
+    { "path": "fallbacks.0.products.0.sale_price", "assert": "equals", "value": "$36" },
+    { "path": "fallbacks.0.products.0.description", "assert": "equals", "value": "Warm focused light for any desk." },
+    { "path": "fallbacks.0.products.0.image.src", "assert": "equals", "value": "/img/lamp.jpg" },
+    { "path": "fallbacks.0.products.0.image.alt", "assert": "equals", "value": "Desk Lamp" },
+    { "path": "fallbacks.0.products.0.has_cart_control", "assert": "equals", "value": true },
+    { "path": "fallbacks.0.products.0.source_selector", "assert": "equals", "value": "main:nth-of-type(1) > ul:nth-of-type(1) > li:nth-of-type(1)" },
+    { "path": "fallbacks.0.products.1.name", "assert": "equals", "value": "Wall Clock" },
+    { "path": "fallbacks.0.products.1.price", "assert": "equals", "value": "$29" },
+    { "path": "fallbacks.0.products.1.sale_price", "assert": "equals", "value": null },
+    { "path": "fallbacks.0.products.1.has_cart_control", "assert": "equals", "value": true }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a generic **product-card/grid recognizer** to the PHP transformer that emits an additive `html_product_grid_fallback` conversion finding so a downstream consumer can materialize products. This is **PR1** of the static-product-grid → WooCommerce capability. SSI's existing WooCommerce seeder (SSI PR2) consumes this finding.

Refs SSI #510, epic #489.

The transformer already recognized commerce structure (`structureSignals()`: `price_like`, `name_price_row`, `card_like`, `grid_like`, `repeated_card_children`, `featured_badge_like`; plus `hasCommerceToken()`, `looksLikePriceText()`, `isPriceElement()`, `isNameElement()`) but only fed it into provenance/wrapper-preservation and never emitted a finding. This composes those existing primitives with schema.org microdata into a recognizer, mirroring the `html_form_fallback` emission path exactly.

## Detection signals (generic — structural/semantic + schema.org only)

A **grid container** is a `<ul>`/`<ol>` or any element flagged `grid_like` by the existing `structureSignals()`. A **product card** is a repeated direct-child sibling (≥2) that **either**:

- declares **schema.org** structure — microdata `itemtype` `…/Product`, both `itemprop="name"` and `itemprop="price"`, or a nested `…/Offer` (authoritative commerce signal, qualifies on its own); **or**
- carries the full **structural triad**:
  1. **name** — `itemprop="name"`, else first heading, else an element with a name/title/product token;
  2. **currency-formatted price** — `itemprop="price"`, else text matching `looksLikePriceText()` / a price token;
  3. **add-to-cart/buy control** — a `button`/`a`/`input` (or `role="button"`) whose text/class/id/name/aria-label/value/data-* carries `cart`/`buy`/`purchase`/`checkout`/`order`/`add-to-cart` semantics (bare "add" requires a co-occurring cart/bag/basket word).

A sale price is the price element marked with a `sale`/`discount`/`special`/`reduced`/`now` token. Detection reads only structural/semantic signals and schema.org vocabulary — **never fixture names or specific class strings**. Generic feature/service grids and price-only pricing tables (CTA without cart semantics) stay unflagged.

The recognizer prefers the innermost qualifying container and is capped at `MAX_INTERACTION_CANDIDATES`.

## Emitted finding contract (consumed by SSI PR2)

```
diagnostic_code / kind: "html_product_grid_fallback"
container_selector:     "<css selector for the grid container>"
products: [
  {
    name:             "<text>",
    price:            "<currency-formatted price text, e.g. '$24'>",
    sale_price:       "<optional sale price text or null>",
    description:      "<optional short description or null>",
    image:            { "src": "...", "alt": "..." } | null,
    has_cart_control: true|false,
    source_selector:  "<css selector for this card>"
  }, ...
]
```

The finding also carries the canonical classification triplet (`reason_code: html_product_grid_fallback`, `pattern_family: commerce_product_grid`, `repair_bucket: materialize_commerce_products`), satisfying `ConversionFindingContract`.

## Additive guarantee

The existing grid → `core/group`/`core/columns` layout output is **unchanged**; this only appends a diagnostic. The two updated store fixtures keep their original `expected_blocks` and only gain the new fallback assertion — proving consumers that ignore the finding see no regression.

## Tests

- Baseline `composer test:canonical` + `composer parity` green before changes (34 findings, 167 fixtures).
- New focused fixture `html-product-grid-schema-and-structural` asserts the finding on a schema.org Product grid (name/price/sale_price/description/image/cart control) while leaving a generic services grid and a price-only pricing table unflagged (genericity proof).
- Updated `generated-store-inferred-html` and `html-product-card-svg-price-grid` (real product-store fixtures) to assert the additive finding with correct per-card name/price/cart-control; their layout assertions are untouched.
- Full `composer test` green (168 parity fixtures, canonical contracts, packaging). `php -l` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Recognizer design, implementation, and test fixtures.