### PR TITLE
figma-transformer: wire paragraphIndent, textAutoResize, stackCounterSpacing

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2854,7 +2854,23 @@ final class StaticHtmlEmitter
         }
 
         if ( isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ) {
-            $styles[] = 'gap:' . $this->number((float) $layout['item_spacing']) . 'px';
+            $mainGap = $this->number((float) $layout['item_spacing']);
+            if ( 'wrap' === ($layout['flex_wrap'] ?? null)
+                && isset($layout['counter_axis_spacing'])
+                && is_numeric($layout['counter_axis_spacing'])
+                && (float) $layout['counter_axis_spacing'] !== (float) $layout['item_spacing'] ) {
+                // CSS `gap` shorthand is `row-gap column-gap`. In a wrapping flex
+                // row the main-axis item spacing is the column gap while the
+                // counter-axis spacing (the gap between wrapped rows) is the row
+                // gap; a wrapping column is the inverse.
+                $counterGap = $this->number((float) $layout['counter_axis_spacing']);
+                $isColumn = 'column' === ($layout['flex_direction'] ?? null);
+                $rowGap = $isColumn ? $mainGap : $counterGap;
+                $columnGap = $isColumn ? $counterGap : $mainGap;
+                $styles[] = 'gap:' . $rowGap . 'px ' . $columnGap . 'px';
+            } else {
+                $styles[] = 'gap:' . $mainGap . 'px';
+            }
         }
 
         if ( ! $isDecorativeFlexUnderlay ) {
@@ -4001,6 +4017,12 @@ final class StaticHtmlEmitter
             $styles[] = 'letter-spacing:' . $this->number((float) $style['letter_spacing']) . 'px';
         } elseif ( isset($style['letter_spacing_em']) && is_numeric($style['letter_spacing_em']) ) {
             $styles[] = 'letter-spacing:' . $this->number((float) $style['letter_spacing_em']) . 'em';
+        }
+
+        // Figma `paragraphIndent` → CSS first-line indent. A zero indent is the
+        // default, so it is left implicit.
+        if ( isset($style['paragraph_indent']) && is_numeric($style['paragraph_indent']) && 0.0 !== (float) $style['paragraph_indent'] ) {
+            $styles[] = 'text-indent:' . $this->number((float) $style['paragraph_indent']) . 'px';
         }
 
         $color = $this->color($style['color'] ?? null);

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1640,6 +1640,13 @@ final class ScenegraphNormalizer
             $style['paragraph_spacing'] = (float) $source['paragraphSpacing'];
         }
 
+        // Figma `paragraphIndent` (px first-line indent of each paragraph). Decoded
+        // by the Kiwi parser but previously never read here, so it was dropped for
+        // .fig input. Maps directly onto CSS `text-indent` in the emitter.
+        if ( isset($source['paragraphIndent']) && is_numeric($source['paragraphIndent']) ) {
+            $style['paragraph_indent'] = (float) $source['paragraphIndent'];
+        }
+
         return $style;
     }
 
@@ -3540,6 +3547,32 @@ final class ScenegraphNormalizer
             }
         }
 
