### PR TITLE
figma-transformer: replace source image paints on overrides

### DIFF
--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -75,6 +75,51 @@ final class PaintNormalizer
         return $normalizedPaints;
     }
 
+    /**
+     * @param array<int, mixed> $overridePaints
+     * @param array<int, mixed> $sourcePaints
+     * @return array<int, mixed>
+     */
+    public function removeSourceImagePaintsFromOverrideList(array $overridePaints, array $sourcePaints): array
+    {
+        $sourceRefs = array();
+        foreach ( $sourcePaints as $paint ) {
+            $ref = is_array($paint) ? $this->readImagePaintRef($paint) : null;
+            if ( null !== $ref ) {
+                $sourceRefs[$ref] = true;
+            }
+        }
+
+        if ( empty($sourceRefs) ) {
+            return $overridePaints;
+        }
+
+        $hasReplacementImage = false;
+        foreach ( $overridePaints as $paint ) {
+            $ref = is_array($paint) ? $this->readImagePaintRef($paint) : null;
+            if ( null !== $ref && ! isset($sourceRefs[$ref]) ) {
+                $hasReplacementImage = true;
+                break;
+            }
+        }
+
+        if ( ! $hasReplacementImage ) {
+            return $overridePaints;
+        }
+
+        $filtered = array();
+        foreach ( $overridePaints as $paint ) {
+            $ref = is_array($paint) ? $this->readImagePaintRef($paint) : null;
+            if ( null !== $ref && isset($sourceRefs[$ref]) ) {
+                continue;
+            }
+
+            $filtered[] = $paint;
+        }
+
+        return $filtered;
+    }
+
     private function readStyleGuidId(mixed $style): ?string
     {
         if ( is_array($style) && isset($style['guid']) ) {
@@ -240,6 +285,28 @@ final class PaintNormalizer
         }
 
         return $this->normalizeImageHash((string) $image['hash']);
+    }
+
+    /**
+     * @param array<string, mixed> $paint
+     */
+    private function readImagePaintRef(array $paint): ?string
+    {
+        $type = strtoupper((string) ($paint['type'] ?? ''));
+        if ( '' !== $type && 'IMAGE' !== $type ) {
+            return null;
+        }
+
+        $ref = $paint['imageRef'] ?? $paint['imageHash'] ?? $paint['ref'] ?? null;
+        if ( is_scalar($ref) && '' !== (string) $ref ) {
+            return $this->normalizeImageHash((string) $ref);
+        }
+
+        if ( is_array($paint['image'] ?? null) ) {
+            return $this->readNestedImageHash($paint['image']);
+        }
+
+        return null;
     }
 
     private function normalizeImageHash(string $hash): string

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1951,7 +1951,15 @@ final class ScenegraphNormalizer
             }
             foreach ( $overrideFields as $field => $value ) {
                 $hasFieldOverride = true;
+                if ( is_array($value) ) {
+                    $value = $this->normalizeInstanceOverridePaintField($child, $field, $value);
+                }
                 $child[$field] = $value;
+                if ( in_array($field, array('fills', 'fillPaints'), true) ) {
+                    unset($child['styleIdForFill']);
+                } elseif ( in_array($field, array('strokes', 'strokePaints'), true) ) {
+                    unset($child['styleIdForStrokeFill'], $child['styleIdForStroke']);
+                }
                 if ( in_array($field, array('characters', 'text'), true) && is_array($child['figma_text'] ?? null) ) {
                     $child['figma_text']['characters'] = (string) $value;
                 }
@@ -1969,6 +1977,31 @@ final class ScenegraphNormalizer
         }
 
         return $children;
