### PR TITLE
Flag duplicate class tokens on any element in CanonicalSaveShapeValidator

### DIFF
--- a/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
+++ b/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
@@ -31,12 +31,24 @@ namespace Automattic\BlocksEngine\PhpTransformer\WordPress;
  * dynamic blocks (`core/navigation` family, `core/icon`) are skipped: their
  * `save()` returns a ref/wrapper or is plugin-provided, so a pure-PHP shape
  * assertion would false-flag them. Those stay the editor gate's job.
+ *
+ * One invariant is asserted for every block, not just the structural wrappers:
+ * no element may carry the same class token twice. `addGeneratedClassName`,
+ * `useBlockProps.save()`, and the block supports all emit each class exactly
+ * once, so a doubled token (the historic `core/button` inner-anchor leak that
+ * merged the structural `wp-element-button` class on top of a source className
+ * that already carried it) makes the stored markup diverge from `save()` and the
+ * editor flags the block invalid. The check scans every element of each block's
+ * own `innerHTML`, so it catches duplicates on structural children the wrapper
+ * shape assertions never inspect.
  */
 final class CanonicalSaveShapeValidator
 {
     public const SCHEMA = 'blocks-engine/php-transformer/canonical-save-shape-report/v1';
 
     public const FINDING_CODE = 'canonical_save_shape_violation';
+
+    public const DUPLICATE_CLASS_TOKEN_CODE = 'duplicate_class_token';
 
     /**
      * Static core wrappers whose canonical save() shape is fully determined by
@@ -105,6 +117,12 @@ final class CanonicalSaveShapeValidator
         if ( null !== $blockName && in_array($blockName, self::TARGET_BLOCKS, true) ) {
             $this->validateWrapper($block, $blockName, $path, $findings);
         }
+
+        // The no-duplicate-class-token invariant holds for every block, not just
+        // the structural wrappers, and applies to every element in the block's
+        // own markup (the wrapper and any structural children), so it runs over
+        // innerHTML for all blocks regardless of name.
+        $this->validateNoDuplicateClassTokens($block, $blockName, $path, $findings);
 
         $innerBlocks = is_array($block['innerBlocks'] ?? null) ? array_values($block['innerBlocks']) : array();
         foreach ( $innerBlocks as $index => $innerBlock ) {
@@ -211,6 +229,55 @@ final class CanonicalSaveShapeValidator
     }
 
     /**
+     * Flag any element in the block's own markup that carries the same class
+     * token more than once. No canonical core save() path emits a class twice,
+     * so a duplicate token is always a divergence the editor rejects — whether
+     * it lands on the wrapper or on a structural child the shape assertions do
+     * not inspect.
+     *
+     * @param array<string, mixed> $block
+     * @param array<int, array<string, mixed>> $findings
+     */
+    private function validateNoDuplicateClassTokens(array $block, ?string $blockName, string $path, array &$findings): void
+    {
+        $innerHTML = is_string($block['innerHTML'] ?? null) ? $block['innerHTML'] : '';
+        if ( '' === $innerHTML || ! preg_match_all('/<[a-zA-Z][a-zA-Z0-9:-]*\b[^>]*>/', $innerHTML, $matches) ) {
+            return;
+        }
+
+        foreach ( $matches[0] as $openingTag ) {
+            $classValue = $this->attributeValue($openingTag, 'class');
+            if ( null === $classValue ) {
+                continue;
+            }
+
+            $seen       = array();
+            $duplicates = array();
+            foreach ( $this->tokens($classValue) as $token ) {
+                if ( isset($seen[$token]) ) {
+                    $duplicates[$token] = true;
+                    continue;
+                }
+                $seen[$token] = true;
+            }
+
+            if ( array() === $duplicates ) {
+                continue;
+            }
+
+            $duplicateTokens = array_keys($duplicates);
+            $this->addFinding(
+                $findings,
+                $path,
+                $blockName,
+                'Element carries duplicate class token(s) "' . implode('", "', $duplicateTokens) . '"; core save() emits each class once, so the stored markup diverges from save() and the editor flags the block invalid.',
+                array( 'reason' => 'duplicate_class_token', 'class' => $classValue, 'duplicate_tokens' => $duplicateTokens ),
+                self::DUPLICATE_CLASS_TOKEN_CODE
+            );
+        }
+    }
+
+    /**
      * A class WordPress' block supports reproduce in save() without any source
      * input: the block base class, element classes, and attribute-derived
      * support classes (alignment, color/border has-*, and is-* state/style).
@@ -256,11 +323,11 @@ final class CanonicalSaveShapeValidator
      * @param array<int, array<string, mixed>> $findings
      * @param array<string, mixed> $details
      */
-    private function addFinding(array &$findings, string $path, ?string $blockName, string $summary, array $details): void
+    private function addFinding(array &$findings, string $path, ?string $blockName, string $summary, array $details, string $code = self::FINDING_CODE): void
     {
         $findings[] = array_filter(
             array(
-                'code'       => self::FINDING_CODE,
+                'code'       => $code,
                 'severity'   => 'warning',
                 'category'   => 'wp_block_validity',
                 'path'       => $path,

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -543,6 +543,39 @@ $invalidBlockLevelButtonReport = ( new \Automattic\BlocksEngine\PhpTransformer\W
 $invalidBlockLevelButtonCodes = array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $invalidBlockLevelButtonReport['findings'] ?? array());
 $assert(in_array('button_block_level_link_markup', $invalidBlockLevelButtonCodes, true), 'runtime reports invalid block-level button link markup');
 
+// A doubled structural class token on the inner element (the historic core/button
+// leak that merged wp-element-button on top of a source className already carrying
+// it) makes the stored markup diverge from save(). The canonical save()-shape
+// validator must flag it as duplicate_class_token in the pure-PHP loop so the
+// regression is caught off the editor gate, even though the duplicate sits on a
+// structural child the wrapper shape assertions never inspect.
+$duplicateClassTokenButtonBlocks = array(
+    array(
+        'blockName'    => 'core/button',
+        'attrs'        => array('text' => 'Book now', 'url' => '/book'),
+        'innerBlocks'  => array(),
+        'innerHTML'    => '<div class="wp-block-button"><a class="wp-element-button wp-block-button__link has-text-color has-background wp-element-button" href="/book">Book now</a></div>',
+        'innerContent' => array('<div class="wp-block-button"><a class="wp-element-button wp-block-button__link has-text-color has-background wp-element-button" href="/book">Book now</a></div>'),
+    ),
+);
+$duplicateClassTokenReport = ( new \Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime() )->validateBlockSerialization($duplicateClassTokenButtonBlocks);
+$duplicateClassTokenCodes = array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $duplicateClassTokenReport['findings'] ?? array());
+$assert('warning' === ($duplicateClassTokenReport['status'] ?? ''), 'runtime warns on a button carrying a doubled class token');
+$assert(in_array('duplicate_class_token', $duplicateClassTokenCodes, true), 'canonical save()-shape validator flags a duplicate class token on the inner button element');
+$duplicateClassTokenFinding = null;
+foreach ( $duplicateClassTokenReport['findings'] ?? array() as $finding ) {
+    if ( 'duplicate_class_token' === ($finding['code'] ?? '') ) {
+        $duplicateClassTokenFinding = $finding;
+        break;
+    }
+}
+$assert(is_array($duplicateClassTokenFinding) && in_array('wp-element-button', $duplicateClassTokenFinding['details']['duplicate_tokens'] ?? array(), true), 'duplicate_class_token finding names the doubled wp-element-button token');
+
+// A canonical button (each class emitted once) must not be false-flagged.
+$canonicalButtonValidity = (array) ($buttonResult['source_reports']['wp_block_validity'] ?? array());
+$canonicalButtonCodes = array_map(static fn (array $finding): string => (string) ($finding['code'] ?? ''), $canonicalButtonValidity['findings'] ?? array());
+$assert(! in_array('duplicate_class_token', $canonicalButtonCodes, true), 'canonical generated buttons are not flagged for duplicate class tokens');
+
 $inlineSvgVisualWrapper = ( new HtmlTransformer() )->transform(
     '<main><section class="visual-region"><div class="map-layer"><div class="map-image" style="background-image:url(assets/map.png)"><svg><path d="M0 0h1v1z"></path></svg></div></div></section></main>'
 )->toArray();


### PR DESCRIPTION
## What
Hardens `CanonicalSaveShapeValidator` to catch duplicate class tokens on ANY element of a block (not just the wrapper), in the fast pure-PHP loop — off the editor gate.

## Context (verify-first finding)
An offloaded eval observed a `core/button` with a doubled `wp-element-button` token (editor-invalid). Deterministic investigation showed this is **NOT a trunk bug**: #296 already routes source `className` to the wrapper (inner element gets `wp-element-button` exactly once), `mergeClassNames` already de-dupes, and a probe over all 72 website fixtures finds **0 duplicate tokens**. The observed string came from a build predating #296 (version skew). No transformer fix was warranted — and none was fabricated.

## Change (the real coverage gap)
`CanonicalSaveShapeValidator` previously inspected only each block's first opening (wrapper) tag, so a duplicate token on a structural child (the exact described inner-`<a>` shape) would slip the gate. Added:
- A generic `duplicate_class_token` finding (`DUPLICATE_CLASS_TOKEN_CODE`); new `validateNoDuplicateClassTokens()` scans every element of each block's innerHTML for all block types (a duplicate token is never canonical for any element). `addFinding` generalized to take a code.
- Contract test: an inner `<a>` with `wp-element-button ... wp-element-button` is flagged; canonical generated buttons are not false-flagged.

## Verification
- `composer test` + `composer parity` green (179 parity + contracts + units + packaging). Only the two intended files changed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Deterministic disconfirmation + the validator coverage guard under human review.
