### PR TITLE
figma-transformer: classify empty form control chrome

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2485,7 +2485,7 @@ final class StaticHtmlEmitter
             $layout['decorative_underlays']['nodes'][] = $this->decorativeUnderlayDiagnostic($node, $parentNode);
         }
 
-        $emptyContainer = $this->emptyVisibleContainerDiagnostic($node);
+        $emptyContainer = $this->emptyVisibleContainerDiagnostic($node, $parentNode);
         if ( null !== $emptyContainer ) {
             $layout['empty_visible_containers'][] = $emptyContainer;
             $category = (string) ($emptyContainer['category'] ?? 'empty_visible_container');
@@ -3027,7 +3027,7 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $node
      * @return array<string, mixed>|null
      */
-    private function emptyVisibleContainerDiagnostic(array $node): ?array
+    private function emptyVisibleContainerDiagnostic(array $node, ?array $parentNode = null): ?array
     {
         $type = strtoupper((string) ($node['type'] ?? ''));
         if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION'), true) || false === ($node['visible'] ?? true) ) {
@@ -3043,7 +3043,7 @@ final class StaticHtmlEmitter
             return null;
         }
 
-        $category = $this->emptyVisibleContainerCategory($node, $type, $width, $height);
+        $category = $this->emptyVisibleContainerCategory($node, $type, $width, $height, $parentNode);
 
         return array(
             'node_id' => (string) ($node['id'] ?? ''),
@@ -3053,18 +3053,22 @@ final class StaticHtmlEmitter
             'width' => $this->reportNumericValue($width),
             'height' => $this->reportNumericValue($height),
             'category' => $category,
-            'blocks_parity' => 'decorative_zero_height_separator' !== $category,
+            'blocks_parity' => ! $this->isNonBlockingEmptyVisibleContainerCategory($category),
         );
     }
 
     /**
      * @param array<string, mixed> $node
      */
-    private function emptyVisibleContainerCategory(array $node, string $type, float $width, float $height): string
+    private function emptyVisibleContainerCategory(array $node, string $type, float $width, float $height, ?array $parentNode = null): string
     {
         $name = trim((string) ($node['name'] ?? ''));
         if ( $height <= 1.0 && preg_match('/^[\x{2013}\x{2014}-]+$/u', $name) ) {
             return 'decorative_zero_height_separator';
+        }
+
+        if ( $this->isFormControlChrome($node, $parentNode, $width, $height) ) {
+            return 'form_control_chrome';
         }
 
         if ( 'INSTANCE' === $type ) {
@@ -3072,6 +3076,44 @@ final class StaticHtmlEmitter
         }
 
         return 'empty_visible_container';
+    }
+
+    private function isNonBlockingEmptyVisibleContainerCategory(string $category): bool
+    {
+        return in_array($category, array('decorative_zero_height_separator', 'form_control_chrome'), true);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed>|null $parentNode
+     */
+    private function isFormControlChrome(array $node, ?array $parentNode, float $width, float $height): bool
+    {
+        if ( null === $parentNode || $width < 10.0 || $height < 10.0 || $width > 40.0 || $height > 40.0 || abs($width - $height) > 2.0 ) {
+            return false;
+        }
+
+        if ( empty($this->strokeStyles($node)) ) {
+            return false;
+        }
+
+        $layout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        if ( ! in_array((string) ($layout['flex_direction'] ?? ''), array('row', 'row-reverse'), true) && 'HORIZONTAL' !== ($layout['mode'] ?? null) ) {
+            return false;
+        }
+
+        $nodeId = (string) ($node['id'] ?? '');
+        foreach ( $this->nodeList($parentNode) as $sibling ) {
+            if ( ! is_array($sibling) || $nodeId === (string) ($sibling['id'] ?? '') ) {
+                continue;
+            }
+
+            if ( '' !== trim($this->subtreePlainText($sibling)) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -491,16 +491,21 @@ $emptyVisibleContainerResult = blocks_engine_figma_transformer_transform_scenegr
                 array('id' => 'empty-container:separator', 'type' => 'FRAME', 'name' => '–', 'width' => 320, 'height' => 0.0002),
                 array('id' => 'empty-container:instance', 'type' => 'INSTANCE', 'name' => 'Missing component body', 'width' => 180, 'height' => 48),
                 array('id' => 'empty-container:frame', 'type' => 'FRAME', 'name' => 'Empty visual frame', 'width' => 24, 'height' => 24),
+                array('id' => 'empty-container:checkbox-row', 'type' => 'FRAME', 'name' => 'Checkbox row', 'width' => 240, 'height' => 24, 'layoutMode' => 'HORIZONTAL', 'itemSpacing' => 8, 'children' => array(
+                    array('id' => 'empty-container:checkbox', 'type' => 'FRAME', 'name' => 'Checkbox', 'width' => 24, 'height' => 24, 'strokeAlign' => 'INSIDE', 'strokeWeight' => 1, 'strokes' => array(array('type' => 'SOLID', 'color' => array('r' => 0.5, 'g' => 0.5, 'b' => 0.5, 'a' => 1)))),
+                    array('id' => 'empty-container:checkbox-label', 'type' => 'TEXT', 'name' => 'Checkbox label', 'characters' => 'Save my details', 'width' => 120, 'height' => 21, 'fontSize' => 14),
+                )),
             ),
         ),
     ),
 ));
 $emptyVisibleLayout = $emptyVisibleContainerResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
