### PR TITLE
figma-transformer: decode hyperlinks and reaction URL/navigation links

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -420,6 +420,15 @@ final class FigKiwiDecoder
                 // `effects` was absent from the policy, so the decoder silently
                 // dropped every Effect from the binary.
                 'effects',
+                // Links + prototype navigation (#328). `hyperlink` is the
+                // text/node-level Hyperlink struct; `prototypeInteractions` is
+                // the Kiwi name for what REST calls `reactions`; `reactions`
+                // is whitelisted too for forward-compatibility. `transitionNodeID`
+                // backs the node-level single-interaction navigation fallback.
+                // Scope is link extraction only (URL + node navigation); the
+                // richer animation/overlay/swap action data is intentionally
+                // not decoded here (a separate prototype-fidelity effort).
+                'hyperlink', 'prototypeInteractions', 'reactions', 'transitionNodeID',
             ),
             'GUID' => array('sessionID', 'localID'),
             'ParentIndex' => array('guid', 'position'),
@@ -463,6 +472,18 @@ final class FigKiwiDecoder
             'HandoffStatusMap' => array('entries', 'values', 'handoffStatuses'),
             'HandoffStatusMapEntry' => array('key', 'guid', 'nodeId', 'value', 'status', 'statusInfo', 'currentStatus'),
             'NodeStatusChange' => array('guid', 'nodeId', 'currentStatus', 'statusInfo', 'status'),
+            // Links + prototype navigation (#328). The Kiwi schema models a
+            // text/node hyperlink as `Hyperlink { url, guid }` and prototype
+            // interactions as `PrototypeInteraction { event, actions }` whose
+            // `PrototypeAction` carries `connectionType` (URL/INTERNAL_NODE),
+            // `connectionURL`, `navigationType`, and the `transitionNodeID`
+            // GUID destination. Only the fields the normalizer needs to build a
+            // URL or node-navigation `figma_link` are whitelisted; animation,
+            // overlay, swap, and variable-mutation action data is left undecoded.
+            'Hyperlink' => array('url', 'guid'),
+            'PrototypeInteraction' => array('event', 'actions', 'id'),
+            'PrototypeEvent' => array('interactionType'),
+            'PrototypeAction' => array('connectionType', 'connectionURL', 'transitionNodeID', 'navigationType'),
         );
     }
 

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2023,8 +2023,11 @@ final class ScenegraphNormalizer
 
         $type = strtoupper((string) ($hyperlink['type'] ?? ''));
         $url = $this->readString($hyperlink, array('url', 'href'));
+        // The Kiwi `Hyperlink` struct has no `type` field and stores the node
+        // target as a `guid` GUID struct, so bridge `guid` onto the REST-shaped
+        // `nodeID` resolution (#328).
         $nodeId = $this->readString($hyperlink, array('nodeID', 'nodeId', 'node_id'))
