### PR TITLE
figma-transformer: decode Kiwi character style overrides for inline text spans

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -412,7 +412,17 @@ final class FigKiwiDecoder
             'Color' => array('r', 'g', 'b', 'a'),
             'ColorStop' => array('position', 'color'),
             'FontName' => array('family', 'style', 'postscript'),
-            'TextData' => array('characters', 'layoutSize'),
+            // Inline styled-text spans (#328, feeding the normalizer path added in
+            // #305/#299). In the Kiwi encoding the per-character style-run IDs ride
+            // on `characterStyleIDs` (the REST API calls the same data
+            // `characterStyleOverrides`), and `styleOverrideTable` is a `NodeChange[]`
+            // of partial style overrides each carrying a `styleID` plus the overriding
+            // properties (`fontName`, `fontSize`, `fillPaints`, ...). The override
+            // entries decode against the existing `NodeChange` policy below, which
+            // already whitelists `styleID`/`fontName`/`fontSize`/`fillPaints`/etc.
+            // Without these two names the per-character override data is dropped by
+            // `skipField()` and every .fig text node emits flat, single-style text.
+            'TextData' => array('characters', 'layoutSize', 'characterStyleIDs', 'styleOverrideTable'),
             'Number' => array('value', 'units'),
             'Paint' => array('type', 'color', 'opacity', 'visible', 'stops', 'transform', 'image', 'imageScaleMode', 'originalImageWidth', 'originalImageHeight', 'altText'),
             'Image' => array('hash', 'name'),

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1733,11 +1733,15 @@ final class ScenegraphNormalizer
      * format produced by {@see normalizeStyledTextSegments}.
      *
      * Figma REST API and .fig files expose per-character style overrides via two
-     * parallel fields:
-     *   - `characterStyleOverrides` — one integer per character; 0 = base style,
-     *     N = an entry in `styleOverrideTable`.
-     *   - `styleOverrideTable` — map from string key (the N above) to a Figma
+     * parallel fields, with different names and shapes per encoding:
+     *   - REST `characterStyleOverrides` / Kiwi `textData.characterStyleIDs` — one
+     *     integer per character; 0 = base style, N = an entry in the override table.
+     *   - REST `styleOverrideTable` — map from string key (the N above) to a Figma
      *     style object carrying only the overriding properties.
+     *   - Kiwi `textData.styleOverrideTable` — a `NodeChange[]` where each entry
+     *     carries a `styleID` (the N above) plus the overriding properties
+     *     (`fontName`, `fontSize`, `fillPaints`, ...). It is bridged into the same
+     *     id-keyed map shape the REST path produces.
      *
      * Adjacent characters sharing the same override ID are collapsed into a single
      * run. For each non-base run the override style is compared against the
@@ -1750,8 +1754,17 @@ final class ScenegraphNormalizer
      */
     private function normalizeCharacterStyleOverrideSegments(array $node): array
     {
+        $textData = is_array($node['textData'] ?? null) ? $node['textData'] : array();
+
         $overrides = is_array($node['characterStyleOverrides'] ?? null) ? array_values($node['characterStyleOverrides']) : array();
+        if ( empty($overrides) && is_array($textData['characterStyleIDs'] ?? null) ) {
+            $overrides = array_values($textData['characterStyleIDs']);
+        }
+
         $overrideTable = is_array($node['styleOverrideTable'] ?? null) ? $node['styleOverrideTable'] : array();
+        if ( empty($overrideTable) && is_array($textData['styleOverrideTable'] ?? null) ) {
+            $overrideTable = $this->indexKiwiStyleOverrideTable($textData['styleOverrideTable']);
+        }
 
         if ( empty($overrides) || empty($overrideTable) ) {
             return array();
@@ -1769,13 +1782,16 @@ final class ScenegraphNormalizer
             return array();
         }
 
-        // Resolve the characters string.
+        // Resolve the characters string. .fig (Kiwi) nests it under `textData`.
         $characters = '';
         foreach ( array('characters', 'text') as $key ) {
             if ( isset($node[$key]) && is_scalar($node[$key]) ) {
                 $characters = (string) $node[$key];
                 break;
             }
+        }
+        if ( '' === $characters && isset($textData['characters']) && is_scalar($textData['characters']) ) {
+            $characters = (string) $textData['characters'];
         }
         if ( '' === $characters ) {
             return array();
@@ -1790,11 +1806,10 @@ final class ScenegraphNormalizer
                 $baseStyle[$key] = $value;
             }
         }
-        // Extract text fill color from the base node's fills when not already in style.
+        // Extract text fill color from the base node's fills when not already in
+        // style. REST encodes these as `fills`; .fig (Kiwi) as `fillPaints`.
         if ( ! isset($baseStyle['color']) ) {
-            $baseFills = is_array($baseStyleSource['fills'] ?? null)
-                ? $baseStyleSource['fills']
-                : ( is_array($node['fills'] ?? null) ? $node['fills'] : array() );
+            $baseFills = $this->firstFillList(array($baseStyleSource['fills'] ?? null, $node['fills'] ?? null, $node['fillPaints'] ?? null));
             $fillColor = $this->solidFillColor($baseFills);
             if ( null !== $fillColor ) {
                 $baseStyle['color'] = $fillColor;
@@ -1843,9 +1858,10 @@ final class ScenegraphNormalizer
                 if ( ! empty($rawOverride) ) {
                     $overrideStyle = $this->normalizeTextStyle($rawOverride);
 
-                    // Figma REST API encodes text color as fills in override entries.
+                    // Figma encodes override text color as fills: REST uses `fills`,
+                    // .fig (Kiwi) NodeChange entries use `fillPaints`.
                     if ( ! isset($overrideStyle['color']) ) {
-                        $overrideFills = is_array($rawOverride['fills'] ?? null) ? $rawOverride['fills'] : array();
+                        $overrideFills = $this->firstFillList(array($rawOverride['fills'] ?? null, $rawOverride['fillPaints'] ?? null));
                         $fillColor = $this->solidFillColor($overrideFills);
                         if ( null !== $fillColor ) {
                             $overrideStyle['color'] = $fillColor;
@@ -1870,6 +1886,48 @@ final class ScenegraphNormalizer
         }
 
         return $segments;
+    }
+
+    /**
+     * Bridges the Kiwi `textData.styleOverrideTable` (a `NodeChange[]` where each
+     * entry carries a `styleID`) into the id-keyed map shape that the REST path —
+     * and the rest of {@see normalizeCharacterStyleOverrideSegments} — expects.
+     *
+     * @param array<int|string, mixed> $table
+     * @return array<string, array<string, mixed>>
+     */
+    private function indexKiwiStyleOverrideTable(array $table): array
+    {
+        $indexed = array();
+        foreach ( $table as $entry ) {
+            if ( ! is_array($entry) ) {
+                continue;
+            }
+            if ( ! isset($entry['styleID']) || ! is_numeric($entry['styleID']) ) {
+                continue;
+            }
+            $indexed[(string) (int) $entry['styleID']] = $entry;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * Returns the first non-empty paint list from a set of candidate sources. Used
+     * to bridge REST `fills` and Kiwi `fillPaints` when resolving text colors.
+     *
+     * @param array<int, mixed> $candidates
+     * @return array<int, mixed>
+     */
+    private function firstFillList(array $candidates): array
+    {
+        foreach ( $candidates as $candidate ) {
+            if ( is_array($candidate) && ! empty($candidate) ) {
+                return $candidate;
+            }
+        }
+
+        return array();
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4333,6 +4333,81 @@ $assert(str_contains($inlineTextStyleHtml, 'Hello blue <span style="color:#0000f
 // Mixed-weight: only "Bold" differs in font-weight — it gets a font-weight span.
 $assert(str_contains($inlineTextStyleHtml, '<span style="font-weight:700">Bold</span> plain text'), 'inline-style-mixed-weight-spans');
 
+// Kiwi (.fig) inline style overrides (#328).
+//
+// The REST API fixture above passes `characters` / `characterStyleOverrides` /
+// `styleOverrideTable` (an id-keyed map) flat on the node. Real `.fig` (Kiwi) files
+// encode the same data differently, and the figma-transformer must decode and
+// bridge that shape into the same `segments` contract:
+//   - text lives under `textData.characters`
+//   - per-character run IDs live under `textData.characterStyleIDs`
+//   - the override table is `textData.styleOverrideTable`, a `NodeChange[]` where
+//     each entry carries a `styleID` plus the overriding properties, and override
+//     text color rides on `fillPaints` (not REST `fills`).
+// This fixture mirrors that .fig shape so the bridge is exercised end-to-end:
+// decode -> normalize (id-keyed + fillPaints color + fontName→weight) -> emit span.
+$kiwiInlineTextStyleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Kiwi Inline Text Style Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'kts:1',
+            'type'     => 'FRAME',
+            'name'     => 'Kiwi inline text frame',
+            'width'    => 1200,
+            'height'   => 400,
+            'children' => array(
+                // "Hello blue " (11 chars) in base black, "world" (5 chars) in blue
+                // via a NodeChange-shaped override entry carrying `fillPaints`.
+                array(
+                    'id'         => 'kts:2',
+                    'type'       => 'TEXT',
+                    'name'       => 'Kiwi two color text',
+                    'fontName'   => array('family' => 'Inter', 'style' => 'Regular'),
+                    'fontSize'   => 16,
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
+                    'textData'   => array(
+                        'characters'        => 'Hello blue world',
+                        'characterStyleIDs' => array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1),
+                        'styleOverrideTable' => array(
+                            array(
+                                'styleID'    => 1,
+                                'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 1, 'a' => 1))),
+                            ),
+                        ),
+                    ),
+                ),
+                // "Bold" (4 chars) at weight 700 via a NodeChange-shaped override
+                // entry carrying a bold `fontName`, " plain text" (11 chars) at base.
+                array(
+                    'id'         => 'kts:3',
+                    'type'       => 'TEXT',
+                    'name'       => 'Kiwi mixed weight text',
+                    'fontName'   => array('family' => 'Inter', 'style' => 'Regular'),
+                    'fontSize'   => 16,
+                    'textData'   => array(
+                        'characters'        => 'Bold plain text',
+                        'characterStyleIDs' => array(1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+                        'styleOverrideTable' => array(
+                            array(
+                                'styleID'  => 1,
+                                'fontName' => array('family' => 'Inter', 'style' => 'Bold'),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$kiwiInlineTextStyleHtml = $fileContent($kiwiInlineTextStyleResult, 'index.html');
+
+// Kiwi two-color: only the "world" run differs in fill color — it gets a color span,
+// and the non-overridden "Hello blue " text is emitted unwrapped.
+$assert(str_contains($kiwiInlineTextStyleHtml, 'Hello blue <span style="color:#0000ff">world</span>'), 'kiwi-inline-style-two-color-spans');
+// Kiwi mixed-weight: only "Bold" differs in font-weight — derived from the override
+// entry's bold `fontName` — and " plain text" stays unwrapped.
+$assert(str_contains($kiwiInlineTextStyleHtml, '<span style="font-weight:700">Bold</span> plain text'), 'kiwi-inline-style-mixed-weight-spans');
+
 // Font embedding: a known web font (Inter) resolves to a weight-aware Google Fonts
 // @font-face import, while an unknown family (Skolar Latin) stays actionable. This
 // mirrors the David Perell .fig matrix where Inter + Skolar Latin rendered in a


### PR DESCRIPTION
## Summary

Wires Figma's **inline styled-text spans** (per-character bold/colored runs within a single text node) from `.fig` (Kiwi) input all the way through to the emitter's `<span style="...">` wrapping.

PR #305 (which closed #299) added the normalizer path — `normalizeStyledTextSegments()` → `normalizeCharacterStyleOverrideSegments()` — and the emitter already wraps differing runs in minimal spans. But that path was only ever fed by **REST-API-shaped JSON**. Per the #328 coverage audit (Text → "Styled segments"), the Kiwi field policy in `FigKiwiDecoder` whitelisted only `characters`/`layoutSize` on `TextData`, so `skipField()` silently dropped the per-character override data and real `.fig` text nodes emitted flat, single-style text. This feeds that finished machinery from `.fig`.

## Kiwi shape found vs. what the normalizer expected

| Concern | REST (what #305 normalizer expected) | Kiwi (`.fig`, what this PR bridges) |
|---|---|---|
| Text characters | `node.characters` | `node.textData.characters` |
| Per-char run IDs | `node.characterStyleOverrides` (int[]) | `node.textData.characterStyleIDs` (int[]) |
| Override table | `node.styleOverrideTable` — **map** keyed by style id | `node.textData.styleOverrideTable` — **`NodeChange[]`**, each entry carries a `styleID` + overriding props |
| Override/base text color | `fills` | `fillPaints` |
| Font weight override | `fontWeight: 700` | `fontName: {style: "Bold"}` (already derived by `normalizeTextStyle`) |

The override entries reuse the **`NodeChange`** struct (already richly whitelisted with `styleID`/`fontName`/`fontSize`/`fillPaints`/etc.), which is why the decoder fix is just the two `TextData` field names — no new nested struct policy is required.

## Changes

- **`FigKiwiDecoder`** — whitelist `characterStyleIDs` and `styleOverrideTable` on the `TextData` field policy. Without these, gate 1 starved the normalizer.
- **`ScenegraphNormalizer`** — `normalizeCharacterStyleOverrideSegments()` now also reads from `textData`, bridges `characterStyleIDs`, indexes the `NodeChange[]` override table by `styleID` into the id-keyed map shape (`indexKiwiStyleOverrideTable()`), and resolves base/override text color from `fillPaints` as well as `fills` (`firstFillList()`). The existing run-collapsing + base-style diffing is reused unchanged, so only changed properties reach each span.
- **`tests/contract/run.php`** — new Kiwi-shaped fixture: two-color (blue `fillPaints` override) and mixed-weight (bold `fontName` override). Asserts the emitted HTML wraps exactly the overridden run (`<span style="color:#0000ff">world</span>`, `<span style="font-weight:700">Bold</span>`) and leaves the non-overridden text unwrapped.

## Test

```
cd figma-transformer && php tests/contract/run.php
# Figma Transformer contract tests passed.
```

Verified end-to-end: the Kiwi-shaped node emits `Hello blue <span style="color:#0000ff">world</span>`.

Refs #328. Builds on #305 (which added the normalizer/emitter path; this feeds it from `.fig`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation