### PR TITLE
Decompose classed-inline list-item cards into valid blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1098,6 +1098,13 @@ final class HtmlTransformer
                 return $this->rememberAccordionDisclosureRoot($navigation, $element);
             }
 
+            if ( $this->isStructuredCardList($element) ) {
+                $decomposed = $this->decomposeStructuredCardList($element, $fallbacks);
+                if ( null !== $decomposed ) {
+                    return $decomposed;
+                }
+            }
+
             $items = $this->listItems($element, $fallbacks);
 
             if ( array() === $items ) {
@@ -1754,15 +1761,16 @@ final class HtmlTransformer
     }
 
     /**
-     * Lift class/style styling hooks out of a paragraph/heading's RichText
-     * `content` so the stored block round-trips through RichText unchanged.
+     * Lift class/style styling hooks out of a paragraph/heading/list-item's
+     * RichText `content` so the stored block round-trips through RichText
+     * unchanged.
      *
-     * core/paragraph and core/heading store `content` as RichText, which only
-     * preserves a fixed set of inline formats (a, strong, em, br, …). A
-     * `<span class="…">` / `<span style="…">` is not a format, so RichText drops
-     * its attributes on parse: the saved markup no longer matches the
-     * re-serialized block ("unexpected or invalid content"), and the class — a
-     * styling hook the materialized CSS targets — would be silently lost.
+     * core/paragraph, core/heading, and core/list-item store `content` as
+     * RichText, which only preserves a fixed set of inline formats (a, strong,
+     * em, br, …). A `<span class="…">` / `<span style="…">` is not a format, so
+     * RichText drops its attributes on parse: the saved markup no longer matches
+     * the re-serialized block ("unexpected or invalid content"), and the class —
+     * a styling hook the materialized CSS targets — would be silently lost.
      *
      * The fix keys off STRUCTURE (a content-bearing span carrying only
      * class/style), never on any specific class name:
@@ -1776,12 +1784,17 @@ final class HtmlTransformer
      *     here, so this is best-effort; the emitted block is always valid.
      * Genuine inline formats (strong/em/a/br/…) are never touched.
      *
+     * A list item whose content carries block-level children (an image/heading/
+     * paragraph "card", e.g. a commerce product grid) is left untouched here:
+     * that is not flowing RichText, so it stays the job of the structured-card
+     * decomposition path and the commerce path rather than per-span unwrapping.
+     *
      * @param array<string, mixed> $attrs
      * @return array<string, mixed>
      */
     private function hoistContentWrappingSpans(string $name, array $attrs): array
     {
-        if ( ! in_array($name, array( 'core/paragraph', 'core/heading' ), true) ) {
+        if ( ! in_array($name, array( 'core/paragraph', 'core/heading', 'core/list-item' ), true) ) {
             return $attrs;
         }
 
@@ -1798,6 +1811,10 @@ final class HtmlTransformer
 
         $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
         if ( ! $body instanceof DOMElement ) {
+            return $attrs;
+        }
+
+        if ( 'core/list-item' === $name && $this->hasBlockContentChildren($body) ) {
             return $attrs;
         }
 
@@ -3656,6 +3673,281 @@ final class HtmlTransformer
         }
 
         return $items;
+    }
+
+    /**
+     * Whether a `<ul>`/`<ol>` is a stack of "structured inline cards" rather than
+     * a normal list.
+     *
+     * A structured card list is one whose every content-bearing `<li>` is built
+     * from MULTIPLE class/style-carrying inline fragments — the universal
+     * blog/news/essay-index row of a title link plus dek/meta spans
+     * (`<a class>` + `<span class>` + `<span class>`). core/list-item stores its
+     * content as RichText, which only preserves a fixed set of inline formats, so
+     * the class on an inner `<a>`/`<span>` is dropped on parse (saved markup
+     * diverges from the regenerated block) and the per-fragment styling hooks the
+     * materialized CSS targets are lost. A single list item also cannot carry the
+     * distinct class of each fragment, so the row is really a mini-card.
+     *
+     * Keys off STRUCTURE (multiple styling-hook inline fragments), never on any
+     * specific class name. A plain-text list, a simple link list, a flowing
+     * sentence with one inline link, or a list item that carries block-level
+     * children (an image/heading/paragraph product card owned by the commerce
+     * path) is NOT a structured card and stays a normal core/list.
+     */
+    private function isStructuredCardList(DOMElement $list): bool
+    {
+        $cardItems = 0;
+        foreach ( $list->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement || 'li' !== strtolower($child->tagName) ) {
+                continue;
+            }
+            if ( '' === trim($this->runtime->stripAllTags($this->innerHtmlWithoutTags($child, array( 'ul', 'ol' )))) ) {
+                continue;
+            }
+            if ( ! $this->isStructuredCardItem($child) ) {
+                return false;
+            }
+            ++$cardItems;
+        }
+
+        return $cardItems > 0;
+    }
+
+    /**
+     * A `<li>` that is a structured inline card: all of its content is inline
+     * (text + inline formats/links — no block-level children), and it carries at
+     * least two class/style styling-hook inline fragments (e.g. a classed title
+     * link plus dek/meta spans). The "two hooks" threshold distinguishes a
+     * stacked card from flowing text that merely contains a single inline link.
+     */
+    private function isStructuredCardItem(DOMElement $item): bool
+    {
+        $stylingHookFragments = 0;
+        foreach ( $item->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                continue;
+            }
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $tag = strtolower($child->tagName);
+            if ( in_array($tag, array( 'ul', 'ol' ), true) ) {
+                continue;
+            }
+
+            // A block-level child means this is not an inline card (e.g. a
+            // product card with <img>/<h3>/<p>); leave it to the normal path.
+            if ( 'br' !== $tag && 'a' !== $tag && ! $this->isInlineContentElement($tag) ) {
+                return false;
+            }
+
+            if ( $this->isStylingHookInline($child) ) {
+                ++$stylingHookFragments;
+            }
+        }
+
+        return $stylingHookFragments >= 2;
+    }
+
+    /**
+     * An inline element carrying a class/style styling hook RichText cannot
+     * store: a styling-hook `<span>` (class/style only), or any link/inline
+     * format element (`<a>`, `<strong>`, …) with a non-empty class or style.
+     */
+    private function isStylingHookInline(DOMElement $element): bool
+    {
+        $tag = strtolower($element->tagName);
+        if ( 'span' === $tag ) {
+            return $this->isStylingHookSpan($element);
+        }
+        if ( 'a' !== $tag && ! $this->isInlineContentElement($tag) ) {
+            return false;
+        }
+
+        return '' !== trim($this->attr($element, 'class')) || '' !== trim($this->attr($element, 'style'));
+    }
+
+    /**
+     * Decompose a structured card `<ul>`/`<ol>` into a `core/group` of per-item
+     * `core/group`s. Each fragment of an item becomes its own block carrying its
+     * hoisted styling hook, so the result is fully valid (group/paragraph
+     * round-trip and store a custom className) while the per-fragment styling
+     * hooks and the working link survive — which a single core/list-item cannot
+     * represent. The outer group inherits the list's presentation, each inner
+     * group inherits its `<li>`'s presentation.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function decomposeStructuredCardList(DOMElement $list, array &$fallbacks): ?array
+    {
+        $itemGroups = array();
+        foreach ( $list->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement || 'li' !== strtolower($child->tagName) ) {
+                continue;
+            }
+
+            $itemGroup = $this->structuredCardItemGroup($child, $fallbacks);
+            if ( null !== $itemGroup ) {
+                $itemGroups[] = $itemGroup;
+            }
+        }
+
+        if ( array() === $itemGroups ) {
+            return null;
+        }
+
+        return $this->createBlock('core/group', $this->presentationAttributes($list), $itemGroups, $list);
+    }
+
+    /**
+     * Build the per-item `core/group` for one structured card `<li>`: a paragraph
+     * per inline fragment (the title link, the dek, the meta), each carrying the
+     * fragment's hoisted styling hook, plus any nested list converted in place.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function structuredCardItemGroup(DOMElement $item, array &$fallbacks): ?array
+    {
+        $fragmentBlocks = array();
+        foreach ( $item->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                $text = trim($child->textContent ?? '');
+                if ( '' !== $text ) {
+                    $fragmentBlocks[] = $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($text) ));
+                }
+                continue;
+            }
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $tag = strtolower($child->tagName);
+            if ( in_array($tag, array( 'ul', 'ol' ), true) ) {
+                $nested = $this->convertElement($child, $fallbacks, true);
+                if ( null !== $nested ) {
+                    $fragmentBlocks[] = $nested;
+                }
+                continue;
+            }
+
+            $block = $this->cardFragmentBlock($child);
+            if ( null !== $block ) {
+                $fragmentBlocks[] = $block;
+            }
+        }
+
+        if ( array() === $fragmentBlocks ) {
+            return null;
+        }
+
+        return $this->createBlock('core/group', $this->presentationAttributes($item), $fragmentBlocks, $item);
+    }
+
+    /**
+     * Turn one inline card fragment into a `core/paragraph` that round-trips
+     * through RichText while keeping the fragment's styling hook on the block.
+     *
+     *   - A link fragment stays a valid RichText anchor (`<a href>` with its
+     *     RichText-dropped class/style stripped) and its class/style are hoisted
+     *     onto the paragraph, so the styling hook survives and the link works.
+     *   - A styling-hook `<span>` is unwrapped to its inner content and its
+     *     class/style are hoisted onto the paragraph.
+     *   - Any other inline fragment is kept verbatim inside the paragraph;
+     *     createBlock's span hoisting normalizes any nested styling-hook spans.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function cardFragmentBlock(DOMElement $element): ?array
+    {
+        $tag = strtolower($element->tagName);
+
+        if ( 'a' === $tag ) {
+            $content = $this->anchorWithoutStylingAttributes($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge(
+                $this->hoistedStylingAttributes($element),
+                array( 'content' => $content )
+            ));
+        }
+
+        if ( 'span' === $tag && $this->isStylingHookSpan($element) ) {
+            $content = $this->innerHtml($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge(
+                $this->hoistedStylingAttributes($element),
+                array( 'content' => $content )
+            ));
+        }
+
+        $content = $this->outerHtml($element);
+        if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+            return null;
+        }
+
+        return $this->createBlock('core/paragraph', array( 'content' => $content ));
+    }
+
+    /**
+     * Map an element's source class/style into the block `className` + canonical
+     * `style` object attributes, so the styling hook rides where the block save()
+     * reproduces it.
+     *
+     * @return array<string, mixed>
+     */
+    private function hoistedStylingAttributes(DOMElement $element): array
+    {
+        $attrs = array();
+
+        $className = $this->promotedClassName($this->attr($element, 'class'));
+        if ( '' !== trim($className) ) {
+            $attrs['className'] = $className;
+        }
+
+        $style = trim($this->attr($element, 'style'));
+        if ( '' !== $style ) {
+            $mapped = $this->styleAttributeMapper()->map($this->cssDeclarations($style))['style'];
+            if ( array() !== $mapped ) {
+                $attrs['style'] = $mapped;
+            }
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * Serialize an `<a>` with its RichText-dropped presentational attributes
+     * (class/style) removed and an unsafe href dropped, leaving a clean anchor
+     * RichText preserves. When no safe href remains, the link text is returned
+     * without the anchor so no broken/empty link is emitted.
+     */
+    private function anchorWithoutStylingAttributes(DOMElement $anchor): string
+    {
+        $attributes = array();
+        foreach ( $this->htmlAttributes($anchor) as $name => $value ) {
+            if ( in_array(strtolower($name), array( 'class', 'style' ), true) ) {
+                continue;
+            }
+            $attributes[$name] = $value;
+        }
+
+        $href = $this->safeNavigationUrl($this->attr($anchor, 'href'));
+        $inner = $this->innerHtml($anchor);
+        if ( '' === $href ) {
+            return $inner;
+        }
+
+        $attributes['href'] = $href;
+        return '<a' . $this->htmlAttributeString($attributes) . '>' . $inner . '</a>';
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-gap-primitives.json
@@ -25,7 +25,7 @@
     { "path": "blocks.0.innerBlocks.3", "name": "core/list", "attrs": { "className": "checks" } },
     { "path": "blocks.0.innerBlocks.3.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "Parent" } },
     { "path": "blocks.0.innerBlocks.3.innerBlocks.0.innerBlocks.0", "name": "core/list" },
-    { "path": "blocks.0.innerBlocks.3.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<span class=\"accent\">Child</span>" } },
+    { "path": "blocks.0.innerBlocks.3.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "Child", "className": "accent" } },
     { "path": "blocks.0.innerBlocks.4", "name": "core/group", "attrs": { "className": "local-widget" } },
     { "path": "blocks.0.innerBlocks.4.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Signup", "level": 2 } },
     { "path": "blocks.0.innerBlocks.4.innerBlocks.1", "name": "core/group" },

--- a/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-expanded-primitives.json
@@ -20,7 +20,7 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Specs", "level": 2, "className": "eyebrow", "style": { "color": { "text": "red" } } } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Use <mark>inline</mark> marks." } },
     { "path": "blocks.0.innerBlocks.2", "name": "core/list", "attrs": { "className": "definitions" } },
-    { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<strong>Latency</strong> <span class=\"metric\">Low</span> response time" } },
+    { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<strong>Latency</strong> Low response time" } },
     { "path": "blocks.0.innerBlocks.2.innerBlocks.1", "name": "core/list-item", "attrs": { "content": "<strong>Fallback</strong> Preserved safely" } },
     { "path": "blocks.0.innerBlocks.3", "name": "core/paragraph", "attrs": { "className": "contact-card", "content": "<strong>Studio</strong><br>142 Bay Street<br>Eureka, CA" } }
   ],

