### PR TITLE
figma-transformer: inventory skipped Kiwi fields

### DIFF
--- a/figma-transformer/scripts/figma-kiwi-skipped-field-inventory.php
+++ b/figma-transformer/scripts/figma-kiwi-skipped-field-inventory.php
@@ -1,0 +1,188 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCapability;
+use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder;
+use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if ( is_readable($autoload) ) {
+    require_once $autoload;
+} else {
+    require_once __DIR__ . '/../figma-transformer.php';
+}
+
+$options = blocks_engine_figma_kiwi_inventory_options($argv);
+if ( true === ($options['help'] ?? false) || '' === ($options['input'] ?? '') ) {
+    blocks_engine_figma_kiwi_inventory_usage(true === ($options['help'] ?? false) ? STDOUT : STDERR);
+    exit(true === ($options['help'] ?? false) ? 0 : 1);
+}
+
+$zstdCommand = $options['zstd_command'] ?? (getenv('FIGMA_TRANSFORMER_ZSTD_COMMAND') ?: null);
+$result = blocks_engine_figma_kiwi_inventory((string) $options['input'], is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null);
+fwrite(STDOUT, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+exit(empty($result['diagnostics']) ? 0 : 0);
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_kiwi_inventory_options(array $argv): array
+{
+    $options = array('input' => '');
+    foreach ( array_slice($argv, 1) as $argument ) {
+        if ( '--help' === $argument || '-h' === $argument ) {
+            $options['help'] = true;
+            continue;
+        }
+        if ( ! str_starts_with($argument, '--') ) {
+            $options['input'] = $argument;
+            continue;
+        }
+        $parts = explode('=', substr($argument, 2), 2);
+        $options[str_replace('-', '_', $parts[0])] = $parts[1] ?? '1';
+    }
+    return $options;
+}
+
+function blocks_engine_figma_kiwi_inventory_usage(mixed $stream): void
+{
+    fwrite($stream, "Usage: figma-kiwi-skipped-field-inventory.php <path-to-fig> [--zstd-command=/opt/homebrew/bin/zstd]\n");
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_kiwi_inventory(string $input, ?string $zstdCommand): array
+{
+    $canvas = blocks_engine_figma_kiwi_inventory_canvas($input);
+    if ( null === $canvas ) {
+        return array(
+            'schema'      => 'blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1',
+            'input'       => array('path' => $input),
+            'diagnostics' => array(array('code' => 'figma_transformer_inventory_canvas_missing', 'message' => 'No canvas.fig entry could be read from the .fig archive.')),
+        );
+    }
+
+    $decoder = new FigKiwiDecoder();
+    $zstd = null === $zstdCommand ? new ZstdCapability() : new ZstdCapability(new ZstdCommandDecoder(array($zstdCommand, '-dc')));
+    $offset = 12;
+    $chunkIndex = 0;
+    $schema = null;
+    $diagnostics = array();
+    $inventories = array();
+
+    while ( $offset + 4 <= strlen($canvas) ) {
+        $length = unpack('V', substr($canvas, $offset, 4));
+        $compressedBytes = is_array($length) ? (int) $length[1] : 0;
+        $payload = substr($canvas, $offset + 4, $compressedBytes);
+        $offset += 4 + $compressedBytes;
+        $inflated = blocks_engine_figma_kiwi_inventory_payload($payload, $zstd, $chunkIndex, $diagnostics);
+        if ( null === $inflated ) {
+            $chunkIndex++;
+            continue;
+        }
+
+        if ( null === $schema ) {
+            $schemaResult = $decoder->decodeSchema($inflated);
+            if ( is_array($schemaResult['schema'] ?? null) && ! empty($schemaResult['schema']['definitions'] ?? array()) ) {
+                $schema = $schemaResult['schema'];
+                $chunkIndex++;
+                continue;
+            }
+        } else {
+            $inventoryResult = $decoder->inventorySkippedFieldsSelective($inflated, $schema);
+            $diagnostics = array_merge($diagnostics, $inventoryResult['diagnostics']);
+            if ( is_array($inventoryResult['inventory'] ?? null) ) {
+                $inventory = $inventoryResult['inventory'];
+                $inventory['chunk_index'] = $chunkIndex;
+                $inventories[] = $inventory;
+            }
+        }
+
+        $chunkIndex++;
+    }
+
+    return array(
+        'schema'      => 'blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1',
+        'input'       => array('path' => $input),
+        'chunks'      => $chunkIndex,
+        'inventories' => $inventories,
+        'summary'     => blocks_engine_figma_kiwi_inventory_file_summary($inventories),
+        'diagnostics' => $diagnostics,
+    );
+}
+
+function blocks_engine_figma_kiwi_inventory_canvas(string $input): ?string
+{
+    if ( ! class_exists(ZipArchive::class) || ! is_readable($input) ) {
+        return null;
+    }
+
+    $zip = new ZipArchive();
+    if ( true !== $zip->open($input) ) {
+        return null;
+    }
+
+    $canvas = $zip->getFromName('canvas.fig');
+    if ( false !== $canvas ) {
+        $zip->close();
+        return $canvas;
+    }
+
+    for ( $index = 0; $index < $zip->numFiles; $index++ ) {
+        $name = $zip->getNameIndex($index);
+        if ( false !== $name && str_ends_with(strtolower($name), '.fig') ) {
+            $nested = $zip->getFromName($name);
+            $zip->close();
+            if ( false === $nested ) {
+                return null;
+            }
+            $tmp = tempnam(sys_get_temp_dir(), 'blocks-engine-fig-inventory-');
+            if ( false === $tmp ) {
+                return null;
+            }
+            file_put_contents($tmp, $nested);
+            $nestedCanvas = blocks_engine_figma_kiwi_inventory_canvas($tmp);
+            @unlink($tmp);
+            return $nestedCanvas;
+        }
+    }
+
+    $zip->close();
+    return null;
+}
+
+function blocks_engine_figma_kiwi_inventory_payload(string $payload, ZstdCapability $zstd, int $chunkIndex, array &$diagnostics): ?string
+{
+    if ( str_starts_with($payload, "\x28\xb5\x2f\xfd") ) {
+        $result = $zstd->uncompress($payload, 'FigKiwiSkippedFieldInventory', $chunkIndex);
+        $diagnostics = array_merge($diagnostics, $result['diagnostics']);
+        return is_string($result['data'] ?? null) ? $result['data'] : null;
+    }
+
+    $inflated = @gzinflate($payload);
+    return false === $inflated ? $payload : $inflated;
+}
+
+/**
+ * @param array<int, array<string, mixed>> $inventories
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_kiwi_inventory_file_summary(array $inventories): array
+{
+    $byRole = array();
+    $fieldCount = 0;
+    $occurrences = 0;
+    foreach ( $inventories as $inventory ) {
+        $summary = is_array($inventory['summary'] ?? null) ? $inventory['summary'] : array();
+        $fieldCount += (int) ($summary['field_count'] ?? 0);
+        $occurrences += (int) ($summary['occurrences'] ?? 0);
+        foreach ( is_array($summary['by_role'] ?? null) ? $summary['by_role'] : array() as $role => $count ) {
+            $byRole[(string) $role] = ($byRole[(string) $role] ?? 0) + (int) $count;
+        }
+    }
+    arsort($byRole);
+    return array('field_count' => $fieldCount, 'occurrences' => $occurrences, 'by_role' => $byRole);
+}

--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -694,7 +694,7 @@ final class FigKiwiDecoder
         if ( str_contains($name, 'bound') || str_contains($name, 'layout') || str_contains($name, 'constraint') || str_contains($name, 'padding') || str_contains($name, 'size') || str_contains($name, 'transform') || str_contains($name, 'corner') || str_contains($name, 'stack') ) {
             return 'geometry_layout';
         }
-        if ( str_contains($name, 'paint') || str_contains($name, 'fill') || str_contains($name, 'stroke') || str_contains($name, 'image') || str_contains($name, 'blob') ) {
+        if ( str_contains($name, 'paint') || str_contains($name, 'fill') || str_contains($name, 'stroke') || str_contains($name, 'image') || str_contains($name, 'blob') || str_contains($name, 'blendmode') ) {
             return 'fills_images';
         }
         if ( str_contains($name, 'mask') || str_contains($name, 'effect') || str_contains($name, 'shadow') || str_contains($name, 'blur') ) {
@@ -706,7 +706,7 @@ final class FigKiwiDecoder
         if ( str_contains($name, 'component') || str_contains($name, 'symbol') || str_contains($name, 'override') || str_contains($name, 'prop') || str_contains($name, 'variant') ) {
             return 'component_overrides';
         }
-        if ( str_contains($name, 'vector') || str_contains($name, 'path') || str_contains($name, 'geometry') ) {
+        if ( str_contains($name, 'vector') || str_contains($name, 'commandsblob') || 'path' === strtolower($type) || 'vectorpath' === strtolower($type) ) {
             return 'vectors';
         }
 

--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -114,6 +114,46 @@ final class FigKiwiDecoder
     }
 
     /**
+     * Inventory fields skipped by the selective scenegraph decoder without changing
+     * the production decoded payload shape.
+     *
+     * @param array<string, mixed> $schema
+     * @return array{inventory: array<string, mixed>|null, diagnostics: array<int, array<string, mixed>>}
+     */
+    public function inventorySkippedFieldsSelective(string $payload, array $schema, string $rootType = 'Message', array $fieldPolicy = array()): array
+    {
+        try {
+            $definitions = $this->definitionsByName($schema);
+            if ( ! isset($definitions[$rootType]) ) {
+                return array('inventory' => null, 'diagnostics' => array($this->diagnostic('figma_transformer_kiwi_message_schema_missing', 'Kiwi schema does not define the expected root message.', $rootType)));
+            }
+
+            $policy = empty($fieldPolicy) ? $this->defaultScenegraphFieldPolicy() : $fieldPolicy;
+            $inventory = array(
+                'schema'        => 'blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1',
+                'root_type'     => $rootType,
+                'policy_groups' => $this->scenegraphFieldPolicyGroups(),
+                'fields'        => array(),
+            );
+            $context = array(
+                'path'        => $rootType,
+                'parent_type' => $rootType,
+                'node_type'   => null,
+                'node_id'     => null,
+            );
+
+            $this->inventoryDefinitionSelective(new FigKiwiByteReader($payload), $definitions[$rootType], $definitions, $policy, $inventory, $context);
+            $inventory['summary'] = $this->summarizeSkippedFieldInventory($inventory['fields']);
+            return array('inventory' => $inventory, 'diagnostics' => array());
+        } catch ( \Throwable $throwable ) {
+            return array(
+                'inventory'   => null,
+                'diagnostics' => array($this->diagnostic('figma_transformer_kiwi_message_decode_failed', 'Kiwi message chunk could not be inventoried.', $throwable->getMessage())),
+            );
+        }
+    }
+
+    /**
      * @param array<string, mixed> $schema
      * @return array<string, array<string, mixed>>
      */
@@ -375,7 +415,7 @@ final class FigKiwiDecoder
     /**
      * @return array<string, array<int, string>>
      */
-    private function defaultScenegraphFieldPolicy(): array
+    public function defaultScenegraphFieldPolicy(): array
     {
         return array(
             'Message' => $this->scenegraphRootFields(),
@@ -437,6 +477,288 @@ final class FigKiwiDecoder
             'PrototypeInteraction' => array('event', 'actions', 'id'),
             'PrototypeEvent' => array('interactionType'),
             'PrototypeAction' => array('connectionType', 'connectionURL', 'transitionNodeID', 'navigationType'),
+        );
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function scenegraphFieldPolicyGroups(): array
+    {
+        return array(
+            'identity' => $this->nodeIdentityFields(),
+            'dev_status' => $this->nodeDevStatusFields(),
+            'geometry_layout' => array_values(array_unique(array_merge($this->nodeGeometryFields(), $this->nodeLayoutFields()))),
+            'fills_images' => array_values(array_unique(array_merge($this->nodePaintAndStrokeFields(), $this->nodeVectorAndImageFields(), array('Paint', 'Image', 'Blob', 'image', 'hash', 'bytes')))),
+            'component_overrides' => $this->nodeComponentFields(),
+            'text_style' => $this->nodeTextFields(),
+            'masks_effects' => array_values(array_unique(array_merge($this->nodeEffectFields(), array('isClip', 'frameMaskDisabled')))),
+            'vectors' => array_values(array_unique(array_merge($this->nodeVectorAndImageFields(), array('Path', 'VectorPath', 'VectorData', 'commandsBlob', 'vectorNetworkBlob', 'vectorNetwork')))),
+            'prototype_links' => $this->nodePrototypeLinkFields(),
+        );
+    }
+
+    /**
+     * @param array<string, mixed>                $definition
+     * @param array<string, array<string, mixed>> $definitions
+     * @param array<string, array<int, string>>   $fieldPolicy
+     * @param array<string, mixed>                $inventory
+     * @param array<string, mixed>                $context
+     */
+    private function inventoryDefinitionSelective(FigKiwiByteReader $reader, array $definition, array $definitions, array $fieldPolicy, array &$inventory, array $context): void
+    {
+        $typeName = (string) ($definition['name'] ?? '');
+        $allowed = array_flip($fieldPolicy[$typeName] ?? array());
+        $context['parent_type'] = $typeName;
+
+        if ( 'MESSAGE' === ($definition['kind'] ?? null) ) {
+            $fieldsByValue = array();
+            foreach ( $definition['fields'] ?? array() as $field ) {
+                if ( is_array($field) ) {
+                    $fieldsByValue[(int) ($field['value'] ?? 0)] = $field;
+                }
+            }
+
+            while ( true ) {
+                $fieldValue = $reader->readVarUint();
+                if ( 0 === $fieldValue ) {
+                    return;
+                }
+                if ( ! isset($fieldsByValue[$fieldValue]) ) {
+                    throw new \RuntimeException('Attempted to inventory invalid message field ' . $fieldValue . '.');
+                }
+
+                $field = $fieldsByValue[$fieldValue];
+                $fieldName = (string) ($field['name'] ?? '');
+                if ( isset($allowed[$fieldName]) ) {
+                    $this->inventoryDecodeFieldSelective($reader, $field, $definitions, $fieldPolicy, $inventory, $context);
+                } else {
+                    $this->recordSkippedField($inventory, $field, $context);
+                    $this->skipField($reader, $field, $definitions);
+                }
+            }
+        }
+
+        foreach ( $definition['fields'] ?? array() as $field ) {
+            if ( ! is_array($field) ) {
+                continue;
+            }
+
+            $fieldName = (string) ($field['name'] ?? '');
+            if ( isset($allowed[$fieldName]) ) {
+                $this->inventoryDecodeFieldSelective($reader, $field, $definitions, $fieldPolicy, $inventory, $context);
+            } else {
+                $this->recordSkippedField($inventory, $field, $context);
+                $this->skipField($reader, $field, $definitions);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed>                $field
+     * @param array<string, array<string, mixed>> $definitions
+     * @param array<string, array<int, string>>   $fieldPolicy
+     * @param array<string, mixed>                $inventory
+     * @param array<string, mixed>                $context
+     */
+    private function inventoryDecodeFieldSelective(FigKiwiByteReader $reader, array $field, array $definitions, array $fieldPolicy, array &$inventory, array &$context): void
+    {
+        $fieldName = (string) ($field['name'] ?? '');
+        $type = (string) ($field['type'] ?? '');
+        $fieldPath = (string) ($context['path'] ?? '') . '.' . $fieldName;
+
+        if ( true === ($field['is_array'] ?? false) ) {
+            if ( 'byte' === $type ) {
+                $value = $reader->readByteArray();
+            } else {
+                $length = $reader->readVarUint();
+                $value = array();
+                for ( $i = 0; $i < $length; $i++ ) {
+                    $elementContext = $context;
+                    $elementContext['path'] = $fieldPath . '[]';
+                    $value[] = $this->inventoryDecodeValueSelective($reader, $type, $definitions, $fieldPolicy, $inventory, $elementContext);
+                }
+            }
+        } else {
+            $value = $this->inventoryDecodeValueSelective($reader, $type, $definitions, $fieldPolicy, $inventory, array_merge($context, array('path' => $fieldPath)));
+        }
+
+        if ( 'NodeChange' === ($context['parent_type'] ?? null) ) {
+            if ( 'type' === $fieldName && is_scalar($value) ) {
+                $context['node_type'] = (string) $value;
+            } elseif ( 'guid' === $fieldName ) {
+                $context['node_id'] = $this->formatInventoryNodeId($value);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $definitions
+     * @param array<string, array<int, string>>   $fieldPolicy
+     * @param array<string, mixed>                $inventory
+     * @param array<string, mixed>                $context
+     */
+    private function inventoryDecodeValueSelective(FigKiwiByteReader $reader, string $type, array $definitions, array $fieldPolicy, array &$inventory, array $context): mixed
+    {
+        return match ( $type ) {
+            'bool' => 0 !== $reader->readByte(),
+            'byte' => $reader->readByte(),
+            'int' => $reader->readVarInt(),
+            'uint' => $reader->readVarUint(),
+            'float' => $reader->readVarFloat(),
+            'string' => $reader->readString(),
+            'int64' => $reader->readVarInt64(),
+            'uint64' => $reader->readVarUint64(),
+            default => $this->inventoryDecodeNamedValueSelective($reader, $type, $definitions, $fieldPolicy, $inventory, $context),
+        };
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $definitions
+     * @param array<string, array<int, string>>   $fieldPolicy
+     * @param array<string, mixed>                $inventory
+     * @param array<string, mixed>                $context
+     */
+    private function inventoryDecodeNamedValueSelective(FigKiwiByteReader $reader, string $type, array $definitions, array $fieldPolicy, array &$inventory, array $context): mixed
+    {
+        $definition = $definitions[$type] ?? null;
+        if ( ! is_array($definition) ) {
+            throw new \RuntimeException('Invalid Kiwi type ' . $type . '.');
+        }
+
+        if ( 'ENUM' === ($definition['kind'] ?? null) ) {
+            $value = $reader->readVarUint();
+            foreach ( $definition['fields'] ?? array() as $field ) {
+                if ( is_array($field) && (int) ($field['value'] ?? -1) === $value ) {
+                    return (string) ($field['name'] ?? $value);
+                }
+            }
+            return $value;
+        }
+
+        if ( 'STRUCT' === ($definition['kind'] ?? null) ) {
+            return $this->decodeDefinitionSelective($reader, $definition, $definitions, $fieldPolicy);
+        }
+
+        $childContext = $context;
+        $childContext['parent_type'] = $type;
+        if ( 'NodeChange' === $type ) {
+            $childContext['node_type'] = null;
+            $childContext['node_id'] = null;
+        }
+
+        $this->inventoryDefinitionSelective($reader, $definition, $definitions, $fieldPolicy, $inventory, $childContext);
+        return array();
+    }
+
+    /**
+     * @param array<string, mixed> $inventory
+     * @param array<string, mixed> $field
+     * @param array<string, mixed> $context
+     */
+    private function recordSkippedField(array &$inventory, array $field, array $context): void
+    {
+        $fieldName = (string) ($field['name'] ?? '');
+        $type = (string) ($field['type'] ?? '');
+        $parentType = (string) ($context['parent_type'] ?? '');
+        $path = (string) ($context['path'] ?? $parentType) . '.' . $fieldName;
+        $role = $this->classifySkippedFieldRole($fieldName, $type);
+        $key = $parentType . '|' . $path . '|' . $fieldName . '|' . $type;
+
+        if ( ! isset($inventory['fields'][$key]) ) {
+            $inventory['fields'][$key] = array(
+                'path'            => $path,
+                'field'           => $fieldName,
+                'type'            => $type,
+                'parent_message'  => $parentType,
+                'field_role'      => $role,
+                'is_array'        => true === ($field['is_array'] ?? false),
+                'occurrences'     => 0,
+                'node_types'      => array(),
+                'sample_node_ids' => array(),
+            );
+        }
+
+        $inventory['fields'][$key]['occurrences']++;
+        $nodeType = is_scalar($context['node_type'] ?? null) ? (string) $context['node_type'] : 'unknown';
+        $inventory['fields'][$key]['node_types'][$nodeType] = ($inventory['fields'][$key]['node_types'][$nodeType] ?? 0) + 1;
+        $nodeId = is_scalar($context['node_id'] ?? null) ? (string) $context['node_id'] : '';
+        if ( '' !== $nodeId && count($inventory['fields'][$key]['sample_node_ids']) < 5 && ! in_array($nodeId, $inventory['fields'][$key]['sample_node_ids'], true) ) {
+            $inventory['fields'][$key]['sample_node_ids'][] = $nodeId;
+        }
+    }
+
+    private function classifySkippedFieldRole(string $fieldName, string $type): string
+    {
+        $name = strtolower($fieldName . ' ' . $type);
+        if ( str_contains($name, 'bound') || str_contains($name, 'layout') || str_contains($name, 'constraint') || str_contains($name, 'padding') || str_contains($name, 'size') || str_contains($name, 'transform') || str_contains($name, 'corner') || str_contains($name, 'stack') ) {
+            return 'geometry_layout';
+        }
+        if ( str_contains($name, 'paint') || str_contains($name, 'fill') || str_contains($name, 'stroke') || str_contains($name, 'image') || str_contains($name, 'blob') ) {
+            return 'fills_images';
+        }
+        if ( str_contains($name, 'mask') || str_contains($name, 'effect') || str_contains($name, 'shadow') || str_contains($name, 'blur') ) {
+            return 'masks_effects';
+        }
+        if ( str_contains($name, 'text') || str_contains($name, 'font') || str_contains($name, 'style') || str_contains($name, 'letter') || str_contains($name, 'paragraph') ) {
+            return 'text_style';
+        }
+        if ( str_contains($name, 'component') || str_contains($name, 'symbol') || str_contains($name, 'override') || str_contains($name, 'prop') || str_contains($name, 'variant') ) {
+            return 'component_overrides';
+        }
+        if ( str_contains($name, 'vector') || str_contains($name, 'path') || str_contains($name, 'geometry') ) {
+            return 'vectors';
+        }
+
+        foreach ( $this->scenegraphFieldPolicyGroups() as $role => $fields ) {
+            if ( in_array($fieldName, $fields, true) || in_array($type, $fields, true) ) {
+                return $role;
+            }
+        }
+
+        return 'unknown';
+    }
+
+    private function formatInventoryNodeId(mixed $value): ?string
+    {
+        if ( is_array($value) ) {
+            $session = $value['sessionID'] ?? null;
+            $local = $value['localID'] ?? null;
+            if ( is_scalar($session) && is_scalar($local) ) {
+                return (string) $session . ':' . (string) $local;
+            }
+            if ( is_scalar($local) ) {
+                return (string) $local;
+            }
+        }
+
+        return is_scalar($value) ? (string) $value : null;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $fields
+     * @return array<string, mixed>
+     */
+    private function summarizeSkippedFieldInventory(array &$fields): array
+    {
+        $byRole = array();
+        $total = 0;
+        foreach ( $fields as &$field ) {
+            arsort($field['node_types']);
+            $role = (string) ($field['field_role'] ?? 'unknown');
+            $count = (int) ($field['occurrences'] ?? 0);
+            $byRole[$role] = ($byRole[$role] ?? 0) + $count;
+            $total += $count;
+        }
+        unset($field);
+
+        uasort($fields, static fn (array $left, array $right): int => ((int) ($right['occurrences'] ?? 0) <=> (int) ($left['occurrences'] ?? 0)) ?: strcmp((string) ($left['path'] ?? ''), (string) ($right['path'] ?? '')));
+        arsort($byRole);
+
+        return array(
+            'field_count' => count($fields),
+            'occurrences' => $total,
+            'by_role'     => $byRole,
         );
     }
 

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contract(callable $assert): void
+{
+    $decoder = new FigKiwiDecoder();
+    $schema = $decoder->decodeSchema(blocks_engine_figma_transformer_kiwi_inventory_schema_fixture())['schema'] ?? array();
+    $inventoryResult = $decoder->inventorySkippedFieldsSelective(blocks_engine_figma_transformer_kiwi_inventory_message_fixture(), $schema);
+    $inventory = $inventoryResult['inventory'] ?? array();
+    $fields = is_array($inventory['fields'] ?? null) ? $inventory['fields'] : array();
+
+    $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1' === ($inventory['schema'] ?? null), 'kiwi-skipped-inventory-schema');
+    $assert(6 === ($inventory['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-field-count');
+    $assert(6 === ($inventory['summary']['occurrences'] ?? null), 'kiwi-skipped-inventory-occurrences');
+    $assert(1 === ($inventory['summary']['by_role']['geometry_layout'] ?? null), 'kiwi-skipped-inventory-geometry-role');
+    $assert(1 === ($inventory['summary']['by_role']['component_overrides'] ?? null), 'kiwi-skipped-inventory-component-role');
+    $assert(1 === ($inventory['summary']['by_role']['fills_images'] ?? null), 'kiwi-skipped-inventory-image-role');
+    $assert(1 === ($inventory['summary']['by_role']['masks_effects'] ?? null), 'kiwi-skipped-inventory-mask-role');
+    $assert(1 === ($inventory['summary']['by_role']['text_style'] ?? null), 'kiwi-skipped-inventory-text-role');
+    $assert(1 === ($inventory['summary']['by_role']['vectors'] ?? null), 'kiwi-skipped-inventory-vector-role');
+
+    $layoutEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'layoutGrids');
+    $assert('NodeChange' === ($layoutEntry['parent_message'] ?? null), 'kiwi-skipped-inventory-parent-message');
+    $assert('FRAME' === array_key_first(is_array($layoutEntry['node_types'] ?? null) ? $layoutEntry['node_types'] : array()), 'kiwi-skipped-inventory-node-type');
+    $assert(array('7:42') === ($layoutEntry['sample_node_ids'] ?? null), 'kiwi-skipped-inventory-node-id-sample');
+
+    $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
+        SyntheticFigKiwiFixtureBuilder::canvas(array(
+            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_schema_fixture()),
+            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_message_fixture()),
+        ))
+    );
+    $command = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-kiwi-skipped-field-inventory.php')
+        . ' ' . escapeshellarg($fixture);
+    $output = shell_exec($command);
+    @unlink($fixture);
+    $cli = is_string($output) ? json_decode($output, true) : null;
+
+    $assert(is_array($cli), 'kiwi-skipped-inventory-cli-json');
+    $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-cli-schema');
+    $assert(6 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
+}
+
+/**
+ * @param array<string, array<string, mixed>> $fields
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_transformer_kiwi_inventory_find_field(array $fields, string $fieldName): array
+{
+    foreach ( $fields as $field ) {
+        if ( $fieldName === ($field['field'] ?? null) ) {
+            return $field;
+        }
+    }
+    return array();
+}
+
+function blocks_engine_figma_transformer_kiwi_inventory_schema_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_string('GUID')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sessionID', -4, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('localID', -4, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('NodeChange')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(9)
+        . blocks_engine_figma_transformer_kiwi_schema_field('guid', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('layoutGrids', -6, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('componentProperties', -6, false, 5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('imageFilters', -6, false, 6)
+        . blocks_engine_figma_transformer_kiwi_schema_field('maskType', -6, false, 7)
+        . blocks_engine_figma_transformer_kiwi_schema_field('textStyleOverrides', -6, false, 8)
+        . blocks_engine_figma_transformer_kiwi_schema_field('vectorNetwork', -6, false, 9)
+        . blocks_engine_figma_transformer_kiwi_string('Message')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 1, true, 2);
+}
+
+function blocks_engine_figma_transformer_kiwi_inventory_message_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('NODE_CHANGES')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(7)
+        . blocks_engine_figma_transformer_wire_varint(42)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('FRAME')
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_string('Inventory Frame')
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_kiwi_string('layout')
+        . blocks_engine_figma_transformer_wire_varint(5)
+        . blocks_engine_figma_transformer_kiwi_string('component')
+        . blocks_engine_figma_transformer_wire_varint(6)
+        . blocks_engine_figma_transformer_kiwi_string('image')
+        . blocks_engine_figma_transformer_wire_varint(7)
+        . blocks_engine_figma_transformer_kiwi_string('mask')
+        . blocks_engine_figma_transformer_wire_varint(8)
+        . blocks_engine_figma_transformer_kiwi_string('text')
+        . blocks_engine_figma_transformer_wire_varint(9)
+        . blocks_engine_figma_transformer_kiwi_string('vector')
+        . blocks_engine_figma_transformer_wire_varint(0)
+        . blocks_engine_figma_transformer_wire_varint(0);
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/ContractHelpers.php';
 require_once __DIR__ . '/DiagnosticsEvidenceContract.php';
 require_once __DIR__ . '/FixtureMatrixContract.php';
 require_once __DIR__ . '/GeometryBoxContract.php';
+require_once __DIR__ . '/KiwiSkippedFieldInventoryContract.php';
 require_once __DIR__ . '/LayoutMismatchContract.php';
 require_once __DIR__ . '/NodeTraceContract.php';
 require_once __DIR__ . '/OriginInferenceContract.php';
@@ -8198,6 +8199,7 @@ $assert(2 === substr_count($rootLevelHtml, '<section'), 'section-refinement-root
 
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 blocks_engine_figma_transformer_run_node_trace_contract($assert);
+blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contract($assert);
 
 // Authored CSS classes: repeated per-node styles collapse into shared, readably
 // named classes (like a hand-authored site reuses `.card`), names derive from


### PR DESCRIPTION
## Summary
- Add a reusable Kiwi selective-decode skipped-field inventory API for `figma-transformer`.
- Add `scripts/figma-kiwi-skipped-field-inventory.php` to run the inventory against `.fig` archives with zstd support.
- Add contract coverage for role grouping, parent path/type metadata, node type grouping, sample node ids, and CLI JSON output.

## Evidence
- `composer test:contract` passed.
- FSE fixture inventory generated at operator-local path: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-kiwi-skipped-field-inventory.json`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the diagnostic API/CLI, contract tests, and generating the skipped-field inventory evidence.
