### PR TITLE
figma-transformer: preserve nested image overrides

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -706,7 +706,7 @@ final class ScenegraphNormalizer
         $sourceId = (string) ($node['figma_component_source_id'] ?? '');
         $refreshId = '' !== $id && isset($nodeMap[$id]) ? $id : $sourceId;
         $refreshesComponentSourceClone = '' !== $sourceId && $refreshId === $sourceId && $this->isRefreshableComponentSourceClone($node, $nodeMap[$refreshId] ?? array());
-        if ( '' !== $refreshId && isset($nodeMap[$refreshId]) && ! in_array($refreshId, $trail, true) && ($refreshId === $id || $refreshesComponentSourceClone) ) {
+        if ( '' !== $refreshId && isset($nodeMap[$refreshId]) && ! in_array($refreshId, $trail, true) && ($refreshId === $id || ($refreshesComponentSourceClone && ! $this->subtreeHasInstanceOverrideApplied($node))) ) {
             $node = $refreshId === $id
                 ? $nodeMap[$refreshId]
                 : $this->mergeRefreshedComponentSource($node, $nodeMap[$refreshId], $refreshId);
@@ -738,6 +738,24 @@ final class ScenegraphNormalizer
         $refreshedType = strtoupper((string) ($refreshed['type'] ?? ''));
 
         return 'INSTANCE' === $cloneType || 'INSTANCE' === $refreshedType || true === ($clone['figma_component']['resolved'] ?? false) || true === ($refreshed['figma_component']['resolved'] ?? false);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function subtreeHasInstanceOverrideApplied(array $node): bool
+    {
+        if ( true === ($node['_figma_instance_override_applied'] ?? false) ) {
+            return true;
+        }
+
+        foreach ( is_array($node['children'] ?? null) ? $node['children'] : array() as $child ) {
+            if ( is_array($child) && $this->subtreeHasInstanceOverrideApplied($child) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -1541,7 +1559,8 @@ final class ScenegraphNormalizer
             }
 
             if ( is_array($child['children'] ?? null) ) {
-                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], $overrides, $diagnostics, $blobs, $paintStyles);
+                $childOverrides = $this->descendantInstanceOverrideFieldsForChild($child, $overrides);
+                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], array_merge($overrides, $childOverrides), $diagnostics, $blobs, $paintStyles);
             }
 
             $children[$index] = $child;
@@ -1579,6 +1598,37 @@ final class ScenegraphNormalizer
     }
 
     /**
+     * Carry parent-scoped guidPath overrides into resolved nested instances.
+     *
+     * Figma can encode an override for a nested component child as
+     * `nested-instance-guid/child-guid`. Once recursion enters the nested
+     * instance, its descendants match the suffix (`child-guid`), not the full
+     * parent path.
+     *
+     * @param array<string, mixed> $child
+     * @param array<string, array<string, mixed>> $overrides
+     * @return array<string, array<string, mixed>>
+     */
+    private function descendantInstanceOverrideFieldsForChild(array $child, array $overrides): array
+    {
+        $scoped = array();
+        foreach ( $this->instanceChildOverrideAliases($child) as $alias ) {
+            foreach ( $overrides as $target => $overrideFields ) {
+                if ( ! is_string($target) || ! is_array($overrideFields) || ! str_starts_with($target, $alias . '/') ) {
+                    continue;
+                }
+
+                $descendantTarget = substr($target, strlen($alias) + 1);
+                if ( '' !== $descendantTarget ) {
+                    $scoped[$descendantTarget] = array_merge($scoped[$descendantTarget] ?? array(), $overrideFields);
+                }
+            }
+        }
+
+        return $scoped;
+    }
+
+    /**
      * @param array<string, mixed> $child
      * @return array<int, string>
      */
@@ -1587,7 +1637,12 @@ final class ScenegraphNormalizer
         $aliases = array();
         foreach ( array('id', 'figma_component_source_id') as $key ) {
             if ( isset($child[$key]) && is_scalar($child[$key]) && '' !== (string) $child[$key] ) {
-                $aliases[] = (string) $child[$key];
+                $id = (string) $child[$key];
+                $aliases[] = $id;
+                if ( str_contains($id, '/') ) {
+                    $parts = explode('/', $id);
+                    $aliases[] = (string) end($parts);
+                }
             }
         }
 
@@ -1667,6 +1722,7 @@ final class ScenegraphNormalizer
         unset($child['figma_vector_scale']);
 
         $child = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles);
+        $child['_figma_instance_override_applied'] = true;
         unset($child[GeometryBox::PROVENANCE_KEY]);
         if ( $hasVectorGeometryOverride && ! $hasExplicitSizeOverride ) {
             $bounds = $this->normalizedVectorPathBounds(is_array($child['figma_vector_paths'] ?? null) ? $child['figma_vector_paths'] : array());

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5692,6 +5692,64 @@ $guidOverrideInstanceHtml = $fileContent($guidOverrideInstanceResult, 'index.htm
 $assert(str_contains($guidOverrideInstanceHtml, 'Learn'), 'guid-override-instance-applies-text');
 $assert(str_contains($guidOverrideInstanceHtml, 'data-figma-node-id="instance:menu-item/180:6416"') && str_contains($guidOverrideInstanceHtml, '>Learn<'), 'guid-override-instance-replaces-default-text');
 
+$nestedImageOverrideResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Nested Image Override Fixture',
+    'nodes' => array(
+        array(
+            'guid'     => array('sessionID' => 700, 'localID' => 1),
+            'type'     => 'COMPONENT',
+            'name'     => 'Image component',
+            'children' => array(
+                array(
+                    'guid'       => array('sessionID' => 700, 'localID' => 2),
+                    'type'       => 'RECTANGLE',
+                    'name'       => 'Image',
+                    'width'      => 100,
+                    'height'     => 50,
+                    'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'default-image')),
+                ),
+            ),
+        ),
+        array(
+            'guid'     => array('sessionID' => 700, 'localID' => 3),
+            'type'     => 'COMPONENT',
+            'name'     => 'Preview component',
+            'children' => array(
+                array(
+                    'guid'       => array('sessionID' => 700, 'localID' => 4),
+                    'type'       => 'INSTANCE',
+                    'name'       => 'Image slot',
+                    'symbolData' => array('symbolID' => array('sessionID' => 700, 'localID' => 1)),
+                ),
+            ),
+        ),
+        array(
+            'id'         => 'instance:preview',
+            'type'       => 'INSTANCE',
+            'name'       => 'Preview instance',
+            'symbolData' => array(
+                'symbolID' => array('sessionID' => 700, 'localID' => 3),
+                'symbolOverrides' => array(
+                    array(
+                        'guidPath'   => array('guids' => array(array('sessionID' => 700, 'localID' => 4), array('sessionID' => 700, 'localID' => 2))),
+                        'fillPaints' => array(
+                            array('type' => 'IMAGE', 'imageRef' => 'default-image'),
+                            array('type' => 'IMAGE', 'imageRef' => 'override-image'),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+    'assets' => array(
+        array('id' => 'default-image', 'content' => 'default'),
+        array('id' => 'override-image', 'content' => 'override'),
+    ),
+));
+$nestedImageOverrideCss = $fileContent($nestedImageOverrideResult, 'style.css');
+$assert(str_contains($nestedImageOverrideCss, '.figma-node-instance-preview-700-4-700-2-image'), 'nested-image-override-emits-nested-image-node');
+$assert(str_contains($nestedImageOverrideCss, 'background-image:url("assets/override-image.bin"),url("assets/default-image.bin")'), 'nested-image-override-preserves-instance-fill-paints');
+
 // Component-property (componentPropAssignments) text overrides (#329 / FSE Pilot).
 //
 // Figma binds per-instance text content through component properties rather than


### PR DESCRIPTION
## Summary
- Preserve nested instance image/fill overrides when resolved component-source clones are refreshed.
- Carry parent-scoped guidPath overrides into nested children so paths like nested-instance/image-node reach the local leaf.
- Add synthetic contract coverage for nested image override fills.

## Evidence
- Before fix on selected frame 3468:1038: generated assets=1, CSS url refs=4, rendered image nodes all used db7b0b518ebf4dc8ce46045ea6a05df9d10f3ebf.
- After fix on selected frame 3468:1038: generated assets=19, CSS url refs=31, rendered image nodes include distinct override refs such as 4ccf6ed80e0b64e00d43c5a85d38e67c8404de4b, 955d7435ff4a394f23628b2c0cf4a13523687f82, and 385397dec7d9584291f70bbeca8be7ca4d8de9a0.

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fixture investigation, implementation, synthetic test coverage, and PR drafting.
