### PR TITLE
figma-transformer: resolve nested instance sources on demand

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -684,7 +684,7 @@ final class ScenegraphNormalizer
                 continue;
             }
 
-            $resolved = $this->cloneComponentForInstance($components[$reference['id']], $node, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles);
+            $resolved = $this->cloneComponentForInstance($components[$reference['id']], $node, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, array($id));
             $nodeMap[$id] = $resolved;
             $resolvedCount++;
         }
@@ -773,7 +773,7 @@ final class ScenegraphNormalizer
         $sourceBox = is_array($refreshed['box'] ?? null) ? $refreshed['box'] : array();
         $merged = '' !== $cloneId ? $this->retargetComponentSourceIds($refreshed, $sourceId, $cloneId) : $refreshed;
 
-        foreach ( array('id', 'figma_component_source_id', 'box', 'figma_box', 'layout') as $key ) {
+        foreach ( array('id', 'figma_component_source_id', 'box', 'figma_box', 'layout', 'x', 'y', 'width', 'height') as $key ) {
             if ( array_key_exists($key, $clone) ) {
                 $merged[$key] = $clone[$key];
             }
@@ -1235,7 +1235,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $nodeMap
      * @return array<string, mixed>
      */
-    private function cloneComponentForInstance(array $component, array $instance, string $componentId, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array()): array
+    private function cloneComponentForInstance(array $component, array $instance, string $componentId, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $resolutionTrail = array()): array
     {
         $context = $this->buildInstanceCloneContext($component, $instance, $componentId, $overrides);
         $resolved = $component;
@@ -1265,7 +1265,7 @@ final class ScenegraphNormalizer
             )
         );
         $resolvedChildren = is_array($resolved['children'] ?? null) ? $resolved['children'] : array();
-        $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap);
+        $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $resolutionTrail);
         $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
         $componentBox = is_array($component['box'] ?? null) ? $component['box'] : array();
         $componentSourceX = isset($componentBox['x']) && is_numeric($componentBox['x']) ? (float) $componentBox['x'] : null;
@@ -1817,7 +1817,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $nodeMap
      * @return array<int, mixed>
      */
-    private function resolveClonedInstanceChildren(array $children, array $nodeMap): array
+    private function resolveClonedInstanceChildren(array $children, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $resolutionTrail = array()): array
     {
         foreach ( $children as $index => $child ) {
             if ( ! is_array($child) ) {
@@ -1826,11 +1826,19 @@ final class ScenegraphNormalizer
 
             $id = (string) ($child['id'] ?? '');
             if ( 'INSTANCE' === strtoupper((string) ($child['type'] ?? '')) && '' !== $id && isset($nodeMap[$id]) ) {
-                $child = $this->mergeRefreshedComponentSource($child, $nodeMap[$id], $id);
+                $refreshed = $nodeMap[$id];
+                $reference = $this->readComponentReference($refreshed);
+                if ( empty($refreshed['children']) && null !== $reference && isset($components[$reference['id']]) && ! in_array($id, $resolutionTrail, true) ) {
+                    $overrides = $this->normalizeInstanceOverrides($refreshed, $id, $diagnostics);
+                    if ( null !== $overrides ) {
+                        $refreshed = $this->cloneComponentForInstance($components[$reference['id']], $refreshed, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, array_merge($resolutionTrail, array($id)));
+                    }
+                }
+                $child = $this->mergeRefreshedComponentSource($child, $refreshed, $id);
             }
 
             if ( is_array($child['children'] ?? null) ) {
-                $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap);
+                $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $resolutionTrail);
             }
 
             $children[$index] = $child;
@@ -2009,7 +2017,7 @@ final class ScenegraphNormalizer
             if ( null !== $swapComponentId && isset($components[$swapComponentId]) ) {
                 $child = $this->mergeRefreshedComponentSource($child, $components[$swapComponentId], $swapComponentId);
                 if ( is_array($child['children'] ?? null) ) {
-                    $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap);
+                    $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles);
                 }
                 $child['_figma_instance_override_applied'] = true;
             }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5992,6 +5992,39 @@ $nestedImageOverrideCss = $fileContent($nestedImageOverrideResult, 'style.css');
 $assert(str_contains($nestedImageOverrideCss, '.figma-node-instance-preview-700-4-700-2-image'), 'nested-image-override-emits-nested-image-node');
 $assert(str_contains($nestedImageOverrideCss, 'background-image:url("assets/override-image.bin"),url("assets/default-image.bin")'), 'nested-image-override-preserves-instance-fill-paints');
 
+$lateNestedInstanceSourceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'        => 'Late Nested Instance Source Fixture',
+    'nodeChanges' => array(
+        array('guid' => array('sessionID' => 1, 'localID' => 1), 'type' => 'FRAME', 'name' => 'Page'),
+        array('guid' => array('sessionID' => 10, 'localID' => 1), 'type' => 'COMPONENT', 'name' => 'Inner component'),
+        array(
+            'guid'        => array('sessionID' => 10, 'localID' => 2),
+            'parentIndex' => array('guid' => array('sessionID' => 10, 'localID' => 1)),
+            'type'        => 'TEXT',
+            'name'        => 'Inner text',
+            'characters'  => 'Nested source content',
+        ),
+        array('guid' => array('sessionID' => 20, 'localID' => 1), 'type' => 'COMPONENT', 'name' => 'Outer component'),
+        array(
+            'guid'        => array('sessionID' => 100, 'localID' => 1),
+            'parentIndex' => array('guid' => array('sessionID' => 1, 'localID' => 1)),
+            'type'        => 'INSTANCE',
+            'name'        => 'Outer instance',
+            'symbolData'  => array('symbolID' => array('sessionID' => 20, 'localID' => 1)),
+        ),
+        array(
+            'guid'        => array('sessionID' => 200, 'localID' => 1),
+            'parentIndex' => array('guid' => array('sessionID' => 20, 'localID' => 1)),
+            'type'        => 'INSTANCE',
+            'name'        => 'Inner slot',
+            'symbolData'  => array('symbolID' => array('sessionID' => 10, 'localID' => 1)),
+        ),
+    ),
+));
+$lateNestedInstanceSourceHtml = $fileContent($lateNestedInstanceSourceResult, 'index.html');
+$assert(str_contains($lateNestedInstanceSourceHtml, 'Nested source content'), 'late-nested-instance-source-renders-descendants');
+$assert(str_contains($lateNestedInstanceSourceHtml, 'data-figma-node-id="100:1/200:1/10:2"'), 'late-nested-instance-source-preserves-namespaced-descendant-id');
+
 // Component-property (componentPropAssignments) text overrides (#329 / FSE Pilot).
 //
 // Figma binds per-instance text content through component properties rather than


### PR DESCRIPTION
## Summary
- Resolve unresolved nested instance source shells on demand while cloning parent component instances.
- Preserve cloned placement geometry when refreshing source instance content.
- Add contract coverage for late-resolved nested instance descendants.

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, implementation, and contract coverage.