-            ?? $this->readGuidId($hyperlink['nodeID'] ?? ($hyperlink['nodeId'] ?? null));
+            ?? $this->readGuidId($hyperlink['nodeID'] ?? ($hyperlink['nodeId'] ?? ($hyperlink['guid'] ?? null)));
 
         if ( 'URL' === $type && null !== $url ) {
             return array('type' => 'url', 'url' => $url);
@@ -2076,7 +2079,14 @@ final class ScenegraphNormalizer
      */
     private function normalizeReactionLink(array $node): ?array
     {
-        foreach ( is_array($node['reactions'] ?? null) ? $node['reactions'] : array() as $reaction ) {
+        // `reactions` is the REST name; `prototypeInteractions` is the Kiwi name
+        // for the same prototype-interaction list decoded from `.fig` (#328).
+        $interactions = is_array($node['reactions'] ?? null) ? $node['reactions'] : array();
+        if ( is_array($node['prototypeInteractions'] ?? null) ) {
+            $interactions = array_merge($interactions, $node['prototypeInteractions']);
+        }
+
+        foreach ( $interactions as $reaction ) {
             if ( ! is_array($reaction) ) {
                 continue;
             }
@@ -2112,16 +2122,22 @@ final class ScenegraphNormalizer
      */
     private function normalizeActionLink(array $action): ?array
     {
+        // REST uses `type`/`url`/`destinationId`/`navigation`; the Kiwi
+        // `PrototypeAction` uses `connectionType` (URL/INTERNAL_NODE),
+        // `connectionURL`, the `transitionNodeID` GUID, and `navigationType`.
+        // Read both so the link path works from `.fig` and REST inputs (#328).
         $type = strtoupper((string) ($action['type'] ?? ''));
-        $url = $this->readString($action, array('url', 'href'));
-        if ( 'URL' === $type && null !== $url ) {
+        $connectionType = strtoupper((string) ($action['connectionType'] ?? ''));
+        $url = $this->readString($action, array('url', 'href', 'connectionURL'));
+        if ( ( 'URL' === $type || 'URL' === $connectionType ) && null !== $url ) {
             return array('type' => 'url', 'url' => $url);
         }
 
         $destination = $this->readString($action, array('destinationId', 'navigationDestinationId', 'transitionNodeID'))
-            ?? $this->readGuidId($action['destinationId'] ?? null);
-        $navigation = strtoupper((string) ($action['navigation'] ?? ''));
+            ?? $this->readGuidId($action['destinationId'] ?? ($action['transitionNodeID'] ?? null));
+        $navigation = strtoupper((string) ($action['navigation'] ?? ($action['navigationType'] ?? '')));
         $navigatesToNode = 'NODE' === $type
+            || 'INTERNAL_NODE' === $connectionType
             || in_array($navigation, array('NAVIGATE', 'OVERLAY', 'SWAP', 'SCROLL_TO'), true);
         if ( $navigatesToNode && null !== $destination && '' !== $destination ) {
             return array('type' => 'node', 'target_node_id' => $destination);

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6078,6 +6078,91 @@ $assert(in_array('link_target_unresolved', $unresolvedSignalCodes, true), 'unres
 $assert(in_array('link_target_unresolved', $unresolvedDiagnosticCodes, true), 'unresolved-link-diagnostic-code');
 
 // ---------------------------------------------------------------------------
+// Figma links from .fig Kiwi shapes (#328): the normalizer + emitter turn the
+// raw decoded `hyperlink` struct and `prototypeInteractions` list (Kiwi field
+// names, distinct from the REST `reactions`) into real <a href> anchors.
+// ---------------------------------------------------------------------------
+
+// (a) A node carrying the Kiwi `Hyperlink` shape ({url} with no REST `type`)
+// emits a real URL anchor.
+$kiwiHyperlinkResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Kiwi Hyperlink Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'kiwilink:1',
+            'type'     => 'FRAME',
+            'name'     => 'Footer',
+            'width'    => 1200,
+            'height'   => 200,
+            'children' => array(
+                array(
+                    'id'         => 'kiwilink:2',
+                    'type'       => 'TEXT',
+                    'name'       => 'External link',
+                    'characters' => 'Visit Automattic',
+                    'hyperlink'  => array('url' => 'https://automattic.com/work'),
+                ),
+            ),
+        ),
+    ),
+));
+$kiwiHyperlinkHtml = $fileContent($kiwiHyperlinkResult, 'index.html');
+$assert(str_contains($kiwiHyperlinkHtml, '<a class="figma-link" href="https://automattic.com/work" data-figma-link-type="url">'), 'kiwi-hyperlink-url-emits-anchor');
+
+// (b) A node carrying an ON_CLICK `prototypeInteractions` entry whose action is
+// a Kiwi URL connection (connectionType/connectionURL) emits a real URL anchor.
+$kiwiReactionResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Kiwi Reaction Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'kiwireact:1',
+            'type'     => 'FRAME',
+            'name'     => 'Home',
+            'width'    => 1280,
+            'height'   => 900,
+            'children' => array(
+                array(
+                    'id'                    => 'kiwireact:cta',
+                    'type'                  => 'FRAME',
+                    'name'                  => 'CTA button',
+                    'width'                 => 160,
+                    'height'                => 48,
+                    'prototypeInteractions' => array(
+                        array(
+                            'event'   => array('interactionType' => 'ON_CLICK'),
+                            'actions' => array(
+                                array('connectionType' => 'URL', 'connectionURL' => 'https://automattic.com/cta'),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$kiwiReactionHtml = $fileContent($kiwiReactionResult, 'index.html');
+$assert(str_contains($kiwiReactionHtml, '<a class="figma-link" href="https://automattic.com/cta" data-figma-link-type="url">'), 'kiwi-prototype-interaction-url-emits-anchor');
+
+// DECODE: the extended field policy carries `hyperlink` and the Kiwi
+// `prototypeInteractions` list through the REAL generic decoder, resolving the
+// connection enums to their token strings and the GUID destination struct.
+$linkDecoder = new FigKiwiDecoder();
+$linkSchema = $linkDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_link_schema_fixture());
+$assert(null !== ($linkSchema['schema'] ?? null), 'link-kiwi-schema-decodes');
+$linkMessage = $linkDecoder->decodeMessageSelective(
+    blocks_engine_figma_transformer_kiwi_link_message_fixture(),
+    $linkSchema['schema'] ?? array()
+);
+$linkNodeChanges = $linkMessage['message']['nodeChanges'] ?? array();
+$assert('https://example.com/about' === ($linkNodeChanges[0]['hyperlink']['url'] ?? null), 'link-field-policy-carries-hyperlink-url');
+$linkInteraction = $linkNodeChanges[1]['prototypeInteractions'][0] ?? array();
+$assert('ON_CLICK' === ($linkInteraction['event']['interactionType'] ?? null), 'link-field-policy-carries-interaction-trigger');
+$assert('URL' === ($linkInteraction['actions'][0]['connectionType'] ?? null), 'link-field-policy-carries-connection-type');
+$assert('https://example.com/cta' === ($linkInteraction['actions'][0]['connectionURL'] ?? null), 'link-field-policy-carries-connection-url');
+$assert('INTERNAL_NODE' === ($linkInteraction['actions'][1]['connectionType'] ?? null), 'link-field-policy-carries-node-connection-type');
+$assert(array('sessionID' => 7, 'localID' => 42) === ($linkInteraction['actions'][1]['transitionNodeID'] ?? null), 'link-field-policy-carries-transition-node-guid');
+
+// ---------------------------------------------------------------------------
 // Figma Dev Mode status (#280): decode -> normalize -> select -> diagnose.
 // ---------------------------------------------------------------------------
 
@@ -7501,6 +7586,114 @@ function blocks_engine_figma_transformer_kiwi_stroke_message_fixture(): string
         . blocks_engine_figma_transformer_kiwi_float(2.0)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
+}
+
+/**
+ * Kiwi schema (version-106 shape) that defines the prototype-link surface (#328):
+ * a `Hyperlink` struct plus the `PrototypeInteraction`/`PrototypeAction` graph
+ * hanging off `NodeChange`, with the real Figma `ConnectionType`/`NavigationType`
+ * enums. Proves the field-policy additions read links through the REAL decoder.
+ */
+function blocks_engine_figma_transformer_kiwi_link_schema_fixture(): string
+{
+    $field = 'blocks_engine_figma_transformer_kiwi_schema_field';
+    $str = 'blocks_engine_figma_transformer_kiwi_string';
+    $varint = 'blocks_engine_figma_transformer_wire_varint';
+
+    return $varint(10)
+        // def0: STRUCT GUID { sessionID, localID }
+        . $str('GUID') . chr(1) . $varint(2)
+        . $field('sessionID', -4, false, 1)
+        . $field('localID', -4, false, 2)
+        // def1: ENUM InteractionType { ON_CLICK = 0 }
+        . $str('InteractionType') . chr(0) . $varint(1)
+        . $field('ON_CLICK', 0, false, 0)
+        // def2: ENUM ConnectionType { NONE = 0, INTERNAL_NODE = 1, URL = 2 }
+        . $str('ConnectionType') . chr(0) . $varint(3)
+        . $field('NONE', 0, false, 0)
+        . $field('INTERNAL_NODE', 0, false, 1)
+        . $field('URL', 0, false, 2)
+        // def3: ENUM NavigationType { NAVIGATE = 0 }
+        . $str('NavigationType') . chr(0) . $varint(1)
+        . $field('NAVIGATE', 0, false, 0)
+        // def4: MESSAGE PrototypeEvent { interactionType }
+        . $str('PrototypeEvent') . chr(2) . $varint(1)
+        . $field('interactionType', 1, false, 1)
+        // def5: MESSAGE PrototypeAction { transitionNodeID, connectionType, connectionURL, navigationType }
+        . $str('PrototypeAction') . chr(2) . $varint(4)
+        . $field('transitionNodeID', 0, false, 1)
+        . $field('connectionType', 2, false, 7)
+        . $field('connectionURL', -6, false, 8)
+        . $field('navigationType', 3, false, 10)
+        // def6: MESSAGE PrototypeInteraction { event, actions[] }
+        . $str('PrototypeInteraction') . chr(2) . $varint(2)
+        . $field('event', 4, false, 2)
+        . $field('actions', 5, true, 3)
+        // def7: MESSAGE Hyperlink { url, guid }
+        . $str('Hyperlink') . chr(2) . $varint(2)
+        . $field('url', -6, false, 1)
+        . $field('guid', 0, false, 2)
+        // def8: MESSAGE NodeChange { type, name, hyperlink, prototypeInteractions[] }
+        . $str('NodeChange') . chr(2) . $varint(4)
+        . $field('type', -6, false, 1)
+        . $field('name', -6, false, 2)
+        . $field('hyperlink', 7, false, 4)
+        . $field('prototypeInteractions', 6, true, 5)
+        // def9: MESSAGE Message { type, nodeChanges[] }
+        . $str('Message') . chr(2) . $varint(2)
+        . $field('type', -6, false, 1)
+        . $field('nodeChanges', 8, true, 2);
+}
+
+/**
+ * Kiwi message for {@see blocks_engine_figma_transformer_kiwi_link_schema_fixture()}:
+ * a TEXT NodeChange with a URL `hyperlink`, and a FRAME NodeChange with an
+ * ON_CLICK `prototypeInteractions` entry whose actions carry a URL connection
+ * and a node-navigation connection (GUID destination).
+ */
+function blocks_engine_figma_transformer_kiwi_link_message_fixture(): string
+{
+    $str = 'blocks_engine_figma_transformer_kiwi_string';
+    $v = 'blocks_engine_figma_transformer_wire_varint';
+
+    // Hyperlink { url = "https://example.com/about" }
+    $hyperlink = $v(1) . $str('https://example.com/about') . $v(0);
+
+    // PrototypeEvent { interactionType = ON_CLICK (0) }
+    $event = $v(1) . $v(0) . $v(0);
+
+    // PrototypeAction { connectionType = URL (2), connectionURL }
+    $actionUrl = $v(7) . $v(2)
+        . $v(8) . $str('https://example.com/cta')
+        . $v(0);
+
+    // PrototypeAction { transitionNodeID = GUID{7,42}, connectionType = INTERNAL_NODE (1), navigationType = NAVIGATE (0) }
+    $actionNode = $v(1) . $v(7) . $v(42) // GUID struct body (sessionID, localID; structs carry no terminator)
+        . $v(7) . $v(1)
+        . $v(10) . $v(0)
+        . $v(0);
+
+    // PrototypeInteraction { event, actions = [actionUrl, actionNode] }
+    $interaction = $v(2) . $event
+        . $v(3) . $v(2) . $actionUrl . $actionNode
+        . $v(0);
+
+    // NodeChange A: TEXT { hyperlink }
+    $nodeA = $v(1) . $str('TEXT')
+        . $v(2) . $str('External link')
+        . $v(4) . $hyperlink
+        . $v(0);
+
+    // NodeChange B: FRAME { prototypeInteractions = [interaction] }
+    $nodeB = $v(1) . $str('FRAME')
+        . $v(2) . $str('CTA')
+        . $v(5) . $v(1) . $interaction
+        . $v(0);
+
+    // Message { type = "DOCUMENT", nodeChanges = [nodeA, nodeB] }
+    return $v(1) . $str('DOCUMENT')
+        . $v(2) . $v(2) . $nodeA . $nodeB
+        . $v(0);
 }
 
 /**


### PR DESCRIPTION
## Summary

Wires Figma hyperlinks and prototype navigation through the figma-transformer. Per coverage issue #328, the normalizer's `normalizeReactionLink()` / `normalizeHyperlinkValue()` and the emitter's `<a class="figma-link">` wrapping already existed, but `hyperlink` and the prototype-interaction list were **not in the selective Kiwi decoder's field policy**, so links carried in `.fig` files were silently skipped at gate 1. Buttons and linked text therefore never became real anchors.

## What changed

- **`FigKiwiDecoder.php`** — whitelist `hyperlink`, `prototypeInteractions`, `reactions`, and `transitionNodeID` on `NodeChange`, plus the supporting `Hyperlink`, `PrototypeInteraction`, `PrototypeEvent`, and `PrototypeAction` struct policies needed for the URL/navigation fields to decode. Kiwi names/enum tokens were verified by decoding a real `.fig` schema chunk (the schema embeds `Hyperlink {url, guid}`, `PrototypeInteraction {event, actions}`, `PrototypeAction {transitionNodeID, connectionType, connectionURL, navigationType}`, `ConnectionType {NONE, INTERNAL_NODE, URL, ...}`, `NavigationType {NAVIGATE, OVERLAY, SWAP, SCROLL_TO}`).
- **`ScenegraphNormalizer.php`** — the decoded Kiwi shape differs from the REST shape the normalizer was written for, so bridge the gaps without changing behavior:
  - read the Kiwi `Hyperlink.guid` as a node target (the struct has no REST `type` field);
  - iterate `prototypeInteractions` alongside `reactions` (same list, different name);
  - map `PrototypeAction.connectionType` (`URL`/`INTERNAL_NODE`), `connectionURL`, `navigationType`, and the `transitionNodeID` GUID onto the existing action-link extraction.
- **Emitter** — unchanged; `wrapWithLink()` already wraps in `<a href>`, resolving node navigation to the target frame's `page_path` (or a `#` placeholder + `link_target_unresolved` diagnostic).

## Scope boundary (prototype animation)

This is about **links** — URL and node navigation — not full prototype fidelity. `PrototypeAction` also carries transition animations, overlay/swap behavior, and variable mutations; those fields are intentionally left undecoded. Full prototype-animation/overlay/swap support is a separate, larger effort.

## Tests (real output)

Added to `tests/contract/run.php` and passing (`php tests/contract/run.php`):
- a Kiwi-shaped `hyperlink` URL node emits `<a class="figma-link" href="https://..." data-figma-link-type="url">`;
- an `ON_CLICK` `prototypeInteractions` entry with a URL action emits the same anchor wrapper;
- a **binary-Kiwi decode fixture** proving the new field policy carries the hyperlink URL, the connection type/URL, the interaction trigger, and the GUID navigation destination through the real generic decoder (gate-1 proof).

Refs #328.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation