### PR TITLE
Resolve CSS var() in font materialization (fix dropped web fonts)

### DIFF
--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -47,11 +47,19 @@ final class FontMaterializationPlanBuilder
      */
     public function fromWebFontSources(string $html = '', string $css = ''): array
     {
+        // Source typography is frequently applied through CSS custom properties
+        // (`body { font-family: var(--font-body) }` defined by
+        // `:root { --font-body: 'Lora', serif }`). Resolve those references to
+        // their concrete typefaces before parsing so the plan captures the real
+        // family — never a literal `var(--font-body)` token, which would corrupt
+        // the materialized Google Fonts request and the body role.
+        $resolvedCss = $this->resolveCssVariables($css);
+
         $fontUsage = array_merge(
             $this->fontUsageFromLinkedStylesheets($html),
-            $this->fontUsageFromCssDeclarations($css)
+            $this->fontUsageFromCssDeclarations($resolvedCss)
         );
-        $roles = $this->fontRolesFromCss($css);
+        $roles = $this->fontRolesFromCss($resolvedCss);
 
         // The base/body `font-family` is the document's foundational typography
         // and must survive into the materialized output even when it is declared
@@ -60,7 +68,7 @@ final class FontMaterializationPlanBuilder
         // typography keeps the source's body face. Heading-only inline fonts are
         // deliberately NOT materialized here: a custom heading face with no
         // loaded web-font cannot render, so it stays a reported drop.
-        $inlineBody = (string) ($this->fontRolesFromCss($this->styleBlockCss($html))['body'] ?? '');
+        $inlineBody = (string) ($this->fontRolesFromCss($this->resolveCssVariables($this->styleBlockCss($html)))['body'] ?? '');
         if ( '' !== $inlineBody ) {
             $fontUsage[] = array('family' => $inlineBody, 'weights' => array(400));
             if ( '' === (string) ($roles['body'] ?? '') ) {
@@ -229,7 +237,7 @@ final class FontMaterializationPlanBuilder
             }
 
             $family = $this->normalizeFamily((string) ($font['family'] ?? $font['font_family'] ?? ''));
-            if ( '' === $family || $this->isWebSafeFontFamily($family) ) {
+            if ( '' === $family || $this->isWebSafeFontFamily($family) || $this->isInvalidFontFamily($family) ) {
                 continue;
             }
 
@@ -282,12 +290,82 @@ final class FontMaterializationPlanBuilder
     {
         foreach ( explode(',', $declaration) as $candidate ) {
             $family = $this->normalizeFamily($candidate);
-            if ( '' !== $family && ! $this->isWebSafeFontFamily($family) ) {
+            if ( '' !== $family && ! $this->isWebSafeFontFamily($family) && ! $this->isInvalidFontFamily($family) ) {
                 return $family;
             }
         }
 
         return '';
+    }
+
+    /**
+     * Expand `var(--name[, fallback])` references within a CSS string using the
+     * custom-property definitions found in that same CSS. Bounded recursive
+     * passes resolve variables whose values reference other variables. Leaves
+     * unresolved references intact so they can be filtered as invalid families.
+     */
+    private function resolveCssVariables(string $css): string
+    {
+        if ( '' === trim($css) || ! str_contains($css, 'var(') ) {
+            return $css;
+        }
+
+        $vars = $this->cssCustomProperties($css);
+        if ( array() === $vars ) {
+            return $css;
+        }
+
+        for ( $pass = 0; $pass < 5; $pass++ ) {
+            $expanded = preg_replace_callback(
+                '/var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,\s*([^()]*))?\)/',
+                static function (array $match) use ($vars): string {
+                    $name = (string) $match[1];
+                    if ( isset($vars[$name]) && '' !== $vars[$name] ) {
+                        return $vars[$name];
+                    }
+
+                    return isset($match[2]) && '' !== trim((string) $match[2]) ? trim((string) $match[2]) : (string) $match[0];
+                },
+                $css
+            );
+
+            if ( ! is_string($expanded) || $expanded === $css ) {
+                break;
+            }
+            $css = $expanded;
+        }
+
+        return $css;
+    }
+
+    /**
+     * Collect `--name: value` custom-property declarations from CSS. Later
+     * declarations win, mirroring the cascade for the common single-scope case.
+     *
+     * @return array<string,string>
+     */
+    private function cssCustomProperties(string $css): array
+    {
+        if ( ! preg_match_all('/(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+)/', $css, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        $vars = array();
+        foreach ( $matches as $match ) {
+            $vars[(string) $match[1]] = trim((string) $match[2]);
+        }
+
+        return $vars;
+    }
+
+    /**
+     * A real typeface name never contains CSS function syntax or starts with a
+     * custom-property prefix. Such tokens (e.g. an unresolved `var(--font-body)`)
+     * must never be emitted as a Google Fonts family — they corrupt the request.
+     */
+    private function isInvalidFontFamily(string $family): bool
+    {
+        return str_contains($family, '(') || str_contains($family, ')') || str_starts_with($family, '--');
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1636,6 +1636,31 @@ $webFontMaterializationPlan = ( new MaterializationPlanBuilder() )->fromCompiled
 ));
 $assert('Oswald' === ($webFontMaterializationPlan['theme']['font_materialization']['roles']['heading'] ?? null), 'materialization plan materializes heading font from web-font sources');
 
+// CSS custom-property (var()) font-families resolve to their concrete typeface.
+// Sources frequently apply fonts through `var(--font-body)` defined in :root.
+// An unresolved `var(--font-body)` token must never reach the Google Fonts
+// request: it is not a real family and corrupts the css2 endpoint (HTTP 400),
+// which drops every linked font and renders the system fallback. The resolver
+// must expand the variable to its real family and assign roles accordingly.
+$varFontHtml = '<head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&amp;family=Lora:wght@400;500&amp;display=swap"></head>';
+$varFontCss  = ":root{--font-disp:'Playfair Display',Georgia,serif;--font-body:'Lora',Georgia,serif;}body{font-family:var(--font-body);}h1,h2,h3{font-family:var(--font-disp);}";
+$varFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources($varFontHtml, $varFontCss);
+$varFontFamilies = array_map(static fn (array $font): string => (string) $font['family'], $varFontPlan['fonts'] ?? array());
+$assert(array('Lora', 'Playfair Display') === $varFontFamilies, 'var() font-family resolves to concrete families and emits no var token family');
+$assert('Lora' === ($varFontPlan['roles']['body'] ?? null), 'var() body font-family resolves to its defined typeface');
+$assert('Playfair Display' === ($varFontPlan['roles']['heading'] ?? null), 'var() heading font-family resolves to its defined typeface');
+$assert(! str_contains((string) ($varFontPlan['css'] ?? ''), 'var('), 'materialized google fonts css carries no unresolved var() token');
+$assert(! str_contains((string) ($varFontPlan['css'] ?? ''), '%28'), 'materialized google fonts css carries no encoded parenthesis family');
+
+// An unresolvable var() (no :root definition, no fallback) must be dropped, not
+// emitted as a bogus family that would break the linked Google Fonts request.
+$unresolvedVarPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
+    '<head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:wght@400&display=swap"></head>',
+    'body{font-family:var(--font-undefined);}'
+);
+$assert(array('Lora') === array_map(static fn (array $font): string => (string) $font['family'], $unresolvedVarPlan['fonts'] ?? array()), 'unresolvable var() font-family is dropped from materialized fonts');
+$assert(! str_contains((string) ($unresolvedVarPlan['css'] ?? ''), 'var('), 'unresolvable var() never reaches the materialized google fonts css');
+
 // Typography/web-font parity diagnostic (semantic-parity finding family).
 $semanticFindings = static function (array $result): array {
     return $result['source_reports']['semantic_parity']['findings'] ?? array();


### PR DESCRIPTION
## What
Imported sites lost their web fonts. Root cause: 15-saas applies fonts via CSS custom properties (`:root{--font-body:'Lora',...}`, `body{font-family:var(--font-body)}`), and `FontMaterializationPlanBuilder` treated `var(--font-body)` as a literal Google Fonts family — emitting `...&family=var(--font-body)...` which returns **HTTP 400**, so Google Fonts dropped the ENTIRE stylesheet → 286-byte fonts.css → system fallback.

## Change (`src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php`)
- Resolve `var(--name[,fallback])` against the source `:root` definitions before parsing font-family declarations/roles; new `isInvalidFontFamily()` guard drops any token with parens or `--` prefix so an unresolvable var() never becomes a Google Fonts family.

## Verification
- 15-saas: fonts.css `@import` 400 → **200** (Lora, Playfair Display, IBM Plex Mono); plan roles `var(--font-disp)` → `Playfair Display`. (Pairs with the SSI theme.json var()-resolution PR.)
- `composer test` + `composer parity`: **165 fixtures** green; new contract assertions (var() resolves, no var(/%28 in css2 URL, unresolvable dropped).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and verification under human review.