### PR TITLE
Canonical recursive serialization in no-WP fallback (gate-accuracy for nested dynamic blocks)

### DIFF
--- a/php-transformer/src/WordPress/Runtime.php
+++ b/php-transformer/src/WordPress/Runtime.php
@@ -429,24 +429,99 @@ final class Runtime
     }
 
     /**
+     * Serialize a single block to canonical comment-delimited block markup, the
+     * way WordPress core's serialize_block()/get_comment_delimited_block_content()
+     * do. The inner content is built by {@see serializeInnerContent()}, which walks
+     * innerContent and emits each nested block as block MARKUP (not rendered static
+     * HTML). This keeps dynamic/nested blocks — core/navigation and its
+     * navigation-link/submenu children, and any nested block — present in the
+     * serialized string instead of collapsing them to a self-closing comment or
+     * dropping them entirely.
+     *
      * @param array<string, mixed> $block
      */
     private function serializeBlock(array $block): string
     {
+        $blockContent = $this->serializeInnerContent($block);
+
         $blockName = isset($block['blockName']) ? (string) $block['blockName'] : '';
         if ( '' === $blockName ) {
-            return $this->renderStaticBlock($block);
+            return $blockContent;
         }
 
         $name  = str_starts_with($blockName, 'core/') ? substr($blockName, 5) : $blockName;
-        $attrs = empty($block['attrs']) ? '' : ' ' . $this->encodeJson($block['attrs']);
-        $inner = $this->renderStaticBlock($block);
+        $attrs = empty($block['attrs']) || ! is_array($block['attrs']) ? '' : ' ' . $this->serializeBlockAttributes($block['attrs']);
 
-        if ( '' === $inner ) {
+        if ( '' === $blockContent ) {
             return '<!-- wp:' . $name . $attrs . ' /-->';
         }
 
-        return '<!-- wp:' . $name . $attrs . ' -->' . $inner . '<!-- /wp:' . $name . ' -->';
+        return '<!-- wp:' . $name . $attrs . ' -->' . $blockContent . '<!-- /wp:' . $name . ' -->';
+    }
+
+    /**
+     * Serialize block attributes for the comment delimiter the way WordPress
+     * core's serialize_block_attributes() does: JSON-encode, then escape the
+     * characters that could otherwise break out of the surrounding HTML comment
+     * (`--`, `<`, `>`, `&`) plus escaped quotes. This keeps the delimiter
+     * comment-safe and WP-canonical even when an attribute value embeds raw HTML
+     * (e.g. a core/paragraph `content` carrying an inline `<a>`), so the comment
+     * stays a single parseable token. The codebase's unescaped-slash/unicode JSON
+     * convention is preserved via encodeJson().
+     *
+     * @param array<string, mixed> $attrs
+     */
+    private function serializeBlockAttributes(array $attrs): string
+    {
+        $encoded = $this->encodeJson($attrs);
+        $encoded = preg_replace('/--/', '\\u002d\\u002d', $encoded) ?? $encoded;
+        $encoded = preg_replace('/</', '\\u003c', $encoded) ?? $encoded;
+        $encoded = preg_replace('/>/', '\\u003e', $encoded) ?? $encoded;
+        $encoded = preg_replace('/&/', '\\u0026', $encoded) ?? $encoded;
+
+        return preg_replace('/\\\\"/', '\\u0022', $encoded) ?? $encoded;
+    }
+
+    /**
+     * Build a block's inner serialized content. Mirrors WordPress core's
+     * serialize_block() inner loop: walk innerContent, append literal string
+     * chunks verbatim, and replace each null placeholder with the recursively
+     * serialized markup of the next inner block. When innerContent is not a
+     * structured array, fall back to serializing any inner blocks as markup
+     * followed by the saved innerHTML so no nested block is silently dropped.
+     *
+     * @param array<string, mixed> $block
+     */
+    private function serializeInnerContent(array $block): string
+    {
+        $innerBlocks  = isset($block['innerBlocks']) && is_array($block['innerBlocks']) ? array_values($block['innerBlocks']) : array();
+        $innerContent = $block['innerContent'] ?? null;
+
+        if ( ! is_array($innerContent) ) {
+            $serialized = '';
+            foreach ( $innerBlocks as $innerBlock ) {
+                if ( is_array($innerBlock) ) {
+                    $serialized .= $this->serializeBlock($innerBlock);
+                }
+            }
+
+            return $serialized . (isset($block['innerHTML']) ? (string) $block['innerHTML'] : '');
+        }
+
+        $serialized = '';
+        $blockIndex = 0;
+        foreach ( $innerContent as $part ) {
+            if ( null === $part ) {
+                $innerBlock  = $innerBlocks[$blockIndex] ?? null;
+                $serialized .= is_array($innerBlock) ? $this->serializeBlock($innerBlock) : '';
+                ++$blockIndex;
+                continue;
+            }
+
+            $serialized .= (string) $part;
+        }
+
+        return $serialized;
     }
 
     /**

--- a/php-transformer/tests/contract/runtime-no-wordpress.php
+++ b/php-transformer/tests/contract/runtime-no-wordpress.php
@@ -21,6 +21,49 @@ $serialized = $runtime->serializeBlocks($blocks);
 assertSame('<!-- wp:paragraph {"content":"Hello"} --><p>Hello</p><!-- /wp:paragraph -->', $serialized, 'Fallback serializer should preserve block comments and inner HTML.');
 assertSame('wordpress_serialize_blocks_unavailable', $runtime->diagnostics()[0]['code'] ?? null, 'Fallback serializer should expose a diagnostic.');
 
+// Dynamic/nested blocks (core/navigation et al.) save() to null inner HTML, so
+// the WordPress-free fallback serializer must emit canonical comment-delimited
+// markup recursively rather than rendering static HTML. A standalone navigation
+// block keeps its navigation-link children, and a navigation block nested inside
+// another block survives with its delimiters and children intact.
+$navigationLink = static fn (string $label, string $url): array => array(
+    'blockName'    => 'core/navigation-link',
+    'attrs'        => array( 'label' => $label, 'url' => $url ),
+    'innerBlocks'  => array(),
+    'innerHTML'    => '',
+    'innerContent' => array( '' ),
+);
+$navigationBlock = array(
+    'blockName'    => 'core/navigation',
+    'attrs'        => array(),
+    'innerBlocks'  => array( $navigationLink('Home', '/'), $navigationLink('About', '/about') ),
+    'innerHTML'    => '',
+    'innerContent' => array( '', null, null, '' ),
+);
+
+$serializedNav = $runtime->serializeBlocks(array( $navigationBlock ));
+assertSame(
+    '<!-- wp:navigation --><!-- wp:navigation-link {"label":"Home","url":"/"} /--><!-- wp:navigation-link {"label":"About","url":"/about"} /--><!-- /wp:navigation -->',
+    $serializedNav,
+    'Fallback serializer should keep a standalone navigation block\'s navigation-link children instead of collapsing to a self-closing comment.'
+);
+assertSame($serializedNav, $runtime->serializeBlocks(array( $navigationBlock )), 'Fallback serializer must be deterministic (byte-identical across runs).');
+
+$groupWithNav = array(
+    'blockName'    => 'core/group',
+    'attrs'        => array(),
+    'innerBlocks'  => array( $navigationBlock ),
+    'innerHTML'    => '<div class="wp-block-group"></div>',
+    'innerContent' => array( '<div class="wp-block-group">', null, '</div>' ),
+);
+$serializedNested = $runtime->serializeBlocks(array( $groupWithNav ));
+assertSame(
+    '<!-- wp:group --><div class="wp-block-group"><!-- wp:navigation --><!-- wp:navigation-link {"label":"Home","url":"/"} /--><!-- wp:navigation-link {"label":"About","url":"/about"} /--><!-- /wp:navigation --></div><!-- /wp:group -->',
+    $serializedNested,
+    'Fallback serializer should keep a nested navigation block (and its children) instead of dropping it from the group output.'
+);
+assertSame($serializedNested, $runtime->serializeBlocks(array( $groupWithNav )), 'Nested-navigation fallback serialization must be deterministic (byte-identical across runs).');
+
 $html = $runtime->renderBlocks($blocks);
 assertSame('<p>Hello</p>', $html, 'Fallback renderer should render static block HTML.');
 assertSame('wordpress_render_block_unavailable', $runtime->diagnostics()[0]['code'] ?? null, 'Fallback renderer should expose a diagnostic.');


### PR DESCRIPTION
## What
Makes the no-WordPress fallback `Runtime::serializeBlock` serialize dynamic/nested blocks canonically (recursive comment-delimited markup), so the render-free static-parity candidate rebuild is nested-nav-aware and residue-free.

## Impact verdict (verify-first): gate-accuracy, NOT a live-import defect
The buggy fallback is reached ONLY when `serialize_blocks()` doesn't exist. Real SSI imports run inside WordPress (`page-materializer html_to_blocks()` → FormatBridge → `Runtime::serializeBlocks()` → delegates to native `serialize_blocks()`), so stored `post_content` was never affected — **nested nav survives in live imports.** The fallback is exercised only in render-free contexts (chiefly the static-parity gate), where the vanished nested nav made the candidate understate parity. The parity/contract harnesses define their own `serialize_blocks` stub, so the 185 fixtures bypass the fallback — **0 parity fixtures changed.**

## Fix (`src/WordPress/Runtime.php`)
- `serializeBlock` + `serializeInnerContent`: walk `innerContent`, append string chunks verbatim, replace each `null` placeholder with the recursively-serialized next inner block (mirrors core `serialize_block()`); empty content → self-closing, else open/close delimiters. (`BlockFactory::create()` already emits matching null placeholders, so children are recovered.) Old code produced `<!-- wp:navigation /-->` (links dropped) or dropped a nested nav entirely.
- `serializeBlockAttributes`: comment-safe attribute encoding matching core `serialize_block_attributes()` (escape `<`/`>`/`&`/`--`/`"`), required because emitting delimiters surfaced attribute JSON with raw inline HTML that would otherwise break the delimiter comment.

## Verification
- `composer test` (contract + unit + 185 parity) + `composer parity`: 100% green.
- New contract assertions (`tests/contract/runtime-no-wordpress.php`): standalone nav keeps its `navigation-link` children; nested nav survives with delimiters + children; byte-identical across runs.
- Determinism: serializer + full static-parity gate JSON byte-identical across 2 runs. Round-trip re-parses losslessly; `BlockValidityValidator` + `CanonicalSaveShapeValidator` pass (0 findings).
- Corpus median 0.7854 → 0.7854 (1 fixture +0.008 from residue now stripped, 0 regressed) — gate-visibility/accuracy gain, not a live-conversion change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Impact verification, the recursive-serialization fix, and tests under human review.
