### PR TITLE
figma-transformer: normalize transform layout coordinates

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1038,7 +1038,7 @@ final class ScenegraphNormalizer
             if ( isset($override['textData']['characters']) && is_scalar($override['textData']['characters']) ) {
                 $overrides[$nodeId]['characters'] = (string) $override['textData']['characters'];
             }
-            foreach ( array('derivedTextData', 'size', 'transform', 'fillPaints', 'fills', 'strokes', 'strokePaints', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'cornerRadius', 'rectangleTopLeftCornerRadius', 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius', 'rectangleBottomRightCornerRadius') as $field ) {
+            foreach ( array('derivedTextData', 'size', 'relativeTransform', 'absoluteTransform', 'transform', 'fillPaints', 'fills', 'strokes', 'strokePaints', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight', 'effects', 'styleIdForFill', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'cornerRadius', 'rectangleTopLeftCornerRadius', 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius', 'rectangleBottomRightCornerRadius') as $field ) {
                 if ( array_key_exists($field, $override) ) {
                     $overrides[$nodeId][$field] = $override[$field];
                 }
@@ -1584,6 +1584,25 @@ final class ScenegraphNormalizer
                 if ( isset($child['size'][$source]) && is_numeric($child['size'][$source]) ) {
                     $child[$target] = (float) $child['size'][$source];
                 }
+            }
+        }
+        if ( is_array($child['relativeTransform'] ?? null) ) {
+            foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
+                if ( isset($child['relativeTransform'][$source]) && is_numeric($child['relativeTransform'][$source]) ) {
+                    $child[$target] = (float) $child['relativeTransform'][$source];
+                }
+            }
+        }
+        if ( is_array($child['absoluteTransform'] ?? null) ) {
+            $absoluteBounds = is_array($child['absoluteBoundingBox'] ?? null) ? $child['absoluteBoundingBox'] : array();
+            foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
+                if ( isset($child['absoluteTransform'][$source]) && is_numeric($child['absoluteTransform'][$source]) ) {
+                    $child[$target] = (float) $child['absoluteTransform'][$source];
+                    $absoluteBounds[$target] = (float) $child['absoluteTransform'][$source];
+                }
+            }
+            if ( ! empty($absoluteBounds) ) {
+                $child['absoluteBoundingBox'] = $absoluteBounds;
             }
         }
         if ( is_array($child['transform'] ?? null) ) {
@@ -3893,12 +3912,11 @@ final class ScenegraphNormalizer
             }
         }
 
-        if ( is_array($node['transform'] ?? null) ) {
-            foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
-                if ( ! array_key_exists($target, $box) && isset($node['transform'][$source]) && is_numeric($node['transform'][$source]) ) {
-                    $box[$target] = (float) $node['transform'][$source];
-                    $coordinateSpaceClassification = GeometryBox::CLASSIFICATION_PARENT_LOCAL;
-                }
+        $transformBox = $this->layoutBoxFromTransform($node);
+        foreach ( array('x', 'y') as $dimension ) {
+            if ( ! array_key_exists($dimension, $box) && isset($transformBox[$dimension]) ) {
+                $box[$dimension] = $transformBox[$dimension];
+                $coordinateSpaceClassification = $transformBox['coordinate_space_classification'];
             }
         }
 
@@ -3907,6 +3925,36 @@ final class ScenegraphNormalizer
         }
 
         return $box;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array{x?: float, y?: float, coordinate_space_classification?: string}
