### PR TITLE
figma-transformer: refactor diagnostic aggregation

### DIFF
--- a/figma-transformer/src/Diagnostics/DiagnosticAggregation.php
+++ b/figma-transformer/src/Diagnostics/DiagnosticAggregation.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Diagnostics;
+
+/**
+ * Small helpers for rolling page-local diagnostic counters and samples upward.
+ */
+final class DiagnosticAggregation
+{
+    /**
+     * @param array<string, mixed>      $target
+     * @param array<string, mixed>      $source
+     * @param array<int, string>        $keys
+     */
+    public static function addIntegerCounts(array &$target, array $source, array $keys): void
+    {
+        foreach ( $keys as $key ) {
+            $target[$key] = (int) ($target[$key] ?? 0) + (int) ($source[$key] ?? 0);
+        }
+    }
+
+    /**
+     * @param array<string, mixed>      $target
+     * @param array<string, mixed>      $source
+     * @param array<string, mixed>      $context
+     */
+    public static function appendContextSamples(array &$target, string $targetKey, array $source, string $sourceKey, array $context): void
+    {
+        $samples = is_array($source[$sourceKey] ?? null) ? $source[$sourceKey] : array();
+        foreach ( $samples as $sample ) {
+            if ( is_array($sample) ) {
+                $target[$targetKey][] = array_merge($context, $sample);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, int>   $target
+     * @param array<string, mixed> $source
+     */
+    public static function addCounterMap(array &$target, array $source): void
+    {
+        foreach ( $source as $key => $count ) {
+            $target[(string) $key] = (int) ($target[(string) $key] ?? 0) + (int) $count;
+        }
+    }
+}

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\FigmaTransformer;
 
 use Automattic\BlocksEngine\FigmaTransformer\Contract\FigmaTransformResult;
+use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\DiagnosticAggregation;
 use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\LayoutMismatchReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\RenderStyleMismatchReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader;
@@ -1011,32 +1012,14 @@ final class FigmaTransformer
             $pages[] = array_merge($pageContext, array('transform_diagnostics' => $diagnostics));
 
             $pageImages = is_array($diagnostics['images'] ?? null) ? $diagnostics['images'] : array();
-            foreach ( array('paint_refs', 'node_refs', 'resolved_assets', 'image_block_count', 'total_node_count') as $key ) {
-                $images[$key] += (int) ($pageImages[$key] ?? 0);
-            }
-            foreach ( is_array($pageImages['image_block_nodes'] ?? null) ? $pageImages['image_block_nodes'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $images['image_block_nodes'][] = array_merge($pageContext, $item);
-                }
-            }
-            foreach ( is_array($pageImages['missing_assets'] ?? null) ? $pageImages['missing_assets'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $images['missing_assets'][] = array_merge($pageContext, $item);
-                }
-            }
+            DiagnosticAggregation::addIntegerCounts($images, $pageImages, array('paint_refs', 'node_refs', 'resolved_assets', 'image_block_count', 'total_node_count'));
+            DiagnosticAggregation::appendContextSamples($images, 'image_block_nodes', $pageImages, 'image_block_nodes', $pageContext);
+            DiagnosticAggregation::appendContextSamples($images, 'missing_assets', $pageImages, 'missing_assets', $pageContext);
 
             $pageVectors = is_array($diagnostics['vectors'] ?? null) ? $diagnostics['vectors'] : array();
-            foreach ( array('nodes', 'rendered_paths', 'rendered_asset_fallbacks', 'vector_network_decoded', 'boolean_operations_composed', 'placeholders') as $key ) {
-                $vectors[$key] += (int) ($pageVectors[$key] ?? 0);
-            }
-            foreach ( is_array($pageVectors['placeholder_nodes'] ?? null) ? $pageVectors['placeholder_nodes'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $vectors['placeholder_nodes'][] = array_merge($pageContext, $item);
-                }
-            }
-            foreach ( is_array($pageVectors['placeholder_reasons'] ?? null) ? $pageVectors['placeholder_reasons'] : array() as $reason => $count ) {
-                $vectors['placeholder_reasons'][(string) $reason] = (int) ($vectors['placeholder_reasons'][(string) $reason] ?? 0) + (int) $count;
-            }
+            DiagnosticAggregation::addIntegerCounts($vectors, $pageVectors, array('nodes', 'rendered_paths', 'rendered_asset_fallbacks', 'vector_network_decoded', 'boolean_operations_composed', 'placeholders'));
+            DiagnosticAggregation::appendContextSamples($vectors, 'placeholder_nodes', $pageVectors, 'placeholder_nodes', $pageContext);
+            DiagnosticAggregation::addCounterMap($vectors['placeholder_reasons'], is_array($pageVectors['placeholder_reasons'] ?? null) ? $pageVectors['placeholder_reasons'] : array());
 
             $pageFonts = is_array($diagnostics['fonts'] ?? null) ? $diagnostics['fonts'] : array();
             $fontFamilies = $this->mergeFontFamilies($fontFamilies, is_array($pageFonts['families'] ?? null) ? $pageFonts['families'] : array());
@@ -1045,31 +1028,11 @@ final class FigmaTransformer
             $fontMaterialized = $fontMaterialized || true === ($pageFonts['materialized'] ?? false);
 
             $pageLayout = is_array($diagnostics['layout'] ?? null) ? $diagnostics['layout'] : array();
-            $layout['large_negative_left_count'] += (int) ($pageLayout['large_negative_left_count'] ?? 0);
-            $layout['large_css_offset_count'] += (int) ($pageLayout['large_css_offset_count'] ?? 0);
-            foreach ( is_array($pageLayout['large_css_offset_nodes'] ?? null) ? $pageLayout['large_css_offset_nodes'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $layout['large_css_offset_nodes'][] = array_merge($pageContext, $item);
-                }
-            }
-            $layout['off_canvas_visual_node_count'] += (int) ($pageLayout['off_canvas_visual_node_count'] ?? 0);
-            foreach ( is_array($pageLayout['off_canvas_visual_nodes'] ?? null) ? $pageLayout['off_canvas_visual_nodes'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $layout['off_canvas_visual_nodes'][] = array_merge($pageContext, $item);
-                }
-            }
-            $layout['large_absolute_offset_count'] += (int) ($pageLayout['large_absolute_offset_count'] ?? 0);
-            foreach ( is_array($pageLayout['large_absolute_offset_nodes'] ?? null) ? $pageLayout['large_absolute_offset_nodes'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $layout['large_absolute_offset_nodes'][] = array_merge($pageContext, $item);
-                }
-            }
-            $layout['empty_visible_container_count'] += (int) ($pageLayout['empty_visible_container_count'] ?? 0);
-            foreach ( is_array($pageLayout['empty_visible_containers'] ?? null) ? $pageLayout['empty_visible_containers'] : array() as $item ) {
-                if ( is_array($item) ) {
-                    $layout['empty_visible_containers'][] = array_merge($pageContext, $item);
-                }
-            }
+            DiagnosticAggregation::addIntegerCounts($layout, $pageLayout, array('large_negative_left_count', 'large_css_offset_count', 'off_canvas_visual_node_count', 'large_absolute_offset_count', 'empty_visible_container_count'));
+            DiagnosticAggregation::appendContextSamples($layout, 'large_css_offset_nodes', $pageLayout, 'large_css_offset_nodes', $pageContext);
+            DiagnosticAggregation::appendContextSamples($layout, 'off_canvas_visual_nodes', $pageLayout, 'off_canvas_visual_nodes', $pageContext);
+            DiagnosticAggregation::appendContextSamples($layout, 'large_absolute_offset_nodes', $pageLayout, 'large_absolute_offset_nodes', $pageContext);
+            DiagnosticAggregation::appendContextSamples($layout, 'empty_visible_containers', $pageLayout, 'empty_visible_containers', $pageContext);
             $underlays = is_array($pageLayout['decorative_underlays']['nodes'] ?? null) ? $pageLayout['decorative_underlays']['nodes'] : array();
             foreach ( $underlays as $item ) {
                 if ( is_array($item) ) {
@@ -1140,9 +1103,7 @@ final class FigmaTransformer
             }
 
             $pageDiagnosticCodes = is_array($page['diagnostic_codes'] ?? null) ? $page['diagnostic_codes'] : (is_array($diagnostics['diagnostic_codes'] ?? null) ? $diagnostics['diagnostic_codes'] : array());
-            foreach ( $pageDiagnosticCodes as $code => $count ) {
-                $diagnosticCodes[(string) $code] = ($diagnosticCodes[(string) $code] ?? 0) + (int) $count;
-            }
+            DiagnosticAggregation::addCounterMap($diagnosticCodes, $pageDiagnosticCodes);
         }
 
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -79,4 +79,52 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     $assert('diag:empty-text' === ($emptyTextDiagnostics['text']['empty_decoded_text_nodes'][0]['node_id'] ?? null), 'diagnostics-evidence-empty-text-sample-node');
     $assert('Empty Text Page' === ($emptyTextDiagnostics['text']['empty_decoded_text_nodes'][0]['page_name'] ?? null), 'diagnostics-evidence-empty-text-page-context');
     $assert(in_array('decoded_text_empty', $emptyTextSignalCodes, true), 'diagnostics-evidence-empty-text-signal');
+
+    $multiPageResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Diagnostics Aggregation Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'diag:aggregation-canvas',
+                'type'     => 'CANVAS',
+                'name'     => 'Aggregation Pages',
+                'children' => array(
+                    array(
+                        'id'       => 'diag:aggregation-home',
+                        'type'     => 'FRAME',
+                        'name'     => 'Aggregation Home',
+                        'width'    => 320,
+                        'height'   => 180,
+                        'children' => array(
+                            array('id' => 'diag:aggregation-home-image', 'type' => 'RECTANGLE', 'name' => 'Missing Home Asset', 'width' => 80, 'height' => 60, 'asset_id' => 'missing-home'),
+                            array('id' => 'diag:aggregation-home-vector', 'type' => 'VECTOR', 'name' => 'Unsupported Home Vector'),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'diag:aggregation-about',
+                        'type'     => 'FRAME',
+                        'name'     => 'Aggregation About',
+                        'width'    => 320,
+                        'height'   => 180,
+                        'children' => array(
+                            array('id' => 'diag:aggregation-about-image', 'type' => 'RECTANGLE', 'name' => 'Missing About Asset', 'width' => 80, 'height' => 60, 'asset_id' => 'missing-about'),
+                            array('id' => 'diag:aggregation-about-vector', 'type' => 'VECTOR', 'name' => 'Unsupported About Vector'),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ), array('multi_page' => true, 'frame_ids' => array('diag:aggregation-home', 'diag:aggregation-about'), 'entry_frame_id' => 'diag:aggregation-home'));
+    $multiPageDiagnostics = $multiPageResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $missingAssets = $multiPageDiagnostics['images']['missing_assets'] ?? array();
+    $placeholderNodes = $multiPageDiagnostics['vectors']['placeholder_nodes'] ?? array();
+    $assert('multi_page' === ($multiPageDiagnostics['scope'] ?? null), 'diagnostics-evidence-multi-page-scope');
+    $assert(2 === ($multiPageDiagnostics['images']['node_refs'] ?? null), 'diagnostics-evidence-multi-page-image-node-count');
+    $assert(2 === count(is_array($missingAssets) ? $missingAssets : array()), 'diagnostics-evidence-multi-page-missing-asset-sample-count');
+    $assert('index.html' === ($missingAssets[0]['page_path'] ?? null), 'diagnostics-evidence-multi-page-missing-asset-home-context');
+    $assert('aggregation-about.html' === ($missingAssets[1]['page_path'] ?? null), 'diagnostics-evidence-multi-page-missing-asset-about-context');
+    $assert(2 === ($multiPageDiagnostics['vectors']['placeholders'] ?? null), 'diagnostics-evidence-multi-page-vector-placeholder-count');
+    $assert(2 === count(is_array($placeholderNodes) ? $placeholderNodes : array()), 'diagnostics-evidence-multi-page-placeholder-sample-count');
+    $assert('diag:aggregation-home-vector' === ($placeholderNodes[0]['node_id'] ?? null), 'diagnostics-evidence-multi-page-placeholder-home-node');
+    $assert('aggregation-about.html' === ($placeholderNodes[1]['page_path'] ?? null), 'diagnostics-evidence-multi-page-placeholder-about-context');
+    $assert(2 === ($multiPageDiagnostics['diagnostic_codes']['unsupported_vector_node_placeholder'] ?? null), 'diagnostics-evidence-multi-page-diagnostic-code-count');
 }


### PR DESCRIPTION
## Summary
- Add a small diagnostics aggregation helper for integer counters, counter maps, and page-context samples.
- Use it in multi-page transform diagnostics aggregation while preserving the existing diagnostic shape.
- Add contract coverage for multi-page sample context and diagnostic code rollups.

## Tests
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnostics aggregation refactor, contract test additions, and verification.