### PR TITLE
php-transformer: preserve class-owned vertical flex

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -33,10 +33,12 @@ trait StyleResolutionTrait
      * Resolve an element's presentation into canonical block attributes.
      *
      * The merged CSS is translated into the canonical block `style` OBJECT
-     * (typography/color/spacing/border) plus the `layout` attribute. A raw inline
+     * (typography/color/spacing/border) plus the `layout` attribute. Class-owned
+     * vertical flex CSS stays owned by the preserved `className` to avoid
+     * WordPress `is-vertical` layout classes overriding source CSS. A raw inline
      * `style` STRING is never emitted on a block: declarations that do not map to
-     * a block support are dropped and ride on the preserved `className` instead
-     * (#261). Frozen responsive/JS hidden base states are normalized away (#259).
+     * a block support are dropped and ride on `className` instead (#261). Frozen
+     * responsive/JS hidden base states are normalized away (#259).
      *
      * @return array<string, mixed>
      */
@@ -417,20 +419,26 @@ trait StyleResolutionTrait
             }
         }
 
-        $style = strtolower('' !== trim($mergedStyle) ? $mergedStyle : $this->attr($element, 'style'));
-        if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $style) ) {
+        $inlineStyle = strtolower($this->attr($element, 'style'));
+        if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $inlineStyle) ) {
             // flex-direction: column / column-reverse is a vertical main axis. A
             // core/group flex layout defaults to a horizontal Row, so the
             // orientation must be made explicit or the children render
             // side-by-side instead of stacked. Row / row-reverse / default flex
             // keeps the implicit horizontal orientation.
-            if ( preg_match('/(?:^|;)\s*flex-direction\s*:\s*column(?:-reverse)?\b/', $style) ) {
+            if ( preg_match('/(?:^|;)\s*flex-direction\s*:\s*column(?:-reverse)?\b/', $inlineStyle) ) {
                 return array(
                     'type'        => 'flex',
                     'orientation' => 'vertical',
                 );
             }
 
+            return array( 'type' => 'flex' );
+        }
+        $style = strtolower('' !== trim($mergedStyle) ? $mergedStyle : $this->attr($element, 'style'));
+        if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $style)
+            && ! preg_match('/(?:^|;)\s*flex-direction\s*:\s*column(?:-reverse)?\b/', $style)
+        ) {
             return array( 'type' => 'flex' );
         }
         if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?grid\b/', $style) ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2170,11 +2170,13 @@ if ( ! str_contains($result['serialized_blocks'], '<!-- wp:heading {"content":"H
 // a block support rides on `className`, and responsive/JS-revealed base hidden
 // states (display:none) are never frozen onto content-bearing elements.
 $canonicalStyleResult = ( new HtmlTransformer() )->transform(
-    '<main>'
+    '<style>.class-owned-flex{display:flex;flex-direction:column;gap:1rem}</style>'
+    . '<main>'
     . '<h2 class="eyebrow" style="font-size:2rem;color:#c0392b;font-weight:700">Styled heading</h2>'
     . '<p class="lede" style="color:#222;line-height:1.6">Styled paragraph</p>'
     . '<div class="hero" style="display:flex;gap:1rem;padding:2rem;background:#101010;color:#fff;position:fixed;inset:0;overflow:hidden">'
     . '<h3>Hero heading</h3><p>Hero content</p></div>'
+    . '<div class="class-owned-flex"><p>Class-owned layout</p></div>'
     . '<nav class="main-nav" style="display:none;gap:1.6rem"><a href="/a">Home</a></nav>'
     . '</main>'
 )->toArray();
@@ -2255,6 +2257,10 @@ assertSame('flex', $hero['attrs']['layout']['type'] ?? null, 'display:flex maps 
 $assert(! is_string($hero['attrs']['style'] ?? null), 'container style is never a raw string');
 assertSame('#fff', $hero['attrs']['style']['color']['text'] ?? null, 'container color maps to style.color.text');
 $assert(str_contains((string) ($hero['attrs']['className'] ?? ''), 'hero'), 'container className is preserved for unmappable CSS');
+
+$classOwnedFlex = $findBlockByClass($canonicalStyleResult['blocks'], 'class-owned-flex');
+$assert(is_array($classOwnedFlex), 'class-owned flex container block is emitted');
+$assert(! isset($classOwnedFlex['attrs']['layout']), 'class-owned flex CSS does not synthesize a WordPress layout attribute');
 
 // Hidden-state safety (#259): a base display:none on content-bearing nav is not
 // frozen; it is normalized away and surfaced as a frozen_hidden_state finding.


### PR DESCRIPTION
## Summary
- keep class-owned vertical flex CSS under the preserved source class instead of synthesizing WordPress vertical flex layout attrs
- preserve explicit inline vertical flex layout mapping and existing horizontal flex/grid inference
- add a contract regression for class-owned vertical flex containers

## Testing
- php php-transformer/tests/contract/run.php
- php php-transformer/tests/parity/run.php
- php php-transformer/tests/unit/corpus-detectors.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the layout parity regression, implementing the transformer/test change, and running targeted verification.