### PR TITLE
figma-transformer: bound vector command blob decoding

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -10,6 +10,8 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
 final class ScenegraphNormalizer
 {
     private const GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE = 'component_source_clone';
+    private const MAX_VECTOR_COMMAND_BLOB_COMMANDS = 2000;
+    private const MAX_VECTOR_COMMAND_BLOB_PATH_BYTES = 65536;
 
     public function __construct(
         private readonly ScenegraphIndex $index = new ScenegraphIndex()
@@ -4077,16 +4079,24 @@ final class ScenegraphNormalizer
         $offset = 0;
         $length = strlen($bytes);
         $parts = array();
+        $commandCount = 0;
+        $pathBytes = 0;
 
         while ( $offset < $length ) {
             $opcode = ord($bytes[$offset]);
             $offset++;
+            $commandCount++;
+            if ( $commandCount > self::MAX_VECTOR_COMMAND_BLOB_COMMANDS ) {
+                return array('status' => 'unsupported', 'path' => null);
+            }
 
             if ( 0 === $opcode ) {
                 if ( empty($parts) ) {
                     continue;
                 }
-                $parts[] = 'Z';
+                if ( ! $this->appendVectorPathPart($parts, $pathBytes, 'Z') ) {
+                    return array('status' => 'unsupported', 'path' => null);
+                }
                 continue;
             }
 
@@ -4095,7 +4105,9 @@ final class ScenegraphNormalizer
                 if ( null === $point ) {
                     return array('status' => 'unsupported', 'path' => null);
                 }
-                $parts[] = ( 1 === $opcode ? 'M ' : 'L ' ) . $this->svgNumber($point[0]) . ' ' . $this->svgNumber($point[1]);
+                if ( ! $this->appendVectorPathPart($parts, $pathBytes, ( 1 === $opcode ? 'M ' : 'L ' ) . $this->svgNumber($point[0]) . ' ' . $this->svgNumber($point[1])) ) {
+                    return array('status' => 'unsupported', 'path' => null);
+                }
                 $offset += 8;
                 continue;
             }
@@ -4109,7 +4121,9 @@ final class ScenegraphNormalizer
                     }
                     $points[] = $point;
                 }
-                $parts[] = 'Q ' . $this->svgNumber($points[0][0]) . ' ' . $this->svgNumber($points[0][1]) . ' ' . $this->svgNumber($points[1][0]) . ' ' . $this->svgNumber($points[1][1]);
+                if ( ! $this->appendVectorPathPart($parts, $pathBytes, 'Q ' . $this->svgNumber($points[0][0]) . ' ' . $this->svgNumber($points[0][1]) . ' ' . $this->svgNumber($points[1][0]) . ' ' . $this->svgNumber($points[1][1])) ) {
+                    return array('status' => 'unsupported', 'path' => null);
+                }
                 $offset += 16;
                 continue;
             }
@@ -4123,7 +4137,9 @@ final class ScenegraphNormalizer
                     }
                     $points[] = $point;
                 }
-                $parts[] = 'C ' . $this->svgNumber($points[0][0]) . ' ' . $this->svgNumber($points[0][1]) . ' ' . $this->svgNumber($points[1][0]) . ' ' . $this->svgNumber($points[1][1]) . ' ' . $this->svgNumber($points[2][0]) . ' ' . $this->svgNumber($points[2][1]);
+                if ( ! $this->appendVectorPathPart($parts, $pathBytes, 'C ' . $this->svgNumber($points[0][0]) . ' ' . $this->svgNumber($points[0][1]) . ' ' . $this->svgNumber($points[1][0]) . ' ' . $this->svgNumber($points[1][1]) . ' ' . $this->svgNumber($points[2][0]) . ' ' . $this->svgNumber($points[2][1])) ) {
+                    return array('status' => 'unsupported', 'path' => null);
+                }
                 $offset += 24;
                 continue;
             }
