### PR TITLE
figma-transformer: extract contract test helpers

### DIFF
--- a/figma-transformer/tests/contract/ContractHelpers.php
+++ b/figma-transformer/tests/contract/ContractHelpers.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param array<string, mixed> $scenegraph
+ * @param array<string, mixed> $options
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_transformer_contract_transform(array $scenegraph, array $options = array()): array
+{
+    return blocks_engine_figma_transformer_transform_scenegraph($scenegraph, $options);
+}
+
+/**
+ * @param array<string, mixed> $result
+ */
+function blocks_engine_figma_transformer_contract_file_content(array $result, string $path): string
+{
+    foreach ( $result['files'] ?? array() as $file ) {
+        if ( is_array($file) && $path === ($file['path'] ?? null) ) {
+            return (string) ($file['content'] ?? '');
+        }
+    }
+
+    return '';
+}
+
+/**
+ * @param array<int, mixed> $visualNodeMap
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_transformer_contract_find_visual_node_in_map(array $visualNodeMap, string $id): ?array
+{
+    foreach ( $visualNodeMap as $node ) {
+        if ( is_array($node) && $id === ($node['id'] ?? null) ) {
+            return $node;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @param array<string, mixed> $result
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_transformer_contract_find_visual_node(array $result, string $id): ?array
+{
+    $visualNodeMap = $result['source_reports']['figma']['html']['visual_node_map'] ?? array();
+    return blocks_engine_figma_transformer_contract_find_visual_node_in_map(is_array($visualNodeMap) ? $visualNodeMap : array(), $id);
+}
+
+/**
+ * @param array<string, mixed> $result
+ * @return array<int, string>
+ */
+function blocks_engine_figma_transformer_contract_artifact_quality_signal_codes(array $result): array
+{
+    $signals = $result['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
+    return array_values(array_map(
+        static fn (array $signal): string => (string) ($signal['code'] ?? ''),
+        is_array($signals) ? $signals : array()
+    ));
+}
+
+/**
+ * @param array<string, mixed> $result
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_transformer_contract_artifact_quality_signal(array $result, string $code): ?array
+{
+    $signals = $result['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
+    foreach ( is_array($signals) ? $signals : array() as $signal ) {
+        if ( is_array($signal) && $code === ($signal['code'] ?? null) ) {
+            return $signal;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @param callable(bool, string): void $assert
+ * @param array<string, mixed>|null $node
+ * @param array<string, float> $expectedRect
+ */
+function blocks_engine_figma_transformer_contract_assert_node_rect(callable $assert, ?array $node, array $expectedRect, string $message): void
+{
+    $assert($expectedRect === ($node['rect'] ?? null), $message);
+}

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  */
 function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(callable $assert): void
 {
-    $normalResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $normalResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Diagnostics Normal Fixture',
         'nodes' => array(
             array(
@@ -23,8 +23,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
         ),
     ));
     $normalDiagnostics = $normalResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
-    $normalSignals = $normalDiagnostics['artifact_quality']['signals'] ?? array();
-    $normalSignalCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), is_array($normalSignals) ? $normalSignals : array());
+    $normalSignalCodes = blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($normalResult);
     $assert(1 === ($normalDiagnostics['text']['decoded_text_node_count'] ?? null), 'diagnostics-evidence-normal-decoded-text-count');
     $assert(1 === ($normalDiagnostics['text']['emitted_text_node_count'] ?? null), 'diagnostics-evidence-normal-emitted-text-count');
     $assert(0 === ($normalDiagnostics['text']['missing_emitted_text_node_count'] ?? null), 'diagnostics-evidence-normal-missing-text-zero');
@@ -32,7 +31,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     $assert(! in_array('decoded_text_not_emitted', $normalSignalCodes, true), 'diagnostics-evidence-normal-no-missing-text-signal');
     $assert(! in_array('clipped_visual_area', $normalSignalCodes, true), 'diagnostics-evidence-normal-no-clipped-area-signal');
 
