### PR TITLE
figma-transformer: clarify instance clone resolution

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1079,8 +1079,9 @@ final class ScenegraphNormalizer
      */
     private function cloneComponentForInstance(array $component, array $instance, string $componentId, array $overrides, array $nodeMap, array &$diagnostics, array $blobs = array(), array $paintStyles = array()): array
     {
+        $context = $this->buildInstanceCloneContext($component, $instance, $componentId, $overrides);
         $resolved = $component;
-        $resolved['id'] = (string) ($instance['id'] ?? $resolved['id'] ?? '');
+        $resolved['id'] = $context['instance_id'];
         $resolved['type'] = 'INSTANCE';
         $resolved['name'] = (string) ($instance['name'] ?? $resolved['name'] ?? '');
         // The resolved node stands in for the instance placement, so its
@@ -1099,9 +1100,9 @@ final class ScenegraphNormalizer
             is_array($instance['figma_component'] ?? null) ? $instance['figma_component'] : array(),
             array(
                 'role'               => 'instance',
-                'instance_id'        => (string) ($instance['id'] ?? ''),
-                'component_id'       => $componentId,
-                'definition_node_id' => (string) ($component['id'] ?? ''),
+                'instance_id'        => $context['instance_id'],
+                'component_id'       => $context['component_id'],
+                'definition_node_id' => $context['definition_node_id'],
                 'resolved'           => true,
             )
         );
@@ -1115,16 +1116,37 @@ final class ScenegraphNormalizer
         // assignments into the override map keyed by the consuming node id so the
         // existing override machinery renders each instance's own content instead of
         // the component master's default placeholder.
-        $overrides = $this->mergeComponentPropertyTextOverrides($overrides, $instance, $component);
+        $overrides = $context['overrides'];
         if ( $this->instanceOverridesUseTransforms($overrides) ) {
             $resolved['layout'] = array('freeform' => true);
         }
         $resolved['children'] = $this->namespaceResolvedInstanceChildren(
             $this->applyInstanceOverridesToChildren($resolvedChildren, $overrides, $diagnostics, $blobs, $paintStyles),
-            (string) ($instance['id'] ?? '')
+            $context['instance_id']
         );
 
         return $resolved;
