### PR TITLE
figma-transformer: allow skipped field inventory output

### DIFF
--- a/figma-transformer/scripts/figma-kiwi-skipped-field-inventory.php
+++ b/figma-transformer/scripts/figma-kiwi-skipped-field-inventory.php
@@ -22,7 +22,21 @@ if ( true === ($options['help'] ?? false) || '' === ($options['input'] ?? '') ) 
 
 $zstdCommand = $options['zstd_command'] ?? (getenv('FIGMA_TRANSFORMER_ZSTD_COMMAND') ?: null);
 $result = blocks_engine_figma_kiwi_inventory((string) $options['input'], is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null);
-fwrite(STDOUT, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+$json = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+$outputPath = $options['output'] ?? null;
+if ( is_string($outputPath) && '' !== $outputPath ) {
+    if ( false === file_put_contents($outputPath, $json) ) {
+        fwrite(STDERR, "Failed to write skipped-field inventory output to {$outputPath}\n");
+        exit(1);
+    }
+    fwrite(STDOUT, json_encode(array(
+        'schema' => 'blocks-engine/figma-transformer/kiwi-skipped-field-inventory-output/v1',
+        'output' => $outputPath,
+        'summary' => $result['summary'] ?? array(),
+    ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+} else {
+    fwrite(STDOUT, $json);
+}
 exit(empty($result['diagnostics']) ? 0 : 0);
 
 /**
@@ -48,7 +62,7 @@ function blocks_engine_figma_kiwi_inventory_options(array $argv): array
 
 function blocks_engine_figma_kiwi_inventory_usage(mixed $stream): void
 {
-    fwrite($stream, "Usage: figma-kiwi-skipped-field-inventory.php <path-to-fig> [--zstd-command=/opt/homebrew/bin/zstd]\n");
+    fwrite($stream, "Usage: figma-kiwi-skipped-field-inventory.php <path-to-fig> [--zstd-command=/opt/homebrew/bin/zstd] [--output=/tmp/inventory.json]\n");
 }
 
 /**

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -46,6 +46,30 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert(is_array($cli), 'kiwi-skipped-inventory-cli-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-cli-schema');
     $assert(6 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
+
+    $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
+        SyntheticFigKiwiFixtureBuilder::canvas(array(
+            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_schema_fixture()),
+            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_message_fixture()),
+        ))
+    );
+    $outputPath = tempnam(sys_get_temp_dir(), 'blocks-engine-kiwi-inventory-output-');
+    $command = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-kiwi-skipped-field-inventory.php')
+        . ' ' . escapeshellarg($fixture)
+        . ' --output=' . escapeshellarg((string) $outputPath);
+    $output = shell_exec($command);
+    @unlink($fixture);
+    $cli = is_string($output) ? json_decode($output, true) : null;
+    $written = is_string($outputPath) && is_readable($outputPath) ? json_decode((string) file_get_contents($outputPath), true) : null;
+    if ( is_string($outputPath) ) {
+        @unlink($outputPath);
+    }
+
+    $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-output/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-output-cli-schema');
+    $assert(is_array($written), 'kiwi-skipped-inventory-output-file-json');
+    $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($written['schema'] ?? null), 'kiwi-skipped-inventory-output-file-schema');
+    $assert(6 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add an --output option to the skipped Kiwi field inventory script.
- Cover JSON output writing in the inventory contract.
- Supports repeatable raw .fig/Kiwi parity ranking artifacts.

## Testing
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Parser parity investigation, tooling update, and verification.