### PR TITLE
figma-transformer: decode node effects (shadows + blur) into emittable CSS

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -403,6 +403,11 @@ final class FigKiwiDecoder
                 'stackPrimaryAlignItems', 'stackCounterAlignItems', 'stackCounterSizing',
                 'stackWrap', 'stackCounterSpacing', 'stackReverseZIndex',
                 'stackChildPrimaryGrow', 'stackChildAlignSelf', 'stackPositioning', 'resizeToFit', 'isClip', 'minSize', 'maxSize',
+                // Visual effects (#328): shadows + blur. `normalizeEffects()` and
+                // `effectStyles()` are already written but were starved because
+                // `effects` was absent from the policy, so the decoder silently
+                // dropped every Effect from the binary.
+                'effects',
             ),
             'GUID' => array('sessionID', 'localID'),
             'ParentIndex' => array('guid', 'position'),
@@ -415,6 +420,10 @@ final class FigKiwiDecoder
             'TextData' => array('characters', 'layoutSize'),
             'Number' => array('value', 'units'),
             'Paint' => array('type', 'color', 'opacity', 'visible', 'stops', 'transform', 'image', 'imageScaleMode', 'originalImageWidth', 'originalImageHeight', 'altText'),
+            // Effect struct (#328). The Kiwi blur token is `FOREGROUND_BLUR`
+            // (REST calls it `LAYER_BLUR`); the normalizer bridges both. `offset`
+            // resolves to the whitelisted `Vector` struct and `color` to `Color`.
+            'Effect' => array('type', 'color', 'offset', 'radius', 'spread', 'visible', 'blendMode'),
             'Image' => array('hash', 'name'),
             'Blob' => array('bytes'),
             'Path' => array('commandsBlob', 'windingRule', 'styleID'),

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -3273,9 +3273,12 @@ final class ScenegraphNormalizer
                 continue;
             }
 
