### PR TITLE
figma-transformer: exclude orphan mobile menu/component-demo frames from page selection

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -300,6 +300,27 @@ final class ScenegraphPagePlanner
             $diagnostics[] = $groupDiagnostic;
         }
 
+        // Orphan mobile menu/component-demo exclusion: when the file has at
+        // least one real responsive desktop+mobile pair, lone mobile-width
+        // frames that never grouped with a desktop sibling AND carry a
+        // menu/nav/component-demo name AND have no recognizable page-type
+        // signal are component demos of the open-menu state — NOT pages.
+        // Explicit frame selection bypasses this filter so a requested frame
+        // is always emitted. The filter never empties the selected set (safety
+        // guard for pathological inputs where every candidate is an orphan).
+        if ( ! $explicitSelected && ! empty($responsiveGroups) ) {
+            $filtered = $this->filterOrphanMenuDemoFrames(
+                $selectedIds,
+                $pageCandidates,
+                $responsiveGroups,
+                $classifications,
+                $detectionById
+            );
+            if ( ! empty($filtered) ) {
+                $selectedIds = $filtered;
+            }
+        }
+
         // Entrypoint (index.html) assignment. The downstream php-transformer and
         // WordPress treat index.html as the FRONT PAGE, so the page classified
         // `front_page` must own it rather than whichever page merely ranked first.
@@ -1200,6 +1221,94 @@ final class ScenegraphPagePlanner
         }
 
         return $variants;