+        // Figma `textAutoResize` (TEXT auto-resize behaviour) governs whether a
+        // text box hugs its content. WIDTH_AND_HEIGHT hugs both axes, HEIGHT keeps
+        // a fixed width while the height hugs content, NONE is a fixed box, and
+        // TRUNCATE is a fixed box that clips overflow. It is decoded by the Kiwi
+        // parser but was never read, so the intent was dropped for .fig input.
+        // Bridge it onto the HUG/FIXED sizing fields and clip flag the emitter
+        // already consumes rather than inventing a parallel sizing channel.
+        if ( isset($node['textAutoResize']) && is_scalar($node['textAutoResize']) && '' !== (string) $node['textAutoResize'] ) {
+            $autoResize = strtoupper((string) $node['textAutoResize']);
+            $layout['text_auto_resize'] = $autoResize;
+            [$autoResizeHorizontal, $autoResizeVertical] = match ( $autoResize ) {
+                'WIDTH_AND_HEIGHT' => array('HUG', 'HUG'),
+                'HEIGHT'           => array(null, 'HUG'),
+                default            => array(null, null),
+            };
+            if ( null !== $autoResizeHorizontal && ! isset($layout['sizing_horizontal']) ) {
+                $layout['sizing_horizontal'] = $autoResizeHorizontal;
+            }
+            if ( null !== $autoResizeVertical && ! isset($layout['sizing_vertical']) ) {
+                $layout['sizing_vertical'] = $autoResizeVertical;
+            }
+            if ( 'TRUNCATE' === $autoResize ) {
+                $layout['clips_content'] = true;
+            }
+        }
+
         foreach ( array(
             'primaryAxisAlignItems' => 'primary_axis_alignment',
             'counterAxisAlignItems' => 'counter_axis_alignment',
@@ -3597,6 +3630,17 @@ final class ScenegraphNormalizer
             $layout['item_spacing'] = (float) $node['itemSpacing'];
         } elseif ( isset($node['stackSpacing']) && is_numeric($node['stackSpacing']) ) {
             $layout['item_spacing'] = (float) $node['stackSpacing'];
+        }
+
+        // REST `counterAxisSpacing`; Kiwi `stackCounterSpacing`. The cross-axis gap
+        // between wrapped rows/columns in a wrapping Auto Layout, distinct from the
+        // main-axis `item_spacing`. Decoded by the Kiwi parser but never read, so
+        // the wrap gap was dropped for .fig input. The emitter folds it into the
+        // two-value CSS `gap` shorthand when it differs from the main spacing.
+        if ( isset($node['counterAxisSpacing']) && is_numeric($node['counterAxisSpacing']) ) {
+            $layout['counter_axis_spacing'] = (float) $node['counterAxisSpacing'];
+        } elseif ( isset($node['stackCounterSpacing']) && is_numeric($node['stackCounterSpacing']) ) {
+            $layout['counter_axis_spacing'] = (float) $node['stackCounterSpacing'];
         }
 
         if ( isset($node['layoutWrap']) && is_scalar($node['layoutWrap']) ) {

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6773,6 +6773,108 @@ $assert(str_contains($hiddenLayerHtml, 'Visible content stays'), 'visible-siblin
 $assert(! str_contains($hiddenLayerHtml, 'data-figma-node-id="vis:hidden-child"'), 'hidden-node-id-not-emitted');
 $assert(! str_contains($hiddenLayerHtml, 'Hidden content must vanish'), 'hidden-node-text-not-emitted');
 
+// --- Decoded-but-dropped trio (coverage issue #328) ----------------------
+// paragraphIndent, textAutoResize, and stackCounterSpacing are decoded by the
+// Kiwi parser but were never read by the normalizer. These contracts assert the
+// exact CSS the wiring now emits.
+
+// paragraphIndent → CSS text-indent on the text style declarations.
+$paragraphIndentResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Paragraph Indent',
+    'nodes' => array(
+        array(
+            'id'         => 'pi:root',
+            'type'       => 'FRAME',
+            'name'       => 'Indent Root',
+            'width'      => 400,
+            'height'     => 200,
+            'layoutMode' => 'VERTICAL',
+            'children'   => array(
+                array(
+                    'id'              => 'pi:text',
+                    'type'            => 'TEXT',
+                    'name'            => 'Indented Copy',
+                    'text'            => 'Indented paragraph',
+                    'paragraphIndent' => 16,
+                ),
+            ),
+        ),
+    ),
+));
+$paragraphIndentCss = $fileContent($paragraphIndentResult, 'style.css');
+$assert('success' === ($paragraphIndentResult['status'] ?? null), 'paragraph-indent-transform-success');
+$assert(str_contains($paragraphIndentCss, 'text-indent:16px'), 'paragraph-indent-emits-text-indent');
+
+// textAutoResize → content sizing. WIDTH_AND_HEIGHT hugs both axes; HEIGHT keeps
+// the fixed width and lets the height hug content.
+$textAutoResizeResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Text Auto Resize',
+    'nodes' => array(
+        array(
+            'id'         => 'tar:root',
+            'type'       => 'FRAME',
+            'name'       => 'Auto Resize Root',
+            'width'      => 600,
+            'height'     => 400,
+            'layoutMode' => 'VERTICAL',
+            'children'   => array(
+                array(
+                    'id'             => 'tar:hug',
+                    'type'           => 'TEXT',
+                    'name'           => 'Hug Copy',
+                    'text'           => 'Hug both axes',
+                    'width'          => 200,
+                    'height'         => 50,
+                    'textAutoResize' => 'WIDTH_AND_HEIGHT',
+                ),
+                array(
+                    'id'             => 'tar:autoheight',
+                    'type'           => 'TEXT',
+                    'name'           => 'Auto Height Copy',
+                    'text'           => 'Fixed width auto height',
+                    'width'          => 180,
+                    'height'         => 50,
+                    'textAutoResize' => 'HEIGHT',
+                ),
+            ),
+        ),
+    ),
+));
+$textAutoResizeCss = $fileContent($textAutoResizeResult, 'style.css');
+$assert('success' === ($textAutoResizeResult['status'] ?? null), 'text-auto-resize-transform-success');
+$assert(str_contains($textAutoResizeCss, 'width:fit-content;height:fit-content'), 'text-auto-resize-width-and-height-hugs-both-axes');
+$assert(! str_contains($textAutoResizeCss, 'width:200px'), 'text-auto-resize-width-and-height-omits-fixed-width');
+$assert(str_contains($textAutoResizeCss, 'width:180px;height:fit-content'), 'text-auto-resize-height-keeps-fixed-width-auto-height');
+
+// stackCounterSpacing → two-value CSS gap on a wrapping Auto Layout. The cross-
+// axis (counter) spacing is the row gap and the main-axis spacing the column gap
+// for a wrapping flex row.
+$counterSpacingResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Counter Axis Spacing',
+    'nodes' => array(
+        array(
+            'id'                  => 'cas:root',
+            'type'                => 'FRAME',
+            'name'                => 'Wrap Root',
+            'width'               => 400,
+            'height'              => 300,
+            'stackMode'           => 'HORIZONTAL',
+            'stackWrap'           => 'WRAP',
+            'stackSpacing'        => 24,
+            'stackCounterSpacing' => 12,
+            'children'            => array(
+                array('id' => 'cas:a', 'type' => 'RECTANGLE', 'name' => 'Tile A', 'width' => 100, 'height' => 80, 'fill' => array('r' => 1, 'g' => 0, 'b' => 0)),
+                array('id' => 'cas:b', 'type' => 'RECTANGLE', 'name' => 'Tile B', 'width' => 100, 'height' => 80, 'fill' => array('r' => 0, 'g' => 1, 'b' => 0)),
+            ),
+        ),
+    ),
+));
+$counterSpacingCss = $fileContent($counterSpacingResult, 'style.css');
+$assert('success' === ($counterSpacingResult['status'] ?? null), 'counter-spacing-transform-success');
+$assert(str_contains($counterSpacingCss, 'flex-wrap:wrap'), 'counter-spacing-wraps');
+$assert(str_contains($counterSpacingCss, 'gap:12px 24px'), 'counter-spacing-emits-two-value-gap');
+$assert(! str_contains($counterSpacingCss, 'gap:24px'), 'counter-spacing-not-single-value-gap');
+
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");
     exit(1);


