### PR TITLE
figma-transformer: classify off-canvas diagnostics

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2647,6 +2647,8 @@ final class StaticHtmlEmitter
             'name' => (string) ($node['name'] ?? ''),
             'type' => strtoupper((string) ($node['type'] ?? '')),
             'class' => $this->nodeDiagnosticClass($node),
+            'empty_visible_container' => null !== $this->emptyVisibleContainerDiagnostic($node),
+            'component_clone_geometry' => $this->hasComponentCloneGeometry($node),
         );
         if ( '' !== $entry['node_id'] ) {
             $index['by_id'][$entry['node_id']] = $entry;
@@ -2691,7 +2693,7 @@ final class StaticHtmlEmitter
             }
 
             $node = is_array($nodeIndex['by_class'][$className] ?? null) ? $nodeIndex['by_class'][$className] : array();
-            $samples[] = array_filter(array(
+            $sample = array_filter(array(
                 'node_id' => (string) ($node['node_id'] ?? ''),
                 'name' => (string) ($node['name'] ?? ''),
                 'type' => (string) ($node['type'] ?? ''),
@@ -2699,6 +2701,11 @@ final class StaticHtmlEmitter
                 'left' => null === $left ? null : $this->reportNumericValue($left),
                 'top' => null === $top ? null : $this->reportNumericValue($top),
             ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+            $classification = $this->largeCssOffsetClassification($node);
+            if ( '' !== $classification ) {
+                $sample['classification'] = $classification;
+            }
+            $samples[] = $sample;
         }
 
         return array_values($samples);
@@ -2753,7 +2760,7 @@ final class StaticHtmlEmitter
             }
 
             $node = is_array($nodeIndex['by_id'][(string) ($entry['id'] ?? '')] ?? null) ? $nodeIndex['by_id'][(string) $entry['id']] : array();
-            $samples[] = array_filter(array(
+            $sample = array_filter(array(
                 'node_id' => (string) ($entry['id'] ?? ''),
                 'name' => (string) ($entry['name'] ?? ($node['name'] ?? '')),
                 'type' => (string) ($entry['type'] ?? ($node['type'] ?? '')),
@@ -2768,9 +2775,68 @@ final class StaticHtmlEmitter
                 'parent_width' => $this->reportNumericValue((float) $parentRect['width']),
                 'parent_height' => $this->reportNumericValue((float) $parentRect['height']),
             ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+            $classification = $this->visualOffCanvasClassification($entry, $parent);
+            if ( '' !== $classification ) {
+                $sample['classification'] = $classification;
+            }
+            $samples[] = $sample;
         }
 
         return array_values($samples);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function largeCssOffsetClassification(array $node): string
+    {
+        if ( true === ($node['component_clone_geometry'] ?? false) ) {
+            return 'component_clone_geometry_leak';
+        }
+
+        if ( true === ($node['empty_visible_container'] ?? false) ) {
+            return 'empty_visible_container';
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     * @param array<string, mixed> $parent
+     */
+    private function visualOffCanvasClassification(array $entry, array $parent): string
+    {
+        $parentLayout = is_array($parent['layout'] ?? null) ? $parent['layout'] : array();
+        $entryLayout = is_array($entry['layout'] ?? null) ? $entry['layout'] : array();
+        if ( in_array((string) ($parentLayout['display'] ?? ''), array('flex', 'inline-flex'), true) && 'absolute' !== ($entryLayout['positioning'] ?? null) ) {
+            return 'flex_flow_overflow';
+        }
+
+        if ( true === ($entry['component_clone_geometry'] ?? false) ) {
+            return 'component_clone_geometry_leak';
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasComponentCloneGeometry(array $node): bool
+    {
+        if ( true === ($node['_component_source_clone_geometry'] ?? false) ) {
+            return true;
+        }
+
+        foreach ( array('box', 'figma_box') as $boxKey ) {
+            $box = is_array($node[$boxKey] ?? null) ? $node[$boxKey] : array();
+            if ( 'component_source_clone' === ($box['geometry_semantics'] ?? null) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -55,6 +55,25 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     $assert('diag:clip-vector' === ($clippedDiagnostics['layout']['clipped_visual_nodes'][0]['node_id'] ?? null), 'diagnostics-evidence-clipped-sample-node');
     $assert(in_array('clipped_visual_area', $clippedSignalCodes, true), 'diagnostics-evidence-clipped-area-signal');
 
+    $largeOffsetResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Diagnostics Large Offset Classification Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'diag:large-offset-page',
+                'type'     => 'FRAME',
+                'name'     => 'Large Offset Page',
+                'width'    => 320,
+                'height'   => 160,
+                'children' => array(
+                    array('id' => 'diag:large-offset-empty', 'type' => 'INSTANCE', 'name' => 'Empty Clone Shell', 'x' => 2000, 'y' => 0, 'width' => 80, 'height' => 40),
+                ),
+            ),
+        ),
+    ));
+    $largeOffsetDiagnostics = $largeOffsetResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $largeOffsetNodes = $largeOffsetDiagnostics['layout']['large_css_offset_nodes'] ?? array();
+    $assert('empty_visible_container' === ($largeOffsetNodes[0]['classification'] ?? null), 'diagnostics-evidence-large-css-offset-classification');
+
     $emptyTextResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Diagnostics Empty Text Fixture',
         'nodes' => array(

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -52,6 +52,29 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $assert(100.0 === ($visualFlexCentered['rect']['x'] ?? null), 'visual-map-column-center-child-x');
     $assert(10.0 === ($visualFlexCentered['rect']['y'] ?? null), 'visual-map-column-padding-child-y');
 
+    $visualFlexOffCanvasResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Visual Flex Off Canvas Classification Fixture',
+        'nodes' => array(
+            array(
+                'id'                    => 'visual-flex-off-canvas:row',
+                'type'                  => 'FRAME',
+                'name'                  => 'Overflowing fixed gap row',
+                'width'                 => 200,
+                'height'                => 80,
+                'layoutMode'            => 'HORIZONTAL',
+                'primaryAxisAlignItems' => 'MIN',
+                'counterAxisAlignItems' => 'MIN',
+                'itemSpacing'           => 500,
+                'children'              => array(
+                    array('id' => 'visual-flex-off-canvas:first', 'type' => 'RECTANGLE', 'name' => 'First child', 'width' => 80, 'height' => 40),
+                    array('id' => 'visual-flex-off-canvas:second', 'type' => 'RECTANGLE', 'name' => 'Second child', 'width' => 80, 'height' => 40),
+                ),
+            ),
+        ),
+    ));
+    $visualFlexOffCanvasNodes = $visualFlexOffCanvasResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['off_canvas_visual_nodes'] ?? array();
+    $assert('flex_flow_overflow' === ($visualFlexOffCanvasNodes[0]['classification'] ?? null), 'visual-map-flex-off-canvas-classification');
+
     $visualFlexCrossOverflowMap = (new Automattic\BlocksEngine\FigmaTransformer\Html\VisualNodeMapBuilder())->build(array(
         array(
             'id'       => 'visual-cross:column',


### PR DESCRIPTION
## Summary

- Classifies large CSS offset diagnostics as component clone geometry leaks or empty visible containers.
- Classifies visual off-canvas diagnostics from overflowing flex-flow children.
- Adds synthetic contract coverage for both diagnostic classifications.

## Verification

- `composer test:contract`
- `php -d memory_limit=1G bin/figma-transformer "/Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig" --multi-page --zstd-command=/opt/homebrew/bin/zstd --output-dir=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-off-canvas-parity-verify > "/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-off-canvas-parity-verify/result.json"`

FSE verification summary:

- `large_negative_left_count=0`
- `large_css_offset_count=6`, all classified as `component_clone_geometry_leak`
- `off_canvas_visual_node_count=5`, all classified as `flex_flow_overflow`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, code changes, synthetic test coverage, verification, and PR description drafting.