+    }
+
+    /**
+     * Remove orphan mobile-width frames that are nav/menu component demos from
+     * the selected ID list when the file has real responsive paired pages.
+     *
+     * A frame is filtered when ALL three structural signals fire:
+     *   1. It is NOT part of any responsive group (orphan — no desktop partner).
+     *   2. Its width sits in the mobile range (≤ {@see ORPHAN_MOBILE_MAX_WIDTH_PX}).
+     *   3. Its name matches the menu/nav/component-demo pattern.
+     *
+     * The file-has-responsive-pairs guard (non-empty $responsiveGroups) is
+     * checked by the caller so a mobile-only design (no desktop variants at all)
+     * never triggers the filter — there are no responsive groups to compare
+     * against, so every frame is treated as a potential page.
+     *
+     * Page_type is intentionally NOT a signal here: a nav-menu component demo
+     * with text nodes (nav links) classifies as `page` rather than `unknown`,
+     * so gating on `unknown` would silently fail to exclude the common case.
+     * The name pattern is specific enough (mobile menu / hamburger / nav drawer
+     * vocabulary) that false positives are near-impossible once the orphan +
+     * mobile-width guards have already narrowed the candidate set.
+     *
+     * @param array<int, string>                  $selectedIds
+     * @param array<string, array<string, mixed>> $pageCandidates
+     * @param array<string, array<int, string>>   $responsiveGroups  member id → ordered group
+     * @param array<string, array<string, mixed>> $classifications    unused; reserved for future expansion
+     * @param array<string, array<string, mixed>> $detectionById      unused; reserved for future expansion
+     * @return array<int, string>
+     */
+    private function filterOrphanMenuDemoFrames(
+        array $selectedIds,
+        array $pageCandidates,
+        array $responsiveGroups,
+        array $classifications,
+        array $detectionById
+    ): array {
+        return array_values(array_filter(
+            $selectedIds,
+            function (string $id) use ($pageCandidates, $responsiveGroups): bool {
+                // Signal 1: part of a responsive group → keep (it has a partner).
+                if ( isset($responsiveGroups[$id]) ) {
+                    return true;
+                }
+
+                // Signal 2: width must be mobile-range to be an orphan mobile frame.
+                $width = (float) ($pageCandidates[$id]['dimensions']['width'] ?? 0);
+                if ( $width > self::ORPHAN_MOBILE_MAX_WIDTH_PX ) {
+                    return true;
+                }
+
+                // Signal 3: name must match a menu/nav/component-demo pattern.
+                $name = (string) ($pageCandidates[$id]['node']['name'] ?? '');
+                if ( ! $this->isMenuOrComponentDemoName($name) ) {
+                    return true;
+                }
+
+                // All three signals fired: exclude as orphan menu/component demo.
+                return false;
+            }
+        ));
+    }
+
+    /**
+     * Maximum width (px) for a frame to be considered a mobile-width orphan
+     * in {@see filterOrphanMenuDemoFrames}. Covers common device widths (320,
+     * 375, 390, 414, 428, 430) with a comfortable margin above the widest
+     * production mobile width while staying well below the tablet range.
+     */
+    private const ORPHAN_MOBILE_MAX_WIDTH_PX = 500.0;
+
+    /**
+     * Whether a frame name matches a navigation menu or component-demo pattern.
+     *
+     * Matches names that describe a menu/nav UI component state (e.g. "Mobile
+     * Menu", "Mobile Nav", "Hamburger Menu", "Nav Drawer") rather than a real
+     * page. The pattern is deliberately focused on navigation-component
+     * vocabulary to avoid false positives on content pages like "Our Menu"
+     * or "Products". The other three structural signals in
+     * {@see filterOrphanMenuDemoFrames} serve as a multi-layer guard so the
+     * pattern does not need to be exhaustive.
+     */
+    private function isMenuOrComponentDemoName(string $name): bool
+    {
+        return 1 === preg_match(
+            '/\b(mobile\s+menu|mobile\s+nav(igation)?|nav(igation)?\s+menu|nav(igation)?\s+(drawer|overlay|open)|hamburger(\s+menu)?|menu\s+(open|expanded|overlay|demo|state)|mobile\s+header|mobile\s+drawer|flyout(\s+menu)?|side\s*bar\s+menu)\b/i',
+            $name
+        );
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6910,6 +6910,148 @@ $assert(! in_array('frame:title-card', $multiPageFrameIds, true), 'multi-page-ov
 $singlePagePlan = ( new ScenegraphPagePlanner() )->plan($multiPageSource);
 $assert(1 === ($singlePagePlan['page_count'] ?? null), 'multi-page-backward-compat-single-page-default');
 
+// ORPHAN MOBILE MENU EXCLUSION: when a .fig file has responsive desktop+mobile
+// page pairs AND contains an extra lone mobile-width frame whose name matches a
+// nav/menu component pattern and whose page_type is unknown, the orphan frame
+// must be excluded from page selection. The 5 real pages must be completely
+// unaffected. This is the regression that the FSE Pilot "Mobile Menu" frame
+// triggered — a component demo of the open-menu state, not a real page.
+$orphanMenuSource = array(
+    'name'  => 'FSE Pilot Orphan Menu Demo',
+    'nodes' => array(
+        array(
+            'id'       => 'canvas:fse',
+            'type'     => 'CANVAS',
+            'name'     => 'FSE Pilot',
+            'children' => array(
+                // Home Page: responsive desktop + mobile pair.
+                array(
+                    'id'       => 'frame:home-d',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home Page – Desktop',
+                    'width'    => 1440,
+                    'height'   => 3200,
+                    'children' => array(
+                        array('id' => 'home-d:hero', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                    ),
+                ),
+                array(
+                    'id'       => 'frame:home-m',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home Page – Mobile',
+                    'width'    => 390,
+                    'height'   => 5200,
+                    'children' => array(
+                        array('id' => 'home-m:hero', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                    ),
+                ),
+                // Blog Post: responsive pair.
+                array(
+                    'id'       => 'frame:blog-d',
+                    'type'     => 'FRAME',
+                    'name'     => 'Blog Post – Desktop',
+                    'width'    => 1440,
+                    'height'   => 4000,
+                    'children' => array(
+                        array('id' => 'blog-d:title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Post Title'),
+                    ),
+                ),
+                array(
+                    'id'       => 'frame:blog-m',
+                    'type'     => 'FRAME',
+                    'name'     => 'Blog Post – Mobile',
+                    'width'    => 390,
+                    'height'   => 6000,
+                    'children' => array(
+                        array('id' => 'blog-m:title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Post Title'),
+                    ),
+                ),
+                // Orphan mobile menu frame: a component demo of the open-menu
+                // state — lone mobile-width, no desktop sibling, unknown page_type.
+                // Matches the FSE Pilot node 4210:11834 "Mobile Menu" pattern.
+                array(
+                    'id'       => 'frame:mobile-menu',
+                    'type'     => 'FRAME',
+                    'name'     => 'Mobile Menu',
+                    'width'    => 390,
+                    'height'   => 844,
+                    'children' => array(
+                        array('id' => 'mm:link1', 'type' => 'TEXT', 'name' => 'Nav link', 'characters' => 'Home'),
+                        array('id' => 'mm:link2', 'type' => 'TEXT', 'name' => 'Nav link', 'characters' => 'About'),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$orphanMenuPlan = ( new ScenegraphPagePlanner() )->plan($orphanMenuSource, array('multi_page' => true, 'max_pages' => 20));
+$orphanMenuByFrame = array();
+foreach ( $orphanMenuPlan['pages'] ?? array() as $orphanMenuPage ) {
+    if ( is_array($orphanMenuPage) && isset($orphanMenuPage['frame_id']) ) {
+        $orphanMenuByFrame[(string) $orphanMenuPage['frame_id']] = $orphanMenuPage;
+    }
+}
+$orphanMenuFrameIds = array_keys($orphanMenuByFrame);
+// Real pages: the two responsive pairs must be selected.
+$assert(2 === ($orphanMenuPlan['page_count'] ?? null), 'orphan-menu-two-real-pages-selected');
+$assert(isset($orphanMenuByFrame['frame:home-d']), 'orphan-menu-home-desktop-selected');
+$assert(true === ($orphanMenuByFrame['frame:home-d']['responsive'] ?? null), 'orphan-menu-home-is-responsive');
+$assert(isset($orphanMenuByFrame['frame:blog-d']), 'orphan-menu-blog-desktop-selected');
+$assert(true === ($orphanMenuByFrame['frame:blog-d']['responsive'] ?? null), 'orphan-menu-blog-is-responsive');
+// Orphan mobile menu frame must be excluded from page selection.
+$assert(! in_array('frame:mobile-menu', $orphanMenuFrameIds, true), 'orphan-menu-mobile-menu-excluded');
+
+// REGRESSION GUARD — mobile-only site: when the file has NO responsive pairs
+// (all frames are mobile-width with no desktop counterpart), a mobile-width
+// frame with a menu-like name must NOT be excluded, because the file is a
+// genuine mobile-only design, not a file with orphan component demos.
+$mobileOnlySource = array(
+    'name'  => 'Mobile Only Site',
+    'nodes' => array(
+        array(
+            'id'       => 'canvas:mob',
+            'type'     => 'CANVAS',
+            'name'     => 'Mobile Pages',
+            'children' => array(
+                // A genuine mobile-only home page.
+                array(
+                    'id'       => 'frame:mob-home',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home',
+                    'width'    => 390,
+                    'height'   => 3200,
+                    'children' => array(
+                        array('id' => 'mob-home:hero', 'type' => 'TEXT', 'name' => 'Hero', 'characters' => 'Welcome'),
+                    ),
+                ),
+                // A genuine mobile-only page whose name contains "Mobile Menu" —
+                // must NOT be filtered because the file has no responsive pairs.
+                array(
+                    'id'       => 'frame:mob-menu',
+                    'type'     => 'FRAME',
+                    'name'     => 'Mobile Menu',
+                    'width'    => 390,
+                    'height'   => 844,
+                    'children' => array(
+                        array('id' => 'mob-menu:link', 'type' => 'TEXT', 'name' => 'Link', 'characters' => 'Home'),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+$mobileOnlyPlan = ( new ScenegraphPagePlanner() )->plan($mobileOnlySource, array('multi_page' => true, 'max_pages' => 20));
+$mobileOnlyByFrame = array();
+foreach ( $mobileOnlyPlan['pages'] ?? array() as $mobileOnlyPage ) {
+    if ( is_array($mobileOnlyPage) && isset($mobileOnlyPage['frame_id']) ) {
+        $mobileOnlyByFrame[(string) $mobileOnlyPage['frame_id']] = $mobileOnlyPage;
+    }
+}
+// Both frames must survive in a mobile-only file (no responsive pairs present).
+$assert(isset($mobileOnlyByFrame['frame:mob-home']), 'mobile-only-home-selected');
+$assert(isset($mobileOnlyByFrame['frame:mob-menu']), 'mobile-only-menu-page-not-excluded');
+$assert(2 === ($mobileOnlyPlan['page_count'] ?? null), 'mobile-only-two-pages-selected');
+
 // Semantic HTML5 elements: a generically-named page structure maps to landmarks
 // (header/nav/main/section/footer), a font-size hierarchy maps to h1/h2, repeated
 // sibling cards map to <ul>/<li>, and a button-like control maps to <button>.


### PR DESCRIPTION
## Summary
- Excludes orphan mobile-width frames that match menu/nav/component-demo name patterns from page selection when the file has responsive paired pages
- Gates on 3 structural signals (file has responsive pairs + frame is orphan + mobile width + name matches regex) so it generalises without catching legitimate mobile-only pages
- Adds contract test fixtures for the new behaviour and a regression guard for mobile-only designs

## Detail

The FSE Pilot `.fig` file has a "Mobile Menu" frame (`4210:11834`, 390×844) that the page planner was emitting as `mobile-menu.html`. It is a component demo of the open-menu state, not a real page. The 5 real pages (Home/Blog Post/Archive/404/Page) each have a Desktop(1440) + Mobile(390) responsive pair; Mobile Menu is a lone mobile-width frame with no desktop partner.

**Root cause:** the frame passes the page-size gate (width 320–2048, height ≥ 700) and the classifier saw no design-system or strong page-type name signal, so it survived into page selection.

**Fix:** after responsive grouping, filter frames where all of these hold:
1. Frame is NOT in any responsive group (orphan — no desktop partner grouped with it)
2. Frame width ≤ 500 px (mobile range)
3. Frame name matches a nav/menu/component-demo regex (`mobile menu`, `mobile nav`, `hamburger`, `nav drawer`, `nav overlay`, `menu open`, `flyout menu`, `sidebar menu`, etc.)

The file-has-responsive-pairs guard (non-empty `$responsiveGroups`) prevents the filter from running at all in mobile-only designs — if there are no pairs, every frame is a candidate page. Explicit `frame_ids` bypass the filter. The filter never empties the selected set.

**Lab validation:** `homeboy ssh homeboy-lab` run over the actual FSE Pilot `.fig` with `--multi-page --max-pages=20` produces exactly:
```
/tmp/fse-m/404-page.html
/tmp/fse-m/archive.html
/tmp/fse-m/blog-post.html
/tmp/fse-m/index.html
/tmp/fse-m/page.html
```
No `mobile-menu.html`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Implementing the orphan mobile frame exclusion filter and test fixtures