+     */
+    private function layoutBoxFromTransform(array $node): array
+    {
+        foreach ( array(
+            'relativeTransform' => GeometryBox::CLASSIFICATION_PARENT_LOCAL,
+            'transform'         => GeometryBox::CLASSIFICATION_PARENT_LOCAL,
+            'absoluteTransform' => GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE,
+        ) as $sourceKey => $classification ) {
+            if ( ! is_array($node[$sourceKey] ?? null) ) {
+                continue;
+            }
+
+            $box = array('coordinate_space_classification' => $classification);
+            foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
+                if ( isset($node[$sourceKey][$source]) && is_numeric($node[$sourceKey][$source]) ) {
+                    $box[$target] = (float) $node[$sourceKey][$source];
+                }
+            }
+
+            if ( isset($box['x']) || isset($box['y']) ) {
+                return $box;
+            }
+        }
+
+        return array();
     }
 
     /**

--- a/figma-transformer/tests/contract/GeometryBoxContract.php
+++ b/figma-transformer/tests/contract/GeometryBoxContract.php
@@ -61,6 +61,76 @@ function blocks_engine_figma_transformer_run_geometry_box_contract(callable $ass
     $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($transformBox), 'geometry-box-transform-coordinate-space');
     $assert(array('width' => 90.0, 'height' => 60.0, 'x' => 7.0, 'y' => 11.0, 'coordinate_space' => GeometryBox::COORDINATE_SPACE_PARENT_LOCAL) === $transformBox, 'geometry-box-transform-values');
 
+    $relativeTransformResult = $normalizer->normalize(array(
+        'name'  => 'Relative Transform Geometry Fixture',
+        'nodes' => array(
+            array(
+                'id'                => 'geometry:relative-transform',
+                'type'              => 'FRAME',
+                'name'              => 'Relative transform position',
+                'size'              => array('x' => 90, 'y' => 60),
+                'relativeTransform' => array('m02' => 13, 'm12' => 17),
+            ),
+        ),
+    ));
+    $relativeTransformBox = $relativeTransformResult['nodes'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($relativeTransformBox), 'geometry-box-relative-transform-coordinate-space');
+    $assert(array('width' => 90.0, 'height' => 60.0, 'x' => 13.0, 'y' => 17.0, 'coordinate_space' => GeometryBox::COORDINATE_SPACE_PARENT_LOCAL) === $relativeTransformBox, 'geometry-box-relative-transform-values');
+
+    $absoluteTransformResult = $normalizer->normalize(array(
+        'name'  => 'Absolute Transform Geometry Fixture',
+        'nodes' => array(
+            array(
+                'id'                => 'geometry:absolute-transform',
+                'type'              => 'FRAME',
+                'name'              => 'Absolute transform position',
+                'size'              => array('x' => 90, 'y' => 60),
+                'absoluteTransform' => array('m02' => 1300, 'm12' => 1700),
+            ),
+        ),
+    ));
+    $absoluteTransformBox = $absoluteTransformResult['nodes'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE === GeometryBox::classifyNormalizedBox($absoluteTransformBox), 'geometry-box-absolute-transform-coordinate-space');
+    $assert(array('width' => 90.0, 'height' => 60.0, 'x' => 1300.0, 'y' => 1700.0, 'coordinate_space' => GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE) === $absoluteTransformBox, 'geometry-box-absolute-transform-values');
+
+    $overrideTransformResult = $normalizer->normalize(array(
+        'name'  => 'Instance Relative Transform Override Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'geometry:component',
+                'type'     => 'COMPONENT',
+                'name'     => 'Component',
+                'key'      => 'geometry-component-key',
+                'children' => array(
+                    array(
+                        'id'     => 'geometry:component-child',
+                        'type'   => 'RECTANGLE',
+                        'name'   => 'Component child',
+                        'x'      => 0,
+                        'y'      => 0,
+                        'width'  => 20,
+                        'height' => 10,
+                    ),
+                ),
+            ),
+            array(
+                'id'          => 'geometry:instance',
+                'type'        => 'INSTANCE',
+                'name'        => 'Instance',
+                'componentId' => 'geometry-component-key',
+                'overrides'   => array(
+                    array(
+                        'nodeId'            => 'geometry:component-child',
+                        'relativeTransform' => array('m02' => 21, 'm12' => 34),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $overrideChildBox = $overrideTransformResult['nodes'][1]['children'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($overrideChildBox), 'geometry-box-instance-relative-transform-override-coordinate-space');
+    $assert(21.0 === ($overrideChildBox['x'] ?? null) && 34.0 === ($overrideChildBox['y'] ?? null), 'geometry-box-instance-relative-transform-override-values');
+
     $selectedFrameResult = $normalizer->normalize(
         array(
             'name'  => 'Selected Frame Rebase Geometry Fixture',


### PR DESCRIPTION
## Summary
- derive normalized layout boxes from relativeTransform and absoluteTransform, not only transform
- preserve coordinate-space classification for parent-local versus canvas-absolute transform coordinates
- accept relativeTransform/absoluteTransform in instance overrides and let transform overrides replace component-source child coordinates
- add direct normalizer contract coverage for transform coordinate-space and instance override behavior

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Audit, implementation, contract tests, and PR preparation.