### PR TITLE
figma-transformer: clarify page frame rebasing

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -51,7 +51,7 @@ final class ScenegraphNormalizer
         if ( $renderDocument ) {
             $documentFrameIds = $this->documentFrameIds($options, $frameIds, $nodeMap);
             foreach ( $documentFrameIds as $documentFrameId ) {
-                $rebasedFrame = $this->rebaseSelectedFrameToOrigin($this->refreshResolvedTree($nodeMap[$documentFrameId], $nodeMap));
+                $rebasedFrame = $this->rebasePageFrameToLocalOrigin($this->refreshResolvedTree($nodeMap[$documentFrameId], $nodeMap));
                 $this->appendNodeMap($rebasedFrame, $nodeMap);
             }
         }
@@ -63,7 +63,7 @@ final class ScenegraphNormalizer
             if ( isset($nodeMap[$id]) ) {
                 $node = $this->refreshResolvedTree($nodeMap[$id], $nodeMap);
                 if ( $explicitSelectedFrameId && $id === $selectedFrameId ) {
-                    $node = $this->rebaseSelectedFrameToOrigin($node);
+                    $node = $this->rebasePageFrameToLocalOrigin($node);
                 }
                 $renderNodes[] = $node;
             }
@@ -731,14 +731,14 @@ final class ScenegraphNormalizer
      * @param array<string, mixed> $node
      * @return array<string, mixed>
      */
-    private function rebaseSelectedFrameToOrigin(array $node): array
+    private function rebasePageFrameToLocalOrigin(array $node): array
     {
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $originX = isset($box['x']) && is_numeric($box['x']) ? (float) $box['x'] : 0.0;
         $originY = isset($box['y']) && is_numeric($box['y']) ? (float) $box['y'] : 0.0;
         $node['_selected_frame_root'] = true;
 
-        return $this->rebaseNodeCoordinates($node, $originX, $originY, true);
+        return $this->rebaseCanvasCoordinateBoxesToPageLocal($node, $originX, $originY, true);
     }
 
     /**
@@ -793,10 +793,10 @@ final class ScenegraphNormalizer
      * @param array<string, mixed> $node
      * @return array<string, mixed>
      */
