### PR TITLE
figma-transformer: scope multi-page planner to top-level page frames

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphFrameInspector.php
@@ -474,7 +474,14 @@ final class ScenegraphFrameInspector
         return array_slice($siblings, 0, 5);
     }
 
-    private function normalizedPageName(string $name): string
+    /**
+     * Normalize a frame name to its page identity by stripping device/breakpoint
+     * and width tokens ("Home Page – Desktop" and "Home Page – Mobile" both
+     * become "home-page"). This is the shared normalization behind responsive
+     * sibling grouping; the page planner also uses it to derive a responsive
+     * page's slug so the slug reflects the PAGE, not its widest variant.
+     */
+    public function normalizedPageName(string $name): string
     {
         $normalized = strtolower($name);
         $normalized = (string) preg_replace('/\b(desktop|mobile|tablet|phone|web|copy|variant|version|v\d+|i\d+)\b/', ' ', $normalized);

--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -40,6 +40,20 @@ final class ScenegraphPagePlanner
      */
     private const RESPONSIVE_WIDTH_MATERIAL_RATIO = 0.2;
 
+    /**
+     * Page-candidacy dimension band. A real page artboard is a tall, scrolling
+     * frame whose width sits in the realistic device range (small mobile through
+     * wide desktop). Frames outside this band are top-level on the canvas but are
+     * not pages: layout-grid guides / chips (narrower than {@see PAGE_MIN_WIDTH_PX}),
+     * oversized presentation / overview / style-guide boards (wider than
+     * {@see PAGE_MAX_WIDTH_PX}), and decorative dividers / cover thumbnails /
+     * device mockups (shorter than {@see PAGE_MIN_HEIGHT_PX}). Explicit
+     * `frame_ids` bypass this band so any requested frame stays selectable.
+     */
+    private const PAGE_MIN_WIDTH_PX  = 320.0;
+    private const PAGE_MAX_WIDTH_PX  = 2048.0;
+    private const PAGE_MIN_HEIGHT_PX = 700.0;
+
     public function __construct(
         private readonly ScenegraphIndex $index = new ScenegraphIndex(),
         private readonly ScenegraphFrameInspector $frameInspector = new ScenegraphFrameInspector(),
@@ -119,26 +133,33 @@ final class ScenegraphPagePlanner
         $diagnostics = is_array($index['diagnostics'] ?? null) ? $index['diagnostics'] : array();
         $statsMemo = array();
         $explicitFrameIds = $this->explicitFrameIds($options);
-        $includeAllPages = true === ($options['include_all_pages'] ?? false) || ! empty($options['frame_ids']);
+        $includeAllPages = true === ($options['include_all_pages'] ?? false)
+            || true === ($options['multi_page'] ?? false)
+            || ! empty($options['frame_ids']);
         $maxPages = isset($options['max_pages']) && is_numeric($options['max_pages']) ? max(1, (int) $options['max_pages']) : null;
         $entryFrameId = isset($options['entry_frame_id']) && is_scalar($options['entry_frame_id']) ? (string) $options['entry_frame_id'] : null;
         $slugMap = is_array($options['frame_slug_map'] ?? null) ? $options['frame_slug_map'] : array();
         $candidates = array();
 
+        // Page candidates are TOP-LEVEL frames: FRAME nodes that sit directly on
+        // a CANVAS (or the document root), with only transparent SECTION grouping
+        // allowed in between. The deeply nested frames (annotation cards like
+        // "Buttons"/"Legend", layout-grid guides, component internals) are NOT
+        // pages and must not drown the real pages or misdirect dev-status
+        // selection. Restricting candidacy to the top level collapses the
+        // candidate set from "every FRAME at any depth" to the handful of real
+        // page frames. Explicit `frame_ids` bypass this scoping (built on demand
+        // in the selection branch below) so a requested frame at any depth stays
+        // selectable.
         foreach ( $nodes as $id => $node ) {
             if ( ! is_string($id) || ! is_array($node) || 'FRAME' !== strtoupper((string) ($node['type'] ?? '')) ) {
                 continue;
             }
+            if ( ! $this->isTopLevelFrame($id, $nodes, $parentIndex) ) {
+                continue;
+            }
 
-            $stats = $this->subtreeStats($id, $nodes, $childrenIndex, $statsMemo);
-            $dimensions = $this->dimensions($node);
-            $candidates[$id] = array(
-                'id'         => $id,
-                'node'       => $node,
-                'stats'      => $stats,
-                'dimensions' => $dimensions,
-                'score'      => $this->scoreCandidate($id, $node, $dimensions, $stats, $nodes, $parentIndex),
-            );
+            $candidates[$id] = $this->buildCandidate($id, $node, $nodes, $childrenIndex, $parentIndex, $statsMemo);
         }
 
         // Frame role classification (#247): decide WHAT each top-level frame IS
@@ -163,6 +184,32 @@ final class ScenegraphPagePlanner
             }
         }
 
