### PR TITLE
blocks-engine 0.2.2: add opt-in structuredStrategy for no-CSS-carry blocks reconstruction

### DIFF
--- a/packages/blocks-engine/CHANGELOG.md
+++ b/packages/blocks-engine/CHANGELOG.md
@@ -8,6 +8,16 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 This package uses [Semantic Versioning](https://semver.org/). Deprecations are warned one minor version ahead of removal.
 
+## [0.2.2] - 2026-06-30
+
+### Added
+
+- `structuredStrategy` — a selectable reconstruction strategy that interprets the `SectionSpec` into clean, theme-styled canonical blocks first (`nativeDecision` → `renderCover`/`renderCardGrid`/`renderMediaText`/…), falling back to a verbatim `core/html` island only on coverage loss. Unlike the preserve-DOM default it does not preserve source classes or whole-section islands, so its output is self-contained and renders from the theme alone with no dependency on carried source CSS. This restores the pre-preserve-DOM fidelity for no-CSS-carry blocks pipelines (e.g. data-liberation's blocks reconstruct path) while leaving the carried-CSS paths (local-convert, theme-carry) on the existing default. Exposed from `@automattic/blocks-engine/theme`.
+
+### Changed
+
+- No change to default behavior. `reconstructNativeAggregate`'s default remains `defaultReconstructStrategy` (preserve-DOM); `structuredStrategy` is strictly additive and opt-in via `SectionRenderOptions.strategy`. The reconstruct/golden suite is byte-identical for callers that do not select it.
+
 ## [0.2.1] - 2026-06-29
 
 ### Changed

--- a/packages/blocks-engine/package.json
+++ b/packages/blocks-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/blocks-engine",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Convert HTML and static sites into WordPress block markup and block themes.",
   "keywords": ["wordpress", "blocks", "gutenberg", "block-theme", "html", "static-site"],
   "license": "GPL-3.0-or-later",

--- a/packages/blocks-engine/src/theme/__tests__/strategy-seam.test.ts
+++ b/packages/blocks-engine/src/theme/__tests__/strategy-seam.test.ts
@@ -6,6 +6,7 @@ import {
   reconstruct,
   reconstructNativeAggregate,
   type SectionStrategy,
+  structuredStrategy,
 } from '../index.js';
 import type { SectionSpec } from '../section-spec.js';
 import type { StageCtx } from '../types.js';
@@ -276,5 +277,45 @@ describe('reconstruct strategy seam default path', () => {
     expect(drainedState).toEqual({ observed: 2 });
     expect(aggregate.sectionMarkup).toEqual([]);
     expect(aggregate.dedup).toEqual({ cssRules: ['.probe-source-identity{}'] });
+  });
+});
+
+describe('structuredStrategy — interpretive theme-styled reconstruction (no-CSS-carry path)', () => {
+  it('is exported from the theme barrel', () => {
+    expect(structuredStrategy.name).toBe('structured');
+    expect(typeof structuredStrategy.render).toBe('function');
+  });
+
+  it('emits native structured blocks (theme-styled) instead of a class-preserving island', () => {
+    // A cover-hero section. The default (preserve-dom) strategy keeps the source
+    // DOM/classes (needs carried CSS). structuredStrategy must interpret the spec
+    // into a native, self-contained block (core/cover) that renders from the theme
+    // alone — no verbatim island, no preserved source `class="hero cover"`.
+    const hero = sectionSpec({
+      sectionIndex: 0,
+      interactionModel: 'cover-with-headline',
+      height: 720,
+      headings: ['Cover hero'],
+      bodyText: ['Hero body copy.'],
+      fullBleed: true,
+      images: [sectionImage('/wp-content/uploads/2026/hero.jpg', { width: 1440, height: 900 })],
+      sectionHtml:
+        '<section id="hero" class="hero cover"><h1>Cover hero</h1><p>Hero body copy.</p><img src="/wp-content/uploads/2026/hero.jpg" alt="Fixture image"></section>',
+    });
+
+    const structured = reconstructNativeAggregate([hero], { ...options, strategy: structuredStrategy });
+    const defaulted = reconstructNativeAggregate([hero], options);
+
+    const structuredBody = structured.sectionMarkup.join('\n');
+    const defaultedBody = defaulted.sectionMarkup.join('\n');
+
+    // structured → a native canonical block, not a verbatim source island.
+    expect(structuredBody).toContain('wp:cover');
+    expect(structuredBody).not.toContain('lib-coverage-island');
+    expect(structuredBody).not.toContain('class="hero cover"');
+    // content still preserved (provenance-faithful copy).
+    expect(structured.expectedText).toContain('Cover hero');
+    // and it genuinely differs from the default preserve-dom output (regression guard).
+    expect(structuredBody).not.toEqual(defaultedBody);
   });
 });

