### PR TITLE
Fix php-transformer dropping inline SVG icons/diagrams as decorative

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1401,8 +1401,29 @@ final class HtmlTransformer
             // its sizing class(es), and correct-case viewBox so the
             // materialized source CSS can size it.
             if ( $this->isSafeDecorativeSvgElement($element) ) {
-                if ( $this->hasIconLikeContext($element) ) {
-                    return $this->inlineSvgBlockFromElement($element);
+                // Faithfully preserve any inline SVG that carries real drawable
+                // artwork — icons, diagrams, illustrations — even when it is
+                // marked aria-hidden / role=presentation. aria-hidden hides the
+                // graphic from the accessibility tree; it does NOT mean the
+                // artwork is visually disposable. WordPress cannot reconstruct
+                // arbitrary vector artwork from CSS, so routing such an SVG into
+                // the visual-layer group (empty) or dropping it (return null)
+                // silently erased every shape — service icons collapsed to empty
+                // blocks and pipe/boiler diagrams to whitespace + comments.
+                //
+                // The exception is genuine decorative chrome the materialized
+                // source CSS recreates: a positioned visual layer (an absolutely
+                // positioned full-bleed background) or a stretched-to-fit band
+                // (preserveAspectRatio="none", which distorts geometry and so is
+                // never used for meaningful icons/diagrams). Those still collapse
+                // to a styleable group / are dropped below.
+                $isDecorativeChrome = $this->isVisualLayerElement($element)
+                    || 'none' === strtolower(trim($this->attr($element, 'preserveaspectratio')));
+                if ( ! $isDecorativeChrome && $this->svgHasDrawableContent($element) ) {
+                    $svgBlock = $this->inlineSvgBlockFromElement($element);
+                    if ( null !== $svgBlock ) {
+                        return $svgBlock;
+                    }
                 }
                 if ( $this->isVisualLayerElement($element) ) {
                     return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
@@ -3693,16 +3714,18 @@ final class HtmlTransformer
         // javascript: URLs stripped via sanitizeInlineSvgMarkup + verified by
         // isSafeSvgContent), and the original outer SVG preserves
         // viewBox/role/aria-label/class.
-        return $this->createBlock('core/html', array( 'content' => $this->restoreSvgAttributeCasing($html) ), array(), $element);
+        return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($html) ), array(), $element);
     }
 
     /**
-     * Restore the canonical camelCase casing of SVG attribute names that the
-     * HTML parser lowercases (e.g. `viewbox` -> `viewBox`). SVG attribute names
-     * are case-sensitive, so a lowercased `viewbox` is ignored by browsers and
-     * the inline SVG would not scale to its viewport.
+     * Restore the canonical camelCase casing of SVG element and attribute names
+     * that the HTML parser lowercases (e.g. `viewbox` -> `viewBox`,
+     * `<lineargradient>` -> `<linearGradient>`). SVG element and attribute names
+     * are case-sensitive, so a lowercased `viewbox` is ignored (the SVG would not
+     * scale to its viewport) and a lowercased `<lineargradient>` is an unknown
+     * element the browser does not render (the gradient fill disappears).
      */