+        // The SELECTABLE page pool: top-level candidates that are neither
+        // design-system frames nor off-page-sized noise (grid guides, decorative
+        // dividers, cover/device boards, oversized overview artboards). Selection,
+        // dev-status ranking, responsive detection and grouping all operate over
+        // THIS pool so noise frames never become pages and never get pulled into a
+        // real page's responsive group. The full `$candidates` set is retained for
+        // candidate_count and classification coverage. If dimension filtering
+        // empties the pool (unusual designs), fall back to all non-design-system
+        // candidates so a plan is still produced and single-page never yields zero.
+        $pageCandidates = array();
+        foreach ( $candidates as $candidateId => $candidate ) {
+            if ( isset($designSystemIds[$candidateId]) ) {
+                continue;
+            }
+            if ( ! $this->isPageSizedCandidate(
+                (float) ($candidate['dimensions']['width'] ?? 0),
+                (float) ($candidate['dimensions']['height'] ?? 0)
+            ) ) {
+                continue;
+            }
+            $pageCandidates[$candidateId] = $candidate;
+        }
+        if ( array() === $pageCandidates ) {
+            $pageCandidates = array_diff_key($candidates, $designSystemIds);
+        }
+
         // Figma Dev Mode status (#280): when ANY node in the file carries a
         // normalized dev status, it becomes the PRIMARY frame-selection signal.
         $nodeDevStatus = $this->resolveNodeDevStatus($nodes);
@@ -172,35 +219,52 @@ final class ScenegraphPagePlanner
         $selectedIds = array();
         $explicitSelected = false;
         $selectionSource = 'heuristic';
+        // Dev-status is the PRIMARY selector ONLY when a real top-level page
+        // candidate carries a mark. Because page candidacy is top-level scoped,
+        // dev marks that live solely on nested/annotation frames never enter
+        // this set, so they can no longer suppress unmarked real pages —
+        // selection then falls back to the heuristic ranking over top-level
+        // page candidates. Design-system frames never become pages even when
+        // dev-marked.
+        $markedPageCandidates = array_intersect_key($pageCandidates, $frameDevStatus);
         if ( ! empty($explicitFrameIds) ) {
             $explicitSelected = true;
             foreach ( $explicitFrameIds as $id ) {
-                if ( isset($candidates[$id]) ) {
-                    $selectedIds[] = $id;
-                    continue;
-                }
+                if ( ! isset($candidates[$id]) ) {
+                    $node = is_array($nodes[$id] ?? null) ? $nodes[$id] : null;
+                    if ( null === $node || 'FRAME' !== strtoupper((string) ($node['type'] ?? '')) ) {
+                        $diagnostics[] = array(
+                            'severity' => 'warning',
+                            'code'     => 'figma_page_plan_frame_missing',
+                            'message'  => 'Skipped a requested frame because it was not found as a FRAME node.',
+                            'frame_id' => $id,
+                        );
+                        continue;
+                    }
 
-                $diagnostics[] = array(
-                    'severity' => 'warning',
-                    'code'     => 'figma_page_plan_frame_missing',
-                    'message'  => 'Skipped a requested frame because it was not found as a FRAME node.',
-                    'frame_id' => $id,
-                );
+                    // Explicit selection bypasses top-level + page-size scoping:
+                    // build the requested frame as a candidate on demand so a
+                    // frame at any depth stays selectable and emits a page, and
+                    // add it to the page pool so it still participates in
+                    // responsive grouping with its explicitly-selected siblings.
+                    $candidates[$id] = $this->buildCandidate($id, $node, $nodes, $childrenIndex, $parentIndex, $statsMemo);
+                    $classifications[$id] = $this->classifyCandidate($id, $candidates[$id], $nodes, $childrenIndex, $parentIndex);
+                }
+                $pageCandidates[$id] = $candidates[$id];
+
+                $selectedIds[] = $id;
             }
-        } elseif ( $fileHasDevStatus && array() !== $frameDevStatus ) {
+        } elseif ( $fileHasDevStatus && array() !== $markedPageCandidates ) {
             // Prefer ready_for_dev/completed frames (and frames under a marked
             // section); skip WIP/unmarked frames. Heuristics stay as the order
             // within the marked set and as the fallback when no frame qualifies.
-            // Design-system frames never become pages even when dev-marked.
             $selectionSource = 'dev_status';
-            $markedCandidates = array_diff_key(array_intersect_key($candidates, $frameDevStatus), $designSystemIds);
-            $selectedIds = $this->rankedCandidateIdsByDevStatus($markedCandidates, $frameDevStatus);
+            $selectedIds = $this->rankedCandidateIdsByDevStatus($markedPageCandidates, $frameDevStatus);
             if ( ! $includeAllPages ) {
                 $selectedIds = array_slice($selectedIds, 0, 1);
             }
         } else {
-            $selectableCandidates = array_diff_key($candidates, $designSystemIds);
-            $selectedIds = $this->rankedCandidateIds($selectableCandidates);
+            $selectedIds = $this->rankedCandidateIds($pageCandidates);
             if ( ! $includeAllPages ) {
                 $selectedIds = array_slice($selectedIds, 0, 1);
             }
@@ -218,7 +282,7 @@ final class ScenegraphPagePlanner
             }
         }
 
