### PR TITLE
figma-transformer: honor Kiwi sortPosition layer order

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -223,7 +223,7 @@ final class FigKiwiDecodePolicy
      */
     private function nodeIdentityFields(): array
     {
-        return array('guid', 'parentIndex', 'type', 'name', 'visible', 'opacity', 'blendMode');
+        return array('guid', 'parentIndex', 'sortPosition', 'type', 'name', 'visible', 'opacity', 'blendMode');
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphIndex.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphIndex.php
@@ -215,6 +215,11 @@ final class ScenegraphIndex
      */
     private function readParentSortPosition(array $node): ?string
     {
+        if ( isset($node['sortPosition']) && is_scalar($node['sortPosition']) ) {
+            $position = (string) $node['sortPosition'];
+            return '' === $position ? null : $position;
+        }
+
         if ( isset($node['parentIndex']['position']) && is_scalar($node['parentIndex']['position']) ) {
             $position = (string) $node['parentIndex']['position'];
             return '' === $position ? null : $position;
@@ -277,11 +282,23 @@ final class ScenegraphIndex
     private function sortNodeIds(array $ids, array $nodeMap, array $parentNode = array()): array
     {
         $parentMode = strtoupper((string) ($parentNode['layoutMode'] ?? $parentNode['stackMode'] ?? ''));
+        $hasExplicitLayerOrder = false;
+        foreach ( $ids as $id ) {
+            if ( isset($nodeMap[$id]['_parent_sort_position']) ) {
+                $hasExplicitLayerOrder = true;
+                break;
+            }
+        }
+
         usort(
             $ids,
-            static function (string $left, string $right) use ($nodeMap, $parentMode, $parentNode): int {
+            static function (string $left, string $right) use ($nodeMap, $parentMode, $parentNode, $hasExplicitLayerOrder): int {
                 $leftNode  = $nodeMap[$left] ?? array();
                 $rightNode = $nodeMap[$right] ?? array();
+
+                if ( $hasExplicitLayerOrder ) {
+                    return self::layerOrderKey($leftNode, $left) <=> self::layerOrderKey($rightNode, $right);
+                }
 
                 $leftBox  = self::readBounds($leftNode);
                 $rightBox = self::readBounds($rightNode);

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -299,6 +299,27 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $transitionAbsolute, array('x' => 250.0, 'y' => 20.0, 'width' => 40.0, 'height' => 24.0), 'visual-map-layout-transition-absolute-position');
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $transitionLocalCard, array('x' => 44.0, 'y' => 66.0, 'width' => 90.0, 'height' => 30.0), 'visual-map-layout-transition-freeform-local-position');
 
+    $explicitLayerOrderResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Explicit Kiwi Layer Order Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'layer-order:frame',
+                'type'     => 'FRAME',
+                'name'     => 'Layer order frame',
+                'width'    => 320,
+                'height'   => 120,
+                'children' => array(
+                    array('id' => 'layer-order:front', 'type' => 'RECTANGLE', 'name' => 'Front layer', 'x' => 0, 'y' => 80, 'width' => 100, 'height' => 20, 'sortPosition' => 'b'),
+                    array('id' => 'layer-order:back', 'type' => 'RECTANGLE', 'name' => 'Back layer', 'x' => 0, 'y' => 0, 'width' => 100, 'height' => 20, 'sortPosition' => 'a'),
+                ),
+            ),
+        ),
+    ));
+    $explicitLayerOrderHtml = blocks_engine_figma_transformer_contract_file_content($explicitLayerOrderResult, 'index.html');
+    $explicitLayerOrderBackPosition = strpos($explicitLayerOrderHtml, 'data-figma-node-id="layer-order:back"');
+    $explicitLayerOrderFrontPosition = strpos($explicitLayerOrderHtml, 'data-figma-node-id="layer-order:front"');
+    $assert(false !== $explicitLayerOrderBackPosition && false !== $explicitLayerOrderFrontPosition && $explicitLayerOrderBackPosition < $explicitLayerOrderFrontPosition, 'visual-map-explicit-sort-position-overrides-geometry-order');
+
     $nestedInstanceResult = blocks_engine_figma_transformer_contract_transform(
         array(
             'name'  => 'Nested Instance Transform Override Fixture',


### PR DESCRIPTION
## Summary
- Decode Kiwi sortPosition for node/layer order.
- Prefer explicit sibling order before geometry fallback in ScenegraphIndex.
- Add contract coverage that sortPosition overrides geometry-derived order.

## Testing
- composer test:contract
- full FSE .fig transform with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Parser parity investigation, implementation, and verification.