### PR TITLE
figma-transformer: resolve text fill style refs

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -401,7 +401,7 @@ final class ScenegraphNormalizer
         }
 
         if ( 'TEXT' === $type ) {
-            $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics);
+            $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics, $paintStyles);
             if ( ! empty($text) ) {
                 $node['figma_text'] = $text;
             }

--- a/figma-transformer/src/Scenegraph/TextNormalizer.php
+++ b/figma-transformer/src/Scenegraph/TextNormalizer.php
@@ -20,7 +20,7 @@ final class TextNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    public function normalizeText(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array()): array
+    public function normalizeText(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array(), array $paintStyles = array()): array
     {
         $text = array();
 
@@ -64,7 +64,7 @@ final class TextNormalizer
             $text['derived_layout'] = $derivedLayout;
         }
 
-        $segments = $this->normalizeStyledTextSegments($node);
+        $segments = $this->normalizeStyledTextSegments($node, $paintStyles);
         if ( ! empty($segments) ) {
             $text['segments'] = $segments;
         }
@@ -413,7 +413,7 @@ final class TextNormalizer
      * @param array<string, mixed> $node
      * @return array<int, array<string, mixed>>
      */
-    private function normalizeStyledTextSegments(array $node): array
+    private function normalizeStyledTextSegments(array $node, array $paintStyles = array()): array
     {
         $segments = array();
         $rawSegments = null;
@@ -426,7 +426,7 @@ final class TextNormalizer
 
         if ( ! is_array($rawSegments) ) {
             // Fall back to character-level override encoding when no segment list is present.
-            return $this->normalizeCharacterStyleOverrideSegments($node);
+            return $this->normalizeCharacterStyleOverrideSegments($node, $paintStyles);
         }
 
         foreach ( $rawSegments as $segment ) {
@@ -466,7 +466,7 @@ final class TextNormalizer
      * @param array<string, mixed> $node
      * @return array<int, array<string, mixed>>
      */
-    private function normalizeCharacterStyleOverrideSegments(array $node): array
+    private function normalizeCharacterStyleOverrideSegments(array $node, array $paintStyles = array()): array
     {
         $textData = is_array($node['textData'] ?? null) ? $node['textData'] : array();
 
@@ -524,6 +524,12 @@ final class TextNormalizer
                 $baseStyle['color'] = $fillColor;
             }
         }
+        if ( ! isset($baseStyle['color']) ) {
+            $styleFillColor = $this->styleFillColor($node['styleIdForFill'] ?? null, $paintStyles);
+            if ( null !== $styleFillColor ) {
+                $baseStyle['color'] = $styleFillColor;
+            }
+        }
 
         $chars = preg_split('//u', $characters, -1, PREG_SPLIT_NO_EMPTY);
         if ( ! is_array($chars) ) {
@@ -570,6 +576,12 @@ final class TextNormalizer
                         $fillColor = $this->solidFillColor($overrideFills);
                         if ( null !== $fillColor ) {
                             $overrideStyle['color'] = $fillColor;
+                        }
+                    }
+                    if ( ! isset($overrideStyle['color']) ) {
+                        $styleFillColor = $this->styleFillColor($rawOverride['styleIdForFill'] ?? null, $paintStyles);
+                        if ( null !== $styleFillColor ) {
+                            $overrideStyle['color'] = $styleFillColor;
                         }
                     }
 
@@ -654,6 +666,29 @@ final class TextNormalizer
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, array<string, array<int, array<string, mixed>>>> $paintStyles
+     * @return array{r: float, g: float, b: float, a?: float}|null
+     */
+    private function styleFillColor(mixed $styleIdForFill, array $paintStyles): ?array
+    {
+        $styleId = $this->readStyleGuidId($styleIdForFill);
+        if ( null === $styleId || empty($paintStyles[$styleId]['fills']) ) {
+            return null;
+        }
+
+        return $this->solidFillColor($paintStyles[$styleId]['fills']);
+    }
+
+    private function readStyleGuidId(mixed $style): ?string
+    {
+        if ( is_array($style) && isset($style['guid']) ) {
+            return $this->readGuidId($style['guid']);
+        }
+
+        return $this->readGuidId($style);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4870,6 +4870,13 @@ $kiwiInlineTextStyleResult = blocks_engine_figma_transformer_transform_scenegrap
                 // "Hello blue " (11 chars) in base black, "world" (5 chars) in blue
                 // via a NodeChange-shaped override entry carrying `fillPaints`.
                 array(
+                    'guid'       => array('sessionID' => 3267, 'localID' => 11418),
+                    'type'       => 'ROUNDED_RECTANGLE',
+                    'name'       => 'Lego Blue',
+                    'styleType'  => 'FILL',
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 109, 'b' => 183, 'a' => 1))),
+                ),
+                array(
                     'id'         => 'kts:2',
                     'type'       => 'TEXT',
                     'name'       => 'Kiwi two color text',
@@ -4889,6 +4896,24 @@ $kiwiInlineTextStyleResult = blocks_engine_figma_transformer_transform_scenegrap
                 ),
                 // "Bold" (4 chars) at weight 700 via a NodeChange-shaped override
                 // entry carrying a bold `fontName`, " plain text" (11 chars) at base.
+                array(
+                    'id'         => 'kts:4',
+                    'type'       => 'TEXT',
+                    'name'       => 'Kiwi style-referenced text color',
+                    'fontName'   => array('family' => 'Inter', 'style' => 'Regular'),
+                    'fontSize'   => 16,
+                    'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
+                    'textData'   => array(
+                        'characters'        => 'We\'re all about Lego',
+                        'characterStyleIDs' => array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 38, 38, 38, 38),
+                        'styleOverrideTable' => array(
+                            array(
+                                'styleID'        => 38,
+                                'styleIdForFill' => array('guid' => array('sessionID' => 3267, 'localID' => 11418)),
+                            ),
+                        ),
+                    ),
+                ),
                 array(
                     'id'         => 'kts:3',
                     'type'       => 'TEXT',
@@ -4915,6 +4940,9 @@ $kiwiInlineTextStyleHtml = $fileContent($kiwiInlineTextStyleResult, 'index.html'
 // Kiwi two-color: only the "world" run differs in fill color — it gets a color span,
 // and the non-overridden "Hello blue " text is emitted unwrapped.
 $assert(str_contains($kiwiInlineTextStyleHtml, 'Hello blue <span style="color:#0000ff">world</span>'), 'kiwi-inline-style-two-color-spans');
+// Kiwi style-referenced text fill: the Lego run resolves through styleIdForFill
+// to the FILL style node instead of requiring duplicate inline fillPaints.
+$assert(str_contains($kiwiInlineTextStyleHtml, 'We&#039;re all about <span style="color:#006db7">Lego</span>'), 'kiwi-inline-style-fill-reference-spans');
 // Kiwi mixed-weight: only "Bold" differs in font-weight — derived from the override
 // entry's bold `fontName` — and " plain text" stays unwrapped.
 $assert(str_contains($kiwiInlineTextStyleHtml, '<span style="font-weight:700">Bold</span> plain text'), 'kiwi-inline-style-mixed-weight-spans');


### PR DESCRIPTION
## Summary
- Pass paint style definitions into TextNormalizer.
- Resolve Kiwi text override styleIdForFill refs into segment fill colors.
- Add contract coverage for style-referenced text fill overrides.

## Testing
- composer test:contract
- focused FSE transform for frame 3468:1038 confirms <span style="color:#006db7">Lego</span>

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Parser parity investigation, implementation, and verification.