-        $detectionResult = $this->detectResponsive($candidates, $nodes, $parentIndex, $options);
+        $detectionResult = $this->detectResponsive($pageCandidates, $nodes, $parentIndex, $options);
         $detectionById = $detectionResult['detection'];
         if ( $detectionResult['bounded'] ) {
             $diagnostics[] = array(
@@ -230,7 +294,7 @@ final class ScenegraphPagePlanner
             );
         }
 
-        $grouping = $this->responsiveGroups($candidates, $detectionById);
+        $grouping = $this->responsiveGroups($pageCandidates, $detectionById);
         $responsiveGroups = $grouping['groups'];
         foreach ( $grouping['diagnostics'] as $groupDiagnostic ) {
             $diagnostics[] = $groupDiagnostic;
@@ -332,6 +396,86 @@ final class ScenegraphPagePlanner
             'dev_status_coverage'     => $devStatusCoverage,
             'classification_coverage' => $classificationCoverage,
             'diagnostics'             => $diagnostics,
+        );
+    }
+
+    /**
+     * Whether a FRAME node is a TOP-LEVEL page candidate: walking up its ancestor
+     * chain reaches a CANVAS or the document root WITHOUT first passing through
+     * another container FRAME/GROUP/INSTANCE/COMPONENT. SECTION nodes are
+     * transparent because they are Figma's on-canvas organizational grouping (a
+     * dev-handoff "folder"), so a page frame placed inside a section is still
+     * top-level; likewise a frame at the document root (a CANVAS-less synthetic
+     * source) is top-level. This is the generic structural test that separates
+     * real page frames from the nested frames (annotation cards, layout-grid
+     * guides, component internals) that must never compete for page selection.
+     *
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, string|null>          $parentIndex
+     */
+    private function isTopLevelFrame(string $id, array $nodes, array $parentIndex): bool
+    {
+        $cursor = $parentIndex[$id] ?? null;
+        $guard = 0;
+        while ( is_string($cursor) && isset($nodes[$cursor]) && is_array($nodes[$cursor]) && $guard < 4096 ) {
+            ++$guard;
+            $type = strtoupper((string) ($nodes[$cursor]['type'] ?? ''));
+            if ( 'CANVAS' === $type ) {
+                return true;
+            }
+            if ( 'SECTION' !== $type ) {
+                // Nested inside another frame/group/component → content, not a page.
+                return false;
+            }
+            $cursor = $parentIndex[$cursor] ?? null;
+        }
+
+        // Reached the document root (no parent, or only SECTIONs above) without
+        // passing through a container frame: a depth-1 frame, i.e. a page.
+        return true;
+    }
+
+    /**
+     * Whether a candidate frame has PAGE-SIZED dimensions: a width inside the
+     * realistic page-width band (mobile through wide desktop) and a height tall
+     * enough to be a scrolling page. This is the dimension half of page
+     * candidacy — it drops top-level frames that are structurally on the canvas
+     * but are plainly not pages: layout-grid guides and chips (too narrow),
+     * decorative "Title Card" dividers / cover thumbnails / device mockups (too
+     * short), and oversized presentation/overview artboards (too wide, e.g. a
+     * 2238px "Home Page – Desktop" overview board colliding with the real 1440px
+     * page). Explicit `frame_ids` bypass this gate entirely.
+     */
+    private function isPageSizedCandidate(float $width, float $height): bool
+    {
+        return $width >= self::PAGE_MIN_WIDTH_PX
+            && $width <= self::PAGE_MAX_WIDTH_PX
+            && $height >= self::PAGE_MIN_HEIGHT_PX;
+    }
+
+    /**
+     * Build a single page-candidate record (subtree stats, dimensions, score).
+     * Shared by the top-level candidacy scan and the explicit-`frame_ids`
+     * on-demand path so a requested frame at any depth is scored identically.
+     *
+     * @param array<string, mixed>                $node
+     * @param array<string, array<string, mixed>> $nodes
+     * @param array<string, array<int, string>>   $childrenIndex
+     * @param array<string, string|null>          $parentIndex
+     * @param array<string, array<string, int>>   $statsMemo
+     * @return array{id:string,node:array<string, mixed>,stats:array{nodes:int,texts:int,assets:int},dimensions:array{width:float|null,height:float|null},score:int}
+     */
+    private function buildCandidate(string $id, array $node, array $nodes, array $childrenIndex, array $parentIndex, array &$statsMemo): array
+    {
+        $stats = $this->subtreeStats($id, $nodes, $childrenIndex, $statsMemo);
+        $dimensions = $this->dimensions($node);
+
+        return array(
+            'id'         => $id,
+            'node'       => $node,
+            'stats'      => $stats,
+            'dimensions' => $dimensions,
+            'score'      => $this->scoreCandidate($id, $node, $dimensions, $stats, $nodes, $parentIndex),
         );
     }
 

