### PR TITLE
figma-transformer: improve off-canvas diagnostics

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -954,8 +954,14 @@ final class FigmaTransformer
         $vectors = array('nodes' => 0, 'rendered_paths' => 0, 'rendered_asset_fallbacks' => 0, 'vector_network_decoded' => 0, 'boolean_operations_composed' => 0, 'placeholders' => 0, 'placeholder_nodes' => array(), 'placeholder_reasons' => array());
         $layout = array(
             'large_negative_left_count' => 0,
+            'large_css_offset_count' => 0,
+            'large_css_offset_nodes' => array(),
+            'off_canvas_visual_node_count' => 0,
+            'off_canvas_visual_nodes' => array(),
             'large_absolute_offset_count' => 0,
             'large_absolute_offset_nodes' => array(),
+            'empty_visible_container_count' => 0,
+            'empty_visible_containers' => array(),
             'decorative_underlays' => array('count' => 0, 'nodes' => array()),
             'image_heavy_landmark_candidates' => array(),
             'layout_mismatch_count' => 0,
@@ -1040,10 +1046,28 @@ final class FigmaTransformer
 
             $pageLayout = is_array($diagnostics['layout'] ?? null) ? $diagnostics['layout'] : array();
             $layout['large_negative_left_count'] += (int) ($pageLayout['large_negative_left_count'] ?? 0);
+            $layout['large_css_offset_count'] += (int) ($pageLayout['large_css_offset_count'] ?? 0);
+            foreach ( is_array($pageLayout['large_css_offset_nodes'] ?? null) ? $pageLayout['large_css_offset_nodes'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $layout['large_css_offset_nodes'][] = array_merge($pageContext, $item);
+                }
+            }
+            $layout['off_canvas_visual_node_count'] += (int) ($pageLayout['off_canvas_visual_node_count'] ?? 0);
+            foreach ( is_array($pageLayout['off_canvas_visual_nodes'] ?? null) ? $pageLayout['off_canvas_visual_nodes'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $layout['off_canvas_visual_nodes'][] = array_merge($pageContext, $item);
+                }
+            }
             $layout['large_absolute_offset_count'] += (int) ($pageLayout['large_absolute_offset_count'] ?? 0);
             foreach ( is_array($pageLayout['large_absolute_offset_nodes'] ?? null) ? $pageLayout['large_absolute_offset_nodes'] : array() as $item ) {
                 if ( is_array($item) ) {
                     $layout['large_absolute_offset_nodes'][] = array_merge($pageContext, $item);
+                }
+            }
+            $layout['empty_visible_container_count'] += (int) ($pageLayout['empty_visible_container_count'] ?? 0);
+            foreach ( is_array($pageLayout['empty_visible_containers'] ?? null) ? $pageLayout['empty_visible_containers'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $layout['empty_visible_containers'][] = array_merge($pageContext, $item);
                 }
             }
             $underlays = is_array($pageLayout['decorative_underlays']['nodes'] ?? null) ? $pageLayout['decorative_underlays']['nodes'] : array();
@@ -1122,6 +1146,9 @@ final class FigmaTransformer
         }
 
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
+        $layout['large_css_offset_nodes'] = array_values($layout['large_css_offset_nodes']);
+        $layout['off_canvas_visual_nodes'] = array_values($layout['off_canvas_visual_nodes']);
+        $layout['empty_visible_containers'] = array_values($layout['empty_visible_containers']);
         $layout['layout_mismatches'] = array_values($layout['layout_mismatches']);
         $layout['render_style']['diagnostics'] = array_values($layout['render_style']['diagnostics']);
         if ( 'not_evaluated' === $layout['render_style_mismatch_status'] ) {
@@ -1191,7 +1218,20 @@ final class FigmaTransformer
             );
         }
         if ( ! empty($layout['large_negative_left_count']) ) {
-            $signals[] = array('severity' => 'warning', 'code' => 'off_canvas_left_css', 'count' => (int) $layout['large_negative_left_count']);
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'off_canvas_left_css',
+                'count' => (int) $layout['large_negative_left_count'],
+                'sample_nodes' => array_slice(is_array($layout['large_css_offset_nodes'] ?? null) ? $layout['large_css_offset_nodes'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($layout['off_canvas_visual_node_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'off_canvas_visual_nodes',
+                'count' => (int) $layout['off_canvas_visual_node_count'],
+                'sample_nodes' => array_slice(is_array($layout['off_canvas_visual_nodes'] ?? null) ? $layout['off_canvas_visual_nodes'] : array(), 0, 10),
+            );
         }
         if ( ! empty($layout['large_absolute_offset_count']) ) {
             $signals[] = array(
@@ -1263,9 +1303,12 @@ final class FigmaTransformer
                 'externalized_svg_asset_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
+                'large_css_offset_count' => (int) ($layout['large_css_offset_count'] ?? 0),
+                'off_canvas_visual_node_count' => (int) ($layout['off_canvas_visual_node_count'] ?? 0),
                 'render_style_mismatch_count' => (int) ($layout['render_style_mismatch_count'] ?? 0),
                 'render_style_mismatch_status' => (string) ($layout['render_style_mismatch_status'] ?? 'not_run'),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
+                'empty_visible_container_count' => (int) ($layout['empty_visible_container_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
                 'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
                 'layout_mismatch_status' => (string) ($layout['layout_mismatch_status'] ?? 'not_evaluated'),

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -197,7 +197,7 @@ final class StaticHtmlEmitter
         $files = $this->withInlineCssFiles($files, $css);
 
         $visualNodeMap = $this->visualNodeMap($nodes);
-        $transformDiagnostics = $this->transformDiagnostics($nodes, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics);
+        $transformDiagnostics = $this->transformDiagnostics($nodes, $visualNodeMap, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics);
         foreach ( $this->unresolvedSourceFontDiagnostics($fontResolution) as $diagnostic ) {
             $diagnostics[] = $diagnostic;
         }
@@ -394,7 +394,7 @@ final class StaticHtmlEmitter
         $files = $this->withInlineCssFiles($files, $css);
 
         $visualNodeMap = $this->visualNodeMap($renderedNodes);
-        $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics);
+        $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $visualNodeMap, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics);
         foreach ( $this->unresolvedSourceFontDiagnostics($fontResolution) as $diagnostic ) {
             $diagnostics[] = $diagnostic;
         }
@@ -1938,6 +1938,7 @@ final class StaticHtmlEmitter
      * Build production-transform diagnostics for Figma import development.
      *
      * @param array<int, array<string, mixed>> $nodes
+     * @param array<int, array<string, mixed>> $visualNodeMap
      * @param array<int, array<string, mixed>> $assetFiles
      * @param array<int, string> $fontFamilies
      * @param array<int, array<string, mixed>> $fontUsage
@@ -1945,7 +1946,7 @@ final class StaticHtmlEmitter
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    private function transformDiagnostics(array $nodes, array $assetFiles, array $fontFamilies, array $fontUsage, array $fontResolution, string $css, array $diagnostics): array
+    private function transformDiagnostics(array $nodes, array $visualNodeMap, array $assetFiles, array $fontFamilies, array $fontUsage, array $fontResolution, string $css, array $diagnostics): array
     {
         $image = array(
             'paint_refs'      => 0,
@@ -1966,10 +1967,19 @@ final class StaticHtmlEmitter
             'placeholder_reasons'         => array(),
             'placeholder_nodes'           => array(),
         );
+        $nodeDiagnosticIndex = $this->nodeDiagnosticIndex($nodes);
+        $cssOffsetDiagnostics = $this->cssAbsoluteOffsetDiagnostics($css, $nodeDiagnosticIndex);
+        $visualOffsetDiagnostics = $this->visualOffCanvasDiagnostics($visualNodeMap, $nodeDiagnosticIndex);
         $layout = array(
             'large_negative_left_count' => preg_match_all('/left:-[0-9]{3,}/', $css),
+            'large_css_offset_count' => count($cssOffsetDiagnostics),
+            'large_css_offset_nodes' => $cssOffsetDiagnostics,
+            'off_canvas_visual_node_count' => count($visualOffsetDiagnostics),
+            'off_canvas_visual_nodes' => $visualOffsetDiagnostics,
             'large_absolute_offset_count' => 0,
             'large_absolute_offset_nodes' => array(),
+            'empty_visible_container_count' => 0,
+            'empty_visible_containers' => array(),
             'decorative_underlays'      => array(
                 'count' => 0,
                 'nodes' => array(),
@@ -1992,6 +2002,8 @@ final class StaticHtmlEmitter
         $layout['decorative_underlays']['nodes'] = array_values($layout['decorative_underlays']['nodes']);
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
         $layout['large_absolute_offset_nodes'] = array_values($layout['large_absolute_offset_nodes']);
+        $layout['empty_visible_containers'] = array_values($layout['empty_visible_containers']);
+        $layout['empty_visible_container_count'] = count($layout['empty_visible_containers']);
         $layout['image_heavy_landmark_candidates'] = array_values($layout['image_heavy_landmark_candidates']);
         $generatedSvgAssets = $this->generatedSvgAssetDiagnostics($assetFiles);
         $assets = array(
@@ -2070,6 +2082,15 @@ final class StaticHtmlEmitter
                 'severity' => 'warning',
                 'code' => 'off_canvas_left_css',
                 'count' => (int) $layout['large_negative_left_count'],
+                'sample_nodes' => array_slice(is_array($layout['large_css_offset_nodes'] ?? null) ? $layout['large_css_offset_nodes'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($layout['off_canvas_visual_node_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'off_canvas_visual_nodes',
+                'count' => (int) $layout['off_canvas_visual_node_count'],
+                'sample_nodes' => array_slice(is_array($layout['off_canvas_visual_nodes'] ?? null) ? $layout['off_canvas_visual_nodes'] : array(), 0, 10),
             );
         }
         if ( ! empty($layout['large_absolute_offset_count']) ) {
@@ -2153,7 +2174,10 @@ final class StaticHtmlEmitter
                 'externalized_svg_asset_count' => (int) ($generatedSvgAssets['count'] ?? 0),
                 'generated_svg_bytes' => (int) ($generatedSvgAssets['bytes'] ?? 0),
                 'large_negative_left_count' => (int) ($layout['large_negative_left_count'] ?? 0),
+                'large_css_offset_count' => (int) ($layout['large_css_offset_count'] ?? 0),
+                'off_canvas_visual_node_count' => (int) ($layout['off_canvas_visual_node_count'] ?? 0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
+                'empty_visible_container_count' => (int) ($layout['empty_visible_container_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
                 'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
                 'layout_mismatch_status' => (string) ($layout['layout_mismatch_status'] ?? 'not_evaluated'),
@@ -2395,6 +2419,11 @@ final class StaticHtmlEmitter
             $layout['decorative_underlays']['nodes'][] = $this->decorativeUnderlayDiagnostic($node, $parentNode);
         }
 
+        $emptyContainer = $this->emptyVisibleContainerDiagnostic($node);
+        if ( null !== $emptyContainer ) {
+            $layout['empty_visible_containers'][] = $emptyContainer;
+        }
+
         $landmarkCandidate = $this->imageHeavyLandmarkCandidate($node);
         if ( null !== $landmarkCandidate ) {
             $layout['image_heavy_landmark_candidates'][] = $landmarkCandidate;
@@ -2522,11 +2551,197 @@ final class StaticHtmlEmitter
             'node_id' => (string) ($node['id'] ?? ''),
             'name' => (string) ($node['name'] ?? ''),
             'type' => strtoupper((string) ($node['type'] ?? '')),
+            'class' => $this->nodeDiagnosticClass($node),
             'parent_id' => (string) ($parentNode['id'] ?? ''),
             'left' => null === $left ? null : $this->reportNumericValue($left),
             'top' => null === $top ? null : $this->reportNumericValue($top),
+            'width' => $this->reportNumericValue($width),
+            'height' => $this->reportNumericValue($height),
             'parent_width' => null === $parentWidth ? null : $this->reportNumericValue($parentWidth),
             'parent_height' => null === $parentHeight ? null : $this->reportNumericValue($parentHeight),
+        );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $nodes
+     * @return array{by_id: array<string, array<string, mixed>>, by_class: array<string, array<string, mixed>>}
+     */
+    private function nodeDiagnosticIndex(array $nodes): array
+    {
+        $index = array('by_id' => array(), 'by_class' => array());
+        foreach ( $nodes as $node ) {
+            if ( is_array($node) ) {
+                $this->appendNodeDiagnosticIndex($node, $index);
+            }
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array{by_id: array<string, array<string, mixed>>, by_class: array<string, array<string, mixed>>} $index
+     */
+    private function appendNodeDiagnosticIndex(array $node, array &$index): void
+    {
+        $entry = array(
+            'node_id' => (string) ($node['id'] ?? ''),
+            'name' => (string) ($node['name'] ?? ''),
+            'type' => strtoupper((string) ($node['type'] ?? '')),
+            'class' => $this->nodeDiagnosticClass($node),
+        );
+        if ( '' !== $entry['node_id'] ) {
+            $index['by_id'][$entry['node_id']] = $entry;
+        }
+        if ( '' !== $entry['class'] ) {
+            $index['by_class'][$entry['class']] = $entry;
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                $this->appendNodeDiagnosticIndex($child, $index);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeDiagnosticClass(array $node): string
+    {
+        return 'figma-node-' . $this->slug((string) ($node['id'] ?? '') . '-' . (string) ($node['name'] ?? ''));
+    }
+
+    /**
+     * @param array{by_id: array<string, array<string, mixed>>, by_class: array<string, array<string, mixed>>} $nodeIndex
+     * @return array<int, array<string, mixed>>
+     */
+    private function cssAbsoluteOffsetDiagnostics(string $css, array $nodeIndex): array
+    {
+        $samples = array();
+        if ( ! preg_match_all('/\.(figma-node-[A-Za-z0-9_-]+)\{([^}]*)\}/s', $css, $rules, PREG_SET_ORDER) ) {
+            return $samples;
+        }
+
+        foreach ( $rules as $rule ) {
+            $className = (string) ($rule[1] ?? '');
+            $body = (string) ($rule[2] ?? '');
+            $left = $this->cssPixelDeclarationValue($body, 'left');
+            $top = $this->cssPixelDeclarationValue($body, 'top');
+            if ( (null === $left || abs($left) < 1000.0) && (null === $top || abs($top) < 1000.0) ) {
+                continue;
+            }
+
+            $node = is_array($nodeIndex['by_class'][$className] ?? null) ? $nodeIndex['by_class'][$className] : array();
+            $samples[] = array_filter(array(
+                'node_id' => (string) ($node['node_id'] ?? ''),
+                'name' => (string) ($node['name'] ?? ''),
+                'type' => (string) ($node['type'] ?? ''),
+                'class' => $className,
+                'left' => null === $left ? null : $this->reportNumericValue($left),
+                'top' => null === $top ? null : $this->reportNumericValue($top),
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+        }
+
+        return array_values($samples);
+    }
+
+    private function cssPixelDeclarationValue(string $body, string $property): ?float
+    {
+        return preg_match('/(?:^|;)\s*' . preg_quote($property, '/') . ':\s*(-?\d+(?:\.\d+)?)px(?:;|$)/', $body, $match)
+            ? (float) $match[1]
+            : null;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $visualNodeMap
+     * @param array{by_id: array<string, array<string, mixed>>, by_class: array<string, array<string, mixed>>} $nodeIndex
+     * @return array<int, array<string, mixed>>
+     */
+    private function visualOffCanvasDiagnostics(array $visualNodeMap, array $nodeIndex): array
+    {
+        $byId = array();
+        foreach ( $visualNodeMap as $entry ) {
+            if ( is_array($entry) && isset($entry['id']) && is_scalar($entry['id']) ) {
+                $byId[(string) $entry['id']] = $entry;
+            }
+        }
+
+        $samples = array();
+        foreach ( $visualNodeMap as $entry ) {
+            if ( ! is_array($entry) || ! isset($entry['parent_id']) || '' === (string) $entry['parent_id'] || ! is_array($entry['rect'] ?? null) ) {
+                continue;
+            }
+            $parent = $byId[(string) $entry['parent_id']] ?? null;
+            if ( ! is_array($parent) || ! is_array($parent['rect'] ?? null) ) {
+                continue;
+            }
+            $rect = $entry['rect'];
+            $parentRect = $parent['rect'];
+            foreach ( array('x', 'y', 'width', 'height') as $key ) {
+                if ( ! is_numeric($rect[$key] ?? null) || ! is_numeric($parentRect[$key] ?? null) ) {
+                    continue 2;
+                }
+            }
+
+            $offCanvas = (float) $rect['x'] < (float) $parentRect['x'] - 100.0
+                || (float) $rect['x'] > (float) $parentRect['x'] + (float) $parentRect['width'] + 100.0
+                || (float) $rect['x'] + (float) $rect['width'] < (float) $parentRect['x'] - 100.0
+                || (float) $rect['y'] < (float) $parentRect['y'] - 100.0
+                || (float) $rect['y'] > (float) $parentRect['y'] + (float) $parentRect['height'] + 100.0
+                || (float) $rect['y'] + (float) $rect['height'] < (float) $parentRect['y'] - 100.0;
+            if ( ! $offCanvas ) {
+                continue;
+            }
+
+            $node = is_array($nodeIndex['by_id'][(string) ($entry['id'] ?? '')] ?? null) ? $nodeIndex['by_id'][(string) $entry['id']] : array();
+            $samples[] = array_filter(array(
+                'node_id' => (string) ($entry['id'] ?? ''),
+                'name' => (string) ($entry['name'] ?? ($node['name'] ?? '')),
+                'type' => (string) ($entry['type'] ?? ($node['type'] ?? '')),
+                'class' => (string) ($node['class'] ?? ''),
+                'parent_id' => (string) ($entry['parent_id'] ?? ''),
+                'left' => $this->reportNumericValue((float) $rect['x'] - (float) $parentRect['x']),
+                'top' => $this->reportNumericValue((float) $rect['y'] - (float) $parentRect['y']),
+                'x' => $this->reportNumericValue((float) $rect['x']),
+                'y' => $this->reportNumericValue((float) $rect['y']),
+                'width' => $this->reportNumericValue((float) $rect['width']),
+                'height' => $this->reportNumericValue((float) $rect['height']),
+                'parent_width' => $this->reportNumericValue((float) $parentRect['width']),
+                'parent_height' => $this->reportNumericValue((float) $parentRect['height']),
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+        }
+
+        return array_values($samples);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>|null
+     */
+    private function emptyVisibleContainerDiagnostic(array $node): ?array
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION'), true) || false === ($node['visible'] ?? true) ) {
+            return null;
+        }
+        if ( ! empty($this->nodeList($node)) || '' !== trim($this->textContent($node)) || ! empty($this->nodeImagePaints($node)) || ! empty($this->explicitNodeAssetReferences($node)) ) {
+            return null;
+        }
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : 0.0;
+        $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : 0.0;
+        if ( $width <= 0.0 || $height <= 0.0 ) {
+            return null;
+        }
+
+        return array(
+            'node_id' => (string) ($node['id'] ?? ''),
+            'name' => (string) ($node['name'] ?? ''),
+            'type' => $type,
+            'class' => $this->nodeDiagnosticClass($node),
+            'width' => $this->reportNumericValue($width),
+            'height' => $this->reportNumericValue($height),
         );
     }
 

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -324,6 +324,11 @@ $assert(in_array('excessive_vector_image_fallbacks', $qualitySignalCodes, true),
 $largeOffsetSignal = $artifactQualitySignal($qualityDiagnosticsResult, 'large_absolute_offsets');
 $assert('quality:offcanvas' === ($largeOffsetSignal['sample_nodes'][0]['node_id'] ?? null), 'quality-diagnostics-large-absolute-offset-sample-node');
 $assert('quality:root' === ($largeOffsetSignal['sample_nodes'][0]['parent_id'] ?? null), 'quality-diagnostics-large-absolute-offset-sample-parent');
+$assert('figma-node-quality-offcanvas-off-canvas-promo' === ($largeOffsetSignal['sample_nodes'][0]['class'] ?? null), 'quality-diagnostics-large-absolute-offset-sample-class');
+$assert(2000.0 === (float) ($largeOffsetSignal['sample_nodes'][0]['left'] ?? 0), 'quality-diagnostics-large-absolute-offset-sample-left');
+$visualOffsetSignal = $artifactQualitySignal($qualityDiagnosticsResult, 'off_canvas_visual_nodes');
+$assert('quality:offcanvas' === ($visualOffsetSignal['sample_nodes'][0]['node_id'] ?? null), 'quality-diagnostics-off-canvas-visual-sample-node');
+$assert('figma-node-quality-offcanvas-off-canvas-promo' === ($visualOffsetSignal['sample_nodes'][0]['class'] ?? null), 'quality-diagnostics-off-canvas-visual-sample-class');
 $assert('needs_review' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['status'] ?? null), 'quality-diagnostics-status-needs-review');
 $assert('warn' === ($qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['quality_status'] ?? null), 'quality-diagnostics-quality-status-warn');
 $qualitySignals = $qualityDiagnosticsResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
@@ -370,6 +375,76 @@ $normalImageQuality = $normalImageResult['source_reports']['figma']['html']['tra
 $assert(! in_array('excessive_image_blocks', $artifactQualitySignalCodes($normalImageResult), true), 'quality-diagnostics-normal-image-count-no-excessive-signal');
 $assert(12 === ($normalImageQuality['summary']['image_block_count'] ?? null), 'quality-diagnostics-normal-image-count-summary');
 $assert(($normalImageQuality['summary']['image_node_density'] ?? 1) < 0.35, 'quality-diagnostics-normal-image-density-summary');
+
+$normalLocalPlacementResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Normal Local Placement Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'normal-local:root',
+            'type'     => 'FRAME',
+            'name'     => 'Normal local root',
+            'width'    => 480,
+            'height'   => 320,
+            'children' => array(
+                array('id' => 'normal-local:card', 'type' => 'FRAME', 'name' => 'Local card', 'x' => 40, 'y' => 60, 'width' => 180, 'height' => 90, 'layoutPositioning' => 'ABSOLUTE', 'children' => array(
+                    array('id' => 'normal-local:copy', 'type' => 'TEXT', 'name' => 'Card copy', 'characters' => 'Normal placement', 'fontSize' => 16),
+                )),
+            ),
+        ),
+    ),
+));
+$normalLocalSignalCodes = $artifactQualitySignalCodes($normalLocalPlacementResult);
+$assert(! in_array('large_absolute_offsets', $normalLocalSignalCodes, true), 'quality-diagnostics-normal-local-no-large-offset-signal');
+$assert(! in_array('off_canvas_visual_nodes', $normalLocalSignalCodes, true), 'quality-diagnostics-normal-local-no-visual-off-canvas-signal');
+$assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['large_absolute_offset_count'] ?? null), 'quality-diagnostics-normal-local-large-offset-count-zero');
+$assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['off_canvas_visual_node_count'] ?? null), 'quality-diagnostics-normal-local-visual-offset-count-zero');
+
+$multiPageOffCanvasResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Multi Page Off Canvas Diagnostics Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'multi-offset:canvas',
+            'type'     => 'CANVAS',
+            'name'     => 'Site pages',
+            'children' => array(
+                array(
+                    'id'       => 'multi-offset:home',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home',
+                    'width'    => 400,
+                    'height'   => 300,
+                    'children' => array(
+                        array('id' => 'multi-offset:home-title', 'type' => 'TEXT', 'name' => 'Home title', 'characters' => 'Home', 'fontSize' => 20),
+                    ),
+                ),
+                array(
+                    'id'       => 'multi-offset:about',
+                    'type'     => 'FRAME',
+                    'name'     => 'About',
+                    'width'    => 400,
+                    'height'   => 300,
+                    'children' => array(
+                        array('id' => 'multi-offset:hero', 'type' => 'FRAME', 'name' => 'Drifted hero', 'x' => 1200, 'y' => 0, 'width' => 120, 'height' => 80, 'layoutPositioning' => 'ABSOLUTE', 'children' => array(
+                            array('id' => 'multi-offset:hero-copy', 'type' => 'TEXT', 'name' => 'Hero copy', 'characters' => 'About', 'fontSize' => 18),
+                        )),
+                    ),
+                ),
+            ),
+        ),
+    ),
+), array('multi_page' => true, 'frame_ids' => array('multi-offset:home', 'multi-offset:about'), 'entry_frame_id' => 'multi-offset:home'));
+$multiPageOffCanvasDiagnostics = $multiPageOffCanvasResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$multiPageOffCanvasSignal = null;
+foreach ( is_array($multiPageOffCanvasDiagnostics['artifact_quality']['signals'] ?? null) ? $multiPageOffCanvasDiagnostics['artifact_quality']['signals'] : array() as $signal ) {
+    if ( is_array($signal) && 'off_canvas_visual_nodes' === ($signal['code'] ?? null) ) {
+        $multiPageOffCanvasSignal = $signal;
+        break;
+    }
+}
+$assert('multi_page' === ($multiPageOffCanvasDiagnostics['scope'] ?? null), 'quality-diagnostics-multi-page-off-canvas-scope');
+$assert(1 === ($multiPageOffCanvasDiagnostics['layout']['off_canvas_visual_node_count'] ?? null), 'quality-diagnostics-multi-page-off-canvas-count');
+$assert('multi-offset:hero' === ($multiPageOffCanvasSignal['sample_nodes'][0]['node_id'] ?? null), 'quality-diagnostics-multi-page-off-canvas-sample-node');
+$assert('about.html' === ($multiPageOffCanvasSignal['sample_nodes'][0]['page_path'] ?? null), 'quality-diagnostics-multi-page-off-canvas-sample-page');
 
 $cleanQualityResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Clean Quality Fixture',


### PR DESCRIPTION
## Summary
- Add CSS and visual-node-map off-canvas diagnostic samples with node id, name, type, class, and offsets.
- Preserve off-canvas diagnostics through multi-page aggregation with page path/name/frame context.
- Add contract coverage for synthetic off-canvas placement, normal local placement, and multi-page page-context samples.

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing diagnostic-only code changes, adding contract tests, running verification, and preparing this PR description.