### PR TITLE
figma-transformer: split multi-paragraph text so paragraphSpacing renders

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -635,7 +635,17 @@ final class StaticHtmlEmitter
         $name = (string) ($node['name'] ?? '');
         $attributeName = $this->sanitizeAttribute($name);
         $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
-        $text = 'TEXT' === $type ? ( $this->textGlyphSvg($node) ?? $this->textContent($node) ) : $this->textContent($node);
+        if ( 'TEXT' === $type ) {
+            $text = $this->textGlyphSvg($node);
+            if ( null === $text ) {
+                // Multi-paragraph text splits into per-paragraph boxes so
+                // `paragraphSpacing` lands as a margin; otherwise render the node
+                // as a single element.
+                $text = $this->multiParagraphTextContent($node) ?? $this->textContent($node);
+            }
+        } else {
+            $text = $this->textContent($node);
+        }
         $tag = $this->semanticTag($node, $type, $name, $depth, $parentNode);
         $className = 'figma-node-' . $this->slug($id . '-' . $name);
         $children = $this->nodeList($node);
@@ -3605,13 +3615,7 @@ final class StaticHtmlEmitter
                     continue;
                 }
 
-                $segmentStyles = is_array($segment['style'] ?? null) ? $this->textStyleDeclarations($segment['style']) : array();
-                if ( empty($segmentStyles) ) {
-                    $content .= $this->sanitizeText($segmentText);
-                    continue;
-                }
-
-                $content .= '<span style="' . $this->sanitizeAttribute(implode(';', $segmentStyles)) . '">' . $this->sanitizeText($segmentText) . '</span>';
+                $content .= $this->segmentRunHtml($segmentText, is_array($segment['style'] ?? null) ? $segment['style'] : null);
             }
 
             if ( '' !== $content ) {
@@ -3634,6 +3638,175 @@ final class StaticHtmlEmitter
         }
 
         return $this->sanitizeText($characters);