--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -300,10 +300,41 @@ final class ScenegraphPagePlanner
             $diagnostics[] = $groupDiagnostic;
         }
 
+        // Entrypoint (index.html) assignment. The downstream php-transformer and
+        // WordPress treat index.html as the FRONT PAGE, so the page classified
+        // `front_page` must own it rather than whichever page merely ranked first.
+        // An explicit `entry_frame_id` always wins; otherwise the highest-ranked
+        // `front_page` page is the entrypoint, falling back to rank order when no
+        // page classifies as a front page.
+        $entrypointPrimaryId = null;
+        if ( null === $entryFrameId ) {
+            $seenPrimary = array();
+            $rankFirstPrimaryId = null;
+            foreach ( $selectedIds as $id ) {
+                $members = $responsiveGroups[$id] ?? array($id);
+                $primaryId = $members[0];
+                if ( isset($seenPrimary[$primaryId]) ) {
+                    continue;
+                }
+                $seenPrimary[$primaryId] = true;
+                if ( null === $rankFirstPrimaryId ) {
+                    $rankFirstPrimaryId = $primaryId;
+                }
+                $primaryClassification = $classifications[$primaryId]
+                    ?? $this->classifyCandidate($primaryId, $candidates[$primaryId], $nodes, $childrenIndex, $parentIndex);
+                if ( ScenegraphFrameClassifier::PAGE_TYPE_FRONT_PAGE === ($primaryClassification['page_type'] ?? '') ) {
+                    $entrypointPrimaryId = $primaryId;
+                    break;
+                }
+            }
+            if ( null === $entrypointPrimaryId ) {
+                $entrypointPrimaryId = $rankFirstPrimaryId;
+            }
+        }
+
         $slugs = array();
         $pages = array();
         $consumed = array();