--- a/php-transformer/tests/fixtures/parity/html-list-item-simple-list-not-decomposed.json
+++ b/php-transformer/tests/fixtures/parity/html-list-item-simple-list-not-decomposed.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-list-item-simple-list-not-decomposed",
+  "description": "A plain-text list and a simple link list stay normal core/list blocks: the structured-card decomposition keys off STRUCTURE (multiple class/style styling-hook inline fragments per item), so a list of plain text or a list of bare <a href> links — which round-trip through core/list-item RichText unchanged — is never over-decomposed into groups.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-list-item-simple-list-not-decomposed.json",
+    "notes": "Negative guard for html-list-item-structured-card-decompose: only the structured-card-in-list-item shape gets special handling."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture asserts that simple lists are left as the legacy/normal core/list output."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<ul><li>Apples</li><li>Oranges</li></ul><ul><li><a href=\"/a\">Alpha</a></li><li><a href=\"/b\">Beta</a></li></ul>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/list" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "Apples" } },
+    { "path": "blocks.1", "name": "core/list" },
+    { "path": "blocks.1.innerBlocks.0", "name": "core/list-item", "attrs": { "content": "<a href=\"/a\">Alpha</a>" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<li>Apples</li>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<li><a href=\"/a\">Alpha</a></li>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp:list-item" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:group" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-list-item-structured-card-decompose.json
+++ b/php-transformer/tests/fixtures/parity/html-list-item-structured-card-decompose.json
@@ -1,0 +1,42 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-list-item-structured-card-decompose",
+  "description": "Decomposes a <ul>/<ol> of structured inline cards (the universal blog/news/essay-index row: a classed title link plus dek/meta styling-hook spans inside each <li>) into a core/group of per-item core/groups. core/list-item stores its content as RichText, which strips the class from an inner <a>/<span> on parse, so the saved markup diverges from the regenerated block and the per-fragment styling hooks are lost; a single list item also cannot carry the distinct class of each fragment. Each fragment instead becomes a paragraph carrying its hoisted styling hook, with the title link kept as a valid RichText anchor — fully valid (group/paragraph round-trip and store a custom className) while every styling hook and the working link survive.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-list-item-structured-card-decompose.json",
+    "notes": "Real blog/essay-index pattern: <li> = <a class=\"title\"> + <span class=\"dek\"> + <span class=\"meta\">. The list-item follow-up to the paragraph/heading classed-span hoist (#323)."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers WordPress block-validity normalization beyond the legacy converter behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><ul class=\"essay-index\"><li><a class=\"title\" href=\"/essay\">The thing about January</a> <span class=\"dek\">The light comes in at an angle…</span> <span class=\"meta\">2026 · 01 · 24 · 9 min read</span></li><li><a class=\"title\" href=\"/february\">February notes</a> <span class=\"dek\">Short days, long thoughts.</span> <span class=\"meta\">2026 · 02 · 02 · 6 min read</span></li></ul></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "essay-index" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "title" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "dek", "content": "The light comes in at an angle…" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "className": "meta", "content": "2026 · 01 · 24 · 9 min read" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "title" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-group essay-index\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"title\"><a href=\"/essay\">The thing about January</a></p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"dek\">The light comes in at an angle…</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"meta\">2026 · 01 · 24 · 9 min read</p>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<span" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<a class=" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<li" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-paragraph-heading-classed-span-hoist.json
+++ b/php-transformer/tests/fixtures/parity/html-paragraph-heading-classed-span-hoist.json
@@ -30,7 +30,7 @@
     { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"section-label\">Our Kitchen</p>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"has-text-color badge\" style=\"color:#ffffff\">New</p>" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<h2>Ember &amp; Rye</h2>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<h2 class=\"wp-block-heading\">Ember &amp; Rye</h2>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"lead\"><strong>Bold</strong> and <a href=\"/x\">link</a></p>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<p>Plain <strong>bold</strong> text</p>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "class=\"section-label\">Our Kitchen</span>" },


### PR DESCRIPTION
## What

The list-item follow-up to #323 (which fixed `core/paragraph` / `core/heading` classed-span hoisting but explicitly left `core/list-item` out of scope).

`core/list-item` stores its `content` as RichText, which only preserves a fixed set of inline formats (`a`, `strong`, `em`, `br`, …). A `class` on an inner `<a>` or `<span>` is **not** a format, so RichText drops it on parse: the saved markup no longer matches the regenerated block ("unexpected or invalid content"), and the styling hook the materialized CSS targets is silently lost.

The dominant real-world shape is the **blog / news / essay-index row** — a `<li>` holding a classed title link plus dek/meta spans:

```html
<li>
  <a class="title" href="/essay">The thing about January</a>
  <span class="dek">The light comes in at an angle…</span>
  <span class="meta">2026 · 01 · 24 · 9 min read</span>
</li>
```

A single `core/list-item` cannot hold nested blocks, cannot keep the per-fragment classes as valid RichText, and cannot carry the *distinct* class of each fragment. The row is really a mini-card, not flowing text.

## Approach chosen: structural decomposition into groups (+ why)

I evaluated all three options from the brief:

- **Hoist a single wrapping span** → only fits a single-span item, not the multi-fragment card.
- **Convert each classed span to an inline `<span style>`** → can't preserve a *class* hook generically (no class→style map without static CSS), and still can't make the classed `<a>` valid; would silently drop the hooks.
- **Decompose the structured-card `<ul>`/`<ol>` into per-item `core/group`s** ✅ — the only option that is **both valid and faithful** for the multi-fragment card.

Keying off **structure** (never class names), a `<ul>`/`<ol>` whose every content-bearing `<li>` is built from **multiple class/style styling-hook inline fragments** is decomposed into a `core/group` of per-item `core/group`s:

- each fragment becomes a `core/paragraph` carrying its **hoisted styling hook** (class → `className`, inline style → canonical `style` object);
- the **title link stays a valid RichText anchor** — its class/style are stripped onto the paragraph and the working `href` is kept (`<p class="title"><a href="/essay">…</a></p>`);
- the `<li>` and `<ul>` container classes ride the inner/outer group `className`.

`core/group` and `core/paragraph` round-trip and store a custom `className` (block.json `className: false` only disables the generated `wp-block-*` class; `customClassName` stays on), so the output is **fully valid** while **every styling hook and the link survive**.

Why paragraph (not heading) for the title link: choosing a heading level generically would be fabrication; the `title` className carries the styling distinction, and paragraph is deterministic and valid.

## Simpler list items stay lists

`hoistContentWrappingSpans` now also normalizes `core/list-item` content (reusing #323's helpers, no duplication): a sole wrapping styling-hook span is hoisted onto the list-item `className`/`style` and unwrapped; sibling styling-hook spans are unwrapped best-effort. It is **guarded to skip items with block-level children**, so commerce product grids (`<li>` with `<img>`/`<h3>`/`<p>`) are left entirely to their own path. A plain-text list, a simple link list, or flowing text with one inline link is **never over-decomposed** and stays a normal `core/list`.

## Before / after (real blog-index row)

**Before (trunk)** — classed `<a>`/`<span>` survive in list-item RichText; the editor strips the classes on parse → invalid + hooks lost:
```
<!-- wp:list {"className":"essay-index"} --><ul class="wp-block-list essay-index"><li><a class="title" href="/essay">The thing about January</a> <span class="dek">…</span> <span class="meta">…</span></li></ul><!-- /wp:list -->
```

**After** — valid groups, hooks preserved as block classes, clean link, no surviving `<span>`/`<a class>`:
```
<!-- wp:group {"className":"essay-index"} --><div class="wp-block-group essay-index"><div class="wp-block-group"><p class="title"><a href="/essay">The thing about January</a></p><p class="dek">…</p><p class="meta">…</p></div></div><!-- /wp:group -->
```

## Tests

- `composer test` green; `composer parity` green (171 fixtures); `php -l` clean.
- **New** `html-list-item-structured-card-decompose` — the blog-index row: asserts `source_reports.wp_block_validity.status == pass`, the `title`/`dek`/`meta`/`essay-index` styling hooks are preserved on the emitted blocks, and no `<span>` / `<a class>` / `<li>` survives.
- **New** `html-list-item-simple-list-not-decomposed` — plain-text list and bare-link list stay `core/list` (no over-decomposition).
- Updated `html-expanded-gap-primitives` and `html-expanded-primitives` — list items now hoist/unwrap their styling-hook spans (the bug being fixed).
- Updated `html-paragraph-heading-classed-span-hoist` — its heading expectation predated the canonical `wp-block-heading` class added in #326 (stale on trunk); refreshed to the current canonical markup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Investigating #323's machinery, implementing the decomposition + list-item span hoist, and authoring fixtures.