+    }
+
+    /**
+     * Renders a single styled text run, wrapping it in a minimal `<span style>`
+     * only when the run carries overriding style declarations. Mirrors the inline
+     * segment rendering in {@see textContent} so per-character override spans
+     * (color/weight/etc.) emit identically whether the text node is a single
+     * element or split into per-paragraph boxes.
+     *
+     * @param array<string, mixed>|null $style
+     */
+    private function segmentRunHtml(string $characters, ?array $style): string
+    {
+        if ( '' === $characters ) {
+            return '';
+        }
+
+        $segmentStyles = is_array($style) ? $this->textStyleDeclarations($style) : array();
+        if ( empty($segmentStyles) ) {
+            return $this->sanitizeText($characters);
+        }
+
+        return '<span style="' . $this->sanitizeAttribute(implode(';', $segmentStyles)) . '">' . $this->sanitizeText($characters) . '</span>';
+    }
+
+    /**
+     * Splits a text node into per-paragraph buckets of styled runs.
+     *
+     * Figma encodes a hard paragraph break (the Enter key, the boundary
+     * `paragraphSpacing` applies between) as a `\n` in the node's characters.
+     * Soft line wraps are not present in the source characters — they are
+     * recovered separately as derived baselines — so this split keys only on the
+     * real `\n` separators and never treats a wrapped line as a paragraph.
+     *
+     * Each bucket is an ordered list of `['characters' => string, 'style' =>
+     * ?array]` runs. When a styled run straddles a `\n` it is divided at the
+     * break and the same style is carried into both paragraphs, so per-character
+     * override spans land in the correct paragraph. Leading/trailing empty
+     * paragraphs (from a stray boundary `\n`) are dropped; interior blank
+     * paragraphs are preserved.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, array<int, array{characters: string, style: array<string, mixed>|null}>>
+     */
+    private function paragraphBuckets(array $node): array
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $segments = is_array($text['segments'] ?? null) ? $text['segments'] : array();
+
+        $runs = array();
+        foreach ( $segments as $segment ) {
+            if ( ! is_array($segment) ) {
+                continue;
+            }
+            $segmentText = (string) ($segment['characters'] ?? '');
+            if ( '' === $segmentText ) {
+                continue;
+            }
+            $runs[] = array(
+                'characters' => $segmentText,
+                'style'      => is_array($segment['style'] ?? null) ? $segment['style'] : null,
+            );
+        }
+
+        if ( empty($runs) ) {
+            $characters = isset($text['characters']) && is_scalar($text['characters'])
+                ? (string) $text['characters']
+                : (string) ($node['characters'] ?? $node['text'] ?? '');
+            if ( '' === $characters || $this->isUnresolvedComponentPlaceholderText($node, $characters) ) {
+                return array();
+            }
+            $runs[] = array('characters' => $characters, 'style' => null);
+        }
+
+        $paragraphs = array(array());
+        foreach ( $runs as $run ) {
+            $parts = explode("\n", (string) $run['characters']);
+            foreach ( $parts as $index => $part ) {
+                if ( $index > 0 ) {
+                    $paragraphs[] = array();
+                }
+                if ( '' !== $part ) {
+                    $paragraphs[count($paragraphs) - 1][] = array(
+                        'characters' => $part,
+                        'style'      => $run['style'],
+                    );
+                }
+            }
+        }
+
+        // Drop empty paragraphs at the head and tail (a stray boundary newline),
+        // while keeping interior blank paragraphs that carry a real blank line.
+        while ( ! empty($paragraphs) && empty($paragraphs[0]) ) {
+            array_shift($paragraphs);
+        }
+        while ( ! empty($paragraphs) && empty($paragraphs[count($paragraphs) - 1]) ) {
+            array_pop($paragraphs);
+        }
+
+        return array_values($paragraphs);
+    }
+
+    /**
+     * Whether a text node carries real paragraph spacing that can be rendered by
+     * splitting it into separate per-paragraph boxes.
+     *
+     * Requires a positive `paragraphSpacing` and at least two real paragraphs
+     * (`\n`-separated). Glyph-rendered text has no paragraph boxes to carry a
+     * margin, so it is excluded and reported via {@see paragraphSpacingDiagnostic}.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function shouldSplitParagraphs(array $node): bool
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $style = is_array($text['style'] ?? null) ? $text['style'] : array();
+        if ( ! isset($style['paragraph_spacing']) || ! is_numeric($style['paragraph_spacing']) || 0.0 >= (float) $style['paragraph_spacing'] ) {
+            return false;
+        }
+
+        if ( null !== $this->textGlyphSvg($node) ) {
+            return false;
+        }
+
+        return count($this->paragraphBuckets($node)) >= 2;
+    }
+
+    /**
+     * Renders a multi-paragraph text node as one block element per paragraph so
+     * Figma `paragraphSpacing` lands as a real `margin-bottom` between paragraphs.
+     *
+     * Each paragraph is a block-level `<span>` (valid inside the node's `<p>` /
+     * heading container) and carries the spacing as `margin-bottom` on every
+     * paragraph except the last. Inline override spans are preserved within each
+     * paragraph via {@see segmentRunHtml}. Returns null when the node is not a
+     * splittable multi-paragraph node, so the caller falls back to {@see
+     * textContent}.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function multiParagraphTextContent(array $node): ?string
+    {
+        if ( ! $this->shouldSplitParagraphs($node) ) {
+            return null;
+        }
+
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $style = is_array($text['style'] ?? null) ? $text['style'] : array();
+        $spacing = (float) $style['paragraph_spacing'];
+
+        $paragraphs = $this->paragraphBuckets($node);
+        $last = count($paragraphs) - 1;
+
+        $html = '';
+        foreach ( $paragraphs as $index => $runs ) {
+            $inner = '';
+            foreach ( $runs as $run ) {
+                $inner .= $this->segmentRunHtml((string) $run['characters'], $run['style']);
+            }
+
+            $styles = array('display:block');
+            if ( $index < $last ) {
+                $styles[] = 'margin-bottom:' . $this->number($spacing) . 'px';
+            }
+
+            $html .= '<span style="' . $this->sanitizeAttribute(implode(';', $styles)) . '">' . $inner . '</span>';
+        }
+
+        return '' === $html ? null : $html;
     }
 
     /**
@@ -3830,7 +4003,7 @@ final class StaticHtmlEmitter
             ));
             $styles[] = 'line-height:' . $this->number($derivedLineHeight) . 'px';
         }
-        if ( $this->textHasLineBreaks($node) || $this->textHasDerivedLineBreaks($node) ) {
+        if ( ( $this->textHasLineBreaks($node) || $this->textHasDerivedLineBreaks($node) ) && ! $this->shouldSplitParagraphs($node) ) {
             $styles[] = 'white-space:pre-line';
         }
 
@@ -3838,13 +4011,15 @@ final class StaticHtmlEmitter
     }
 
     /**
-     * Reports a Figma `paragraphSpacing` value that cannot be applied as CSS.
+     * Reports a Figma `paragraphSpacing` value that genuinely cannot be applied.
      *
-     * Multi-paragraph text nodes are emitted as a single element with
-     * `white-space:pre-line`, so there is no per-paragraph box to carry a
-     * `margin-bottom`. When such a node carries paragraph spacing the value is
-     * surfaced as an `info` diagnostic instead of being faked into the CSS.
-     * Single-paragraph nodes are ignored because paragraph spacing has no effect.
+     * Multi-paragraph text is normally split into per-paragraph boxes that carry
+     * the spacing as `margin-bottom` ({@see multiParagraphTextContent}), so no
+     * diagnostic is emitted in that case. The value is only surfaced as an `info`
+     * diagnostic when the node has multiple real paragraphs but cannot be split —
+     * for example glyph-rendered text, which has no paragraph boxes to carry a
+     * margin. Single-paragraph nodes (including soft-wrap-only text) are ignored
+     * because paragraph spacing has no paragraph boundary to apply between.
      *
      * @param array<string, mixed> $node
      * @return array<string, mixed>|null
@@ -3857,14 +4032,21 @@ final class StaticHtmlEmitter
             return null;
         }
 
-        if ( ! $this->textHasLineBreaks($node) && ! $this->textHasDerivedLineBreaks($node) ) {
+        // Spacing is actually applied as per-paragraph margins — nothing to report.
+        if ( $this->shouldSplitParagraphs($node) ) {
+            return null;
+        }
+
+        // Only a node with multiple real paragraphs that could not be split is a
+        // genuine "not applied" case. Single-paragraph text has no boundary.
+        if ( count($this->paragraphBuckets($node)) < 2 ) {
             return null;
         }
 
         return array(
             'severity' => 'info',
             'code'     => 'paragraph_spacing_not_applied',
-            'message'  => 'Figma paragraphSpacing cannot be applied to a single-element text node rendered with white-space:pre-line; the value is reported but not emitted as CSS.',
+            'message'  => 'Figma paragraphSpacing could not be applied: this multi-paragraph text node cannot be split into per-paragraph boxes (for example glyph-rendered text); the value is reported but not emitted as CSS.',
             'context'  => array(
                 'node_id'           => (string) ($node['id'] ?? ''),
                 'paragraph_spacing' => (float) $style['paragraph_spacing'],

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4317,7 +4317,15 @@ $assert(str_contains($textCaseCss, '.figma-node-tc-2-upper-text{position:absolut
 $assert(str_contains($textCaseCss, 'text-transform:lowercase'), 'text-case-lower-text-transform');
 $assert(str_contains($textCaseCss, 'text-transform:capitalize'), 'text-case-title-text-transform');
 $assert(str_contains($textCaseCss, '.figma-node-tc-5-small-caps-forced-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px;text-transform:uppercase;font-variant:small-caps}'), 'text-case-small-caps-forced');
-$assert(str_contains($textCaseCss, '.figma-node-tc-6-original-case-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px}'), 'text-case-original-no-transform');
+// ORIGINAL text case emits no text-transform. With paragraphSpacing now applied
+// by splitting (no white-space:pre-line), tc:7's box style matches tc:6's, so the
+// emitter dedupes them into one shared rule — assert on the un-transformed
+// declaration body and that tc:6 carries no transform-bearing rule of its own.
+$assert(str_contains($textCaseCss, '{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px}'), 'text-case-original-no-transform');
+$assert(! str_contains($textCaseCss, '.figma-node-tc-6-original-case-text{'), 'text-case-original-deduped-into-shared-rule');
+// `paragraphSpacing` is now applied by splitting the multi-paragraph node into
+// per-paragraph boxes (completing the path started in #318), so the
+// `paragraph_spacing_not_applied` diagnostic must no longer fire for tc:7.
 $textCaseParagraphDiagnostic = null;
 foreach ( $textCaseResult['diagnostics'] ?? array() as $diagnostic ) {
     if ( 'paragraph_spacing_not_applied' === ($diagnostic['code'] ?? null) ) {
@@ -4325,10 +4333,15 @@ foreach ( $textCaseResult['diagnostics'] ?? array() as $diagnostic ) {
         break;
     }
 }
-$assert(null !== $textCaseParagraphDiagnostic, 'paragraph-spacing-diagnostic-present');
-$assert('tc:7' === ($textCaseParagraphDiagnostic['context']['node_id'] ?? null), 'paragraph-spacing-diagnostic-node-id');
-$assert(24.0 === ($textCaseParagraphDiagnostic['context']['paragraph_spacing'] ?? null), 'paragraph-spacing-diagnostic-value');
+$assert(null === $textCaseParagraphDiagnostic, 'paragraph-spacing-diagnostic-dropped-when-applied');
 $assert(! str_contains($textCaseCss, 'paragraph-spacing') && ! str_contains($textCaseCss, 'paragraph_spacing'), 'paragraph-spacing-not-emitted-as-css');
+
+// The two paragraphs render as separate block boxes; the first carries the
+// 24px paragraph spacing as a margin-bottom, the last carries none. The split
+// node also drops the single-element white-space:pre-line fallback.
+$textCaseHtml = $fileContent($textCaseResult, 'index.html');
+$assert(str_contains($textCaseHtml, '<span style="display:block;margin-bottom:24px">First paragraph.</span><span style="display:block">Second paragraph.</span>'), 'paragraph-spacing-split-into-margin-boxes');
+$assert(! str_contains($textCaseCss, 'white-space:pre-line'), 'paragraph-spacing-split-drops-pre-line');
 
 // Node-level blendMode → CSS mix-blend-mode. A non-default Figma blend mode
 // (MULTIPLY) must surface as `mix-blend-mode:multiply`, while the default
@@ -4448,6 +4461,72 @@ $assert(str_contains($inlineTextStyleHtml, 'Hello blue <span style="color:#0000f
 
 // Mixed-weight: only "Bold" differs in font-weight — it gets a font-weight span.
 $assert(str_contains($inlineTextStyleHtml, '<span style="font-weight:700">Bold</span> plain text'), 'inline-style-mixed-weight-spans');
+
+// Paragraph splitting must preserve inline override spans inside the correct
+// paragraph, and single-paragraph nodes must not gain a wrapper (#318 follow-up).
+//
+// "Bold intro\nplain rest" (21 chars): the first 4 characters ("Bold") map to a
+// weight-700 override, the rest to the base style. The `\n` (index 10) is the
+// paragraph boundary, so the bold span belongs to the first paragraph and only
+// the first paragraph carries the 12px margin-bottom.
+$paragraphSplitResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Paragraph Split Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'psplit:1',
+            'type'     => 'FRAME',
+            'name'     => 'Paragraph split frame',
+            'width'    => 1200,
+            'height'   => 400,
+            'children' => array(
+                // Multi-paragraph node with an inline weight override in paragraph 1.
+                array(
+                    'id'                      => 'psplit:2',
+                    'type'                    => 'TEXT',
+                    'name'                    => 'Styled multi paragraph',
+                    'characters'              => "Bold intro\nplain rest",
+                    'style'                   => array(
+                        'fontFamily'       => 'Inter',
+                        'fontWeight'       => 400,
+                        'fontSize'         => 16,
+                        'paragraphSpacing' => 12,
+                    ),
+                    'characterStyleOverrides' => array(1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+                    'styleOverrideTable'      => array(
+                        '1' => array('fontWeight' => 700),
+                    ),
+                ),
+                // Single-paragraph node that also declares paragraphSpacing: there
+                // is no paragraph boundary, so it must render exactly as before —
+                // no per-paragraph wrapper, no margin, no diagnostic.
+                array(
+                    'id'         => 'psplit:3',
+                    'type'       => 'TEXT',
+                    'name'       => 'Single paragraph spacing',
+                    'characters' => 'Only one paragraph here',
+                    'style'      => array(
+                        'fontFamily'       => 'Inter',
+                        'fontSize'         => 16,
+                        'paragraphSpacing' => 18,
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$paragraphSplitHtml = $fileContent($paragraphSplitResult, 'index.html');
+$paragraphSplitDiagnostics = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $paragraphSplitResult['diagnostics'] ?? array()
+);
+
+// The bold override span survives, nested inside the first paragraph box, and
+// the second paragraph is its own box with no margin.
+$assert(str_contains($paragraphSplitHtml, '<span style="display:block;margin-bottom:12px"><span style="font-weight:700">Bold</span> intro</span><span style="display:block">plain rest</span>'), 'paragraph-split-preserves-inline-span-in-correct-paragraph');
+
+// Single-paragraph node: no per-paragraph wrapper and no diagnostic.
+$assert(str_contains($paragraphSplitHtml, '>Only one paragraph here</p>'), 'single-paragraph-spacing-no-wrapper');
+$assert(! in_array('paragraph_spacing_not_applied', $paragraphSplitDiagnostics, true), 'single-paragraph-spacing-no-diagnostic');
 
 // Kiwi (.fig) inline style overrides (#328).
 //


### PR DESCRIPTION
## Summary

Completes the `paragraphSpacing` path started in #318. PR #318 normalized `paragraphSpacing` onto the text style and emitted a `paragraph_spacing_not_applied` info diagnostic, because the emitter rendered a multi-paragraph TEXT node as a single `white-space:pre-line` element — there was no per-paragraph box to carry a `margin-bottom`, so the normalized value had nowhere to land.

The `StaticHtmlEmitter` now splits a multi-paragraph TEXT node into one block-level `<span>` per paragraph and applies `margin-bottom:{paragraphSpacing}px` to every paragraph except the last, so the spacing renders as real CSS.

This is the figma-transformer (`.fig` → static HTML) layer only — visual parity of the static rendering. Nothing about WordPress blocks.

## Behavior

- **Paragraph boundary = real `\n`.** Paragraphs are split on the actual `\n` separators in the node characters (the hard returns `paragraphSpacing` applies between), never on soft-wrap-derived baselines. A wrapped line is not a paragraph.
- **Inline override spans preserved.** Per-character override runs (color / weight from `characterStyleOverrides`, #305/#334) are kept inside the correct paragraph by splitting a styled run at the paragraph boundary and carrying its style into both sides.
- **Block element choice.** Each paragraph is a block-level `<span style="display:block;...">`, which is valid inside the node's `<p>` / heading container (a nested `<p>`/`<div>` would be invalid HTML there) and stacks vertically with the margin between.
- **`white-space:pre-line` dropped** on split nodes — the `\n` separators are now element boundaries.
- **Diagnostic narrowed.** `paragraph_spacing_not_applied` now fires only when a node has multiple real paragraphs that genuinely cannot be split (e.g. glyph-rendered text). Single-paragraph nodes — including soft-wrap-only text that the #318 blanket diagnostic over-reported — no longer flag it, because paragraph spacing has no paragraph boundary to apply between.
- **No regression for single-paragraph or `paragraphSpacing: 0`** text: rendered exactly as before, no wrapper.

## Validation (FSE Pilot fixture, on the lab)

`paragraph_spacing_not_applied` dropped from **87 → 0**:

| | before (trunk) | after |
|---|---|---|
| `paragraph_spacing_not_applied` | 87 | 0 |

- 4 text nodes were split into per-paragraph boxes with the correct `margin-bottom` (spot-checked the emitted HTML — e.g. `<span style="display:block;margin-bottom:16px">…para 1…</span><span style="display:block">…para 2…</span>`).
- The other 83 of the original 87 were single-paragraph soft-wrapped text (derived line breaks, no hard `\n`); they correctly no longer flag, since `paragraphSpacing` has no paragraph boundary there.
- **No residual** `paragraph_spacing_not_applied` — the FSE Pilot has no glyph-rendered multi-paragraph nodes, the only un-splittable case.

## Tests

`figma-transformer/tests/contract/run.php` (all green):
- Multi-paragraph TEXT node with `paragraphSpacing` → asserts separate paragraph boxes with the right `margin-bottom` and that the split drops `white-space:pre-line`.
- Multi-paragraph node **with** an inline weight override → asserts the `<span style="font-weight:700">` survives inside the correct (first) paragraph.
- Single-paragraph node that also declares `paragraphSpacing` → asserts no wrapper and no diagnostic.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementation (emitter paragraph-splitting logic, contract tests) and lab validation.