### PR TITLE
figma-transformer: preserve paint blend modes

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -400,7 +400,7 @@ final class FigKiwiDecoder
             // `skipField()` and every .fig text node emits flat, single-style text.
             'TextData' => array('characters', 'layoutSize', 'characterStyleIDs', 'styleOverrideTable'),
             'Number' => array('value', 'units'),
-            'Paint' => array('type', 'color', 'opacity', 'visible', 'stops', 'transform', 'image', 'imageScaleMode', 'originalImageWidth', 'originalImageHeight', 'altText'),
+            'Paint' => array('type', 'color', 'opacity', 'visible', 'blendMode', 'stops', 'transform', 'image', 'imageThumbnail', 'imageScaleMode', 'originalImageWidth', 'originalImageHeight', 'altText'),
             // Effect struct (#328). The Kiwi blur token is `FOREGROUND_BLUR`
             // (REST calls it `LAYER_BLUR`); the normalizer bridges both. `offset`
             // resolves to the whitelisted `Vector` struct and `color` to `Color`.

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3402,6 +3402,10 @@ final class StaticHtmlEmitter
         if ( ! empty($assetPaths) ) {
             $urlList = implode(',', array_map(static fn (string $p): string => 'url("' . $p . '")', $assetPaths));
             $styles[] = 'background-image:' . $urlList;
+            $blendModes = $this->imageBackgroundBlendModes($node);
+            if ( ! empty($blendModes) ) {
+                $styles[] = 'background-blend-mode:' . implode(',', $blendModes);
+            }
             foreach ( $this->imageBackgroundStyles($node) as $style ) {
                 $styles[] = $style;
             }
@@ -5048,6 +5052,41 @@ final class StaticHtmlEmitter
         }
 
         return array('background-size:cover', 'background-position:center');
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function imageBackgroundBlendModes(array $node): array
+    {
+        $blendModes = array();
+        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+            $paintCollections = array();
+            if ( is_array($node[$paintKey] ?? null) ) {
+                $paintCollections[] = $node[$paintKey];
+            }
+            if ( is_array($node['figma_paints'][$paintKey] ?? null) ) {
+                $paintCollections[] = $node['figma_paints'][$paintKey];
+            }
+
+            foreach ( $paintCollections as $paints ) {
+                foreach ( array_reverse(array_values($paints)) as $paint ) {
+                    if ( ! is_array($paint) || 'IMAGE' !== strtoupper((string) ($paint['type'] ?? '')) || false === ($paint['visible'] ?? true) ) {
+                        continue;
+                    }
+
+                    $blendMode = null;
+                    if ( isset($paint['blendMode']) && is_scalar($paint['blendMode']) ) {
+                        $blendMode = $this->blendModeCss((string) $paint['blendMode']);
+                    }
+
+                    $blendModes[] = $blendMode ?? 'normal';
+                }
+            }
+        }
+
+        return in_array(true, array_map(static fn (string $mode): bool => 'normal' !== $mode, $blendModes), true) ? $blendModes : array();
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -3163,6 +3163,9 @@ final class ScenegraphNormalizer
             if ( isset($paint['opacity']) && is_numeric($paint['opacity']) ) {
                 $normalized['opacity'] = (float) $paint['opacity'];
             }
+            if ( isset($paint['blendMode']) && is_scalar($paint['blendMode']) ) {
+                $normalized['blendMode'] = strtoupper((string) $paint['blendMode']);
+            }
 
             return $normalized;
         }
@@ -3201,6 +3204,9 @@ final class ScenegraphNormalizer
                     $normalized[$key] = (string) $paint[$key];
                 }
             }
