### PR TITLE
figma-transformer: introduce geometry box coordinate primitive

### DIFF
--- a/figma-transformer/src/Scenegraph/GeometryBox.php
+++ b/figma-transformer/src/Scenegraph/GeometryBox.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Coordinate-space names for normalized scenegraph boxes.
+ */
+final class GeometryBox
+{
+    public const CLASSIFICATION_CANVAS_ABSOLUTE = 'canvas-absolute';
+    public const CLASSIFICATION_PARENT_LOCAL = 'parent-local';
+    public const CLASSIFICATION_PAGE_LOCAL = 'page-local';
+
+    public const COORDINATE_SPACE_CANVAS_ABSOLUTE = 'absolute';
+    public const COORDINATE_SPACE_PARENT_LOCAL = 'local';
+    public const COORDINATE_SPACE_PAGE_LOCAL = self::COORDINATE_SPACE_PARENT_LOCAL;
+
+    /**
+     * @param array<string, mixed> $box
+     */
+    public static function coordinateSpace(array $box): string
+    {
+        return isset($box['coordinate_space']) && is_scalar($box['coordinate_space'])
+            ? (string) $box['coordinate_space']
+            : self::COORDINATE_SPACE_CANVAS_ABSOLUTE;
+    }
+
+    public static function coordinateSpaceForClassification(string $classification): string
+    {
+        return self::CLASSIFICATION_CANVAS_ABSOLUTE === $classification
+            ? self::COORDINATE_SPACE_CANVAS_ABSOLUTE
+            : self::COORDINATE_SPACE_PARENT_LOCAL;
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     */
+    public static function classifyNormalizedBox(array $box, bool $isPageLocal = false): string
+    {
+        if ( self::COORDINATE_SPACE_CANVAS_ABSOLUTE === self::coordinateSpace($box) ) {
+            return self::CLASSIFICATION_CANVAS_ABSOLUTE;
+        }
+
+        return $isPageLocal ? self::CLASSIFICATION_PAGE_LOCAL : self::CLASSIFICATION_PARENT_LOCAL;
+    }
+}

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -824,15 +824,17 @@ final class ScenegraphNormalizer
         }
 
         $box = $node[$boxKey];
-        $coordinateSpace = (string) ($box['coordinate_space'] ?? 'absolute');
-        if ( $isRoot || 'absolute' === $coordinateSpace ) {
+        $coordinateSpace = GeometryBox::coordinateSpace($box);
+        if ( $isRoot || GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE === $coordinateSpace ) {
             if ( isset($box['x']) && is_numeric($box['x']) ) {
                 $box['x'] = $isRoot ? 0.0 : (float) $box['x'] - $originX;
             }
             if ( isset($box['y']) && is_numeric($box['y']) ) {
                 $box['y'] = $isRoot ? 0.0 : (float) $box['y'] - $originY;
             }
-            $box['coordinate_space'] = 'local';
+            $box['coordinate_space'] = GeometryBox::coordinateSpaceForClassification(
+                $isRoot ? GeometryBox::CLASSIFICATION_PAGE_LOCAL : GeometryBox::CLASSIFICATION_PARENT_LOCAL
+            );
         }
 
         $node[$boxKey] = $box;
@@ -3765,7 +3767,7 @@ final class ScenegraphNormalizer
     private function normalizeLayoutBox(array $node): array
     {
         $box = array();
-        $coordinateSpace = null;
+        $coordinateSpaceClassification = null;
 
         foreach ( array('absoluteBoundingBox', 'absoluteRenderBounds') as $boundsKey ) {
             if ( ! is_array($node[$boundsKey] ?? null) ) {
@@ -3779,7 +3781,7 @@ final class ScenegraphNormalizer
             }
 
             if ( isset($node[$boundsKey]['x']) || isset($node[$boundsKey]['y']) ) {
-                $coordinateSpace = 'absolute';
+                $coordinateSpaceClassification = GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE;
             }
         }
 
@@ -3787,7 +3789,7 @@ final class ScenegraphNormalizer
             if ( ! array_key_exists($dimension, $box) && isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
                 $box[$dimension] = (float) $node[$dimension];
                 if ( 'x' === $dimension || 'y' === $dimension ) {
-                    $coordinateSpace = 'local';
+                    $coordinateSpaceClassification = GeometryBox::CLASSIFICATION_PARENT_LOCAL;
                 }
             }
         }
@@ -3804,13 +3806,13 @@ final class ScenegraphNormalizer
             foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
                 if ( ! array_key_exists($target, $box) && isset($node['transform'][$source]) && is_numeric($node['transform'][$source]) ) {
                     $box[$target] = (float) $node['transform'][$source];
-                    $coordinateSpace = 'local';
+                    $coordinateSpaceClassification = GeometryBox::CLASSIFICATION_PARENT_LOCAL;
                 }
             }
         }
 
