### PR TITLE
figma-transformer: rebase component vector clone geometry

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -750,6 +750,7 @@ final class ScenegraphNormalizer
     private function mergeRefreshedComponentSource(array $clone, array $refreshed, string $sourceId): array
     {
         $cloneId = (string) ($clone['id'] ?? '');
+        $sourceBox = is_array($refreshed['box'] ?? null) ? $refreshed['box'] : array();
         $merged = '' !== $cloneId ? $this->retargetComponentSourceIds($refreshed, $sourceId, $cloneId) : $refreshed;
 
         foreach ( array('id', 'figma_component_source_id', 'box', 'figma_box', 'layout') as $key ) {
@@ -758,7 +759,99 @@ final class ScenegraphNormalizer
             }
         }
 
+        $sourceX = isset($sourceBox['x']) && is_numeric($sourceBox['x']) ? (float) $sourceBox['x'] : null;
+        $sourceY = isset($sourceBox['y']) && is_numeric($sourceBox['y']) ? (float) $sourceBox['y'] : null;
+        $sourceWidth = isset($sourceBox['width']) && is_numeric($sourceBox['width']) ? (float) $sourceBox['width'] : null;
+        $sourceHeight = isset($sourceBox['height']) && is_numeric($sourceBox['height']) ? (float) $sourceBox['height'] : null;
+        if ( null !== $sourceX || null !== $sourceY ) {
+            $merged = $this->rebaseComponentSourceCloneDescendants($merged, $sourceX, $sourceY, $sourceWidth, $sourceHeight);
+        }
+
         return $this->markComponentSourceCloneGeometry($merged);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function rebaseComponentSourceCloneDescendants(array $node, ?float $parentSourceX, ?float $parentSourceY, ?float $parentSourceWidth = null, ?float $parentSourceHeight = null): array
+    {
+        if ( ! is_array($node['children'] ?? null) ) {
+            return $node;
+        }
+
+        foreach ( $node['children'] as $index => $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $childSourceX = $this->componentSourceCloneBoxCoordinate($child, 'x');
+            $childSourceY = $this->componentSourceCloneBoxCoordinate($child, 'y');
+            $childSourceWidth = $this->componentSourceCloneBoxCoordinate($child, 'width');
+            $childSourceHeight = $this->componentSourceCloneBoxCoordinate($child, 'height');
+            $child = $this->rebaseComponentSourceCloneBox($child, 'box', $parentSourceX, $parentSourceY, $parentSourceWidth, $parentSourceHeight);
+            $child = $this->rebaseComponentSourceCloneBox($child, 'figma_box', $parentSourceX, $parentSourceY, $parentSourceWidth, $parentSourceHeight);
+            $node['children'][$index] = $this->rebaseComponentSourceCloneDescendants(
+                $child,
+                null !== $childSourceX ? $childSourceX : $parentSourceX,
+                null !== $childSourceY ? $childSourceY : $parentSourceY,
+                null !== $childSourceWidth ? $childSourceWidth : $parentSourceWidth,
+                null !== $childSourceHeight ? $childSourceHeight : $parentSourceHeight
+            );
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function componentSourceCloneBoxCoordinate(array $node, string $dimension): ?float
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        return isset($box[$dimension]) && is_numeric($box[$dimension]) ? (float) $box[$dimension] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function rebaseComponentSourceCloneBox(array $node, string $boxKey, ?float $parentSourceX, ?float $parentSourceY, ?float $parentSourceWidth = null, ?float $parentSourceHeight = null): array
+    {
+        if ( ! is_array($node[$boxKey] ?? null) ) {
+            return $node;
+        }
+
+        $box = $node[$boxKey];
+        if ( 'page' !== ($box['local_origin'] ?? null) && GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE !== GeometryBox::coordinateSpace($box) ) {
+            return $node;
+        }
+
+        foreach ( array('x' => array($parentSourceX, $parentSourceWidth), 'y' => array($parentSourceY, $parentSourceHeight)) as $dimension => $parentSource ) {
+            [$parentSourceCoordinate, $parentSourceSize] = $parentSource;
+            if ( null === $parentSourceCoordinate || ! isset($node[$boxKey][$dimension]) || ! is_numeric($node[$boxKey][$dimension]) ) {
+                continue;
+            }
+            if ( GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE === GeometryBox::coordinateSpace($box) && ! $this->componentSourceCoordinateOverlapsParent((float) $node[$boxKey][$dimension], $parentSourceCoordinate, $parentSourceSize) ) {
+                continue;
+            }
+
+            $node[$boxKey][$dimension] = (float) $node[$boxKey][$dimension] - $parentSourceCoordinate;
+        }
+
+        unset($node[$boxKey]['local_origin']);
+        $node[$boxKey]['coordinate_space'] = GeometryBox::COORDINATE_SPACE_PARENT_LOCAL;
+
+        return $node;
+    }
+
+    private function componentSourceCoordinateOverlapsParent(float $coordinate, float $parentSourceCoordinate, ?float $parentSourceSize): bool
+    {
+        if ( null === $parentSourceSize ) {
+            return $coordinate >= $parentSourceCoordinate - 0.5;
+        }
+
+        return $coordinate >= $parentSourceCoordinate - 0.5 && $coordinate <= $parentSourceCoordinate + $parentSourceSize + 0.5;
     }
 
     /**
@@ -1108,6 +1201,15 @@ final class ScenegraphNormalizer
         $resolvedChildren = is_array($resolved['children'] ?? null) ? $resolved['children'] : array();
         $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap);
         $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
+        $componentBox = is_array($component['box'] ?? null) ? $component['box'] : array();
+        $componentSourceX = isset($componentBox['x']) && is_numeric($componentBox['x']) ? (float) $componentBox['x'] : null;
+        $componentSourceY = isset($componentBox['y']) && is_numeric($componentBox['y']) ? (float) $componentBox['y'] : null;
+        $componentSourceWidth = isset($componentBox['width']) && is_numeric($componentBox['width']) ? (float) $componentBox['width'] : null;
+        $componentSourceHeight = isset($componentBox['height']) && is_numeric($componentBox['height']) ? (float) $componentBox['height'] : null;
+        if ( null !== $componentSourceX || null !== $componentSourceY ) {
+            $rebasedSource = $this->rebaseComponentSourceCloneDescendants(array('children' => $resolvedChildren), $componentSourceX, $componentSourceY, $componentSourceWidth, $componentSourceHeight);
+            $resolvedChildren = is_array($rebasedSource['children'] ?? null) ? $rebasedSource['children'] : $resolvedChildren;
+        }
         // Figma binds per-instance text content through component properties: each
         // master text node references a property definition (componentPropRefs ->
         // componentPropNodeField: TEXT_DATA) and the instance assigns the real value

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -295,4 +295,70 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedInstanceRoot, array('x' => 30.0, 'y' => 40.0, 'width' => 160.0, 'height' => 60.0), 'visual-map-nested-instance-root-position');
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedInstanceLabel, array('x' => 78.0, 'y' => 58.0, 'width' => 90.0, 'height' => 22.0), 'visual-map-nested-instance-transform-override-position');
     $assert(null !== $nestedInstanceIconVector, 'visual-map-nested-instance-resolves-nested-instance-vector');
+
+    $nestedVectorSourceResult = blocks_engine_figma_transformer_contract_transform(
+        array(
+            'name'  => 'Nested Vector Component Source Geometry Fixture',
+            'nodes' => array(
+                array(
+                    'id'                  => 'source:icon',
+                    'type'                => 'COMPONENT',
+                    'name'                => 'Source icon',
+                    'absoluteBoundingBox' => array('x' => 1000, 'y' => 500, 'width' => 40, 'height' => 40),
+                    'children'            => array(
+                        array(
+                            'id'                  => 'source:icon/vector',
+                            'type'                => 'VECTOR',
+                            'name'                => 'Source vector',
+                            'absoluteBoundingBox' => array('x' => 1012, 'y' => 508, 'width' => 16, 'height' => 16),
+                            'pathData'            => 'M0 0H16V16H0Z',
+                        ),
+                        array(
+                            'id'                  => 'source:icon/union',
+                            'type'                => 'BOOLEAN_OPERATION',
+                            'name'                => 'Source union',
+                            'absoluteBoundingBox' => array('x' => 1004, 'y' => 530, 'width' => 20, 'height' => 6),
+                            'children'            => array(
+                                array(
+                                    'id'                  => 'source:icon/union/part',
+                                    'type'                => 'VECTOR',
+                                    'name'                => 'Union part',
+                                    'absoluteBoundingBox' => array('x' => 1004, 'y' => 530, 'width' => 20, 'height' => 6),
+                                    'pathData'            => 'M0 0H20V6H0Z',
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'                  => 'source:page',
+                    'type'                => 'FRAME',
+                    'name'                => 'Page',
+                    'absoluteBoundingBox' => array('x' => 300, 'y' => 200, 'width' => 200, 'height' => 120),
+                    'children'            => array(
+                        array(
+                            'id'          => 'instance:icon',
+                            'type'        => 'INSTANCE',
+                            'name'        => 'Placed icon',
+                            'componentId' => 'source:icon',
+                            'x'           => 30,
+                            'y'           => 40,
+                            'width'       => 40,
+                            'height'      => 40,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array('frame_id' => 'source:page')
+    );
+    $nestedVectorSourceHtml = blocks_engine_figma_transformer_contract_file_content($nestedVectorSourceResult, 'index.html');
+    $nestedVectorSourceCss = blocks_engine_figma_transformer_contract_file_content($nestedVectorSourceResult, 'style.css');
+    $nestedVectorSourceVector = blocks_engine_figma_transformer_contract_find_visual_node($nestedVectorSourceResult, 'instance:icon/source:icon/vector');
+    $nestedVectorSourceUnion = blocks_engine_figma_transformer_contract_find_visual_node($nestedVectorSourceResult, 'instance:icon/source:icon/union');
+    $assert(str_contains($nestedVectorSourceHtml, 'viewBox="0 0 16 16"'), 'visual-map-component-source-vector-viewbox-stays-zero-origin');
+    $assert(str_contains($nestedVectorSourceCss, '.source-vector{width:16px;height:16px;position:absolute;left:12px;top:8px}'), 'visual-map-component-source-vector-css-parent-local');
+    $assert(str_contains($nestedVectorSourceCss, '.source-union{width:20px;height:6px;position:absolute;left:4px;top:30px}'), 'visual-map-component-source-boolean-css-parent-local');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedVectorSourceVector, array('x' => 42.0, 'y' => 48.0, 'width' => 16.0, 'height' => 16.0), 'visual-map-component-source-vector-rect-parent-local');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedVectorSourceUnion, array('x' => 34.0, 'y' => 70.0, 'width' => 20.0, 'height' => 6.0), 'visual-map-component-source-boolean-rect-parent-local');
 }


### PR DESCRIPTION
## Summary
- Rebase component-source clone descendants into their wrapper-local coordinate space before SVG/CSS emission.
- Preserve zero-origin SVG path/viewBox content while fixing wrapper CSS and visual-node map placement for nested vector and boolean descendants.
- Add synthetic nested vector/boolean component-source contract coverage.

## Evidence
- `composer test:contract` passes in `figma-transformer`.
- Focused transform verified with `php -d memory_limit=1G bin/figma-transformer /Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig --frame-id=3468:1038 --zstd-command=/opt/homebrew/bin/zstd --output-dir=<temp>/output`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, test coverage, and PR description drafting.