### PR TITLE
Classify telemetry script self-targets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -85,6 +85,10 @@ final class RuntimeDependencyParityReport
                     continue;
                 }
 
+                if ( $this->isTelemetryScriptSelfTarget($scriptKind, $scriptPath, $target) ) {
+                    continue;
+                }
+
                 $flaggedSelectors[$selector] = true;
 
                 $severity = 'telemetry' === $scriptKind ? 'info' : 'warning';
@@ -471,7 +475,7 @@ final class RuntimeDependencyParityReport
     }
 
     /**
-     * @return array<string, array{tag: string, source_path: string, id?: string, class?: string}>
+     * @return array<string, array{tag: string, source_path: string, id?: string, class?: string, src?: string}>
      */
     private function sourceTargets(string $html, string $sourcePath): array
     {
@@ -490,13 +494,14 @@ final class RuntimeDependencyParityReport
                 continue;
             }
             $tag = strtolower($element->tagName);
+            $src = 'script' === $tag && $element->hasAttribute('src') ? trim($element->getAttribute('src')) : '';
             $id = trim($element->hasAttribute('id') ? $element->getAttribute('id') : '');
             if ( '' !== $id ) {
-                $targets['#' . $id] = array('tag' => $tag, 'source_path' => $sourcePath, 'id' => $id);
+                $targets['#' . $id] = array_filter(array('tag' => $tag, 'source_path' => $sourcePath, 'id' => $id, 'src' => $src), static fn (string $value): bool => '' !== $value);
             }
             foreach ( preg_split('/\s+/', trim($element->hasAttribute('class') ? $element->getAttribute('class') : '')) ?: array() as $class ) {
                 if ( '' !== $class ) {
-                    $targets['.' . $class] = array('tag' => $tag, 'source_path' => $sourcePath, 'class' => $class);
+                    $targets['.' . $class] = array_filter(array('tag' => $tag, 'source_path' => $sourcePath, 'class' => $class, 'src' => $src), static fn (string $value): bool => '' !== $value);
                 }
             }
         }
@@ -671,6 +676,23 @@ final class RuntimeDependencyParityReport
         }
 
         return $this->dedupeDependencies($dependencies);
+    }
+
+    /**
+     * Telemetry bundles often read configuration from their own source <script>
+     * tag. SSI materializes/enqueues scripts outside block markup, so that tag id
+     * is not a visible page DOM target that block serialization must preserve.
+     *
+     * @param array<string, mixed> $target
+     */
+    private function isTelemetryScriptSelfTarget(string $scriptKind, string $scriptPath, array $target): bool
+    {
+        if ( 'telemetry' !== $scriptKind || 'script' !== ($target['tag'] ?? '') ) {
+            return false;
+        }
+
+        $src = $this->normalizeScriptPath((string) ($target['src'] ?? ''));
+        return '' !== $src && $src === $this->normalizeScriptPath($scriptPath);
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1338,9 +1338,10 @@ $runtimeDependencySite = $compiler->compile(
     array(
         'entrypoint' => 'index.html',
         'files'      => array(
-            'index.html' => '<main><canvas id="canvas" class="stage"></canvas><canvas id="unused-canvas"></canvas><div id="status-container"><h2>Status</h2><p>Ready</p></div><script src="js/script.js"></script><script src="js/rum.js"></script></main>',
+            'index.html' => '<main><canvas id="canvas" class="stage"></canvas><canvas id="unused-canvas"></canvas><div id="status-container"><h2>Status</h2><p>Ready</p></div><script src="js/script.js"></script><script src="js/rum.js"></script><script id="netlify-rum-container" src="js/self-rum.js" data-netlify-cwv-token="token"></script></main>',
             'js/script.js' => 'const canvas = document.getElementById("canvas"); canvas.getContext("2d"); const stage = document.querySelector(".stage"); stage.getContext("2d"); const status = document.querySelector("#status-container"); status.addEventListener("click", function () {});',
             'js/rum.js' => 'document.querySelector("#netlify-rum-target");',
+            'js/self-rum.js' => 'document.querySelector("#netlify-rum-container")?.getAttribute("data-netlify-cwv-token");',
         ),
     )
 )->toArray();
@@ -1349,6 +1350,7 @@ $runtimeDependencyConversionReport = $runtimeDependencySite['source_reports']['c
 $runtimeFindings = $runtimeDependencyReport['findings'] ?? array();
 $canvasFinding = null;
 $rumFinding = null;
+$selfRumFinding = null;
 foreach ( $runtimeFindings as $finding ) {
     if ( '#canvas' === ($finding['selector'] ?? '') ) {
         $canvasFinding = $finding;
@@ -1356,10 +1358,14 @@ foreach ( $runtimeFindings as $finding ) {
     if ( '#netlify-rum-target' === ($finding['selector'] ?? '') ) {
         $rumFinding = $finding;
     }
+    if ( '#netlify-rum-container' === ($finding['selector'] ?? '') ) {
+        $selfRumFinding = $finding;
+    }
 }
 $canvasDependency = null;
 $stageDependency = null;
 $statusDependency = null;
+$selfRumDependency = null;
 foreach ( $runtimeDependencyReport['dependencies'] ?? array() as $dependency ) {
     if ( '#canvas' === ($dependency['selector'] ?? '') ) {
         $canvasDependency = $dependency;
@@ -1369,6 +1375,9 @@ foreach ( $runtimeDependencyReport['dependencies'] ?? array() as $dependency ) {
     }
     if ( '#status-container' === ($dependency['selector'] ?? '') ) {
         $statusDependency = $dependency;
+    }
+    if ( '#netlify-rum-container' === ($dependency['selector'] ?? '') ) {
+        $selfRumDependency = $dependency;
     }
 }
 $runtimeDependencyMarkup = (string) ($runtimeDependencySite['serialized_blocks'] ?? '');
@@ -1408,6 +1417,9 @@ $assert(true === ($statusDependency['generated_present'] ?? null), 'runtime depe
 $assert(false === ($statusDependency['canvas_api'] ?? null), 'runtime dependency parity does not mark non-canvas DOM targets as canvas API dependencies');
 $assert(! empty($statusDependency['events'] ?? array()), 'runtime dependency parity records simple addEventListener usage');
 $assert('info' === ($rumFinding['severity'] ?? ''), 'telemetry-like runtime dependency misses are info severity');
+$assert(null === $selfRumFinding, 'telemetry script self-target is not reported as a missing block DOM target');
+$assert(null !== $selfRumDependency, 'runtime dependency parity records telemetry script self-target dependency');
+$assert('script' === ($selfRumDependency['target_kind'] ?? ''), 'runtime dependency parity identifies telemetry script self-target kind');
 
 $decorativeCanvasSite = $compiler->compile(
     array(


### PR DESCRIPTION
## Summary
- suppress runtime DOM-target gap findings when telemetry scripts read configuration from their own source script tag id
- keep true missing telemetry targets reported as info severity
- include source script src metadata in runtime dependency target rows for this classification

## Testing
- php php-transformer/tests/contract/run.php
- php php-transformer/tests/parity/run.php

## Context
Liquid Bonsai includes a Netlify RUM script tag with id="netlify-rum-container". The script reads its own tag attributes, but SSI materializes scripts outside serialized block markup, so treating that script tag id as a missing page DOM target blocks release proof even though it is telemetry configuration, not visible runtime UI.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the telemetry self-target runtime dependency finding, implementing the analyzer classification, adding contract coverage, and running targeted verification.