### PR TITLE
figma-transformer: fix image layering, list reset, and responsive breakpoint

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -138,6 +138,7 @@ final class StaticHtmlEmitter
             'body{margin:0}',
             '.figma-root{position:relative;width:100%}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
+            'ul,ol{margin:0;padding:0;list-style:none}',
             'img{display:block;max-width:100%;height:auto}',
             'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -259,6 +260,7 @@ final class StaticHtmlEmitter
             'body{margin:0}',
             '.figma-root{position:relative;width:100%}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
+            'ul,ol{margin:0;padding:0;list-style:none}',
             'img{display:block;max-width:100%;height:auto}',
             'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',
             '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
@@ -458,10 +460,25 @@ final class StaticHtmlEmitter
         $baseStyles = array();
         $this->collectVariantNodeStyles($baseNode, 0, null, 'r', $baseStyles);
 
+        // Derive the primary (base) viewport width from the variants list so we
+        // can compute midpoint breakpoints between adjacent variant widths.
+        $primaryViewportWidth = null;
+        foreach ( $variants as $variant ) {
+            if ( is_array($variant) && true === ($variant['primary'] ?? false) && is_numeric($variant['viewport_width'] ?? null) ) {
+                $primaryViewportWidth = (float) $variant['viewport_width'];
+                break;
+            }
+        }
+
         $blocks = array();
         // Variants are ordered widest-first, so iterating in order emits the
         // narrower breakpoints later in the cascade — exactly the precedence
         // overlapping `max-width` queries need.
+        // Track the previously seen (wider) viewport width so each breakpoint
+        // keys at the midpoint between adjacent variant widths rather than at
+        // the narrow variant's own width, which would be too narrow for most
+        // browsers and phones.
+        $prevViewportWidth = $primaryViewportWidth;
         foreach ( $variants as $variant ) {
             if ( ! is_array($variant) || true === ($variant['primary'] ?? false) ) {
                 continue;
@@ -478,11 +495,26 @@ final class StaticHtmlEmitter
 
             $rules = $this->breakpointDiffRules($baseStyles, $variantStyles);
             if ( empty($rules) ) {
+                $prevViewportWidth = (float) $viewportWidth;
                 continue;
             }
 
-            $blocks[] = '@media (max-width:' . $this->number((float) $viewportWidth) . 'px){'
+            // Key the breakpoint at the midpoint between this variant and its
+            // next-wider neighbour (the previous iteration, or the primary).
+            // Midpoint avoids keying at the narrow variant's own width (e.g.
+            // 390px) which would leave most desktop-resized browsers outside
+            // the mobile styles. Falls back to the variant's own width when no
+            // wider neighbour width is known.
+            if ( null !== $prevViewportWidth && $prevViewportWidth > (float) $viewportWidth ) {
+                $breakpointPx = (int) round(($prevViewportWidth + (float) $viewportWidth) / 2);
+            } else {
+                $breakpointPx = (int) round((float) $viewportWidth);
+            }
+
+            $blocks[] = '@media (max-width:' . $this->number((float) $breakpointPx) . 'px){'
                 . "\n" . implode("\n", $rules) . "\n}";
+
+            $prevViewportWidth = (float) $viewportWidth;
         }
 
         return $blocks;
@@ -2822,9 +2854,10 @@ final class StaticHtmlEmitter
             $styles[] = $style;
         }
 