-    $clippedResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $clippedResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Diagnostics Clipped Fixture',
         'nodes' => array(
             array(
@@ -50,14 +49,13 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
         ),
     ));
     $clippedDiagnostics = $clippedResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
-    $clippedSignals = $clippedDiagnostics['artifact_quality']['signals'] ?? array();
-    $clippedSignalCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), is_array($clippedSignals) ? $clippedSignals : array());
+    $clippedSignalCodes = blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($clippedResult);
     $assert(1 === ($clippedDiagnostics['layout']['clipped_visual_node_count'] ?? null), 'diagnostics-evidence-clipped-count');
     $assert(0.5 === ($clippedDiagnostics['layout']['clipped_visual_area_ratio'] ?? null), 'diagnostics-evidence-clipped-area-ratio');
     $assert('diag:clip-vector' === ($clippedDiagnostics['layout']['clipped_visual_nodes'][0]['node_id'] ?? null), 'diagnostics-evidence-clipped-sample-node');
     $assert(in_array('clipped_visual_area', $clippedSignalCodes, true), 'diagnostics-evidence-clipped-area-signal');
 
-    $emptyTextResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $emptyTextResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Diagnostics Empty Text Fixture',
         'nodes' => array(
             array(
@@ -73,8 +71,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
         ),
     ));
     $emptyTextDiagnostics = $emptyTextResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
-    $emptyTextSignals = $emptyTextDiagnostics['artifact_quality']['signals'] ?? array();
-    $emptyTextSignalCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), is_array($emptyTextSignals) ? $emptyTextSignals : array());
+    $emptyTextSignalCodes = blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($emptyTextResult);
     $assert(1 === ($emptyTextDiagnostics['text']['empty_decoded_text_node_count'] ?? null), 'diagnostics-evidence-empty-text-count');
     $assert('diag:empty-text' === ($emptyTextDiagnostics['text']['empty_decoded_text_nodes'][0]['node_id'] ?? null), 'diagnostics-evidence-empty-text-sample-node');
     $assert('Empty Text Page' === ($emptyTextDiagnostics['text']['empty_decoded_text_nodes'][0]['page_name'] ?? null), 'diagnostics-evidence-empty-text-page-context');

--- a/figma-transformer/tests/contract/OriginInferenceContract.php
+++ b/figma-transformer/tests/contract/OriginInferenceContract.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 /**
  * @param callable(bool, string): void $assert
- * @param callable(array<string, mixed>, string): string $fileContent
- * @param callable(array<string, mixed>, string): ?array<string, mixed> $findVisualNode
  */
-function blocks_engine_figma_transformer_run_origin_inference_contract(callable $assert, callable $fileContent, callable $findVisualNode): void
+function blocks_engine_figma_transformer_run_origin_inference_contract(callable $assert): void
 {
-    $decorativeOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $decorativeOriginResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Decorative Origin Candidate Fixture',
         'nodes' => array(
             array(
@@ -43,12 +41,12 @@ function blocks_engine_figma_transformer_run_origin_inference_contract(callable 
             ),
         ),
     ));
-    $decorativeOriginCss = $fileContent($decorativeOriginResult, 'style.css');
-    $decorativeOriginCopy = $findVisualNode($decorativeOriginResult, 'origin-pref:copy');
+    $decorativeOriginCss = blocks_engine_figma_transformer_contract_file_content($decorativeOriginResult, 'style.css');
+    $decorativeOriginCopy = blocks_engine_figma_transformer_contract_find_visual_node($decorativeOriginResult, 'origin-pref:copy');
     $assert(str_contains($decorativeOriginCss, '.figma-node-origin-pref-copy-headline{width:320px;height:48px;position:absolute;left:100px;top:80px'), 'origin-inference-ignores-decorative-outlier-css');
-    $assert(array('x' => 100.0, 'y' => 80.0, 'width' => 320.0, 'height' => 48.0) === ($decorativeOriginCopy['rect'] ?? null), 'origin-inference-ignores-decorative-outlier-visual-map');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $decorativeOriginCopy, array('x' => 100.0, 'y' => 80.0, 'width' => 320.0, 'height' => 48.0), 'origin-inference-ignores-decorative-outlier-visual-map');
 
-    $shapeOnlyOriginResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $shapeOnlyOriginResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Shape Only Origin Candidate Fixture',
         'nodes' => array(
             array(
@@ -73,8 +71,8 @@ function blocks_engine_figma_transformer_run_origin_inference_contract(callable 
             ),
         ),
     ));
-    $shapeOnlyOriginCss = $fileContent($shapeOnlyOriginResult, 'style.css');
-    $shapeOnlyFirst = $findVisualNode($shapeOnlyOriginResult, 'shape-origin:first');
+    $shapeOnlyOriginCss = blocks_engine_figma_transformer_contract_file_content($shapeOnlyOriginResult, 'style.css');
+    $shapeOnlyFirst = blocks_engine_figma_transformer_contract_find_visual_node($shapeOnlyOriginResult, 'shape-origin:first');
     $assert(str_contains($shapeOnlyOriginCss, '.figma-node-shape-origin-first-first-shape{width:200px;height:160px;position:absolute;left:0px;top:0px'), 'origin-inference-shape-only-fallback-css');
-    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 200.0, 'height' => 160.0) === ($shapeOnlyFirst['rect'] ?? null), 'origin-inference-shape-only-fallback-visual-map');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $shapeOnlyFirst, array('x' => 0.0, 'y' => 0.0, 'width' => 200.0, 'height' => 160.0), 'origin-inference-shape-only-fallback-visual-map');
 }

--- a/figma-transformer/tests/contract/RenderStyleMismatchContract.php
+++ b/figma-transformer/tests/contract/RenderStyleMismatchContract.php
@@ -9,14 +9,6 @@ use Automattic\BlocksEngine\FigmaTransformer\Diagnostics\RenderStyleMismatchRepo
  */
 function blocks_engine_figma_transformer_run_render_style_mismatch_contract(callable $assert): void
 {
-    $artifactQualitySignalCodes = static function (array $result): array {
-        $signals = $result['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
-        return array_values(array_map(
-            static fn (array $signal): string => (string) ($signal['code'] ?? ''),
-            is_array($signals) ? $signals : array()
-        ));
-    };
-
     $report = ( new RenderStyleMismatchReportBuilder() )->build(
         array(
             'node_style_diagnostics' => array(
@@ -122,7 +114,7 @@ function blocks_engine_figma_transformer_run_render_style_mismatch_contract(call
     $assert(1 === ($pageScopedSummary['render_node_count'] ?? null), 'render-style-page-scope-render-count');
     $assert(1 === ($pageScopedSummary['color_mismatch_count'] ?? null), 'render-style-page-scope-selected-page-color');
 
-    $transformResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $transformResult = blocks_engine_figma_transformer_contract_transform(array(
         'name' => 'Render Style Fixture',
         'nodes' => array(
             array(
@@ -164,5 +156,5 @@ function blocks_engine_figma_transformer_run_render_style_mismatch_contract(call
     $assert('fail' === ($transformDiagnostics['status'] ?? null), 'render-style-transform-status');
     $assert(1 === ($transformDiagnostics['summary']['font_mismatch_count'] ?? null), 'render-style-transform-font-count');
     $assert(1 === ($transformDiagnostics['summary']['color_mismatch_count'] ?? null), 'render-style-transform-color-count');
-    $assert(in_array('render_style_mismatch', $artifactQualitySignalCodes($transformResult), true), 'render-style-artifact-quality-signal');
+    $assert(in_array('render_style_mismatch', blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($transformResult), true), 'render-style-artifact-quality-signal');
 }

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 /**
  * @param callable(bool, string): void $assert
- * @param callable(array<string, mixed>, string): ?array<string, mixed> $findVisualNode
- * @param callable(array<string, mixed>, string): string $fileContent
  */
-function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $assert, callable $findVisualNode, callable $fileContent): void
+function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $assert): void
 {
-    $visualFlexAlignmentResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $visualFlexAlignmentResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Visual Flex Alignment Fixture',
         'nodes' => array(
             array(
@@ -44,9 +42,9 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
             ),
         ),
     ));
-    $visualFlexFirst = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:first');
-    $visualFlexSecond = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:second');
-    $visualFlexCentered = $findVisualNode($visualFlexAlignmentResult, 'visual-flex:centered');
+    $visualFlexFirst = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexAlignmentResult, 'visual-flex:first');
+    $visualFlexSecond = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexAlignmentResult, 'visual-flex:second');
+    $visualFlexCentered = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexAlignmentResult, 'visual-flex:centered');
     $assert(330.0 === ($visualFlexFirst['rect']['x'] ?? null), 'visual-map-flex-end-first-x');
     $assert(40.0 === ($visualFlexFirst['rect']['y'] ?? null), 'visual-map-flex-center-first-y');
     $assert(450.0 === ($visualFlexSecond['rect']['x'] ?? null), 'visual-map-flex-end-second-x');
@@ -66,16 +64,10 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
             ),
         ),
     ));