-    private function rebaseNodeCoordinates(array $node, float $originX, float $originY, bool $isRoot = false): array
+    private function rebaseCanvasCoordinateBoxesToPageLocal(array $node, float $originX, float $originY, bool $isRoot = false): array
     {
-        $node = $this->rebaseNodeBox($node, 'box', $originX, $originY, $isRoot);
-        $node = $this->rebaseNodeBox($node, 'figma_box', $originX, $originY, $isRoot);
+        $node = $this->rebaseCanvasCoordinateBoxToPageLocal($node, 'box', $originX, $originY, $isRoot);
+        $node = $this->rebaseCanvasCoordinateBoxToPageLocal($node, 'figma_box', $originX, $originY, $isRoot);
 
         foreach ( array('children', 'nodes') as $childrenKey ) {
             if ( ! is_array($node[$childrenKey] ?? null) ) {
@@ -805,7 +805,7 @@ final class ScenegraphNormalizer
 
             foreach ( $node[$childrenKey] as $index => $child ) {
                 if ( is_array($child) ) {
-                    $node[$childrenKey][$index] = $this->rebaseNodeCoordinates($child, $originX, $originY);
+                    $node[$childrenKey][$index] = $this->rebaseCanvasCoordinateBoxesToPageLocal($child, $originX, $originY);
                 }
             }
         }
@@ -817,7 +817,7 @@ final class ScenegraphNormalizer
      * @param array<string, mixed> $node
      * @return array<string, mixed>
      */
-    private function rebaseNodeBox(array $node, string $boxKey, float $originX, float $originY, bool $isRoot): array
+    private function rebaseCanvasCoordinateBoxToPageLocal(array $node, string $boxKey, float $originX, float $originY, bool $isRoot): array
     {
         if ( ! is_array($node[$boxKey] ?? null) ) {
             return $node;
@@ -833,6 +833,7 @@ final class ScenegraphNormalizer
                 $box['y'] = $isRoot ? 0.0 : (float) $box['y'] - $originY;
             }
             $box['coordinate_space'] = 'local';
+            $box['local_origin'] = 'page';
         }
 
         $node[$boxKey] = $box;

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5494,6 +5494,34 @@ $assert(str_contains($positiveRootCanvasOriginCss, '.figma-node-positive-origin-
 $assert(str_contains($positiveRootCanvasOriginCss, '.figma-node-positive-origin-cta-cta{width:240px;height:40px;position:absolute;left:200px;top:400px'), 'positive-root-canvas-origin-normalizes-text-child');
 $positiveRootCanvasOriginDiagnostics = $positiveRootCanvasOriginResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
 $assert(0 === ($positiveRootCanvasOriginDiagnostics['layout']['large_absolute_offset_count'] ?? null), 'positive-root-canvas-origin-diagnostics-no-large-offset');
+
+$selectedFrameRebaseNormalizer = new \Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer();
+$selectedFrameRebaseNormalized = $selectedFrameRebaseNormalizer->normalize(array(
+    'name'  => 'Selected Frame Explicit Rebase Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'selected-rebase:frame',
+            'type'                => 'FRAME',
+            'name'                => 'Selected Rebase Frame',
+            'absoluteBoundingBox' => array('x' => 12000, 'y' => 500, 'width' => 1440, 'height' => 900),
+            'children'            => array(
+                array(
+                    'id'                  => 'selected-rebase:child',
+                    'type'                => 'RECTANGLE',
+                    'name'                => 'Child',
+                    'absoluteBoundingBox' => array('x' => 12120, 'y' => 680, 'width' => 160, 'height' => 60),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+            ),
+        ),
+    ),
+), array('frame_id' => 'selected-rebase:frame'));
+$selectedFrameRebaseRoot = $selectedFrameRebaseNormalized['nodes'][0] ?? array();
+$selectedFrameRebaseChild = $selectedFrameRebaseRoot['children'][0] ?? array();
+$assert(0.0 === ($selectedFrameRebaseRoot['box']['x'] ?? null) && 0.0 === ($selectedFrameRebaseRoot['box']['y'] ?? null), 'selected-frame-rebase-root-origin-zero');
+$assert('local' === ($selectedFrameRebaseRoot['box']['coordinate_space'] ?? null) && 'page' === ($selectedFrameRebaseRoot['box']['local_origin'] ?? null), 'selected-frame-rebase-root-marked-page-local');
+$assert(120.0 === ($selectedFrameRebaseChild['box']['x'] ?? null) && 180.0 === ($selectedFrameRebaseChild['box']['y'] ?? null), 'selected-frame-rebase-child-subtracts-page-origin');
+$assert('local' === ($selectedFrameRebaseChild['box']['coordinate_space'] ?? null) && 'page' === ($selectedFrameRebaseChild['box']['local_origin'] ?? null), 'selected-frame-rebase-child-marked-page-local');
 blocks_engine_figma_transformer_run_origin_inference_contract($assert, $fileContent, $findVisualNode);
 
 $resolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -6391,6 +6419,21 @@ $documentModeNormalized = $documentModeNormalizer->normalize($documentModeSceneg
     'render_document' => true,
     'document_frame_ids' => array('mpoc:home', 'mpoc:about'),
 ));
+$documentModeNodeMap = is_array($documentModeNormalized['node_map'] ?? null) ? $documentModeNormalized['node_map'] : array();
+$documentModeHomeFrame = is_array($documentModeNodeMap['mpoc:home'] ?? null) ? $documentModeNodeMap['mpoc:home'] : array();
+$documentModeAboutFrame = is_array($documentModeNodeMap['mpoc:about'] ?? null) ? $documentModeNodeMap['mpoc:about'] : array();
+$documentModeHomeInstance = is_array($documentModeHomeFrame['children'][0] ?? null) ? $documentModeHomeFrame['children'][0] : array();
+$documentModeAboutInstance = is_array($documentModeAboutFrame['children'][0] ?? null) ? $documentModeAboutFrame['children'][0] : array();
+$documentModeHomeLogo = is_array($documentModeHomeInstance['children'][0] ?? null) ? $documentModeHomeInstance['children'][0] : array();
+$documentModeAboutLogo = is_array($documentModeAboutInstance['children'][0] ?? null) ? $documentModeAboutInstance['children'][0] : array();
+$assert(0.0 === ($documentModeHomeFrame['box']['x'] ?? null) && 0.0 === ($documentModeHomeFrame['box']['y'] ?? null), 'document-mode-home-page-root-origin-zero');
+$assert(0.0 === ($documentModeAboutFrame['box']['x'] ?? null) && 0.0 === ($documentModeAboutFrame['box']['y'] ?? null), 'document-mode-about-page-root-origin-zero');
+$assert('local' === ($documentModeHomeFrame['box']['coordinate_space'] ?? null) && 'page' === ($documentModeHomeFrame['box']['local_origin'] ?? null), 'document-mode-home-page-root-marked-page-local');
+$assert('local' === ($documentModeAboutFrame['box']['coordinate_space'] ?? null) && 'page' === ($documentModeAboutFrame['box']['local_origin'] ?? null), 'document-mode-about-page-root-marked-page-local');
+$assert(0.0 === ($documentModeHomeInstance['box']['x'] ?? null) && 700.0 === ($documentModeHomeInstance['box']['y'] ?? null), 'document-mode-home-instance-subtracts-page-origin');
+$assert(0.0 === ($documentModeAboutInstance['box']['x'] ?? null) && 700.0 === ($documentModeAboutInstance['box']['y'] ?? null), 'document-mode-about-instance-subtracts-page-origin');
+$assert(120.0 === ($documentModeHomeLogo['box']['x'] ?? null) && 860.0 === ($documentModeHomeLogo['box']['y'] ?? null), 'document-mode-home-override-child-subtracts-page-origin');
+$assert(150.0 === ($documentModeAboutLogo['box']['x'] ?? null) && 860.0 === ($documentModeAboutLogo['box']['y'] ?? null), 'document-mode-about-override-child-subtracts-page-origin');
 $documentModeSite = $documentModeEmitter->emitSite($documentModeNormalized, array(
     'pages' => array(
         array('frame_id' => 'mpoc:home', 'name' => 'Home', 'path' => 'index.html', 'entrypoint' => true),


### PR DESCRIPTION
## Summary
- routes selected-frame and document-frame origin rebasing through explicit page-local helper methods
- marks rebased boxes as local with page origin metadata
- strengthens selected-frame and multi-page document-mode contract assertions while preserving canvas-global override behavior

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the focused normalizer refactor, adding contract coverage, and running verification.