### PR TITLE
figma-transformer: add parser parity report

### DIFF
--- a/figma-transformer/scripts/figma-parser-parity.php
+++ b/figma-transformer/scripts/figma-parser-parity.php
@@ -1,0 +1,505 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCapability;
+use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder;
+use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader;
+use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiParser;
+use Automattic\BlocksEngine\FigmaTransformer\FigmaTransformer;
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphIndex;
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer;
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if ( is_readable($autoload) ) {
+    require_once $autoload;
+} else {
+    require_once __DIR__ . '/../figma-transformer.php';
+}
+
+$options = blocks_engine_figma_parser_parity_options($argv);
+if ( true === ($options['help'] ?? false) ) {
+    blocks_engine_figma_parser_parity_usage(STDOUT);
+    exit(0);
+}
+
+if ( '' === ($options['input'] ?? '') ) {
+    blocks_engine_figma_parser_parity_usage(STDERR);
+    exit(1);
+}
+
+$input = (string) $options['input'];
+$zstdCommand = $options['zstd_command'] ?? (getenv('FIGMA_TRANSFORMER_ZSTD_COMMAND') ?: null);
+$zstdCommand = is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null;
+$limit = max(1, (int) ($options['limit'] ?? 20));
+$sampleLimit = max(1, (int) ($options['sample_limit'] ?? 5));
+$maxNodes = isset($options['max_nodes']) ? (int) $options['max_nodes'] : null;
+
+$archive = null;
+$source = blocks_engine_figma_parser_parity_read_source($input, $zstdCommand, $archive);
+$scenegraph = is_array($source['scenegraph'] ?? null) ? $source['scenegraph'] : array();
+$transformOptions = array();
+if ( isset($options['frame_id']) && '' !== (string) $options['frame_id'] ) {
+    $transformOptions['frame_id'] = (string) $options['frame_id'];
+}
+if ( null !== $maxNodes ) {
+    $transformOptions['max_nodes'] = max(0, $maxNodes);
+}
+
+$archiveReader = blocks_engine_figma_parser_parity_archive_reader($zstdCommand);
+$normalizer = new ScenegraphNormalizer();
+$normalized = $normalizer->normalize($scenegraph, $transformOptions);
+$transformer = new FigmaTransformer($archiveReader);
+$result = str_ends_with(strtolower($input), '.json')
+    ? $transformer->transformScenegraph($scenegraph, $transformOptions)->toArray()
+    : $transformer->transformFile($input, $transformOptions)->toArray();
+
+$report = blocks_engine_figma_parser_parity_report($input, $source, $archive, $scenegraph, $normalized, $result, $transformOptions, $limit, $sampleLimit, $zstdCommand);
+$json = blocks_engine_figma_parser_parity_json_encode($report) . "\n";
+
+if ( isset($options['output']) && '' !== (string) $options['output'] ) {
+    $output = (string) $options['output'];
+    $directory = dirname($output);
+    if ( ! is_dir($directory) && ! mkdir($directory, 0777, true) && ! is_dir($directory) ) {
+        fwrite(STDERR, "Unable to create output directory: {$directory}\n");
+        exit(1);
+    }
+    file_put_contents($output, $json);
+}
+
+fwrite(STDOUT, $json);
+exit(0);
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_parser_parity_options(array $argv): array
+{
+    $options = array();
+    foreach ( array_slice($argv, 1) as $argument ) {
+        if ( '--help' === $argument || '-h' === $argument ) {
+            $options['help'] = true;
+            continue;
+        }
+        if ( ! str_starts_with($argument, '--') ) {
+            $options['input'] ??= $argument;
+            continue;
+        }
+
+        $parts = explode('=', substr($argument, 2), 2);
+        $options[str_replace('-', '_', $parts[0])] = $parts[1] ?? '1';
+    }
+
+    return $options;
+}
+
+function blocks_engine_figma_parser_parity_usage(mixed $stream): void
+{
+    fwrite($stream, "Usage: figma-parser-parity.php <path-to-fig-or-scenegraph-json> [--frame-id=<id>] [--zstd-command=/opt/homebrew/bin/zstd] [--max-nodes=5000] [--limit=20] [--sample-limit=5] [--output=/tmp/parity.json]\n");
+}
+
+/**
+ * @return array{scenegraph: array<string, mixed>, shape: string, decoded_scenegraph?: array<string, mixed>}
+ */
+function blocks_engine_figma_parser_parity_read_source(string $input, ?string $zstdCommand, ?array &$archive): array
+{
+    if ( str_ends_with(strtolower($input), '.json') ) {
+        $decoded = is_readable($input) ? json_decode((string) file_get_contents($input), true) : null;
+        return array('scenegraph' => is_array($decoded) ? $decoded : array(), 'shape' => 'json');
+    }
+
+    $archiveReader = blocks_engine_figma_parser_parity_archive_reader($zstdCommand);
+    $archive = $archiveReader->read($input);
+    $candidate = blocks_engine_figma_parser_parity_decoded_scenegraph_candidate($archive);
+    return array(
+        'scenegraph' => is_array($candidate['payload'] ?? null) ? $candidate['payload'] : array(),
+        'shape' => 'fig',
+        'decoded_scenegraph' => is_array($candidate['report'] ?? null) ? $candidate['report'] : array(),
+    );
+}
+
+function blocks_engine_figma_parser_parity_archive_reader(?string $zstdCommand): FigArchiveReader
+{
+    if ( null === $zstdCommand || '' === $zstdCommand ) {
+        return new FigArchiveReader();
+    }
+
+    return new FigArchiveReader(new FigKiwiParser(new ZstdCapability(new ZstdCommandDecoder(array($zstdCommand, '-dc')))));
+}
+
+/**
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_parser_parity_decoded_scenegraph_candidate(array $archive): ?array
+{
+    $chunks = $archive['archive']['canvas']['chunks'] ?? array();
+    if ( ! is_array($chunks) ) {
+        return null;
+    }
+
+    $candidates = array();
+    foreach ( $chunks as $chunk ) {
+        if ( ! is_array($chunk) || ! is_array($chunk['payload'] ?? null) ) {
+            continue;
+        }
+        $payload = $chunk['payload'];
+        $json = null;
+        if ( 'json' === ($payload['classification'] ?? null) && is_array($payload['json'] ?? null) ) {
+            $json = $payload['json'];
+        } elseif ( 'kiwi_message' === ($payload['classification'] ?? null) && is_array($payload['kiwi_message'] ?? null) ) {
+            $json = $payload['kiwi_message'];
+        }
+        if ( ! is_array($json) || ! blocks_engine_figma_parser_parity_is_scenegraph_payload($json) ) {
+            continue;
+        }
+        $shape = blocks_engine_figma_parser_parity_scenegraph_shape($json);
+        $candidates[] = array(
+            'payload' => $json,
+            'score' => blocks_engine_figma_parser_parity_scenegraph_score($json, $shape),
+            'report' => array(
+                'chunk_index' => (int) ($chunk['index'] ?? count($candidates)),
+                'shape' => $shape,
+                'classification' => $payload['classification'] ?? null,
+            ),
+        );
+    }
+
+    usort($candidates, static fn (array $left, array $right): int => ($right['score'] <=> $left['score']) ?: ((int) ($left['report']['chunk_index'] ?? 0) <=> (int) ($right['report']['chunk_index'] ?? 0)));
+    return $candidates[0] ?? null;
+}
+
+function blocks_engine_figma_parser_parity_is_scenegraph_payload(array $payload): bool
+{
+    return is_array($payload['NODE_CHANGES'] ?? null)
+        || is_array($payload['node_changes'] ?? null)
+        || is_array($payload['nodeChanges'] ?? null)
+        || is_array($payload['document'] ?? null)
+        || is_array($payload['nodes'] ?? null);
+}
+
+function blocks_engine_figma_parser_parity_scenegraph_shape(array $payload): string
+{
+    foreach ( array('NODE_CHANGES', 'node_changes', 'nodeChanges', 'document', 'nodes') as $key ) {
+        if ( is_array($payload[$key] ?? null) ) {
+            return $key;
+        }
+    }
+    return 'unknown';
+}
+
+function blocks_engine_figma_parser_parity_scenegraph_score(array $payload, string $shape): int
+{
+    $score = 'document' === $shape ? 40 : ('nodes' === $shape ? 30 : 20);
+    $index = (new ScenegraphIndex())->build($payload);
+    return $score + count(is_array($index['nodes'] ?? null) ? $index['nodes'] : array());
+}
+
+/**
+ * @param array<string, mixed>|null $archive
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_parser_parity_report(string $input, array $source, ?array $archive, array $scenegraph, array $normalized, array $result, array $transformOptions, int $limit, int $sampleLimit, ?string $zstdCommand): array
+{
+    $rawIndex = (new ScenegraphIndex())->build($scenegraph);
+    $rawNodes = is_array($rawIndex['nodes'] ?? null) ? $rawIndex['nodes'] : array();
+    $normalizedNodes = is_array($normalized['node_map'] ?? null) ? $normalized['node_map'] : array();
+    $htmlReport = is_array($result['source_reports']['figma']['html'] ?? null) ? $result['source_reports']['figma']['html'] : array();
+    $visualNodeIds = blocks_engine_figma_parser_parity_visual_node_ids($htmlReport);
+    $htmlNodeIds = blocks_engine_figma_parser_parity_html_node_ids(blocks_engine_figma_parser_parity_file_content($result, 'index.html'));
+    $rawFieldReport = blocks_engine_figma_parser_parity_field_report($rawNodes, $normalizedNodes, $limit, $sampleLimit);
+    $rawTextNodeIds = array_values(array_unique(array_merge(
+        blocks_engine_figma_parser_parity_node_ids_by_type($rawNodes, array('TEXT')),
+        blocks_engine_figma_parser_parity_node_ids_with_paths($rawNodes, array('text', 'characters', 'figma_text.characters'))
+    )));
+    $rawVectorNodeIds = blocks_engine_figma_parser_parity_node_ids_by_type($rawNodes, array('VECTOR', 'BOOLEAN_OPERATION'));
+    $rawComponentPropNodeIds = blocks_engine_figma_parser_parity_node_ids_with_paths($rawNodes, array('componentProperties', 'componentPropertyDefinitions', 'component_property_definitions', 'symbolData', 'derivedSymbolData'));
+    $rawAssetRefs = blocks_engine_figma_parser_parity_raw_asset_reference_node_ids($rawNodes);
+    $emittedNodeIds = array_fill_keys(array_values(array_unique(array_merge($visualNodeIds, $htmlNodeIds))), true);
+
+    return array(
+        'schema' => 'blocks-engine/figma-transformer/parser-parity/v1',
+        'input' => array_filter(array(
+            'path' => $input,
+            'shape' => $source['shape'] ?? null,
+            'decoded_scenegraph' => $source['decoded_scenegraph'] ?? null,
+            'archive_input' => is_array($archive) ? ($archive['input'] ?? null) : null,
+            'zstd_command' => $zstdCommand,
+        ), static fn (mixed $value): bool => null !== $value),
+        'options' => $transformOptions,
+        'raw' => array(
+            'node_count' => count($rawNodes),
+            'field_path_count' => count($rawFieldReport['raw_field_paths']),
+            'blob_count' => count(is_array($scenegraph['blobs'] ?? null) ? $scenegraph['blobs'] : array()),
+            'asset_count' => count(is_array($scenegraph['assets'] ?? null) ? $scenegraph['assets'] : array()),
+            'asset_reference_node_count' => count($rawAssetRefs),
+            'text_node_count' => count($rawTextNodeIds),
+            'vector_node_count' => count($rawVectorNodeIds),
+            'component_prop_node_count' => count($rawComponentPropNodeIds),
+        ),
+        'normalized' => array(
+            'node_count' => count($normalizedNodes),
+            'field_path_count' => count($rawFieldReport['normalized_field_paths']),
+            'blob_count' => count(is_array($normalized['figma_blobs'] ?? null) ? $normalized['figma_blobs'] : array()),
+            'asset_count' => count(is_array($normalized['assets'] ?? null) ? $normalized['assets'] : array()),
+            'asset_reference_count' => count(is_array($normalized['asset_references'] ?? null) ? $normalized['asset_references'] : array()),
+            'text_node_count' => count(is_array($normalized['text_inventory'] ?? null) ? $normalized['text_inventory'] : array()),
+            'component_definition_count' => $normalized['source_report']['component_definition_count'] ?? null,
+            'instance_node_count' => $normalized['source_report']['instance_node_count'] ?? null,
+            'diagnostic_count' => count(is_array($normalized['diagnostics'] ?? null) ? $normalized['diagnostics'] : array()),
+        ),
+        'emitted' => array(
+            'status' => $result['status'] ?? null,
+            'file_count' => count(is_array($result['files'] ?? null) ? $result['files'] : array()),
+            'asset_count' => count(is_array($result['assets'] ?? null) ? $result['assets'] : array()),
+            'visual_node_count' => count($visualNodeIds),
+            'html_node_attr_count' => count($htmlNodeIds),
+            'css_rule_count' => blocks_engine_figma_parser_parity_css_rule_count(blocks_engine_figma_parser_parity_file_content($result, 'style.css')),
+            'diagnostic_count' => count(is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array()),
+        ),
+        'coverage' => array(
+            'raw_to_normalized_node' => blocks_engine_figma_parser_parity_id_coverage(array_keys($rawNodes), array_keys($normalizedNodes), $sampleLimit),
+            'raw_to_emitted_node' => blocks_engine_figma_parser_parity_id_coverage(array_keys($rawNodes), array_keys($emittedNodeIds), $sampleLimit),
+            'raw_text_to_normalized_text' => blocks_engine_figma_parser_parity_id_coverage($rawTextNodeIds, blocks_engine_figma_parser_parity_normalized_text_node_ids($normalized), $sampleLimit),
+            'raw_asset_refs_to_normalized_asset_refs' => blocks_engine_figma_parser_parity_id_coverage($rawAssetRefs, blocks_engine_figma_parser_parity_normalized_asset_reference_node_ids($normalized), $sampleLimit),
+            'raw_vector_to_emitted' => blocks_engine_figma_parser_parity_id_coverage($rawVectorNodeIds, array_keys($emittedNodeIds), $sampleLimit),
+            'raw_component_props_to_normalized' => blocks_engine_figma_parser_parity_id_coverage($rawComponentPropNodeIds, array_keys($normalizedNodes), $sampleLimit),
+        ),
+        'top_missing_field_paths' => $rawFieldReport['top_missing_field_paths'],
+        'diagnostics' => array(
+            'normalized_sample' => array_slice(is_array($normalized['diagnostics'] ?? null) ? $normalized['diagnostics'] : array(), 0, $limit),
+            'emitted_sample' => array_slice(is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array(), 0, $limit),
+        ),
+    );
+}
+
+/**
+ * @return array{raw_field_paths: array<string, true>, normalized_field_paths: array<string, true>, top_missing_field_paths: array<int, array<string, mixed>>}
+ */
+function blocks_engine_figma_parser_parity_field_report(array $rawNodes, array $normalizedNodes, int $limit, int $sampleLimit): array
+{
+    $rawFieldPaths = array();
+    $normalizedFieldPaths = array();
+    $missing = array();
+    foreach ( $rawNodes as $nodeId => $rawNode ) {
+        if ( ! is_array($rawNode) ) {
+            continue;
+        }
+        $rawPaths = blocks_engine_figma_parser_parity_flat_paths($rawNode);
+        foreach ( $rawPaths as $path ) {
+            $rawFieldPaths[$path] = true;
+        }
+        $normalizedNode = is_array($normalizedNodes[$nodeId] ?? null) ? $normalizedNodes[$nodeId] : array();
+        $normalizedPaths = blocks_engine_figma_parser_parity_flat_paths($normalizedNode);
+        foreach ( $normalizedPaths as $path ) {
+            $normalizedFieldPaths[$path] = true;
+        }
+        $normalizedPathSet = array_fill_keys($normalizedPaths, true);
+        foreach ( $rawPaths as $path ) {
+            if ( isset($normalizedPathSet[$path]) ) {
+                continue;
+            }
+            $missing[$path] ??= array('path' => $path, 'count' => 0, 'sample_node_ids' => array());
+            $missing[$path]['count']++;
+            if ( count($missing[$path]['sample_node_ids']) < $sampleLimit ) {
+                $missing[$path]['sample_node_ids'][] = (string) $nodeId;
+            }
+        }
+    }
+
+    usort($missing, static fn (array $left, array $right): int => ((int) $right['count'] <=> (int) $left['count']) ?: strcmp((string) $left['path'], (string) $right['path']));
+    return array(
+        'raw_field_paths' => $rawFieldPaths,
+        'normalized_field_paths' => $normalizedFieldPaths,
+        'top_missing_field_paths' => array_slice(array_values($missing), 0, $limit),
+    );
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_flat_paths(array $value, string $prefix = ''): array
+{
+    $paths = array();
+    foreach ( $value as $key => $child ) {
+        if ( 'children' === $key || str_starts_with((string) $key, '_') ) {
+            continue;
+        }
+        $path = '' === $prefix ? (string) $key : $prefix . '.' . (is_int($key) ? '*' : (string) $key);
+        if ( is_array($child) && ! blocks_engine_figma_parser_parity_is_list_of_scalars($child) ) {
+            $paths = array_merge($paths, blocks_engine_figma_parser_parity_flat_paths($child, $path));
+        } else {
+            $paths[] = $path;
+        }
+    }
+    return array_values(array_unique($paths));
+}
+
+function blocks_engine_figma_parser_parity_is_list_of_scalars(array $value): bool
+{
+    if ( array() === $value ) {
+        return true;
+    }
+    foreach ( $value as $child ) {
+        if ( is_array($child) ) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_visual_node_ids(array $htmlReport): array
+{
+    $ids = array();
+    foreach ( is_array($htmlReport['visual_node_map'] ?? null) ? $htmlReport['visual_node_map'] : array() as $node ) {
+        if ( is_array($node) && isset($node['id']) && is_scalar($node['id']) ) {
+            $ids[] = (string) $node['id'];
+        }
+    }
+    return array_values(array_unique($ids));
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_html_node_ids(string $html): array
+{
+    if ( '' === $html || 1 !== preg_match_all('/data-figma-node-id="([^"]+)"/', $html, $matches) ) {
+        return array();
+    }
+    return array_values(array_unique(array_map('html_entity_decode', $matches[1])));
+}
+
+function blocks_engine_figma_parser_parity_css_rule_count(string $css): int
+{
+    return '' !== $css && 1 === preg_match_all('/\{/', $css, $matches) ? count($matches[0]) : 0;
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_node_ids_by_type(array $nodes, array $types): array
+{
+    $allowed = array_fill_keys($types, true);
+    $ids = array();
+    foreach ( $nodes as $id => $node ) {
+        if ( is_array($node) && isset($allowed[strtoupper((string) ($node['type'] ?? ''))]) ) {
+            $ids[] = (string) $id;
+        }
+    }
+    return $ids;
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_node_ids_with_paths(array $nodes, array $paths): array
+{
+    $ids = array();
+    foreach ( $nodes as $id => $node ) {
+        if ( ! is_array($node) ) {
+            continue;
+        }
+        foreach ( $paths as $path ) {
+            if ( blocks_engine_figma_parser_parity_has_path($node, $path) ) {
+                $ids[] = (string) $id;
+                break;
+            }
+        }
+    }
+    return array_values(array_unique($ids));
+}
+
+function blocks_engine_figma_parser_parity_has_path(array $value, string $path): bool
+{
+    $current = $value;
+    foreach ( explode('.', $path) as $part ) {
+        if ( ! is_array($current) || ! array_key_exists($part, $current) ) {
+            return false;
+        }
+        $current = $current[$part];
+    }
+    return true;
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_raw_asset_reference_node_ids(array $nodes): array
+{
+    $ids = array();
+    foreach ( $nodes as $id => $node ) {
+        if ( ! is_array($node) ) {
+            continue;
+        }
+        $encoded = json_encode($node, JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+        if ( is_string($encoded) && preg_match('/("asset_id"|"imageHash"|"hash"|"ref")/', $encoded) ) {
+            $ids[] = (string) $id;
+        }
+    }
+    return array_values(array_unique($ids));
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_normalized_asset_reference_node_ids(array $normalized): array
+{
+    $ids = array();
+    foreach ( is_array($normalized['asset_references'] ?? null) ? $normalized['asset_references'] : array() as $reference ) {
+        if ( is_array($reference) && isset($reference['node_id']) && is_scalar($reference['node_id']) ) {
+            $ids[] = (string) $reference['node_id'];
+        }
+    }
+    return array_values(array_unique($ids));
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_normalized_text_node_ids(array $normalized): array
+{
+    $ids = array();
+    foreach ( is_array($normalized['text_inventory'] ?? null) ? $normalized['text_inventory'] : array() as $record ) {
+        if ( is_array($record) && isset($record['id']) && is_scalar($record['id']) ) {
+            $ids[] = (string) $record['id'];
+        }
+    }
+    return array_values(array_unique($ids));
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_parser_parity_id_coverage(array $sourceIds, array $coveredIds, int $sampleLimit): array
+{
+    $sourceIds = array_values(array_unique(array_map('strval', $sourceIds)));
+    $covered = array_fill_keys(array_values(array_unique(array_map('strval', $coveredIds))), true);
+    $missing = array_values(array_filter($sourceIds, static fn (string $id): bool => ! isset($covered[$id])));
+    $coveredCount = count($sourceIds) - count($missing);
+    return array(
+        'source_count' => count($sourceIds),
+        'covered_count' => $coveredCount,
+        'missing_count' => count($missing),
+        'coverage_ratio' => 0 === count($sourceIds) ? 1.0 : round($coveredCount / count($sourceIds), 4),
+        'missing_sample_node_ids' => array_slice($missing, 0, $sampleLimit),
+    );
+}
+
+function blocks_engine_figma_parser_parity_file_content(array $result, string $path): string
+{
+    foreach ( is_array($result['files'] ?? null) ? $result['files'] : array() as $file ) {
+        if ( is_array($file) && $path === ($file['path'] ?? null) && is_scalar($file['content'] ?? null) ) {
+            return (string) $file['content'];
+        }
+    }
+    return '';
+}
+
+function blocks_engine_figma_parser_parity_json_encode(array $value): string
+{
+    return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR) ?: '{}';
+}

--- a/figma-transformer/tests/contract/ParserParityContract.php
+++ b/figma-transformer/tests/contract/ParserParityContract.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_parser_parity_contract(callable $assert): void
+{
+    $fixturePath = sys_get_temp_dir() . '/figma-parser-parity-contract-' . getmypid() . '-' . bin2hex(random_bytes(4)) . '.json';
+    file_put_contents($fixturePath, json_encode(array(
+        'name'   => 'Parser Parity Fixture',
+        'blobs'  => array(array('bytes' => 'synthetic-vector-blob')),
+        'assets' => array(
+            'fixture-asset' => array(
+                'name'      => 'Fixture Asset',
+                'mime_type' => 'image/svg+xml',
+                'content'   => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>',
+            ),
+        ),
+        'nodes'  => array(
+            array(
+                'id'                           => 'parity:frame',
+                'type'                         => 'FRAME',
+                'name'                         => 'Parity Frame',
+                'width'                        => 600,
+                'height'                       => 320,
+                'componentPropertyDefinitions' => array('Variant' => array('type' => 'TEXT')),
+                'children'                     => array(
+                    array(
+                        'id'         => 'parity:text',
+                        'type'       => 'TEXT',
+                        'name'       => 'Parity Text',
+                        'characters' => 'Parity copy',
+                        'fontSize'   => 24,
+                    ),
+                    array(
+                        'id'       => 'parity:asset',
+                        'type'     => 'RECTANGLE',
+                        'name'     => 'Parity Asset',
+                        'width'    => 100,
+                        'height'   => 80,
+                        'asset_id' => 'fixture-asset',
+                    ),
+                    array(
+                        'id'           => 'parity:vector',
+                        'type'         => 'VECTOR',
+                        'name'         => 'Parity Vector',
+                        'width'        => 20,
+                        'height'       => 20,
+                        'fillGeometry' => array(array('commandsBlob' => 0)),
+                    ),
+                ),
+            ),
+        ),
+    ), JSON_THROW_ON_ERROR));
+
+    $command = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-parser-parity.php')
+        . ' ' . escapeshellarg($fixturePath)
+        . ' --frame-id=' . escapeshellarg('parity:frame')
+        . ' --limit=10 --sample-limit=3';
+    $output = shell_exec($command);
+    @unlink($fixturePath);
+
+    $report = is_string($output) ? json_decode($output, true) : null;
+    $assert(is_array($report), 'parser-parity-json-output');
+    $assert('blocks-engine/figma-transformer/parser-parity/v1' === ($report['schema'] ?? null), 'parser-parity-schema');
+    $assert('parity:frame' === ($report['options']['frame_id'] ?? null), 'parser-parity-frame-option');
+    $assert(4 === ($report['raw']['node_count'] ?? null), 'parser-parity-raw-node-count');
+    $assert(4 === ($report['normalized']['node_count'] ?? null), 'parser-parity-normalized-node-count');
+    $assert(1 === ($report['raw']['blob_count'] ?? null), 'parser-parity-raw-blob-count');
+    $assert(1 === ($report['raw']['asset_count'] ?? null), 'parser-parity-raw-asset-count');
+    $assert(1 === ($report['raw']['text_node_count'] ?? null), 'parser-parity-raw-text-node-count');
+    $assert(1 === ($report['raw']['vector_node_count'] ?? null), 'parser-parity-raw-vector-node-count');
+    $assert(1 === ($report['raw']['component_prop_node_count'] ?? null), 'parser-parity-component-prop-node-count');
+    $assert(4 === ($report['coverage']['raw_to_normalized_node']['covered_count'] ?? null), 'parser-parity-raw-normalized-node-coverage');
+    $assert(($report['coverage']['raw_asset_refs_to_normalized_asset_refs']['covered_count'] ?? 0) >= 1, 'parser-parity-asset-reference-coverage');
+    $assert(is_array($report['top_missing_field_paths'] ?? null), 'parser-parity-missing-field-paths-present');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/GeometryBoxContract.php';
 require_once __DIR__ . '/LayoutMismatchContract.php';
 require_once __DIR__ . '/NodeTraceContract.php';
 require_once __DIR__ . '/OriginInferenceContract.php';
+require_once __DIR__ . '/ParserParityContract.php';
 require_once __DIR__ . '/RenderStyleMismatchContract.php';
 require_once __DIR__ . '/SyntheticFigKiwiFixtureBuilder.php';
 require_once __DIR__ . '/VisualNodeMapContract.php';
@@ -8198,6 +8199,7 @@ $assert(2 === substr_count($rootLevelHtml, '<section'), 'section-refinement-root
 
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 blocks_engine_figma_transformer_run_node_trace_contract($assert);
+blocks_engine_figma_transformer_run_parser_parity_contract($assert);
 
 // Authored CSS classes: repeated per-node styles collapse into shared, readably
 // named classes (like a hand-authored site reuses `.card`), names derive from


### PR DESCRIPTION
## Summary
- Add a generic parser parity report CLI for comparing decoded raw .fig/JSON data to normalized scenegraph and emitted artifacts.
- Report raw/normalized/emitted counts, coverage ratios, top missing raw field paths, diagnostics samples, and sample missing node ids.
- Add a synthetic contract test covering raw fields, blobs, assets, text, vectors, and component properties.

## Testing
- composer test:contract
- php -l scripts/figma-parser-parity.php
- php -l tests/contract/ParserParityContract.php
- php -d memory_limit=1G scripts/figma-parser-parity.php "/Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig" --zstd-command=/opt/homebrew/bin/zstd --max-nodes=5000 --limit=10 --sample-limit=5 --output=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/figma-parser-parity-fse.json

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the parser parity report CLI, adding contract coverage, running verification, and preparing this PR.