### PR TITLE
figma-transformer: map Kiwi distributed spacing

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3444,7 +3444,9 @@ final class StaticHtmlEmitter
             }
         }
 
-        if ( isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ) {
+        $justifyContent = (string) ($layout['justify_content'] ?? '');
+        $usesDistributedMainAxis = in_array($justifyContent, array('space-between', 'space-around', 'space-evenly'), true);
+        if ( ! $usesDistributedMainAxis && isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ) {
             $mainGap = $this->number((float) $layout['item_spacing']);
             if ( 'wrap' === ($layout['flex_wrap'] ?? null)
                 && isset($layout['counter_axis_spacing'])

--- a/figma-transformer/src/Html/VisualNodeMapBuilder.php
+++ b/figma-transformer/src/Html/VisualNodeMapBuilder.php
@@ -118,6 +118,10 @@ final class VisualNodeMapBuilder
         $childX = $paddingLeft;
         $childY = $paddingTop;
         $gap = isset($layout['item_spacing']) && is_numeric($layout['item_spacing']) ? (float) $layout['item_spacing'] : 0.0;
+        $justifyContent = (string) ($layout['justify_content'] ?? '');
+        if ( in_array($justifyContent, array('space-between', 'space-around', 'space-evenly'), true) ) {
+            $gap = 0.0;
+        }
         $isRow = 'row' === ($layout['flex_direction'] ?? null);
         $isFlex = 'flex' === ($layout['display'] ?? null);
         $contentWidth = isset($box['width']) && is_numeric($box['width']) ? max(0.0, (float) $box['width'] - $paddingLeft - $paddingRight) : null;

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -4892,6 +4892,7 @@ final class ScenegraphNormalizer
             'CENTER' => 'center',
             'MAX' => 'flex-end',
             'SPACE_BETWEEN' => 'space-between',
+            'SPACE_EVENLY' => 'space-between',
             'BASELINE' => 'baseline',
             'STRETCH' => 'stretch',
             default => null,

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -75,6 +75,37 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $visualFlexOffCanvasNodes = $visualFlexOffCanvasResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['off_canvas_visual_nodes'] ?? array();
     $assert('flex_flow_overflow' === ($visualFlexOffCanvasNodes[0]['classification'] ?? null), 'visual-map-flex-off-canvas-classification');
 
+    $visualDistributedSpacingResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Visual Distributed Spacing Fixture',
+        'nodes' => array(
+            array(
+                'id'                    => 'visual-distributed:row',
+                'type'                  => 'FRAME',
+                'name'                  => 'Distributed row',
+                'width'                 => 1440,
+                'height'                => 131,
+                'layoutMode'            => 'HORIZONTAL',
+                'stackPrimaryAlignItems' => 'SPACE_EVENLY',
+                'counterAxisAlignItems' => 'CENTER',
+                'paddingLeft'           => 112,
+                'paddingRight'          => 112,
+                'itemSpacing'           => 920,
+                'children'              => array(
+                    array('id' => 'visual-distributed:first', 'type' => 'RECTANGLE', 'name' => 'First child', 'width' => 228, 'height' => 35),
+                    array('id' => 'visual-distributed:second', 'type' => 'RECTANGLE', 'name' => 'Second child', 'width' => 265, 'height' => 26),
+                    array('id' => 'visual-distributed:third', 'type' => 'TEXT', 'name' => 'Third child', 'characters' => 'Proudly powered by WordPress.com', 'width' => 281, 'height' => 26),
+                ),
+            ),
+        ),
+    ));
+    $visualDistributedThird = blocks_engine_figma_transformer_contract_find_visual_node($visualDistributedSpacingResult, 'visual-distributed:third');
+    $visualDistributedOffCanvasNodes = $visualDistributedSpacingResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['off_canvas_visual_nodes'] ?? array();
+    $visualDistributedCss = blocks_engine_figma_transformer_contract_file_content($visualDistributedSpacingResult, 'index.html');
+    $assert(1047.0 === ($visualDistributedThird['rect']['x'] ?? null), 'visual-map-distributed-spacing-third-x');
+    $assert(array() === $visualDistributedOffCanvasNodes, 'visual-map-distributed-spacing-no-off-canvas');
+    $assert(str_contains($visualDistributedCss, 'justify-content:space-between'), 'visual-map-distributed-spacing-emits-justify-content');
+    $assert(! str_contains($visualDistributedCss, 'gap:920px'), 'visual-map-distributed-spacing-suppresses-packed-gap');
+
     $visualFlexCrossOverflowMap = (new Automattic\BlocksEngine\FigmaTransformer\Html\VisualNodeMapBuilder())->build(array(
         array(
             'id'       => 'visual-cross:column',


### PR DESCRIPTION
## Summary
- Map Kiwi SPACE_EVENLY main-axis alignment into distributed CSS layout.
- Suppress fixed itemSpacing gaps when distributed justify-content owns main-axis spacing.
- Add visual-map contract coverage for the footer overflow shape.

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, implementation, and contract coverage.