### PR TITLE
figma-transformer: preserve refreshed nested instance geometry

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -9,6 +9,8 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
  */
 final class ScenegraphNormalizer
 {
+    private const GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE = 'component_source_clone';
+
     public function __construct(
         private readonly ScenegraphIndex $index = new ScenegraphIndex()
     ) {
@@ -701,13 +703,14 @@ final class ScenegraphNormalizer
     private function refreshResolvedTree(array $node, array $nodeMap, array $trail = array()): array
     {
         $id = (string) ($node['id'] ?? '');
-        if ( '' !== $id && isset($nodeMap[$id]) && ! in_array($id, $trail, true) ) {
-            $node = $nodeMap[$id];
-            $trail[] = $id;
-        }
-
-        if ( true === ($node['figma_component']['resolved'] ?? false) ) {
-            return $node;
+        $sourceId = (string) ($node['figma_component_source_id'] ?? '');
+        $refreshId = '' !== $id && isset($nodeMap[$id]) ? $id : $sourceId;
+        $refreshesComponentSourceClone = '' !== $sourceId && $refreshId === $sourceId && $this->isRefreshableComponentSourceClone($node, $nodeMap[$refreshId] ?? array());
+        if ( '' !== $refreshId && isset($nodeMap[$refreshId]) && ! in_array($refreshId, $trail, true) && ($refreshId === $id || $refreshesComponentSourceClone) ) {
+            $node = $refreshId === $id
+                ? $nodeMap[$refreshId]
+                : $this->mergeRefreshedComponentSource($node, $nodeMap[$refreshId], $refreshId);
+            $trail[] = $refreshId;
         }
 
         if ( ! is_array($node['children'] ?? null) ) {
@@ -720,6 +723,93 @@ final class ScenegraphNormalizer
             }
 
             $node['children'][$index] = $this->refreshResolvedTree($child, $nodeMap, $trail);
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $clone
+     * @param array<string, mixed> $refreshed
+     */
+    private function isRefreshableComponentSourceClone(array $clone, array $refreshed): bool
+    {
+        $cloneType = strtoupper((string) ($clone['type'] ?? ''));
+        $refreshedType = strtoupper((string) ($refreshed['type'] ?? ''));
+
+        return 'INSTANCE' === $cloneType || 'INSTANCE' === $refreshedType || true === ($clone['figma_component']['resolved'] ?? false) || true === ($refreshed['figma_component']['resolved'] ?? false);
+    }
+
+    /**
+     * Refresh a namespaced component-source clone without replacing its instance placement.
+     *
+     * @param array<string, mixed> $clone
+     * @param array<string, mixed> $refreshed
+     * @return array<string, mixed>
+     */
+    private function mergeRefreshedComponentSource(array $clone, array $refreshed, string $sourceId): array
+    {
+        $cloneId = (string) ($clone['id'] ?? '');
+        $merged = '' !== $cloneId ? $this->retargetComponentSourceIds($refreshed, $sourceId, $cloneId) : $refreshed;
+
+        foreach ( array('id', 'figma_component_source_id', 'box', 'figma_box', 'layout') as $key ) {
+            if ( array_key_exists($key, $clone) ) {
+                $merged[$key] = $clone[$key];
+            }
+        }
+
+        return $this->markComponentSourceCloneGeometry($merged);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function retargetComponentSourceIds(array $node, string $sourceId, string $cloneId): array
+    {
+        foreach ( array('id', 'figma_component_source_id') as $key ) {
+            if ( ! isset($node[$key]) || ! is_scalar($node[$key]) ) {
+                continue;
+            }
+
+            $id = (string) $node[$key];
+            if ( $sourceId === $id ) {
+                $node[$key] = 'id' === $key ? $cloneId : $sourceId;
+            } elseif ( str_starts_with($id, $sourceId . '/') ) {
+                $node[$key] = ('id' === $key ? $cloneId : $sourceId) . substr($id, strlen($sourceId));
+            }
+        }
+
+        if ( is_array($node['children'] ?? null) ) {
+            foreach ( $node['children'] as $index => $child ) {
+                if ( is_array($child) ) {
+                    $node['children'][$index] = $this->retargetComponentSourceIds($child, $sourceId, $cloneId);
+                }
+            }
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function markComponentSourceCloneGeometry(array $node): array
+    {
+        foreach ( array('box', 'figma_box') as $boxKey ) {
+            if ( ! is_array($node[$boxKey] ?? null) ) {
+                continue;
+            }
+
+            foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
+                if ( isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
+                    $node[$boxKey][$dimension] = (float) $node[$dimension];
+                }
+            }
+
+            $node[$boxKey]['coordinate_space'] = 'local';
+            $node[$boxKey]['geometry_semantics'] = self::GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE;
         }
 
         return $node;
@@ -1231,7 +1321,7 @@ final class ScenegraphNormalizer
 
             $id = (string) ($child['id'] ?? '');
             if ( 'INSTANCE' === strtoupper((string) ($child['type'] ?? '')) && '' !== $id && isset($nodeMap[$id]) ) {
-                $child = $nodeMap[$id];
+                $child = $this->mergeRefreshedComponentSource($child, $nodeMap[$id], $id);
             }
 
             if ( is_array($child['children'] ?? null) ) {

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5914,6 +5914,71 @@ $nestedInstanceVectorHtml = $fileContent($nestedInstanceVectorResult, 'index.htm
 $assert(str_contains($nestedInstanceVectorHtml, 'data-figma-node-id="nested-wrapper:instance/nested-wrapper:icon/nested-icon:vector"'), 'nested-instance-vector-child-id-namespaced');
 $assert(str_contains($nestedInstanceVectorHtml, 'data-figma-vector="true"'), 'nested-instance-vector-renders-svg');
 
+$nestedInstanceSelectedOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Nested Instance Selected Origin Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'selected-origin:logo-component',
+            'type'     => 'COMPONENT',
+            'name'     => 'Logo component',
+            'key'      => 'selected-origin-logo-key',
+            'width'    => 40,
+            'height'   => 20,
+            'children' => array(
+                array(
+                    'id'     => 'selected-origin:logo-mark',
+                    'type'   => 'RECTANGLE',
+                    'name'   => 'Logo mark',
+                    'width'  => 40,
+                    'height' => 20,
+                ),
+            ),
+        ),
+        array(
+            'id'       => 'selected-origin:header-component',
+            'type'     => 'COMPONENT',
+            'name'     => 'Header component',
+            'key'      => 'selected-origin-header-key',
+            'width'    => 1200,
+            'height'   => 120,
+            'children' => array(
+                array(
+                    'id'                  => 'selected-origin:nested-logo',
+                    'type'                => 'INSTANCE',
+                    'name'                => 'Nested logo',
+                    'componentId'         => 'selected-origin-logo-key',
+                    'x'                   => 120,
+                    'y'                   => 32,
+                    'width'               => 40,
+                    'height'              => 20,
+                    // The stale source node may still carry canvas geometry. The
+                    // clone placement above is parent-local and must win.
+                    'absoluteBoundingBox' => array('x' => -2948, 'y' => -362.5, 'width' => 40, 'height' => 20),
+                ),
+            ),
+        ),
+        array(
+            'id'                  => 'selected-origin:frame',
+            'type'                => 'FRAME',
+            'name'                => 'Selected nonzero frame',
+            'absoluteBoundingBox' => array('x' => -3068, 'y' => -394.5, 'width' => 1200, 'height' => 800),
+            'children'            => array(
+                array(
+                    'id'                  => 'selected-origin:header-instance',
+                    'type'                => 'INSTANCE',
+                    'name'                => 'Header instance',
+                    'componentId'         => 'selected-origin-header-key',
+                    'absoluteBoundingBox' => array('x' => -3068, 'y' => -394.5, 'width' => 1200, 'height' => 120),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+            ),
+        ),
+    ),
+), array('frame_id' => 'selected-origin:frame'));
+$nestedInstanceSelectedOriginCss = $fileContent($nestedInstanceSelectedOriginResult, 'style.css');
+$assert(str_contains($nestedInstanceSelectedOriginCss, '.figma-node-selected-origin-header-instance-selected-origin-nested-logo-nested-logo{width:40px;height:20px;position:absolute;left:120px;top:32px'), 'selected-origin-nested-instance-keeps-local-placement');
+$assert(! str_contains($nestedInstanceSelectedOriginCss, 'left:-2948px;top:-362.5px'), 'selected-origin-nested-instance-no-page-origin-subtracted-placement');
+
 $scaledVectorInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Scaled Vector Instance Fixture',
     'blobs' => array(array('bytes' => $vectorCommandBlob)),


### PR DESCRIPTION
## Summary
- Refresh nested resolved instance clones by component source id without replacing their clone id or placement.
- Mark refreshed component-source clone geometry as local so selected-frame rebasing does not subtract the page origin from parent-local placements.
- Add a synthetic contract covering a nonzero selected frame with a stale nested instance source, while preserving canvas-global transform override behavior.

## Testing
- composer test:contract
- Focused FSE Pilot transform for frame `3468:1038` with zstd and `php -d memory_limit=1024M`; exact header logo negative offset signature `left:-2948px;top:-362.5px` was absent from emitted CSS.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the nested instance geometry refresh path, implementing the scoped normalizer change, adding contract coverage, and running verification.