-$assert(3 === ($emptyVisibleLayout['empty_visible_container_count'] ?? null), 'empty-visible-container-classification-count');
+$assert(4 === ($emptyVisibleLayout['empty_visible_container_count'] ?? null), 'empty-visible-container-classification-count');
 $assert(2 === ($emptyVisibleLayout['empty_visible_container_blocker_count'] ?? null), 'empty-visible-container-classification-blocker-count');
 $assert(1 === ($emptyVisibleLayout['empty_visible_container_categories']['decorative_zero_height_separator'] ?? null), 'empty-visible-container-classification-decorative-count');
 $assert(1 === ($emptyVisibleLayout['empty_visible_container_categories']['missing_instance_descendants'] ?? null), 'empty-visible-container-classification-instance-count');
 $assert(1 === ($emptyVisibleLayout['empty_visible_container_categories']['empty_visible_container'] ?? null), 'empty-visible-container-classification-frame-count');
+$assert(1 === ($emptyVisibleLayout['empty_visible_container_categories']['form_control_chrome'] ?? null), 'empty-visible-container-classification-form-control-count');
 $emptyVisibleById = array();
 foreach ( is_array($emptyVisibleLayout['empty_visible_containers'] ?? null) ? $emptyVisibleLayout['empty_visible_containers'] : array() as $sample ) {
     if ( is_array($sample) ) {
@@ -508,6 +513,8 @@ foreach ( is_array($emptyVisibleLayout['empty_visible_containers'] ?? null) ? $e
     }
 }
 $assert(false === ($emptyVisibleById['empty-container:separator']['blocks_parity'] ?? null), 'empty-visible-container-decorative-non-blocking');
+$assert(false === ($emptyVisibleById['empty-container:checkbox']['blocks_parity'] ?? null), 'empty-visible-container-form-control-non-blocking');
+$assert('form_control_chrome' === ($emptyVisibleById['empty-container:checkbox']['category'] ?? null), 'empty-visible-container-form-control-category');
 $assert(true === ($emptyVisibleById['empty-container:instance']['blocks_parity'] ?? null), 'empty-visible-container-instance-blocking');
 $assert('missing_instance_descendants' === ($emptyVisibleById['empty-container:instance']['category'] ?? null), 'empty-visible-container-instance-category');
 


### PR DESCRIPTION
## Summary
- Classify small stroked empty squares in horizontal text rows as form control chrome.
- Treat form control chrome as non-blocking in empty visible container diagnostics.
- Add contract coverage for checkbox-style chrome beside label text.

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, implementation, and contract coverage.