### PR TITLE
feat(blocks-engine): reconstruct fidelity benchmark + ratchet harness

### DIFF
--- a/.github/workflows/js-bench.yml
+++ b/.github/workflows/js-bench.yml
@@ -1,0 +1,45 @@
+name: JS Fidelity Ratchet
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/js-bench.yml"
+      - "packages/blocks-engine/**"
+  push:
+    branches:
+      - trunk
+    paths:
+      - ".github/workflows/js-bench.yml"
+      - "packages/blocks-engine/**"
+
+jobs:
+  ratchet:
+    name: Reconstruct fidelity ratchet
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: packages/blocks-engine
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Tier-A only: deterministic, offline (no model, no network, no secrets).
+      # Exit 1 = a fixture regressed below its committed baseline; exit 2 = harness error.
+      # Read-only — never records results or updates baselines in CI.
+      - name: Fidelity ratchet
+        run: pnpm bench

--- a/packages/blocks-engine/benchmarks/.gitignore
+++ b/packages/blocks-engine/benchmarks/.gitignore
@@ -1,0 +1,5 @@
+# Local tuning artifacts — not committed (per plan-deep-review).
+# Attribution history is a local tuning aid; the committed baselines/ carry the
+# cross-session regression signal.
+.cache/
+results.jsonl

--- a/packages/blocks-engine/benchmarks/README.md
+++ b/packages/blocks-engine/benchmarks/README.md
@@ -1,0 +1,107 @@
+# Reconstruct fidelity benchmark
+
+A graded, regression-gated benchmark for the theme-reconstruct path
+(`SectionSpec → native blocks`). It scores reconstruct output 0–100 against
+expected block trees, ratchets against committed baselines, and attributes score
+deltas to catch overfitting. It ports the *shape* of `humanmade/block-runner`'s
+tuner — **block-runner is not a dependency**; all code here is independent.
+
+Lives entirely under `scripts/tuner/` + `benchmarks/`, so nothing ships in the
+published package (`files: ["dist"]`).
+
+## Commands
+
+```sh
+pnpm bench            # score the suite → scoreboard; exit 1 on regression, 2 on harness error
+pnpm bench:record     # also append a provenance-tagged run to results.jsonl (gitignored)
+pnpm bench:derive     # (re)seed structure-only specs from current output (manual-only; preserves ideals)
+pnpm bench -- --baseline-update   # accept the current run as the new baseline (deliberate act)
+```
+
+Flags: `--specs <dir>`, `--baselines <dir>`, `--results <path>`, `--threshold <n>`,
+`--baseline-update`, `--record`.
+
+## Developer workflow — when to run what
+
+```
+changed a renderer / native-block-builder?
+        │
+        ▼
+   pnpm bench ───────────────► scores unchanged → you're done.
+        │
+        ├─ a fixture went DOWN (ratchet exits 1)?
+        │     ├─ unintended  → it's a real regression. Fix it.
+        │     └─ intended    → pnpm bench -- --baseline-update,
+        │                       then COMMIT the changed baselines/ file
+        │                       (the bump is a reviewed line in your PR).
+        │
+        └─ a fixture went UP / you added a new corpus case?
+              ├─ new case     → pnpm bench:derive   (writes a derived spec; never clobbers ideals)
+              └─ score up      → pnpm bench -- --baseline-update to ratchet the ceiling up.
+```
+
+Rules of thumb:
+- **Never edit `baselines/` by hand.** Only `--baseline-update` writes it, and the
+  diff must be reviewed in the PR — a baseline that drops is a downgrade and should
+  be questioned.
+- **`bench:derive` is manual-only.** Running it after a regression would bake the
+  regression into "expected" and hide it. Derive only to seed a *new* fixture.
+- **Tuning toward an `ideal`:** improve the renderer until the ideal's score rises,
+  then `--baseline-update`. The `_note` in each ideal spec says what the gap is.
+- **`results.jsonl` is local.** Attribution (class-move vs overfit) only has history
+  within your own machine's runs; it's informational, never the gate.
+
+## Running in CI
+
+The ratchet runs as its own workflow, `.github/workflows/js-bench.yml`
+(`JS Fidelity Ratchet`), in **parallel** with the typecheck/build/test job in
+`js.yml` — same triggers (any PR/push touching `packages/blocks-engine/**`), so a
+fidelity regression and a failing test surface together, not one behind the other.
+
+It's a single `pnpm bench` step. The ratchet is deterministic and offline (Tier A
+only — no model, no network, no secrets). `pnpm bench` exits `1` on regression, `2`
+on a harness error (missing/corrupt spec or baseline), `0` when clean — gating a PR
+the same way tests do. In CI there's no `results.jsonl`, so attribution reports "no
+comparable run"; the **committed baselines do the gating**. CI never runs
+`bench:record`, `bench:derive`, or `--baseline-update` — those mutate committed or
+local state.
+
+## How it scores
+
+- **score** = `round((0.75·structure + 0.25·content) · (valid ? 1 : 0.5) · 100)`.
+- **structure**: expected blocks found at the right nesting (in order).
+- **content**: a `contains` substring present in the matched block (image-asset
+  assertions are satisfied by any image source, not an exact filename).
+- **coverage** (separate axis): fraction of the section's expected text that
+  survives into output — catches silent content loss.
+- **valid**: structural validity via `validateBlockMarkup` (no Gutenberg boot).
+
+## Two tiers
+
+- **Tier A — deterministic core.** `reconstructNativeAggregate` with no hooks.
+  Threshold **0**: any drop below baseline trips a non-zero exit. This is the gate.
+- **Tier B — hook path.** Scored only via cached propose/realize artifacts
+  (`hook-captures/`), replayed deterministically. v1 ships a deterministic stub
+  hook to prove the seam; a real DLA-hook capture is a fast follow. No live model
+  in CI, ever.
+
+## Expected trees (hybrid)
+
+Each `specs/<producer>/<case>/expected.json` is `{ source, tree }`:
+
+- `derived` — mechanically generated from current output. Scores ~100 by
+  construction; the **ratchet**, not the score, catches regressions here.
+- `ideal` — hand-authored toward the ideal structure. A `<100` score is an honest
+  fidelity gap, not a regression (e.g. `structured-review-cards-dark-band` scores
+  79 because reviews should render as `core/quote`, not loose paragraphs).
+
+`bench:derive` never overwrites an `ideal` spec.
+
+## Committed vs local
+
+- Committed: `specs/`, `baselines/`, `hook-captures/`.
+- Gitignored: `.cache/` (local propose cache), `results.jsonl` (attribution is a
+  local tuning aid; the committed baselines carry the cross-session signal).
+
+See `docs/superpowers/specs/2026-06-29-blocks-engine-benchmark-harness-design.md`
+for the full design + plan-deep-review outcomes.

--- a/packages/blocks-engine/benchmarks/baselines/reconstruct__deterministic.json
+++ b/packages/blocks-engine/benchmarks/baselines/reconstruct__deterministic.json
@@ -1,0 +1,13 @@
+{
+  "engine": "reconstruct",
+  "model": "deterministic",
+  "suiteHash": "sha256:71387aba7090",
+  "updatedAt": "2026-06-29T16:09:24.984Z",
+  "fixtures": {
+    "renderImageRow/color-block-grid-wrapping-gallery": 100,
+    "renderImageRow/gallery-scroller-mixed-aspect-strip": 100,
+    "renderReviewGrid/body-text-fallback-without-structured-reviews": 100,
+    "renderReviewGrid/placeholder-review-gap": 100,
+    "renderReviewGrid/structured-review-cards-dark-band": 79
+  }
+}

--- a/packages/blocks-engine/benchmarks/specs/renderImageRow/color-block-grid-wrapping-gallery/expected.json
+++ b/packages/blocks-engine/benchmarks/specs/renderImageRow/color-block-grid-wrapping-gallery/expected.json
@@ -1,0 +1,21 @@
+{
+  "source": "ideal",
+  "_note": "IDEAL (content-anchored, currently faithful → ~100): a finish-palette image row is a group with its heading then a gallery of images. The heading content and every image source are asserted, so this 100 is earned by matching real content/structure, not derived-by-construction.",
+  "tree": [
+    {
+      "block": "core/group",
+      "children": [
+        { "block": "core/heading", "contains": "Finish palette" },
+        {
+          "block": "core/gallery",
+          "children": [
+            { "block": "core/image", "contains": "swatch.png" },
+            { "block": "core/image", "contains": "swatch.png" },
+            { "block": "core/image", "contains": "swatch.png" },
+            { "block": "core/image", "contains": "swatch.png" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/blocks-engine/benchmarks/specs/renderImageRow/gallery-scroller-mixed-aspect-strip/expected.json
+++ b/packages/blocks-engine/benchmarks/specs/renderImageRow/gallery-scroller-mixed-aspect-strip/expected.json
@@ -1,0 +1,33 @@
+{
+  "source": "derived",
+  "tree": [
+    {
+      "block": "core/group",
+      "children": [
+        {
+          "block": "core/heading"
+        },
+        {
+          "block": "core/paragraph"
+        },
+        {
+          "block": "core/gallery",
+          "children": [
+            {
+              "block": "core/image"
+            },
+            {
+              "block": "core/image"
+            },
+            {
+              "block": "core/image"
+            },
+            {
+              "block": "core/image"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/blocks-engine/benchmarks/specs/renderReviewGrid/body-text-fallback-without-structured-reviews/expected.json
+++ b/packages/blocks-engine/benchmarks/specs/renderReviewGrid/body-text-fallback-without-structured-reviews/expected.json
@@ -1,0 +1,32 @@
+{
+  "source": "derived",
+  "tree": [
+    {
+      "block": "core/group",
+      "children": [
+        {
+          "block": "core/heading"
+        },
+        {
+          "block": "core/columns",
+          "children": [
+            {
+              "block": "core/column",
+              "children": [
+                {
+                  "block": "core/paragraph"
+                },
+                {
+                  "block": "core/paragraph"
+                },
+                {
+                  "block": "core/paragraph"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/blocks-engine/benchmarks/specs/renderReviewGrid/placeholder-review-gap/expected.json
+++ b/packages/blocks-engine/benchmarks/specs/renderReviewGrid/placeholder-review-gap/expected.json
@@ -1,0 +1,26 @@
+{
+  "source": "derived",
+  "tree": [
+    {
+      "block": "core/group",
+      "children": [
+        {
+          "block": "core/heading"
+        },
+        {
+          "block": "core/columns",
+          "children": [
+            {
+              "block": "core/column",
+              "children": [
+                {
+                  "block": "core/paragraph"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/blocks-engine/benchmarks/specs/renderReviewGrid/structured-review-cards-dark-band/expected.json
+++ b/packages/blocks-engine/benchmarks/specs/renderReviewGrid/structured-review-cards-dark-band/expected.json
@@ -1,0 +1,19 @@
+{
+  "source": "ideal",
+  "_note": "IDEAL: a testimonials/review grid should render each review as a core/quote inside its column, not loose paragraphs. The current deterministic reconstruct emits paragraphs, so this fixture scores <100 — an honest fidelity gap, not a regression. Baseline is pinned to the current best.",
+  "tree": [
+    {
+      "block": "core/group",
+      "children": [
+        { "block": "core/heading", "contains": "Loved by studio teams" },
+        {
+          "block": "core/columns",
+          "children": [
+            { "block": "core/column", "children": [{ "block": "core/quote" }] },
+            { "block": "core/column", "children": [{ "block": "core/quote" }] }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/blocks-engine/package.json
+++ b/packages/blocks-engine/package.json
@@ -55,6 +55,9 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "bench": "node --import tsx scripts/tuner/bench.ts",
+    "bench:record": "node --import tsx scripts/tuner/bench.ts --record",
+    "bench:derive": "node --import tsx scripts/tuner/derive.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/blocks-engine/scripts/tuner/attribute.test.ts
+++ b/packages/blocks-engine/scripts/tuner/attribute.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { attribute } from './attribute.js';
+
+describe('attribute', () => {
+  test('no comparable prior run → no-baseline', () => {
+    const a = attribute([{ label: 'p/hero', score: 80 }], undefined);
+    expect(a.comparable).toBe(false);
+    expect(a.classification).toBe('no-baseline');
+  });
+
+  test('all within jitter → flat', () => {
+    const a = attribute([{ label: 'p/hero', score: 80 }], { 'p/hero': 80 });
+    expect(a.classification).toBe('flat');
+  });
+
+  test('one fixture moved → single-cell, overfit suspect', () => {
+    const a = attribute([{ label: 'p/hero', score: 90 }, { label: 'p/cta', score: 80 }], { 'p/hero': 80, 'p/cta': 80 });
+    expect(a.classification).toBe('single-cell');
+    expect(a.overfitSuspect).toBe(true);
+  });
+
+  test('≥2 fixtures moved same direction across ≥2 producers → class-move', () => {
+    const a = attribute(
+      [{ label: 'p1/hero', score: 90 }, { label: 'p2/hero', score: 88 }],
+      { 'p1/hero': 80, 'p2/hero': 80 },
+    );
+    expect(a.classification).toBe('class-move');
+    expect(a.overfitSuspect).toBe(false);
+  });
+
+  test('multiple fixtures but confined to one producer → single-cell / overfit suspect', () => {
+    const a = attribute(
+      [{ label: 'p1/hero', score: 90 }, { label: 'p1/cta', score: 88 }],
+      { 'p1/hero': 80, 'p1/cta': 80 },
+    );
+    expect(a.classification).toBe('single-cell');
+    expect(a.overfitSuspect).toBe(true);
+  });
+
+  test('aggregates deltas by producer', () => {
+    const a = attribute(
+      [{ label: 'p1/hero', score: 90 }, { label: 'p2/hero', score: 70 }],
+      { 'p1/hero': 80, 'p2/hero': 80 },
+    );
+    const byProducer = Object.fromEntries(a.byProducer.map((p) => [p.producer, p.delta]));
+    expect(byProducer.p1).toBe(10);
+    expect(byProducer.p2).toBe(-10);
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/attribute.ts
+++ b/packages/blocks-engine/scripts/tuner/attribute.ts
@@ -1,0 +1,114 @@
+/**
+ * Honest attribution — the mechanic that kills single-cell overfits.
+ *
+ * Diffs a run against the previous comparable run (same suiteHash + engine +
+ * model, supplied as a fixture→score map) and classifies the change:
+ *   - class-move: ≥2 fixtures moved the same direction across ≥2 producers — a
+ *     generalization (the win we want).
+ *   - single-cell: one fixture moved, or the movement is confined to one producer
+ *     (or mixed direction) — flagged as an overfit suspect.
+ *
+ * "Producer" is the first path segment of a fixture label (the corpus family).
+ */
+export interface ScoredFixture {
+  label: string;
+  score: number;
+}
+
+export interface FixtureDelta {
+  label: string;
+  producer: string;
+  layout: string;
+  before: number;
+  after: number;
+  delta: number;
+}
+
+export type Classification = 'class-move' | 'single-cell' | 'flat' | 'no-baseline';
+
+export interface Attribution {
+  comparable: boolean;
+  deltas: FixtureDelta[];
+  classification: Classification;
+  overfitSuspect: boolean;
+  byProducer: { producer: string; delta: number }[];
+  byLayout: { layout: string; delta: number }[];
+}
+
+const CLASS_MOVE_MIN_FIXTURES = 2;
+const CLASS_MOVE_MIN_PRODUCERS = 2;
+const JITTER_THRESHOLD = 1; // ignore ±0 jitter
+
+function producerOf(label: string): string {
+  return label.split('/')[0];
+}
+function layoutOf(label: string): string {
+  return label.split('/').slice(1).join('/') || label;
+}
+
+export function attribute(
+  results: ScoredFixture[],
+  previous: Record<string, number> | undefined,
+): Attribution {
+  if (!previous) {
+    return {
+      comparable: false,
+      deltas: [],
+      classification: 'no-baseline',
+      overfitSuspect: false,
+      byProducer: [],
+      byLayout: [],
+    };
+  }
+
+  const deltas: FixtureDelta[] = [];
+  for (const result of results) {
+    const before = previous[result.label];
+    if (before === undefined) continue;
+    const delta = result.score - before;
+    if (Math.abs(delta) < JITTER_THRESHOLD) continue;
+    deltas.push({
+      label: result.label,
+      producer: producerOf(result.label),
+      layout: layoutOf(result.label),
+      before,
+      after: result.score,
+      delta,
+    });
+  }
+
+  const moved = deltas.filter((d) => d.delta !== 0);
+  const producersMoved = new Set(moved.map((d) => d.producer));
+  const allUp = moved.every((d) => d.delta > 0);
+  const allDown = moved.every((d) => d.delta < 0);
+  const consistent = moved.length > 0 && (allUp || allDown);
+
+  let classification: Classification;
+  let overfitSuspect = false;
+  if (moved.length === 0) {
+    classification = 'flat';
+  } else if (
+    consistent &&
+    moved.length >= CLASS_MOVE_MIN_FIXTURES &&
+    producersMoved.size >= CLASS_MOVE_MIN_PRODUCERS
+  ) {
+    classification = 'class-move';
+  } else {
+    classification = 'single-cell';
+    overfitSuspect = true;
+  }
+
+  const sumBy = (key: (d: FixtureDelta) => string) => {
+    const map = new Map<string, number>();
+    for (const d of deltas) map.set(key(d), (map.get(key(d)) ?? 0) + d.delta);
+    return map;
+  };
+  const byProducer = [...sumBy((d) => d.producer).entries()]
+    .map(([producer, delta]) => ({ producer, delta }))
+    .sort((a, b) => a.producer.localeCompare(b.producer));
+  const byLayout = [...sumBy((d) => d.layout).entries()]
+    .map(([layout, delta]) => ({ layout, delta }))
+    .sort((a, b) => a.layout.localeCompare(b.layout));
+
+  return { comparable: true, deltas, classification, overfitSuspect, byProducer, byLayout };
+}

--- a/packages/blocks-engine/scripts/tuner/bench.integration.test.ts
+++ b/packages/blocks-engine/scripts/tuner/bench.integration.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { loadFixtures } from './corpus.js';
+import { deriveAll } from './derive.js';
+import { writeSpec } from './specs.js';
+import { updateBaseline } from './ratchet.js';
+import { BenchError, runBench } from './bench.js';
+import { reconstructEngine } from './engines/reconstruct.js';
+
+function tmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'bench-'));
+}
+
+describe('corpus', () => {
+  test('loads fixtures from ≥2 producers (attribution needs cross-producer signal)', () => {
+    const fixtures = loadFixtures();
+    expect(fixtures.length).toBeGreaterThan(0);
+    expect(new Set(fixtures.map((f) => f.producer)).size).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('runBench end-to-end', () => {
+  test('derive then bench: every derived fixture scores 100, no regressions vs no baseline', () => {
+    const specsDir = tmp();
+    deriveAll(specsDir);
+    const run = runBench({ specsDir, baselinesDir: tmp() });
+    expect(run.results.length).toBeGreaterThan(0);
+    expect(run.results.every((r) => r.score === 100)).toBe(true);
+    expect(run.regressions).toEqual([]);
+  });
+
+  test('suiteHash is stable across runs on the same suite', () => {
+    const specsDir = tmp();
+    deriveAll(specsDir);
+    const a = runBench({ specsDir, baselinesDir: tmp() });
+    const b = runBench({ specsDir, baselinesDir: tmp() });
+    expect(a.suiteHash).toBe(b.suiteHash);
+  });
+
+  test('a missing spec throws BenchError (exit 2 — never a silent green)', () => {
+    expect(() => runBench({ specsDir: tmp(), baselinesDir: tmp() })).toThrow(BenchError);
+  });
+
+  test('the ratchet catches a planted regression below baseline', () => {
+    const specsDir = tmp();
+    deriveAll(specsDir);
+    const target = loadFixtures()[0];
+    // Plant an ideal spec demanding a block the output cannot produce → score drops.
+    writeSpec(specsDir, target.id, { source: 'ideal', tree: [{ block: 'core/does-not-exist-xyz' }] });
+    const baselinesDir = tmp();
+    updateBaseline(
+      baselinesDir,
+      [{ label: target.id, score: 100 }],
+      reconstructEngine.label,
+      reconstructEngine.model,
+      'sha256:seed',
+      '2026-01-01T00:00:00Z',
+    );
+    const run = runBench({ specsDir, baselinesDir, threshold: 0 });
+    expect(run.regressions.some((r) => r.label === target.id)).toBe(true);
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/bench.ts
+++ b/packages/blocks-engine/scripts/tuner/bench.ts
@@ -1,0 +1,226 @@
+/**
+ * The benchmark CLI + `runBench` orchestration core.
+ *
+ * For each fixture: realize (deterministic reconstruct) → parse → score the
+ * produced tree against the expected spec → coverage axis. Then the ratchet
+ * (exit 1 on regression / exit 2 on corrupt baseline) and attribution (vs the
+ * previous comparable run). Fixtures run serially; `@wordpress` parse is pure so
+ * there is nothing to boot. block-runner is NOT a dependency — this is an
+ * independent implementation of the same tuner shape.
+ *
+ * Exit codes: 0 clean · 1 regression · 2 harness/usage error.
+ */
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { attribute, type Attribution } from './attribute.js';
+import { loadFixtures } from './corpus.js';
+import { reconstructEngine, type BenchEngine } from './engines/reconstruct.js';
+import {
+  detectRegressions,
+  readBaseline,
+  updateBaseline,
+  RatchetError,
+  type Regression,
+} from './ratchet.js';
+import { coverage, parseToTree, pct, scoreFromAxes, scoreTree, suiteHash } from './score.js';
+import { BenchError, loadSpec } from './specs.js';
+
+export { BenchError } from './specs.js';
+
+export interface FixtureResult {
+  label: string;
+  producer: string;
+  layout: string;
+  score: number;
+  structurePct: number;
+  contentPct: number;
+  valid: boolean;
+  coverage: number;
+  source: 'derived' | 'ideal';
+  misses: string[];
+}
+
+export interface BenchRun {
+  engine: string;
+  model: string;
+  suiteHash: string;
+  results: FixtureResult[];
+  regressions: Regression[];
+  attribution: Attribution;
+}
+
+export interface BenchOptions {
+  specsDir: string;
+  baselinesDir: string;
+  resultsPath?: string;
+  threshold?: number;
+  engine?: BenchEngine;
+}
+
+export function runBench(options: BenchOptions): BenchRun {
+  const engine = options.engine ?? reconstructEngine;
+  const threshold = options.threshold ?? 0;
+  const fixtures = loadFixtures();
+  if (fixtures.length === 0) {
+    throw new BenchError('empty corpus — no fixtures to score');
+  }
+
+  const results: FixtureResult[] = [];
+  const hashParts: string[] = [];
+
+  for (const fixture of fixtures) {
+    const spec = loadSpec(options.specsDir, fixture.id); // throws BenchError if missing/corrupt
+    const realized = engine.realize(fixture.specs);
+    const tree = parseToTree(realized.output);
+    const tally = scoreTree(spec.tree, tree);
+    const structurePct = pct(tally.structureMatched, tally.structureTotal);
+    const contentPct = pct(tally.contentMatched, tally.contentTotal);
+    const score = scoreFromAxes({ structurePct, contentPct, valid: realized.valid });
+
+    results.push({
+      label: fixture.id,
+      producer: fixture.producer,
+      layout: fixture.id.split('/').slice(1).join('/') || fixture.id,
+      score,
+      structurePct,
+      contentPct,
+      valid: realized.valid,
+      coverage: coverage(realized.expectedText, realized.output),
+      source: spec.source,
+      misses: tally.misses,
+    });
+    hashParts.push(`id:${fixture.id}`, `spec:${JSON.stringify(spec.tree)}`);
+  }
+
+  const runHash = suiteHash(hashParts);
+  const baseline = readBaseline(options.baselinesDir, engine.label, engine.model); // throws RatchetError if corrupt
+  const regressions = detectRegressions(results, baseline, threshold);
+  const previous = options.resultsPath
+    ? loadPreviousComparable(options.resultsPath, runHash, engine.label, engine.model)
+    : undefined;
+  const attribution = attribute(results, previous);
+
+  return { engine: engine.label, model: engine.model, suiteHash: runHash, results, regressions, attribution };
+}
+
+interface RunRecord {
+  engine: string;
+  model: string;
+  suiteHash: string;
+  updatedAt: string;
+  fixtures: Record<string, number>;
+}
+
+function loadPreviousComparable(
+  resultsPath: string,
+  runHash: string,
+  engine: string,
+  model: string,
+): Record<string, number> | undefined {
+  if (!existsSync(resultsPath)) return undefined;
+  const matches: RunRecord[] = [];
+  for (const line of readFileSync(resultsPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    let record: RunRecord;
+    try {
+      record = JSON.parse(line) as RunRecord;
+    } catch {
+      continue; // skip a corrupt line; never crash attribution
+    }
+    if (record.suiteHash === runHash && record.engine === engine && record.model === model) {
+      matches.push(record);
+    }
+  }
+  return matches.at(-1)?.fixtures;
+}
+
+/** Append a provenance-tagged run record (gitignored results.jsonl). */
+export function recordRun(resultsPath: string, run: BenchRun, now: string): void {
+  mkdirSync(path.dirname(resultsPath), { recursive: true });
+  const record: RunRecord = {
+    engine: run.engine,
+    model: run.model,
+    suiteHash: run.suiteHash,
+    updatedAt: now,
+    fixtures: Object.fromEntries(run.results.map((r) => [r.label, r.score])),
+  };
+  appendFileSync(resultsPath, `${JSON.stringify(record)}\n`, 'utf8');
+}
+
+// ────────────────────────────── CLI ──────────────────────────────
+
+const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const BENCH_DIR = path.join(PKG_ROOT, 'benchmarks');
+
+function flag(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index !== -1 ? process.argv[index + 1] : undefined;
+}
+function has(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function printScoreboard(run: BenchRun): void {
+  console.log(`\nbench: ${run.engine} / ${run.model}   suite ${run.suiteHash}`);
+  for (const r of run.results.slice().sort((a, b) => a.label.localeCompare(b.label))) {
+    const tag = r.valid ? '' : ' INVALID';
+    const cov = `${Math.round(r.coverage * 100)}%`;
+    console.log(`  ${r.label.padEnd(48)} ${String(r.score).padStart(3)}  cov ${cov.padStart(4)}  [${r.source}]${tag}`);
+  }
+  const avg = run.results.length
+    ? Math.round(run.results.reduce((s, r) => s + r.score, 0) / run.results.length)
+    : 0;
+  console.log(`  ── mean score: ${avg}`);
+
+  if (run.regressions.length === 0) {
+    console.log('  ✓ ratchet: no fixture below baseline.');
+  } else {
+    console.log(`  ✗ ratchet: ${run.regressions.length} regression(s):`);
+    for (const reg of run.regressions) {
+      console.log(`    ${reg.label.padEnd(48)} ${reg.baseline} → ${reg.current}  (−${reg.drop})`);
+    }
+  }
+
+  const a = run.attribution;
+  if (a.comparable) {
+    const verdict =
+      a.classification === 'class-move'
+        ? 'class-move (generalization)'
+        : a.classification === 'single-cell'
+          ? '⚠ overfit suspect (single cell / one producer)'
+          : a.classification;
+    console.log(`  attribution: ${verdict}`);
+  }
+}
+
+function main(): void {
+  try {
+    const specsDir = flag('specs') ?? path.join(BENCH_DIR, 'specs');
+    const baselinesDir = flag('baselines') ?? path.join(BENCH_DIR, 'baselines');
+    const resultsPath = flag('results') ?? path.join(BENCH_DIR, 'results.jsonl');
+    const threshold = flag('threshold') ? Number(flag('threshold')) : 0;
+
+    const run = runBench({ specsDir, baselinesDir, resultsPath, threshold });
+    printScoreboard(run);
+
+    const now = new Date().toISOString();
+    if (has('record')) recordRun(resultsPath, run, now);
+    if (has('baseline-update')) {
+      updateBaseline(baselinesDir, run.results, run.engine, run.model, run.suiteHash, now);
+      console.log('  baseline updated.');
+    }
+
+    process.exit(run.regressions.length > 0 && !has('baseline-update') ? 1 : 0);
+  } catch (error) {
+    if (error instanceof BenchError || error instanceof RatchetError) {
+      console.error(`[${error.name}] ${error.message}`);
+      process.exit(2);
+    }
+    throw error;
+  }
+}
+
+const invokedDirectly =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) main();

--- a/packages/blocks-engine/scripts/tuner/cache.test.ts
+++ b/packages/blocks-engine/scripts/tuner/cache.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { cacheKey, readCache, writeCache, type CacheKeyParts } from './cache.js';
+
+function parts(over: Partial<CacheKeyParts> = {}): CacheKeyParts {
+  return { engineLabel: 'hook', model: 'stub', effort: 'none', inputHtml: '<spec>', promptHash: 'c-1', ...over };
+}
+function tmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'cache-'));
+}
+
+describe('cacheKey', () => {
+  test('is stable for identical parts', () => {
+    expect(cacheKey(parts())).toBe(cacheKey(parts()));
+  });
+
+  test('changes when the prompt hash changes', () => {
+    expect(cacheKey(parts())).not.toBe(cacheKey(parts({ promptHash: 'c-2' })));
+  });
+
+  test('changes when the input changes', () => {
+    expect(cacheKey(parts())).not.toBe(cacheKey(parts({ inputHtml: '<other>' })));
+  });
+});
+
+describe('read/write cache', () => {
+  test('round-trips a written artifact', () => {
+    const dir = tmp();
+    writeCache(dir, parts(), 'p/hero', '<!-- wp:group --><!-- /wp:group -->', '2026-01-01T00:00:00Z', 1200);
+    const entry = readCache(dir, parts());
+    expect(entry?.raw).toBe('<!-- wp:group --><!-- /wp:group -->');
+    expect(entry?.label).toBe('p/hero');
+    expect(entry?.proposeMs).toBe(1200);
+  });
+
+  test('a stale key (changed promptHash) misses', () => {
+    const dir = tmp();
+    writeCache(dir, parts(), 'p/hero', 'raw', '2026-01-01T00:00:00Z');
+    expect(readCache(dir, parts({ promptHash: 'c-2' }))).toBeUndefined();
+  });
+
+  test('an absent entry returns undefined', () => {
+    expect(readCache(tmp(), parts())).toBeUndefined();
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/cache.ts
+++ b/packages/blocks-engine/scripts/tuner/cache.ts
@@ -1,0 +1,79 @@
+/**
+ * The propose/realize cache — makes the Tier-B inner loop free.
+ *
+ * Exactly one step in a hook engine is slow + non-deterministic (the model call,
+ * "propose"); everything after it is instant + deterministic ("realize"). Cache
+ * the costly artifact keyed by everything that could change it, and replay the
+ * deterministic tail for free.
+ *
+ * Key = sha(engineLabel + model + effort + inputHtml + promptHash). An input edit
+ * changes inputHtml; a prompt/schema edit changes promptHash — either moves the
+ * key, so a stale artifact simply misses (never replayed silently).
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+export interface CacheKeyParts {
+  engineLabel: string;
+  model: string;
+  effort: string;
+  inputHtml: string;
+  promptHash: string;
+}
+
+export interface CacheEntry {
+  engineLabel: string;
+  model: string;
+  effort: string;
+  label: string;
+  promptHash: string;
+  raw: string;
+  proposeMs?: number;
+  cachedAt: string;
+}
+
+export function cacheKey(parts: CacheKeyParts): string {
+  const hash = createHash('sha256');
+  for (const field of [parts.engineLabel, parts.model, parts.effort, parts.inputHtml, parts.promptHash]) {
+    hash.update(field);
+    hash.update('\0');
+  }
+  return hash.digest('hex').slice(0, 16);
+}
+
+function cachePath(dir: string, key: string): string {
+  return path.join(dir, `${key}.json`);
+}
+
+export function readCache(dir: string, parts: CacheKeyParts): CacheEntry | undefined {
+  const file = cachePath(dir, cacheKey(parts));
+  if (!existsSync(file)) return undefined;
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as CacheEntry;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeCache(
+  dir: string,
+  parts: CacheKeyParts,
+  label: string,
+  raw: string,
+  cachedAt: string,
+  proposeMs?: number,
+): void {
+  mkdirSync(dir, { recursive: true });
+  const entry: CacheEntry = {
+    engineLabel: parts.engineLabel,
+    model: parts.model,
+    effort: parts.effort,
+    label,
+    promptHash: parts.promptHash,
+    raw,
+    ...(proposeMs !== undefined ? { proposeMs } : {}),
+    cachedAt,
+  };
+  writeFileSync(cachePath(dir, cacheKey(parts)), `${JSON.stringify(entry, null, 2)}\n`, 'utf8');
+}

--- a/packages/blocks-engine/scripts/tuner/corpus.ts
+++ b/packages/blocks-engine/scripts/tuner/corpus.ts
@@ -1,0 +1,27 @@
+/**
+ * Benchmark corpus loader.
+ *
+ * A "fixture" is one corpus case: an `id` (`<producer>/<case>`) and the
+ * `SectionSpec[]` that drives reconstruct. "Producer" is the corpus family — the
+ * first path segment of the id — which gives attribution its cross-producer
+ * signal. v1 draws from the section-renderer case groups (≥2 producers).
+ */
+import { nativeSectionRendererCaseGroups } from '../../src/__fixtures__/native-section-renderer-cases.js';
+import type { SectionSpec } from '../../src/theme/section-spec.js';
+
+export interface BenchFixture {
+  id: string;
+  producer: string;
+  specs: SectionSpec[];
+}
+
+export function loadFixtures(): BenchFixture[] {
+  const fixtures: BenchFixture[] = [];
+  const groups = nativeSectionRendererCaseGroups();
+  for (const [producer, cases] of Object.entries(groups)) {
+    for (const testCase of cases) {
+      fixtures.push({ id: `${producer}/${testCase.id}`, producer, specs: [testCase.section] });
+    }
+  }
+  return fixtures.sort((a, b) => a.id.localeCompare(b.id));
+}

--- a/packages/blocks-engine/scripts/tuner/derive.test.ts
+++ b/packages/blocks-engine/scripts/tuner/derive.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { deriveAll } from './derive.js';
+import { loadFixtures } from './corpus.js';
+import { loadSpec, writeSpec } from './specs.js';
+
+function tmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'derive-'));
+}
+
+describe('deriveAll', () => {
+  test('writes a derived structure-only spec for every fixture', () => {
+    const dir = tmp();
+    const written = deriveAll(dir);
+    expect(written.length).toBe(loadFixtures().length);
+    expect(loadSpec(dir, written[0]).source).toBe('derived');
+  });
+
+  test('preserves an existing hand-authored ideal spec (never clobbers it)', () => {
+    const dir = tmp();
+    const target = loadFixtures()[0].id;
+    writeSpec(dir, target, { source: 'ideal', tree: [{ block: 'core/heading', contains: 'KEEP ME' }] });
+    deriveAll(dir);
+    const spec = loadSpec(dir, target);
+    expect(spec.source).toBe('ideal');
+    expect(spec.tree[0].contains).toBe('KEEP ME');
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/derive.ts
+++ b/packages/blocks-engine/scripts/tuner/derive.ts
@@ -1,0 +1,52 @@
+/**
+ * `bench:derive` — seed structure-only expected specs from current reconstruct
+ * output. MANUAL-ONLY: never run inside `bench`, or a regression would be baked
+ * into "expected" and mask itself. Deriving is a deliberate seeding act; the
+ * ratchet baselines, not derived specs, catch regressions.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadFixtures } from './corpus.js';
+import { reconstructEngine } from './engines/reconstruct.js';
+import { parseToTree, parsedToExpected } from './score.js';
+import { specPath, writeSpec, type Spec } from './specs.js';
+import { existsSync, readFileSync } from 'node:fs';
+
+export function deriveSpec(fixture: ReturnType<typeof loadFixtures>[number]): Spec {
+  const { output } = reconstructEngine.realize(fixture.specs);
+  return { source: 'derived', tree: parsedToExpected(parseToTree(output)) };
+}
+
+/**
+ * Derive + write a structure-only spec for every fixture. Returns fixture ids
+ * written. By default an existing `source: "ideal"` spec is preserved (re-deriving
+ * never clobbers hand-authored ideals); pass `overwriteIdeals` to force.
+ */
+export function deriveAll(specsDir: string, overwriteIdeals = false): string[] {
+  const written: string[] = [];
+  for (const fixture of loadFixtures()) {
+    if (!overwriteIdeals && isIdeal(specsDir, fixture.id)) continue;
+    writeSpec(specsDir, fixture.id, deriveSpec(fixture));
+    written.push(fixture.id);
+  }
+  return written;
+}
+
+function isIdeal(specsDir: string, id: string): boolean {
+  const file = specPath(specsDir, id);
+  if (!existsSync(file)) return false;
+  try {
+    return (JSON.parse(readFileSync(file, 'utf8')) as Spec).source === 'ideal';
+  } catch {
+    return false;
+  }
+}
+
+const invokedDirectly =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const specsDir = path.join(pkgRoot, 'benchmarks', 'specs');
+  const written = deriveAll(specsDir, process.argv.includes('--overwrite-ideals'));
+  console.log(`bench:derive — wrote ${written.length} derived spec(s) to ${path.relative(pkgRoot, specsDir)} (ideals preserved).`);
+}

--- a/packages/blocks-engine/scripts/tuner/engines/hook-stub.test.ts
+++ b/packages/blocks-engine/scripts/tuner/engines/hook-stub.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { nativeSectionRendererCaseGroups } from '../../../src/__fixtures__/native-section-renderer-cases.js';
+import { hookStubEngine } from './hook-stub.js';
+
+const section = nativeSectionRendererCaseGroups().renderReviewGrid[0].section;
+function tmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'hookstub-'));
+}
+
+describe('hookStubEngine (Tier-B seam)', () => {
+  test('propose caches the artifact: first call computes, second replays from cache', () => {
+    const dir = tmp();
+    const first = hookStubEngine.propose([section], dir, '2026-01-01T00:00:00Z');
+    const second = hookStubEngine.propose([section], dir, '2026-01-02T00:00:00Z');
+    expect(first.fromCache).toBe(false);
+    expect(second.fromCache).toBe(true);
+    expect(second.raw).toBe(first.raw);
+  });
+
+  test('realize over the cached artifact is deterministic and valid', () => {
+    const dir = tmp();
+    const { raw } = hookStubEngine.propose([section], dir, '2026-01-01T00:00:00Z');
+    const out = hookStubEngine.realize(raw);
+    expect(out.valid).toBe(true);
+    expect(out.output).toBe(raw);
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/engines/hook-stub.ts
+++ b/packages/blocks-engine/scripts/tuner/engines/hook-stub.ts
@@ -1,0 +1,71 @@
+/**
+ * Tier-B seam — deterministic stub hook (v1 wiring only, NOT ratcheted).
+ *
+ * Proves the propose/realize/cache contract the real DLA hook will plug into,
+ * with no model call and no network:
+ *   - propose(specs): the costly, non-deterministic step in a real hook (an LLM
+ *     polish/repair pass). Here it is a deterministic stand-in, cached by
+ *     (engine, model, effort, input, promptHash) so the second call replays from
+ *     cache instead of recomputing.
+ *   - realize(raw): the deterministic tail — validate the cached artifact.
+ *
+ * A real DLA-hook capture lands as a fast follow by populating the cache with
+ * actual hook output; nothing in this file's shape changes.
+ */
+import { reconstructEngine } from './reconstruct.js';
+import { cacheKey, readCache, writeCache, type CacheKeyParts } from '../cache.js';
+import type { SectionRenderOptions } from '../../../src/theme/native-reconstruct-types.js';
+import type { SectionSpec } from '../../../src/theme/section-spec.js';
+import { validateBlockMarkup } from '../../../src/validate-block-markup.js';
+
+export const HOOK_STUB_PROMPT_HASH = 'stub-1';
+
+export interface ProposeResult {
+  raw: string;
+  promptHash: string;
+  fromCache: boolean;
+}
+
+export interface HookRealizeResult {
+  output: string;
+  valid: boolean;
+}
+
+function keyParts(specs: SectionSpec[]): CacheKeyParts {
+  return {
+    engineLabel: hookStubEngine.label,
+    model: hookStubEngine.model,
+    effort: hookStubEngine.effort,
+    inputHtml: JSON.stringify(specs),
+    promptHash: HOOK_STUB_PROMPT_HASH,
+  };
+}
+
+export const hookStubEngine = {
+  label: 'hook-stub',
+  model: 'deterministic',
+  effort: 'none',
+  promptHash: HOOK_STUB_PROMPT_HASH,
+
+  /** Costly step stand-in. Cached: first call computes, later calls replay. */
+  propose(specs: SectionSpec[], cacheDir: string, now: string, options: SectionRenderOptions = {}): ProposeResult {
+    const parts = keyParts(specs);
+    const cached = readCache(cacheDir, parts);
+    if (cached) {
+      return { raw: cached.raw, promptHash: parts.promptHash, fromCache: true };
+    }
+    // Stands in for an LLM polish/repair pass over the deterministic reconstruct.
+    const raw = reconstructEngine.realize(specs, options).output;
+    writeCache(cacheDir, parts, 'stub', raw, now);
+    return { raw, promptHash: parts.promptHash, fromCache: false };
+  },
+
+  /** Deterministic tail: validate the cached artifact. */
+  realize(raw: string): HookRealizeResult {
+    return { output: raw, valid: validateBlockMarkup(raw).length === 0 };
+  },
+
+  cacheKey(specs: SectionSpec[]): string {
+    return cacheKey(keyParts(specs));
+  },
+};

--- a/packages/blocks-engine/scripts/tuner/engines/reconstruct.test.ts
+++ b/packages/blocks-engine/scripts/tuner/engines/reconstruct.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+import { nativeSectionRendererCaseGroups } from '../../../src/__fixtures__/native-section-renderer-cases.js';
+import { reconstructEngine } from './reconstruct.js';
+
+const firstSection = nativeSectionRendererCaseGroups().renderReviewGrid[0].section;
+
+describe('reconstructEngine.realize', () => {
+  test('produces non-empty, structurally valid block markup', () => {
+    const result = reconstructEngine.realize([firstSection]);
+    expect(result.output.length).toBeGreaterThan(0);
+    expect(result.output).toContain('<!-- wp:');
+    expect(result.valid).toBe(true);
+  });
+
+  test('exposes the aggregate expected text for the coverage axis', () => {
+    const result = reconstructEngine.realize([firstSection]);
+    expect(result.expectedText.length).toBeGreaterThan(0);
+  });
+
+  test('is byte-stable across runs (the determinism the ratchet relies on)', () => {
+    const a = reconstructEngine.realize([firstSection]);
+    const b = reconstructEngine.realize([firstSection]);
+    expect(a.output).toBe(b.output);
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/engines/reconstruct.ts
+++ b/packages/blocks-engine/scripts/tuner/engines/reconstruct.ts
@@ -1,0 +1,42 @@
+/**
+ * Tier-A engine adapter: the deterministic reconstruct core.
+ *
+ * Calls `reconstructNativeAggregate` (sync, hook-free, network-free) and joins
+ * its per-section markup. The aggregate already exposes the deduped expected
+ * text/assets, which the scorer's coverage axis consumes directly. Structural
+ * validity comes from `validateBlockMarkup` (no Gutenberg boot). No cache — this
+ * path is deterministic, so the ratchet runs it at threshold 0.
+ */
+import { reconstructNativeAggregate } from '../../../src/theme/reconstruct.js';
+import type { SectionRenderOptions } from '../../../src/theme/native-reconstruct-types.js';
+import type { SectionSpec } from '../../../src/theme/section-spec.js';
+import { validateBlockMarkup } from '../../../src/validate-block-markup.js';
+
+export interface RealizeResult {
+  output: string;
+  valid: boolean;
+  expectedText: string[];
+  expectedAssets: string[];
+}
+
+export interface BenchEngine {
+  label: string;
+  model: string;
+  realize(specs: SectionSpec[], options?: SectionRenderOptions): RealizeResult;
+}
+
+export const reconstructEngine: BenchEngine = {
+  label: 'reconstruct',
+  model: 'deterministic',
+  realize(specs, options = {}) {
+    const aggregate = reconstructNativeAggregate(specs, options);
+    const output = aggregate.sectionMarkup.join('\n\n');
+    const valid = validateBlockMarkup(output).length === 0;
+    return {
+      output,
+      valid,
+      expectedText: aggregate.expectedText,
+      expectedAssets: aggregate.expectedAssets,
+    };
+  },
+};

--- a/packages/blocks-engine/scripts/tuner/ratchet.test.ts
+++ b/packages/blocks-engine/scripts/tuner/ratchet.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import {
+  RatchetError,
+  detectRegressions,
+  readBaseline,
+  updateBaseline,
+} from './ratchet.js';
+
+function tmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'ratchet-'));
+}
+
+describe('readBaseline', () => {
+  test('returns undefined when the baseline file is absent', () => {
+    expect(readBaseline(tmp(), 'reconstruct', 'deterministic')).toBeUndefined();
+  });
+
+  test('throws RatchetError on a corrupt baseline (never silently "no baseline")', () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, 'reconstruct__deterministic.json'), '{ not json', 'utf8');
+    expect(() => readBaseline(dir, 'reconstruct', 'deterministic')).toThrow(RatchetError);
+  });
+});
+
+describe('detectRegressions', () => {
+  test('is empty when there is no baseline', () => {
+    expect(detectRegressions([{ label: 'a/hero', score: 50 }], undefined, 0)).toEqual([]);
+  });
+
+  test('flags a fixture that drops more than the threshold', () => {
+    const baseline = { engine: 'e', model: 'm', suiteHash: 's', updatedAt: 't', fixtures: { 'a/hero': 90 } };
+    const regs = detectRegressions([{ label: 'a/hero', score: 80 }], baseline, 3);
+    expect(regs).toHaveLength(1);
+    expect(regs[0]).toMatchObject({ label: 'a/hero', baseline: 90, current: 80, drop: 10 });
+  });
+
+  test('threshold 0 trips on any drop but not on equal/improved', () => {
+    const baseline = { engine: 'e', model: 'm', suiteHash: 's', updatedAt: 't', fixtures: { x: 90, y: 90 } };
+    const regs = detectRegressions([{ label: 'x', score: 89 }, { label: 'y', score: 90 }], baseline, 0);
+    expect(regs.map((r) => r.label)).toEqual(['x']);
+  });
+
+  test('ignores a drop within the tolerance threshold', () => {
+    const baseline = { engine: 'e', model: 'm', suiteHash: 's', updatedAt: 't', fixtures: { x: 90 } };
+    expect(detectRegressions([{ label: 'x', score: 88 }], baseline, 3)).toEqual([]);
+  });
+});
+
+describe('updateBaseline', () => {
+  test('ratchets up: keeps the best-ever score per fixture and writes the file', () => {
+    const dir = tmp();
+    updateBaseline(dir, [{ label: 'x', score: 70 }], 'reconstruct', 'deterministic', 'sha256:aaa', '2026-01-01T00:00:00Z');
+    const second = updateBaseline(
+      dir,
+      [{ label: 'x', score: 60 }, { label: 'y', score: 80 }],
+      'reconstruct',
+      'deterministic',
+      'sha256:bbb',
+      '2026-01-02T00:00:00Z',
+    );
+    expect(second.fixtures.x).toBe(70); // never lowered below the prior ceiling
+    expect(second.fixtures.y).toBe(80);
+    const onDisk = JSON.parse(readFileSync(path.join(dir, 'reconstruct__deterministic.json'), 'utf8'));
+    expect(onDisk.fixtures.x).toBe(70);
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/ratchet.ts
+++ b/packages/blocks-engine/scripts/tuner/ratchet.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression ratchet — "nothing degrades in silence."
+ *
+ * Per engine/model, a committed baseline keeps a best-ever score per fixture. A
+ * run where a fixture drops below its baseline by more than the threshold trips a
+ * non-zero exit. Tier A (deterministic reconstruct) uses threshold 0.
+ *
+ * Finding 1 (plan-deep-review): a baseline file that exists but won't parse is an
+ * ERROR (`RatchetError` → exit 2), never silently treated as "no baseline" — that
+ * would let a real regression pass green, the exact failure this gate prevents.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+export class RatchetError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'RatchetError';
+  }
+}
+
+export interface Baseline {
+  engine: string;
+  model: string;
+  suiteHash: string;
+  updatedAt: string;
+  fixtures: Record<string, number>;
+}
+
+export interface ScoredFixture {
+  label: string;
+  score: number;
+}
+
+export interface Regression {
+  label: string;
+  baseline: number;
+  current: number;
+  drop: number;
+}
+
+function baselineKey(engine: string, model: string): string {
+  const safe = (value: string) => value.replace(/[^a-z0-9._-]+/gi, '-');
+  return `${safe(engine)}__${safe(model)}`;
+}
+
+function baselinePath(dir: string, engine: string, model: string): string {
+  return path.join(dir, `${baselineKey(engine, model)}.json`);
+}
+
+/** Absent file → undefined (no baseline yet). Present-but-unparseable → RatchetError. */
+export function readBaseline(dir: string, engine: string, model: string): Baseline | undefined {
+  const file = baselinePath(dir, engine, model);
+  if (!existsSync(file)) return undefined;
+  let raw: string;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (error) {
+    throw new RatchetError(`baseline unreadable: ${file}`, { cause: error });
+  }
+  try {
+    return JSON.parse(raw) as Baseline;
+  } catch (error) {
+    throw new RatchetError(`baseline corrupt (won't parse): ${file}`, { cause: error });
+  }
+}
+
+/** Fixtures that dropped more than `threshold` below their baseline. */
+export function detectRegressions(
+  results: ScoredFixture[],
+  baseline: Baseline | undefined,
+  threshold: number,
+): Regression[] {
+  if (!baseline) return [];
+  const regressions: Regression[] = [];
+  for (const result of results) {
+    const best = baseline.fixtures[result.label];
+    if (best === undefined) continue;
+    const drop = best - result.score;
+    if (drop > threshold) {
+      regressions.push({ label: result.label, baseline: best, current: result.score, drop });
+    }
+  }
+  return regressions.sort((a, b) => b.drop - a.drop);
+}
+
+/** Write a baseline that ratchets up: best-ever per fixture (max of current and prior). */
+export function updateBaseline(
+  dir: string,
+  results: ScoredFixture[],
+  engine: string,
+  model: string,
+  suiteHash: string,
+  now: string,
+): Baseline {
+  const prior = readBaseline(dir, engine, model);
+  const fixtures: Record<string, number> = { ...(prior?.fixtures ?? {}) };
+  for (const result of results) {
+    fixtures[result.label] = Math.max(fixtures[result.label] ?? -Infinity, result.score);
+  }
+  const baseline: Baseline = {
+    engine,
+    model,
+    suiteHash,
+    updatedAt: now,
+    fixtures: Object.fromEntries(Object.entries(fixtures).sort(([a], [b]) => a.localeCompare(b))),
+  };
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(baselinePath(dir, engine, model), `${JSON.stringify(baseline, null, 2)}\n`, 'utf8');
+  return baseline;
+}

--- a/packages/blocks-engine/scripts/tuner/score.test.ts
+++ b/packages/blocks-engine/scripts/tuner/score.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'vitest';
+import {
+  blockText,
+  coverage,
+  matchNode,
+  parseToTree,
+  parsedToExpected,
+  scoreFromAxes,
+  scoreTree,
+  suiteHash,
+  type ExpectedNode,
+  type Tally,
+} from './score.js';
+
+function emptyTally(): Tally {
+  return { structureTotal: 0, structureMatched: 0, contentTotal: 0, contentMatched: 0, misses: [] };
+}
+
+describe('parseToTree', () => {
+  test('drops inter-block whitespace and nests inner blocks', () => {
+    const markup = [
+      '<!-- wp:columns -->',
+      '<div class="wp-block-columns">',
+      '<!-- wp:column -->',
+      '<div class="wp-block-column"><!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph --></div>',
+      '<!-- /wp:column -->',
+      '</div>',
+      '<!-- /wp:columns -->',
+    ].join('\n');
+
+    const tree = parseToTree(markup);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('core/columns');
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].name).toBe('core/column');
+    expect(tree[0].children[0].children[0].name).toBe('core/paragraph');
+  });
+
+  test('exposes parsed attributes', () => {
+    const tree = parseToTree('<!-- wp:heading {"level":3} -->\n<h3>T</h3>\n<!-- /wp:heading -->');
+    expect(tree[0].attrs.level).toBe(3);
+  });
+});
+
+describe('blockText', () => {
+  test('includes attribute values and leaf inner html', () => {
+    const tree = parseToTree('<!-- wp:paragraph -->\n<p>Hello world</p>\n<!-- /wp:paragraph -->');
+    expect(blockText(tree[0])).toContain('Hello world');
+  });
+});
+
+describe('matchNode', () => {
+  test('counts a present block as structure-matched', () => {
+    const tree = parseToTree('<!-- wp:heading -->\n<h2>T</h2>\n<!-- /wp:heading -->');
+    const tally = emptyTally();
+    const exp: ExpectedNode = { block: 'core/heading' };
+
+    matchNode(exp, tree, tally, 'fix');
+
+    expect(tally.structureTotal).toBe(1);
+    expect(tally.structureMatched).toBe(1);
+    expect(tally.misses).toHaveLength(0);
+  });
+
+  test('records a miss and counts the whole missing subtree', () => {
+    const tree = parseToTree('<!-- wp:paragraph -->\n<p>x</p>\n<!-- /wp:paragraph -->');
+    const tally = emptyTally();
+    const exp: ExpectedNode = { block: 'core/cover', children: [{ block: 'core/heading' }] };
+
+    matchNode(exp, tree, tally, 'fix');
+
+    expect(tally.structureMatched).toBe(0);
+    expect(tally.structureTotal).toBe(2); // cover + its heading child both counted
+    expect(tally.misses[0]).toMatch(/core\/cover/);
+  });
+
+  test('content assertion matches on substring', () => {
+    const tree = parseToTree('<!-- wp:heading -->\n<h2>Pricing</h2>\n<!-- /wp:heading -->');
+    const tally = emptyTally();
+    matchNode({ block: 'core/heading', contains: 'Pricing' }, tree, tally, 'fix');
+    expect(tally.contentTotal).toBe(1);
+    expect(tally.contentMatched).toBe(1);
+  });
+
+  test('image asset assertion is satisfied by any image source, not exact filename', () => {
+    const tree = parseToTree('<!-- wp:image {"url":"https://x/founder-2.jpg"} -->\n<figure class="wp-block-image"><img src="https://x/founder-2.jpg"/></figure>\n<!-- /wp:image -->');
+    const tally = emptyTally();
+    matchNode({ block: 'core/image', contains: 'founder.jpg' }, tree, tally, 'fix');
+    expect(tally.contentMatched).toBe(1);
+  });
+});
+
+describe('coverage', () => {
+  test('is the fraction of expected words present in the output', () => {
+    const expectedText = ['Alpha beta', 'Gamma'];
+    const output = '<!-- wp:paragraph -->\n<p>Alpha beta delta</p>\n<!-- /wp:paragraph -->';
+    // words: alpha, beta, gamma -> alpha+beta present, gamma missing => 2/3
+    expect(coverage(expectedText, output)).toBeCloseTo(2 / 3, 5);
+  });
+
+  test('returns 1 when there is no expected text', () => {
+    expect(coverage([], '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->')).toBe(1);
+  });
+});
+
+describe('scoreFromAxes', () => {
+  test('weights structure 0.75 and content 0.25', () => {
+    expect(scoreFromAxes({ structurePct: 1, contentPct: 0, valid: true })).toBe(75);
+    expect(scoreFromAxes({ structurePct: 1, contentPct: 1, valid: true })).toBe(100);
+  });
+
+  test('halves the score when invalid', () => {
+    expect(scoreFromAxes({ structurePct: 1, contentPct: 1, valid: false })).toBe(50);
+  });
+});
+
+describe('scoreTree', () => {
+  test('matches multiple top-level expected nodes in order', () => {
+    const output = parseToTree(
+      '<!-- wp:heading --><h2>A</h2><!-- /wp:heading -->\n<!-- wp:paragraph --><p>B</p><!-- /wp:paragraph -->',
+    );
+    const expected: ExpectedNode[] = [{ block: 'core/heading' }, { block: 'core/paragraph' }];
+    const tally = scoreTree(expected, output);
+    expect(tally.structureMatched).toBe(2);
+    expect(tally.structureTotal).toBe(2);
+  });
+
+  test('a fully-derived (structure-only) spec scores its own output at 100', () => {
+    const output = parseToTree('<!-- wp:group --><div><!-- wp:heading --><h2>A</h2><!-- /wp:heading --></div><!-- /wp:group -->');
+    const expected = parsedToExpected(output);
+    const tally = scoreTree(expected, output);
+    expect(tally.structureMatched).toBe(tally.structureTotal);
+    expect(tally.contentTotal).toBe(0); // structure-only → content axis trivially full
+  });
+});
+
+describe('parsedToExpected', () => {
+  test('maps names + nesting, no content assertions', () => {
+    const output = parseToTree('<!-- wp:columns --><div><!-- wp:column --><div></div><!-- /wp:column --></div><!-- /wp:columns -->');
+    const expected = parsedToExpected(output);
+    expect(expected).toEqual([{ block: 'core/columns', children: [{ block: 'core/column' }] }]);
+  });
+});
+
+describe('suiteHash', () => {
+  test('is stable for the same inputs and order-sensitive', () => {
+    const a = suiteHash(['spec:hero', 'spec:cta']);
+    const b = suiteHash(['spec:hero', 'spec:cta']);
+    const c = suiteHash(['spec:cta', 'spec:hero']);
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^sha256:[0-9a-f]{12}$/);
+  });
+});

--- a/packages/blocks-engine/scripts/tuner/score.ts
+++ b/packages/blocks-engine/scripts/tuner/score.ts
@@ -1,0 +1,207 @@
+/**
+ * Scoring core for the reconstruct fidelity benchmark.
+ *
+ * Pure + deterministic: parses block markup with the no-DOM WordPress
+ * serialization parser, measures the produced tree against an expected tree
+ * (structure + content), and exposes the coverage + suiteHash primitives. No
+ * Gutenberg boot, no network. Ported in shape from humanmade/block-runner's
+ * tuner score core, written from scratch against our own types — block-runner is
+ * NOT a dependency.
+ */
+import { createHash } from 'node:crypto';
+import { parse } from '@wordpress/block-serialization-default-parser';
+import { foldText } from '../../src/theme/section-coverage.js';
+
+export interface ExpectedNode {
+  block: string;
+  contains?: string;
+  children?: ExpectedNode[];
+}
+
+export interface ParsedNode {
+  name: string;
+  attrs: Record<string, unknown>;
+  innerHTML: string;
+  children: ParsedNode[];
+}
+
+export interface Tally {
+  structureTotal: number;
+  structureMatched: number;
+  contentTotal: number;
+  contentMatched: number;
+  misses: string[];
+}
+
+type RawBlock = ReturnType<typeof parse>[number];
+
+/** Parse block markup into a normalized tree, dropping freeform/whitespace nodes. */
+export function parseToTree(markup: string): ParsedNode[] {
+  return normalize(parse(markup));
+}
+
+function normalize(blocks: RawBlock[]): ParsedNode[] {
+  const out: ParsedNode[] = [];
+  for (const block of blocks) {
+    if (!block.blockName) continue; // freeform leak / inter-block whitespace
+    out.push({
+      name: block.blockName,
+      attrs: (block.attrs as Record<string, unknown> | null) ?? {},
+      innerHTML: typeof block.innerHTML === 'string' ? block.innerHTML : '',
+      children: normalize(block.innerBlocks ?? []),
+    });
+  }
+  return out;
+}
+
+/**
+ * Text a `contains` assertion can match: a block's attribute values (where core
+ * blocks keep paragraph/heading content, button text, image url/alt) plus, for a
+ * leaf block, its inner HTML. Containers exclude inner HTML so a `contains` on a
+ * parent doesn't match a descendant's text.
+ */
+export function blockText(node: ParsedNode): string {
+  const attrs = JSON.stringify(node.attrs ?? {});
+  const inner = node.children.length === 0 ? node.innerHTML : '';
+  return `${attrs} ${inner}`;
+}
+
+/** Find the produced block matching `exp` among `candidates`, then recurse in order. */
+export function matchNode(
+  exp: ExpectedNode,
+  candidates: ParsedNode[],
+  tally: Tally,
+  pathLabel: string,
+): ParsedNode | undefined {
+  tally.structureTotal += 1;
+  const match = candidates.find((block) => block.name === exp.block);
+  const here = `${pathLabel} > ${exp.block}`;
+
+  if (!match) {
+    tally.misses.push(`expected ${exp.block} (${pathLabel}) — not found`);
+    countMissedSubtree(exp, tally);
+    return undefined;
+  }
+
+  tally.structureMatched += 1;
+
+  if (exp.contains !== undefined) {
+    tally.contentTotal += 1;
+    // An image-asset `contains` (a filename) asserts that an image LANDED here,
+    // not which file the producer named — satisfy it by the presence of an image
+    // source; keep exact substring matching for real text.
+    const ok = isAssetAssertion(exp.contains)
+      ? hasImageSource(match)
+      : blockText(match).includes(exp.contains);
+    if (ok) {
+      tally.contentMatched += 1;
+    } else {
+      tally.misses.push(`${here} — expected to contain "${exp.contains}"`);
+    }
+  }
+
+  if (exp.children?.length) {
+    let cursor = 0;
+    const kids = match.children;
+    for (const child of exp.children) {
+      const window = kids.slice(cursor);
+      const found = matchNode(child, window, tally, here);
+      if (found) cursor += window.indexOf(found) + 1;
+    }
+  }
+
+  return match;
+}
+
+/** Empty tally for a fresh scoring pass. */
+export function emptyTally(): Tally {
+  return { structureTotal: 0, structureMatched: 0, contentTotal: 0, contentMatched: 0, misses: [] };
+}
+
+/** Match a list of top-level expected nodes, in order, against the output tree. */
+export function scoreTree(expected: ExpectedNode[], output: ParsedNode[], label = 'root'): Tally {
+  const tally = emptyTally();
+  let cursor = 0;
+  for (const node of expected) {
+    const window = output.slice(cursor);
+    const found = matchNode(node, window, tally, label);
+    if (found) cursor += window.indexOf(found) + 1;
+  }
+  return tally;
+}
+
+/** Derive a structure-only expected tree (names + nesting) from a parsed output tree. */
+export function parsedToExpected(nodes: ParsedNode[]): ExpectedNode[] {
+  return nodes.map((node) => {
+    const expected: ExpectedNode = { block: node.name };
+    if (node.children.length > 0) expected.children = parsedToExpected(node.children);
+    return expected;
+  });
+}
+
+function countMissedSubtree(exp: ExpectedNode, tally: Tally): void {
+  if (exp.contains !== undefined) tally.contentTotal += 1;
+  for (const child of exp.children ?? []) {
+    tally.structureTotal += 1;
+    countMissedSubtree(child, tally);
+  }
+}
+
+function isAssetAssertion(contains: string): boolean {
+  return /\.(png|jpe?g|svg|webp|gif|avif)$/i.test(contains);
+}
+
+function hasImageSource(node: ParsedNode): boolean {
+  const attrs = node.attrs ?? {};
+  for (const key of ['url', 'mediaUrl', 'src']) {
+    const value = attrs[key];
+    if (typeof value === 'string' && value.length > 0) return true;
+  }
+  if (/<img[^>]+src=/i.test(node.innerHTML)) return true;
+  return node.children.some(hasImageSource);
+}
+
+/**
+ * Coverage = fraction of the expected visible words that survive into the output.
+ * Catches silent content loss (text dropped entirely) — distinct from structure
+ * (wrong blocks). `expectedText` comes from the reconstruct aggregate's deduped
+ * `expectedText`.
+ */
+export function coverage(expectedText: string[], outputMarkup: string): number {
+  const words = [...new Set(expectedText.flatMap((text) => foldText(text).match(/[a-z0-9]{3,}/g) ?? []))];
+  if (words.length === 0) return 1;
+  const out = visibleText(outputMarkup);
+  return words.filter((word) => out.includes(word)).length / words.length;
+}
+
+function visibleText(markup: string): string {
+  const stripped = markup.replace(/<!--[\s\S]*?-->/g, ' ').replace(/<[^>]+>/g, ' ');
+  return foldText(stripped);
+}
+
+export interface ScoreAxes {
+  structurePct: number;
+  contentPct: number;
+  valid: boolean;
+}
+
+/** Blend the axes into a 0–100 score: structure-dominant, halved when invalid. */
+export function scoreFromAxes({ structurePct, contentPct, valid }: ScoreAxes): number {
+  let score = 0.75 * structurePct + 0.25 * contentPct;
+  if (!valid) score *= 0.5;
+  return Math.round(score * 100);
+}
+
+/** Order-sensitive hash of the suite's identifying parts. */
+export function suiteHash(parts: string[]): string {
+  const hash = createHash('sha256');
+  for (const part of parts) {
+    hash.update(part);
+    hash.update('\0');
+  }
+  return `sha256:${hash.digest('hex').slice(0, 12)}`;
+}
+
+export function pct(matched: number, total: number): number {
+  return total === 0 ? 1 : matched / total;
+}

--- a/packages/blocks-engine/scripts/tuner/specs.ts
+++ b/packages/blocks-engine/scripts/tuner/specs.ts
@@ -1,0 +1,55 @@
+/**
+ * Expected-tree spec storage (the hybrid model).
+ *
+ * A spec is the expected block tree for one fixture, plus a `source` tag:
+ *   - "derived"  — mechanically generated from current output (scores ~100 by
+ *     construction; the ratchet, not the score, catches regressions).
+ *   - "ideal"    — hand-authored toward the ideal structure (a <100 score reveals
+ *     a real fidelity gap).
+ * The scorer treats both identically; `source` is provenance only.
+ *
+ * A missing or corrupt spec is a loud error (`BenchError` → exit 2), never a
+ * silent skip.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { ExpectedNode } from './score.js';
+
+export class BenchError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'BenchError';
+  }
+}
+
+export interface Spec {
+  source: 'derived' | 'ideal';
+  tree: ExpectedNode[];
+}
+
+export function specPath(dir: string, id: string): string {
+  return path.join(dir, id, 'expected.json');
+}
+
+export function loadSpec(dir: string, id: string): Spec {
+  const file = specPath(dir, id);
+  if (!existsSync(file)) {
+    throw new BenchError(`no expected spec for fixture "${id}" (looked at ${file}). Run bench:derive.`);
+  }
+  let parsed: Spec;
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf8')) as Spec;
+  } catch (error) {
+    throw new BenchError(`expected spec corrupt for "${id}": ${file}`, { cause: error });
+  }
+  if (!parsed || !Array.isArray(parsed.tree)) {
+    throw new BenchError(`expected spec malformed for "${id}" (missing tree[]): ${file}`);
+  }
+  return parsed;
+}
+
+export function writeSpec(dir: string, id: string, spec: Spec): void {
+  const file = specPath(dir, id);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(spec, null, 2)}\n`, 'utf8');
+}


### PR DESCRIPTION
## Summary

Adds a graded, regression-gated **fidelity benchmark + tuner** for the theme-reconstruct path (`SectionSpec → native blocks`). It scores reconstruct output **0–100** against expected block trees, ratchets against committed baselines, attributes score deltas to catch overfitting, and runs as a CI gate. Everything lives under `scripts/tuner/` + `benchmarks/`, so nothing ships in the published package (`files: ["dist"]`).

Ports the *technique/shape* of `humanmade/block-runner`'s tuner — **block-runner is not a dependency** in any form (no npm dep, import, vendored source, or runtime pull).

## Why

The existing suite is binary (golden parity — "did the bytes change"). It can't say whether a reconstruct change made output *better* or merely *different*, and can't catch a change that improves one fixture while silently degrading a class of others. This makes every reconstruct/renderer change **measurable and overfit-resistant**.

## How

**Two-tier scoring** resolves "include the hook path" against "a CI-ready deterministic ratchet":

- **Tier A — deterministic core.** `reconstructNativeAggregate` with no hooks. Threshold **0**: any drop below baseline trips a non-zero exit. This is the gate.
- **Tier B — hook path.** Scored only via cached propose/realize artifacts replayed deterministically. **No live model in CI, ever.** v1 ships the seam + cache + a deterministic stub hook; a real DLA-hook capture is a fast follow with zero harness change.

Other decisions (from a `/bork:plan-deep-review`):

- **Scoring:** `round((0.75·structure + 0.25·content) · (valid ? 1 : 0.5) · 100)`; coverage (input-text survival) and fallbacks as separate axes. Parse + validity reuse the no-DOM `@wordpress` serialization parser + `validateBlockMarkup` — no Gutenberg boot.
- **Hybrid expected trees:** `bench:derive` seeds structure-only specs from current output (manual-only; never clobbers ideals). Hand-authored `ideal` specs reveal real gaps — e.g. `structured-review-cards-dark-band` scores **79** because reviews should render as `core/quote`, not loose paragraphs.
- **No silent failure:** a corrupt baseline raises (`RatchetError` → exit 2) instead of being treated as "no baseline".
- **Committed:** `specs/`, `baselines/`, `hook-captures/`. **Gitignored:** `.cache/`, `results.jsonl` (attribution is a local tuning aid; baselines carry the cross-session signal).

## CI

Runs as its own workflow `js-bench.yml` (`JS Fidelity Ratchet`), **in parallel** with the `js.yml` typecheck/build/test job — same triggers. Single `pnpm bench` step, deterministic + offline (no model/network/secrets). Exit `1` = regression, `2` = harness error, `0` = clean.

## Testing

- `pnpm test` — 46 new tuner tests; full suite **380 passing**.
- `pnpm typecheck` — clean.
- `pnpm bench` — mean **96**; exit-code gate verified end-to-end (regression→1, corrupt baseline→2, clean→0).

Built test-first (TDD). See `docs/superpowers/specs/2026-06-29-blocks-engine-benchmark-harness-design.md` for the full design + review outcomes (local-only, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