+            if ( isset($paint['blendMode']) && is_scalar($paint['blendMode']) ) {
+                $normalized['blendMode'] = strtoupper((string) $paint['blendMode']);
+            }
             foreach ( array('originalImageWidth', 'originalImageHeight', 'scale', 'rotation', 'opacity') as $key ) {
                 if ( isset($paint[$key]) && is_numeric($paint[$key]) ) {
                     $normalized[$key] = (float) $paint[$key];
@@ -3228,6 +3234,9 @@ final class ScenegraphNormalizer
                 );
                 if ( isset($paint['opacity']) && is_numeric($paint['opacity']) ) {
                     $normalized['opacity'] = (float) $paint['opacity'];
+                }
+                if ( isset($paint['blendMode']) && is_scalar($paint['blendMode']) ) {
+                    $normalized['blendMode'] = strtoupper((string) $paint['blendMode']);
                 }
                 if ( is_array($paint['gradientTransform'] ?? null) ) {
                     $normalized['gradientTransform'] = $paint['gradientTransform'];

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4628,6 +4628,44 @@ $blendModeCss = $fileContent($blendModeResult, 'style.css');
 $assert(str_contains($blendModeCss, '.figma-node-blend-1-multiply-layer{') && str_contains($blendModeCss, 'mix-blend-mode:multiply'), 'node-blend-mode-multiply-emits');
 $assert(1 === substr_count($blendModeCss, 'mix-blend-mode'), 'node-blend-mode-normal-and-pass-through-omit');
 
+// Paint-level blendMode maps to CSS background-blend-mode for image layers.
+// NORMAL remains omitted, while mixed image layers keep one blend token per
+// background-image layer so CSS applies the non-default mode to the right layer.
+$paintBlendModeResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'   => 'Paint Blend Mode Fixture',
+    'assets' => array(
+        'blend-top'    => array('mime_type' => 'image/png', 'content' => 'top image'),
+        'blend-bottom' => array('mime_type' => 'image/png', 'content' => 'bottom image'),
+        'blend-normal' => array('mime_type' => 'image/png', 'content' => 'normal image'),
+    ),
+    'nodes'  => array(
+        array(
+            'id'         => 'paint-blend:mixed',
+            'type'       => 'RECTANGLE',
+            'name'       => 'Mixed paint blends',
+            'width'      => 100,
+            'height'     => 80,
+            'fillPaints' => array(
+                array('type' => 'IMAGE', 'imageRef' => 'blend-bottom', 'blendMode' => 'NORMAL'),
+                array('type' => 'IMAGE', 'imageRef' => 'blend-top', 'blendMode' => 'MULTIPLY'),
+            ),
+        ),
+        array(
+            'id'         => 'paint-blend:normal',
+            'type'       => 'RECTANGLE',
+            'name'       => 'Normal paint blend',
+            'width'      => 100,
+            'height'     => 80,
+            'fillPaints' => array(
+                array('type' => 'IMAGE', 'imageRef' => 'blend-normal', 'blendMode' => 'NORMAL'),
+            ),
+        ),
+    ),
+));
+$paintBlendModeCss = $fileContent($paintBlendModeResult, 'style.css');
+$assert(str_contains($paintBlendModeCss, '.figma-node-paint-blend-mixed-mixed-paint-blends{width:100px;height:80px;background-image:url("assets/blend-top.png"),url("assets/blend-bottom.png");background-blend-mode:multiply,normal;background-size:cover;background-position:center}'), 'paint-blend-mode-image-layers-emit-background-blend');
+$assert(1 === substr_count($paintBlendModeCss, 'background-blend-mode'), 'paint-blend-mode-normal-omits-background-blend');
+
 // Inline character-level style overrides (characterStyleOverrides + styleOverrideTable).
 //
 // The Figma API encodes per-character style overrides as a parallel array of integer


### PR DESCRIPTION
## Summary
- decode raw Kiwi paint-level blendMode and imageThumbnail fields
- preserve paint blendMode through normalization for solid, image, and gradient paints
- emit CSS background-blend-mode for image paint layers when a non-default paint blend mode is present
- add synthetic contract coverage for mixed image paint blend modes while keeping NORMAL omitted

## Verification
- composer test:contract
- FSE raw paint inventory with zstd command adapter against `figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig`
- FSE transform evidence with zstd command adapter: status `success_with_warnings`, diagnostics limited to zstd adapter/use, design system extracted, missing font CSS

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Paint payload inventory, implementation, synthetic test coverage, and verification.