-    $visualFlexCrossOverflowWide = null;
-    foreach ( $visualFlexCrossOverflowMap as $visualNode ) {
-        if ( is_array($visualNode) && 'visual-cross:wide' === ($visualNode['id'] ?? null) ) {
-            $visualFlexCrossOverflowWide = $visualNode;
-            break;
-        }
-    }
+    $visualFlexCrossOverflowWide = blocks_engine_figma_transformer_contract_find_visual_node_in_map($visualFlexCrossOverflowMap, 'visual-cross:wide');
     $assert(-40.0 === ($visualFlexCrossOverflowWide['rect']['x'] ?? null), 'visual-map-column-overflow-center-child-x');
 
-    $visualFlexOverflowResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $visualFlexOverflowResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Visual Flex Overflow Alignment Fixture',
         'nodes' => array(
             array(
@@ -110,16 +102,16 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
             ),
         ),
     ));
-    $visualOverflowEndFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-first');
-    $visualOverflowEndSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:end-second');
-    $visualOverflowCenterFirst = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-first');
-    $visualOverflowCenterSecond = $findVisualNode($visualFlexOverflowResult, 'visual-overflow:center-second');
+    $visualOverflowEndFirst = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexOverflowResult, 'visual-overflow:end-first');
+    $visualOverflowEndSecond = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexOverflowResult, 'visual-overflow:end-second');
+    $visualOverflowCenterFirst = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexOverflowResult, 'visual-overflow:center-first');
+    $visualOverflowCenterSecond = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexOverflowResult, 'visual-overflow:center-second');
     $assert(-28.0 === ($visualOverflowEndFirst['rect']['x'] ?? null), 'visual-map-overflow-flex-end-first-x');
     $assert(30.0 === ($visualOverflowEndSecond['rect']['x'] ?? null), 'visual-map-overflow-flex-end-second-x');
     $assert(-14.0 === ($visualOverflowCenterFirst['rect']['x'] ?? null), 'visual-map-overflow-center-first-x');
     $assert(44.0 === ($visualOverflowCenterSecond['rect']['x'] ?? null), 'visual-map-overflow-center-second-x');
 
-    $visualFlexWrapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $visualFlexWrapResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Visual Flex Wrap Fixture',
         'nodes' => array(
             array(
@@ -140,16 +132,16 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
             ),
         ),
     ));