-        $assetPath = $this->nodeAssetPath($node);
-        if ( null !== $assetPath ) {
-            $styles[] = 'background-image:url("' . $assetPath . '")';
+        $assetPaths = $this->nodeAssetPaths($node);
+        if ( ! empty($assetPaths) ) {
+            $urlList = implode(',', array_map(static fn (string $p): string => 'url("' . $p . '")', $assetPaths));
+            $styles[] = 'background-image:' . $urlList;
             foreach ( $this->imageBackgroundStyles($node) as $style ) {
                 $styles[] = $style;
             }
@@ -4663,6 +4696,79 @@ final class StaticHtmlEmitter
         }
 
         return null;
+    }
+
+    /**
+     * Return all image-fill asset paths for a node ordered top→bottom (Figma's
+     * topmost paint first), matching CSS background-image layer stacking order.
+     * Figma stores fills bottom→top in the array, so fills are reversed before
+     * resolution. Paints with `visible === false` are skipped. Every resolved
+     * path is marked used so its blob is emitted.
+     *
+     * When a node carries no fill-based image paints the method falls back to
+     * the legacy node-level reference (same as {@see nodeAssetPath()}) so that
+     * simple `asset_id` nodes continue to work unchanged.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function nodeAssetPaths(array $node): array
+    {
+        $paths = array();
+
+        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+            $paintCollections = array();
+            if ( is_array($node[$paintKey] ?? null) ) {
+                $paintCollections[] = $node[$paintKey];
+            }
+            if ( is_array($node['figma_paints'][$paintKey] ?? null) ) {
+                $paintCollections[] = $node['figma_paints'][$paintKey];
+            }
+
+            foreach ( $paintCollections as $paints ) {
+                // Figma stores fills bottom→top; reverse so topmost is first
+                // (CSS background-image: first url = topmost layer).
+                $orderedPaints = array_reverse(array_values($paints));
+                foreach ( $orderedPaints as $paint ) {
+                    if ( ! is_array($paint) || 'IMAGE' !== strtoupper((string) ($paint['type'] ?? '')) ) {
+                        continue;
+                    }
+                    // Honour Figma visibility flag.
+                    if ( false === ($paint['visible'] ?? true) ) {
+                        continue;
+                    }
+
+                    foreach ( array('ref', 'imageRef', 'imageHash', 'asset_id', 'image_ref') as $key ) {
+                        if ( ! isset($paint[$key]) || ! is_scalar($paint[$key]) || '' === (string) $paint[$key] ) {
+                            continue;
+                        }
+                        $assetId = (string) $paint[$key];
+                        if ( isset($this->assetsById[$assetId]) ) {
+                            $p = (string) $this->assetsById[$assetId]['path'];
+                            $this->usedAssetPaths[$p] = true;
+                            $paths[] = $p;
+                            break;
+                        }
+                        $slugged = $this->slug($assetId);
+                        if ( isset($this->assetsById[$slugged]) ) {
+                            $p = (string) $this->assetsById[$slugged]['path'];
+                            $this->usedAssetPaths[$p] = true;
+                            $paths[] = $p;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if ( ! empty($paths) ) {
+            return array_values(array_unique($paths));
+        }
+
+        // Fallback: node-level asset reference (e.g. explicit `asset_id` key
+        // not expressed as a fill paint).
+        $fallbackPath = $this->nodeAssetPath($node);
+        return null !== $fallbackPath ? array($fallbackPath) : array();
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2084,22 +2084,26 @@ foreach ( $responsiveEmitResult['files'] ?? array() as $responsiveEmitFile ) {
 }
 $assert('success' === ($responsiveEmitResult['status'] ?? null), 'responsive-emit-status-success');
 $assert('' !== $responsiveEmitCss, 'responsive-emit-stylesheet-present');
-// Two narrower breakpoints => exactly two media blocks at the variant widths.
+// Two narrower breakpoints => exactly two media blocks, keyed at the MIDPOINT
+// between adjacent variant widths (not the narrow variant's own width).
+// desktop=1440, tablet=834, mobile=390:
+//   tablet breakpoint = round((1440+834)/2) = 1137
+//   mobile breakpoint = round((834+390)/2)  = 612
 $assert(2 === substr_count($responsiveEmitCss, '@media'), 'responsive-emit-two-media-blocks');
-$assert(str_contains($responsiveEmitCss, '@media (max-width:834px){'), 'responsive-emit-tablet-media-query');
-$assert(str_contains($responsiveEmitCss, '@media (max-width:390px){'), 'responsive-emit-mobile-media-query');
+$assert(str_contains($responsiveEmitCss, '@media (max-width:1137px){'), 'responsive-emit-tablet-media-query');
+$assert(str_contains($responsiveEmitCss, '@media (max-width:612px){'), 'responsive-emit-mobile-media-query');
 // Base layout uses the primary (desktop) variant styles, emitted before media.
 $responsiveEmitBasePos = strpos($responsiveEmitCss, '.figma-node-card-desktop-hero-card{width:1200px;height:400px;background:#ff0000}');
 $assert(false !== $responsiveEmitBasePos, 'responsive-emit-base-uses-primary-variant');
 $responsiveEmitFirstMediaPos = strpos($responsiveEmitCss, '@media');
 $assert(false !== $responsiveEmitFirstMediaPos && $responsiveEmitBasePos < $responsiveEmitFirstMediaPos, 'responsive-emit-base-precedes-media');
 // Narrower-wins cascade: tablet block precedes mobile block.
-$assert(strpos($responsiveEmitCss, '@media (max-width:834px)') < strpos($responsiveEmitCss, '@media (max-width:390px)'), 'responsive-emit-cascade-widest-first');
+$assert(strpos($responsiveEmitCss, '@media (max-width:1137px)') < strpos($responsiveEmitCss, '@media (max-width:612px)'), 'responsive-emit-cascade-widest-first');
 // Media blocks override on the BASE class names, carrying only changed props.
-$responsiveEmitTabletBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:834px)'), strpos($responsiveEmitCss, '@media (max-width:390px)') - strpos($responsiveEmitCss, '@media (max-width:834px)'));
+$responsiveEmitTabletBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:1137px)'), strpos($responsiveEmitCss, '@media (max-width:612px)') - strpos($responsiveEmitCss, '@media (max-width:1137px)'));
 $assert(str_contains($responsiveEmitTabletBlock, '.figma-node-card-desktop-hero-card{width:700px}'), 'responsive-emit-tablet-card-width-diff-only');
 $assert(! str_contains($responsiveEmitTabletBlock, 'background:'), 'responsive-emit-tablet-omits-unchanged-background');
-$responsiveEmitMobileBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:390px)'));
+$responsiveEmitMobileBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:612px)'));
 $assert(str_contains($responsiveEmitMobileBlock, '.figma-node-card-desktop-hero-card{width:350px;height:500px;background:#00ff00}'), 'responsive-emit-mobile-card-diffs-width-height-background');
 // The single-variant About page contributes NO media override for its nodes.
 $assert(0 === preg_match('/@media[^@]*figma-node-card-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-no-media');
@@ -2537,8 +2541,9 @@ $assert(str_contains($responsiveLiveStyle, '.figma-root'), 'responsive-live-base
 $assert(str_contains($responsiveLiveStyle, 'width:1200px') || str_contains($responsiveLiveStyle, 'width:1200px;'), 'responsive-live-base-uses-desktop-width');
 // The merged stylesheet carries an `@media` block (the mobile breakpoint),
 // proving the responsive emission fired through the LIVE transform path.
+// desktop=1440, mobile=390: midpoint = round((1440+390)/2) = 915.
 $assert(str_contains($responsiveLiveStyle, '@media'), 'responsive-live-media-block-present');
-$assert(str_contains($responsiveLiveStyle, '@media (max-width:390px)'), 'responsive-live-mobile-media-query');
+$assert(str_contains($responsiveLiveStyle, '@media (max-width:915px)'), 'responsive-live-mobile-media-query');
 // `@media` block survived chunk merging intact (balanced braces, base before media).
 $assert(strpos($responsiveLiveStyle, '.figma-root') < strpos($responsiveLiveStyle, '@media'), 'responsive-live-base-precedes-media');
 $assert(substr_count($responsiveLiveStyle, '{') === substr_count($responsiveLiveStyle, '}'), 'responsive-live-balanced-braces');
@@ -7528,6 +7533,155 @@ $assert('success' === ($counterSpacingResult['status'] ?? null), 'counter-spacin
 $assert(str_contains($counterSpacingCss, 'flex-wrap:wrap'), 'counter-spacing-wraps');
 $assert(str_contains($counterSpacingCss, 'gap:12px 24px'), 'counter-spacing-emits-two-value-gap');
 $assert(! str_contains($counterSpacingCss, 'gap:24px'), 'counter-spacing-not-single-value-gap');
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PARITY FIX 1 — Multi-layer image fills: comma-separated background-image,
+// topmost Figma paint first, matching CSS stacking order.
+// A node with two IMAGE fills should emit both paths as a comma-separated
+// background-image list, with the topmost (last in the fills array) first.
+// ──────────────────────────────────────────────────────────────────────────────
+$multiLayerImageResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'   => 'Multi-Layer Image Fixture',
+    'assets' => array(
+        'placeholder-id' => array(
+            'name'      => 'placeholder.png',
+            'mime_type' => 'image/png',
+            'content'   => 'placeholder bytes',
+        ),
+        'real-photo-id' => array(
+            'name'      => 'real-photo.png',
+            'mime_type' => 'image/png',
+            'content'   => 'real photo bytes',
+        ),
+    ),
+    'nodes' => array(
+        array(
+            'id'     => 'multi:card',
+            'type'   => 'RECTANGLE',
+            'name'   => 'Photo Card',
+            'width'  => 400,
+            'height' => 300,
+            // fills[0] = bottom layer (placeholder), fills[1] = topmost (real photo).
+            // Figma stores fills bottom→top; CSS background-image is top→bottom.
+            'fills' => array(
+                array('type' => 'IMAGE', 'ref' => 'placeholder-id'),
+                array('type' => 'IMAGE', 'ref' => 'real-photo-id'),
+            ),
+        ),
+    ),
+));
+$multiLayerImageCss = $fileContent($multiLayerImageResult, 'style.css');
+$assert('success' === ($multiLayerImageResult['status'] ?? null), 'multi-layer-image-transform-success');
+// Both asset blobs must be emitted (both marked used).
+$assert(2 === ($multiLayerImageResult['metrics']['asset_count'] ?? null), 'multi-layer-image-both-assets-emitted');
+// The CSS must carry a comma-separated background-image, topmost fill first.
+// Asset names like "real-photo.png" are slugified to "real-photo-png.png" by
+// the path normalizer (dots become dashes, then extension is re-appended).
+$assert(
+    str_contains($multiLayerImageCss, 'background-image:url("assets/real-photo-png.png"),url("assets/placeholder-png.png")'),
+    'multi-layer-image-comma-separated-topmost-first'
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PARITY FIX 2 — ul/ol CSS reset present in BOTH emit() and emitSite() paths.
+// ──────────────────────────────────────────────────────────────────────────────
+// Single-page path (emit()).
+$ulResetSingleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'UL Reset Single-Page Fixture',
+    'nodes' => array(
+        array(
+            'id'   => 'ul:root',
+            'type' => 'FRAME',
+            'name' => 'Grid Root',
+            'width'  => 1440,
+            'height' => 900,
+            'children' => array(
+                array('id' => 'ul:item', 'type' => 'RECTANGLE', 'name' => 'Card', 'width' => 400, 'height' => 300),
+            ),
+        ),
+    ),
+));
+$ulResetSingleCss = $fileContent($ulResetSingleResult, 'style.css');
+$assert('success' === ($ulResetSingleResult['status'] ?? null), 'ul-reset-single-page-transform-success');
+$assert(str_contains($ulResetSingleCss, 'ul,ol{margin:0;padding:0;list-style:none}'), 'ul-reset-single-page-present');
+
+// Multi-page / emitSite() path.
+$ulResetSiteResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
+    array(
+        'name'   => 'UL Reset Site Fixture',
+        'assets' => array(),
+        'nodes'  => array(
+            array('id' => 'ulsite:frame', 'type' => 'FRAME', 'name' => 'Home Page', 'width' => 1440, 'height' => 900, 'children' => array()),
+        ),
+    ),
+    array(
+        'pages' => array(
+            array('frame_id' => 'ulsite:frame', 'name' => 'Home', 'path' => 'index.html', 'entrypoint' => true, 'variants' => array(
+                array('frame_id' => 'ulsite:frame', 'viewport_width' => 1440.0, 'primary' => true),
+            )),
+        ),
+    )
+);
+$ulResetSiteCss = '';
+foreach ( $ulResetSiteResult['files'] ?? array() as $ulResetSiteFile ) {
+    if ( is_array($ulResetSiteFile) && 'style.css' === ($ulResetSiteFile['path'] ?? null) ) {
+        $ulResetSiteCss = (string) ($ulResetSiteFile['content'] ?? '');
+    }
+}
+$assert('success' === ($ulResetSiteResult['status'] ?? null), 'ul-reset-site-path-transform-success');
+$assert(str_contains($ulResetSiteCss, 'ul,ol{margin:0;padding:0;list-style:none}'), 'ul-reset-site-path-present');
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PARITY FIX 3 — Responsive breakpoint keyed at midpoint, not variant width.
+// Two-variant case: desktop=1440, mobile=390 → midpoint = 915 (not 390).
+// ──────────────────────────────────────────────────────────────────────────────
+$midpointBreakpointResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
+    array(
+        'name'   => 'Midpoint Breakpoint Fixture',
+        'assets' => array(),
+        'nodes'  => array(
+            array(
+                'id' => 'bp:desktop', 'type' => 'FRAME', 'name' => 'Home Desktop',
+                'box' => array('width' => 1440, 'height' => 900),
+                'children' => array(
+                    array('id' => 'bp:card', 'type' => 'RECTANGLE', 'name' => 'Card', 'box' => array('width' => 1200, 'height' => 400), 'background' => '#ff0000'),
+                ),
+            ),
+            array(
+                'id' => 'bp:mobile', 'type' => 'FRAME', 'name' => 'Home Mobile',
+                'box' => array('width' => 390, 'height' => 900),
+                'children' => array(
+                    array('id' => 'bp:card-m', 'type' => 'RECTANGLE', 'name' => 'Card', 'box' => array('width' => 350, 'height' => 400), 'background' => '#ff0000'),
+                ),
+            ),
+        ),
+    ),
+    array(
+        'pages' => array(
+            array(
+                'frame_id'   => 'bp:desktop',
+                'name'       => 'Home',
+                'path'       => 'index.html',
+                'entrypoint' => true,
+                'variants'   => array(
+                    array('frame_id' => 'bp:desktop', 'viewport_width' => 1440.0, 'primary' => true),
+                    array('frame_id' => 'bp:mobile',  'viewport_width' => 390.0,  'primary' => false),
+                ),
+            ),
+        ),
+    )
+);
+$midpointBreakpointCss = '';
+foreach ( $midpointBreakpointResult['files'] ?? array() as $midpointBpFile ) {
+    if ( is_array($midpointBpFile) && 'style.css' === ($midpointBpFile['path'] ?? null) ) {
+        $midpointBreakpointCss = (string) ($midpointBpFile['content'] ?? '');
+    }
+}
+$assert('success' === ($midpointBreakpointResult['status'] ?? null), 'midpoint-breakpoint-transform-success');
+// Midpoint of 1440 and 390 = round((1440+390)/2) = 915.
+$assert(str_contains($midpointBreakpointCss, '@media (max-width:915px){'), 'midpoint-breakpoint-keyed-at-midpoint');
+// The narrow variant's own width (390) must NOT be the breakpoint.
+$assert(! str_contains($midpointBreakpointCss, '@media (max-width:390px){'), 'midpoint-breakpoint-not-variant-own-width');
 
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");


### PR DESCRIPTION
Three root-caused, deterministic HTML emitter parity fixes, all in \`StaticHtmlEmitter.php\`. Validated against the real FSE Pilot \`.fig\` on homeboy-lab.

## Summary

**FIX 1 — Image fills: emit ALL layers as comma-separated \`background-image\`, topmost first**

Root cause: \`nodeAssetPath()\` returned \`fills[0]\` (the bottom-most = inherited component-master placeholder \`Group 4.png\`/hash \`db7b…\`), dropping ~29 of 31 real per-card images on the FSE Pilot. Figma stores fills bottom→top in the array; the visible image is the topmost (last) fill. Figma's own "copy as code" for this file confirms comma-separated layering with the real image first:
\`\`\`css
background: url(DALL·E 2023-12-27 09.52.png), url(image.png), url(Group 4.png);
\`\`\`
Fix: added \`nodeAssetPaths()\` which reverses the fills array before resolution (topmost fill → first CSS layer), honours \`visible:false\`, and marks every resolved path used so its blob is emitted. Lab: **2 distinct PNGs → 26**.

**FIX 2 — \`ul,ol\` CSS reset missing from base stylesheet**

Root cause: the emitter renders post grids as \`<ul>/<li>\` but the reset arrays in both \`emit()\` (~line 144) and \`emitSite()\` (~line 265) had no list normalization. The browser UA applied \`padding-inline-start:40px; margin-block:16px; list-style:disc\`, shifting every grid 40px right, adding stray bullets, and collapsing the 3-column query-loop (3×376 + 2×44 gap = 1216px) to 2 columns because the 40px indent consumed the remaining row width.
Fix: add \`ul,ol{margin:0;padding:0;list-style:none}\` to both reset arrays.

**FIX 3 — Responsive \`@media\` breakpoint keyed at variant's own width, not midpoint**

Root cause: the sole \`@media\` emission site in \`breakpointMediaBlocks()\` (~line 484) keyed at \`max-width: <variant's own width>\` (e.g. \`390px\`). Mobile styles only fired below 390px — narrower than most phones and every desktop resize window. The responsive overlay was functionally invisible.
Fix: track the previous (wider) viewport width as we iterate variants and compute \`round((prev + current) / 2)\` as the breakpoint threshold. For the FSE Pilot's desktop=1440 / mobile=390 pair: **(1440+390)/2 = 915px**. Multi-variant (3+) cascades: each keyed at midpoint to its next-wider neighbour. Lab: **\`@media (max-width:915px)\`**, not \`390px\`.

## Lab validation (FSE Pilot \`.fig\`)

| Signal | Before | After |
|--------|--------|-------|
| Distinct PNGs in assets/ | 2 | 26 |
| \`@media\` threshold | \`390px\` | \`915px\` |
| \`ul,ol\` reset in style.css | absent | 1 occurrence |

## Test plan

- Contract tests updated: existing responsive breakpoint assertions updated to midpoint values (1137px/612px for the 3-variant fixture, 915px for the 2-variant live fixture).
- Three new contract fixtures: multi-layer image node → comma-separated background-image topmost-first; \`emit()\` and \`emitSite()\` paths both carry the \`ul,ol\` reset; 2-variant responsive page → \`@media\` at 915px not 390px.
- \`cd figma-transformer && php tests/contract/run.php\` — all green.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (claude-sonnet-4-6 via Claude Code)
- **Used for:** Implementation of all three fixes and contract tests, with root-cause analysis, line numbers, and lab evidence provided upfront by the requester