-        $emittedPosition = 0;
         foreach ( $selectedIds as $id ) {
             if ( isset($consumed[$id]) ) {
                 continue;
@@ -320,8 +351,8 @@ final class ScenegraphPagePlanner
             $page = $this->nearestAncestor($primaryId, array('CANVAS'), $nodes, $parentIndex);
             $section = $this->nearestAncestor($primaryId, array('SECTION'), $nodes, $parentIndex);
             $name = (string) ($node['name'] ?? $primaryId);
-            $slug = $this->dedupeSlug($this->configuredSlug($primaryId, $slugMap) ?? $this->slugify($name), $slugs);
-            $entrypoint = null !== $entryFrameId ? in_array($entryFrameId, $members, true) : 0 === $emittedPosition;
+            $slug = $this->dedupeSlug($this->pageSlug($primaryId, $name, $members, $slugMap), $slugs);
+            $entrypoint = null !== $entryFrameId ? in_array($entryFrameId, $members, true) : $primaryId === $entrypointPrimaryId;
             $variants = $this->breakpointVariants($members, $primaryId, $candidates, $detectionById);
             $classification = $classifications[$primaryId] ?? $this->classifyCandidate($primaryId, $candidate, $nodes, $childrenIndex, $parentIndex);
 
@@ -348,7 +379,6 @@ final class ScenegraphPagePlanner
                 'variants'              => $variants,
                 'diagnostics'           => $this->pageDiagnostics($primaryId, $node, $candidate['dimensions'], $explicitSelected),
             );
-            ++$emittedPosition;
         }
 
         $classificationCoverage = $this->classificationCoverage($candidates, $classifications, $pages);