-    $visualFlexWrapCss = $fileContent($visualFlexWrapResult, 'style.css');
-    $visualFlexWrapFirst = $findVisualNode($visualFlexWrapResult, 'visual-wrap:first');
-    $visualFlexWrapSecond = $findVisualNode($visualFlexWrapResult, 'visual-wrap:second');
-    $visualFlexWrapThird = $findVisualNode($visualFlexWrapResult, 'visual-wrap:third');
+    $visualFlexWrapCss = blocks_engine_figma_transformer_contract_file_content($visualFlexWrapResult, 'style.css');
+    $visualFlexWrapFirst = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexWrapResult, 'visual-wrap:first');
+    $visualFlexWrapSecond = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexWrapResult, 'visual-wrap:second');
+    $visualFlexWrapThird = blocks_engine_figma_transformer_contract_find_visual_node($visualFlexWrapResult, 'visual-wrap:third');
     $assert(str_contains($visualFlexWrapCss, 'flex-wrap:wrap;align-content:flex-start'), 'visual-map-flex-wrap-align-content-packed');
-    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 100.0, 'height' => 40.0) === ($visualFlexWrapFirst['rect'] ?? null), 'visual-map-flex-wrap-first-line-first-card');
-    $assert(array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0) === ($visualFlexWrapSecond['rect'] ?? null), 'visual-map-flex-wrap-first-line-second-card');
-    $assert(array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0) === ($visualFlexWrapThird['rect'] ?? null), 'visual-map-flex-wrap-second-line-card');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $visualFlexWrapFirst, array('x' => 0.0, 'y' => 0.0, 'width' => 100.0, 'height' => 40.0), 'visual-map-flex-wrap-first-line-first-card');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $visualFlexWrapSecond, array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0), 'visual-map-flex-wrap-first-line-second-card');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $visualFlexWrapThird, array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0), 'visual-map-flex-wrap-second-line-card');
 
-    $visualCrossAxisFillResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $visualCrossAxisFillResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Visual Cross Axis Fill Fixture',
         'nodes' => array(
             array(
@@ -177,15 +169,15 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
             ),
         ),
     ));
-    $visualCrossAxisFillCss = $fileContent($visualCrossAxisFillResult, 'style.css');
-    $visualCrossAxisFillTall = $findVisualNode($visualCrossAxisFillResult, 'visual-cross-fill:tall');
-    $visualCrossAxisFillNext = $findVisualNode($visualCrossAxisFillResult, 'visual-cross-fill:next');
+    $visualCrossAxisFillCss = blocks_engine_figma_transformer_contract_file_content($visualCrossAxisFillResult, 'style.css');
+    $visualCrossAxisFillTall = blocks_engine_figma_transformer_contract_find_visual_node($visualCrossAxisFillResult, 'visual-cross-fill:tall');
+    $visualCrossAxisFillNext = blocks_engine_figma_transformer_contract_find_visual_node($visualCrossAxisFillResult, 'visual-cross-fill:next');
     $assert(str_contains($visualCrossAxisFillCss, '.figma-node-visual-cross-fill-tall-tall-fill-child{width:50px;height:100%;flex-shrink:0}'), 'visual-map-cross-axis-fill-does-not-grow-main-axis-css');
     $assert(! str_contains($visualCrossAxisFillCss, '.figma-node-visual-cross-fill-tall-tall-fill-child{width:50px;height:100%;flex-grow:1'), 'visual-map-cross-axis-fill-no-flex-grow-css');
-    $assert(array('x' => 100.0, 'y' => 0.0, 'width' => 50.0, 'height' => 100.0) === ($visualCrossAxisFillTall['rect'] ?? null), 'visual-map-cross-axis-fill-source-width-preserved');
-    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 80.0, 'height' => 40.0) === ($visualCrossAxisFillNext['rect'] ?? null), 'visual-map-cross-axis-fill-next-child-not-pushed');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $visualCrossAxisFillTall, array('x' => 100.0, 'y' => 0.0, 'width' => 50.0, 'height' => 100.0), 'visual-map-cross-axis-fill-source-width-preserved');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $visualCrossAxisFillNext, array('x' => 0.0, 'y' => 0.0, 'width' => 80.0, 'height' => 40.0), 'visual-map-cross-axis-fill-next-child-not-pushed');
 
-    $freeformTransitionResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    $freeformTransitionResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Auto Layout Freeform Transition Fixture',
         'nodes' => array(
             array(
@@ -214,19 +206,19 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
             ),
         ),
     ));
-    $transitionCss = $fileContent($freeformTransitionResult, 'style.css');
-    $transitionFlowA = $findVisualNode($freeformTransitionResult, 'layout-transition:flow-a');
-    $transitionAbsolute = $findVisualNode($freeformTransitionResult, 'layout-transition:absolute');
-    $transitionFlowB = $findVisualNode($freeformTransitionResult, 'layout-transition:flow-b');
-    $transitionLocalCard = $findVisualNode($freeformTransitionResult, 'layout-transition:local-card');
+    $transitionCss = blocks_engine_figma_transformer_contract_file_content($freeformTransitionResult, 'style.css');
+    $transitionFlowA = blocks_engine_figma_transformer_contract_find_visual_node($freeformTransitionResult, 'layout-transition:flow-a');
+    $transitionAbsolute = blocks_engine_figma_transformer_contract_find_visual_node($freeformTransitionResult, 'layout-transition:absolute');
+    $transitionFlowB = blocks_engine_figma_transformer_contract_find_visual_node($freeformTransitionResult, 'layout-transition:flow-b');
+    $transitionLocalCard = blocks_engine_figma_transformer_contract_find_visual_node($freeformTransitionResult, 'layout-transition:local-card');
     $assert(str_contains($transitionCss, '.figma-node-layout-transition-flex-auto-layout-shell{width:360px;height:180px;position:relative;display:flex;flex-direction:row;gap:12px}'), 'visual-map-layout-transition-flex-css');
     $assert(str_contains($transitionCss, '.figma-node-layout-transition-freeform-freeform-board{width:360px;height:180px;position:relative}'), 'visual-map-layout-transition-freeform-css');
-    $assert(array('x' => 0.0, 'y' => 0.0, 'width' => 80.0, 'height' => 40.0) === ($transitionFlowA['rect'] ?? null), 'visual-map-layout-transition-flow-first-position');
-    $assert(array('x' => 92.0, 'y' => 0.0, 'width' => 60.0, 'height' => 40.0) === ($transitionFlowB['rect'] ?? null), 'visual-map-layout-transition-flow-skips-absolute-position');
-    $assert(array('x' => 250.0, 'y' => 20.0, 'width' => 40.0, 'height' => 24.0) === ($transitionAbsolute['rect'] ?? null), 'visual-map-layout-transition-absolute-position');
-    $assert(array('x' => 44.0, 'y' => 66.0, 'width' => 90.0, 'height' => 30.0) === ($transitionLocalCard['rect'] ?? null), 'visual-map-layout-transition-freeform-local-position');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $transitionFlowA, array('x' => 0.0, 'y' => 0.0, 'width' => 80.0, 'height' => 40.0), 'visual-map-layout-transition-flow-first-position');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $transitionFlowB, array('x' => 92.0, 'y' => 0.0, 'width' => 60.0, 'height' => 40.0), 'visual-map-layout-transition-flow-skips-absolute-position');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $transitionAbsolute, array('x' => 250.0, 'y' => 20.0, 'width' => 40.0, 'height' => 24.0), 'visual-map-layout-transition-absolute-position');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $transitionLocalCard, array('x' => 44.0, 'y' => 66.0, 'width' => 90.0, 'height' => 30.0), 'visual-map-layout-transition-freeform-local-position');
 
