### PR TITLE
figma-transformer: emit angular gradients as CSS conic-gradient

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -5513,7 +5513,7 @@ final class StaticHtmlEmitter
                 }
             }
 
-            if ( in_array(($paint['type'] ?? null), array('GRADIENT_LINEAR', 'GRADIENT_RADIAL'), true) ) {
+            if ( in_array(($paint['type'] ?? null), array('GRADIENT_LINEAR', 'GRADIENT_RADIAL', 'GRADIENT_ANGULAR'), true) ) {
                 $gradient = $this->gradientPaint($paint);
                 if ( null !== $gradient ) {
                     return array('css' => $gradient, 'gradient' => true);
@@ -5584,7 +5584,91 @@ final class StaticHtmlEmitter
             return 'radial-gradient(circle,' . implode(',', $cssStops) . ')';
         }
 
+        if ( 'GRADIENT_ANGULAR' === ($paint['type'] ?? null) ) {
+            $geometry = $this->angularGradientGeometry($paint);
+
+            return 'conic-gradient(from ' . $this->number($geometry['from']) . 'deg at '
+                . $this->number($geometry['cx']) . '% ' . $this->number($geometry['cy']) . '%,'
+                . implode(',', $cssStops) . ')';
+        }
+
         return 'linear-gradient(' . $this->number($this->linearGradientAngle($paint)) . 'deg,' . implode(',', $cssStops) . ')';
+    }
+
+    /**
+     * Computes the CSS conic-gradient geometry (start angle + center) for a
+     * Figma angular paint from its gradientTransform matrix.
+     *
+     * Figma evaluates an angular (conic) gradient in the same canonical space
+     * the linear/radial paths use: the 2x3 gradientTransform maps the shape's
+     * normalized bounding-box space (0..1, y-down) into the gradient's canonical
+     * space, and the angular parameter is t = atan2(v - 0.5, u - 0.5) / 2pi
+     * around the canonical center (0.5, 0.5). So t = 0 (the gradient's first
+     * stop / seam) points along the canonical +u axis -- the very same handle
+     * direction the linear path treats as start->end. Mapping +u back through
+     * the INVERSE matrix yields (d/det, -c/det), the t=0 radial direction in the
+     * shape's own y-down space.
+     *
+     * CSS conic-gradient `from` angles share the linear-gradient clock: 0deg
+     * points up, 90deg right, 180deg down, 270deg left, sweeping clockwise. For
+     * a y-down direction (dx, dy) the matching angle is atan2(dx, -dy), so the
+     * seam direction reuses the exact linearGradientAngle convention. The center
+     * is the canonical point (0.5, 0.5) mapped back through the inverse affine,
+     * expressed as percentages of the shape box.
+     *
+     * Returns `from 0deg at 50% 50%` (seam at top, centered) when no usable
+     * transform is present, so geometry-less angular paints stay deterministic.
+     *
+     * @param array<string, mixed> $paint
+     * @return array{from: float, cx: float, cy: float}
+     */
+    private function angularGradientGeometry(array $paint): array
+    {
+        $default = array('from' => 0.0, 'cx' => 50.0, 'cy' => 50.0);
+
+        $matrix = $paint['gradientTransform'] ?? null;
+        if ( ! is_array($matrix) || ! is_array($matrix[0] ?? null) || ! is_array($matrix[1] ?? null) ) {
+            return $default;
+        }
+
+        $a = $this->numericOrNull($matrix[0][0] ?? null);
+        $b = $this->numericOrNull($matrix[0][1] ?? null);
+        $tx = $this->numericOrNull($matrix[0][2] ?? null);
+        $c = $this->numericOrNull($matrix[1][0] ?? null);
+        $d = $this->numericOrNull($matrix[1][1] ?? null);
+        $ty = $this->numericOrNull($matrix[1][2] ?? null);
+        if ( null === $a || null === $b || null === $tx || null === $c || null === $d || null === $ty ) {
+            return $default;
+        }
+
+        $det = $a * $d - $b * $c;
+        if ( abs($det) < 1e-9 ) {
+            return $default;
+        }
+
+        // Canonical +u axis mapped to the shape's y-down space: the t=0 seam
+        // direction. Identical first column of the inverse linear part the
+        // linear path uses, so the seam angle matches linearGradientAngle.
+        $dx = $d / $det;
+        $dy = -$c / $det;
+        $from = 0.0;
+        if ( abs($dx) >= 1e-9 || abs($dy) >= 1e-9 ) {
+            $from = fmod(rad2deg(atan2($dx, -$dy)), 360.0);
+            if ( $from < 0.0 ) {
+                $from += 360.0;
+            }
+        }
+
+        // Canonical center (0.5, 0.5) mapped back through the inverse affine
+        // gives the conic center in the shape's normalized space.
+        $cx = ($d * (0.5 - $tx) - $b * (0.5 - $ty)) / $det;
+        $cy = ($a * (0.5 - $ty) - $c * (0.5 - $tx)) / $det;
+
+        return array(
+            'from' => $from,
+            'cx'   => $cx * 100.0,
+            'cy'   => $cy * 100.0,
+        );
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2225,7 +2225,7 @@ final class ScenegraphNormalizer
             return $normalized;
         }
 
-        if ( in_array($type, array('GRADIENT_LINEAR', 'GRADIENT_RADIAL'), true) ) {
+        if ( in_array($type, array('GRADIENT_LINEAR', 'GRADIENT_RADIAL', 'GRADIENT_ANGULAR'), true) ) {
             $stops = $this->normalizeGradientStops($paint['gradientStops'] ?? $paint['stops'] ?? array());
             if ( ! empty($stops) ) {
                 $normalized = array(

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3869,6 +3869,70 @@ $gradientPaintResult = blocks_engine_figma_transformer_transform_scenegraph(arra
             ),
         ),
         array(
+            'id'     => 'gradient:angular',
+            'type'   => 'RECTANGLE',
+            'name'   => 'Angular gradient',
+            'width'  => 100,
+            'height' => 100,
+            'fills'  => array(
+                array(
+                    'type'              => 'GRADIENT_ANGULAR',
+                    // Identity gradientTransform: the angular seam (t=0) runs
+                    // along the shape's +x axis (3 o'clock) => CSS conic
+                    // `from 90deg`, centered at 50% 50%.
+                    'gradientTransform' => array(
+                        array(1, 0, 0),
+                        array(0, 1, 0),
+                    ),
+                    'gradientStops'     => array(
+                        array('position' => 0, 'color' => array('r' => 1, 'g' => 0, 'b' => 0, 'a' => 1)),
+                        array('position' => 1, 'color' => array('r' => 0, 'g' => 0, 'b' => 1, 'a' => 1)),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'     => 'gradient:angular-top',
+            'type'   => 'RECTANGLE',
+            'name'   => 'Angular gradient top',
+            'width'  => 100,
+            'height' => 100,
+            'fills'  => array(
+                array(
+                    'type'              => 'GRADIENT_ANGULAR',
+                    // A transform whose canonical +u axis maps to the shape's
+                    // -y (up) direction: the seam starts at the top (12 o'clock)
+                    // => CSS conic `from 0deg`, still centered at 50% 50%.
+                    'gradientTransform' => array(
+                        array(0, -1, 1),
+                        array(1, 0, 0),
+                    ),
+                    'gradientStops'     => array(
+                        array('position' => 0, 'color' => array('r' => 0, 'g' => 1, 'b' => 0, 'a' => 1)),
+                        array('position' => 1, 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1)),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'     => 'gradient:angular-default',
+            'type'   => 'RECTANGLE',
+            'name'   => 'Angular gradient default',
+            'width'  => 100,
+            'height' => 100,
+            'fills'  => array(
+                array(
+                    // No gradientTransform: emit a deterministic centered conic
+                    // gradient with its seam at the top.
+                    'type'          => 'GRADIENT_ANGULAR',
+                    'gradientStops' => array(
+                        array('position' => 0, 'color' => array('r' => 1, 'g' => 1, 'b' => 0, 'a' => 1)),
+                        array('position' => 1, 'color' => array('r' => 1, 'g' => 0, 'b' => 1, 'a' => 1)),
+                    ),
+                ),
+            ),
+        ),
+        array(
             'id'     => 'gradient:malformed',
             'type'   => 'RECTANGLE',
             'name'   => 'Malformed gradient',
@@ -3890,6 +3954,9 @@ $assert(str_contains($gradientPaintCss, '.figma-node-gradient-linear-h-horizonta
 $assert(str_contains($gradientPaintCss, '.figma-node-gradient-linear-v-vertical-gradient{width:110px;height:80px;background:linear-gradient(180deg,#ff0000 0%,#0000ff 100%)}'), 'linear-gradient-vertical-transform-emits-180deg');
 $assert(str_contains($gradientPaintCss, '.figma-node-gradient-radial-radial-gradient{width:90px;height:70px;background:radial-gradient(circle,rgba(0,255,0,0.5) 25%,rgba(0,0,0,0.5) 100%)}'), 'radial-gradient-background-emits');
 $assert(str_contains($gradientPaintCss, '.figma-node-gradient-stroke-gradient-stroke{width:70px;height:60px;border:3px solid transparent;border-image:linear-gradient(180deg,#ffff00 0%,#ff00ff 100%) 1}'), 'linear-gradient-stroke-emits-border-image');
+$assert(str_contains($gradientPaintCss, '.figma-node-gradient-angular-angular-gradient{width:100px;height:100px;background:conic-gradient(from 90deg at 50% 50%,#ff0000 0%,#0000ff 100%)}'), 'angular-gradient-identity-transform-emits-from-90deg');
+$assert(str_contains($gradientPaintCss, '.figma-node-gradient-angular-top-angular-gradient-top{width:100px;height:100px;background:conic-gradient(from 0deg at 50% 50%,#00ff00 0%,#000000 100%)}'), 'angular-gradient-top-seam-transform-emits-from-0deg');
+$assert(str_contains($gradientPaintCss, '.figma-node-gradient-angular-default-angular-gradient-default{width:100px;height:100px;background:conic-gradient(from 0deg at 50% 50%,#ffff00 0%,#ff00ff 100%)}'), 'angular-gradient-no-transform-emits-centered-default');
 $assert(in_array('unsupported_figma_paint_type', $gradientDiagnosticCodes, true), 'unsupported-malformed-gradient-diagnostic');
 
 $metadataResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary

Closes coverage gap in issue #328. Previously only `GRADIENT_LINEAR` and `GRADIENT_RADIAL` reached CSS; `GRADIENT_ANGULAR` fills were dropped at the normalizer with an `unsupported_figma_paint_type` diagnostic and rendered as nothing/fallback. Angular gradients now emit real CSS `conic-gradient(...)`.

**Emitter-only** — the Kiwi decoder is untouched, so this won't conflict with the other gradient/decoder work.

## What changed

- **`ScenegraphNormalizer.php`** — `GRADIENT_ANGULAR` now passes its stops + `gradientTransform` through, alongside linear/radial (they were being dropped here, so the passthrough had to be wired).
- **`StaticHtmlEmitter.php`** — angular paints emit `conic-gradient(from {angle}deg at {cx}% {cy}%, {stops})` via a new `angularGradientGeometry()` helper.

## Geometry / convention

Figma evaluates an angular gradient in the same canonical space the linear path (#317) uses: `t = atan2(v - 0.5, u - 0.5) / 2π` around the canonical center `(0.5, 0.5)`. So the `t = 0` seam (first stop) points along the canonical `+u` axis — the identical handle direction the linear start→end uses. Mapping `+u` back through the inverse matrix gives `(d/det, -c/det)`, and because CSS conic `from` angles share the linear clock (0deg up, clockwise), the seam angle reuses the exact `linearGradientAngle` convention `atan2(dx, -dy)`. The center is the canonical `(0.5, 0.5)` mapped back through the inverse affine, expressed as box percentages.

Verified known cases through the full normalize+emit pipeline:
- identity transform → `from 90deg at 50% 50%` (seam at 3 o'clock)
- top-seam transform `[[0,-1,1],[1,0,0]]` → `from 0deg at 50% 50%` (seam at top)
- no transform → deterministic `from 0deg at 50% 50%`

## DIAMOND

`GRADIENT_DIAMOND` has no faithful native CSS equivalent and is rare, so it keeps the existing `unsupported_figma_paint_type` diagnostic rather than a lossy approximation. (The existing malformed-diamond contract assertion still passes.)

## Tests

Added three angular contract fixtures in `tests/contract/run.php`. All existing tests pass, including the #317 linear-gradient angle tests:

```
cd figma-transformer && php tests/contract/run.php
# Figma Transformer contract tests passed.
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation