### PR TITLE
Harden corpus-diagnostics harness: severity-ranked, defect-faithful worklist

### DIFF
--- a/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
+++ b/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
@@ -12,28 +12,84 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
  * Every detector keys off structure and syntax only — never fixture names — so
  * the same signals surface across the entire website-fixture corpus. None of
  * these methods mutate the transformer or its output; they exclusively read the
- * canonical result array produced by HtmlTransformer::transform()->toArray().
+ * canonical result array produced by HtmlTransformer::transform()->toArray()
+ * (plus, for layout-direction faithfulness, the immutable source HTML string).
+ *
+ * Each finding carries a `severity` (high | medium | info) so the worklist can
+ * rank real defects above bulk-but-acceptable behavior, rather than ranking by
+ * raw occurrence count alone.
  */
 final class CorpusDetectors
 {
     /**
      * WordPress preset custom properties (var(--wp--...)) are materialized by the
-     * theme/global-styles layer and are not part of the custom-property gap, so
-     * they are tracked for visibility but excluded from the actionable worklist.
+     * theme/global-styles layer and are not part of any gap, so they are tracked
+     * for visibility but excluded from the actionable worklist.
      */
     private const PRESET_VAR_PREFIX = '--wp--';
+
+    public const SEVERITY_HIGH   = 'high';
+    public const SEVERITY_MEDIUM = 'medium';
+    public const SEVERITY_INFO   = 'info';
+
+    /**
+     * Severity ordering used by the runner to rank clusters by importance before
+     * raw count. Higher wins.
+     */
+    private const SEVERITY_RANK = array(
+        self::SEVERITY_HIGH   => 3,
+        self::SEVERITY_MEDIUM => 2,
+        self::SEVERITY_INFO   => 1,
+    );
+
+    /**
+     * Repair lanes that represent genuine, editor-visible defects: missing
+     * artwork, content the block editor would mark invalid, serialization
+     * invalidity, and layout that is rendered in the wrong direction. These rank
+     * above generic conversion gaps.
+     */
+    private const HIGH_SEVERITY_BUCKETS = array(
+        'svg_content_lost',
+        'richtext_invalid_content_risk',
+        'block_serialization_validity_repair',
+        'layout_direction_misrecognition',
+    );
+
+    /**
+     * Repair lanes that describe working downstream behavior rather than a defect
+     * — they are reported for visibility but kept out of the actionable worklist.
+     */
+    private const INFO_BUCKETS = array(
+        'informational_var_density',
+    );
+
+    /**
+     * Transformer fallback reason codes that mean an inline <svg> was dropped
+     * (its artwork lost) rather than preserved. Routed through the dedicated
+     * svg_content_lost detector so they rank by severity instead of hiding among
+     * generic asset-materialization findings.
+     */
+    private const SVG_LOSS_REASON_CODES = array(
+        'html_inline_svg_fallback',
+        'html_unsafe_inline_svg',
+    );
 
     /**
      * Run every detector over one transformer result envelope.
      *
-     * @param array<string, mixed> $result Canonical transformer result array.
+     * @param array<string, mixed>      $result          Canonical transformer result array.
+     * @param string                    $sourceHtml      Original source HTML for the document (for source-aware detectors).
+     * @param callable(string): bool|null $columnsVerifier Optional predicate that returns true when a source-element
+     *                                                     fragment actually converts to a top-level core/columns block.
+     *                                                     Lets the layout-direction detector confirm a misrecognition
+     *                                                     instead of guessing from source CSS alone.
      * @return array{
      *     metrics: array<string, int|float>,
      *     findings: array<int, array<string, mixed>>,
      *     var_names: array<int, string>
      * }
      */
-    public static function collect(array $result): array
+    public static function collect(array $result, string $sourceHtml = '', ?callable $columnsVerifier = null): array
     {
         $blocks = is_array($result['blocks'] ?? null) ? $result['blocks'] : array();
         $flat = self::flatten($blocks);
@@ -41,6 +97,10 @@ final class CorpusDetectors
         $native = self::nativeRate($flat);
         $varReport = self::varDependentStyling($flat);
         $validityReport = self::blockValidity($result);
+
+        $richTextRisk = self::richTextInvalidRisk($flat);
+        $svgLost = self::svgContentLost($result, $flat);
+        $layoutMisrecognition = self::layoutDirectionMisrecognition($sourceHtml, $columnsVerifier);
 
         $findings = array();
         foreach ( self::transformerFindings($result) as $finding ) {
@@ -52,7 +112,13 @@ final class CorpusDetectors
         foreach ( $varReport['findings'] as $finding ) {
             $findings[] = $finding;
         }
-        foreach ( self::classedSpanInContent($flat) as $finding ) {
+        foreach ( $richTextRisk as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( $svgLost as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( $layoutMisrecognition as $finding ) {
             $findings[] = $finding;
         }
         foreach ( self::emptyCoreHtml($flat) as $finding ) {
@@ -63,14 +129,24 @@ final class CorpusDetectors
         }
 
         $metrics = array(
-            'block_count'         => $native['total'],
-            'native_count'        => $native['native'],
-            'core_html_count'     => $native['html'],
-            'freeform_count'      => $native['freeform'],
-            'native_rate'         => $native['rate'],
-            'var_ref_count'       => $varReport['count'],
-            'var_custom_ref_count' => $varReport['custom_count'],
-            'invalid_block_count' => $validityReport['invalid_block_count'],
+            'block_count'                 => $native['total'],
+            'native_count'                => $native['native'],
+            'core_html_count'             => $native['html'],
+            'freeform_count'              => $native['freeform'],
+            'native_rate'                 => $native['rate'],
+            'var_ref_count'               => $varReport['count'],
+            'var_custom_ref_count'        => $varReport['custom_count'],
+            // Structural serialization round-trip count. Kept for transparency,
+            // but it is NOT the editor-invalidity signal — see the RichText risk
+            // metric below.
+            'invalid_block_count'         => $validityReport['invalid_block_count'],
+            // The authoritative "the editor would flag this as invalid/unexpected
+            // content" signal: blocks whose RichText content carries a
+            // class/style-bearing inline <span>/<a> that RichText will not
+            // preserve on parse.
+            'richtext_invalid_risk_count' => count($richTextRisk),
+            'svg_content_lost_count'      => count($svgLost),
+            'layout_direction_misrecognition_count' => count($layoutMisrecognition),
         );
 
         return array(
@@ -78,6 +154,29 @@ final class CorpusDetectors
             'findings'  => $findings,
             'var_names' => $varReport['names'],
         );
+    }
+
+    /**
+     * Map a repair lane to its severity tier.
+     */
+    public static function severityForBucket(string $bucket): string
+    {
+        if ( in_array($bucket, self::HIGH_SEVERITY_BUCKETS, true) ) {
+            return self::SEVERITY_HIGH;
+        }
+        if ( in_array($bucket, self::INFO_BUCKETS, true) ) {
+            return self::SEVERITY_INFO;
+        }
+
+        return self::SEVERITY_MEDIUM;
+    }
+
+    /**
+     * Numeric rank for a severity label (higher = more important).
+     */
+    public static function severityRank(string $severity): int
+    {
+        return self::SEVERITY_RANK[$severity] ?? self::SEVERITY_RANK[self::SEVERITY_MEDIUM];
     }
 
     /**
@@ -146,10 +245,14 @@ final class CorpusDetectors
     }
 
     /**
-     * var(--x) references in the emitted block markup. A high density of custom
-     * (non-preset) custom-property references signals the CSS custom-property
-     * materialization gap, because nothing defines those properties in the
-     * generated WordPress output.
+     * var(--x) references in the emitted block markup.
+     *
+     * These references are materialized downstream (the SSI compile layer
+     * resolves them end-to-end), so a high density of resolved var() references
+     * is NOT a repair gap — it is working behavior. The findings are therefore
+     * labeled informational (`informational_var_density`) and tracked for
+     * visibility, kept out of the actionable defect worklist. WordPress preset
+     * properties (var(--wp--...)) are excluded from the findings entirely.
      *
      * @param array<int, array<string, mixed>> $flat Flattened block list.
      * @return array{
@@ -188,7 +291,8 @@ final class CorpusDetectors
             $findings[] = array(
                 'source'        => 'detector',
                 'detector'      => 'var_dependent_styling',
-                'repair_bucket' => 'css_custom_property_materialization',
+                'repair_bucket' => 'informational_var_density',
+                'severity'      => self::SEVERITY_INFO,
                 'pattern'       => $name,
                 'count'         => $count,
             );
@@ -206,30 +310,40 @@ final class CorpusDetectors
     }
 
     /**
-     * core/paragraph and core/heading whose content carries an inline
-     * <span class=...> or <span style=...>. These classed/styled spans inside
-     * RichText content are a common block-invalidity risk.
+     * RichText editor-invalidity risk: paragraph/heading/list-item blocks whose
+     * RichText `content` carries an inline <span> or <a> that bears a class or
+     * style attribute. RichText normalizes such content on parse — it strips the
+     * unsupported class/style off inline formats it does not model — so the
+     * editor shows "unexpected/invalid content" even though the structural
+     * serialization round-trip (wp_block_validity) reports the block as valid.
+     *
+     * This is the authoritative editor-invalid-risk signal, ranked HIGH. The
+     * structural `invalid_block_count` of 0 does NOT mean there is no invalid
+     * content.
      *
      * @param array<int, array<string, mixed>> $flat Flattened block list.
      * @return array<int, array<string, mixed>>
      */
-    public static function classedSpanInContent(array $flat): array
+    public static function richTextInvalidRisk(array $flat): array
     {
+        $richTextBlocks = array( 'core/paragraph', 'core/heading', 'core/list-item' );
+
         $findings = array();
         foreach ( $flat as $block ) {
             $name = is_string($block['blockName'] ?? null) ? $block['blockName'] : '';
-            if ( 'core/paragraph' !== $name && 'core/heading' !== $name ) {
+            if ( ! in_array($name, $richTextBlocks, true) ) {
                 continue;
             }
             $content = self::richTextContent($block);
             if ( '' === $content ) {
                 continue;
             }
-            if ( preg_match('/<span\b[^>]*\s(?:class|style)\s*=/i', $content) ) {
+            if ( preg_match('/<(?:span|a)\b[^>]*\s(?:class|style)\s*=/i', $content) ) {
                 $findings[] = array(
                     'source'        => 'detector',
-                    'detector'      => 'classed_span_in_content',
-                    'repair_bucket' => 'richtext_inline_span_normalization',
+                    'detector'      => 'richtext_invalid_risk',
+                    'repair_bucket' => 'richtext_invalid_content_risk',
+                    'severity'      => self::SEVERITY_HIGH,
                     'pattern'       => $name,
                     'count'         => 1,
                 );
@@ -240,8 +354,164 @@ final class CorpusDetectors
     }
 
     /**
+     * SVG-loss detector (HIGH severity): the recurring missing-image signal.
+     *
+     * Two complementary sources are routed into one `svg_content_lost` lane:
+     *   1. Transformer inline-SVG fallback diagnostics — an <svg> whose artwork
+     *      was dropped (no drawable/safe content left) rather than preserved.
+     *   2. core/html blocks that are empty or whitespace+HTML-comments-only yet
+     *      whose raw content still bears an SVG remnant/marker (the image was
+     *      stripped, leaving a dead block).
+     *
+     * A core/html that PRESERVES an <svg> with real shape elements
+     * (path/circle/rect/...) is acceptable and is NOT flagged here.
+     *
+     * @param array<string, mixed>             $result Canonical transformer result array.
+     * @param array<int, array<string, mixed>> $flat   Flattened block list.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function svgContentLost(array $result, array $flat): array
+    {
+        $findings = array();
+
+        $diagnostics = is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array();
+        foreach ( $diagnostics as $diagnostic ) {
+            if ( ! is_array($diagnostic) ) {
+                continue;
+            }
+            $code = (string) ($diagnostic['reason_code'] ?? $diagnostic['code'] ?? '');
+            if ( ! in_array($code, self::SVG_LOSS_REASON_CODES, true) ) {
+                continue;
+            }
+            $findings[] = array(
+                'source'        => 'detector',
+                'detector'      => 'svg_content_lost',
+                'repair_bucket' => 'svg_content_lost',
+                'severity'      => self::SEVERITY_HIGH,
+                'pattern'       => 'html_unsafe_inline_svg' === $code ? 'unsafe_inline_svg_dropped' : 'inline_svg_dropped',
+                'count'         => 1,
+            );
+        }
+
+        foreach ( $flat as $block ) {
+            $name = is_string($block['blockName'] ?? null) ? $block['blockName'] : '';
+            if ( 'core/html' !== $name ) {
+                continue;
+            }
+            $content = self::rawContent($block);
+            if ( ! self::looksLikeSvgSource($content) ) {
+                continue;
+            }
+            if ( self::svgHasPreservedShapes($content) ) {
+                // SVG preserved as core/html with real shape elements — acceptable.
+                continue;
+            }
+            $stripped = trim(preg_replace('/<!--.*?-->/s', '', $content) ?? '');
+            if ( '' !== $stripped ) {
+                continue;
+            }
+            $findings[] = array(
+                'source'        => 'detector',
+                'detector'      => 'svg_content_lost',
+                'repair_bucket' => 'svg_content_lost',
+                'severity'      => self::SEVERITY_HIGH,
+                'pattern'       => 'empty_core_html_from_svg',
+                'count'         => 1,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Layout-direction faithfulness (HIGH severity): a vertical stack
+     * (display:flex; flex-direction:column / column-reverse) emitted as a
+     * horizontal core/columns block is a misrecognition — the content renders in
+     * the wrong direction.
+     *
+     * Detection is conservative: it only inspects source container elements
+     * (div/section/article/...) whose inline style explicitly declares a column
+     * flex direction and that hold two or more element children. Genuine
+     * horizontal flex (row / default) and grid layouts are never matched, so
+     * faithful horizontal columns are not flagged. When a verifier callback is
+     * supplied, each candidate is confirmed to actually convert to a top-level
+     * core/columns block before it is reported, eliminating cases the transformer
+     * routes to core/group or core/list instead.
+     *
+     * @param string                       $sourceHtml Original source HTML for the document.
+     * @param callable(string): bool|null  $verifier   Optional confirmation predicate over an element fragment.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function layoutDirectionMisrecognition(string $sourceHtml, ?callable $verifier = null): array
+    {
+        if ( '' === trim($sourceHtml) ) {
+            return array();
+        }
+
+        $containerTags = array( 'div', 'section', 'article', 'aside', 'main', 'header', 'footer', 'nav' );
+
+        $previous = libxml_use_internal_errors(true);
+        $doc = new \DOMDocument();
+        $loaded = $doc->loadHTML('<?xml encoding="utf-8"?>' . $sourceHtml);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if ( ! $loaded ) {
+            return array();
+        }
+
+        $findings = array();
+        $xpath = new \DOMXPath($doc);
+        $nodes = $xpath->query('//*[@style]');
+        if ( false === $nodes ) {
+            return array();
+        }
+
+        foreach ( $nodes as $node ) {
+            if ( ! $node instanceof \DOMElement ) {
+                continue;
+            }
+            if ( ! in_array(strtolower($node->tagName), $containerTags, true) ) {
+                continue;
+            }
+            $style = strtolower($node->getAttribute('style'));
+            if ( ! preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?flex\b/', $style) ) {
+                continue;
+            }
+            if ( ! preg_match('/flex-direction\s*:\s*column(?:-reverse)?\b/', $style) ) {
+                continue;
+            }
+            $elementChildren = 0;
+            foreach ( $node->childNodes as $child ) {
+                if ( $child instanceof \DOMElement ) {
+                    ++$elementChildren;
+                }
+            }
+            if ( $elementChildren < 2 ) {
+                continue;
+            }
+            if ( null !== $verifier ) {
+                $fragment = $doc->saveHTML($node);
+                if ( ! is_string($fragment) || ! $verifier($fragment) ) {
+                    continue;
+                }
+            }
+            $findings[] = array(
+                'source'        => 'detector',
+                'detector'      => 'layout_direction_misrecognition',
+                'repair_bucket' => 'layout_direction_misrecognition',
+                'severity'      => self::SEVERITY_HIGH,
+                'pattern'       => 'columns_from_vertical_flex',
+                'count'         => 1,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
      * core/html blocks whose content is only whitespace and/or HTML comments —
-     * dead blocks, typically left behind when SVG or script content is stripped.
+     * dead blocks. SVG-sourced empties are excluded here because they are the
+     * higher-severity svg_content_lost signal.
      *
      * @param array<int, array<string, mixed>> $flat Flattened block list.
      * @return array<int, array<string, mixed>>
@@ -260,10 +530,15 @@ final class CorpusDetectors
             if ( '' !== $stripped ) {
                 continue;
             }
+            if ( self::looksLikeSvgSource($content) ) {
+                // Reported by svgContentLost (HIGH) instead of as a generic empty.
+                continue;
+            }
             $findings[] = array(
                 'source'        => 'detector',
                 'detector'      => 'empty_core_html',
                 'repair_bucket' => 'drop_empty_html_block',
+                'severity'      => self::SEVERITY_MEDIUM,
                 'pattern'       => $hadComment ? 'comment_only_or_stripped' : 'whitespace_only',
                 'count'         => 1,
             );
@@ -300,6 +575,7 @@ final class CorpusDetectors
                 'source'        => 'detector',
                 'detector'      => 'core_html_fallback',
                 'repair_bucket' => 'native_block_recognition',
+                'severity'      => self::SEVERITY_MEDIUM,
                 'pattern'       => $tag,
                 'count'         => 1,
             );
@@ -335,6 +611,7 @@ final class CorpusDetectors
                 'source'        => 'validity',
                 'detector'      => 'wp_block_validity',
                 'repair_bucket' => 'block_serialization_validity_repair',
+                'severity'      => self::SEVERITY_HIGH,
                 'pattern'       => $code . '@' . $blockName,
                 'count'         => 1,
             );
@@ -350,7 +627,8 @@ final class CorpusDetectors
      * The transformer's own emitted diagnostics, normalized through the canonical
      * finding contract so each carries the (reason_code, pattern_family,
      * repair_bucket) classification triplet. Purely informational summary
-     * findings (no_repair_needed) are dropped from the worklist.
+     * findings (no_repair_needed) are dropped from the worklist, and inline-SVG
+     * loss diagnostics are routed to the dedicated svg_content_lost detector.
      *
      * @param array<string, mixed> $result Canonical transformer result array.
      * @return array<int, array<string, mixed>>
@@ -362,6 +640,10 @@ final class CorpusDetectors
         $findings = array();
         foreach ( $diagnostics as $diagnostic ) {
             if ( ! is_array($diagnostic) ) {
+                continue;
+            }
+            $reasonCode = (string) ($diagnostic['reason_code'] ?? $diagnostic['code'] ?? '');
+            if ( in_array($reasonCode, self::SVG_LOSS_REASON_CODES, true) ) {
                 continue;
             }
             $classified = ConversionFindingContract::withClassification($diagnostic);
@@ -380,6 +662,7 @@ final class CorpusDetectors
                 'source'        => 'transformer',
                 'detector'      => 'emitted_finding',
                 'repair_bucket' => $repairBucket,
+                'severity'      => self::severityForBucket($repairBucket),
                 'pattern'       => $pattern,
                 'count'         => 1,
             );
@@ -406,6 +689,34 @@ final class CorpusDetectors
     }
 
     /**
+     * Whether the raw content of a core/html block carries an SVG remnant/marker
+     * — either a literal <svg ...> tag or an HTML comment that names svg (the
+     * trace left when SVG artwork is stripped out of a wrapper block).
+     */
+    private static function looksLikeSvgSource(string $content): bool
+    {
+        if ( preg_match('/<\s*svg\b/i', $content) ) {
+            return true;
+        }
+
+        return (bool) preg_match('/<!--[^>]*\bsvg\b[^>]*-->/i', $content);
+    }
+
+    /**
+     * Whether SVG content was preserved with real, renderable shape elements
+     * (as opposed to an empty/stripped shell).
+     */
+    private static function svgHasPreservedShapes(string $content): bool
+    {
+        $stripped = preg_replace('/<!--.*?-->/s', '', $content) ?? $content;
+
+        return (bool) preg_match(
+            '/<\s*(?:path|circle|rect|polygon|polyline|line|ellipse|g|use|text|image|symbol|defs|tspan)\b/i',
+            $stripped
+        );
+    }
+
+    /**
      * Emitted markup for one block — the saved innerHTML, which is the single
      * source of the rendered style="..." declarations. Reading only innerHTML
      * (rather than also the attribute JSON, which carries the same values) keeps
@@ -419,8 +730,8 @@ final class CorpusDetectors
     }
 
     /**
-     * RichText content for a paragraph/heading block: the explicit content
-     * attribute, falling back to saved innerHTML.
+     * RichText content for a paragraph/heading/list-item block: the explicit
+     * content attribute, falling back to saved innerHTML.
      *
      * @param array<string, mixed> $block
      */

--- a/php-transformer/src/CorpusDiagnostics/CorpusDiagnosticsRunner.php
+++ b/php-transformer/src/CorpusDiagnostics/CorpusDiagnosticsRunner.php
@@ -45,6 +45,9 @@ final class CorpusDiagnosticsRunner
             'core_html_count'     => 0,
             'freeform_count'      => 0,
             'invalid_block_count' => 0,
+            'richtext_invalid_risk_count' => 0,
+            'svg_content_lost_count' => 0,
+            'layout_direction_misrecognition_count' => 0,
             'var_ref_count'       => 0,
             'var_custom_ref_count' => 0,
             'finding_count'       => 0,
@@ -53,7 +56,7 @@ final class CorpusDiagnosticsRunner
         foreach ( $documents as $document ) {
             $html = (string) file_get_contents($document['path']);
             $result = $this->transformer->transform($html, array())->toArray();
-            $collected = CorpusDetectors::collect($result);
+            $collected = CorpusDetectors::collect($result, $html, $this->columnsVerifier());
 
             $relPath = $document['rel'];
             $fixtures[$relPath] = array(
@@ -73,6 +76,9 @@ final class CorpusDiagnosticsRunner
             $totals['core_html_count'] += (int) $metrics['core_html_count'];
             $totals['freeform_count'] += (int) $metrics['freeform_count'];
             $totals['invalid_block_count'] += (int) $metrics['invalid_block_count'];
+            $totals['richtext_invalid_risk_count'] += (int) $metrics['richtext_invalid_risk_count'];
+            $totals['svg_content_lost_count'] += (int) $metrics['svg_content_lost_count'];
+            $totals['layout_direction_misrecognition_count'] += (int) $metrics['layout_direction_misrecognition_count'];
             $totals['var_ref_count'] += (int) $metrics['var_ref_count'];
             $totals['var_custom_ref_count'] += (int) $metrics['var_custom_ref_count'];
 
@@ -88,6 +94,7 @@ final class CorpusDiagnosticsRunner
                         'detector'      => (string) ($finding['detector'] ?? ''),
                         'source'        => (string) ($finding['source'] ?? ''),
                         'pattern'       => (string) ($finding['pattern'] ?? ''),
+                        'severity'      => (string) ($finding['severity'] ?? CorpusDetectors::SEVERITY_MEDIUM),
                         'count'         => 0,
                         'fixtures'      => array(),
                     );
@@ -125,16 +132,31 @@ final class CorpusDiagnosticsRunner
         $lines = array();
         $lines[] = 'Corpus diagnostics — ' . $totals['document_count'] . ' document(s) across ' . $totals['fixture_count'] . ' fixture(s)';
         $lines[] = sprintf(
-            'blocks=%d native_rate=%.1f%% invalid_blocks=%d var_refs=%d (custom=%d) findings=%d',
+            'blocks=%d native_rate=%.1f%% findings=%d',
             $totals['block_count'],
             ((float) $totals['native_rate']) * 100,
-            $totals['invalid_block_count'],
-            $totals['var_ref_count'],
-            $totals['var_custom_ref_count'],
             $totals['finding_count']
         );
+        $lines[] = sprintf(
+            'EDITOR-INVALID RISK: richtext_invalid_risk=%d block(s) — class/style-bearing inline <span>/<a> that RichText drops.',
+            (int) ($totals['richtext_invalid_risk_count'] ?? 0)
+        );
+        $lines[] = sprintf(
+            '  (structural wp_block_validity=%d is a serialization round-trip count, NOT proof of "no invalid content".)',
+            (int) ($totals['invalid_block_count'] ?? 0)
+        );
+        $lines[] = sprintf(
+            'MISSING ARTWORK: svg_content_lost=%d   LAYOUT: columns_from_vertical_flex=%d',
+            (int) ($totals['svg_content_lost_count'] ?? 0),
+            (int) ($totals['layout_direction_misrecognition_count'] ?? 0)
+        );
+        $lines[] = sprintf(
+            'INFORMATIONAL var density (materialized downstream by SSI — not a repair gap): var_refs=%d (custom=%d)',
+            (int) $totals['var_ref_count'],
+            (int) $totals['var_custom_ref_count']
+        );
         $lines[] = '';
-        $lines[] = 'TOP RANKED CLUSTERS (occurrences :: cluster :: fixtures):';
+        $lines[] = 'TOP RANKED CLUSTERS (severity | occurrences :: cluster :: fixtures):';
 
         $rank = 0;
         foreach ( $report['clusters'] as $cluster ) {
@@ -144,8 +166,9 @@ final class CorpusDiagnosticsRunner
             ++$rank;
             $examples = implode(', ', array_slice($cluster['example_fixtures'], 0, 3));
             $lines[] = sprintf(
-                '%2d. [%4d in %3d files] %s',
+                '%2d. [%-6s %4d in %3d files] %s',
                 $rank,
+                strtoupper((string) ($cluster['severity'] ?? CorpusDetectors::SEVERITY_MEDIUM)),
                 $cluster['count'],
                 $cluster['fixture_count'],
                 $cluster['key']
@@ -277,11 +300,35 @@ final class CorpusDiagnosticsRunner
         }
 
         usort($ranked, static function (array $a, array $b): int {
-            return ($b['count'] <=> $a['count'])
+            $severityA = CorpusDetectors::severityRank((string) ($a['severity'] ?? CorpusDetectors::SEVERITY_MEDIUM));
+            $severityB = CorpusDetectors::severityRank((string) ($b['severity'] ?? CorpusDetectors::SEVERITY_MEDIUM));
+
+            return ($severityB <=> $severityA)
+                ?: ($b['count'] <=> $a['count'])
                 ?: ($b['fixture_count'] <=> $a['fixture_count'])
                 ?: strcmp($a['key'], $b['key']);
         });
 
         return $ranked;
+    }
+
+    /**
+     * Predicate the layout-direction detector uses to confirm that a vertical
+     * flex source fragment really converts to a top-level core/columns block,
+     * rather than core/group/core/list. Runs the same transformer over the
+     * isolated element so misrecognitions are reported only when they actually
+     * occur.
+     *
+     * @return callable(string): bool
+     */
+    private function columnsVerifier(): callable
+    {
+        return function (string $fragment): bool {
+            $result = $this->transformer->transform($fragment, array())->toArray();
+            $blocks = is_array($result['blocks'] ?? null) ? $result['blocks'] : array();
+            $first = $blocks[0] ?? null;
+
+            return is_array($first) && 'core/columns' === ($first['blockName'] ?? '');
+        };
     }
 }

--- a/php-transformer/tests/unit/corpus-detectors.php
+++ b/php-transformer/tests/unit/corpus-detectors.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
  * Unit tests for the corpus-diagnostics detectors.
  *
  * Plain-PHP test script in the style of tests/unit/css-value-splitter.php — no
- * PHPUnit. A single inline HTML document carries an inline classed/styled span
- * inside RichText and a custom var() reference, and the detectors must report
- * each while leaving the WordPress-preset var() out of the actionable worklist.
- * The empty (stripped-SVG) core/html detector is exercised directly against a
- * synthetic block tree, since it reads the canonical result array the same way
- * the harness does.
+ * PHPUnit. The four hardened detectors are exercised:
+ *   1. RichText editor-invalid risk: a class/style-bearing inline <span>/<a> in
+ *      paragraph/heading/list-item content is the authoritative invalidity
+ *      signal, ranked HIGH (structural wp_block_validity=0 is not "no invalid
+ *      content").
+ *   2. Layout-direction faithfulness: a display:flex;flex-direction:column source
+ *      that converts to core/columns flags layout_direction_misrecognition,
+ *      while genuine horizontal flex does not.
+ *   3. SVG loss: an <svg>-sourced empty/comment-only core/html flags
+ *      svg_content_lost, while a shape-bearing svg core/html does NOT.
+ *   4. var density is informational (severity=info), not a top-ranked repair gap.
  */
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
@@ -31,10 +36,14 @@ $assert = static function (bool $condition, string $message, string $detail = ''
     fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
 };
 
+// Spans carry aria-hidden so the transformer preserves them in RichText content
+// (a bare classed span is collapsed) — this mirrors how class/style-bearing
+// inline formats actually survive into the corpus, where RichText would then
+// drop the unsupported class on parse.
 $html = <<<'HTML'
 <div>
-  <p>Hello <span class="accent">world</span></p>
-  <h2 style="color:var(--brand-color)">Big <span style="font-weight:bold">title</span></h2>
+  <p>Total <span class="metric-unit" aria-hidden="true">+</span> growth and var(--brand-color)</p>
+  <h2 style="color:var(--brand-color)">Big <span class="quote-glyph" aria-hidden="true">&ldquo;</span> title</h2>
   <p style="background:var(--wp--preset--color--primary)">Preset paragraph</p>
 </div>
 HTML;
@@ -50,84 +59,162 @@ $byDetector = static function (array $findings, string $detector): array {
 };
 
 // ---------------------------------------------------------------------------
-// 1. classed-span-in-content: the paragraph and heading each report once.
+// 1. RichText invalid risk: the classed/styled-span paragraph and heading each
+//    report once as HIGH-severity editor-invalid risk.
 // ---------------------------------------------------------------------------
-$spanFindings = $byDetector($collected['findings'], 'classed_span_in_content');
-$assert(2 === count($spanFindings), '1: both classed/styled spans are reported', 'got ' . count($spanFindings));
-$spanPatterns = array_map(static fn (array $f): string => (string) $f['pattern'], $spanFindings);
-sort($spanPatterns);
+$riskFindings = $byDetector($collected['findings'], 'richtext_invalid_risk');
+$assert(2 === count($riskFindings), '1: both classed/styled spans are reported as richtext invalid risk', 'got ' . count($riskFindings));
+$riskPatterns = array_map(static fn (array $f): string => (string) $f['pattern'], $riskFindings);
+sort($riskPatterns);
 $assert(
-    array('core/heading', 'core/paragraph') === $spanPatterns,
-    '1b: classed-span findings carry the offending block name as pattern',
-    implode(',', $spanPatterns)
+    array('core/heading', 'core/paragraph') === $riskPatterns,
+    '1b: richtext-risk findings carry the offending block name as pattern',
+    implode(',', $riskPatterns)
+);
+$assert(
+    array() === array_values(array_filter($riskFindings, static fn (array $f): bool => CorpusDetectors::SEVERITY_HIGH !== ($f['severity'] ?? ''))),
+    '1c: richtext invalid risk is HIGH severity'
+);
+$assert(
+    2 === (int) $collected['metrics']['richtext_invalid_risk_count'],
+    '1d: richtext_invalid_risk_count metric surfaces the real invalidity count',
+    (string) $collected['metrics']['richtext_invalid_risk_count']
+);
+
+// A classed inline <a> inside paragraph/list-item content also counts; a plain
+// (attribute-free) span/anchor does not.
+$anchorResult = ( new HtmlTransformer() )->transform(
+    '<ul><li>See <a class="cta" href="/x" aria-hidden="true">link</a></li><li>plain <span>text</span></li></ul>',
+    array()
+)->toArray();
+$anchorRisk = $byDetector(CorpusDetectors::collect($anchorResult)['findings'], 'richtext_invalid_risk');
+$assert(
+    1 === count($anchorRisk) && 'core/list-item' === $anchorRisk[0]['pattern'],
+    '1e: a classed <a> in list-item content is richtext invalid risk; a plain span is not',
+    (string) count($anchorRisk) . ':' . (string) ($anchorRisk[0]['pattern'] ?? '(none)')
 );
 
 // ---------------------------------------------------------------------------
-// 2. var-dependent styling: the custom property is reported; the wp-preset is
-//    counted for visibility but excluded from the actionable findings.
+// 2. var density: the custom property is reported as INFORMATIONAL (not a repair
+//    gap, not top-ranked); the wp-preset is excluded from findings entirely.
 // ---------------------------------------------------------------------------
 $varFindings = $byDetector($collected['findings'], 'var_dependent_styling');
-$assert(1 === count($varFindings), '2: only the custom var() is an actionable finding', 'got ' . count($varFindings));
+$assert(1 === count($varFindings), '2: only the custom var() yields a finding', 'got ' . count($varFindings));
 $assert(
     1 === count($varFindings) && '--brand-color' === $varFindings[0]['pattern'],
     '2b: custom var() finding names the custom property',
     $varFindings[0]['pattern'] ?? '(none)'
 );
 $assert(
+    1 === count($varFindings) && CorpusDetectors::SEVERITY_INFO === ($varFindings[0]['severity'] ?? ''),
+    '2c: var density is informational severity, not an actionable defect'
+);
+$assert(
+    1 === count($varFindings) && 'informational_var_density' === ($varFindings[0]['repair_bucket'] ?? ''),
+    '2d: var density is labeled informational, not a css materialization repair gap',
+    (string) ($varFindings[0]['repair_bucket'] ?? '(none)')
+);
+$assert(
     in_array('--wp--preset--color--primary', $collected['var_names'], true),
-    '2c: preset var() is still tracked in var_names for visibility'
+    '2e: preset var() is still tracked in var_names for visibility'
 );
 $assert(
-    (int) $collected['metrics']['var_ref_count'] >= 2,
-    '2d: var_ref_count counts both custom and preset references',
-    (string) $collected['metrics']['var_ref_count']
-);
-$assert(
-    1 === (int) $collected['metrics']['var_custom_ref_count'],
-    '2e: var_custom_ref_count counts only the custom reference',
+    (int) $collected['metrics']['var_custom_ref_count'] >= 1,
+    '2f: var_custom_ref_count counts the custom reference',
     (string) $collected['metrics']['var_custom_ref_count']
 );
 
 // ---------------------------------------------------------------------------
-// 3. empty core/html: a comment-only (stripped-SVG) block and a whitespace-only
-//    block are each reported, while a non-empty raw-HTML block is not.
+// 3. SVG loss: an <svg>-sourced empty/comment-only core/html flags
+//    svg_content_lost (HIGH); a shape-bearing svg core/html does NOT; a generic
+//    empty html (no svg trace) is the lower-severity empty_core_html signal.
 // ---------------------------------------------------------------------------
-$syntheticBlocks = array(
-    array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => '<!-- svg stripped -->' ),
+$svgBlocks = array(
+    array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => '<!-- svg icon stripped -->' ),
+    array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => '<svg viewBox="0 0 10 10"><path d="M0 0"></path></svg>' ),
     array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => "   \n  " ),
-    array( 'blockName' => 'core/html', 'attrs' => array(), 'innerHTML' => '<svg><path></path></svg>' ),
 );
-$emptyFindings = CorpusDetectors::emptyCoreHtml($syntheticBlocks);
-$assert(2 === count($emptyFindings), '3: both empty/stripped core/html blocks are reported', 'got ' . count($emptyFindings));
-$emptyPatterns = array_map(static fn (array $f): string => (string) $f['pattern'], $emptyFindings);
-sort($emptyPatterns);
+$svgLost = CorpusDetectors::svgContentLost(array(), $svgBlocks);
+$assert(1 === count($svgLost), '3: only the stripped-svg empty block flags svg_content_lost', 'got ' . count($svgLost));
 $assert(
-    array('comment_only_or_stripped', 'whitespace_only') === $emptyPatterns,
-    '3b: empty-html pattern distinguishes comment-only/stripped from whitespace-only',
-    implode(',', $emptyPatterns)
+    1 === count($svgLost) && 'empty_core_html_from_svg' === ($svgLost[0]['pattern'] ?? '') && CorpusDetectors::SEVERITY_HIGH === ($svgLost[0]['severity'] ?? ''),
+    '3b: svg_content_lost is HIGH severity and names the empty-from-svg pattern',
+    (string) ($svgLost[0]['pattern'] ?? '(none)')
 );
-$fallbackFindings = CorpusDetectors::coreHtmlFallback($syntheticBlocks);
+$emptyFindings = CorpusDetectors::emptyCoreHtml($svgBlocks);
 $assert(
-    1 === count($fallbackFindings) && '<svg>' === $fallbackFindings[0]['pattern'],
-    '3c: a non-empty raw-HTML block is clustered by its leading tag, not flagged empty',
-    (string) ($fallbackFindings[0]['pattern'] ?? '(none)')
+    1 === count($emptyFindings) && 'whitespace_only' === ($emptyFindings[0]['pattern'] ?? ''),
+    '3c: the whitespace-only block is a generic empty_core_html; the svg one is not double-counted here',
+    (string) count($emptyFindings) . ':' . (string) ($emptyFindings[0]['pattern'] ?? '(none)')
 );
 
+// SVG loss also surfaces from the transformer inline-svg fallback diagnostics.
+$diagResult = array(
+    'diagnostics' => array(
+        array( 'reason_code' => 'html_inline_svg_fallback', 'message' => 'dropped' ),
+        array( 'reason_code' => 'html_unsafe_inline_svg', 'message' => 'unsafe' ),
+    ),
+);
+$diagSvg = CorpusDetectors::svgContentLost($diagResult, array());
+$assert(2 === count($diagSvg), '3d: inline-svg fallback diagnostics route into svg_content_lost', 'got ' . count($diagSvg));
+
 // ---------------------------------------------------------------------------
-// 4. Cluster keys pair the repair bucket with the structural pattern.
+// 4. Layout-direction misrecognition: a vertical flex container that converts to
+//    core/columns flags columns_from_vertical_flex; horizontal flex does not.
+// ---------------------------------------------------------------------------
+$verticalFlex = '<div style="display:flex; flex-direction:column; gap:1rem; max-width:760px;">'
+    . '<p>One</p><p>Two</p><p>Three</p></div>';
+$layout = CorpusDetectors::layoutDirectionMisrecognition(
+    $verticalFlex,
+    static function (string $fragment): bool {
+        $blocks = ( new HtmlTransformer() )->transform($fragment, array())->toArray()['blocks'] ?? array();
+
+        return is_array($blocks[0] ?? null) && 'core/columns' === ($blocks[0]['blockName'] ?? '');
+    }
+);
+$assert(1 === count($layout), '4: a vertical-flex container that becomes core/columns is flagged', 'got ' . count($layout));
+$assert(
+    1 === count($layout)
+        && 'columns_from_vertical_flex' === ($layout[0]['pattern'] ?? '')
+        && CorpusDetectors::SEVERITY_HIGH === ($layout[0]['severity'] ?? ''),
+    '4b: layout misrecognition is HIGH severity with the columns_from_vertical_flex pattern',
+    (string) ($layout[0]['pattern'] ?? '(none)')
+);
+
+$horizontalFlex = '<div style="display:flex; flex-direction:row; gap:1rem;"><div>A</div><div>B</div></div>';
+$horizontal = CorpusDetectors::layoutDirectionMisrecognition(
+    $horizontalFlex,
+    static fn (string $fragment): bool => true
+);
+$assert(0 === count($horizontal), '4c: genuine horizontal flex is never flagged as a misrecognition', 'got ' . count($horizontal));
+
+// Verifier veto: a vertical-flex source that does NOT convert to columns is not flagged.
+$vetoed = CorpusDetectors::layoutDirectionMisrecognition(
+    $verticalFlex,
+    static fn (string $fragment): bool => false
+);
+$assert(0 === count($vetoed), '4d: a vertical-flex candidate that does not become columns is vetoed', 'got ' . count($vetoed));
+
+// ---------------------------------------------------------------------------
+// 5. Severity ranking and cluster keys.
 // ---------------------------------------------------------------------------
 $assert(
-    'css_custom_property_materialization :: --brand-color' === CorpusDetectors::clusterKey($varFindings[0]),
-    '4: cluster key joins repair bucket and pattern',
+    CorpusDetectors::severityRank(CorpusDetectors::SEVERITY_HIGH) > CorpusDetectors::severityRank(CorpusDetectors::SEVERITY_MEDIUM)
+        && CorpusDetectors::severityRank(CorpusDetectors::SEVERITY_MEDIUM) > CorpusDetectors::severityRank(CorpusDetectors::SEVERITY_INFO),
+    '5: severity ranks high > medium > info'
+);
+$assert(
+    'informational_var_density :: --brand-color' === CorpusDetectors::clusterKey($varFindings[0]),
+    '5b: cluster key joins repair bucket and pattern',
     CorpusDetectors::clusterKey($varFindings[0])
 );
 
 // ---------------------------------------------------------------------------
-// 5. Native-rate metric stays a bounded ratio.
+// 6. Native-rate metric stays a bounded ratio.
 // ---------------------------------------------------------------------------
 $rate = (float) $collected['metrics']['native_rate'];
-$assert($rate >= 0.0 && $rate <= 1.0, '5: native_rate is a bounded ratio', (string) $rate);
-$assert((int) $collected['metrics']['block_count'] > 0, '5b: block_count is populated');
+$assert($rate >= 0.0 && $rate <= 1.0, '6: native_rate is a bounded ratio', (string) $rate);
+$assert((int) $collected['metrics']['block_count'] > 0, '6b: block_count is populated');
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "CorpusDetectors unit tests: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
## Summary

Hardens the php-transformer **corpus-diagnostics harness** (added in #327) so its numbers are trustworthy. This closes four known blind spots where the harness either under-reported real defects or inflated the worklist with working behavior. **Reporting/detector-only — no transformer conversion logic is touched.** All changes stay within `php-transformer/src/CorpusDiagnostics/` and its tests.

Clusters now rank by **severity tier first, then occurrence count**, so the actionable worklist leads with real, editor-visible defects.

## Blind spots closed

### 1. Validity headline no longer lies (RichText invalidity is now the headline)
The structural `wp_block_validity` proxy reports `invalid_blocks=0` even when the editor would flag content invalid, because it does not model RichText stripping `class`/`style` off inline `<span>`/`<a>` in `content`. The classed-span detector is promoted to the authoritative **editor-invalid-risk** signal (`richtext_invalid_content_risk`, HIGH severity), extended to also cover `<a>` and `core/list-item` content, surfaced via a new `richtext_invalid_risk_count` metric, and the summary stops presenting structural `invalid_blocks=0` as "no invalid content."

### 2. Layout-direction faithfulness
New `layout_direction_misrecognition :: columns_from_vertical_flex` detector: a `core/columns` emitted from a `display:flex; flex-direction:column` source (a vertical stack rendered as horizontal columns) is a misrecognition. Conservative — only inline column-direction flex on container elements with 2+ children, confirmed by a verifier that the fragment actually converts to `core/columns`. Genuine horizontal flex / grid is never flagged.

### 3. SVG-loss surfaced as HIGH severity
New `svg_content_lost` lane routes the transformer's inline-SVG fallback diagnostics **and** empty/comment-only `core/html` blocks that carry an SVG remnant into one signal, while keeping the distinction from SVG preserved as `core/html` with real shape elements (acceptable, not flagged). Previously this hid at rank ~61 under generic asset findings.

### 4. CSS `var()` false-positive down-ranked to informational
`var()` references are materialized downstream by SSI (verified end-to-end), so resolved var density is **not** a repair gap. Relabeled `informational_var_density` (severity `info`) and ranked below all actionable clusters, instead of flooding the top of the worklist with 233 css clusters.

## Before / after ranking

Full corpus: 368 documents / 77 fixtures, 54,123 blocks.

**Before** (count-only ranking):
1. `preserve_runtime_island :: runtime_script` — 1224
2. `native_block_recognition :: <svg>` — 696
3. `richtext_inline_span_normalization :: core/paragraph` — 308
4. `preserve_runtime_island :: interactive_form` — 206
5. `semantic_structure_parity_restoration :: navigation_menu` — 95
6–30. **all 25 remaining slots are `css_custom_property_materialization :: --*`** (working behavior)
- `materialize_static_asset :: inline_svg` (the SVG-loss signal): rank **61**
- headline: `invalid_blocks=0` (the lie)

**After** (severity-first ranking) — new actionable top-15:
| # | sev | count | files | cluster |
|--:|-----|------:|------:|---------|
| 1 | HIGH | 1280 | 350 | `richtext_invalid_content_risk :: core/paragraph` |
| 2 | HIGH | 311 | 38 | `richtext_invalid_content_risk :: core/list-item` |
| 3 | HIGH | 36 | 13 | `richtext_invalid_content_risk :: core/heading` |
| 4 | HIGH | 21 | 17 | `layout_direction_misrecognition :: columns_from_vertical_flex` |
| 5 | HIGH | 16 | 15 | `svg_content_lost :: inline_svg_dropped` |
| 6 | MEDIUM | 1224 | 347 | `preserve_runtime_island :: runtime_script` |
| 7 | MEDIUM | 696 | 162 | `native_block_recognition :: <svg>` (svg preserved — acceptable) |
| 8 | MEDIUM | 206 | 95 | `preserve_runtime_island :: interactive_form` |
| 9 | MEDIUM | 95 | 82 | `semantic_structure_parity_restoration :: navigation_menu` |
| 10 | MEDIUM | 68 | 25 | `restore_interactive_behavior :: interactive_control` |
| 11 | MEDIUM | 46 | 46 | `semantic_structure_parity_restoration :: semantic_landmark` |
| 12 | MEDIUM | 38 | 33 | `typography_parity_restoration :: typography` |
| 13 | MEDIUM | 15 | 3 | `preserve_runtime_island :: html_template` |
| 14 | MEDIUM | 15 | 3 | `preserve_runtime_island :: runtime_template` |
| 15 | MEDIUM | 14 | 7 | `materialize_commerce_products :: commerce_product_grid` |

The 233 `informational_var_density` clusters now begin at rank 18 (severity `info`), out of the actionable worklist. New headline surfaces `richtext_invalid_risk=1627`, `svg_content_lost=16`, `columns_from_vertical_flex=21`, and labels var density as informational.

## Tests
- `tests/unit/corpus-detectors.php` extended for all four cases (classed `<span>`/`<a>` in paragraph/list-item = richtext invalid risk; vertical-flex→columns flags layout misrecognition while horizontal flex does not; `<svg>`→empty/comment `core/html` flags `svg_content_lost` while a shape-bearing svg `core/html` does not; var density is informational, not top-ranked). 23 assertions pass.
- `composer test` green (canonical + 171 parity fixtures + packaging); `php -l` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Detector/reporting implementation, tests, corpus run analysis, and this PR description. All changes reviewed by the submitter.