### PR DESCRIPTION
Wires up the three 🔴 decoded-but-dropped fields from coverage issue #328 — fields already decoded by the Kiwi parser that the normalizer simply never read. **Normalizer + emitter only**; the decoder whitelist is untouched, so this does not conflict with the parallel decoder work.

## Changes

### `paragraphIndent` → CSS `text-indent`
`normalizeTextStyle` now reads `paragraphIndent` into `text_style.paragraph_indent`, and the emitter renders it as `text-indent:{n}px` in the text style declarations (a zero indent stays implicit).

### `textAutoResize` → content sizing
`normalizeLayout` bridges the `textAutoResize` enum onto the HUG/FIXED sizing fields the emitter already consumes, rather than inventing a parallel sizing channel:
- `WIDTH_AND_HEIGHT` → hug both axes → `width:fit-content;height:fit-content`
- `HEIGHT` → fixed width, auto height → keeps explicit width, `height:fit-content`
- `NONE` → fixed box → explicit width/height (unchanged)
- `TRUNCATE` → fixed box + `overflow:hidden`

### `stackCounterSpacing` → two-value CSS `gap`
For wrapping Auto Layout (`stackWrap: WRAP`), the cross-axis spacing is read into `layout.counter_axis_spacing`. The emitter's single `gap` emission is extended so that when the counter spacing differs from the main spacing it emits the two-value shorthand `gap: {row-gap} {column-gap}`, mapping main/counter axes to row/column gap by `flex-direction` (e.g. a wrapping row → `gap:{counter}px {main}px`).

## Tests

Added contract fixtures in `tests/contract/run.php` asserting the exact emitted CSS for each field:
- `paragraphIndent: 16` → `text-indent:16px`
- `textAutoResize: WIDTH_AND_HEIGHT` → `width:fit-content;height:fit-content` (and `HEIGHT` → `width:180px;height:fit-content`)
- A wrapping stack with `stackCounterSpacing` (12) ≠ `stackSpacing` (24) → `gap:12px 24px`

```
cd figma-transformer && php tests/contract/run.php
# Figma Transformer contract tests passed.
```

Refs #328

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation