### PR TITLE
Fix static-parity gate understating quality (root-inheritance + whitespace subsumption)

### DIFF
--- a/php-transformer/src/VisualParity/StaticStyleParityComparator.php
+++ b/php-transformer/src/VisualParity/StaticStyleParityComparator.php
@@ -336,14 +336,31 @@ final class StaticStyleParityComparator
      * wrapper merely because its single character appears somewhere in the source.
      * Equal texts satisfy containment, which also covers the probe's shared
      * 80-char truncation boundary.
+     *
+     * Comparison is whitespace-insensitive. The transform serializes blocks as
+     * minified markup, so adjacent block children render back-to-back with no
+     * separating whitespace ("JanuaryThe"), whereas the source carried inter-
+     * element whitespace from its indentation ("January The"). That spacing is
+     * not visual content — it is a serialization artifact of how the two
+     * documents lay out the SAME text. Collapsing all whitespace before the
+     * containment test lets a collapsed parent wrapper (a `<li>` merged into a
+     * group whose children are absorbed) still be recognized as carrying its
+     * content, while a genuine drop — whose characters are simply absent from
+     * every candidate — still fails containment and stays a counted loss.
      */
     private function contentSubsumed(string $sourceText, string $candidateText): bool
     {
+        $sourceText = $this->stripWhitespace($sourceText);
         if ( '' === $sourceText ) {
             return true;
         }
 
-        return str_contains($candidateText, $sourceText);
+        return str_contains($this->stripWhitespace($candidateText), $sourceText);
+    }
+
+    private function stripWhitespace(string $text): string
+    {
+        return preg_replace('/\s+/', '', $text) ?? $text;
     }
 
     /**

--- a/php-transformer/src/VisualParity/StaticStyleParityProbe.php
+++ b/php-transformer/src/VisualParity/StaticStyleParityProbe.php
@@ -86,7 +86,18 @@ final class StaticStyleParityProbe
     {
         $document = new DOMDocument();
         $previous = libxml_use_internal_errors(true);
-        $sourceHtml = preg_match('/<(?:!doctype|html|head|body)\b/i', $html) ? $html : '<body>' . $html . '</body>';
+        // Fragments (e.g. the transform candidate, which is body-level block
+        // markup with no document scaffold) are wrapped in a full <html><body>
+        // root so that author rules targeting the document root — `html { ... }`,
+        // `body { ... }` — bind to a real element and their inheritable values
+        // (font-family, font-size, color, line-height, …) cascade into the
+        // fragment's elements exactly as they do in a full source document. A
+        // bare <body> wrapper left `html { font-family }` with no element to
+        // match, so every candidate element silently lost the root-inherited
+        // typography the source kept — a measurement asymmetry that depressed
+        // coverage for faithfully-preserved content. Full documents already carry
+        // their own root and are probed as-is.
+        $sourceHtml = preg_match('/<(?:!doctype|html|head|body)\b/i', $html) ? $html : '<html><body>' . $html . '</body></html>';
         $loaded = $document->loadHTML('<?xml encoding="utf-8" ?>' . $sourceHtml, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         libxml_clear_errors();
         libxml_use_internal_errors($previous);

--- a/php-transformer/tests/fixtures/parity/static-style-parity-compare-collapsed-wrapper-whitespace.json
+++ b/php-transformer/tests/fixtures/parity/static-style-parity-compare-collapsed-wrapper-whitespace.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "static-style-parity-compare-collapsed-wrapper-whitespace",
+  "description": "Collapsed-wrapper coverage must survive the transform's minified serialization. The source list carries authored whitespace between its inline children (\"Title Detail\"), but the candidate merges those children back-to-back with no separating whitespace (\"TitleDetail\") and re-tags the wrapper, so the list element owns no 1:1 candidate. The inter-child whitespace is a serialization artifact, not visual content, so the absorption content test compares whitespace-insensitively: the collapsed list wrapper is recognized as carrying its content and earns coverage credit, exactly as its absorbed children do. A genuine drop — content simply absent from every candidate — still fails containment and stays a counted loss.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/static-style-parity-compare-collapsed-wrapper-whitespace.json",
+    "notes": "Locks in whitespace-insensitive content subsumption so minified collapsed wrappers are not counted as loss."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Static style parity comparison emits the shared visual-parity report contract."
+  },
+  "operation": "static_style_parity.compare",
+  "input": {
+    "source_content": "<body><ul class=\"list\"><li>\n  <span class=\"t\">Title</span>\n  <span class=\"d\">Detail</span>\n</li></ul></body>",
+    "source_css": ".t{color:#111}.d{color:#222}",
+    "target_content": "<div class=\"list\"><div><p class=\"t\">Title</p><p class=\"d\">Detail</p></div></div>",
+    "target_css": ".t{color:#111}.d{color:#222}"
+  },
+  "expect": [
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/visual-parity-report/v1" },
+    { "path": "status", "assert": "equals", "value": "pass" },
+    { "path": "parity.property_parity", "assert": "equals", "value": 1.0 },
+    { "path": "parity.coverage", "assert": "equals", "value": 1.0 },
+    { "path": "parity.score", "assert": "equals", "value": 1.0 },
+    { "path": "summary.source_total", "assert": "equals", "value": 3 },
+    { "path": "summary.matched_total", "assert": "equals", "value": 0 },
+    { "path": "summary.absorbed_source_total", "assert": "equals", "value": 3 },
+    { "path": "summary.covered_total", "assert": "equals", "value": 3 },
+    { "path": "summary.unmatched_source_total", "assert": "equals", "value": 0 },
+    { "path": "summary.finding_total", "assert": "equals", "value": 0 },
+    { "path": "absorbed_source.0.tag", "assert": "equals", "value": "ul" },
+    { "path": "absorbed_source.0.source_selector", "assert": "equals", "value": "ul.list" },
+    { "path": "absorbed_source.0.absorbed_into_selector", "assert": "equals", "value": "div.list" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/static-style-parity-compare-root-inheritance-fragment.json
+++ b/php-transformer/tests/fixtures/parity/static-style-parity-compare-root-inheritance-fragment.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "static-style-parity-compare-root-inheritance-fragment",
+  "description": "The transform candidate is body-level block markup with no document scaffold, while the source is a full document. Author rules that target the document root (html { font-family; color }) inherit into every source element, so the fragment candidate must be probed inside an equivalent <html><body> root or those root-inherited values silently vanish from the candidate and faithfully-preserved content reads as a property regression. Here source and candidate carry identical structure and classes; with symmetric root scaffolding both elements resolve the same root-inherited font-family and color, so property parity is whole and nothing is reported. Without the scaffold the fragment loses the html-level typography and the comparator emits spurious style deltas.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/static-style-parity-compare-root-inheritance-fragment.json",
+    "notes": "Locks in symmetric document-root scaffolding so root-inherited author styles bind on fragment candidates."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Static style parity comparison emits the shared visual-parity report contract."
+  },
+  "operation": "static_style_parity.compare",
+  "input": {
+    "source_content": "<html><body><section class=\"wrap\"><p class=\"lead\">Hello world</p></section></body></html>",
+    "source_css": "html{font-family:Inter,sans-serif;color:#111}.lead{font-size:18px}",
+    "target_content": "<section class=\"wrap\"><p class=\"lead\">Hello world</p></section>",
+    "target_css": "html{font-family:Inter,sans-serif;color:#111}.lead{font-size:18px}"
+  },
+  "expect": [
+    { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/visual-parity-report/v1" },
+    { "path": "status", "assert": "equals", "value": "pass" },
+    { "path": "parity.property_parity", "assert": "equals", "value": 1.0 },
+    { "path": "parity.coverage", "assert": "equals", "value": 1.0 },
+    { "path": "parity.score", "assert": "equals", "value": 1.0 },
+    { "path": "summary.source_total", "assert": "equals", "value": 2 },
+    { "path": "summary.matched_total", "assert": "equals", "value": 2 },
+    { "path": "summary.compared_properties", "assert": "equals", "value": 5 },
+    { "path": "summary.agreed_properties", "assert": "equals", "value": 5 },
+    { "path": "summary.finding_total", "assert": "equals", "value": 0 },
+    { "path": "matches.0.source_selector", "assert": "equals", "value": "section.wrap" },
+    { "path": "matches.0.target_selector", "assert": "equals", "value": "section.wrap" },
+    { "path": "matches.1.source_selector", "assert": "equals", "value": "section.wrap > p.lead" },
+    { "path": "matches.1.target_selector", "assert": "equals", "value": "section.wrap > p.lead" }
+  ]
+}


### PR DESCRIPTION
## What
Corrects two comparator/probe bugs that made the deterministic static-parity gate **understate** real conversion quality. These are honest measurement corrections of faithfully-preserved content — property_parity RISES and there are zero regressions, confirming nothing is masked.

## Root cause (the 35-hyper-minimal-blog 0.02 outlier)
A *minimal* blog scoring 0.02 was almost entirely a measurement artifact — the content converts faithfully. Two stacked bugs:
1. **Bare-fragment probe:** the candidate was probed as a bare `<body>` fragment, so source `html { font-family/font-size/color/line-height }` root rules bound to nothing → every candidate element lost root-inherited typography the source kept.
2. **Whitespace subsumption:** minified candidate markup has no whitespace between block children (`"JanuaryThe"`) vs the source's authored whitespace (`"January The"`), defeating the collapsed-wrapper content-subsumption check.

## Fixes
- `StaticStyleParityProbe.php`: wrap fragments in `<html><body>…` so root author rules cascade symmetrically on both sides.
- `StaticStyleParityComparator.php` `contentSubsumed()`: whitespace-insensitive subsumption for collapsed wrappers.
- Two guard fixtures that pass with the fixes and fail without (A 0.2→1.0, B 0.667→1.0).

## Corpus before/after (77 fixtures, no regressions)
- Median score **0.742 → 0.785**; median coverage **0.789 → 0.813**; **median property_parity 0.966 → 0.971 (rose → nothing masked)**.
- 35-hyper-minimal-blog **0.023 → 0.945**; 5-documentation +0.28; 7-event +0.25; 8-local-service +0.20; others.

## Honest framing
All gains are honest matching correction, NOT real-conversion changes. The dominant *remaining* residual is structural-but-real: source `<nav>` converts to `core/navigation` (a **dynamic, server-rendered block** the render-free gate cannot see by design) — only a live-WP render can measure it.

## Determinism + tests
- Corpus JSON byte-identical across two runs (sha 6ba7584b…). `composer test` + `composer parity` green at 185 fixtures.

## Found-but-not-fixed (tracked follow-up)
A real serializer data-loss bug: the no-WordPress fallback `serializeBlock` (`Runtime.php`) computes inner content via `renderStaticBlock`, which returns '' for dynamic blocks — so a **nested** `core/navigation` vanishes from serialized output entirely (links survive in the in-memory block tree). Fixing it = canonical recursive comment-delimited serialization (high blast radius, ~183 fixtures), left as a tracked finding rather than bundled here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Root-cause diagnosis, gate-accuracy fixes, corpus verification under human review.