+    }
+
+    /**
+     * Gather the stable identifiers and normalized overrides that drive a resolved
+     * instance clone. Keeping these together makes the clone steps below explicit:
+     * preserve instance placement, refresh source children, apply overrides, then
+     * namespace cloned source ids under the instance id.
+     *
+     * @param array<string, mixed>                 $component
+     * @param array<string, mixed>                 $instance
+     * @param array<string, array<string, mixed>> $overrides
+     * @return array{instance_id: string, component_id: string, definition_node_id: string, overrides: array<string, array<string, mixed>>}
+     */
+    private function buildInstanceCloneContext(array $component, array $instance, string $componentId, array $overrides): array
+    {
+        return array(
+            'instance_id'        => (string) ($instance['id'] ?? $component['id'] ?? ''),
+            'component_id'       => $componentId,
+            'definition_node_id' => (string) ($component['id'] ?? ''),
+            'overrides'          => $this->mergeComponentPropertyTextOverrides($overrides, $instance, $component),
+        );
     }
 
     /**
@@ -1302,12 +1324,20 @@ final class ScenegraphNormalizer
     private function instanceOverridesUseTransforms(array $overrides): bool
     {
         foreach ( $overrides as $override ) {
-            if ( is_array($override) && is_array($override['transform'] ?? null) ) {
+            if ( is_array($override) && $this->isTransformOverrideGeometry($override) ) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @param array<string, mixed> $override
+     */
+    private function isTransformOverrideGeometry(array $override): bool
+    {
+        return is_array($override['transform'] ?? null);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5804,6 +5804,113 @@ $assert(substr_count($componentPropTextHtml, 'Welcome to LEGO City') === 1 && su
 $assert(substr_count($componentPropTextHtml, '>Post Title<') === 2, 'component-prop-text-default-only-without-assignment');
 $assert(str_contains($componentPropTextHtml, 'data-figma-node-id="instance:card-c/component:post-heading"'), 'component-prop-text-no-override-preserves-default-node');
 
+$instanceCloneNormalizer = new \Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer();
+$instanceCloneNormalized = $instanceCloneNormalizer->normalize(array(
+    'name'  => 'Instance Clone Pattern Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'component:icon',
+            'type'     => 'COMPONENT',
+            'name'     => 'Icon source',
+            'key'      => 'icon-key',
+            'children' => array(
+                array(
+                    'id'     => 'component:icon/vector',
+                    'type'   => 'VECTOR',
+                    'name'   => 'Icon vector',
+                    'width'  => 10,
+                    'height' => 10,
+                    'pathData' => 'M0 0H10V10Z',
+                ),
+            ),
+        ),
+        array(
+            'id'       => 'component:button-with-icon',
+            'type'     => 'COMPONENT',
+            'name'     => 'Button source',
+            'key'      => 'button-with-icon-key',
+            'children' => array(
+                array(
+                    'id'          => 'component:button-with-icon/icon-slot',
+                    'type'        => 'INSTANCE',
+                    'name'        => 'Icon slot',
+                    'componentId' => 'icon-key',
+                    'width'       => 10,
+                    'height'      => 10,
+                ),
+                array(
+                    'id'         => 'component:button-with-icon/label',
+                    'type'       => 'TEXT',
+                    'name'       => 'Button label',
+                    'characters' => 'Default CTA',
+                    'componentPropRefs' => array(
+                        array(
+                            'defID'                  => array('sessionID' => 500, 'localID' => 1),
+                            'componentPropNodeField' => 'TEXT_DATA',
+                        ),
+                    ),
+                ),
+                array(
+                    'id'       => 'component:button-with-icon/badge',
+                    'type'     => 'RECTANGLE',
+                    'name'     => 'Badge',
+                    'width'    => 20,
+                    'height'   => 20,
+                ),
+            ),
+        ),
+        array(
+            'id'          => 'instance:button-with-icon',
+            'type'        => 'INSTANCE',
+            'name'        => 'Button instance',
+            'componentId' => 'button-with-icon-key',
+            'x'           => 40,
+            'y'           => 50,
+            'width'       => 160,
+            'height'      => 48,
+            'componentPropAssignments' => array(
+                array(
+                    'defID' => array('sessionID' => 500, 'localID' => 1),
+                    'value' => array('textValue' => array('characters' => 'Assigned CTA')),
+                ),
+            ),
+            'overrides'   => array(
+                array(
+                    'nodeId'    => 'component:button-with-icon/label',
+                    'characters' => 'Explicit CTA',
+                ),
+                array(
+                    'nodeId'    => 'component:button-with-icon/badge',
+                    'transform' => array('m00' => 1, 'm01' => 0, 'm02' => 72, 'm10' => 0, 'm11' => 1, 'm12' => 14),
+                ),
+            ),
+        ),
+    ),
+));
+$instanceClone = $instanceCloneNormalized['node_map']['instance:button-with-icon'] ?? array();
+$instanceCloneIcon = array();
+$instanceCloneLabel = array();
+$instanceCloneBadge = array();
+foreach ( is_array($instanceClone['children'] ?? null) ? $instanceClone['children'] : array() as $child ) {
+    if ( ! is_array($child) ) {
+        continue;
+    }
+    if ( 'component:button-with-icon/icon-slot' === ($child['figma_component_source_id'] ?? null) ) {
+        $instanceCloneIcon = $child;
+    } elseif ( 'component:button-with-icon/label' === ($child['figma_component_source_id'] ?? null) ) {
+        $instanceCloneLabel = $child;
+    } elseif ( 'component:button-with-icon/badge' === ($child['figma_component_source_id'] ?? null) ) {
+        $instanceCloneBadge = $child;
+    }
+}
+$instanceCloneIconVector = $instanceCloneIcon['children'][0] ?? array();
+$assert('instance:button-with-icon/component:button-with-icon/icon-slot' === ($instanceCloneIcon['id'] ?? null), 'instance-clone-retargets-refreshed-nested-instance-root');
+$assert('component:button-with-icon/icon-slot' === ($instanceCloneIcon['figma_component_source_id'] ?? null), 'instance-clone-preserves-nested-instance-source-id');
+$assert('instance:button-with-icon/component:button-with-icon/icon-slot/component:icon/vector' === ($instanceCloneIconVector['id'] ?? null), 'instance-clone-refreshes-nested-source-child');
+$assert('Explicit CTA' === ($instanceCloneLabel['figma_text']['characters'] ?? null), 'instance-clone-explicit-text-override-beats-component-property');
+$assert(true === ($instanceClone['layout']['freeform'] ?? null), 'instance-clone-transform-override-marks-root-freeform');
+$assert(72.0 === ($instanceCloneBadge['box']['x'] ?? null) && 14.0 === ($instanceCloneBadge['box']['y'] ?? null), 'instance-clone-transform-override-preserves-geometry');
+
 $fontAwesomeIconNameResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Font Awesome Icon Name Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- gather instance clone identifiers and merged component-property text overrides into a small clone context boundary
- route transform override geometry detection through an explicit helper
- add synthetic contract coverage for nested source refresh/retargeting, transform override geometry, and component-property text override precedence

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Refactor implementation, synthetic contract test additions, and local verification.