### PR TITLE
figma-transformer: preserve clone-local geometry on frame rebase

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -797,11 +797,13 @@ final class ScenegraphNormalizer
      */
     private function markComponentSourceCloneGeometry(array $node): array
     {
+        $node['_component_source_clone_geometry'] = true;
         foreach ( array('box', 'figma_box') as $boxKey ) {
             if ( ! is_array($node[$boxKey] ?? null) ) {
                 continue;
             }
 
+            $sourceKind = GeometryBox::sourceKind($node[$boxKey]);
             foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
                 if ( isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
                     $node[$boxKey][$dimension] = (float) $node[$dimension];
@@ -810,6 +812,17 @@ final class ScenegraphNormalizer
 
             $node[$boxKey] = GeometryBox::withoutProvenance(GeometryBox::withProvenance($node[$boxKey], GeometryBox::SOURCE_COMPONENT_CLONE));
             $node[$boxKey]['geometry_semantics'] = self::GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE;
+            if ( null !== $sourceKind ) {
+                $node[$boxKey]['component_clone_source_kind'] = $sourceKind;
+            }
+        }
+
+        if ( is_array($node['children'] ?? null) ) {
+            foreach ( $node['children'] as $index => $child ) {
+                if ( is_array($child) ) {
+                    $node['children'][$index] = $this->markComponentSourceCloneGeometry($child);
+                }
+            }
         }
 
         return $node;
@@ -914,6 +927,13 @@ final class ScenegraphNormalizer
         }
 
         $box = $node[$boxKey];
+        if ( ! $isRoot && $this->isComponentSourceCloneDescendant($node, $box) ) {
+            $box = GeometryBox::withoutProvenance($box);
+            $box['coordinate_space'] = GeometryBox::COORDINATE_SPACE_PARENT_LOCAL;
+            $node[$boxKey] = $box;
+            return $node;
+        }
+
         $coordinateSpace = GeometryBox::coordinateSpace($box);
         if ( $isRoot || GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE === $coordinateSpace ) {
             if ( isset($box['x']) && is_numeric($box['x']) ) {
@@ -929,6 +949,32 @@ final class ScenegraphNormalizer
 
         $node[$boxKey] = $box;
         return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $box
+     */
+    private function isComponentSourceCloneDescendant(array $node, array $box): bool
+    {
+        $sourceKind = isset($box['component_clone_source_kind']) && is_scalar($box['component_clone_source_kind']) ? (string) $box['component_clone_source_kind'] : null;
+        if ( in_array($sourceKind, array(GeometryBox::SOURCE_TRANSFORM, GeometryBox::SOURCE_ABSOLUTE_TRANSFORM, GeometryBox::SOURCE_OVERRIDE_TRANSFORM), true) ) {
+            return false;
+        }
+
+        if ( ! empty($node['_component_source_clone_geometry']) || self::GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE === ($box['geometry_semantics'] ?? null) ) {
+            return true;
+        }
+
+        $id = isset($node['id']) && is_scalar($node['id']) ? (string) $node['id'] : '';
+        $sourceId = isset($node['figma_component_source_id']) && is_scalar($node['figma_component_source_id']) ? (string) $node['figma_component_source_id'] : '';
+        if ( '' === $id || '' === $sourceId || $id === $sourceId || ! str_contains($id, '/') ) {
+            return false;
+        }
+
+        $x = isset($box['x']) && is_numeric($box['x']) ? abs((float) $box['x']) : 0.0;
+        $y = isset($box['y']) && is_numeric($box['y']) ? abs((float) $box['y']) : 0.0;
+        return $x < 1000.0 && $y < 1000.0;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5612,6 +5612,56 @@ $assert(0.0 === ($selectedFrameRebaseRoot['box']['x'] ?? null) && 0.0 === ($sele
 $assert('local' === ($selectedFrameRebaseRoot['box']['coordinate_space'] ?? null) && 'page' === ($selectedFrameRebaseRoot['box']['local_origin'] ?? null), 'selected-frame-rebase-root-marked-page-local');
 $assert(120.0 === ($selectedFrameRebaseChild['box']['x'] ?? null) && 180.0 === ($selectedFrameRebaseChild['box']['y'] ?? null), 'selected-frame-rebase-child-subtracts-page-origin');
 $assert('local' === ($selectedFrameRebaseChild['box']['coordinate_space'] ?? null) && 'page' === ($selectedFrameRebaseChild['box']['local_origin'] ?? null), 'selected-frame-rebase-child-marked-page-local');
+$selectedFrameComponentCloneResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Selected Frame Component Clone Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'clone-rebase:component',
+            'type'                => 'COMPONENT',
+            'name'                => 'Featured card component',
+            'key'                 => 'featured-card-key',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 400, 'height' => 200),
+            'children'            => array(
+                array(
+                    'id'                  => 'clone-rebase:component/content',
+                    'type'                => 'FRAME',
+                    'name'                => 'Content frame',
+                    'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 400, 'height' => 200),
+                    'layoutMode'          => 'VERTICAL',
+                    'children'            => array(
+                        array(
+                            'id'                  => 'clone-rebase:component/title',
+                            'type'                => 'TEXT',
+                            'name'                => 'Title',
+                            'characters'          => 'Component title',
+                            'absoluteBoundingBox' => array('x' => 24, 'y' => 24, 'width' => 180, 'height' => 32),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'                  => 'clone-rebase:page',
+            'type'                => 'FRAME',
+            'name'                => 'Selected page',
+            'absoluteBoundingBox' => array('x' => 3000, 'y' => 400, 'width' => 800, 'height' => 600),
+            'children'            => array(
+                array(
+                    'id'                  => 'clone-rebase:instance',
+                    'type'                => 'INSTANCE',
+                    'name'                => 'Featured card instance',
+                    'componentId'         => 'featured-card-key',
+                    'absoluteBoundingBox' => array('x' => 3120, 'y' => 480, 'width' => 400, 'height' => 200),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                ),
+            ),
+        ),
+    ),
+), array('frame_id' => 'clone-rebase:page'));
+$selectedFrameComponentCloneCss = $fileContent($selectedFrameComponentCloneResult, 'style.css');
+$selectedFrameComponentCloneContent = $findVisualNode($selectedFrameComponentCloneResult, 'clone-rebase:instance/clone-rebase:component/content');
+$assert(str_contains($selectedFrameComponentCloneCss, '.figma-node-clone-rebase-instance-clone-rebase-component-content-content-frame{width:400px;height:200px;position:absolute;left:0px;top:0px'), 'selected-frame-rebase-keeps-component-clone-child-local-css');
+blocks_engine_figma_transformer_contract_assert_node_rect($assert, $selectedFrameComponentCloneContent, array('x' => 120.0, 'y' => 80.0, 'width' => 400.0, 'height' => 200.0), 'selected-frame-rebase-keeps-component-clone-child-local-visual-map');
 blocks_engine_figma_transformer_run_origin_inference_contract($assert);
 
 $resolvedInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary
- Preserve component-source clone-local geometry when rebasing an explicitly selected frame to page origin.
- Keep transform/override-derived clone geometry eligible for normal page-origin localization.
- Add synthetic contract coverage for a selected frame containing a resolved component instance from a different canvas origin.

## Verification
- `composer test:contract`
- `php -d memory_limit=1G figma-transformer/bin/figma-transformer /Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig --zstd-command=/opt/homebrew/bin/zstd --frame-id=3468:1038 --output-dir=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-pilot-compare/fix-transform`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the FSE Pilot fixture mismatch, implementing the normalizer fix, adding contract coverage, and running verification.
