### PR TITLE
Emit generated base class for core/heading + core/list (block validity)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -77,7 +77,7 @@ final class BlockFactory
         if ( 'core/heading' === $name ) {
             $level = (int) ($attrs['level'] ?? 2);
             $level = max(1, min(6, $level));
-            return '<h' . $level . $this->blockSupportAttrs($attrs) . '>' . ($attrs['content'] ?? '') . '</h' . $level . '>';
+            return '<h' . $level . $this->blockSupportAttrs($attrs, 'wp-block-heading') . '>' . ($attrs['content'] ?? '') . '</h' . $level . '>';
         }
 
         if ( 'core/paragraph' === $name ) {
@@ -94,7 +94,7 @@ final class BlockFactory
 
         if ( 'core/list' === $name ) {
             $tagName = ! empty($attrs['ordered']) ? 'ol' : 'ul';
-            return array( 'opening' => '<' . $tagName . $this->blockSupportAttrs($attrs) . '>', 'closing' => '</' . $tagName . '>' );
+            return array( 'opening' => '<' . $tagName . $this->blockSupportAttrs($attrs, 'wp-block-list') . '>', 'closing' => '</' . $tagName . '>' );
         }
 
         if ( 'core/quote' === $name ) {

--- a/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
+++ b/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
@@ -19,11 +19,13 @@ namespace Automattic\BlocksEngine\PhpTransformer\WordPress;
  *
  * When the transformer puts a source class on a structural child instead of the
  * wrapper (the historic `core/button` leak routed `className` onto the inner
- * `<a>`/`<button>` rather than the `wp-block-button` wrapper), or drops the
- * `anchor` id, the stored markup diverges from `save()` and the editor flags the
- * block invalid. This validator catches that class of regression in the fast
- * pure-PHP loop — no WordPress runtime required — so most invalid-block
- * detection moves off the editor gate.
+ * `<a>`/`<button>` rather than the `wp-block-button` wrapper), drops the
+ * `anchor` id, or omits the generated `wp-block-*` base class that
+ * `addGeneratedClassName` always reproduces for a `className`-supporting block
+ * (the historic `core/heading` / `core/list` leak), the stored markup diverges
+ * from `save()` and the editor flags the block invalid. This validator catches
+ * that class of regression in the fast pure-PHP loop — no WordPress runtime
+ * required — so most invalid-block detection moves off the editor gate.
  *
  * Scope is deliberately the static structural wrappers. Registry-versioned and
  * dynamic blocks (`core/navigation` family, `core/icon`) are skipped: their
@@ -49,6 +51,31 @@ final class CanonicalSaveShapeValidator
         'core/buttons',
         'core/button',
         'core/details',
+        'core/heading',
+        'core/list',
+        'core/quote',
+    );
+
+    /**
+     * The base `wp-block-{name}` class WordPress' `addGeneratedClassName` filter
+     * reproduces in `save()` for every block whose `className` support is true
+     * (the default). For these blocks the stored wrapper must carry the class or
+     * `wp.blocks.validateBlock` flags the block invalid, since the current
+     * `save()` always emits it. Keyed by block name so the assertion stays a
+     * pure-PHP shape check.
+     *
+     * @var array<string, string>
+     */
+    private const GENERATED_BASE_CLASS = array(
+        'core/group'   => 'wp-block-group',
+        'core/columns' => 'wp-block-columns',
+        'core/column'  => 'wp-block-column',
+        'core/buttons' => 'wp-block-buttons',
+        'core/button'  => 'wp-block-button',
+        'core/details' => 'wp-block-details',
+        'core/heading' => 'wp-block-heading',
+        'core/list'    => 'wp-block-list',
+        'core/quote'   => 'wp-block-quote',
     );
 
     /**
@@ -106,6 +133,22 @@ final class CanonicalSaveShapeValidator
         $classNameValue = is_string($attrs['className'] ?? null) ? $attrs['className'] : '';
         $classNameTokens = $this->tokens($classNameValue);
         $anchor          = is_string($attrs['anchor'] ?? null) ? $attrs['anchor'] : '';
+
+        // The block base class core's `addGeneratedClassName` always reproduces
+        // in save() must be present on the stored wrapper. A block emitted
+        // without it (the historic core/heading / core/list leak that dropped
+        // the generated wp-block-* class) diverges from the current save() and
+        // the editor flags it invalid.
+        $generatedClass = self::GENERATED_BASE_CLASS[$blockName] ?? '';
+        if ( '' !== $generatedClass && ! in_array($generatedClass, $wrapperClasses, true) ) {
+            $this->addFinding(
+                $findings,
+                $path,
+                $blockName,
+                'Wrapper is missing the generated class "' . $generatedClass . '" that core save() always emits for this block; the stored markup diverges from save().',
+                array( 'reason' => 'missing_generated_class', 'class' => $generatedClass )
+            );
+        }
 
         // Every wrapper class must be either a structural/support class or a
         // token core would reproduce from the className attribute. A leftover

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2241,7 +2241,7 @@ assertSame('core/heading', $markdownToBlocksResult['blocks'][0]['blockName'], 'M
 $blocksToHtmlResult = $bridge->convertResult('<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->', 'blocks', 'html')->toArray();
 assertSame('<p>Hello</p>', $blocksToHtmlResult['documents'][0]['content'], 'Serialized blocks should render to HTML through the default blocks/html adapters.');
 $markdownToHtmlResult = $bridge->convertResult("# Title\n\nBody", 'markdown', 'html')->toArray();
-assertStringContains('<h1>Title</h1>', $markdownToHtmlResult['documents'][0]['content'], 'Markdown should convert to HTML through the block pivot.');
+assertStringContains('<h1 class="wp-block-heading">Title</h1>', $markdownToHtmlResult['documents'][0]['content'], 'Markdown should convert to HTML through the block pivot with the canonical heading class core save() emits.');
 $blocksToMarkdownResult = $bridge->convertResult('<!-- wp:heading {"content":"Hello","level":1} --><h1>Hello</h1><!-- /wp:heading -->', 'blocks', 'markdown')->toArray();
 assertStringContains('# Hello', $blocksToMarkdownResult['documents'][0]['content'], 'Serialized blocks should convert to markdown through rendered HTML.');
 $htmlToBlocksResult = $bridge->convertResult('<h2>Hello</h2>', 'html', 'blocks')->toArray();

--- a/php-transformer/tests/fixtures/contract/wp-block-validity.json
+++ b/php-transformer/tests/fixtures/contract/wp-block-validity.json
@@ -61,6 +61,34 @@
       "expected_codes": []
     },
     {
+      "name": "valid-heading-canonical-save-shape",
+      "input": "<!-- wp:heading {\"level\":2} --><h2 class=\"wp-block-heading\">Section</h2><!-- /wp:heading -->",
+      "expected_status": "pass",
+      "expected_codes": []
+    },
+    {
+      "name": "invalid-heading-missing-generated-class",
+      "input": "<!-- wp:heading {\"level\":2} --><h2>Section</h2><!-- /wp:heading -->",
+      "expected_status": "warning",
+      "expected_codes": [
+        "canonical_save_shape_violation"
+      ]
+    },
+    {
+      "name": "valid-list-canonical-save-shape",
+      "input": "<!-- wp:list --><ul class=\"wp-block-list\"></ul><!-- /wp:list -->",
+      "expected_status": "pass",
+      "expected_codes": []
+    },
+    {
+      "name": "invalid-list-missing-generated-class",
+      "input": "<!-- wp:list --><ul></ul><!-- /wp:list -->",
+      "expected_status": "warning",
+      "expected_codes": [
+        "canonical_save_shape_violation"
+      ]
+    },
+    {
       "name": "invalid-navigation-serialized-child-comments",
       "blocks": [
         {

--- a/php-transformer/tests/fixtures/parity/artifact-generated-html.json
+++ b/php-transformer/tests/fixtures/parity/artifact-generated-html.json
@@ -26,7 +26,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"tagName\":\"article\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<article class=\"wp-block-group\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:heading {\"content\":\"Hello artifact\",\"level\":1} -->" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<h1>Hello artifact</h1>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<h1 class=\"wp-block-heading\">Hello artifact</h1>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html -->" },
     { "path": "source_reports.artifact.html.element_count", "assert": "equals", "value": 3 },
     { "path": "source_reports.conversion_report.metrics.fallback_count", "assert": "equals", "value": 0 },

--- a/php-transformer/tests/fixtures/parity/html-core-text-structure.json
+++ b/php-transformer/tests/fixtures/parity/html-core-text-structure.json
@@ -33,6 +33,9 @@
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 7 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<h2 class=\"wp-block-heading\">Section title</h2>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<ul class=\"wp-block-list\">" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/markdown-conversion.json
+++ b/php-transformer/tests/fixtures/parity/markdown-conversion.json
@@ -14,7 +14,7 @@
     "content": "# Title\n\nBody with **strong** text.\n\n- One\n- Two\n"
   },
   "expect": [
-    { "path": "converted", "assert": "contains", "value": "<h1>Title</h1>" },
+    { "path": "converted", "assert": "contains", "value": "<h1 class=\"wp-block-heading\">Title</h1>" },
     { "path": "converted", "assert": "contains", "value": "<strong>strong</strong>" },
     { "path": "blocks", "assert": "count", "count": 3 },
     { "path": "blocks.0.blockName", "assert": "equals", "value": "core/heading" },
@@ -22,7 +22,7 @@
     { "path": "result.schema", "assert": "equals", "value": "blocks-engine/php-transformer/result/v1" },
     { "path": "result.status", "assert": "equals", "value": "success" },
     { "path": "result.documents.0.format", "assert": "equals", "value": "html" },
-    { "path": "result.documents.0.content", "assert": "contains", "value": "<h1>Title</h1>" },
+    { "path": "result.documents.0.content", "assert": "contains", "value": "<h1 class=\"wp-block-heading\">Title</h1>" },
     { "path": "result.blocks.0.blockName", "assert": "equals", "value": "core/heading" },
     { "path": "result.diagnostics.0.code", "assert": "equals", "value": "format_bridge_conversion_completed" },
     { "path": "result.provenance.0.source_format", "assert": "equals", "value": "markdown" },

--- a/php-transformer/tests/fixtures/parity/mixed-source-markdown.json
+++ b/php-transformer/tests/fixtures/parity/mixed-source-markdown.json
@@ -18,7 +18,7 @@
     "content": "# Markdown Story\n\nThis page came from a nested Markdown source document.\n\n[Read the notes](notes.markdown)\n"
   },
   "expect": [
-    { "path": "converted", "assert": "contains", "value": "<h1>Markdown Story</h1>" },
+    { "path": "converted", "assert": "contains", "value": "<h1 class=\"wp-block-heading\">Markdown Story</h1>" },
     { "path": "converted", "assert": "contains", "value": "href=\"notes.markdown\"" },
     { "path": "blocks", "assert": "count", "count": 3 },
     { "path": "blocks.0.blockName", "assert": "equals", "value": "core/heading" },


### PR DESCRIPTION
## What
Closes the statically-preventable block-validity residual. On a real 15-saas import, `core/heading` (17) and `core/list` (3) were emitted WITHOUT their generated `wp-block-{name}` base class, which core `save()` always adds — so they failed editor block validation (`core/list` genuinely invalid by construction; `core/heading` non-canonical). A corpus scan confirmed these were the only two static block types ever missing their generated class (788 headings, 161 lists across 79 fixtures).

## Change
- `src/HtmlToBlocks/BlockFactory.php`: emit the generated base class for heading (:80) and list (:97), matching the existing quote/columns/button idiom.
- `src/WordPress/CanonicalSaveShapeValidator.php`: added `GENERATED_BASE_CLASS` map + `missing_generated_class` assertion (requires `wp-block-{name}` on every className-supporting static block), extended to heading/list/quote — caught in the fast pure-PHP loop.

## Verification
- 15-saas missing-generated-class: 17 headings + 3 lists → **0**; validator 0 violations, proven to flag when the class is removed.
- `composer test` + `composer parity`: **165 fixtures** green; canonical-output fixtures updated to assert `<h2 class="wp-block-heading">`/`<ul class="wp-block-list">`.
- Confirmed: `core/icon` invalids already cleared (inline SVGs route to core/html). Remaining residual = dynamic core/navigation(-link), correctly editor-gate-only.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and verification under human review.