### PR TITLE
figma-transformer: constrain flex fill growth to main axis

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3827,8 +3827,9 @@ final class StaticHtmlEmitter
         $styles = array();
         $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
         $isFlexChild = in_array((string) ($parentLayout['display'] ?? ''), array('flex', 'inline-flex'), true);
+        $parentMainAxisSizingKey = 'column' === ($parentLayout['flex_direction'] ?? null) ? 'sizing_vertical' : 'sizing_horizontal';
 
-        if ( 'FILL' === ($layout['sizing_horizontal'] ?? null) || 'FILL' === ($layout['sizing_vertical'] ?? null) ) {
+        if ( 'FILL' === ($layout[$parentMainAxisSizingKey] ?? null) ) {
             $styles[] = 'flex-grow:1';
             $styles[] = 'flex-shrink:1';
         } elseif ( isset($layout['grow']) && is_numeric($layout['grow']) ) {

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -148,4 +148,40 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 100.0, 'height' => 40.0) === ($visualFlexWrapFirst['rect'] ?? null), 'visual-map-flex-wrap-first-line-first-card');
     $assert(array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0) === ($visualFlexWrapSecond['rect'] ?? null), 'visual-map-flex-wrap-first-line-second-card');
     $assert(array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0) === ($visualFlexWrapThird['rect'] ?? null), 'visual-map-flex-wrap-second-line-card');
+
+    $visualCrossAxisFillResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Visual Cross Axis Fill Fixture',
+        'nodes' => array(
+            array(
+                'id'                    => 'visual-cross-fill:row',
+                'type'                  => 'FRAME',
+                'name'                  => 'Cross axis fill row',
+                'width'                 => 300,
+                'height'                => 100,
+                'layoutMode'            => 'HORIZONTAL',
+                'primaryAxisAlignItems' => 'MIN',
+                'counterAxisAlignItems' => 'MIN',
+                'itemSpacing'           => 20,
+                'children'              => array(
+                    array(
+                        'id'                     => 'visual-cross-fill:tall',
+                        'type'                   => 'RECTANGLE',
+                        'name'                   => 'Tall fill child',
+                        'width'                  => 50,
+                        'height'                 => 100,
+                        'layoutSizingHorizontal' => 'FIXED',
+                        'layoutSizingVertical'   => 'FILL',
+                    ),
+                    array('id' => 'visual-cross-fill:next', 'type' => 'RECTANGLE', 'name' => 'Next child', 'width' => 80, 'height' => 40),
+                ),
+            ),
+        ),
+    ));
+    $visualCrossAxisFillCss = $fileContent($visualCrossAxisFillResult, 'style.css');
+    $visualCrossAxisFillTall = $findVisualNode($visualCrossAxisFillResult, 'visual-cross-fill:tall');
+    $visualCrossAxisFillNext = $findVisualNode($visualCrossAxisFillResult, 'visual-cross-fill:next');
+    $assert(str_contains($visualCrossAxisFillCss, '.figma-node-visual-cross-fill-tall-tall-fill-child{width:50px;height:100%;flex-shrink:0}'), 'visual-map-cross-axis-fill-does-not-grow-main-axis-css');
+    $assert(! str_contains($visualCrossAxisFillCss, '.figma-node-visual-cross-fill-tall-tall-fill-child{width:50px;height:100%;flex-grow:1'), 'visual-map-cross-axis-fill-no-flex-grow-css');
+    $assert(array('x' => 100.0, 'y' => 0.0, 'width' => 50.0, 'height' => 100.0) === ($visualCrossAxisFillTall['rect'] ?? null), 'visual-map-cross-axis-fill-source-width-preserved');
+    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 80.0, 'height' => 40.0) === ($visualCrossAxisFillNext['rect'] ?? null), 'visual-map-cross-axis-fill-next-child-not-pushed');
 }


### PR DESCRIPTION
## Summary
- Constrain flex item growth for Figma FILL sizing to the parent flex main axis.
- Preserve cross-axis FILL as a size rule without emitting flex-grow.
- Add a synthetic contract fixture covering emitted CSS and visual-node-map geometry.

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the figma-transformer layout emitter path, implementing the CSS emission fix, and adding contract coverage.