-            if ( in_array($type, array('LAYER_BLUR', 'BACKGROUND_BLUR'), true) ) {
+            // The decoded Kiwi enum names layer blur `FOREGROUND_BLUR`; the REST
+            // shape calls the same effect `LAYER_BLUR`. Bridge both onto the
+            // emitter's `layer_blur` (→ `filter:blur()`) branch (#328).
+            if ( in_array($type, array('LAYER_BLUR', 'FOREGROUND_BLUR', 'BACKGROUND_BLUR'), true) ) {
                 $effects[] = array(
-                    'type' => 'LAYER_BLUR' === $type ? 'layer_blur' : 'background_blur',
+                    'type' => 'BACKGROUND_BLUR' === $type ? 'background_blur' : 'layer_blur',
                     'radius' => is_numeric($effect['radius'] ?? null) ? (float) $effect['radius'] : 0.0,
                 );
                 continue;

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5535,6 +5535,51 @@ $assert(str_contains($effectsCss, 'backdrop-filter:blur(5px)'), 'effects-backgro
 $assert(str_contains($effectsCss, 'text-shadow:1px 1px 2px 0px rgba(0,0,0,0.4)'), 'effects-text-shadow-css');
 $assert(! in_array('unsupported_figma_effect_type', $effectsDiagnosticCodes, true), 'effects-supported-no-diagnostic');
 
+// ---------------------------------------------------------------------------
+// Effects from a REAL Kiwi binary (#328): the field policy was starved, so
+// shadows/blur never decoded even though the normalizer + emitter were written.
+// DECODE the binary through the generic selective decoder, then prove the
+// decoded Kiwi effects (carrying the `FOREGROUND_BLUR` token) emit the exact CSS.
+// ---------------------------------------------------------------------------
+$kiwiEffectsDecoder = new FigKiwiDecoder();
+$kiwiEffectsSchema = $kiwiEffectsDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_effects_schema_fixture());
+$assert(null !== ($kiwiEffectsSchema['schema'] ?? null), 'kiwi-effects-schema-decodes');
+$kiwiEffectsMessage = $kiwiEffectsDecoder->decodeMessageSelective(
+    blocks_engine_figma_transformer_kiwi_effects_message_fixture(),
+    $kiwiEffectsSchema['schema'] ?? array()
+);
+$kiwiEffectsNodeChange = $kiwiEffectsMessage['message']['nodeChanges'][0] ?? array();
+$kiwiDecodedEffects = is_array($kiwiEffectsNodeChange['effects'] ?? null) ? $kiwiEffectsNodeChange['effects'] : array();
+$assert(2 === count($kiwiDecodedEffects), 'kiwi-effects-field-policy-decodes-effects-array');
+$assert('DROP_SHADOW' === ($kiwiDecodedEffects[0]['type'] ?? null), 'kiwi-effects-decodes-drop-shadow-token');
+$assert('FOREGROUND_BLUR' === ($kiwiDecodedEffects[1]['type'] ?? null), 'kiwi-effects-decodes-foreground-blur-token');
+$assert(6 === (int) round((float) ($kiwiDecodedEffects[0]['offset']['y'] ?? 0)), 'kiwi-effects-decodes-shadow-offset');
+$assert(8 === (int) round((float) ($kiwiDecodedEffects[1]['radius'] ?? 0)), 'kiwi-effects-decodes-blur-radius');
+
+// EMIT: feed the decoded Kiwi effects verbatim through normalize -> emit and
+// assert the exact box-shadow + filter CSS reaches style.css.
+$kiwiEffectsRenderResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Kiwi Effects Fixture',
+    'nodes' => array(
+        array(
+            'id'      => 'kiwi:effects-frame',
+            'type'    => (string) ($kiwiEffectsNodeChange['type'] ?? 'FRAME'),
+            'name'    => (string) ($kiwiEffectsNodeChange['name'] ?? 'Effects Frame'),
+            'width'   => 200,
+            'height'  => 120,
+            'effects' => $kiwiDecodedEffects,
+        ),
+    ),
+));
+$kiwiEffectsCss = $fileContent($kiwiEffectsRenderResult, 'style.css');
+$kiwiEffectsDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $kiwiEffectsRenderResult['diagnostics'] ?? array()
+);
+$assert(str_contains($kiwiEffectsCss, 'box-shadow:0px 6px 6px 0px rgba(0,0,0,0.5)'), 'kiwi-effects-emits-drop-shadow-css');
+$assert(str_contains($kiwiEffectsCss, 'filter:blur(8px)'), 'kiwi-effects-emits-foreground-blur-css');
+$assert(! in_array('unsupported_figma_effect_type', $kiwiEffectsDiagnosticCodes, true), 'kiwi-effects-foreground-blur-no-diagnostic');
+
 $symbolInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Symbol Instance Fixture',
     'nodes' => array(
@@ -6948,6 +6993,126 @@ function blocks_engine_figma_transformer_kiwi_dev_status_message_fixture(): stri
         . blocks_engine_figma_transformer_wire_varint(2)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
+}
+
+/**
+ * Encode a float using Kiwi's varFloat format (the inverse of
+ * {@see FigKiwiByteReader::readVarFloat()}): rotate the IEEE-754 bits left by 9
+ * so the sign/exponent land in the low byte, and collapse exact 0.0 to one byte.
+ */
+function blocks_engine_figma_transformer_kiwi_varfloat(float $value): string
+{
+    $bits = unpack('V', pack('f', $value));
+    $raw = is_array($bits) ? (int) $bits[1] : 0;
+    if ( 0 === $raw ) {
+        return chr(0);
+    }
+
+    $rotated = ( ( $raw << 9 ) & 0xffffffff ) | ( ( $raw >> 23 ) & 0x1ff );
+    return pack('V', $rotated);
+}
+
+/**
+ * Kiwi schema (version-106 shape) defining Color/Vector structs, the EffectType
+ * enum (with the real `FOREGROUND_BLUR` token), an Effect struct, and a
+ * NodeChange/Message pair carrying `effects`. Proves the #328 field-policy
+ * additions decode shadows + blur through the REAL generic decoder.
+ */
+function blocks_engine_figma_transformer_kiwi_effects_schema_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(6)
+        // def0: STRUCT Color { float r, g, b, a }
+        . blocks_engine_figma_transformer_kiwi_string('Color')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('r', -5, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('g', -5, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('b', -5, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('a', -5, false, 4)
+        // def1: STRUCT Vector { float x, y }
+        . blocks_engine_figma_transformer_kiwi_string('Vector')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('x', -5, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('y', -5, false, 2)
+        // def2: ENUM EffectType (real Figma tokens/values)
+        . blocks_engine_figma_transformer_kiwi_string('EffectType')
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('INNER_SHADOW', 0, false, 0)
+        . blocks_engine_figma_transformer_kiwi_schema_field('DROP_SHADOW', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('FOREGROUND_BLUR', 0, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('BACKGROUND_BLUR', 0, false, 3)
+        // def3: STRUCT Effect { EffectType type; Color color; Vector offset; float radius; float spread; bool visible }
+        . blocks_engine_figma_transformer_kiwi_string('Effect')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(6)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', 2, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('color', 0, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('offset', 1, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('radius', -5, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('spread', -5, false, 5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('visible', -1, false, 6)
+        // def4: MESSAGE NodeChange { type, name, effects[] }
+        . blocks_engine_figma_transformer_kiwi_string('NodeChange')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('effects', 3, true, 3)
+        // def5: MESSAGE Message { type, nodeChanges[] }
+        . blocks_engine_figma_transformer_kiwi_string('Message')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 4, true, 2);
+}
+
+/**
+ * Kiwi message for {@see blocks_engine_figma_transformer_kiwi_effects_schema_fixture()}:
+ * one FRAME NodeChange carrying a DROP_SHADOW (offset 0,6 / radius 6 / black @ 0.5)
+ * and a FOREGROUND_BLUR (radius 8). Struct fields decode sequentially.
+ */
+function blocks_engine_figma_transformer_kiwi_effects_message_fixture(): string
+{
+    $dropShadow = blocks_engine_figma_transformer_wire_varint(1) // EffectType DROP_SHADOW
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // color.r
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // color.g
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // color.b
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.5)   // color.a
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // offset.x
+        . blocks_engine_figma_transformer_kiwi_varfloat(6.0)   // offset.y
+        . blocks_engine_figma_transformer_kiwi_varfloat(6.0)   // radius
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // spread
+        . chr(1);                                              // visible
+
+    $foregroundBlur = blocks_engine_figma_transformer_wire_varint(2) // EffectType FOREGROUND_BLUR
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // color.r
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // color.g
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // color.b
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // color.a
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // offset.x
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // offset.y
+        . blocks_engine_figma_transformer_kiwi_varfloat(8.0)   // radius
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)   // spread
+        . chr(1);                                              // visible
+
+    $nodeChange = blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('FRAME')          // type
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('Effects Frame')  // name
+        . blocks_engine_figma_transformer_wire_varint(3)                // effects field
+        . blocks_engine_figma_transformer_wire_varint(2)                // array length
+        . $dropShadow
+        . $foregroundBlur
+        . blocks_engine_figma_transformer_wire_varint(0);              // end NodeChange
+
+    return blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('DOCUMENT')      // Message.type
+        . blocks_engine_figma_transformer_wire_varint(2)              // nodeChanges field
+        . blocks_engine_figma_transformer_wire_varint(1)             // array length
+        . $nodeChange
+        . blocks_engine_figma_transformer_wire_varint(0);            // end Message
 }
 
 /**


### PR DESCRIPTION
## Summary

Wires Figma visual effects (drop shadow, inner shadow, layer blur, background blur) through the `figma-transformer` end-to-end. Per the #328 coverage matrix, this was the single highest payoff-to-effort gap: the normalizer's `normalizeEffects()` and the emitter's `effectStyles()` were **already fully written** but starved — node-level `effects` was absent from the Kiwi selective-decode field policy, so `skipField()` silently dropped every `Effect` from the `.fig` binary before it could become CSS.

## The fix (gate 1 — decode)

- Add `effects` to the `NodeChange` field policy in `FigKiwiDecoder::defaultScenegraphFieldPolicy()`.
- Register an `Effect` struct policy entry (`type`, `color`, `offset`, `radius`, `spread`, `visible`, `blendMode`). The nested `offset`/`color` resolve to the already-whitelisted `Vector`/`Color` structs, so no further policy work was needed.

## Shape bridge (gate 2 — normalize)

The decoded **Kiwi** enum names layer blur `FOREGROUND_BLUR`, whereas the REST API shape (and the pre-existing normalizer branch) used `LAYER_BLUR`. `normalizeEffects()` now accepts both `LAYER_BLUR` and `FOREGROUND_BLUR` and maps them onto the emitter's existing `layer_blur` → `filter:blur()` path. `BACKGROUND_BLUR`, `DROP_SHADOW`, and `INNER_SHADOW` tokens are identical between the two shapes and needed no bridging. This was the only divergence between the decoded Kiwi effect shape and what the normalizer expected — field names (`offset.x/y`, `radius`, `spread`, `color.r/g/b/a`, `visible`) all matched.

## Emit (gate 3)

`effectStyles()` was already correct and unchanged:
- `DROP_SHADOW` → `box-shadow`, `INNER_SHADOW` → `box-shadow: inset …`
- `DROP_SHADOW` on a `TEXT` node → `text-shadow`
- `LAYER_BLUR`/`FOREGROUND_BLUR` → `filter: blur(…)`
- `BACKGROUND_BLUR` → `backdrop-filter: blur(…)`

## Test (real, not smoke-test theater)

Adds a contract fixture that builds a **real Kiwi schema + message** in binary — `EffectType` enum with the genuine `FOREGROUND_BLUR` token, an `Effect` struct, and a `FRAME` `NodeChange` carrying a `DROP_SHADOW` (offset 0,6 / radius 6 / black @ 0.5) plus a `FOREGROUND_BLUR` (radius 8). It decodes through the **generic selective decoder** (exercising the real field policy), asserts the Kiwi tokens/values decode, then feeds the decoded effects verbatim through normalize → emit and asserts the **exact** CSS reaches `style.css`:

- `box-shadow:0px 6px 6px 0px rgba(0,0,0,0.5)`
- `filter:blur(8px)`

Proven load-bearing: reverting the decoder policy fails 7 assertions; reverting the normalizer bridge alone fails the `FOREGROUND_BLUR` emit + diagnostic assertions. All contract tests pass (`php tests/contract/run.php`).

Refs #328.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation