### PR TITLE
figma-transformer: decode stroke weight/align/dashes so borders render at design width

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -391,6 +391,18 @@ final class FigKiwiDecoder
                 'useAbsoluteBounds', 'cornerRadius', 'rectangleTopLeftCornerRadius',
                 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius',
                 'rectangleBottomRightCornerRadius', 'fillPaints', 'strokePaints', 'backgroundPaints',
+                // Stroke geometry (#328): without these the emitter's strokeStyles()
+                // never sees a weight/align/dash and every border falls back to the
+                // 1px default. `strokeWeight` (float) and `dashPattern` (float[]) carry
+                // the size/dash; `strokeAlign` is the INSIDE/OUTSIDE/CENTER enum and
+                // resolves to its token string. Per-side weights ride on
+                // `borderStrokeWeightsIndependent` + the four `border*Weight` floats;
+                // the `stroke*Weight` aliases are over-listed defensively — unlisted
+                // names are skipped, not mis-read, so listing both shapes is safe.
+                'strokeWeight', 'strokeAlign', 'strokeCap', 'strokeJoin', 'dashPattern',
+                'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight',
+                'borderLeftWeight', 'borderRightWeight',
+                'strokeTopWeight', 'strokeBottomWeight', 'strokeLeftWeight', 'strokeRightWeight',
                 'fillGeometry', 'strokeGeometry', 'vectorData', 'booleanOperation', 'key', 'componentKey',
                 'componentOrStateGroupKey', 'originComponentKey', 'componentId', 'mainComponentId',
                 'mainComponent', 'component', 'symbolData', 'derivedSymbolData', 'guidPath',

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -4118,23 +4118,115 @@ final class StaticHtmlEmitter
             return array();
         }
 
-        $width = 1;
+        $width = 1.0;
         if ( isset($node['strokeWeight']) && is_numeric($node['strokeWeight']) ) {
             $width = (float) $node['strokeWeight'];
         }
 
+        $align     = strtoupper((string) ($node['strokeAlign'] ?? ''));
+        $sideWidths = $this->strokeSideWidths($node, $width);
+        $dashed    = $this->hasDashPattern($node);
+        // CSS borders can't reproduce an exact Figma dash array (border-style only
+        // exposes the `dashed` keyword), so a non-empty dashPattern degrades to a
+        // dashed border. Precise dash lengths would need an SVG/background stroke,
+        // which is out of scope here.
+        $lineStyle = $dashed ? 'dashed' : 'solid';
+
         if ( true === $stroke['gradient'] ) {
             return array(
-                'border:' . $this->number((float) $width) . 'px solid transparent',
+                'border:' . $this->number($width) . 'px ' . $lineStyle . ' transparent',
                 'border-image:' . $stroke['css'] . ' 1',
             );
         }
 
-        if ( 'OUTSIDE' === strtoupper((string) ($node['strokeAlign'] ?? '')) ) {
-            return array('box-shadow:0 0 0 ' . $this->number((float) $width) . 'px ' . $stroke['css']);
+        // Outside strokes don't grow the layout box; the emitter renders them as an
+        // outset box-shadow ring at the real weight. box-shadow can't express dashes
+        // or per-side weights, so those fall through to the border path below.
+        if ( 'OUTSIDE' === $align && null === $sideWidths && ! $dashed ) {
+            return array('box-shadow:0 0 0 ' . $this->number($width) . 'px ' . $stroke['css']);
         }
 
-        return array('border:' . $this->number((float) $width) . 'px solid ' . $stroke['css']);
+        if ( null !== $sideWidths || $dashed ) {
+            $styles = array();
+            if ( null !== $sideWidths ) {
+                foreach ( $sideWidths as $side => $sideWidth ) {
+                    $styles[] = 'border-' . $side . '-width:' . $this->number($sideWidth) . 'px';
+                }
+            } else {
+                $styles[] = 'border-width:' . $this->number($width) . 'px';
+            }
+            $styles[] = 'border-style:' . $lineStyle;
+            $styles[] = 'border-color:' . $stroke['css'];
+            // Inside strokes are drawn within the node bounds; keep the border from
+            // expanding the box so the design's dimensions stay intact.
+            if ( 'INSIDE' === $align ) {
+                $styles[] = 'box-sizing:border-box';
+            }
+
+            return $styles;
+        }
+
+        $styles = array('border:' . $this->number($width) . 'px solid ' . $stroke['css']);
+        if ( 'INSIDE' === $align ) {
+            $styles[] = 'box-sizing:border-box';
+        }
+
+        return $styles;
+    }
+
+    /**
+     * Resolve per-side stroke widths when a node carries independent border
+     * weights. Returns null when the stroke is uniform so callers use the
+     * single-weight border path.
+     *
+     * @param array<string, mixed> $node
+     * @return array<string, float>|null
+     */
+    private function strokeSideWidths(array $node, float $fallback): ?array
+    {
+        $sides = array(
+            'top'    => array('borderTopWeight', 'strokeTopWeight'),
+            'right'  => array('borderRightWeight', 'strokeRightWeight'),
+            'bottom' => array('borderBottomWeight', 'strokeBottomWeight'),
+            'left'   => array('borderLeftWeight', 'strokeLeftWeight'),
+        );
+
+        $widths = array();
+        $found  = false;
+        foreach ( $sides as $side => $keys ) {
+            $value = null;
+            foreach ( $keys as $key ) {
+                if ( isset($node[$key]) && is_numeric($node[$key]) ) {
+                    $value = (float) $node[$key];
+                    break;
+                }
+            }
+            if ( null !== $value ) {
+                $found = true;
+            }
+            $widths[$side] = null !== $value ? $value : $fallback;
+        }
+
+        return $found ? $widths : null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasDashPattern(array $node): bool
+    {
+        $pattern = $node['dashPattern'] ?? null;
+        if ( ! is_array($pattern) ) {
+            return false;
+        }
+
+        foreach ( $pattern as $value ) {
+            if ( is_numeric($value) && (float) $value > 0 ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -890,7 +890,7 @@ final class ScenegraphNormalizer
             if ( isset($override['textData']['characters']) && is_scalar($override['textData']['characters']) ) {
                 $overrides[$nodeId]['characters'] = (string) $override['textData']['characters'];
             }
-            foreach ( array('derivedTextData', 'size', 'transform', 'fillPaints', 'fills', 'strokes', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'cornerRadius', 'rectangleTopLeftCornerRadius', 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius', 'rectangleBottomRightCornerRadius') as $field ) {
+            foreach ( array('derivedTextData', 'size', 'transform', 'fillPaints', 'fills', 'strokes', 'strokePaints', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'cornerRadius', 'rectangleTopLeftCornerRadius', 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius', 'rectangleBottomRightCornerRadius') as $field ) {
                 if ( array_key_exists($field, $override) ) {
                     $overrides[$nodeId][$field] = $override[$field];
                 }
@@ -941,7 +941,7 @@ final class ScenegraphNormalizer
         // the definition's visibility and incorrectly emit to HTML.
         $resolved['visible'] = $instance['visible'] ?? true;
 
-        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd') as $key ) {
+        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight') as $key ) {
             if ( array_key_exists($key, $instance) ) {
                 $resolved[$key] = $instance[$key];
             }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3771,6 +3771,52 @@ $outsideStrokeCss = $fileContent($outsideStrokeResult, 'style.css');
 $assert(str_contains($outsideStrokeCss, '.figma-node-stroke-outside-outside-stroke-image{width:100px;height:80px;box-shadow:0 0 0 8px #ffffff}'), 'outside-stroke-emits-non-shrinking-shadow');
 $assert(! str_contains($outsideStrokeCss, 'border:8px solid #ffffff'), 'outside-stroke-does-not-shrink-border-box');
 
+// Stroke geometry (#328): an INSIDE stroke must render at the design weight (3px),
+// not the stale 1px default, and stay inside the box via box-sizing.
+$insideStrokeResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Inside Stroke Fixture',
+    'nodes' => array(
+        array(
+            'id'           => 'stroke:inside',
+            'type'         => 'RECTANGLE',
+            'name'         => 'Inside stroke box',
+            'width'        => 120,
+            'height'       => 90,
+            'strokeAlign'  => 'INSIDE',
+            'strokeWeight' => 3,
+            'strokes'      => array(
+                array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1)),
+            ),
+        ),
+    ),
+));
+$insideStrokeCss = $fileContent($insideStrokeResult, 'style.css');
+$assert(str_contains($insideStrokeCss, '.figma-node-stroke-inside-inside-stroke-box{width:120px;height:90px;border:3px solid #000000;box-sizing:border-box}'), 'inside-stroke-emits-design-width-border');
+$assert(! str_contains($insideStrokeCss, 'border:1px solid'), 'inside-stroke-does-not-default-to-1px');
+
+// A non-empty dashPattern degrades to a dashed border at the design weight.
+$dashedStrokeResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Dashed Stroke Fixture',
+    'nodes' => array(
+        array(
+            'id'           => 'stroke:dashed',
+            'type'         => 'RECTANGLE',
+            'name'         => 'Dashed stroke box',
+            'width'        => 80,
+            'height'       => 60,
+            'strokeAlign'  => 'INSIDE',
+            'strokeWeight' => 2,
+            'dashPattern'  => array(4, 2),
+            'strokes'      => array(
+                array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1)),
+            ),
+        ),
+    ),
+));
+$dashedStrokeCss = $fileContent($dashedStrokeResult, 'style.css');
+$assert(str_contains($dashedStrokeCss, 'border-style:dashed'), 'dashed-stroke-emits-dashed-border-style');
+$assert(str_contains($dashedStrokeCss, 'border-width:2px'), 'dashed-stroke-emits-design-width');
+
 $gradientPaintResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Gradient Paint Fixture',
     'nodes' => array(
@@ -6049,6 +6095,25 @@ $assert('DOCUMENT' === ($devStatusMessage['message']['type'] ?? null), 'dev-stat
 $assert('SECTION' === ($devStatusNodeChange['type'] ?? null), 'dev-status-kiwi-section-node-decodes');
 $assert('COMPLETED' === ($devStatusNodeChange['sectionStatus'] ?? null), 'dev-status-field-policy-carries-section-status');
 
+// Stroke geometry (#328): the extended field policy must carry strokeWeight,
+// strokeAlign and dashPattern through the REAL generic Kiwi decoder. Before the
+// whitelist fix these were skipped and every border defaulted to 1px.
+$strokeDecoder = new FigKiwiDecoder();
+$strokeSchema  = $strokeDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_stroke_schema_fixture());
+$assert(null !== ($strokeSchema['schema'] ?? null), 'stroke-kiwi-schema-decodes');
+$strokeMessage = $strokeDecoder->decodeMessageSelective(
+    blocks_engine_figma_transformer_kiwi_stroke_message_fixture(),
+    $strokeSchema['schema'] ?? array()
+);
+$strokeNodeChange = $strokeMessage['message']['nodeChanges'][0] ?? array();
+$assert('RECTANGLE' === ($strokeNodeChange['type'] ?? null), 'stroke-kiwi-node-decodes');
+$assert(3.0 === round((float) ($strokeNodeChange['strokeWeight'] ?? 0.0), 4), 'stroke-field-policy-carries-stroke-weight');
+$assert('INSIDE' === ($strokeNodeChange['strokeAlign'] ?? null), 'stroke-field-policy-carries-stroke-align');
+$assert(
+    array(4.0, 2.0) === array_map(static fn ($value): float => round((float) $value, 4), is_array($strokeNodeChange['dashPattern'] ?? null) ? $strokeNodeChange['dashPattern'] : array()),
+    'stroke-field-policy-carries-dash-pattern'
+);
+
 // NORMALIZE: raw sectionStatus tokens map onto a clean dev_status with the raw
 // value carried for auditability.
 $devStatusNormalizer = new \Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer();
@@ -7257,6 +7322,24 @@ function blocks_engine_figma_transformer_kiwi_varfloat(float $value): string
 }
 
 /**
+ * Encode a float in the Kiwi "compressed float" form that
+ * {@see FigKiwiByteReader::readVarFloat()} consumes: a single 0 byte for zero,
+ * otherwise the IEEE-754 bits rotated right by 23 and emitted little-endian.
+ */
+function blocks_engine_figma_transformer_kiwi_float(float $value): string
+{
+    if ( 0.0 === $value ) {
+        return chr(0);
+    }
+
+    $bits = unpack('V', pack('f', $value));
+    $ieee = is_array($bits) ? (int) $bits[1] : 0;
+    // Inverse of the decoder's rotate-left-by-23 so the round trip reproduces $value.
+    $rotated = ( ( $ieee << 9 ) & 0xffffffff ) | ( ( $ieee >> 23 ) & 0x1ff );
+    return pack('V', $rotated);
+}
+
+/**
  * Kiwi schema (version-106 shape) defining Color/Vector structs, the EffectType
  * enum (with the real `FOREGROUND_BLUR` token), an Effect struct, and a
  * NodeChange/Message pair carrying `effects`. Proves the #328 field-policy
@@ -7357,6 +7440,67 @@ function blocks_engine_figma_transformer_kiwi_effects_message_fixture(): string
         . blocks_engine_figma_transformer_wire_varint(1)             // array length
         . $nodeChange
         . blocks_engine_figma_transformer_wire_varint(0);            // end Message
+}
+
+/**
+ * Kiwi schema defining a StrokeAlign enum plus a NodeChange/Message pair that
+ * carries `strokeWeight` (float), `strokeAlign` (enum) and `dashPattern`
+ * (float[]). Proves the field-policy extension (#328) reads stroke geometry
+ * through the REAL generic decoder instead of dropping it at the whitelist.
+ */
+function blocks_engine_figma_transformer_kiwi_stroke_schema_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(3)
+        // def0: ENUM StrokeAlign { CENTER = 1, INSIDE = 2, OUTSIDE = 3 }
+        . blocks_engine_figma_transformer_kiwi_string('StrokeAlign')
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('CENTER', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('INSIDE', 0, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('OUTSIDE', 0, false, 3)
+        // def1: MESSAGE NodeChange { type, name, strokeWeight, strokeAlign, dashPattern[] }
+        . blocks_engine_figma_transformer_kiwi_string('NodeChange')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('strokeWeight', -5, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('strokeAlign', 0, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('dashPattern', -5, true, 5)
+        // def2: MESSAGE Message { type, nodeChanges[] }
+        . blocks_engine_figma_transformer_kiwi_string('Message')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 1, true, 2);
+}
+
+/**
+ * Kiwi message for {@see blocks_engine_figma_transformer_kiwi_stroke_schema_fixture()}:
+ * one RECTANGLE NodeChange with strokeWeight = 3, strokeAlign = INSIDE and a
+ * dashPattern of [4, 2].
+ */
+function blocks_engine_figma_transformer_kiwi_stroke_message_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('DOCUMENT')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        // NodeChange[0]
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('RECTANGLE')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('Bordered Rect')
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_float(3.0)
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(5)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_float(4.0)
+        . blocks_engine_figma_transformer_kiwi_float(2.0)
+        . blocks_engine_figma_transformer_wire_varint(0)
+        . blocks_engine_figma_transformer_wire_varint(0);
 }
 
 /**


### PR DESCRIPTION
## Summary

Per coverage issue #328, the Kiwi decoder's `NodeChange` field policy never whitelisted the stroke geometry fields, so `strokeWeight`/`strokeAlign`/`dashPattern` were dropped during selective decode. The emitter's `strokeStyles()` already read `strokeWeight`/`strokeAlign`, but with those fields gone every border rendered at the **1px default** regardless of the design.

## Changes

- **`FigKiwiDecoder`** — whitelist `strokeWeight`, `strokeAlign`, `strokeCap`, `strokeJoin`, `dashPattern`, and the per-side border weights on the `NodeChange` policy. Per-side names are over-listed across both `border*Weight`/`stroke*Weight` shapes; unlisted fields are skipped (not mis-read), so the over-list is safe.
- **`ScenegraphNormalizer`** — carry the stroke fields through component-instance resolution and instance-child override merges so instances render their own strokes.
- **`StaticHtmlEmitter::strokeStyles()`** — honour the decoded geometry:
  - real `strokeWeight` on the `border` / outside `box-shadow` ring
  - per-side `border-*-width` when independent weights are present
  - `box-sizing:border-box` for `INSIDE` strokes so the box isn't grown
  - `border-style:dashed` for a non-empty `dashPattern`

  CSS borders can't reproduce exact Figma dash lengths (`border-style` only exposes the `dashed` keyword); precise dashes would need an SVG/background stroke, which is out of scope here.

## Test

`php tests/contract/run.php` — all pass. New coverage:
- A real Kiwi decode fixture (schema + message through the generic decoder) proving `strokeWeight=3`, `strokeAlign=INSIDE` and `dashPattern=[4,2]` survive the field policy.
- An emitter fixture asserting an `INSIDE` stroke emits the exact `border:3px solid #000000;box-sizing:border-box` (no longer the 1px default).
- An emitter fixture asserting a `dashPattern` emits `border-style:dashed` at the design width.

Refs #328

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation