### PR TITLE
figma-transformer: align fixture matrix page selection

### DIFF
--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -18,13 +18,20 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
         static fn (mixed $candidate): bool => is_array($candidate) && 'design_system' !== matrix_candidate_role($candidate)
     ));
 
-    // Figma Dev Mode status (#280) is the PRIMARY signal when present: restrict
-    // to ready_for_dev/completed candidates and let heuristics order them.
-    if ( 'dev_status' === matrix_selection_source($candidates) ) {
-        $candidates = array_values(array_filter(
-            $candidates,
-            static fn (mixed $candidate): bool => is_array($candidate) && null !== matrix_candidate_dev_status($candidate)
-        ));
+    $pageLikeCandidates = array_values(array_filter(
+        $candidates,
+        static fn (mixed $candidate): bool => is_array($candidate) && matrix_is_page_like_candidate($candidate)
+    ));
+
+    // Figma Dev Mode status (#280) is the PRIMARY signal only when it marks a
+    // real page-like candidate. Otherwise fall back to heuristic page selection,
+    // matching ScenegraphPagePlanner and avoiding dev-marked title/divider cards.
+    $devMarkedPageLikeCandidates = array_values(array_filter(
+        $pageLikeCandidates,
+        static fn (mixed $candidate): bool => is_array($candidate) && null !== matrix_candidate_dev_status($candidate)
+    ));
+    if ( ! empty($devMarkedPageLikeCandidates) ) {
+        $candidates = $devMarkedPageLikeCandidates;
     }
 
     usort($candidates, static fn (mixed $a, mixed $b): int => matrix_candidate_rank(is_array($b) ? $b : array()) <=> matrix_candidate_rank(is_array($a) ? $a : array()));
@@ -64,7 +71,8 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
     }
 
     if ( empty($selected) ) {
-        foreach ( $candidates as $candidate ) {
+        $fallbackCandidates = ! empty($pageLikeCandidates) ? $pageLikeCandidates : $candidates;
+        foreach ( $fallbackCandidates as $candidate ) {
             if ( count($selected) >= $maxPages || ! is_array($candidate) ) {
                 break;
             }
@@ -328,7 +336,7 @@ function matrix_is_page_like_candidate(array $candidate): bool
         }
     }
 
-    return $width >= 900.0 && $height >= 500.0 && $textCount > 0 && in_array($parentType, array('CANVAS', 'SECTION'), true);
+    return $width >= 900.0 && $width <= 2048.0 && $height >= 700.0 && $textCount > 0 && in_array($parentType, array('CANVAS', 'SECTION'), true);
 }
 
 function matrix_is_reference_page_name(string $pageName): bool

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -12,6 +12,51 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     file_put_contents($matrixFixtureDir . '/alias.fig', 'placeholder fig fixture');
     file_put_contents($matrixFixtureDir . '/explicit.fig', 'explicit fig fixture');
 
+    $matrixSelection = matrix_select_frame_ids(array(
+        'candidates' => array(
+            array(
+                'id'         => 'frame:title-card',
+                'name'       => 'Title Card',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'page',
+                'dev_status' => 'ready_for_dev',
+                'score'      => 2000,
+                'width'      => 2238,
+                'height'     => 291,
+                'text_count' => 1,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+            array(
+                'id'         => 'frame:home-desktop',
+                'name'       => 'Home Page - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 500,
+                'width'      => 1440,
+                'height'     => 4400,
+                'text_count' => 2,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+            array(
+                'id'         => 'frame:single-desktop',
+                'name'       => 'Blog Post - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'single',
+                'score'      => 650,
+                'width'      => 1440,
+                'height'     => 8400,
+                'text_count' => 31,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+        ),
+    ), 5);
+
     $matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
     file_put_contents($matrixSelectionLockPath, json_encode(array(
         'schema'   => 'blocks-engine/figma-transformer/fixture-matrix/v1',
@@ -83,6 +128,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
         . ' 2>&1';
     exec($missingExplicitFixtureCommand, $missingExplicitFixtureOutput, $missingExplicitFixtureExitCode);
 
+    $assert(! in_array('frame:title-card', $matrixSelection, true), 'fixture-matrix-selection-skips-dev-marked-title-card');
+    $assert(array('frame:home-desktop', 'frame:single-desktop') === $matrixSelection, 'fixture-matrix-selection-falls-back-to-page-like-frames');
     $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
     $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
     $assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');


### PR DESCRIPTION
## Summary
- align fixture matrix dev-status selection with the page planner by only using dev-status when it marks page-like candidates
- tighten matrix page-likeness to exclude oversized/short title and overview frames
- add a contract test for a dev-marked Title Card fallback case

## Testing
- composer test:contract
- php scripts/figma-fixture-matrix.php --fixture='/Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig' --max-pages=50 --output-dir='/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-page-selection-20260630-fixed'
- php -d memory_limit=1536M bin/figma-transformer '/Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig' --zstd-command='/opt/homebrew/bin/zstd' --multi-page --max-pages=50 --output-dir='/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-page-selection-20260630-direct-fixed'

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the matrix/direct selection divergence, editing the fixture matrix selection logic, adding contract coverage, and running verification.