@@ -4134,6 +4150,20 @@ final class ScenegraphNormalizer
         return empty($parts)
             ? array('status' => 'empty', 'path' => null)
             : array('status' => 'path', 'path' => implode(' ', $parts));
+    }
+
+    /**
+     * @param array<int, string> $parts
+     */
+    private function appendVectorPathPart(array &$parts, int &$pathBytes, string $part): bool
+    {
+        $pathBytes += strlen($part) + ( empty($parts) ? 0 : 1 );
+        if ( $pathBytes > self::MAX_VECTOR_COMMAND_BLOB_PATH_BYTES ) {
+            return false;
+        }
+
+        $parts[] = $part;
+        return true;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -42,6 +42,7 @@ $quadraticCommandBlob = chr(0)
     . chr(1) . pack('g', 0.0) . pack('g', 0.0)
     . chr(3) . pack('g', 4.0) . pack('g', 8.0) . pack('g', 8.0) . pack('g', 0.0)
     . chr(0);
+$oversizedCommandBlob = chr(1) . pack('g', 0.0) . pack('g', 0.0) . str_repeat(chr(2) . pack('g', 1.0) . pack('g', 1.0), 10001);
 
 $scenegraph = array(
     'name'   => 'Fixture Site',
@@ -177,6 +178,37 @@ $assert(str_contains($css, '.figma-node-1-2-hero-title{font-size:48px;font-weigh
 $assert(str_contains($css, '.figma-node-1-4-hero-image-rectangle{width:320px;height:180px;position:absolute;left:10px;top:20px;background:#ff0000;background-image:url("assets/hero-image.svg")'), 'css-rectangle-asset-style');
 $assert(str_contains($css, '.figma-node-1-5-nested-image-paint{') && str_contains($css, 'background-image:url("assets/fixture-photo.jpg")'), 'css-nested-image-hash-asset-style');
 $assert('fixture image bytes' === $fileContent($result, 'assets/fixture-photo.jpg'), 'asset-content-preserved');
+
+$oversizedCommandResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Oversized Command Blob Fixture',
+    'blobs' => array(array('bytes' => $oversizedCommandBlob)),
+    'nodes' => array(
+        array(
+            'id'       => 'oversized:root',
+            'type'     => 'FRAME',
+            'name'     => 'Oversized command root',
+            'width'    => 100,
+            'height'   => 100,
+            'children' => array(
+                array(
+                    'id'           => 'oversized:vector',
+                    'type'         => 'VECTOR',
+                    'name'         => 'Oversized vector command blob',
+                    'width'        => 10,
+                    'height'       => 10,
+                    'fillGeometry' => array(array('commandsBlob' => 0)),
+                ),
+            ),
+        ),
+    ),
+));
+$oversizedCommandDiagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    $oversizedCommandResult['diagnostics'] ?? array()
+);
+$assert(in_array('unsupported_vector_command_blob', $oversizedCommandDiagnosticCodes, true), 'oversized-command-blob-diagnostic');
+$oversizedCommandTransformDiagnostics = $oversizedCommandResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$assert(1 === ($oversizedCommandTransformDiagnostics['vectors']['placeholders'] ?? null), 'oversized-command-blob-placeholder');
 
 $missingEmissionResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Missing Emission Diagnostics Fixture',


### PR DESCRIPTION
## Summary
- Bounds direct vector command blob decoding by command count and emitted SVG path bytes.
- Keeps oversized/degenerate command blobs on the existing unsupported-vector diagnostic/placeholder path instead of allowing unbounded path assembly.
- Adds synthetic contract coverage for an oversized command blob.

## Evidence
- `composer test:contract` passes.
- FSE fixture coverage generated with `php -d memory_limit=1G bin/figma-transformer "/Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig" --zstd-command=/opt/homebrew/bin/zstd --max-kiwi-message-decode-bytes=1 --multi-page --output-dir=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/figma-blob-coverage.vOaPsJ`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** FSE blob coverage investigation, parser safety patch, synthetic test, and PR drafting.