@@ -1361,6 +1391,31 @@ final class ScenegraphPagePlanner
     private function isWebLikeDimensions(float $width, float $height): bool
     {
         return $width >= 320 && $width <= 2400 && $height >= 700 && $height <= 20000;
+    }
+
+    /**
+     * Resolve a page's slug source. A configured `frame_slug_map` entry always
+     * wins. For a RESPONSIVE page (more than one breakpoint variant) the slug is
+     * derived from the normalized page name so it reflects the page rather than
+     * its widest variant — "Home Page – Desktop" + "Home Page – Mobile" collapse
+     * to the slug "home-page", not "home-page-desktop". A single-variant page
+     * keeps its own name (e.g. "Mobile Menu" stays "mobile-menu").
+     *
+     * @param array<int, string>   $members
+     * @param array<string, mixed> $slugMap
+     */
+    private function pageSlug(string $primaryId, string $name, array $members, array $slugMap): string
+    {
+        $configured = $this->configuredSlug($primaryId, $slugMap);
+        if ( null !== $configured ) {
+            return $configured;
+        }
+
+        if ( count($members) > 1 ) {
+            return $this->slugify($this->frameInspector->normalizedPageName($name));
+        }
+
+        return $this->slugify($name);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1988,7 +1988,10 @@ $assert(2 === ($responsivePagePlan['page_count'] ?? null), 'page-plan-responsive
 $assert(null !== $responsiveHomePage, 'page-plan-responsive-home-primary-is-desktop');
 $assert(true === ($responsiveHomePage['responsive'] ?? null), 'page-plan-responsive-home-flagged-responsive');
 $assert(3 === ($responsiveHomePage['breakpoint_count'] ?? null), 'page-plan-responsive-home-three-breakpoints');
-$assert('home-page-desktop' === ($responsiveHomePage['slug'] ?? null), 'page-plan-responsive-primary-drives-slug');
+// A responsive page's slug reflects the PAGE, not its widest variant: the
+// breakpoint token ("Desktop") is stripped so desktop+mobile collapse to one
+// stable slug.
+$assert('home-page' === ($responsiveHomePage['slug'] ?? null), 'page-plan-responsive-slug-strips-breakpoint-token');
 $assert(array('frame:home-desktop', 'frame:home-tablet', 'frame:home-mobile')
     === array_map(static fn (array $variant): string => (string) ($variant['frame_id'] ?? ''), $responsiveHomePage['variants'] ?? array()), 'page-plan-responsive-variants-ordered-widest-first');
 $assert(array('desktop', 'tablet', 'mobile')
@@ -6705,6 +6708,16 @@ $assert(array('frame:home-desktop', 'frame:home-mobile')
     === array_map(static fn (array $variant): string => (string) ($variant['frame_id'] ?? ''), $multiPageByFrame['frame:home-desktop']['variants'] ?? array()), 'multi-page-home-variants-widest-first');
 $assert(isset($multiPageByFrame['frame:contact-desktop'])
     && true === ($multiPageByFrame['frame:contact-desktop']['responsive'] ?? null), 'multi-page-contact-groups-desktop-mobile');
+// The `front_page`-classified page owns the index.html entrypoint, not whichever
+// page merely ranked first.
+$assert(ScenegraphFrameClassifier::PAGE_TYPE_FRONT_PAGE === ($multiPageByFrame['frame:home-desktop']['page_type'] ?? null), 'multi-page-home-classified-front-page');
+$assert(true === ($multiPageByFrame['frame:home-desktop']['entrypoint'] ?? null)
+    && 'index.html' === ($multiPageByFrame['frame:home-desktop']['path'] ?? null), 'multi-page-front-page-is-entrypoint');
+$assert(false === ($multiPageByFrame['frame:contact-desktop']['entrypoint'] ?? null), 'multi-page-non-front-page-not-entrypoint');
+// Responsive page slugs/paths strip the breakpoint token.
+$assert('home-page' === ($multiPageByFrame['frame:home-desktop']['slug'] ?? null), 'multi-page-home-slug-normalized');
+$assert('contact' === ($multiPageByFrame['frame:contact-desktop']['slug'] ?? null)
+    && 'contact.html' === ($multiPageByFrame['frame:contact-desktop']['path'] ?? null), 'multi-page-contact-slug-and-path-normalized');
 // (b) Nested annotation frame is NOT a page.
 $assert(! in_array('frame:home-annotation', $multiPageFrameIds, true), 'multi-page-nested-frame-not-a-page');
 // (c) Design-system frame is excluded from pages (and reported as such).

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6593,6 +6593,129 @@ $assert(in_array('frame:palette', $contentShapeCoverage['excluded_design_system_
 $assert(ScenegraphFrameClassifier::PAGE_TYPE_ARCHIVE === ($contentShapeByFrame['frame:list']['page_type'] ?? null), 'classification-content-card-list-archive');
 $assert(in_array('content:card_list', $contentShapeByFrame['frame:list']['classification_signals'] ?? array(), true), 'classification-content-card-list-signal');
 
+// MULTI-PAGE SELECTION (#280/#242 FSE Pilot acceptance): `--multi-page` (no
+// `frame_ids`) selects the TOP-LEVEL page frames on a canvas, groups each
+// page's desktop+mobile variants into ONE responsive page, excludes the
+// design-system frame, and ignores both nested annotation frames and oversized
+// decorative boards. Backward compat: the SAME scenegraph with neither
+// `multi_page` nor `frame_ids` still slices to a single page.
+$multiPageSource = array(
+    'name'  => 'Multi Page Selection Site',
+    'nodes' => array(
+        array(
+            'id'       => 'canvas:mockups',
+            'type'     => 'CANVAS',
+            'name'     => 'Mockups (dev handoff)',
+            'children' => array(
+                // Home: a desktop + mobile pair → one responsive page. The
+                // desktop frame also carries a NESTED annotation frame that must
+                // never be selected as a page of its own.
+                array(
+                    'id'       => 'frame:home-desktop',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home Page – Desktop',
+                    'width'    => 1440,
+                    'height'   => 3200,
+                    'children' => array(
+                        array('id' => 'home:hero', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                        array(
+                            'id'       => 'frame:home-annotation',
+                            'type'     => 'FRAME',
+                            'name'     => 'Buttons',
+                            'width'    => 240,
+                            'height'   => 120,
+                            'children' => array(
+                                array('id' => 'home:btn', 'type' => 'TEXT', 'name' => 'Button label', 'characters' => 'Click'),
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'       => 'frame:home-mobile',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home Page – Mobile',
+                    'width'    => 390,
+                    'height'   => 5200,
+                    'children' => array(
+                        array('id' => 'home-m:hero', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                    ),
+                ),
+                // Contact: a second desktop + mobile pair → one responsive page.
+                array(
+                    'id'       => 'frame:contact-desktop',
+                    'type'     => 'FRAME',
+                    'name'     => 'Contact – Desktop',
+                    'width'    => 1440,
+                    'height'   => 2000,
+                    'children' => array(
+                        array('id' => 'contact:title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Contact us'),
+                    ),
+                ),
+                array(
+                    'id'       => 'frame:contact-mobile',
+                    'type'     => 'FRAME',
+                    'name'     => 'Contact – Mobile',
+                    'width'    => 390,
+                    'height'   => 2600,
+                    'children' => array(
+                        array('id' => 'contact-m:title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Contact us'),
+                    ),
+                ),
+                // Design-system frame: excluded from page selection by role.
+                array(
+                    'id'       => 'frame:styleguide',
+                    'type'     => 'FRAME',
+                    'name'     => 'Style Guide',
+                    'width'    => 1440,
+                    'height'   => 2000,
+                    'children' => array(
+                        array('id' => 'sg:swatch', 'type' => 'TEXT', 'name' => 'Colors', 'characters' => 'Brand Colors'),
+                    ),
+                ),
+                // Oversized decorative divider board: off the page-width band, so
+                // excluded as a non-page even though it is top-level on the canvas.
+                array(
+                    'id'       => 'frame:title-card',
+                    'type'     => 'FRAME',
+                    'name'     => 'Title Card',
+                    'width'    => 2238,
+                    'height'   => 291,
+                    'children' => array(
+                        array('id' => 'tc:label', 'type' => 'TEXT', 'name' => 'Section label', 'characters' => 'Mockups'),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$multiPagePlan = ( new ScenegraphPagePlanner() )->plan($multiPageSource, array('multi_page' => true, 'max_pages' => 20));
+$multiPageByFrame = array();
+foreach ( $multiPagePlan['pages'] ?? array() as $multiPagePage ) {
+    if ( is_array($multiPagePage) && isset($multiPagePage['frame_id']) ) {
+        $multiPageByFrame[(string) $multiPagePage['frame_id']] = $multiPagePage;
+    }
+}
+$multiPageFrameIds = array_keys($multiPageByFrame);
+// (a) One responsive page per distinct page name (Home, Contact).
+$assert(2 === ($multiPagePlan['page_count'] ?? null), 'multi-page-selects-one-page-per-distinct-name');
+$assert(isset($multiPageByFrame['frame:home-desktop']), 'multi-page-home-primary-is-desktop');
+$assert(true === ($multiPageByFrame['frame:home-desktop']['responsive'] ?? null)
+    && 2 === ($multiPageByFrame['frame:home-desktop']['breakpoint_count'] ?? null), 'multi-page-home-groups-desktop-mobile');
+$assert(array('frame:home-desktop', 'frame:home-mobile')
+    === array_map(static fn (array $variant): string => (string) ($variant['frame_id'] ?? ''), $multiPageByFrame['frame:home-desktop']['variants'] ?? array()), 'multi-page-home-variants-widest-first');
+$assert(isset($multiPageByFrame['frame:contact-desktop'])
+    && true === ($multiPageByFrame['frame:contact-desktop']['responsive'] ?? null), 'multi-page-contact-groups-desktop-mobile');
+// (b) Nested annotation frame is NOT a page.
+$assert(! in_array('frame:home-annotation', $multiPageFrameIds, true), 'multi-page-nested-frame-not-a-page');
+// (c) Design-system frame is excluded from pages (and reported as such).
+$assert(! in_array('frame:styleguide', $multiPageFrameIds, true), 'multi-page-design-system-excluded');
+$assert(in_array('frame:styleguide', $multiPagePlan['classification_coverage']['excluded_design_system_frame_ids'] ?? array(), true), 'multi-page-design-system-reported-excluded');
+// Oversized decorative board is excluded as a non-page.
+$assert(! in_array('frame:title-card', $multiPageFrameIds, true), 'multi-page-oversized-divider-not-a-page');
+// (d) Backward compat: no multi_page / no frame_ids → single page.
+$singlePagePlan = ( new ScenegraphPagePlanner() )->plan($multiPageSource);
+$assert(1 === ($singlePagePlan['page_count'] ?? null), 'multi-page-backward-compat-single-page-default');
+
 // Semantic HTML5 elements: a generically-named page structure maps to landmarks
 // (header/nav/main/section/footer), a font-size hierarchy maps to h1/h2, repeated
 // sibling cards map to <ul>/<li>, and a button-like control maps to <button>.


### PR DESCRIPTION
## Summary

Multi-page Figma extraction (`--multi-page --max-pages=N`, no `--frame-ids`) on a real multi-page `.fig` emitted only **one** page. This fixes `ScenegraphPagePlanner::plan()` so it emits all the real pages, with the correct WordPress front page and clean slugs — validated against the **FSE Pilot Build Theme `.fig`**, Automattic's designer litmus test for "build a block theme with parity" (epic #242, issue #280). The FSE Pilot is the acceptance fixture.

## Three core defects (proven via runtime planner probes against the FSE Pilot)

1. **Gate ignored `multi_page`.** `$includeAllPages` checked only `include_all_pages` / `frame_ids`, so a bare `--multi-page` run hit the `array_slice($ids, 0, 1)` single-page collapse *before* `max_pages` applied. The fixture matrix hid this because it always also passes `--frame-ids`.
2. **Candidates were FRAME nodes at every depth** (`candidate_count` 601). Real pages — depth-1 frames on a CANVAS — drowned in nested annotation frames ("Buttons", "Legend") and component internals.
3. **Dev-status selection misfired.** Zero real-page frames carried a Figma dev mark, but a nested decorative "Title Card" did, so the `dev_status` branch selected the marked junk. Simulating only the gate fix emitted **17 garbage frames** with not one real page (1 → 17-garbage → correct).

## Fixes

- Open the gate for `multi_page`.
- Scope page candidacy to **top-level frames**: a FRAME whose ancestor chain reaches a CANVAS (or the document root) through only transparent SECTION grouping, never through another container frame. 601 → 46 candidates. Explicit `frame_ids` bypass scoping (built on demand) so a requested frame at any depth stays selectable.
- Derive a page-sized, non-design-system **selectable pool** that drives selection, dev-status ranking, responsive detection and grouping, so off-page noise (grid guides, "Title Card" dividers, cover/device boards, and the oversized 2238px "Home Page – Desktop" overview board that collides with the real 1440px page) never becomes a page nor pollutes a real page's responsive group. Full `$candidates` is retained for `candidate_count` and classification coverage.
- **Dev-status precedence:** primary selector only when a real top-level page candidate carries a mark; marks on nested/decorative frames can no longer suppress unmarked real pages.

## Follow-up fixes (from lab verification)

4. **Front-page entrypoint.** `index.html` (the WordPress front page downstream) was assigned by selection rank order, so "Blog Post" became the homepage. The entrypoint now prefers the page classified `front_page` (explicit `entry_frame_id` still wins; falls back to rank order when no front page exists). On the FSE Pilot `index.html` is now Home Page (frame `3468:1038`).
5. **Breakpoint-free responsive slugs.** Responsive page slugs carried the widest variant's raw name (`home-page-desktop.html`, `archive-desktop.html`). They now derive from the normalized page name, dropping the breakpoint token. `normalizedPageName()` is promoted to public on `ScenegraphFrameInspector` so the planner reuses the one canonical normalization. Single-variant pages keep their own name (`mobile-menu.html`).

## FSE Pilot result (`--multi-page --max-pages=20`)

`selection_source: heuristic`, `candidate_count: 46`, `page_count: 6`:

| Path | Frame | Page | page_type | Entrypoint | Responsive (variants) |
|------|-------|------|-----------|------------|------------------------|
| `index.html` | 3468:1038 | Home Page | front_page | **YES** | Desktop 1440 + Mobile 390 |
| `blog-post.html` | 3468:1118 | Blog Post | single | no | Desktop 1440 + Mobile 390 |
| `archive.html` | 4192:10704 | Archive | archive | no | Desktop 1440 + Mobile 390 |
| `page.html` | 4194:2032 | Page | page | no | Desktop 1440 + Mobile 390 |
| `404-page.html` | 4192:11090 | 404 Page | page | no | Desktop 1440 + Mobile 390 |
| `mobile-menu.html` | 4210:11834 | Mobile Menu | unknown | no | single |

Excluded as designed: Style Guide (design-system), 7× "Title Card" dividers, "Wide layout width" guide, the duplicate 2238px "Home Page – Desktop" board, and off-canvas internal/cover frames.

## Backward compatibility

- Default single-page (no `multi_page`, no `frame_ids`) still slices to 1 (`index.html`).
- Explicit `--frame-ids=a,b` still emit exactly those frames at any depth (verified: top-level page → `index.html`, deeply nested frame → `layout.html`).
- The fixture matrix selector and the full contract suite (`php tests/contract/run.php`) pass.

## Tests

Adds/extends a contract fixture (`tests/contract/run.php`) building a synthetic CANVAS with desktop+mobile page pairs, a nested annotation frame, a style-guide frame, and an oversized divider. Asserts: one responsive page per distinct page name; nested frames are not pages; the design-system frame is excluded (and reported); the oversized divider is excluded; the `front_page` page owns the `index.html` entrypoint; responsive slugs strip the breakpoint token; and the same scenegraph without `multi_page`/`frame_ids` emits 1 page.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Diagnosis (runtime planner probes) and implementation