### PR TITLE
figma-transformer: add geometry provenance classification

### DIFF
--- a/figma-transformer/src/Scenegraph/GeometryBox.php
+++ b/figma-transformer/src/Scenegraph/GeometryBox.php
@@ -9,6 +9,8 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
  */
 final class GeometryBox
 {
+    public const PROVENANCE_KEY = '_geometry_provenance';
+
     public const CLASSIFICATION_CANVAS_ABSOLUTE = 'canvas-absolute';
     public const CLASSIFICATION_PARENT_LOCAL = 'parent-local';
     public const CLASSIFICATION_PAGE_LOCAL = 'page-local';
@@ -16,6 +18,14 @@ final class GeometryBox
     public const COORDINATE_SPACE_CANVAS_ABSOLUTE = 'absolute';
     public const COORDINATE_SPACE_PARENT_LOCAL = 'local';
     public const COORDINATE_SPACE_PAGE_LOCAL = self::COORDINATE_SPACE_PARENT_LOCAL;
+
+    public const SOURCE_ABSOLUTE_BOUNDS = 'absolute_bounds';
+    public const SOURCE_TRANSFORM = 'transform';
+    public const SOURCE_ABSOLUTE_TRANSFORM = 'absolute_transform';
+    public const SOURCE_EXPLICIT_LOCAL = 'explicit_local';
+    public const SOURCE_SIZE_ONLY = 'size_only';
+    public const SOURCE_OVERRIDE_TRANSFORM = 'override_transform';
+    public const SOURCE_COMPONENT_CLONE = 'component_clone';
 
     /**
      * @param array<string, mixed> $box
@@ -34,11 +44,67 @@ final class GeometryBox
             : self::COORDINATE_SPACE_PARENT_LOCAL;
     }
 
+    public static function classificationForSourceKind(string $sourceKind, bool $isPageLocal = false): ?string
+    {
+        return match ( $sourceKind ) {
+            self::SOURCE_ABSOLUTE_BOUNDS,
+            self::SOURCE_ABSOLUTE_TRANSFORM => self::CLASSIFICATION_CANVAS_ABSOLUTE,
+            self::SOURCE_EXPLICIT_LOCAL,
+            self::SOURCE_TRANSFORM,
+            self::SOURCE_OVERRIDE_TRANSFORM,
+            self::SOURCE_COMPONENT_CLONE => $isPageLocal ? self::CLASSIFICATION_PAGE_LOCAL : self::CLASSIFICATION_PARENT_LOCAL,
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     * @return array<string, mixed>
+     */
+    public static function withProvenance(array $box, string $sourceKind, bool $isPageLocal = false): array
+    {
+        $box[self::PROVENANCE_KEY] = $sourceKind;
+        $classification = self::classificationForSourceKind($sourceKind, $isPageLocal);
+        if ( null !== $classification ) {
+            $box['coordinate_space'] = self::coordinateSpaceForClassification($classification);
+        }
+
+        return $box;
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     */
+    public static function sourceKind(array $box): ?string
+    {
+        return isset($box[self::PROVENANCE_KEY]) && is_scalar($box[self::PROVENANCE_KEY])
+            ? (string) $box[self::PROVENANCE_KEY]
+            : null;
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     * @return array<string, mixed>
+     */
+    public static function withoutProvenance(array $box): array
+    {
+        unset($box[self::PROVENANCE_KEY]);
+        return $box;
+    }
+
     /**
      * @param array<string, mixed> $box
      */
     public static function classifyNormalizedBox(array $box, bool $isPageLocal = false): string
     {
+        $sourceKind = self::sourceKind($box);
+        if ( null !== $sourceKind ) {
+            $classification = self::classificationForSourceKind($sourceKind, $isPageLocal);
+            if ( null !== $classification ) {
+                return $classification;
+            }
+        }
+
         if ( self::COORDINATE_SPACE_CANVAS_ABSOLUTE === self::coordinateSpace($box) ) {
             return self::CLASSIFICATION_CANVAS_ABSOLUTE;
         }

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -808,7 +808,7 @@ final class ScenegraphNormalizer
                 }
             }
 
-            $node[$boxKey]['coordinate_space'] = 'local';
+            $node[$boxKey] = GeometryBox::withoutProvenance(GeometryBox::withProvenance($node[$boxKey], GeometryBox::SOURCE_COMPONENT_CLONE));
             $node[$boxKey]['geometry_semantics'] = self::GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE;
         }
 
@@ -922,9 +922,8 @@ final class ScenegraphNormalizer
             if ( isset($box['y']) && is_numeric($box['y']) ) {
                 $box['y'] = $isRoot ? 0.0 : (float) $box['y'] - $originY;
             }
-            $box['coordinate_space'] = GeometryBox::coordinateSpaceForClassification(
-                $isRoot ? GeometryBox::CLASSIFICATION_PAGE_LOCAL : GeometryBox::CLASSIFICATION_PARENT_LOCAL
-            );
+            $box = GeometryBox::withProvenance($box, GeometryBox::SOURCE_EXPLICIT_LOCAL, $isRoot);
+            $box = GeometryBox::withoutProvenance($box);
             $box['local_origin'] = 'page';
         }
 
@@ -1590,6 +1589,7 @@ final class ScenegraphNormalizer
             foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
                 if ( isset($child['relativeTransform'][$source]) && is_numeric($child['relativeTransform'][$source]) ) {
                     $child[$target] = (float) $child['relativeTransform'][$source];
+                    $child[GeometryBox::PROVENANCE_KEY] = GeometryBox::SOURCE_OVERRIDE_TRANSFORM;
                 }
             }
         }
@@ -1598,6 +1598,7 @@ final class ScenegraphNormalizer
             foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
                 if ( isset($child['absoluteTransform'][$source]) && is_numeric($child['absoluteTransform'][$source]) ) {
                     $child[$target] = (float) $child['absoluteTransform'][$source];
+                    $child[GeometryBox::PROVENANCE_KEY] = GeometryBox::SOURCE_ABSOLUTE_TRANSFORM;
                     $absoluteBounds[$target] = (float) $child['absoluteTransform'][$source];
                 }
             }
@@ -1617,6 +1618,7 @@ final class ScenegraphNormalizer
             foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
                 if ( isset($child['transform'][$source]) && is_numeric($child['transform'][$source]) ) {
                     $child[$target] = (float) $child['transform'][$source];
+                    $child[GeometryBox::PROVENANCE_KEY] = GeometryBox::SOURCE_ABSOLUTE_TRANSFORM;
                     // Only backfill absoluteBoundingBox where the dimension is not already
                     // present — preserve any richer absolute bounds the payload already has.
                     if ( ! isset($absoluteBounds[$target]) ) {
@@ -1635,6 +1637,7 @@ final class ScenegraphNormalizer
         unset($child['figma_vector_scale']);
 
         $child = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles);
+        unset($child[GeometryBox::PROVENANCE_KEY]);
         if ( $hasVectorGeometryOverride && ! $hasExplicitSizeOverride ) {
             $bounds = $this->normalizedVectorPathBounds(is_array($child['figma_vector_paths'] ?? null) ? $child['figma_vector_paths'] : array());
             if ( null !== $bounds ) {
@@ -3877,7 +3880,7 @@ final class ScenegraphNormalizer
     private function normalizeLayoutBox(array $node): array
     {
         $box = array();
-        $coordinateSpaceClassification = null;
+        $sourceKind = null;
 
         foreach ( array('absoluteBoundingBox', 'absoluteRenderBounds') as $boundsKey ) {
             if ( ! is_array($node[$boundsKey] ?? null) ) {
@@ -3891,7 +3894,7 @@ final class ScenegraphNormalizer
             }
 
             if ( isset($node[$boundsKey]['x']) || isset($node[$boundsKey]['y']) ) {
-                $coordinateSpaceClassification = GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE;
+                $sourceKind = GeometryBox::SOURCE_ABSOLUTE_BOUNDS;
             }
         }
 
@@ -3899,7 +3902,9 @@ final class ScenegraphNormalizer
             if ( ! array_key_exists($dimension, $box) && isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
                 $box[$dimension] = (float) $node[$dimension];
                 if ( 'x' === $dimension || 'y' === $dimension ) {
-                    $coordinateSpaceClassification = GeometryBox::CLASSIFICATION_PARENT_LOCAL;
+                    $sourceKind = isset($node[GeometryBox::PROVENANCE_KEY]) && is_scalar($node[GeometryBox::PROVENANCE_KEY])
+                        ? (string) $node[GeometryBox::PROVENANCE_KEY]
+                        : GeometryBox::SOURCE_EXPLICIT_LOCAL;
                 }
             }
         }
@@ -3908,6 +3913,7 @@ final class ScenegraphNormalizer
             foreach ( array('x' => 'width', 'y' => 'height') as $source => $target ) {
                 if ( ! array_key_exists($target, $box) && isset($node['size'][$source]) && is_numeric($node['size'][$source]) ) {
                     $box[$target] = (float) $node['size'][$source];
+                    $sourceKind ??= GeometryBox::SOURCE_SIZE_ONLY;
                 }
             }
         }
@@ -3916,33 +3922,33 @@ final class ScenegraphNormalizer
         foreach ( array('x', 'y') as $dimension ) {
             if ( ! array_key_exists($dimension, $box) && isset($transformBox[$dimension]) ) {
                 $box[$dimension] = $transformBox[$dimension];
-                $coordinateSpaceClassification = $transformBox['coordinate_space_classification'];
+                $sourceKind = $transformBox[GeometryBox::PROVENANCE_KEY];
             }
         }
 
-        if ( null !== $coordinateSpaceClassification ) {
-            $box['coordinate_space'] = GeometryBox::coordinateSpaceForClassification($coordinateSpaceClassification);
+        if ( null !== $sourceKind ) {
+            $box = GeometryBox::withProvenance($box, $sourceKind);
         }
 
-        return $box;
+        return GeometryBox::withoutProvenance($box);
     }
 
     /**
      * @param array<string, mixed> $node
-     * @return array{x?: float, y?: float, coordinate_space_classification?: string}
+     * @return array{x?: float, y?: float, _geometry_provenance?: string}
      */
     private function layoutBoxFromTransform(array $node): array
     {
         foreach ( array(
-            'relativeTransform' => GeometryBox::CLASSIFICATION_PARENT_LOCAL,
-            'transform'         => GeometryBox::CLASSIFICATION_PARENT_LOCAL,
-            'absoluteTransform' => GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE,
-        ) as $sourceKey => $classification ) {
+            'relativeTransform' => GeometryBox::SOURCE_TRANSFORM,
+            'transform'         => GeometryBox::SOURCE_TRANSFORM,
+            'absoluteTransform' => GeometryBox::SOURCE_ABSOLUTE_TRANSFORM,
+        ) as $sourceKey => $sourceKind ) {
             if ( ! is_array($node[$sourceKey] ?? null) ) {
                 continue;
             }
 
-            $box = array('coordinate_space_classification' => $classification);
+            $box = array(GeometryBox::PROVENANCE_KEY => $sourceKind);
             foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
                 if ( isset($node[$sourceKey][$source]) && is_numeric($node[$sourceKey][$source]) ) {
                     $box[$target] = (float) $node[$sourceKey][$source];

--- a/figma-transformer/tests/contract/GeometryBoxContract.php
+++ b/figma-transformer/tests/contract/GeometryBoxContract.php
@@ -12,6 +12,32 @@ function blocks_engine_figma_transformer_run_geometry_box_contract(callable $ass
 {
     $normalizer = new ScenegraphNormalizer();
 
+    $absoluteProvenanceBox = GeometryBox::withProvenance(array('x' => 100.0), GeometryBox::SOURCE_ABSOLUTE_BOUNDS);
+    $assert(GeometryBox::SOURCE_ABSOLUTE_BOUNDS === GeometryBox::sourceKind($absoluteProvenanceBox), 'geometry-box-provenance-absolute-bounds-source-kind');
+    $assert(GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE === GeometryBox::classifyNormalizedBox($absoluteProvenanceBox), 'geometry-box-provenance-absolute-bounds-classification');
+    $assert(GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE === ($absoluteProvenanceBox['coordinate_space'] ?? null), 'geometry-box-provenance-absolute-bounds-coordinate-space');
+
+    $transformProvenanceBox = GeometryBox::withProvenance(array('x' => 7.0), GeometryBox::SOURCE_TRANSFORM);
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($transformProvenanceBox), 'geometry-box-provenance-transform-classification');
+    $assert(GeometryBox::COORDINATE_SPACE_PARENT_LOCAL === ($transformProvenanceBox['coordinate_space'] ?? null), 'geometry-box-provenance-transform-coordinate-space');
+
+    $absoluteTransformProvenanceBox = GeometryBox::withProvenance(array('x' => 1300.0), GeometryBox::SOURCE_ABSOLUTE_TRANSFORM);
+    $assert(GeometryBox::CLASSIFICATION_CANVAS_ABSOLUTE === GeometryBox::classifyNormalizedBox($absoluteTransformProvenanceBox), 'geometry-box-provenance-absolute-transform-classification');
+
+    $explicitLocalProvenanceBox = GeometryBox::withProvenance(array('x' => 12.0), GeometryBox::SOURCE_EXPLICIT_LOCAL);
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($explicitLocalProvenanceBox), 'geometry-box-provenance-explicit-local-classification');
+
+    $sizeOnlyProvenanceBox = GeometryBox::withProvenance(array('width' => 90.0), GeometryBox::SOURCE_SIZE_ONLY);
+    $assert(null === GeometryBox::classificationForSourceKind(GeometryBox::SOURCE_SIZE_ONLY), 'geometry-box-provenance-size-only-unclassified');
+    $assert(! isset($sizeOnlyProvenanceBox['coordinate_space']), 'geometry-box-provenance-size-only-no-coordinate-space');
+
+    $overrideTransformProvenanceBox = GeometryBox::withProvenance(array('x' => 21.0), GeometryBox::SOURCE_OVERRIDE_TRANSFORM);
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($overrideTransformProvenanceBox), 'geometry-box-provenance-override-transform-classification');
+
+    $componentCloneProvenanceBox = GeometryBox::withProvenance(array('x' => 0.0), GeometryBox::SOURCE_COMPONENT_CLONE);
+    $assert(GeometryBox::CLASSIFICATION_PARENT_LOCAL === GeometryBox::classifyNormalizedBox($componentCloneProvenanceBox), 'geometry-box-provenance-component-clone-classification');
+    $assert(! isset(GeometryBox::withoutProvenance($componentCloneProvenanceBox)[GeometryBox::PROVENANCE_KEY]), 'geometry-box-provenance-strip-internal-marker');
+
     $absoluteResult = $normalizer->normalize(array(
         'name'  => 'Absolute Bounds Geometry Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- Add a small GeometryBox provenance abstraction for source-kind classification.
- Route nearby normalizer box construction and rebase classification through the helper while stripping internal provenance from serialized boxes.
- Add synthetic contract coverage for representative provenance patterns.

## Tests
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the refactor, adding contract tests, running verification, and drafting this PR description.