-        if ( null !== $coordinateSpace ) {
-            $box['coordinate_space'] = $coordinateSpace;
+        if ( null !== $coordinateSpaceClassification ) {
+            $box['coordinate_space'] = GeometryBox::coordinateSpaceForClassification($coordinateSpaceClassification);
         }
 
         return $box;

--- a/figma-transformer/tests/contract/GeometryBoxContract.php
+++ b/figma-transformer/tests/contract/GeometryBoxContract.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\GeometryBox;
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer;
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_geometry_box_contract(callable $assert): void
+{
+    $normalizer = new ScenegraphNormalizer();
+
+    $absoluteResult = $normalizer->normalize(array(
+        'name'  => 'Absolute Bounds Geometry Fixture',
+        'nodes' => array(
+            array(
+                'id'                  => 'geometry:absolute',
+                'type'                => 'FRAME',
+                'name'                => 'Absolute bounds',
+                'absoluteBoundingBox' => array('x' => 100, 'y' => 50, 'width' => 320, 'height' => 200),
+            ),
+        ),
+    ));
+    $absoluteBox = $absoluteResult['nodes'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE === GeometryBox::classifyNormalizedBox($absoluteBox), 'geometry-box-absolute-bounds-coordinate-space');
+    $assert(array('x' => 100.0, 'y' => 50.0, 'width' => 320.0, 'height' => 200.0, 'coordinate_space' => GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE) === $absoluteBox, 'geometry-box-absolute-bounds-values');
+
+    $rawPositionResult = $normalizer->normalize(array(
+        'name'  => 'Raw Position Geometry Fixture',
+        'nodes' => array(
+            array(
+                'id'     => 'geometry:raw',
+                'type'   => 'FRAME',
+                'name'   => 'Raw position',
+                'x'      => 12,
+                'y'      => 34,
+                'width'  => 120,
+                'height' => 80,
+            ),
+        ),
+    ));
+    $rawPositionBox = $rawPositionResult['nodes'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($rawPositionBox), 'geometry-box-raw-xy-coordinate-space');
+    $assert(array('x' => 12.0, 'y' => 34.0, 'width' => 120.0, 'height' => 80.0, 'coordinate_space' => GeometryBox::COORDINATE_SPACE_PARENT_LOCAL) === $rawPositionBox, 'geometry-box-raw-xy-values');
+
+    $transformResult = $normalizer->normalize(array(
+        'name'  => 'Transform Geometry Fixture',
+        'nodes' => array(
+            array(
+                'id'        => 'geometry:transform',
+                'type'      => 'FRAME',
+                'name'      => 'Transform position',
+                'size'      => array('x' => 90, 'y' => 60),
+                'transform' => array('m02' => 7, 'm12' => 11),
+            ),
+        ),
+    ));
+    $transformBox = $transformResult['nodes'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($transformBox), 'geometry-box-transform-coordinate-space');
+    $assert(array('width' => 90.0, 'height' => 60.0, 'x' => 7.0, 'y' => 11.0, 'coordinate_space' => GeometryBox::COORDINATE_SPACE_PARENT_LOCAL) === $transformBox, 'geometry-box-transform-values');
+
+    $selectedFrameResult = $normalizer->normalize(
+        array(
+            'name'  => 'Selected Frame Rebase Geometry Fixture',
+            'nodes' => array(
+                array(
+                    'id'                  => 'geometry:page',
+                    'type'                => 'FRAME',
+                    'name'                => 'Page',
+                    'absoluteBoundingBox' => array('x' => 1000, 'y' => 500, 'width' => 800, 'height' => 600),
+                    'children'            => array(
+                        array(
+                            'id'                  => 'geometry:selected',
+                            'type'                => 'FRAME',
+                            'name'                => 'Selected frame',
+                            'absoluteBoundingBox' => array('x' => 1200, 'y' => 700, 'width' => 400, 'height' => 300),
+                            'children'            => array(
+                                array(
+                                    'id'                  => 'geometry:selected-child',
+                                    'type'                => 'TEXT',
+                                    'name'                => 'Selected child',
+                                    'characters'          => 'Child',
+                                    'absoluteBoundingBox' => array('x' => 1250, 'y' => 740, 'width' => 100, 'height' => 30),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array('frame_id' => 'geometry:selected')
+    );
+    $selectedFrameBox = $selectedFrameResult['nodes'][0]['box'] ?? array();
+    $selectedChildBox = $selectedFrameResult['nodes'][0]['children'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_PAGE_LOCAL === GeometryBox::classifyNormalizedBox($selectedFrameBox, true), 'geometry-box-selected-frame-page-local-coordinate-space');
+    $assert(0.0 === ($selectedFrameBox['x'] ?? null) && 0.0 === ($selectedFrameBox['y'] ?? null), 'geometry-box-selected-frame-rebased-root-origin');
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($selectedChildBox), 'geometry-box-selected-frame-child-local-coordinate-space');
+    $assert(50.0 === ($selectedChildBox['x'] ?? null) && 40.0 === ($selectedChildBox['y'] ?? null), 'geometry-box-selected-frame-child-rebased-position');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../figma-transformer.php';
 require_once __DIR__ . '/../../scripts/figma-fixture-selection.php';
 require_once __DIR__ . '/FixtureMatrixContract.php';
+require_once __DIR__ . '/GeometryBoxContract.php';
 require_once __DIR__ . '/LayoutMismatchContract.php';
 require_once __DIR__ . '/OriginInferenceContract.php';
 require_once __DIR__ . '/RenderStyleMismatchContract.php';
@@ -1772,6 +1773,7 @@ $assert(in_array('generated-vs-source-clipping', $genericCauses, true), 'layout-
 $assert(in_array('vector-shell-wrapper-offset', $genericCauses, true), 'layout-mismatch-vector-shell-wrapper-offset-suspected-cause');
 blocks_engine_figma_transformer_run_layout_mismatch_contract($assert);
 blocks_engine_figma_transformer_run_render_style_mismatch_contract($assert);
+blocks_engine_figma_transformer_run_geometry_box_contract($assert);
 
 $layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name' => 'Layout Mismatch Fixture',


### PR DESCRIPTION
## Summary
- Add a small Scenegraph\GeometryBox primitive with explicit coordinate-space classifications.
- Use the primitive in ScenegraphNormalizer layout-box creation and selected-frame rebase code while preserving existing serialized coordinate_space values.
- Add focused contract coverage for absoluteBoundingBox, raw x/y, transform fallback, and selected-frame rebase classification.

## Tests
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the geometry primitive, focused normalizer migration, contract coverage, and PR preparation.