### PR TITLE
figma-transformer: classify empty visible containers

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -962,6 +962,8 @@ final class FigmaTransformer
             'large_absolute_offset_count' => 0,
             'large_absolute_offset_nodes' => array(),
             'empty_visible_container_count' => 0,
+            'empty_visible_container_blocker_count' => 0,
+            'empty_visible_container_categories' => array(),
             'empty_visible_containers' => array(),
             'decorative_underlays' => array('count' => 0, 'nodes' => array()),
             'image_heavy_landmark_candidates' => array(),
@@ -1028,11 +1030,12 @@ final class FigmaTransformer
             $fontMaterialized = $fontMaterialized || true === ($pageFonts['materialized'] ?? false);
 
             $pageLayout = is_array($diagnostics['layout'] ?? null) ? $diagnostics['layout'] : array();
-            DiagnosticAggregation::addIntegerCounts($layout, $pageLayout, array('large_negative_left_count', 'large_css_offset_count', 'off_canvas_visual_node_count', 'large_absolute_offset_count', 'empty_visible_container_count'));
+            DiagnosticAggregation::addIntegerCounts($layout, $pageLayout, array('large_negative_left_count', 'large_css_offset_count', 'off_canvas_visual_node_count', 'large_absolute_offset_count', 'empty_visible_container_count', 'empty_visible_container_blocker_count'));
             DiagnosticAggregation::appendContextSamples($layout, 'large_css_offset_nodes', $pageLayout, 'large_css_offset_nodes', $pageContext);
             DiagnosticAggregation::appendContextSamples($layout, 'off_canvas_visual_nodes', $pageLayout, 'off_canvas_visual_nodes', $pageContext);
             DiagnosticAggregation::appendContextSamples($layout, 'large_absolute_offset_nodes', $pageLayout, 'large_absolute_offset_nodes', $pageContext);
             DiagnosticAggregation::appendContextSamples($layout, 'empty_visible_containers', $pageLayout, 'empty_visible_containers', $pageContext);