+    }
+
+    /**
+     * @param array<string, mixed> $child
+     * @param array<int, mixed>    $value
+     * @return array<int, mixed>
+     */
+    private function normalizeInstanceOverridePaintField(array $child, string $field, array $value): array
+    {
+        if ( ! in_array($field, array('fills', 'fillPaints', 'strokes', 'strokePaints'), true) ) {
+            return $value;
+        }
+
+        $sourceFields = in_array($field, array('fills', 'fillPaints'), true)
+            ? array('fillPaints', 'fills')
+            : array('strokePaints', 'strokes');
+        $sourcePaints = array();
+        foreach ( $sourceFields as $sourceField ) {
+            if ( is_array($child[$sourceField] ?? null) ) {
+                $sourcePaints = $child[$sourceField];
+                break;
+            }
+        }
+
+        return $this->paintNormalizer->removeSourceImagePaintsFromOverrideList($value, $sourcePaints);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5999,7 +5999,56 @@ $nestedImageOverrideResult = blocks_engine_figma_transformer_transform_scenegrap
 ));
 $nestedImageOverrideCss = $fileContent($nestedImageOverrideResult, 'style.css');
 $assert(str_contains($nestedImageOverrideCss, '.figma-node-instance-preview-700-4-700-2-image'), 'nested-image-override-emits-nested-image-node');
-$assert(str_contains($nestedImageOverrideCss, 'background-image:url("assets/override-image.bin"),url("assets/default-image.bin")'), 'nested-image-override-preserves-instance-fill-paints');
+$assert(str_contains($nestedImageOverrideCss, 'background-image:url("assets/override-image.bin")'), 'nested-image-override-replaces-source-image-paint');
+$assert(! str_contains($nestedImageOverrideCss, 'background-image:url("assets/override-image.bin"),url("assets/default-image.bin")'), 'nested-image-override-drops-stale-source-image-paint');
+
+$styleBackedImageOverrideResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Style Backed Image Override Fixture',
+    'nodes' => array(
+        array(
+            'guid'       => array('sessionID' => 701, 'localID' => 1),
+            'type'       => 'RECTANGLE',
+            'name'       => 'Image style source',
+            'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'styled-default-image')),
+        ),
+        array(
+            'guid'     => array('sessionID' => 701, 'localID' => 2),
+            'type'     => 'COMPONENT',
+            'name'     => 'Styled image component',
+            'children' => array(
+                array(
+                    'guid'           => array('sessionID' => 701, 'localID' => 3),
+                    'type'           => 'RECTANGLE',
+                    'name'           => 'Styled image',
+                    'width'          => 100,
+                    'height'         => 50,
+                    'styleIdForFill' => array('guid' => array('sessionID' => 701, 'localID' => 1)),
+                ),
+            ),
+        ),
+        array(
+            'id'         => 'instance:styled-preview',
+            'type'       => 'INSTANCE',
+            'name'       => 'Styled preview instance',
+            'symbolData' => array(
+                'symbolID' => array('sessionID' => 701, 'localID' => 2),
+                'symbolOverrides' => array(
+                    array(
+                        'guidPath'   => array('guids' => array(array('sessionID' => 701, 'localID' => 3))),
+                        'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'styled-override-image')),
+                    ),
+                ),
+            ),
+        ),
+    ),
+    'assets' => array(
+        array('id' => 'styled-default-image', 'content' => 'styled default'),
+        array('id' => 'styled-override-image', 'content' => 'styled override'),
+    ),
+));
+$styleBackedImageOverrideCss = $fileContent($styleBackedImageOverrideResult, 'style.css');
+$assert(str_contains($styleBackedImageOverrideCss, 'background-image:url("assets/styled-override-image.bin")'), 'style-backed-image-override-replaces-style-image-paint');
+$assert(! str_contains($styleBackedImageOverrideCss, 'styled-default-image.bin'), 'style-backed-image-override-drops-stale-style-image-paint');
 
 $lateNestedInstanceSourceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'        => 'Late Nested Instance Source Fixture',


### PR DESCRIPTION
## Summary
- Drop component-source image paints from instance override paint lists when replacement image refs are present.
- Clear inherited fill/stroke style IDs when explicit override paints are applied.
- Add contract coverage for nested and style-backed image replacement paints.

## Testing
- composer test:contract
- full FSE .fig transform with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Parser parity investigation, implementation, and verification.