### PR TITLE
figma-transformer: expand synthetic contract regression coverage

### DIFF
--- a/figma-transformer/tests/contract/GeometryBoxContract.php
+++ b/figma-transformer/tests/contract/GeometryBoxContract.php
@@ -98,4 +98,52 @@ function blocks_engine_figma_transformer_run_geometry_box_contract(callable $ass
     $assert(0.0 === ($selectedFrameBox['x'] ?? null) && 0.0 === ($selectedFrameBox['y'] ?? null), 'geometry-box-selected-frame-rebased-root-origin');
     $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($selectedChildBox), 'geometry-box-selected-frame-child-local-coordinate-space');
     $assert(50.0 === ($selectedChildBox['x'] ?? null) && 40.0 === ($selectedChildBox['y'] ?? null), 'geometry-box-selected-frame-child-rebased-position');
+
+    $documentModeResult = $normalizer->normalize(
+        array(
+            'name'  => 'Document Mode Rebase Geometry Fixture',
+            'nodes' => array(
+                array(
+                    'id'                  => 'geometry:doc-home',
+                    'type'                => 'FRAME',
+                    'name'                => 'Home page',
+                    'absoluteBoundingBox' => array('x' => 800, 'y' => 200, 'width' => 320, 'height' => 240),
+                    'children'            => array(
+                        array(
+                            'id'                  => 'geometry:doc-home-child',
+                            'type'                => 'RECTANGLE',
+                            'name'                => 'Home card',
+                            'absoluteBoundingBox' => array('x' => 830, 'y' => 250, 'width' => 100, 'height' => 60),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'                  => 'geometry:doc-about',
+                    'type'                => 'FRAME',
+                    'name'                => 'About page',
+                    'absoluteBoundingBox' => array('x' => 1400, 'y' => 900, 'width' => 320, 'height' => 240),
+                    'children'            => array(
+                        array(
+                            'id'                  => 'geometry:doc-about-child',
+                            'type'                => 'TEXT',
+                            'name'                => 'About copy',
+                            'characters'          => 'About',
+                            'absoluteBoundingBox' => array('x' => 1415, 'y' => 920, 'width' => 80, 'height' => 20),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array('render_document' => true, 'document_frame_ids' => array('geometry:doc-home', 'geometry:doc-about'))
+    );
+    $documentHomeBox = $documentModeResult['nodes'][0]['box'] ?? array();
+    $documentHomeChildBox = $documentModeResult['nodes'][0]['children'][0]['box'] ?? array();
+    $documentAboutBox = $documentModeResult['nodes'][1]['box'] ?? array();
+    $documentAboutChildBox = $documentModeResult['nodes'][1]['children'][0]['box'] ?? array();
+    $assert(GeometryBox::CLASSIFICATION_PAGE_LOCAL === GeometryBox::classifyNormalizedBox($documentHomeBox, true), 'geometry-box-document-mode-home-page-local-coordinate-space');
+    $assert(0.0 === ($documentHomeBox['x'] ?? null) && 0.0 === ($documentHomeBox['y'] ?? null), 'geometry-box-document-mode-home-rebased-root-origin');
+    $assert(30.0 === ($documentHomeChildBox['x'] ?? null) && 50.0 === ($documentHomeChildBox['y'] ?? null), 'geometry-box-document-mode-home-child-rebased-position');
+    $assert(GeometryBox::CLASSIFICATION_PAGE_LOCAL === GeometryBox::classifyNormalizedBox($documentAboutBox, true), 'geometry-box-document-mode-about-page-local-coordinate-space');
+    $assert(0.0 === ($documentAboutBox['x'] ?? null) && 0.0 === ($documentAboutBox['y'] ?? null), 'geometry-box-document-mode-about-rebased-root-origin');
+    $assert(15.0 === ($documentAboutChildBox['x'] ?? null) && 20.0 === ($documentAboutChildBox['y'] ?? null), 'geometry-box-document-mode-about-child-rebased-position');
 }

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -148,4 +148,123 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 100.0, 'height' => 40.0) === ($visualFlexWrapFirst['rect'] ?? null), 'visual-map-flex-wrap-first-line-first-card');
     $assert(array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0) === ($visualFlexWrapSecond['rect'] ?? null), 'visual-map-flex-wrap-first-line-second-card');
     $assert(array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0) === ($visualFlexWrapThird['rect'] ?? null), 'visual-map-flex-wrap-second-line-card');
+
+    $freeformTransitionResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Auto Layout Freeform Transition Fixture',
+        'nodes' => array(
+            array(
+                'id'         => 'layout-transition:flex',
+                'type'       => 'FRAME',
+                'name'       => 'Auto layout shell',
+                'width'      => 360,
+                'height'     => 180,
+                'layoutMode' => 'HORIZONTAL',
+                'itemSpacing' => 12,
+                'children'   => array(
+                    array('id' => 'layout-transition:flow-a', 'type' => 'RECTANGLE', 'name' => 'Flow A', 'width' => 80, 'height' => 40),
+                    array('id' => 'layout-transition:absolute', 'type' => 'RECTANGLE', 'name' => 'Pinned badge', 'x' => 250, 'y' => 20, 'width' => 40, 'height' => 24, 'layoutPositioning' => 'ABSOLUTE'),
+                    array('id' => 'layout-transition:flow-b', 'type' => 'RECTANGLE', 'name' => 'Flow B', 'width' => 60, 'height' => 40),
+                ),
+            ),
+            array(
+                'id'       => 'layout-transition:freeform',
+                'type'     => 'FRAME',
+                'name'     => 'Freeform board',
+                'width'    => 360,
+                'height'   => 180,
+                'children' => array(
+                    array('id' => 'layout-transition:local-card', 'type' => 'RECTANGLE', 'name' => 'Local card', 'x' => 44, 'y' => 66, 'width' => 90, 'height' => 30),
+                ),
+            ),
+        ),
+    ));
+    $transitionCss = $fileContent($freeformTransitionResult, 'style.css');
+    $transitionFlowA = $findVisualNode($freeformTransitionResult, 'layout-transition:flow-a');
+    $transitionAbsolute = $findVisualNode($freeformTransitionResult, 'layout-transition:absolute');
+    $transitionFlowB = $findVisualNode($freeformTransitionResult, 'layout-transition:flow-b');
+    $transitionLocalCard = $findVisualNode($freeformTransitionResult, 'layout-transition:local-card');
+    $assert(str_contains($transitionCss, '.figma-node-layout-transition-flex-auto-layout-shell{width:360px;height:180px;position:relative;display:flex;flex-direction:row;gap:12px}'), 'visual-map-layout-transition-flex-css');
+    $assert(str_contains($transitionCss, '.figma-node-layout-transition-freeform-freeform-board{width:360px;height:180px;position:relative}'), 'visual-map-layout-transition-freeform-css');
+    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 80.0, 'height' => 40.0) === ($transitionFlowA['rect'] ?? null), 'visual-map-layout-transition-flow-first-position');
+    $assert(array('x' => 92.0, 'y' => 0.0, 'width' => 60.0, 'height' => 40.0) === ($transitionFlowB['rect'] ?? null), 'visual-map-layout-transition-flow-skips-absolute-position');
+    $assert(array('x' => 250.0, 'y' => 20.0, 'width' => 40.0, 'height' => 24.0) === ($transitionAbsolute['rect'] ?? null), 'visual-map-layout-transition-absolute-position');
+    $assert(array('x' => 44.0, 'y' => 66.0, 'width' => 90.0, 'height' => 30.0) === ($transitionLocalCard['rect'] ?? null), 'visual-map-layout-transition-freeform-local-position');
+
+    $nestedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(
+        array(
+            'name'  => 'Nested Instance Transform Override Fixture',
+            'nodes' => array(
+                array(
+                    'id'       => 'instance:canvas',
+                    'type'     => 'CANVAS',
+                    'name'     => 'Canvas',
+                    'children' => array(
+                        array(
+                            'id'       => 'component:icon',
+                            'type'     => 'COMPONENT',
+                            'name'     => 'Icon component',
+                            'width'    => 16,
+                            'height'   => 16,
+                            'children' => array(
+                                array('id' => 'component:icon/vector', 'type' => 'VECTOR', 'name' => 'Icon vector', 'width' => 16, 'height' => 16, 'pathData' => 'M0 0H16V16Z'),
+                            ),
+                        ),
+                        array(
+                            'id'         => 'component:button',
+                            'type'       => 'COMPONENT',
+                            'name'       => 'Button component',
+                            'width'      => 120,
+                            'height'     => 44,
+                            'layoutMode' => 'HORIZONTAL',
+                            'itemSpacing' => 8,
+                            'children'   => array(
+                                array('id' => 'component:button/icon', 'type' => 'INSTANCE', 'name' => 'Nested icon', 'componentId' => 'component:icon', 'width' => 16, 'height' => 16),
+                                array('id' => 'component:button/label', 'type' => 'TEXT', 'name' => 'Button label', 'characters' => 'Default label', 'width' => 80, 'height' => 20),
+                            ),
+                        ),
+                        array(
+                            'id'       => 'instance:page',
+                            'type'     => 'FRAME',
+                            'name'     => 'Page',
+                            'width'    => 320,
+                            'height'   => 180,
+                            'children' => array(
+                                array(
+                                    'id'          => 'instance:button',
+                                    'type'        => 'INSTANCE',
+                                    'name'        => 'Buy button',
+                                    'componentId' => 'component:button',
+                                    'x'           => 30,
+                                    'y'           => 40,
+                                    'width'       => 160,
+                                    'height'      => 60,
+                                    'overrides'   => array(
+                                        array(
+                                            'nodeId'     => 'component:button/label',
+                                            'characters' => 'Buy now',
+                                            'size'       => array('x' => 90, 'y' => 22),
+                                            'transform'  => array('m02' => 48, 'm12' => 18),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array('frame_id' => 'instance:page')
+    );
+    $nestedInstanceHtml = $fileContent($nestedInstanceResult, 'index.html');
+    $nestedInstanceCss = $fileContent($nestedInstanceResult, 'style.css');
+    $nestedInstanceRoot = $findVisualNode($nestedInstanceResult, 'instance:button');
+    $nestedInstanceLabel = $findVisualNode($nestedInstanceResult, 'instance:button/component:button/label');
+    $nestedInstanceIconVector = $findVisualNode($nestedInstanceResult, 'instance:button/component:button/icon/component:icon/vector');
+    $assert(str_contains($nestedInstanceHtml, 'Buy now'), 'visual-map-nested-instance-text-override-emits');
+    $assert(! str_contains($nestedInstanceHtml, 'Default label'), 'visual-map-nested-instance-text-override-replaces-default');
+    $assert(str_contains($nestedInstanceHtml, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"'), 'visual-map-nested-instance-vector-emits');
+    $assert(str_contains($nestedInstanceCss, '.figma-node-instance-button-buy-button{width:160px;height:60px;position:absolute;left:30px;top:40px}'), 'visual-map-nested-instance-transform-override-freeform-css');
+    $assert(array('x' => 30.0, 'y' => 40.0, 'width' => 160.0, 'height' => 60.0) === ($nestedInstanceRoot['rect'] ?? null), 'visual-map-nested-instance-root-position');
+    $assert(array('x' => 78.0, 'y' => 58.0, 'width' => 90.0, 'height' => 22.0) === ($nestedInstanceLabel['rect'] ?? null), 'visual-map-nested-instance-transform-override-position');
+    $assert(null !== $nestedInstanceIconVector, 'visual-map-nested-instance-resolves-nested-instance-vector');
 }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -198,6 +198,33 @@ $assert(str_contains($css, '.figma-node-1-4-hero-image-rectangle{width:320px;hei
 $assert(str_contains($css, '.figma-node-1-5-nested-image-paint{') && str_contains($css, 'background-image:url("assets/fixture-photo.jpg")'), 'css-nested-image-hash-asset-style');
 $assert('fixture image bytes' === $fileContent($result, 'assets/fixture-photo.jpg'), 'asset-content-preserved');
 
+$missingEmissionResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Missing Emission Diagnostics Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'missing:root',
+            'type'     => 'FRAME',
+            'name'     => 'Missing emission root',
+            'width'    => 320,
+            'height'   => 180,
+            'children' => array(
+                array('id' => 'missing:text', 'type' => 'TEXT', 'name' => 'Visible text', 'characters' => 'Synthetic visible copy', 'width' => 180, 'height' => 24),
+                array('id' => 'missing:asset', 'type' => 'RECTANGLE', 'name' => 'Missing asset', 'width' => 80, 'height' => 60, 'asset_id' => 'missing-image'),
+                array('id' => 'missing:vector', 'type' => 'VECTOR', 'name' => 'Missing vector geometry', 'width' => 20, 'height' => 20),
+            ),
+        ),
+    ),
+));
+$missingEmissionHtml = $fileContent($missingEmissionResult, 'index.html');
+$missingEmissionQualitySignalCodes = $artifactQualitySignalCodes($missingEmissionResult);
+$missingAssetsSignal = $artifactQualitySignal($missingEmissionResult, 'missing_render_assets');
+$vectorPlaceholderSignal = $artifactQualitySignal($missingEmissionResult, 'vector_placeholders');
+$assert(str_contains($missingEmissionHtml, 'Synthetic visible copy'), 'missing-emission-text-still-emits');
+$assert(in_array('missing_render_assets', $missingEmissionQualitySignalCodes, true), 'missing-emission-missing-asset-signal');
+$assert(1 === ($missingAssetsSignal['count'] ?? null), 'missing-emission-missing-asset-count');
+$assert(in_array('vector_placeholders', $missingEmissionQualitySignalCodes, true), 'missing-emission-vector-placeholder-signal');
+$assert(1 === ($vectorPlaceholderSignal['count'] ?? null), 'missing-emission-vector-placeholder-count');
+
 $cliOutputRoot = sys_get_temp_dir() . '/figma-transformer-cli-output-' . getmypid() . '-' . bin2hex(random_bytes(4));
 $cliScenegraphPath = $cliOutputRoot . '/scenegraph.json';
 $cliScenegraph = array(


### PR DESCRIPTION
## Summary
- Add synthetic document-mode geometry rebase assertions across multiple page frames.
- Add visual-node-map coverage for auto-layout/freeform transitions, absolute children, nested instances, transform overrides, and vector/text emission from resolved instances.
- Add missing render asset and vector placeholder diagnostic checks while asserting visible text still emits.

## Tests
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting synthetic contract tests, running verification, and preparing this PR.