### PR TITLE
figma-transformer: merge stroke and effect shadows

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3369,7 +3369,37 @@ final class StaticHtmlEmitter
             }
         }
 
-        return array_values(array_unique($styles));
+        return $this->mergeBoxShadowDeclarations(array_values(array_unique($styles)));
+    }
+
+    /**
+     * @param array<int, string> $styles
+     * @return array<int, string>
+     */
+    private function mergeBoxShadowDeclarations(array $styles): array
+    {
+        $merged = array();
+        $boxShadows = array();
+        $boxShadowIndex = null;
+
+        foreach ( $styles as $style ) {
+            if ( str_starts_with($style, 'box-shadow:') ) {
+                $boxShadows[] = substr($style, strlen('box-shadow:'));
+                if ( null === $boxShadowIndex ) {
+                    $boxShadowIndex = count($merged);
+                    $merged[] = $style;
+                }
+                continue;
+            }
+
+            $merged[] = $style;
+        }
+
+        if ( null !== $boxShadowIndex && count($boxShadows) > 1 ) {
+            $merged[$boxShadowIndex] = 'box-shadow:' . implode(',', $boxShadows);
+        }
+
+        return $merged;
     }
 
     /**

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -141,6 +141,33 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $visualFlexWrapSecond, array('x' => 110.0, 'y' => 0.0, 'width' => 100.0, 'height' => 60.0), 'visual-map-flex-wrap-first-line-second-card');
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $visualFlexWrapThird, array('x' => 0.0, 'y' => 70.0, 'width' => 100.0, 'height' => 30.0), 'visual-map-flex-wrap-second-line-card');
 
+    $strokeShadowResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Stroke Shadow Fixture',
+        'nodes' => array(
+            array(
+                'id'           => 'stroke-shadow:rect',
+                'type'         => 'RECTANGLE',
+                'name'         => 'Stroke and shadow',
+                'width'        => 100,
+                'height'       => 100,
+                'strokeWeight' => 5,
+                'strokeAlign'  => 'OUTSIDE',
+                'strokePaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0.8117647059, 'b' => 0, 'a' => 1))),
+                'effects'      => array(array(
+                    'type'    => 'DROP_SHADOW',
+                    'offset'  => array('x' => 0, 'y' => 0),
+                    'radius'  => 16,
+                    'spread'  => 0,
+                    'visible' => true,
+                    'color'   => array('r' => 1, 'g' => 0.8117647059, 'b' => 0, 'a' => 0.5),
+                )),
+            ),
+        ),
+    ));
+    $strokeShadowCss = blocks_engine_figma_transformer_contract_file_content($strokeShadowResult, 'style.css');
+    $assert(str_contains($strokeShadowCss, 'box-shadow:0 0 0 5px #ffcf00,0px 0px 16px 0px rgba(255,207,0,0.5)'), 'visual-map-stroke-and-effect-box-shadows-merged');
+    $assert(1 === substr_count($strokeShadowCss, 'box-shadow:'), 'visual-map-stroke-and-effect-single-box-shadow-declaration');
+
     $visualCrossAxisFillResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Visual Cross Axis Fill Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- Merge multiple emitted `box-shadow` declarations for one node into a single comma-separated declaration.
- Preserves both stroke ring shadows and Figma effect shadows instead of letting the later declaration overwrite the earlier one.
- Adds a synthetic contract fixture for a rectangle with outside stroke plus drop shadow.

## Evidence
- FSE fixture decoded via zstd from `/Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig`.
- Raw decoded fixture includes `DROP_SHADOW` effects; latest emitted artifact showed duplicate `box-shadow` declarations on affected Union nodes, dropping the stroke ring in CSS cascade.

## Tests
- `composer test:contract`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating decoded Figma mask/effect parity, implementing the narrow CSS shadow merge, and adding the synthetic contract test.