### PR TITLE
figma-transformer: fix overridden instance child canvas-global coordinate mislabeling

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1439,10 +1439,26 @@ final class ScenegraphNormalizer
             }
         }
         if ( is_array($child['transform'] ?? null) ) {
+            // m02 and m12 carry canvas-global (absolute) coordinates, not parent-local
+            // coordinates. Stamp them into absoluteBoundingBox so that normalizeLayoutBox
+            // labels the resulting box coordinate_space='absolute'. Without this, the bare
+            // x/y values written below are picked up by the local-coordinate fallback path
+            // and mislabeled coordinate_space='local', causing positionOffset() to emit the
+            // raw canvas value verbatim (e.g. 13842 px) instead of subtracting the
+            // containing-block origin.
+            $absoluteBounds = is_array($child['absoluteBoundingBox'] ?? null) ? $child['absoluteBoundingBox'] : array();
             foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
                 if ( isset($child['transform'][$source]) && is_numeric($child['transform'][$source]) ) {
                     $child[$target] = (float) $child['transform'][$source];
+                    // Only backfill absoluteBoundingBox where the dimension is not already
+                    // present — preserve any richer absolute bounds the payload already has.
+                    if ( ! isset($absoluteBounds[$target]) ) {
+                        $absoluteBounds[$target] = (float) $child['transform'][$source];
+                    }
                 }
+            }
+            if ( ! empty($absoluteBounds) ) {
+                $child['absoluteBoundingBox'] = $absoluteBounds;
             }
         }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6247,6 +6247,83 @@ $assert(! str_contains($derivedSymbolInstanceHtml, '<g transform="scale'), 'deri
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-2-derived-label{width:90px;height:24px;position:absolute;left:12px;top:6px'), 'derived-symbol-instance-label-size-position');
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-3-derived-icon{width:10px;height:10px;position:absolute;left:110px;top:10px'), 'derived-symbol-instance-icon-size-position');
 
+// OVERRIDDEN INSTANCE CHILD CANVAS-GLOBAL COORDINATE BUG (#xxx).
+//
+// When an instance resolves a component and an override carries a positional
+// `transform`, the m02/m12 values are canvas-global (absolute) coordinates —
+// NOT parent-local offsets. A page frame at canvas x=12000 y=0 containing a
+// Footer instance should resolve the Logo child's override transform m02=12120
+// as CSS left:120px (= 12120 - 12000), NOT left:12120px (the raw canvas value).
+//
+// Before the fix, normalizeOverriddenInstanceChild stamped bare x/y from m02/m12
+// onto the child, which normalizeLayoutBox then mislabeled coordinate_space='local',
+// causing positionOffset() to emit the raw canvas value verbatim instead of
+// subtracting the containing-block origin.
+//
+// The instance must have NO pre-populated children so that resolveInstances clones
+// them from the component and runs applyInstanceOverridesToChildren, which is the
+// code path that calls normalizeOverriddenInstanceChild.
+$canvasGlobalOverrideResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Canvas-Global Override Coordinate Fixture',
+    'nodes' => array(
+        // Component master: Logo child has NO absoluteBoundingBox — only width/height.
+        // The instance override will supply a canvas-global transform (m02=12120).
+        // Without the fix, normalizeLayoutBox picks up the stamped bare x/y and labels
+        // them coordinate_space='local', causing positionOffset() to emit 12120px verbatim.
+        array(
+            'id'       => 'cgoc:component',
+            'type'     => 'COMPONENT',
+            'name'     => 'Footer component',
+            'key'      => 'footer-key',
+            'absoluteBoundingBox' => array('x' => 12000, 'y' => 700, 'width' => 1440, 'height' => 200),
+            'children' => array(
+                array(
+                    'id'    => 'cgoc:logo',
+                    'type'  => 'RECTANGLE',
+                    'name'  => 'Logo',
+                    // No absoluteBoundingBox — the override transform is the only position source.
+                    'width' => 160,
+                    'height' => 60,
+                ),
+            ),
+        ),
+        // Page frame at canvas offset x=12000, containing the footer instance.
+        // The instance has NO children — resolution will clone them from the component.
+        array(
+            'id'                  => 'cgoc:page',
+            'type'                => 'FRAME',
+            'name'                => 'Page',
+            'absoluteBoundingBox' => array('x' => 12000, 'y' => 0, 'width' => 1440, 'height' => 900),
+            'children'            => array(
+                array(
+                    'id'          => 'cgoc:instance',
+                    'type'        => 'INSTANCE',
+                    'name'        => 'Footer',
+                    'componentId' => 'footer-key',
+                    'absoluteBoundingBox' => array('x' => 12000, 'y' => 700, 'width' => 1440, 'height' => 200),
+                    // Override: the Logo child's transform carries a canvas-global position
+                    // (m02=12120 is an absolute canvas X). This mimics the FSE Pilot .fig
+                    // pattern where m02=13842 leaked through as CSS left:13842px.
+                    'overrides'   => array(
+                        array(
+                            'nodeId'    => 'cgoc:logo',
+                            'transform' => array('m00' => 1, 'm01' => 0, 'm02' => 12120, 'm10' => 0, 'm11' => 1, 'm12' => 860),
+                        ),
+                    ),
+                    // No 'children' key — instance resolution clones from the component.
+                ),
+            ),
+        ),
+    ),
+), array('frame_id' => 'cgoc:page'));
+$canvasGlobalOverrideCss = $fileContent($canvasGlobalOverrideResult, 'style.css');
+// The Logo node's CSS left must be page-relative (120px), NOT the raw canvas value (12120px).
+// A value >= 1440 (canvas width) proves the bug: the raw canvas coordinate leaked through.
+// The namespaced class is "cgoc-instance-cgoc-logo-logo" (instanceId/childId).
+preg_match('/figma-node-cgoc-instance-cgoc-logo[^{]*\{[^}]*left:([\d.]+)px/', $canvasGlobalOverrideCss, $canvasGlobalLogoLeft);
+$canvasGlobalLogoLeftPx = isset($canvasGlobalLogoLeft[1]) ? (float) $canvasGlobalLogoLeft[1] : -1.0;
+$assert($canvasGlobalLogoLeftPx >= 0.0 && $canvasGlobalLogoLeftPx < 1440.0, 'overridden-instance-child-canvas-global-transform-localizes-x');
+
 // Real anchor tags: a TEXT node carrying a URL hyperlink emits a real <a href>.
 $urlLinkResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Url Link Fixture',


### PR DESCRIPTION
## Root cause

`normalizeOverriddenInstanceChild()` in `ScenegraphNormalizer.php` reads
`transform.m02` / `m12` (canvas-global coordinates) and stamps them as bare
top-level `x` / `y` on the child node. When `normalizeLayoutBox()` rebuilds
the node's `box`, it has no `absoluteBoundingBox` to read from, so it falls
through to the bare-`x`/`y` path and assigns `coordinate_space = 'local'`.
`StaticHtmlEmitter::positionOffset()` trusts that label and returns the raw
canvas value verbatim — no containing-block subtraction.

Non-overridden instance children are not affected: they keep their
`absoluteBoundingBox` intact, get labeled `coordinate_space = 'absolute'`,
and go through the correct rebase path.

## Triangulated evidence (FSE Pilot Build Theme .fig)

All three sources agree on the same raw canvas value for the footer Logo node:

| Source | Value |
|--------|-------|
| Raw .fig scenegraph `transform.m02` | **13842** |
| IR `visual_node_map` `rect.x` | **13842** |
| Rendered DOM `getBoundingClientRect().x` | **13842** |

The node ID is `4192:11092/4177:10488` (overridden instance child).
The unaffected sibling `4192:11093`'s Logo resolves correctly to `x = 112`
because it carries an intact `absoluteBoundingBox` and never hits the bug path.

## Fix

After extracting `x`/`y` from `transform.m02`/`m12`, backfill
`absoluteBoundingBox` with those values so `normalizeLayoutBox` reads them
via the absolute-bounds branch (`coordinate_space = 'absolute'`) and the
existing rebase machinery subtracts the containing-block origin.
Existing `absoluteBoundingBox` values on the payload take precedence
(guarded by `isset` check).

## Before / after oracle numbers

Max CSS right edge per page (max positive `left + width` across all nodes):

| Page | Before | After |
|------|--------|-------|
| 404 | **14070 px** | 1552 px ✓ |
| archive | **14070 px** | 1642 px ✓ |
| page | **14070 px** | 1552 px ✓ |
| home | 1552 px | 1552 px ✓ |
| blog-post | 1636 px | 1636 px ✓ |

Overflow nodes before the fix:
- `.figma-node-4192-11092-4177-10488-logo` — `left: 13842px` (404)
- `.figma-node-4192-10706-4177-10488-logo` — `left: 13842px` (archive)
- `.figma-node-4194-2034-4177-10488-logo` — `left: 13842px` (page)

After the fix: no node on any page has `left > 1440px`.

## Contract test

Added `overridden-instance-child-canvas-global-transform-localizes-x`:
- Component master has a Logo child with `width: 160, height: 60` (no `absoluteBoundingBox`)
- Instance override carries `transform.m02 = 12120` (canvas-global) inside a page frame at canvas `x = 12000`
- The test asserts the emitted CSS `left` is `120 px` (page-relative), not `12120 px` (raw canvas)
- The test fails on the unfixed code and passes on the fix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** root-cause investigation, fix implementation, contract test authoring, and oracle verification