### PR TITLE
figma-transformer: stop warning on empty-path (whitespace) text glyph blobs

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1490,17 +1490,19 @@ final class ScenegraphNormalizer
                 if ( isset($glyph['commandsBlob']) ) {
                     $bytes = $this->readCommandBlobBytes($glyph['commandsBlob'], $blobs);
                     if ( null !== $bytes ) {
-                        $path = $this->decodeVectorCommandBlob($bytes);
-                        if ( null === $path ) {
+                        $decoded = $this->classifyVectorCommandBlob($bytes);
+                        if ( 'path' === $decoded['status'] ) {
+                            $glyphPath['data'] = $decoded['path'];
+                        } elseif ( 'unsupported' === $decoded['status'] ) {
                             $diagnostics[] = array(
                                 'severity' => 'warning',
                                 'code'     => 'unsupported_text_glyph_command_blob',
                                 'message'  => 'Unsupported Figma text glyph command blob was omitted from derived glyph metadata.',
                                 'context'  => array('node_id' => $nodeId, 'glyph_index' => $index),
                             );
-                        } else {
-                            $glyphPath['data'] = $path;
                         }
+                        // 'empty' blobs (e.g. whitespace glyphs encoded as a single
+                        // 0x00 byte) carry no drawable outline and are not warnings.
                     }
                 }
 
@@ -3143,6 +3145,24 @@ final class ScenegraphNormalizer
 
     private function decodeVectorCommandBlob(string $bytes): ?string
     {
+        return $this->classifyVectorCommandBlob($bytes)['path'];
+    }
+
+    /**
+     * Walk a Figma vector/glyph command blob once and classify the outcome.
+     *
+     * The status distinguishes three cases the single ?string decoder cannot:
+     *  - 'path'        the blob decoded to one or more drawable SVG commands.
+     *  - 'empty'       the blob is well-formed but draws nothing (e.g. the
+     *                  whitespace glyphs Figma emits as a single 0x00 byte).
+     *                  These are valid, not unsupported, and must not warn.
+     *  - 'unsupported' an opcode was unknown or a point ran past the blob,
+     *                  so the encoding could not be honored.
+     *
+     * @return array{status: 'path'|'empty'|'unsupported', path: ?string}
+     */
+    private function classifyVectorCommandBlob(string $bytes): array
+    {
         $offset = 0;
         $length = strlen($bytes);
         $parts = array();
@@ -3162,7 +3182,7 @@ final class ScenegraphNormalizer
             if ( 1 === $opcode || 2 === $opcode ) {
                 $point = $this->readFloatPair($bytes, $offset);
                 if ( null === $point ) {
-                    return null;
+                    return array('status' => 'unsupported', 'path' => null);
                 }
                 $parts[] = ( 1 === $opcode ? 'M ' : 'L ' ) . $this->svgNumber($point[0]) . ' ' . $this->svgNumber($point[1]);
                 $offset += 8;
@@ -3174,7 +3194,7 @@ final class ScenegraphNormalizer
                 for ( $i = 0; $i < 2; $i++ ) {
                     $point = $this->readFloatPair($bytes, $offset + ( $i * 8 ));
                     if ( null === $point ) {
-                        return null;
+                        return array('status' => 'unsupported', 'path' => null);
                     }
                     $points[] = $point;
                 }
@@ -3188,7 +3208,7 @@ final class ScenegraphNormalizer
                 for ( $i = 0; $i < 3; $i++ ) {
                     $point = $this->readFloatPair($bytes, $offset + ( $i * 8 ));
                     if ( null === $point ) {
-                        return null;
+                        return array('status' => 'unsupported', 'path' => null);
                     }
                     $points[] = $point;
                 }
@@ -3197,10 +3217,12 @@ final class ScenegraphNormalizer
                 continue;
             }
 
-            return null;
+            return array('status' => 'unsupported', 'path' => null);
         }
 
-        return empty($parts) ? null : implode(' ', $parts);
+        return empty($parts)
+            ? array('status' => 'empty', 'path' => null)
+            : array('status' => 'path', 'path' => implode(' ', $parts));
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2794,6 +2794,61 @@ $assert(array('text:unsupported-glyph-a', 'text:unsupported-glyph-b') === ($unsu
 $assert(str_contains($fileContent($unsupportedGlyphResult, 'index.html'), 'Unsupported glyph A'), 'unsupported-glyph-diagnostics-preserve-text-a');
 $assert(str_contains($fileContent($unsupportedGlyphResult, 'index.html'), 'Unsupported glyph B'), 'unsupported-glyph-diagnostics-preserve-text-b');
 
+// Whitespace glyphs are emitted by Figma as a single 0x00 (empty-path) command
+// blob: well-formed, but carrying no drawable outline. These are valid, not
+// unsupported, and must NOT raise unsupported_text_glyph_command_blob warnings
+// (the FSE Pilot footer text "Proudly powered by WordPress.com" produced
+// thousands of these false-positive warnings before this gate).
+$emptyGlyphCommandBlob = chr(0);
+$whitespaceGlyphScenegraph = array(
+    'name'  => 'Whitespace Glyph Empty-Path Fixture',
+    'blobs' => array(
+        array('bytes' => $quadraticCommandBlob),
+        array('bytes' => $emptyGlyphCommandBlob),
+    ),
+    'nodes' => array(
+        array(
+            'id'              => 'text:whitespace-glyph',
+            'type'            => 'TEXT',
+            'name'            => 'Measured Whitespace Text',
+            'characters'      => 'A B',
+            'width'           => 146.5,
+            'height'          => 32.25,
+            'fontSize'        => 10,
+            'fontName'        => array('family' => 'Example Sans', 'style' => 'Regular'),
+            'derivedTextData' => array(
+                'layoutSize' => array('x' => 146.5, 'y' => 32.25),
+                'glyphs' => array(
+                    array('firstCharacter' => 0, 'advance' => 0.5, 'fontSize' => 10, 'x' => 2, 'y' => 3, 'commandsBlob' => 0),
+                    array('firstCharacter' => 1, 'advance' => 0.5, 'fontSize' => 10, 'commandsBlob' => 1),
+                    array('firstCharacter' => 2, 'advance' => 0.5, 'fontSize' => 10, 'commandsBlob' => 0),
+                ),
+            ),
+        ),
+    ),
+);
+$whitespaceGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($whitespaceGlyphScenegraph);
+$whitespaceGlyphDiagnostics = array_values(array_filter(
+    $whitespaceGlyphResult['diagnostics'] ?? array(),
+    static fn (array $diagnostic): bool => 'unsupported_text_glyph_command_blob' === ($diagnostic['code'] ?? null)
+));
+$assert(0 === count($whitespaceGlyphDiagnostics), 'whitespace-glyph-empty-path-no-warning');
+$assert(str_contains($fileContent($whitespaceGlyphResult, 'index.html'), 'A B'), 'whitespace-glyph-preserves-text');
+$whitespaceGlyphVisualNodes = $whitespaceGlyphResult['source_reports']['figma']['html']['visual_node_map'] ?? array();
+$whitespaceGlyphVisualNode = null;
+foreach ( is_array($whitespaceGlyphVisualNodes) ? $whitespaceGlyphVisualNodes : array() as $visualNode ) {
+    if ( is_array($visualNode) && 'text:whitespace-glyph' === ($visualNode['id'] ?? null) ) {
+        $whitespaceGlyphVisualNode = $visualNode;
+        break;
+    }
+}
+$whitespaceGlyphPaths = $whitespaceGlyphVisualNode['text']['derived_layout']['glyph_paths'] ?? array();
+$whitespaceGlyphPathData = array_values(array_filter(array_map(
+    static fn ($glyphPath): ?string => is_array($glyphPath) && isset($glyphPath['data']) ? (string) $glyphPath['data'] : null,
+    is_array($whitespaceGlyphPaths) ? $whitespaceGlyphPaths : array()
+)));
+$assert(array('M 0 0 Q 4 8 8 0 Z', 'M 0 0 Q 4 8 8 0 Z') === $whitespaceGlyphPathData, 'whitespace-glyph-keeps-drawable-paths-only');
+
 $derivedTextGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($derivedTextLayoutScenegraph, array('render_text_glyph_paths' => true));
 $derivedTextGlyphHtml = $fileContent($derivedTextGlyphResult, 'index.html');
 $derivedTextGlyphCss = $fileContent($derivedTextGlyphResult, 'style.css');


### PR DESCRIPTION
## Summary

The `unsupported_text_glyph_command_blob` diagnostic was a **100% false positive**. Figma encodes whitespace glyphs (the spaces in text runs) as a single `0x00` command blob — a well-formed but *empty* path with no drawable outline. `decodeVectorCommandBlob()` collapses both that valid empty case and genuinely unsupported encodings into `null`, so the glyph-derivation loop in `ScenegraphNormalizer` raised a warning for every space character.

### Investigation (FSE Pilot `.fig`)
Decoded the FSE Pilot fixture and replicated the decoder against the real nodes:
- 380 text nodes "affected", **29,797** warnings.
- Every single failing glyph blob decoded with reason `empty_path` — a single `0x00` byte. **2,821 of 2,822** raw failures are the space character `" "`; the one other is a `U+FE0F` variation selector. **Zero** `bad_opcode` or `truncated_float` failures.
- The readable `characters` string is **always present** (`textData.characters` — e.g. `"Proudly powered by WordPress.com "`, `"Privacy Policy"`, `"Color Name"`). Text renders as normal DOM text (default `render_text_glyph_paths=false`), so this **never affected visual parity** — it was diagnostic noise masking any real unsupported-blob signal.

### Fix
Classify a command blob once into `path` / `empty` / `unsupported` and only warn on `unsupported`. Empty blobs are skipped silently; drawable glyph paths are still derived for SVG glyph rendering. `decodeVectorCommandBlob()` keeps its `?string` contract for the vector-geometry callers.

### Validation
- `php tests/contract/run.php` — all green, including a new fixture proving empty-path (whitespace) glyphs emit **zero** warnings, preserve text, and keep only the drawable glyph paths.
- Re-ran the FSE Pilot transform with this branch: `unsupported_text_glyph_command_blob` count **29,797 → 0** (total normalizer diagnostics 1 → 0).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Investigation (decoding the fixture, categorizing failures), the fix, and the contract fixture.