-    $nestedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(
+    $nestedInstanceResult = blocks_engine_figma_transformer_contract_transform(
         array(
             'name'  => 'Nested Instance Transform Override Fixture',
             'nodes' => array(
@@ -291,16 +283,16 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
         ),
         array('frame_id' => 'instance:page')
     );
-    $nestedInstanceHtml = $fileContent($nestedInstanceResult, 'index.html');
-    $nestedInstanceCss = $fileContent($nestedInstanceResult, 'style.css');
-    $nestedInstanceRoot = $findVisualNode($nestedInstanceResult, 'instance:button');
-    $nestedInstanceLabel = $findVisualNode($nestedInstanceResult, 'instance:button/component:button/label');
-    $nestedInstanceIconVector = $findVisualNode($nestedInstanceResult, 'instance:button/component:button/icon/component:icon/vector');
+    $nestedInstanceHtml = blocks_engine_figma_transformer_contract_file_content($nestedInstanceResult, 'index.html');
+    $nestedInstanceCss = blocks_engine_figma_transformer_contract_file_content($nestedInstanceResult, 'style.css');
+    $nestedInstanceRoot = blocks_engine_figma_transformer_contract_find_visual_node($nestedInstanceResult, 'instance:button');
+    $nestedInstanceLabel = blocks_engine_figma_transformer_contract_find_visual_node($nestedInstanceResult, 'instance:button/component:button/label');
+    $nestedInstanceIconVector = blocks_engine_figma_transformer_contract_find_visual_node($nestedInstanceResult, 'instance:button/component:button/icon/component:icon/vector');
     $assert(str_contains($nestedInstanceHtml, 'Buy now'), 'visual-map-nested-instance-text-override-emits');
     $assert(! str_contains($nestedInstanceHtml, 'Default label'), 'visual-map-nested-instance-text-override-replaces-default');
     $assert(str_contains($nestedInstanceHtml, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"'), 'visual-map-nested-instance-vector-emits');
     $assert(str_contains($nestedInstanceCss, '.figma-node-instance-button-buy-button{width:160px;height:60px;position:absolute;left:30px;top:40px}'), 'visual-map-nested-instance-transform-override-freeform-css');
-    $assert(array('x' => 30.0, 'y' => 40.0, 'width' => 160.0, 'height' => 60.0) === ($nestedInstanceRoot['rect'] ?? null), 'visual-map-nested-instance-root-position');
-    $assert(array('x' => 78.0, 'y' => 58.0, 'width' => 90.0, 'height' => 22.0) === ($nestedInstanceLabel['rect'] ?? null), 'visual-map-nested-instance-transform-override-position');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedInstanceRoot, array('x' => 30.0, 'y' => 40.0, 'width' => 160.0, 'height' => 60.0), 'visual-map-nested-instance-root-position');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedInstanceLabel, array('x' => 78.0, 'y' => 58.0, 'width' => 90.0, 'height' => 22.0), 'visual-map-nested-instance-transform-override-position');
     $assert(null !== $nestedInstanceIconVector, 'visual-map-nested-instance-resolves-nested-instance-vector');
 }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../figma-transformer.php';
 require_once __DIR__ . '/../../scripts/figma-fixture-selection.php';
+require_once __DIR__ . '/ContractHelpers.php';
 require_once __DIR__ . '/DiagnosticsEvidenceContract.php';
 require_once __DIR__ . '/FixtureMatrixContract.php';
 require_once __DIR__ . '/GeometryBoxContract.php';
@@ -141,22 +142,10 @@ $result = blocks_engine_figma_transformer_transform_scenegraph($scenegraph);
 $sameResult = blocks_engine_figma_transformer_transform_scenegraph($scenegraph);
 
 $fileContent = static function (array $result, string $path): string {
-    foreach ( $result['files'] ?? array() as $file ) {
-        if ( $path === ($file['path'] ?? null) ) {
-            return (string) ($file['content'] ?? '');
-        }
-    }
-
-    return '';
+    return blocks_engine_figma_transformer_contract_file_content($result, $path);
 };
 $findVisualNode = static function (array $result, string $id): ?array {
-    foreach ( $result['source_reports']['figma']['html']['visual_node_map'] ?? array() as $node ) {
-        if ( is_array($node) && $id === ($node['id'] ?? null) ) {
-            return $node;
-        }
-    }
-
-    return null;
+    return blocks_engine_figma_transformer_contract_find_visual_node($result, $id);
 };
 
 $html = $fileContent($result, 'index.html');
@@ -166,21 +155,10 @@ $diagnosticCodes = array_map(
     $result['diagnostics'] ?? array()
 );
 $artifactQualitySignalCodes = static function (array $result): array {
-    $signals = $result['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
-    return array_values(array_map(
-        static fn (array $signal): string => (string) ($signal['code'] ?? ''),
-        is_array($signals) ? $signals : array()
-    ));
+    return blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($result);
 };
 $artifactQualitySignal = static function (array $result, string $code): ?array {
-    $signals = $result['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['signals'] ?? array();
-    foreach ( is_array($signals) ? $signals : array() as $signal ) {
-        if ( is_array($signal) && $code === ($signal['code'] ?? null) ) {
-            return $signal;
-        }
-    }
-
-    return null;
+    return blocks_engine_figma_transformer_contract_artifact_quality_signal($result, $code);
 };
 
 $assert('blocks-engine/figma-transformer/result/v1' === ($result['schema'] ?? null), 'result-schema');
@@ -5217,7 +5195,7 @@ $hugOverflowResult = blocks_engine_figma_transformer_transform_scenegraph(array(
 $hugOverflowCss = $fileContent($hugOverflowResult, 'style.css');
 $assert(str_contains($hugOverflowCss, '.figma-node-hug-overflow-button-hug-overflow-button{width:max-content;height:40px;display:flex;flex-direction:row;justify-content:flex-end;align-items:center;padding-right:6px;padding-left:6px;gap:8px}'), 'layout-hug-flex-main-axis-expands-to-intrinsic-span');
 
-blocks_engine_figma_transformer_run_visual_node_map_contract($assert, $findVisualNode, $fileContent);
+blocks_engine_figma_transformer_run_visual_node_map_contract($assert);
 blocks_engine_figma_transformer_run_diagnostics_evidence_contract($assert);
 
 $kiwiStackLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -5628,7 +5606,7 @@ $assert(0.0 === ($selectedFrameRebaseRoot['box']['x'] ?? null) && 0.0 === ($sele
 $assert('local' === ($selectedFrameRebaseRoot['box']['coordinate_space'] ?? null) && 'page' === ($selectedFrameRebaseRoot['box']['local_origin'] ?? null), 'selected-frame-rebase-root-marked-page-local');
 $assert(120.0 === ($selectedFrameRebaseChild['box']['x'] ?? null) && 180.0 === ($selectedFrameRebaseChild['box']['y'] ?? null), 'selected-frame-rebase-child-subtracts-page-origin');
 $assert('local' === ($selectedFrameRebaseChild['box']['coordinate_space'] ?? null) && 'page' === ($selectedFrameRebaseChild['box']['local_origin'] ?? null), 'selected-frame-rebase-child-marked-page-local');
-blocks_engine_figma_transformer_run_origin_inference_contract($assert, $fileContent, $findVisualNode);
+blocks_engine_figma_transformer_run_origin_inference_contract($assert);
 
 $resolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Component Instance Fixture',


### PR DESCRIPTION
## Summary
- Add shared figma-transformer contract helpers for scenegraph transforms, result file lookup, visual node lookup, artifact-quality signal lookup, and rect assertions.
- Switch high-churn synthetic contract files to use the helpers while preserving assertion labels and test output behavior.
- Keep the existing contract harness shape intact; no broad framework rewrite.

## Tests
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Contract helper extraction, refactor implementation, and local verification.