--- a/packages/blocks-engine/src/theme/index.ts
+++ b/packages/blocks-engine/src/theme/index.ts
@@ -41,7 +41,7 @@ export {
   sanitizeSvgAsset,
   stripChrome,
 } from './page-reconstruct-helpers.js';
-export { classifySemanticStrategy, reconstruct, reconstructNativeAggregate } from './reconstruct.js';
+export { classifySemanticStrategy, reconstruct, reconstructNativeAggregate, structuredStrategy } from './reconstruct.js';
 export {
   buildCoverageIsland,
   buildHtmlFallbackBlock,

--- a/packages/blocks-engine/src/theme/reconstruct.ts
+++ b/packages/blocks-engine/src/theme/reconstruct.ts
@@ -630,6 +630,27 @@ export const defaultReconstructStrategy: SectionStrategy = {
   },
 };
 
+// Structured reconstruction (the pre-preserve-dom DLA blocks-path fidelity): interpret the
+// SectionSpec into clean, theme-styled canonical blocks FIRST (nativeDecision → renderSection →
+// renderCover/renderCardGrid/renderMediaText/…), with a verbatim core/html island only as the
+// coverage fallback. Unlike defaultReconstructStrategy/classifySemanticStrategy, it does NOT
+// preserve source classes or island whole sections by default — so the output is self-contained
+// and renders from the THEME alone, with no dependency on carried source CSS. This is the right
+// strategy for a no-CSS-carry blocks pipeline (e.g. data-liberation's blocks reconstruct path);
+// the carried-CSS paths (local-convert, theme-carry) keep defaultReconstructStrategy. Additive:
+// selecting it does not change the default, so those paths are unaffected.
+export const structuredStrategy: SectionStrategy = {
+  name: 'structured',
+  render(section, options, ctx) {
+    const converted = options.convertedSections?.get(section.sectionIndex);
+    return (
+      convertedDecision(section, converted, options) ??
+      nativeDecision(section, options, ctx) ??
+      islandDecision(section, options)
+    );
+  },
+};
+
 function optionsFromCtx(ctx: StageCtx): SectionRenderOptions {
   const rewriteCtx = ctx as RewriteCtx;
   return {


### PR DESCRIPTION
## Summary
Adds `structuredStrategy`, a selectable reconstruction strategy exported from `@automattic/blocks-engine/theme`. It interprets the `SectionSpec` into clean, theme-styled canonical blocks first (`nativeDecision` → `renderCover` / `renderCardGrid` / `renderMediaText` / …), falling back to a verbatim `core/html` island only on coverage loss. Unlike the preserve-DOM default it does **not** preserve source classes or whole-section islands, so its output is self-contained and renders from the theme alone — no dependency on carried source CSS.

Bumps the package to **0.2.2** with a CHANGELOG entry and a strategy-seam test.

## Why
The interpretive structured renderers still exist in the engine, but both shipped strategies (`defaultReconstructStrategy`, `classifySemanticStrategy`) route through preserve-DOM / verbatim islands first — keeping source classes and therefore requiring carried source CSS to render. A no-CSS-carry blocks pipeline (data-liberation's blocks reconstruct path) had no way to select the structured renderers, so its output rendered unstyled (class-preserving blocks with no backing CSS, e.g. a Wix homepage stacking to ~20× the source height). `structuredStrategy` restores that pre-preserve-DOM fidelity.

## Safety
Strictly **additive** and opt-in via `SectionRenderOptions.strategy`. The default remains `defaultReconstructStrategy` (preserve-DOM), so the carried-CSS paths (local-convert, theme-carry) are byte-identical — verified by the existing strategy-seam byte-identity test and the full suite (441 tests green).

## Test plan
- `vitest run` — full suite green (441), including the new `structuredStrategy` seam tests and the unchanged default-path byte-identity test.
- Dogfood (data-liberation blocks path, Wix source): structured output is gate-passing with 0 preserved source classes / 0 islands / 0 remote URLs; renders theme-styled chrome + `wp:cover` hero + gallery columns at ~source height (vs. unstyled stack under the default).