+            DiagnosticAggregation::addCounterMap($layout['empty_visible_container_categories'], is_array($pageLayout['empty_visible_container_categories'] ?? null) ? $pageLayout['empty_visible_container_categories'] : array());
             $underlays = is_array($pageLayout['decorative_underlays']['nodes'] ?? null) ? $pageLayout['decorative_underlays']['nodes'] : array();
             foreach ( $underlays as $item ) {
                 if ( is_array($item) ) {
@@ -1110,6 +1113,7 @@ final class FigmaTransformer
         $layout['large_css_offset_nodes'] = array_values($layout['large_css_offset_nodes']);
         $layout['off_canvas_visual_nodes'] = array_values($layout['off_canvas_visual_nodes']);
         $layout['empty_visible_containers'] = array_values($layout['empty_visible_containers']);
+        ksort($layout['empty_visible_container_categories']);
         $layout['layout_mismatches'] = array_values($layout['layout_mismatches']);
         $layout['render_style']['diagnostics'] = array_values($layout['render_style']['diagnostics']);
         if ( 'not_evaluated' === $layout['render_style_mismatch_status'] ) {
@@ -1270,6 +1274,7 @@ final class FigmaTransformer
                 'render_style_mismatch_status' => (string) ($layout['render_style_mismatch_status'] ?? 'not_run'),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'empty_visible_container_count' => (int) ($layout['empty_visible_container_count'] ?? 0),
+                'empty_visible_container_blocker_count' => (int) ($layout['empty_visible_container_blocker_count'] ?? 0),
                 'image_heavy_landmark_candidates' => count($layout['image_heavy_landmark_candidates'] ?? array()),
                 'layout_mismatch_count' => (int) ($layout['layout_mismatch_count'] ?? 0),
                 'layout_mismatch_status' => (string) ($layout['layout_mismatch_status'] ?? 'not_evaluated'),

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2004,6 +2004,8 @@ final class StaticHtmlEmitter
             'large_absolute_offset_count' => 0,
             'large_absolute_offset_nodes' => array(),
             'empty_visible_container_count' => 0,
+            'empty_visible_container_blocker_count' => 0,
+            'empty_visible_container_categories' => array(),
             'empty_visible_containers' => array(),
             'decorative_underlays'      => array(
                 'count' => 0,
@@ -2029,6 +2031,11 @@ final class StaticHtmlEmitter
         $layout['large_absolute_offset_nodes'] = array_values($layout['large_absolute_offset_nodes']);
         $layout['empty_visible_containers'] = array_values($layout['empty_visible_containers']);
         $layout['empty_visible_container_count'] = count($layout['empty_visible_containers']);
+        $layout['empty_visible_container_blocker_count'] = count(array_filter(
+            $layout['empty_visible_containers'],
+            static fn (array $container): bool => true === ($container['blocks_parity'] ?? true)
+        ));
+        ksort($layout['empty_visible_container_categories']);
         $layout['image_heavy_landmark_candidates'] = array_values($layout['image_heavy_landmark_candidates']);
         $generatedSvgAssets = $this->generatedSvgAssetDiagnostics($assetFiles);
         $assets = array(
@@ -2232,6 +2239,7 @@ final class StaticHtmlEmitter
                 'clipped_visual_area_ratio' => (float) ($layout['clipped_visual_area_ratio'] ?? 0.0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'empty_visible_container_count' => (int) ($layout['empty_visible_container_count'] ?? 0),
+                'empty_visible_container_blocker_count' => (int) ($layout['empty_visible_container_blocker_count'] ?? 0),
                 'decoded_text_nodes' => (int) ($text['decoded_text_node_count'] ?? 0),
                 'emitted_text_nodes' => (int) ($text['emitted_text_node_count'] ?? 0),
                 'empty_decoded_text_nodes' => (int) ($text['empty_decoded_text_node_count'] ?? 0),
@@ -2480,6 +2488,8 @@ final class StaticHtmlEmitter
         $emptyContainer = $this->emptyVisibleContainerDiagnostic($node);
         if ( null !== $emptyContainer ) {
             $layout['empty_visible_containers'][] = $emptyContainer;
+            $category = (string) ($emptyContainer['category'] ?? 'empty_visible_container');
+            $layout['empty_visible_container_categories'][$category] = (int) ($layout['empty_visible_container_categories'][$category] ?? 0) + 1;
         }
 
         $landmarkCandidate = $this->imageHeavyLandmarkCandidate($node);
@@ -2967,6 +2977,8 @@ final class StaticHtmlEmitter
             return null;
         }
 
+        $category = $this->emptyVisibleContainerCategory($node, $type, $width, $height);
+
         return array(
             'node_id' => (string) ($node['id'] ?? ''),
             'name' => (string) ($node['name'] ?? ''),
@@ -2974,7 +2986,26 @@ final class StaticHtmlEmitter
             'class' => $this->nodeDiagnosticClass($node),
             'width' => $this->reportNumericValue($width),
             'height' => $this->reportNumericValue($height),
+            'category' => $category,
+            'blocks_parity' => 'decorative_zero_height_separator' !== $category,
         );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function emptyVisibleContainerCategory(array $node, string $type, float $width, float $height): string
+    {
+        $name = trim((string) ($node['name'] ?? ''));
+        if ( $height <= 1.0 && preg_match('/^[\x{2013}\x{2014}-]+$/u', $name) ) {
+            return 'decorative_zero_height_separator';
+        }
+
+        if ( 'INSTANCE' === $type ) {
+            return 'missing_instance_descendants';
+        }
+
+        return 'empty_visible_container';
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -407,6 +407,63 @@ $assert(! in_array('off_canvas_visual_nodes', $normalLocalSignalCodes, true), 'q
 $assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['large_absolute_offset_count'] ?? null), 'quality-diagnostics-normal-local-large-offset-count-zero');
 $assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['off_canvas_visual_node_count'] ?? null), 'quality-diagnostics-normal-local-visual-offset-count-zero');
 
+$emptyVisibleContainerResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Empty Visible Container Classification Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'empty-container:root',
+            'type'     => 'FRAME',
+            'name'     => 'Empty visible root',
+            'width'    => 480,
+            'height'   => 320,
+            'children' => array(
+                array('id' => 'empty-container:separator', 'type' => 'FRAME', 'name' => '–', 'width' => 320, 'height' => 0.0002),
+                array('id' => 'empty-container:instance', 'type' => 'INSTANCE', 'name' => 'Missing component body', 'width' => 180, 'height' => 48),
+                array('id' => 'empty-container:frame', 'type' => 'FRAME', 'name' => 'Empty visual frame', 'width' => 24, 'height' => 24),
+            ),
+        ),
+    ),
+));
+$emptyVisibleLayout = $emptyVisibleContainerResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+$assert(3 === ($emptyVisibleLayout['empty_visible_container_count'] ?? null), 'empty-visible-container-classification-count');
+$assert(2 === ($emptyVisibleLayout['empty_visible_container_blocker_count'] ?? null), 'empty-visible-container-classification-blocker-count');
+$assert(1 === ($emptyVisibleLayout['empty_visible_container_categories']['decorative_zero_height_separator'] ?? null), 'empty-visible-container-classification-decorative-count');
+$assert(1 === ($emptyVisibleLayout['empty_visible_container_categories']['missing_instance_descendants'] ?? null), 'empty-visible-container-classification-instance-count');
+$assert(1 === ($emptyVisibleLayout['empty_visible_container_categories']['empty_visible_container'] ?? null), 'empty-visible-container-classification-frame-count');
+$emptyVisibleById = array();
+foreach ( is_array($emptyVisibleLayout['empty_visible_containers'] ?? null) ? $emptyVisibleLayout['empty_visible_containers'] : array() as $sample ) {
+    if ( is_array($sample) ) {
+        $emptyVisibleById[(string) ($sample['node_id'] ?? '')] = $sample;
+    }
+}
+$assert(false === ($emptyVisibleById['empty-container:separator']['blocks_parity'] ?? null), 'empty-visible-container-decorative-non-blocking');
+$assert(true === ($emptyVisibleById['empty-container:instance']['blocks_parity'] ?? null), 'empty-visible-container-instance-blocking');
+$assert('missing_instance_descendants' === ($emptyVisibleById['empty-container:instance']['category'] ?? null), 'empty-visible-container-instance-category');
+
+$multiPageEmptyVisibleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Multi Page Empty Visible Classification Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'multi-empty:canvas',
+            'type'     => 'CANVAS',
+            'name'     => 'Pages',
+            'children' => array(
+                array('id' => 'multi-empty:one', 'type' => 'FRAME', 'name' => 'One', 'width' => 320, 'height' => 240, 'children' => array(
+                    array('id' => 'multi-empty:one-separator', 'type' => 'FRAME', 'name' => '–', 'width' => 280, 'height' => 0.0002),
+                )),
+                array('id' => 'multi-empty:two', 'type' => 'FRAME', 'name' => 'Two', 'width' => 320, 'height' => 240, 'children' => array(
+                    array('id' => 'multi-empty:two-instance', 'type' => 'INSTANCE', 'name' => 'Missing component body', 'width' => 120, 'height' => 32),
+                )),
+            ),
+        ),
+    ),
+), array('multi_page' => true, 'frame_ids' => array('multi-empty:one', 'multi-empty:two'), 'entry_frame_id' => 'multi-empty:one'));
+$multiPageEmptyVisibleLayout = $multiPageEmptyVisibleResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+$assert(2 === ($multiPageEmptyVisibleLayout['empty_visible_container_count'] ?? null), 'empty-visible-container-multi-page-count');
+$assert(1 === ($multiPageEmptyVisibleLayout['empty_visible_container_blocker_count'] ?? null), 'empty-visible-container-multi-page-blocker-count');
+$assert(1 === ($multiPageEmptyVisibleLayout['empty_visible_container_categories']['decorative_zero_height_separator'] ?? null), 'empty-visible-container-multi-page-decorative-count');
+$assert(1 === ($multiPageEmptyVisibleLayout['empty_visible_container_categories']['missing_instance_descendants'] ?? null), 'empty-visible-container-multi-page-instance-count');
+
 $multiPageOffCanvasResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Multi Page Off Canvas Diagnostics Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- Classifies empty visible container diagnostics into decorative zero-height separators, missing instance descendants, and other empty containers.
- Adds `empty_visible_container_blocker_count` so decorative separators remain visible evidence without being treated as parity blockers.
- Adds single-page and multi-page synthetic contract coverage.

## Testing
- `composer test:contract`
- Baseline artifact check: `large_negative_left_count=0`, `off_canvas_visual_node_count=5`, `asset_count=28`, `page_count=5`; empty containers classify as 22 decorative separators, 51 missing instance descendants, 1 other empty container.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating FSE empty visible container diagnostics, implementing diagnostic classification, adding contract tests, and preparing this PR.