### PR TITLE
Add live-WP candidate entry to static-parity runner (deterministic, real WP DOM)

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -37,6 +37,7 @@
   "scripts": {
     "parity": "@test:parity",
     "static-parity": "php tools/static-parity/run.php",
+    "live-wp-parity": "php tools/live-wp-parity/run.php",
     "corpus-diagnostics": "php tools/corpus-diagnostics/run.php",
     "test": [
       "@test:canonical",
@@ -55,7 +56,8 @@
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/custom-block-generator.php",
       "php tests/unit/css-value-splitter.php",
-      "php tests/unit/corpus-detectors.php"
+      "php tests/unit/corpus-detectors.php",
+      "php tests/unit/live-wp-parity-runner.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/VisualParity/StaticStyleParityRunner.php
+++ b/php-transformer/src/VisualParity/StaticStyleParityRunner.php
@@ -49,8 +49,51 @@ final class StaticStyleParityRunner
         $result = $this->transformer->transform($sourceHtml, array())->toArray();
         $candidateHtml = self::candidateHtmlFromSerializedBlocks((string) ($result['serialized_blocks'] ?? ''));
 
-        $sourceProbes = $this->probe->extract($sourceHtml, $authorCss);
-        $candidateProbes = $this->probe->extract($candidateHtml, $authorCss);
+        // The render-free proxy carries the SAME author CSS to both sides so the
+        // only variable is the transformed DOM.
+        return $this->compareSourceToCandidate($sourceHtml, $candidateHtml, $authorCss, $authorCss);
+    }
+
+    /**
+     * Compare a source document against an EXTERNALLY produced candidate document.
+     *
+     * Unlike {@see compareSourceToTransform}, which builds the candidate render-free
+     * from serialized blocks, this entry accepts a candidate HTML string produced by
+     * a real WordPress render (e.g. the DOM HTML wp-codebox fetches after SSI import
+     * + activate). It runs the IDENTICAL deterministic probe + comparator so the
+     * report contract, score, and per-property diff are exactly the same shape as the
+     * render-free gate — only the candidate's provenance differs.
+     *
+     * This exercises WordPress's own block rendering + global-styles layer (the layer
+     * the render-free proxy cannot see) while staying fully deterministic: no browser,
+     * no rasterization, no network, no screenshots. The candidate's effective styling
+     * is resolved statically from whatever CSS the rendered DOM already carries
+     * (WP global-styles / block-supports / layout `<style>` blocks) plus any explicit
+     * $candidateCss the caller inlined; nothing is fetched.
+     *
+     * The source and candidate take SEPARATE CSS inputs on purpose: the source side
+     * carries the fixture's own author CSS, while the live-WP candidate must be judged
+     * solely on the styling WordPress actually emitted — feeding the source's author
+     * CSS to the candidate would mask exactly the rendering/global-styles regressions
+     * this variant exists to catch.
+     *
+     * @param string $sourceHtml    Source HTML document.
+     * @param string $candidateHtml Candidate HTML document (e.g. live-WP rendered DOM).
+     * @param string $sourceCss     Author CSS merged into the source-side cascade.
+     * @param string $candidateCss  Extra CSS merged into the candidate-side cascade.
+     *                              Defaults to empty: a self-contained rendered DOM
+     *                              already carries its own <style> blocks.
+     * @return array<string, mixed> VisualParityReportContract report (same contract
+     *                              as {@see compareSourceToTransform}).
+     */
+    public function compareSourceToCandidate(
+        string $sourceHtml,
+        string $candidateHtml,
+        string $sourceCss = '',
+        string $candidateCss = ''
+    ): array {
+        $sourceProbes = $this->probe->extract($sourceHtml, $sourceCss);
+        $candidateProbes = $this->probe->extract($candidateHtml, $candidateCss);
 
         return $this->comparator->compare($sourceProbes, $candidateProbes);
     }

--- a/php-transformer/tests/unit/live-wp-parity-runner.php
+++ b/php-transformer/tests/unit/live-wp-parity-runner.php
@@ -1,0 +1,157 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the live-WP external-candidate runner entry
+ * ({@see StaticStyleParityRunner::compareSourceToCandidate}).
+ *
+ * Plain-PHP test script in the style of tests/unit/css-value-splitter.php — no
+ * PHPUnit. The live-WP variant must:
+ *   1. Run the EXISTING deterministic comparator against an external candidate and
+ *      produce a byte-identical report across repeated runs (determinism).
+ *   2. Reduce to the render-free proxy when fed the proxy's own candidate HTML and
+ *      the same CSS on both sides (wiring proof — same comparator, same contract).
+ *   3. Name the exact diverged CSS property when WP's render emits different
+ *      effective styling than the source (the bug class this variant exists for).
+ *   4. Judge the candidate solely on its own rendered styling: the source's author
+ *      CSS must NOT leak onto the candidate side.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\StaticStyleParityRunner;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$runner = new StaticStyleParityRunner();
+
+$sourceHtml = <<<'HTML'
+<!doctype html>
+<html><head><style>
+.hero { color: #112233; font-size: 24px; text-align: center; }
+.cta  { background-color: #ff0000; border-radius: 8px; }
+</style></head>
+<body>
+  <div class="hero">Welcome aboard</div>
+  <a class="cta">Get started</a>
+</body></html>
+HTML;
+
+// A faithful "live-WP render": same content, same effective styling, but expressed
+// the way WordPress would emit it (block wrapper classes + an inline global-styles
+// <style> block carrying the same declarations). The DOM differs; the effective
+// style on the matched content does not.
+$candidateFaithful = <<<'HTML'
+<!doctype html>
+<html><head><style id="global-styles-inline-css">
+.hero { color: #112233; font-size: 24px; text-align: center; }
+.cta  { background-color: #ff0000; border-radius: 8px; }
+</style></head>
+<body>
+  <div class="wp-block-group">
+    <div class="hero">Welcome aboard</div>
+    <a class="cta">Get started</a>
+  </div>
+</body></html>
+HTML;
+
+// A regressed "live-WP render": WP's rendering layer dropped the CTA background
+// color and shifted the hero color — exactly the global-styles/block-supports
+// regression class the render-free proxy cannot see.
+$candidateRegressed = <<<'HTML'
+<!doctype html>
+<html><head><style id="global-styles-inline-css">
+.hero { color: #999999; font-size: 24px; text-align: center; }
+.cta  { border-radius: 8px; }
+</style></head>
+<body>
+  <div class="wp-block-group">
+    <div class="hero">Welcome aboard</div>
+    <a class="cta">Get started</a>
+  </div>
+</body></html>
+HTML;
+
+// ---------------------------------------------------------------------------
+// 1. Determinism: same inputs -> byte-identical report across two runs.
+// ---------------------------------------------------------------------------
+$run1 = $runner->compareSourceToCandidate($sourceHtml, $candidateRegressed);
+$run2 = $runner->compareSourceToCandidate($sourceHtml, $candidateRegressed);
+$json1 = json_encode($run1);
+$json2 = json_encode($run2);
+$assert($json1 === $json2, '1: external-candidate report is byte-identical across runs');
+
+// ---------------------------------------------------------------------------
+// 2. Wiring proof: feeding the render-free proxy's own candidate HTML through the
+//    external entry (same CSS both sides) reproduces compareSourceToTransform.
+// ---------------------------------------------------------------------------
+$proxyCss = '.hero { color: #112233; font-size: 24px; } .cta { background-color: #ff0000; }';
+$proxyReport = $runner->compareSourceToTransform($sourceHtml, $proxyCss);
+$transformResult = (new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer())
+    ->transform($sourceHtml, array())->toArray();
+$proxyCandidateHtml = StaticStyleParityRunner::candidateHtmlFromSerializedBlocks(
+    (string) ($transformResult['serialized_blocks'] ?? '')
+);
+$viaExternal = $runner->compareSourceToCandidate($sourceHtml, $proxyCandidateHtml, $proxyCss, $proxyCss);
+$assert(
+    json_encode($proxyReport) === json_encode($viaExternal),
+    '2: external entry reproduces the render-free proxy when fed the proxy candidate + same CSS'
+);
+
+// ---------------------------------------------------------------------------
+// 3. Faithful live render scores perfectly (parity == 1.0, no findings).
+// ---------------------------------------------------------------------------
+$faithful = $runner->compareSourceToCandidate($sourceHtml, $candidateFaithful);
+$faithfulScore = (float) ($faithful['parity']['score'] ?? 0.0);
+$faithfulFindings = (int) ($faithful['summary']['finding_total'] ?? -1);
+$assert($faithfulScore >= 0.999, '3: faithful live render reaches full parity', sprintf('score=%.4f', $faithfulScore));
+$assert(0 === $faithfulFindings, '3b: faithful live render yields no findings', sprintf('findings=%d', $faithfulFindings));
+
+// ---------------------------------------------------------------------------
+// 4. Regressed live render is caught and names the exact diverged properties.
+// ---------------------------------------------------------------------------
+$regressed = $runner->compareSourceToCandidate($sourceHtml, $candidateRegressed);
+$regressedScore = (float) ($regressed['parity']['score'] ?? 1.0);
+$assert($regressedScore < $faithfulScore, '4: regressed live render scores below faithful render', sprintf('regressed=%.4f faithful=%.4f', $regressedScore, $faithfulScore));
+
+$divergedProperties = array();
+foreach ( (array) ($regressed['matches'] ?? array()) as $match ) {
+    foreach ( (array) ($match['style_deltas'] ?? array()) as $delta ) {
+        $divergedProperties[(string) ($delta['property'] ?? '')] = true;
+    }
+}
+$assert(isset($divergedProperties['background-color']), '4b: dropped CTA background-color is reported as a per-property diff');
+$assert(isset($divergedProperties['color']), '4c: shifted hero color is reported as a per-property diff');
+
+// ---------------------------------------------------------------------------
+// 5. Source author CSS must NOT leak onto the candidate side. If the source's CSS
+//    were applied to the candidate, the regressed candidate (whose own <style>
+//    dropped the background) would falsely score as a match.
+// ---------------------------------------------------------------------------
+$sourceOnlyCss = '.cta { background-color: #ff0000; }';
+$leakCheck = $runner->compareSourceToCandidate($sourceHtml, $candidateRegressed, $sourceOnlyCss, '');
+$leakDiverged = array();
+foreach ( (array) ($leakCheck['matches'] ?? array()) as $match ) {
+    foreach ( (array) ($match['style_deltas'] ?? array()) as $delta ) {
+        $leakDiverged[(string) ($delta['property'] ?? '')] = true;
+    }
+}
+$assert(isset($leakDiverged['background-color']), '5: source author CSS does not leak onto the candidate side');
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "live-wp-parity runner unit tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "live-wp-parity runner unit tests: {$passes} passed\n");

--- a/php-transformer/tools/live-wp-parity/run.php
+++ b/php-transformer/tools/live-wp-parity/run.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Live-WP visual-parity gate harness.
+ *
+ * Companion to tools/static-parity/run.php. The render-free static gate builds the
+ * candidate from serialized blocks and never exercises WordPress's own block
+ * rendering + global-styles layer. This harness instead consumes a candidate HTML
+ * document produced by a REAL WordPress render — the rendered DOM HTML that
+ * wp-codebox fetches after Static Site Importer import + theme activate — and runs
+ * the IDENTICAL deterministic probe + comparator
+ * ({@see StaticStyleParityRunner::compareSourceToCandidate}).
+ *
+ * It is still pure PHP: no browser, no rasterization, no network, no screenshots.
+ * The candidate's effective styling is resolved statically from whatever CSS the
+ * rendered DOM already carries (WP global-styles / block-supports / layout <style>
+ * blocks) plus any explicit --candidate-css the caller inlined. Same inputs ->
+ * byte-identical report.
+ *
+ * Output is the same VisualParityReportContract report as the static gate, under
+ * the `live_wp` key. With --with-proxy it also computes the render-free proxy score
+ * for the same source so callers (e.g. homeboy-rigs) can surface live-WP parity
+ * alongside the render-free proxy parity and read the delta directly.
+ *
+ * Usage:
+ *   php tools/live-wp-parity/run.php --source <file> --candidate <file>
+ *       [--source-css <file>] [--candidate-css <file>]
+ *       [--with-proxy] [--json] [--fail-under <score>]
+ *
+ * Options:
+ *   --source <file>        Source HTML document (required).
+ *   --candidate <file>     Live-WP rendered DOM HTML document (required).
+ *   --source-css <file>    CSS for the source side. When omitted, author CSS is
+ *                          auto-extracted from the source's own <style> blocks and
+ *                          same-origin linked stylesheets (matching the static gate).
+ *   --candidate-css <file> Extra CSS for the candidate side. When omitted, empty —
+ *                          a self-contained rendered DOM carries its own styles.
+ *   --with-proxy           Also compute the render-free proxy score for --source and
+ *                          report the live-WP vs proxy comparison.
+ *   --json                 Emit the machine-readable JSON report to stdout.
+ *   --fail-under <s>       Exit non-zero if the live-WP score is below <s>.
+ */
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\StaticStyleParityRunner;
+
+$options = parseArguments($argv);
+
+$sourcePath = $options['source'] ?? null;
+$candidatePath = $options['candidate'] ?? null;
+if ( null === $sourcePath || null === $candidatePath ) {
+    fwrite(STDERR, "Usage: php tools/live-wp-parity/run.php --source <file> --candidate <file> [--source-css <file>] [--candidate-css <file>] [--with-proxy] [--json] [--fail-under <score>]\n");
+    exit(2);
+}
+if ( ! is_file($sourcePath) ) {
+    fwrite(STDERR, "Source file not found: {$sourcePath}\n");
+    exit(2);
+}
+if ( ! is_file($candidatePath) ) {
+    fwrite(STDERR, "Candidate file not found: {$candidatePath}\n");
+    exit(2);
+}
+
+$sourceHtml = (string) file_get_contents($sourcePath);
+$candidateHtml = (string) file_get_contents($candidatePath);
+
+$sourceCss = isset($options['source-css'])
+    ? readCssFile((string) $options['source-css'])
+    : authorCss($sourceHtml, dirname($sourcePath));
+$candidateCss = isset($options['candidate-css'])
+    ? readCssFile((string) $options['candidate-css'])
+    : '';
+
+$runner = new StaticStyleParityRunner();
+
+$liveReport = $runner->compareSourceToCandidate($sourceHtml, $candidateHtml, $sourceCss, $candidateCss);
+$liveScore = parityScore($liveReport);
+
+$report = array(
+    'schema' => 'blocks-engine/php-transformer/live-wp-parity-report/v1',
+    'source' => basename($sourcePath),
+    'candidate' => basename($candidatePath),
+    'live_wp' => $liveReport,
+);
+
+if ( isset($options['with-proxy']) ) {
+    $proxyReport = $runner->compareSourceToTransform($sourceHtml, $sourceCss);
+    $proxyScore = parityScore($proxyReport);
+    $report['render_free_proxy'] = $proxyReport;
+    $report['comparison'] = array(
+        'live_wp_score' => $liveScore,
+        'proxy_score' => $proxyScore,
+        'delta' => round($liveScore - $proxyScore, 4),
+    );
+}
+
+if ( isset($options['json']) ) {
+    $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    fwrite(STDOUT, ( false === $json ? '{}' : $json ) . "\n");
+} else {
+    fwrite(STDOUT, renderSummary($report));
+}
+
+if ( array_key_exists('fail-under', $options) ) {
+    $threshold = (float) $options['fail-under'];
+    if ( $liveScore < $threshold ) {
+        fwrite(STDERR, sprintf("\nLive-WP parity gate FAILED: score %.4f < %.4f.\n", $liveScore, $threshold));
+        exit(1);
+    }
+    fwrite(STDOUT, sprintf("\nLive-WP parity gate PASSED: score %.4f >= %.4f.\n", $liveScore, $threshold));
+}
+
+exit(0);
+
+/**
+ * @param array<int, string> $argv
+ * @return array<string, string>
+ */
+function parseArguments(array $argv): array
+{
+    $options = array();
+    $count = count($argv);
+    for ( $i = 1; $i < $count; $i++ ) {
+        $arg = $argv[$i];
+        if ( '--json' === $arg ) {
+            $options['json'] = '1';
+            continue;
+        }
+        if ( '--with-proxy' === $arg ) {
+            $options['with-proxy'] = '1';
+            continue;
+        }
+        if ( str_starts_with($arg, '--') ) {
+            $key = substr($arg, 2);
+            $value = ($i + 1 < $count && ! str_starts_with($argv[$i + 1], '--')) ? $argv[++$i] : '1';
+            $options[$key] = $value;
+        }
+    }
+
+    return $options;
+}
+
+function readCssFile(string $path): string
+{
+    return is_file($path) ? (string) file_get_contents($path) : '';
+}
+
+/**
+ * @param array<string, mixed> $report
+ */
+function parityScore(array $report): float
+{
+    $parity = is_array($report['parity'] ?? null) ? $report['parity'] : array();
+
+    return (float) ($parity['score'] ?? 0.0);
+}
+
+/**
+ * Auto-extract author CSS from a source document's own <style> blocks and
+ * same-origin linked stylesheets. Mirrors tools/static-parity/run.php so the
+ * source side is judged on identical CSS in both gates. Remote stylesheets are
+ * skipped — nothing is fetched.
+ */
+function authorCss(string $html, string $dir): string
+{
+    $css = '';
+    if ( preg_match_all('/<style\b[^>]*>(.*?)<\/style>/is', $html, $styles) ) {
+        $css .= implode("\n", $styles[1]);
+    }
+    if ( preg_match_all('/<link\b[^>]*rel=["\']stylesheet["\'][^>]*>/i', $html, $links) ) {
+        foreach ( $links[0] as $tag ) {
+            if ( ! preg_match('/href=["\']([^"\']+)["\']/i', $tag, $href) ) {
+                continue;
+            }
+            if ( preg_match('#^https?://#i', $href[1]) ) {
+                continue;
+            }
+            $path = $dir . '/' . ltrim($href[1], '/');
+            if ( is_file($path) ) {
+                $css .= "\n" . (string) file_get_contents($path);
+            }
+        }
+    }
+
+    return $css;
+}
+
+/**
+ * @param array<string, mixed> $report
+ */
+function renderSummary(array $report): string
+{
+    $live = is_array($report['live_wp'] ?? null) ? $report['live_wp'] : array();
+    $parity = is_array($live['parity'] ?? null) ? $live['parity'] : array();
+    $summary = is_array($live['summary'] ?? null) ? $live['summary'] : array();
+
+    $out = "Live-WP visual-parity gate (real WordPress render, deterministic DOM-HTML)\n";
+    $out .= str_repeat('-', 72) . "\n";
+    $out .= sprintf("source     : %s\n", (string) ($report['source'] ?? ''));
+    $out .= sprintf("candidate  : %s\n", (string) ($report['candidate'] ?? ''));
+    $out .= sprintf("status     : %s\n", (string) ($live['status'] ?? 'unknown'));
+    $out .= sprintf("score      : %.4f\n", (float) ($parity['score'] ?? 0.0));
+    $out .= sprintf("prop-parity: %.4f\n", (float) ($parity['property_parity'] ?? 0.0));
+    $out .= sprintf("coverage   : %.4f\n", (float) ($parity['coverage'] ?? 0.0));
+    $out .= sprintf(
+        "matched    : %d/%d   findings: %d\n",
+        (int) ($summary['matched_total'] ?? 0),
+        (int) ($summary['source_total'] ?? 0),
+        (int) ($summary['finding_total'] ?? 0)
+    );
+
+    if ( isset($report['comparison']) && is_array($report['comparison']) ) {
+        $cmp = $report['comparison'];
+        $out .= str_repeat('-', 72) . "\n";
+        $out .= sprintf(
+            "live-WP %.4f  vs  render-free proxy %.4f   (delta %+.4f)\n",
+            (float) ($cmp['live_wp_score'] ?? 0.0),
+            (float) ($cmp['proxy_score'] ?? 0.0),
+            (float) ($cmp['delta'] ?? 0.0)
+        );
+    }
+
+    return $out;
+}


### PR DESCRIPTION
## What
Adds a deterministic LIVE-WP variant of the static-parity gate (blocks-engine half) so the same comparator can run against REAL WordPress-rendered DOM (fetched as HTML, not screenshots), closing the gap where the render-free proxy never exercises WP block render + global-styles.

## Change
- New StaticStyleParityRunner::compareSourceToCandidate() — takes an external candidate HTML string + separate source/candidate CSS, runs the existing probe + comparator unchanged. compareSourceToTransform() delegates to it. Separate source/candidate CSS so the live-WP candidate is judged solely on WordPress-emitted styling.
- tools/live-wp-parity/run.php + composer live-wp-parity (--with-proxy emits proxy score + live-vs-proxy delta, --json, --fail-under).
- Unit test wired into composer test:unit.

## Verification
- Wiring proof: feeding the transform's own candidate reproduces the proxy score exactly (delta 0) — the external-candidate path drives the identical comparator.
- Determinism: two JSON runs byte-identical (sha256 match).
- composer test + composer parity green (182 fixtures).
- Honest limit: comparator internals untouched (coverage PR owns those); a real live-vs-proxy number on WP DOM awaits an offloaded run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Design, implementation, determinism/wiring verification under human review.