### PR TITLE
Add corpus-diagnostics harness (fast, deterministic, runner-free)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -36,6 +36,7 @@
   },
   "scripts": {
     "parity": "@test:parity",
+    "corpus-diagnostics": "php tools/corpus-diagnostics/run.php",
     "test": [
       "@test:canonical",
       "@test:parity",
@@ -52,7 +53,8 @@
     "test:unit": [
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/custom-block-generator.php",
-      "php tests/unit/css-value-splitter.php"
+      "php tests/unit/css-value-splitter.php",
+      "php tests/unit/corpus-detectors.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
+++ b/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
@@ -1,0 +1,456 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\CorpusDiagnostics;
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+
+/**
+ * Pure, read-only detectors that turn a transformer result envelope into a flat
+ * list of cluster-ready findings plus per-document metrics.
+ *
+ * Every detector keys off structure and syntax only — never fixture names — so
+ * the same signals surface across the entire website-fixture corpus. None of
+ * these methods mutate the transformer or its output; they exclusively read the
+ * canonical result array produced by HtmlTransformer::transform()->toArray().
+ */
+final class CorpusDetectors
+{
+    /**
+     * WordPress preset custom properties (var(--wp--...)) are materialized by the
+     * theme/global-styles layer and are not part of the custom-property gap, so
+     * they are tracked for visibility but excluded from the actionable worklist.
+     */
+    private const PRESET_VAR_PREFIX = '--wp--';
+
+    /**
+     * Run every detector over one transformer result envelope.
+     *
+     * @param array<string, mixed> $result Canonical transformer result array.
+     * @return array{
+     *     metrics: array<string, int|float>,
+     *     findings: array<int, array<string, mixed>>,
+     *     var_names: array<int, string>
+     * }
+     */
+    public static function collect(array $result): array
+    {
+        $blocks = is_array($result['blocks'] ?? null) ? $result['blocks'] : array();
+        $flat = self::flatten($blocks);
+
+        $native = self::nativeRate($flat);
+        $varReport = self::varDependentStyling($flat);
+        $validityReport = self::blockValidity($result);
+
+        $findings = array();
+        foreach ( self::transformerFindings($result) as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( $validityReport['findings'] as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( $varReport['findings'] as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( self::classedSpanInContent($flat) as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( self::emptyCoreHtml($flat) as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( self::coreHtmlFallback($flat) as $finding ) {
+            $findings[] = $finding;
+        }
+
+        $metrics = array(
+            'block_count'         => $native['total'],
+            'native_count'        => $native['native'],
+            'core_html_count'     => $native['html'],
+            'freeform_count'      => $native['freeform'],
+            'native_rate'         => $native['rate'],
+            'var_ref_count'       => $varReport['count'],
+            'var_custom_ref_count' => $varReport['custom_count'],
+            'invalid_block_count' => $validityReport['invalid_block_count'],
+        );
+
+        return array(
+            'metrics'   => $metrics,
+            'findings'  => $findings,
+            'var_names' => $varReport['names'],
+        );
+    }
+
+    /**
+     * Flatten the recursive block tree into a depth-first list of block arrays.
+     *
+     * @param array<int, mixed> $blocks
+     * @return array<int, array<string, mixed>>
+     */
+    public static function flatten(array $blocks): array
+    {
+        $flat = array();
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+            $flat[] = $block;
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                foreach ( self::flatten($block['innerBlocks']) as $child ) {
+                    $flat[] = $child;
+                }
+            }
+        }
+
+        return $flat;
+    }
+
+    /**
+     * Native-rate metric: structured core/native blocks over total blocks.
+     * core/html and core/freeform (raw HTML escape hatches) count against the
+     * native rate, as do name-less blocks.
+     *
+     * @param array<int, array<string, mixed>> $flat Flattened block list.
+     * @return array{total: int, native: int, html: int, freeform: int, rate: float}
+     */
+    public static function nativeRate(array $flat): array
+    {
+        $total = 0;
+        $html = 0;
+        $freeform = 0;
+        $native = 0;
+
+        foreach ( $flat as $block ) {
+            ++$total;
+            $name = is_string($block['blockName'] ?? null) ? $block['blockName'] : '';
+            if ( 'core/html' === $name ) {
+                ++$html;
+                continue;
+            }
+            if ( 'core/freeform' === $name ) {
+                ++$freeform;
+                continue;
+            }
+            if ( '' === $name ) {
+                continue;
+            }
+            ++$native;
+        }
+
+        return array(
+            'total'    => $total,
+            'native'   => $native,
+            'html'     => $html,
+            'freeform' => $freeform,
+            'rate'     => $total > 0 ? round($native / $total, 4) : 0.0,
+        );
+    }
+
+    /**
+     * var(--x) references in the emitted block markup. A high density of custom
+     * (non-preset) custom-property references signals the CSS custom-property
+     * materialization gap, because nothing defines those properties in the
+     * generated WordPress output.
+     *
+     * @param array<int, array<string, mixed>> $flat Flattened block list.
+     * @return array{
+     *     count: int,
+     *     custom_count: int,
+     *     names: array<int, string>,
+     *     findings: array<int, array<string, mixed>>
+     * }
+     */
+    public static function varDependentStyling(array $flat): array
+    {
+        $occurrences = array();
+        $total = 0;
+
+        foreach ( $flat as $block ) {
+            $haystack = self::blockMarkup($block);
+            if ( '' === $haystack ) {
+                continue;
+            }
+            if ( ! preg_match_all('/var\(\s*(--[A-Za-z0-9_-]+)/', $haystack, $matches) ) {
+                continue;
+            }
+            foreach ( $matches[1] as $name ) {
+                ++$total;
+                $occurrences[$name] = ($occurrences[$name] ?? 0) + 1;
+            }
+        }
+
+        $findings = array();
+        $customCount = 0;
+        foreach ( $occurrences as $name => $count ) {
+            if ( self::isPresetVar($name) ) {
+                continue;
+            }
+            $customCount += $count;
+            $findings[] = array(
+                'source'        => 'detector',
+                'detector'      => 'var_dependent_styling',
+                'repair_bucket' => 'css_custom_property_materialization',
+                'pattern'       => $name,
+                'count'         => $count,
+            );
+        }
+
+        $names = array_keys($occurrences);
+        sort($names);
+
+        return array(
+            'count'        => $total,
+            'custom_count' => $customCount,
+            'names'        => $names,
+            'findings'     => $findings,
+        );
+    }
+
+    /**
+     * core/paragraph and core/heading whose content carries an inline
+     * <span class=...> or <span style=...>. These classed/styled spans inside
+     * RichText content are a common block-invalidity risk.
+     *
+     * @param array<int, array<string, mixed>> $flat Flattened block list.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function classedSpanInContent(array $flat): array
+    {
+        $findings = array();
+        foreach ( $flat as $block ) {
+            $name = is_string($block['blockName'] ?? null) ? $block['blockName'] : '';
+            if ( 'core/paragraph' !== $name && 'core/heading' !== $name ) {
+                continue;
+            }
+            $content = self::richTextContent($block);
+            if ( '' === $content ) {
+                continue;
+            }
+            if ( preg_match('/<span\b[^>]*\s(?:class|style)\s*=/i', $content) ) {
+                $findings[] = array(
+                    'source'        => 'detector',
+                    'detector'      => 'classed_span_in_content',
+                    'repair_bucket' => 'richtext_inline_span_normalization',
+                    'pattern'       => $name,
+                    'count'         => 1,
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * core/html blocks whose content is only whitespace and/or HTML comments —
+     * dead blocks, typically left behind when SVG or script content is stripped.
+     *
+     * @param array<int, array<string, mixed>> $flat Flattened block list.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function emptyCoreHtml(array $flat): array
+    {
+        $findings = array();
+        foreach ( $flat as $block ) {
+            $name = is_string($block['blockName'] ?? null) ? $block['blockName'] : '';
+            if ( 'core/html' !== $name ) {
+                continue;
+            }
+            $content = self::rawContent($block);
+            $hadComment = (bool) preg_match('/<!--.*?-->/s', $content);
+            $stripped = trim(preg_replace('/<!--.*?-->/s', '', $content) ?? '');
+            if ( '' !== $stripped ) {
+                continue;
+            }
+            $findings[] = array(
+                'source'        => 'detector',
+                'detector'      => 'empty_core_html',
+                'repair_bucket' => 'drop_empty_html_block',
+                'pattern'       => $hadComment ? 'comment_only_or_stripped' : 'whitespace_only',
+                'count'         => 1,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Non-empty core/html escape hatches, clustered by the leading element of
+     * their raw content. Surfaces which raw-HTML families still bypass native
+     * block conversion.
+     *
+     * @param array<int, array<string, mixed>> $flat Flattened block list.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function coreHtmlFallback(array $flat): array
+    {
+        $findings = array();
+        foreach ( $flat as $block ) {
+            $name = is_string($block['blockName'] ?? null) ? $block['blockName'] : '';
+            if ( 'core/html' !== $name ) {
+                continue;
+            }
+            $content = self::rawContent($block);
+            $stripped = trim(preg_replace('/<!--.*?-->/s', '', $content) ?? '');
+            if ( '' === $stripped ) {
+                continue;
+            }
+            $tag = preg_match('/<\s*([a-zA-Z][a-zA-Z0-9-]*)/', $stripped, $matches)
+                ? '<' . strtolower($matches[1]) . '>'
+                : 'text';
+            $findings[] = array(
+                'source'        => 'detector',
+                'detector'      => 'core_html_fallback',
+                'repair_bucket' => 'native_block_recognition',
+                'pattern'       => $tag,
+                'count'         => 1,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Block-validity findings drawn from the transformer's own
+     * source_reports.wp_block_validity report — the same serialization round-trip
+     * check the parity suite asserts on. Each finding records the block name and
+     * the cause code as its pattern.
+     *
+     * @param array<string, mixed> $result Canonical transformer result array.
+     * @return array{invalid_block_count: int, findings: array<int, array<string, mixed>>}
+     */
+    public static function blockValidity(array $result): array
+    {
+        $report = $result['source_reports']['wp_block_validity'] ?? array();
+        $rawFindings = is_array($report['findings'] ?? null) ? $report['findings'] : array();
+
+        $findings = array();
+        foreach ( $rawFindings as $finding ) {
+            if ( ! is_array($finding) ) {
+                continue;
+            }
+            $code = (string) ($finding['code'] ?? 'wp_block_validity_warning');
+            $blockName = is_string($finding['block_name'] ?? null) && '' !== $finding['block_name']
+                ? $finding['block_name']
+                : 'unknown';
+            $findings[] = array(
+                'source'        => 'validity',
+                'detector'      => 'wp_block_validity',
+                'repair_bucket' => 'block_serialization_validity_repair',
+                'pattern'       => $code . '@' . $blockName,
+                'count'         => 1,
+            );
+        }
+
+        return array(
+            'invalid_block_count' => count($findings),
+            'findings'            => $findings,
+        );
+    }
+
+    /**
+     * The transformer's own emitted diagnostics, normalized through the canonical
+     * finding contract so each carries the (reason_code, pattern_family,
+     * repair_bucket) classification triplet. Purely informational summary
+     * findings (no_repair_needed) are dropped from the worklist.
+     *
+     * @param array<string, mixed> $result Canonical transformer result array.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function transformerFindings(array $result): array
+    {
+        $diagnostics = is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array();
+
+        $findings = array();
+        foreach ( $diagnostics as $diagnostic ) {
+            if ( ! is_array($diagnostic) ) {
+                continue;
+            }
+            $classified = ConversionFindingContract::withClassification($diagnostic);
+            $repairBucket = (string) ($classified['repair_bucket'] ?? '');
+            if ( 'no_repair_needed' === $repairBucket ) {
+                continue;
+            }
+            $pattern = (string) ($classified['pattern_family'] ?? '');
+            if ( '' === $pattern ) {
+                $pattern = ConversionFindingContract::findingCode($classified);
+            }
+            if ( '' === $pattern ) {
+                $pattern = 'unclassified';
+            }
+            $findings[] = array(
+                'source'        => 'transformer',
+                'detector'      => 'emitted_finding',
+                'repair_bucket' => $repairBucket,
+                'pattern'       => $pattern,
+                'count'         => 1,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Cluster key for a finding: the repair lane (falling back to the detector
+     * name) paired with the structural pattern.
+     *
+     * @param array<string, mixed> $finding
+     */
+    public static function clusterKey(array $finding): string
+    {
+        $bucket = (string) ($finding['repair_bucket'] ?? '');
+        if ( '' === $bucket ) {
+            $bucket = (string) ($finding['detector'] ?? 'unclassified');
+        }
+        $pattern = (string) ($finding['pattern'] ?? 'unclassified');
+
+        return $bucket . ' :: ' . $pattern;
+    }
+
+    /**
+     * Emitted markup for one block — the saved innerHTML, which is the single
+     * source of the rendered style="..." declarations. Reading only innerHTML
+     * (rather than also the attribute JSON, which carries the same values) keeps
+     * each var() reference counted exactly once.
+     *
+     * @param array<string, mixed> $block
+     */
+    private static function blockMarkup(array $block): string
+    {
+        return is_string($block['innerHTML'] ?? null) ? $block['innerHTML'] : '';
+    }
+
+    /**
+     * RichText content for a paragraph/heading block: the explicit content
+     * attribute, falling back to saved innerHTML.
+     *
+     * @param array<string, mixed> $block
+     */
+    private static function richTextContent(array $block): string
+    {
+        $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+        if ( is_string($attrs['content'] ?? null) && '' !== $attrs['content'] ) {
+            return $attrs['content'];
+        }
+
+        return is_string($block['innerHTML'] ?? null) ? $block['innerHTML'] : '';
+    }
+
+    /**
+     * Raw content for a core/html block.
+     *
+     * @param array<string, mixed> $block
+     */
+    private static function rawContent(array $block): string
+    {
+        $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+        if ( is_string($attrs['content'] ?? null) ) {
+            return $attrs['content'];
+        }
+
+        return is_string($block['innerHTML'] ?? null) ? $block['innerHTML'] : '';
+    }
+
+    private static function isPresetVar(string $name): bool
+    {
+        return str_starts_with($name, self::PRESET_VAR_PREFIX);
+    }
+}

--- a/php-transformer/src/CorpusDiagnostics/CorpusDiagnosticsRunner.php
+++ b/php-transformer/src/CorpusDiagnostics/CorpusDiagnosticsRunner.php
@@ -1,0 +1,287 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\CorpusDiagnostics;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+/**
+ * Drives the HTML transformer over an entire website-fixture corpus and produces
+ * a frequency-ranked findings worklist. Pure PHP: no runner, no WordPress
+ * runtime, no browser, no network.
+ *
+ * The corpus layout it expects mirrors fixtures/websites/<fixture>/, where each
+ * fixture directory holds one or more *.html files and an optional fixture.json
+ * describing its class and tags.
+ */
+final class CorpusDiagnosticsRunner
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/corpus-diagnostics-report/v1';
+
+    private HtmlTransformer $transformer;
+
+    public function __construct(?HtmlTransformer $transformer = null)
+    {
+        $this->transformer = $transformer ?? new HtmlTransformer();
+    }
+
+    /**
+     * Run the harness over every HTML document under the corpus root.
+     *
+     * @param string $corpusDir Absolute path to fixtures/websites.
+     * @return array<string, mixed> Machine-readable report.
+     */
+    public function run(string $corpusDir): array
+    {
+        $documents = $this->discoverDocuments($corpusDir);
+
+        $fixtures = array();
+        $clusters = array();
+        $totals = array(
+            'fixture_count'       => count(array_unique(array_map(static fn (array $doc): string => $doc['fixture'], $documents))),
+            'document_count'      => 0,
+            'block_count'         => 0,
+            'native_count'        => 0,
+            'core_html_count'     => 0,
+            'freeform_count'      => 0,
+            'invalid_block_count' => 0,
+            'var_ref_count'       => 0,
+            'var_custom_ref_count' => 0,
+            'finding_count'       => 0,
+        );
+
+        foreach ( $documents as $document ) {
+            $html = (string) file_get_contents($document['path']);
+            $result = $this->transformer->transform($html, array())->toArray();
+            $collected = CorpusDetectors::collect($result);
+
+            $relPath = $document['rel'];
+            $fixtures[$relPath] = array(
+                'fixture'   => $document['fixture'],
+                'class'     => $document['class'],
+                'tags'      => $document['tags'],
+                'status'    => (string) ($result['status'] ?? 'unknown'),
+                'metrics'   => $collected['metrics'],
+                'var_names' => $collected['var_names'],
+                'clusters'  => $this->summarizeFindings($collected['findings']),
+            );
+
+            $metrics = $collected['metrics'];
+            $totals['document_count']++;
+            $totals['block_count'] += (int) $metrics['block_count'];
+            $totals['native_count'] += (int) $metrics['native_count'];
+            $totals['core_html_count'] += (int) $metrics['core_html_count'];
+            $totals['freeform_count'] += (int) $metrics['freeform_count'];
+            $totals['invalid_block_count'] += (int) $metrics['invalid_block_count'];
+            $totals['var_ref_count'] += (int) $metrics['var_ref_count'];
+            $totals['var_custom_ref_count'] += (int) $metrics['var_custom_ref_count'];
+
+            foreach ( $collected['findings'] as $finding ) {
+                $key = CorpusDetectors::clusterKey($finding);
+                $count = (int) ($finding['count'] ?? 1);
+                $totals['finding_count'] += $count;
+
+                if ( ! isset($clusters[$key]) ) {
+                    $clusters[$key] = array(
+                        'key'           => $key,
+                        'repair_bucket' => (string) ($finding['repair_bucket'] ?? ''),
+                        'detector'      => (string) ($finding['detector'] ?? ''),
+                        'source'        => (string) ($finding['source'] ?? ''),
+                        'pattern'       => (string) ($finding['pattern'] ?? ''),
+                        'count'         => 0,
+                        'fixtures'      => array(),
+                    );
+                }
+                $clusters[$key]['count'] += $count;
+                $clusters[$key]['fixtures'][$relPath] = true;
+            }
+        }
+
+        $ranked = $this->rankClusters($clusters);
+        $totals['native_rate'] = $totals['block_count'] > 0
+            ? round($totals['native_count'] / $totals['block_count'], 4)
+            : 0.0;
+
+        ksort($fixtures);
+
+        return array(
+            'schema'       => self::SCHEMA,
+            'generated_at' => gmdate('c'),
+            'corpus_dir'   => $corpusDir,
+            'totals'       => $totals,
+            'clusters'     => $ranked,
+            'fixtures'     => $fixtures,
+        );
+    }
+
+    /**
+     * Render the ranked clusters as a concise human-readable worklist.
+     *
+     * @param array<string, mixed> $report
+     */
+    public function renderSummary(array $report, int $limit = 25): string
+    {
+        $totals = $report['totals'];
+        $lines = array();
+        $lines[] = 'Corpus diagnostics — ' . $totals['document_count'] . ' document(s) across ' . $totals['fixture_count'] . ' fixture(s)';
+        $lines[] = sprintf(
+            'blocks=%d native_rate=%.1f%% invalid_blocks=%d var_refs=%d (custom=%d) findings=%d',
+            $totals['block_count'],
+            ((float) $totals['native_rate']) * 100,
+            $totals['invalid_block_count'],
+            $totals['var_ref_count'],
+            $totals['var_custom_ref_count'],
+            $totals['finding_count']
+        );
+        $lines[] = '';
+        $lines[] = 'TOP RANKED CLUSTERS (occurrences :: cluster :: fixtures):';
+
+        $rank = 0;
+        foreach ( $report['clusters'] as $cluster ) {
+            if ( $rank >= $limit ) {
+                break;
+            }
+            ++$rank;
+            $examples = implode(', ', array_slice($cluster['example_fixtures'], 0, 3));
+            $lines[] = sprintf(
+                '%2d. [%4d in %3d files] %s',
+                $rank,
+                $cluster['count'],
+                $cluster['fixture_count'],
+                $cluster['key']
+            );
+            if ( '' !== $examples ) {
+                $lines[] = '      e.g. ' . $examples;
+            }
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Discover every HTML document and resolve its fixture metadata.
+     *
+     * @return array<int, array{path: string, rel: string, fixture: string, class: string, tags: array<int, string>}>
+     */
+    private function discoverDocuments(string $corpusDir): array
+    {
+        $entries = glob(rtrim($corpusDir, '/') . '/*', GLOB_ONLYDIR);
+        if ( false === $entries ) {
+            return array();
+        }
+        sort($entries);
+
+        $documents = array();
+        foreach ( $entries as $fixtureDir ) {
+            $fixture = basename($fixtureDir);
+            $meta = $this->loadFixtureMeta($fixtureDir);
+            $htmlFiles = $this->findHtmlFiles($fixtureDir);
+            foreach ( $htmlFiles as $htmlFile ) {
+                $rel = $fixture . '/' . ltrim(substr($htmlFile, strlen($fixtureDir)), '/');
+                $documents[] = array(
+                    'path'    => $htmlFile,
+                    'rel'     => $rel,
+                    'fixture' => $fixture,
+                    'class'   => $meta['class'],
+                    'tags'    => $meta['tags'],
+                );
+            }
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @return array{class: string, tags: array<int, string>}
+     */
+    private function loadFixtureMeta(string $fixtureDir): array
+    {
+        $path = $fixtureDir . '/fixture.json';
+        if ( ! is_file($path) ) {
+            return array('class' => '', 'tags' => array());
+        }
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if ( ! is_array($decoded) ) {
+            return array('class' => '', 'tags' => array());
+        }
+        $tags = array();
+        if ( is_array($decoded['tags'] ?? null) ) {
+            foreach ( $decoded['tags'] as $tag ) {
+                if ( is_string($tag) ) {
+                    $tags[] = $tag;
+                }
+            }
+        }
+
+        return array(
+            'class' => is_string($decoded['class'] ?? null) ? $decoded['class'] : '',
+            'tags'  => $tags,
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function findHtmlFiles(string $fixtureDir): array
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($fixtureDir, \FilesystemIterator::SKIP_DOTS)
+        );
+        $files = array();
+        foreach ( $iterator as $file ) {
+            if ( $file instanceof \SplFileInfo && 'html' === strtolower($file->getExtension()) ) {
+                $files[] = $file->getPathname();
+            }
+        }
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * Collapse a document's findings into per-cluster counts for the per-fixture
+     * detail section.
+     *
+     * @param array<int, array<string, mixed>> $findings
+     * @return array<string, int>
+     */
+    private function summarizeFindings(array $findings): array
+    {
+        $summary = array();
+        foreach ( $findings as $finding ) {
+            $key = CorpusDetectors::clusterKey($finding);
+            $summary[$key] = ($summary[$key] ?? 0) + (int) ($finding['count'] ?? 1);
+        }
+        arsort($summary);
+
+        return $summary;
+    }
+
+    /**
+     * Sort clusters by total occurrences, then fixture spread, then key, and
+     * attach the example-fixture list.
+     *
+     * @param array<string, array<string, mixed>> $clusters
+     * @return array<int, array<string, mixed>>
+     */
+    private function rankClusters(array $clusters): array
+    {
+        $ranked = array();
+        foreach ( $clusters as $cluster ) {
+            $fixtures = array_keys($cluster['fixtures']);
+            sort($fixtures);
+            $cluster['fixture_count'] = count($fixtures);
+            $cluster['example_fixtures'] = array_slice($fixtures, 0, 5);
+            unset($cluster['fixtures']);
+            $ranked[] = $cluster;
+        }
+
+        usort($ranked, static function (array $a, array $b): int {
+            return ($b['count'] <=> $a['count'])
+                ?: ($b['fixture_count'] <=> $a['fixture_count'])
+                ?: strcmp($a['key'], $b['key']);
+        });
+
+        return $ranked;
+    }
+}

--- a/php-transformer/tests/unit/corpus-detectors.php
+++ b/php-transformer/tests/unit/corpus-detectors.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the corpus-diagnostics detectors.
+ *
+ * Plain-PHP test script in the style of tests/unit/css-value-splitter.php — no
+ * PHPUnit. A single inline HTML document carries an inline classed/styled span
+ * inside RichText and a custom var() reference, and the detectors must report
+ * each while leaving the WordPress-preset var() out of the actionable worklist.
+ * The empty (stripped-SVG) core/html detector is exercised directly against a
+ * synthetic block tree, since it reads the canonical result array the same way
+ * the harness does.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\CorpusDiagnostics\CorpusDetectors;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$html = <<<'HTML'
+<div>
+  <p>Hello <span class="accent">world</span></p>
+  <h2 style="color:var(--brand-color)">Big <span style="font-weight:bold">title</span></h2>
+  <p style="background:var(--wp--preset--color--primary)">Preset paragraph</p>
+</div>
+HTML;
+
+$result = ( new HtmlTransformer() )->transform($html, array())->toArray();
+$collected = CorpusDetectors::collect($result);
+
+$byDetector = static function (array $findings, string $detector): array {
+    return array_values(array_filter(
+        $findings,
+        static fn (array $finding): bool => ($finding['detector'] ?? '') === $detector
+    ));
+};
+
+// ---------------------------------------------------------------------------
+// 1. classed-span-in-content: the paragraph and heading each report once.
+// ---------------------------------------------------------------------------
+$spanFindings = $byDetector($collected['findings'], 'classed_span_in_content');
+$assert(2 === count($spanFindings), '1: both classed/styled spans are reported', 'got ' . count($spanFindings));
+$spanPatterns = array_map(static fn (array $f): string => (string) $f['pattern'], $spanFindings);
+sort($spanPatterns);
+$assert(
+    array('core/heading', 'core/paragraph') === $spanPatterns,
+    '1b: classed-span findings carry the offending block name as pattern',
+    implode(',', $spanPatterns)
+);
+
+// ---------------------------------------------------------------------------
+// 2. var-dependent styling: the custom property is reported; the wp-preset is
+//    counted for visibility but excluded from the actionable findings.
+// ---------------------------------------------------------------------------
+$varFindings = $byDetector($collected['findings'], 'var_dependent_styling');
+$assert(1 === count($varFindings), '2: only the custom var() is an actionable finding', 'got ' . count($varFindings));
+$assert(
+    1 === count($varFindings) && '--brand-color' === $varFindings[0]['pattern'],
+    '2b: custom var() finding names the custom property',
+    $varFindings[0]['pattern'] ?? '(none)'
+);
+$assert(
+    in_array('--wp--preset--color--primary', $collected['var_names'], true),
+    '2c: preset var() is still tracked in var_names for visibility'
+);
+$assert(
+    (int) $collected['metrics']['var_ref_count'] >= 2,
+    '2d: var_ref_count counts both custom and preset references',
+    (string) $collected['metrics']['var_ref_count']
+);
+$assert(
+    1 === (int) $collected['metrics']['var_custom_ref_count'],
+    '2e: var_custom_ref_count counts only the custom reference',
+    (string) $collected['metrics']['var_custom_ref_count']
+);
+
+// ---------------------------------------------------------------------------
+// 3. empty core/html: a comment-only (stripped-SVG) block and a whitespace-only
+//    block are each reported, while a non-empty raw-HTML block is not.
+// ---------------------------------------------------------------------------
+$syntheticBlocks = array(
+    array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => '<!-- svg stripped -->' ),
+    array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => "   \n  " ),
+    array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => '<svg><path></path></svg>' ),
+);
+$emptyFindings = CorpusDetectors::emptyCoreHtml($syntheticBlocks);
+$assert(2 === count($emptyFindings), '3: both empty/stripped core/html blocks are reported', 'got ' . count($emptyFindings));
+$emptyPatterns = array_map(static fn (array $f): string => (string) $f['pattern'], $emptyFindings);
+sort($emptyPatterns);
+$assert(
+    array('comment_only_or_stripped', 'whitespace_only') === $emptyPatterns,
+    '3b: empty-html pattern distinguishes comment-only/stripped from whitespace-only',
+    implode(',', $emptyPatterns)
+);
+$fallbackFindings = CorpusDetectors::coreHtmlFallback($syntheticBlocks);
+$assert(
+    1 === count($fallbackFindings) && '<svg>' === $fallbackFindings[0]['pattern'],
+    '3c: a non-empty raw-HTML block is clustered by its leading tag, not flagged empty',
+    (string) ($fallbackFindings[0]['pattern'] ?? '(none)')
+);
+
+// ---------------------------------------------------------------------------
+// 4. Cluster keys pair the repair bucket with the structural pattern.
+// ---------------------------------------------------------------------------
+$assert(
+    'css_custom_property_materialization :: --brand-color' === CorpusDetectors::clusterKey($varFindings[0]),
+    '4: cluster key joins repair bucket and pattern',
+    CorpusDetectors::clusterKey($varFindings[0])
+);
+
+// ---------------------------------------------------------------------------
+// 5. Native-rate metric stays a bounded ratio.
+// ---------------------------------------------------------------------------
+$rate = (float) $collected['metrics']['native_rate'];
+$assert($rate >= 0.0 && $rate <= 1.0, '5: native_rate is a bounded ratio', (string) $rate);
+$assert((int) $collected['metrics']['block_count'] > 0, '5b: block_count is populated');
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "CorpusDetectors unit tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "CorpusDetectors unit tests: {$passes} passed\n");

--- a/php-transformer/tools/corpus-diagnostics/run.php
+++ b/php-transformer/tools/corpus-diagnostics/run.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Corpus-diagnostics harness.
+ *
+ * Runs the HTML transformer over the entire website-fixture corpus and emits a
+ * frequency-ranked findings worklist. Pure PHP — no runner, no WordPress
+ * runtime, no browser, no network — so the whole corpus processes in seconds.
+ *
+ * Usage:
+ *   composer corpus-diagnostics -- [--corpus <dir>] [--output <file>] [--top <n>]
+ *
+ * Options:
+ *   --corpus <dir>  Corpus root (default: <repo>/fixtures/websites).
+ *   --output <file> Write the machine-readable JSON report to this path.
+ *   --top <n>       Number of ranked clusters to print to stdout (default: 25).
+ */
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\CorpusDiagnostics\CorpusDiagnosticsRunner;
+
+$options = parseArguments($argv);
+
+$repoRoot = dirname(__DIR__, 3);
+$corpusDir = $options['corpus'] ?? $repoRoot . '/fixtures/websites';
+if ( ! is_dir($corpusDir) ) {
+    fwrite(STDERR, "Corpus directory not found: {$corpusDir}\n");
+    exit(1);
+}
+
+$runner = new CorpusDiagnosticsRunner();
+$report = $runner->run($corpusDir);
+
+if ( null !== ($options['output'] ?? null) ) {
+    $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ( false === $json ) {
+        fwrite(STDERR, "Failed to encode report as JSON.\n");
+        exit(1);
+    }
+    if ( false === file_put_contents($options['output'], $json . "\n") ) {
+        fwrite(STDERR, "Failed to write report to: {$options['output']}\n");
+        exit(1);
+    }
+    fwrite(STDOUT, "Wrote machine-readable report to: {$options['output']}\n\n");
+}
+
+fwrite(STDOUT, $runner->renderSummary($report, (int) ($options['top'] ?? 25)));
+exit(0);
+
+/**
+ * @param array<int, string> $argv
+ * @return array<string, string>
+ */
+function parseArguments(array $argv): array
+{
+    $options = array();
+    $count = count($argv);
+    for ( $i = 1; $i < $count; $i++ ) {
+        $arg = $argv[$i];
+        foreach ( array('corpus', 'output', 'top') as $name ) {
+            if ( $arg === '--' . $name && $i + 1 < $count ) {
+                $options[$name] = $argv[++$i];
+                continue 2;
+            }
+            if ( str_starts_with($arg, '--' . $name . '=') ) {
+                $options[$name] = substr($arg, strlen($name) + 3);
+                continue 2;
+            }
+        }
+    }
+
+    return $options;
+}


### PR DESCRIPTION
## What

A fast, local, deterministic **corpus-diagnostics harness** for the php-transformer. It runs `HtmlToBlocks` over the entire `fixtures/websites/` corpus and emits a frequency-ranked findings worklist — with **no runner, WordPress runtime, browser, or Codebox**. The full corpus (368 documents across 77 fixtures) processes in ~3.4s.

This is additive tooling. It does **not** modify any transformer conversion logic — it only reads the canonical transformer result (`HtmlTransformer::transform()->toArray()`), exactly like the parity suite does.

## Why

The fixture-matrix routes everything through a heavy Lab+Codebox+browser runner that keeps timing out. But the bulk of import-quality signal is pure transformer output and needs none of that. This harness produces the ranked worklist in seconds so generic fixes can be driven at scale without the flaky runner.

## How to run

```bash
cd php-transformer
composer corpus-diagnostics -- --output /tmp/corpus-report.json --top 30
```

Options:
- `--corpus <dir>` — corpus root (default `<repo>/fixtures/websites`)
- `--output <file>` — write the machine-readable JSON report (per-fixture detail + ranked aggregate clusters)
- `--top <n>` — number of ranked clusters printed to stdout (default 25)

It writes machine-readable JSON to `--output` and prints a concise human-readable ranked worklist to stdout.

## Detectors

All detectors key off **structure and syntax only — never fixture names**.

Reused parity/validity infra:
- **block validity** — the same `wp_block_validity` serialization round-trip the parity suite asserts (saved HTML vs. HTML regenerated from attributes). Counts invalid blocks; pattern = `code@block_name`.
- **native-rate** — native structured blocks / total; `core/html` + `core/freeform` count against.
- **emitted findings** — the transformer's own diagnostics, normalized through `ConversionFindingContract` so each carries the `(reason_code, pattern_family, repair_bucket)` triplet (`html_form_fallback`, runtime-island preservation, semantic-parity, etc.).

New structure-only detectors:
- **var-dependent styling** — counts `var(--x)` references in emitted block markup and reports the distinct custom-property names. WordPress preset vars (`var(--wp--...)`) are tracked for visibility but excluded from the actionable worklist; the rest signal the CSS custom-property materialization gap.
- **classed-span-in-content** — `core/paragraph` / `core/heading` whose content contains `<span class=...>` / `<span style=...>` (block-invalidity risk).
- **empty core/html** — `core/html` blocks whose content is only whitespace / HTML comments (stripped-SVG / dead blocks).

Findings are clustered and frequency-ranked by `(repair_bucket || detector) :: pattern`, with per-cluster counts, fixture spread, and example fixtures.

## Top ranked clusters (full corpus — the fanout worklist)

```
 1. [4511 in 352 files] richtext_inline_span_normalization :: core/paragraph
 2. [1224 in 347 files] preserve_runtime_island :: runtime_script
 3. [ 696 in 162 files] native_block_recognition :: <svg>
 4. [ 206 in  95 files] preserve_runtime_island :: interactive_form
 5. [  95 in  82 files] semantic_structure_parity_restoration :: navigation_menu
 6. [  93 in  23 files] css_custom_property_materialization :: --muted
 7. [  82 in   9 files] css_custom_property_materialization :: --forest-mid
 8. [  80 in  21 files] css_custom_property_materialization :: --forest
 9. [  76 in   7 files] css_custom_property_materialization :: --text-sm
10. [  68 in  25 files] restore_interactive_behavior :: interactive_control
11. [  67 in  29 files] css_custom_property_materialization :: --cream
12. [  65 in  31 files] css_custom_property_materialization :: --accent
13. [  65 in  28 files] richtext_inline_span_normalization :: core/heading
14. [  62 in   9 files] css_custom_property_materialization :: --sp-md
15. [  60 in  18 files] css_custom_property_materialization :: --sage
```

Corpus totals: `blocks=53656`, `native_rate=98.7%`, `invalid_blocks=0`, `var_refs=2869` (all custom), `findings=9861`.

Headline signals: inline classed/styled spans in RichText paragraphs/headings dominate (4,511 across 352 files), followed by runtime-script island preservation and raw `<svg>` core/html escape hatches. The CSS custom-property materialization gap is broad and recurring — many distinct unmaterialized custom properties across the corpus.

## Tests

- `composer test` green (canonical contracts, 167 parity fixtures, all unit suites).
- New unit test `tests/unit/corpus-detectors.php` (registered in `test:unit`) covers all three new detectors + clustering. `php -l` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Implementing the harness, detectors, runner, CLI, and unit test; running the corpus and drafting this description.
