### PR TITLE
figma-transformer: apply per-instance content overrides in instance resolution

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -960,6 +960,14 @@ final class ScenegraphNormalizer
         $resolvedChildren = is_array($resolved['children'] ?? null) ? $resolved['children'] : array();
         $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap);
         $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
+        // Figma binds per-instance text content through component properties: each
+        // master text node references a property definition (componentPropRefs ->
+        // componentPropNodeField: TEXT_DATA) and the instance assigns the real value
+        // (componentPropAssignments -> value.textValue.characters). Fold those text
+        // assignments into the override map keyed by the consuming node id so the
+        // existing override machinery renders each instance's own content instead of
+        // the component master's default placeholder.
+        $overrides = $this->mergeComponentPropertyTextOverrides($overrides, $instance, $component);
         if ( $this->instanceOverridesUseTransforms($overrides) ) {
             $resolved['layout'] = array('freeform' => true);
         }
@@ -969,6 +977,175 @@ final class ScenegraphNormalizer
         );
 
         return $resolved;
+    }
+
+    /**
+     * Fold the instance's component-property text assignments into the override map.
+     *
+     * Figma stores per-instance text overrides as component properties rather than as
+     * descendant node changes: the instance carries componentPropAssignments (defID ->
+     * value.textValue.characters) and each master text node carries componentPropRefs
+     * (defID -> componentPropNodeField: TEXT_DATA). Matching them by defID yields the
+     * real per-instance characters for each consuming text node.
+     *
+     * @param array<string, array<string, mixed>> $overrides Existing override map keyed by node id.
+     * @param array<string, mixed>                 $instance  Instance node carrying componentPropAssignments.
+     * @param array<string, mixed>                 $component Component definition whose text nodes carry componentPropRefs.
+     * @return array<string, array<string, mixed>>
+     */
+    private function mergeComponentPropertyTextOverrides(array $overrides, array $instance, array $component): array
+    {
+        $assignments = $this->componentPropertyTextAssignments($instance);
+        if ( empty($assignments) ) {
+            return $overrides;
+        }
+
+        $targets = array();
+        $this->collectComponentPropertyTextTargets($component, $assignments, $targets);
+
+        foreach ( $targets as $nodeId => $fields ) {
+            foreach ( $fields as $field => $value ) {
+                // Do not clobber a value an explicit override already established;
+                // component-property assignments only fill content that is otherwise
+                // left at the component master default.
+                if ( ! isset($overrides[$nodeId][$field]) ) {
+                    $overrides[$nodeId][$field] = $value;
+                }
+            }
+        }
+
+        return $overrides;
+    }
+
+    /**
+     * Read the text-valued component property assignments from an instance.
+     *
+     * @param array<string, mixed> $instance
+     * @return array<string, string> Map of property definition id => assigned characters.
+     */
+    private function componentPropertyTextAssignments(array $instance): array
+    {
+        $assignmentsRaw = $instance['componentPropAssignments'] ?? null;
+        if ( ! is_array($assignmentsRaw) ) {
+            return array();
+        }
+
+        $assignments = array();
+        foreach ( $assignmentsRaw as $assignment ) {
+            if ( ! is_array($assignment) ) {
+                continue;
+            }
+
+            $defId = $this->readGuidId($assignment['defID'] ?? $assignment['defId'] ?? null);
+            if ( null === $defId || '' === $defId ) {
+                continue;
+            }
+
+            $characters = $this->readComponentPropertyAssignmentCharacters($assignment);
+            if ( null === $characters ) {
+                continue;
+            }
+
+            $assignments[$defId] = $characters;
+        }
+
+        return $assignments;
+    }
+
+    /**
+     * @param array<string, mixed> $assignment
+     */
+    private function readComponentPropertyAssignmentCharacters(array $assignment): ?string
+    {
+        $paths = array(
+            array('value', 'textValue', 'characters'),
+            array('value', 'textDataValue', 'characters'),
+            array('varValue', 'value', 'textDataValue', 'characters'),
+            array('varValue', 'value', 'textValue', 'characters'),
+        );
+
+        foreach ( $paths as $path ) {
+            $cursor = $assignment;
+            foreach ( $path as $key ) {
+                if ( ! is_array($cursor) || ! array_key_exists($key, $cursor) ) {
+                    $cursor = null;
+                    break;
+                }
+                $cursor = $cursor[$key];
+            }
+            if ( is_scalar($cursor) ) {
+                return (string) $cursor;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Walk a component subtree and record text overrides for nodes whose TEXT_DATA
+     * property reference matches an instance assignment.
+     *
+     * @param array<string, mixed>  $node
+     * @param array<string, string> $assignments Map of property definition id => characters.
+     * @param array<string, array<string, mixed>> $targets Accumulator keyed by node id.
+     */
+    private function collectComponentPropertyTextTargets(array $node, array $assignments, array &$targets): void
+    {
+        foreach ( $this->componentPropertyTextRefDefIds($node) as $defId ) {
+            if ( ! isset($assignments[$defId]) ) {
+                continue;
+            }
+
+            $nodeId = isset($node['id']) && is_scalar($node['id']) ? (string) $node['id'] : '';
+            if ( '' === $nodeId ) {
+                continue;
+            }
+
+            $targets[$nodeId]['characters'] = $assignments[$defId];
+            $targets[$nodeId]['text'] = $assignments[$defId];
+            break;
+        }
+
+        if ( is_array($node['children'] ?? null) ) {
+            foreach ( $node['children'] as $child ) {
+                if ( is_array($child) ) {
+                    $this->collectComponentPropertyTextTargets($child, $assignments, $targets);
+                }
+            }
+        }
+    }
+
+    /**
+     * Read the property definition ids bound to a node's TEXT_DATA field.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function componentPropertyTextRefDefIds(array $node): array
+    {
+        $refs = $node['componentPropRefs'] ?? $node['componentPropRef'] ?? null;
+        if ( ! is_array($refs) ) {
+            return array();
+        }
+
+        $defIds = array();
+        foreach ( $refs as $ref ) {
+            if ( ! is_array($ref) ) {
+                continue;
+            }
+
+            $field = strtoupper((string) ($ref['componentPropNodeField'] ?? ''));
+            if ( 'TEXT_DATA' !== $field && 'TEXT' !== $field && 'CHARACTERS' !== $field ) {
+                continue;
+            }
+
+            $defId = $this->readGuidId($ref['defID'] ?? $ref['defId'] ?? null);
+            if ( null !== $defId && '' !== $defId ) {
+                $defIds[] = $defId;
+            }
+        }
+
+        return $defIds;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5569,6 +5569,102 @@ $guidOverrideInstanceHtml = $fileContent($guidOverrideInstanceResult, 'index.htm
 $assert(str_contains($guidOverrideInstanceHtml, 'Learn'), 'guid-override-instance-applies-text');
 $assert(str_contains($guidOverrideInstanceHtml, 'data-figma-node-id="instance:menu-item/180:6416"') && str_contains($guidOverrideInstanceHtml, '>Learn<'), 'guid-override-instance-replaces-default-text');
 
+// Component-property (componentPropAssignments) text overrides (#329 / FSE Pilot).
+//
+// Figma binds per-instance text content through component properties rather than
+// descendant node changes: each master text node carries componentPropRefs
+// (componentPropNodeField: TEXT_DATA -> a property definition guid) and each instance
+// carries componentPropAssignments (defID -> value.textValue.characters). Resolution
+// must render each instance's assigned characters instead of the component master's
+// placeholder default. This is the FSE Pilot "Post Title" repeated-placeholder bug:
+// a Query Loop of Preview instances whose real post titles were dropped.
+$componentPropTextResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Component Property Text Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'component:post-card',
+            'type'     => 'COMPONENT',
+            'name'     => 'Post card component',
+            'key'      => 'post-card-key',
+            'children' => array(
+                array(
+                    'id'         => 'component:post-heading',
+                    'type'       => 'TEXT',
+                    'name'       => 'Heading',
+                    'characters' => 'Post Title',
+                    // Heading characters are bound to component property 4166:1.
+                    'componentPropRefs' => array(
+                        array(
+                            'defID'                  => array('sessionID' => 4166, 'localID' => 1),
+                            'componentPropNodeField' => 'TEXT_DATA',
+                        ),
+                    ),
+                ),
+                array(
+                    'id'         => 'component:post-excerpt',
+                    'type'       => 'TEXT',
+                    'name'       => 'Excerpt',
+                    'characters' => 'Placeholder excerpt copy.',
+                    'componentPropRefs' => array(
+                        array(
+                            'defID'                  => array('sessionID' => 4166, 'localID' => 2),
+                            'componentPropNodeField' => 'TEXT_DATA',
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        // Instance A assigns its own real heading + excerpt.
+        array(
+            'id'          => 'instance:card-a',
+            'type'        => 'INSTANCE',
+            'name'        => 'Preview A',
+            'componentId' => 'post-card-key',
+            'componentPropAssignments' => array(
+                array(
+                    'defID' => array('sessionID' => 4166, 'localID' => 1),
+                    'value' => array('textValue' => array('characters' => 'Welcome to LEGO City')),
+                ),
+                array(
+                    'defID' => array('sessionID' => 4166, 'localID' => 2),
+                    'value' => array('textValue' => array('characters' => 'Bricks for everyone.')),
+                ),
+            ),
+        ),
+        // Instance B assigns a different real heading (varValue/textDataValue shape).
+        array(
+            'id'          => 'instance:card-b',
+            'type'        => 'INSTANCE',
+            'name'        => 'Preview B',
+            'componentId' => 'post-card-key',
+            'componentPropAssignments' => array(
+                array(
+                    'defID'    => array('sessionID' => 4166, 'localID' => 1),
+                    'varValue' => array('value' => array('textDataValue' => array('characters' => 'Spaceship Set Review'))),
+                ),
+            ),
+        ),
+        // Instance C has no assignment: it must keep the component master default.
+        array(
+            'id'          => 'instance:card-c',
+            'type'        => 'INSTANCE',
+            'name'        => 'Preview C',
+            'componentId' => 'post-card-key',
+        ),
+    ),
+));
+$componentPropTextHtml = $fileContent($componentPropTextResult, 'index.html');
+$assert(str_contains($componentPropTextHtml, '>Welcome to LEGO City<'), 'component-prop-text-instance-a-heading');
+$assert(str_contains($componentPropTextHtml, '>Bricks for everyone.<'), 'component-prop-text-instance-a-excerpt');
+$assert(str_contains($componentPropTextHtml, '>Spaceship Set Review<'), 'component-prop-text-instance-b-heading');
+// Each instance renders ITS OWN heading, not a shared master clone.
+$assert(substr_count($componentPropTextHtml, 'Welcome to LEGO City') === 1 && substr_count($componentPropTextHtml, 'Spaceship Set Review') === 1, 'component-prop-text-distinct-per-instance');
+// The placeholder default survives only on the component master definition (rendered
+// top-level in this flat fixture) and on instance C which carries no assignment.
+// Instances A and B, which DO assign the heading, no longer clone the placeholder.
+$assert(substr_count($componentPropTextHtml, '>Post Title<') === 2, 'component-prop-text-default-only-without-assignment');
+$assert(str_contains($componentPropTextHtml, 'data-figma-node-id="instance:card-c/component:post-heading"'), 'component-prop-text-no-override-preserves-default-node');
+
 $fontAwesomeIconNameResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Font Awesome Icon Name Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary

Component instance resolution rendered the **component master's default placeholder** content for every instance instead of each instance's real per-instance overridden content. On the FSE Pilot \`.fig\` ("THE BASEPLATE" LEGO site) the source carries 67 real post titles and only 6 placeholder strings, yet the rendered homepage showed \`Post Title\` ×7 / \`Appliance Gaming 2020\` ×8. This was the single biggest visual-parity defect.

## Root cause

In Figma's Kiwi scenegraph, an instance's overridden text is bound through **component properties**, not descendant node changes — the instance's descendant text nodes do not exist as separate \`nodeChanges\` at all (every Query Loop "Preview" instance has \`rawChildCount=0\`; zero of the 501 TEXT nodes live inside any instance subtree).

The real content lives in two linked structures:
- Each **master text node** carries \`componentPropRefs: [{ defID, componentPropNodeField: "TEXT_DATA" }]\`
- Each **instance** carries \`componentPropAssignments: [{ defID, value.textValue.characters }]\`

Matching them by property-definition id yields each instance's real characters for the consuming text node.

\`resolveInstances\` → \`cloneComponentForInstance\` only read \`overrides\` / \`symbolData.symbolOverrides\` / \`derivedSymbolData\` (which carry geometry, fills, and glyph-layout — **not** the characters), and never read \`componentPropAssignments\`. So every cloned card kept the master default and the real per-instance content was discarded.

### Decoded evidence (instance \`3468:1074\`, a homepage Query Loop "Preview" card)

\`\`\`
componentPropAssignments[1] defID=4166:1 value.textValue.characters = "LEGO's New spaceship Set Sparks Galactic..."  (Heading)
componentPropAssignments[2] defID=4166:2 ...characters = "Immerse yourself in the force as LEGO un..."  (Excerpt)
master Heading 3266:27659 componentPropRefs[0] = { defID 4166:1, componentPropNodeField: "TEXT_DATA" }, default "Appliance Gaming 2020"
\`\`\`

## Fix

\`cloneComponentForInstance\` now folds the instance's text-valued component-property assignments into the override map (keyed by the consuming master node id) so the existing override machinery renders each instance's own content. Instances with no assignment still render the master default. The image fill-selection path is untouched (a separate emitter PR handles per-instance images).

## Validation (lab, real \`.fig\`)

\`php bin/figma-transformer /tmp/fse-pilot.fig --multi-page --max-pages=20\`:

| | Before | After |
|---|---|---|
| \`Post Title\` (home) | 7 | **0** |
| \`Appliance Gaming 2020\` (home) | 8 | **0** |
| Placeholders (all 5 pages) | — | **0** |

Homepage cards now render distinct real titles: "A Days of thunder lego set is coming", "We're all about Lego", "LEGO's New spaceship Set ...", "LEGO Ideas Twilight ...", "LEGO Creator Expert ...", etc. (20+ distinct real strings, 0 placeholders).

## Tests

Adds a contract fixture (a component with placeholder text bound to component properties + several instances each assigning their own text): asserts each resolved instance renders its own content, distinct per instance, while an unassigned instance keeps the master default. \`php tests/contract/run.php\` — all green. No regression to the existing instance-resolution / symbolOverrides paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Decoding the \`.fig\` to confirm the component-property override mechanism, implementing the resolution-layer fix, and authoring the contract fixture.