-    private function restoreSvgAttributeCasing(string $html): string
+    private function restoreSvgCasing(string $html): string
     {
         static $camelCaseAttributes = array(
             'viewBox', 'preserveAspectRatio', 'baseProfile', 'attributeName', 'attributeType',
@@ -3718,8 +3741,24 @@ final class HtmlTransformer
             'pointsAtZ', 'systemLanguage',
         );
 
+        // Case-sensitive SVG element names. A lowercased tag is an unknown element
+        // to the browser, so the gradient/clip/filter it defines never applies.
+        static $camelCaseElements = array(
+            'linearGradient', 'radialGradient', 'clipPath', 'textPath', 'foreignObject',
+            'feBlend', 'feColorMatrix', 'feComponentTransfer', 'feComposite',
+            'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap', 'feDistantLight',
+            'feDropShadow', 'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR',
+            'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode', 'feMorphology',
+            'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotLight', 'feTile',
+            'feTurbulence', 'animateMotion', 'animateTransform',
+        );
+
         foreach ( $camelCaseAttributes as $attribute ) {
             $html = preg_replace('/(\s)' . preg_quote($attribute, '/') . '(\s*=)/i', '$1' . $attribute . '$2', $html) ?? $html;
+        }
+
+        foreach ( $camelCaseElements as $tag ) {
+            $html = preg_replace('/<(\/?)' . preg_quote($tag, '/') . '(?=[\s\/>])/i', '<$1' . $tag, $html) ?? $html;
         }
 
         return $html;
@@ -3899,8 +3938,32 @@ final class HtmlTransformer
 
     private function isPassiveSvgMarkup(DOMElement $element): bool
     {
-        $allowedTags = array_flip(array( 'circle', 'clippath', 'defs', 'desc', 'ellipse', 'g', 'line', 'lineargradient', 'mask', 'path', 'polygon', 'polyline', 'radialgradient', 'rect', 'stop', 'svg', 'title' ));
-        $allowedAttributes = array_flip(array( 'aria-hidden', 'aria-label', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd', 'fill', 'fill-opacity', 'fill-rule', 'gradienttransform', 'gradientunits', 'height', 'id', 'offset', 'opacity', 'points', 'preserveaspectratio', 'r', 'role', 'rx', 'ry', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'style', 'transform', 'viewbox', 'width', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2' ));
+        // Full set of safe SVG structure/presentation/text elements. These carry
+        // only geometry, gradients, and text — no scripting or external embedding
+        // (script/style/foreignObject/image are deliberately excluded and are
+        // stripped by the sanitizer). <use>/<symbol> reference handling is gated
+        // separately: a <use> carries href/xlink:href which isPassiveSvgElement()
+        // always rejects, so use-bearing SVGs route through the faithful
+        // inline-preservation path (local refs) or the fallback diagnostic
+        // (external sprite refs) rather than this decorative classification.
+        $allowedTags = array_flip(array(
+            'circle', 'clippath', 'defs', 'desc', 'ellipse', 'g', 'line', 'lineargradient',
+            'marker', 'mask', 'path', 'pattern', 'polygon', 'polyline', 'radialgradient',
+            'rect', 'stop', 'svg', 'symbol', 'text', 'title', 'tspan', 'use',
+        ));
+        $allowedAttributes = array_flip(array(
+            'aria-hidden', 'aria-label', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd',
+            'dominant-baseline', 'dx', 'dy', 'fill', 'fill-opacity', 'fill-rule', 'font-family',
+            'font-size', 'font-style', 'font-weight', 'gradienttransform', 'gradientunits',
+            'height', 'id', 'letter-spacing', 'marker-end', 'marker-mid', 'marker-start',
+            'markerheight', 'markerunits', 'markerwidth', 'mask', 'offset', 'opacity', 'orient',
+            'patterncontentunits', 'patterntransform', 'patternunits', 'points',
+            'preserveaspectratio', 'r', 'refx', 'refy', 'role', 'rotate', 'rx', 'ry',
+            'spreadmethod', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray',
+            'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit',
+            'stroke-opacity', 'stroke-width', 'style', 'text-anchor', 'transform',
+            'vector-effect', 'viewbox', 'width', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2',
+        ));
 
         foreach ( $element->getElementsByTagName('*') as $child ) {
             if ( ! $child instanceof DOMElement || ! $this->isPassiveSvgElement($child, $allowedTags, $allowedAttributes) ) {

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -380,11 +380,38 @@ trait DomHelpersTrait
             if ( $this->hasAncestorTag($child, array( 'foreignobject' )) ) {
                 continue;
             }
+            // A <use> that points at an external sprite file (href="sprite.svg#id"
+            // rather than a local "#id") cannot be inlined: the referenced symbol
+            // lives in another file that does not travel with the imported markup,
+            // so the emitted <use> would render nothing. It carries no drawable
+            // artwork of its own, so it does not, by itself, make the SVG
+            // preservable — the SVG falls through to the bounded fallback
+            // diagnostic instead of emitting a broken external reference. A local
+            // <use href="#id"> (resolved against an in-document symbol/defs) and
+            // any real shape element still count as drawable.
+            if ( 'use' === $tag && $this->isExternalSpriteUse($child) ) {
+                continue;
+            }
 
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * Whether a <use> element references an external sprite file rather than an
+     * in-document fragment. An external reference is any href/xlink:href whose
+     * target is not a bare local "#id" fragment.
+     */
+    private function isExternalSpriteUse(DOMElement $element): bool
+    {
+        $href = trim($this->attr($element, 'href'));
+        if ( '' === $href ) {
+            $href = trim($this->attr($element, 'xlink:href'));
+        }
+
+        return '' !== $href && '#' !== substr($href, 0, 1);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-diagram-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-diagram-preserved.json
@@ -1,0 +1,42 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-diagram-preserved",
+  "description": "Preserves an aria-hidden inline SVG diagram built from the full set of safe structure/geometry elements (defs/linearGradient/stop, line/polyline/polygon/ellipse/circle/rect) plus HTML comments, faithfully as a core/html block. aria-hidden marks the diagram decorative for assistive tech but never makes the artwork disposable: the SVG passes the safe-decorative classification yet must still survive instead of collapsing to an empty block or a comments-only shell. Unsafe parts carried on the same SVG (an inline <script> and an event-handler attribute) are stripped while the artwork is kept.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-diagram-preserved.json",
+    "notes": "Product-neutral regression fixture: an aria-hidden, passive-classified inline SVG diagram must survive the safe-decorative path rather than being dropped to an empty block."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><section class=\"system-diagram\"><svg viewBox=\"0 0 400 300\" aria-hidden=\"true\"><defs><linearGradient id=\"pipe-grad\" x1=\"0\" y1=\"0\" x2=\"0\" y2=\"1\"><stop offset=\"0%\" stop-color=\"#88c\"></stop><stop offset=\"100%\" stop-color=\"#224\"></stop></linearGradient></defs><!-- Vertical main pipe --><line x1=\"200\" y1=\"0\" x2=\"200\" y2=\"300\" stroke=\"#333\" stroke-width=\"6\"></line><!-- Horizontal branch --><polyline points=\"200,150 320,150 320,260\" fill=\"none\" stroke=\"#06c\" stroke-width=\"4\"></polyline><polygon points=\"40,40 100,40 70,92\" fill=\"url(#pipe-grad)\"></polygon><ellipse cx=\"120\" cy=\"210\" rx=\"44\" ry=\"22\" fill=\"#3a3\"></ellipse><circle cx=\"320\" cy=\"260\" r=\"8\" fill=\"#e94560\"></circle><rect width=\"24\" height=\"24\" fill=\"#1a1a2e\" onclick=\"steal()\"></rect><script>track()</script></svg></section></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "system-diagram" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/html" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<svg viewBox=\"0 0 400 300\" aria-hidden=\"true\">" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<linearGradient id=\"pipe-grad\"" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<stop offset=\"0%\" stop-color=\"#88c\"></stop>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<line x1=\"200\" y1=\"0\" x2=\"200\" y2=\"300\" stroke=\"#333\" stroke-width=\"6\"></line>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<polyline points=\"200,150 320,150 320,260\" fill=\"none\" stroke=\"#06c\" stroke-width=\"4\"></polyline>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<polygon points=\"40,40 100,40 70,92\" fill=\"url(#pipe-grad)\"></polygon>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<ellipse cx=\"120\" cy=\"210\" rx=\"44\" ry=\"22\" fill=\"#3a3\"></ellipse>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<circle cx=\"320\" cy=\"260\" r=\"8\" fill=\"#e94560\"></circle>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<rect width=\"24\" height=\"24\" fill=\"#1a1a2e\"></rect>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "<script" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "onclick" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "track()" },
+    { "path": "assets", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-local-use-symbol.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-local-use-symbol.json
@@ -1,0 +1,82 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-local-use-symbol",
+  "description": "Preserves an inline SVG that references in-document artwork via a local <use href=\"#id\"> pointing at an in-document <symbol>/<defs>. The symbol definition and the local <use> instance both survive faithfully in the emitted core/html so the referenced shapes still render. By contrast a <use> that points at an external sprite file (href=\"sprite.svg#id\") cannot be inlined \u2014 the referenced symbol lives in another file that does not travel with the imported markup \u2014 so an SVG whose only artwork is an external-sprite reference carries no inlinable drawable content and is reported through the bounded inline-SVG fallback rather than emitted as a broken external reference.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-local-use-symbol.json",
+    "notes": "Product-neutral fixture covering local-use(#id) preservation alongside external-sprite-use reporting."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><div class=\"icon-row\"><svg viewBox=\"0 0 48 24\" role=\"img\" aria-label=\"Valve pair\"><defs><symbol id=\"valve\"><circle cx=\"6\" cy=\"6\" r=\"5\" fill=\"#e94560\"></circle></symbol></defs><use href=\"#valve\" x=\"0\" y=\"0\"></use><use href=\"#valve\" x=\"24\" y=\"0\"></use></svg></div><div class=\"svc\"><svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><use href=\"icons.svg#gear\"></use></svg></div></main>"
+  },
+  "expected_blocks": [
+    {
+      "path": "blocks.0",
+      "name": "core/group"
+    },
+    {
+      "path": "blocks.0.innerBlocks.0",
+      "name": "core/group",
+      "attrs": {
+        "className": "icon-row"
+      }
+    },
+    {
+      "path": "blocks.0.innerBlocks.0.innerBlocks.0",
+      "name": "core/html"
+    }
+  ],
+  "expect": [
+    {
+      "path": "status",
+      "assert": "equals",
+      "value": "success"
+    },
+    {
+      "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content",
+      "assert": "contains",
+      "value": "<symbol id=\"valve\"><circle cx=\"6\" cy=\"6\" r=\"5\" fill=\"#e94560\"></circle></symbol>"
+    },
+    {
+      "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content",
+      "assert": "contains",
+      "value": "<use href=\"#valve\" x=\"0\" y=\"0\"></use>"
+    },
+    {
+      "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content",
+      "assert": "contains",
+      "value": "<use href=\"#valve\" x=\"24\" y=\"0\"></use>"
+    },
+    {
+      "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content",
+      "assert": "not_contains",
+      "value": "icons.svg#gear"
+    },
+    {
+      "path": "serialized_blocks",
+      "assert": "not_contains",
+      "value": "icons.svg#gear"
+    },
+    {
+      "path": "fallbacks",
+      "assert": "count",
+      "count": 1
+    },
+    {
+      "path": "fallbacks.0.type",
+      "assert": "equals",
+      "value": "inline_svg"
+    },
+    {
+      "path": "fallbacks.0.tag",
+      "assert": "equals",
+      "value": "svg"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Inline SVG artwork (service icons, hero pipe-diagrams, boiler illustrations) was still being **stripped to empty** during HTML-to-blocks conversion despite #311 — service icons surfaced as empty `core/html` blocks and diagrams as `core/html` with only whitespace + HTML comments, every drawing element gone.

## Root cause (the hypothesis was inverted)

The investigation hypothesis was that #311's safe-SVG **element allowlist** was too narrow and stripped shapes like `line/polyline/ellipse/defs/linearGradient/stop`. That is **not** what happens. The sanitizer (`sanitizeInlineSvgMarkup` → `safeFallbackHtml`) preserves *all* shape markup verbatim and strips only `script`/`style`/`foreignObject`/event-handlers/`javascript:`. Reproductions confirmed diagrams using the full geometry set survive the sanitizer untouched.

The real data loss is in `HtmlTransformer::convertElement()`'s SVG branch. An SVG classified **safe-decorative** (`isSafeDecorativeSvgElement` = passive-shape allowlist + `aria-hidden`/`role=presentation`) was:

- **dropped entirely** (`return null`) when it was neither icon-like nor a visual layer — e.g. a `<svg aria-hidden="true">` inside `<div class="svc">`, the empty-`content` service-icon case; or
- converted to an **empty `core/group`** when `isVisualLayerElement()` matched a fuzzy class token like `hero` — the comments/whitespace-only diagram case.

`aria-hidden="true"` hides a graphic from the accessibility tree; it does **not** mean the artwork is visually disposable. Real icons and diagrams routinely set it, so they were silently erased. Expanding the allowlist as hypothesized would have made this **worse** (more SVGs classified passive-decorative → more dropped).

## Fix (SVG sanitize/classification code only)

- **Preserve drawable artwork.** A safe-decorative SVG that has real drawable content is now emitted faithfully as inline `core/html` instead of being dropped. The only SVGs that still collapse to a styleable group / are dropped are genuine decorative chrome the materialized CSS recreates: a **positioned visual layer** or a **`preserveAspectRatio="none"` stretched band** (distorts geometry → never used for meaningful icons/diagrams). This keeps the intentional decorative `wave-layer`/`wave-divider` behavior (`html-hero-decorative-wave-layer`, `html-inline-svg-decorative`) green.
- **Restore camelCase SVG element names.** libxml lowercases tag names, so `<linearGradient>` was emitted as `<lineargradient>` — an unknown element the browser ignores, so the gradient fill disappeared even when "preserved". `restoreSvgAttributeCasing` only fixed attributes; it now also restores element names (`linearGradient`, `radialGradient`, `clipPath`, filter primitives, ...) and is renamed `restoreSvgCasing`.
- **External-sprite `<use>` verdict.** `<use href="sprite.svg#id">` references a symbol in another file that does not travel with the imported markup, so it cannot be inlined. Such SVGs are now **reported via the bounded inline-SVG fallback** rather than emitted as broken external markup. **Local `<use href="#id">`** against an in-document `<symbol>`/`<defs>` is preserved.
- **Expanded the passive-SVG safe allowlist** to the full set of safe structure/geometry/text tags + attributes (`text`, `tspan`, `marker`, `pattern`, `symbol`, `use`, `font-*`, `text-anchor`, `marker-*`, `pattern*`, `ref{x,y}`, ...).

**Security stripping is unchanged** — `<script>`, `on*` handlers, `<foreignObject>`, `javascript:` URLs, and external `url()` references are still removed. Verified a decorative SVG carrying an inline `<script>` + `onclick` keeps the artwork while both unsafe parts are scrubbed.

## Before / after (real diagram)

Input: `<section class="system-diagram"><svg aria-hidden="true" viewBox="0 0 400 300">…defs/linearGradient/stop, line, polyline, polygon, ellipse, circle, rect, comments, script, onclick…</svg></section>`

- **Before:** SVG dropped → `core/group` with empty `innerBlocks` (no `core/html`; drawing gone).
- **After:** faithful `core/html` containing every shape, with `<linearGradient>` correctly cased, `<script>`/`onclick` stripped.

## Tests

- New parity fixtures: `html-inline-svg-diagram-preserved` (aria-hidden diagram survives, unsafe parts scrubbed) and `html-inline-svg-local-use-symbol` (local `use(#id)`+`symbol` preserved; external-sprite `use` reported via fallback).
- Full parity suite green: **170 fixtures**. `php -l` clean. Existing SVG/security fixtures unchanged and green.
- Pre-existing, unrelated baseline failures on `trunk` (corpus-detectors classed/styled-span assertions + `html-paragraph-heading-classed-span-hoist`) are in the span/paragraph-hoist path and untouched by this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause investigation, code changes, and parity fixtures.