### PR TITLE
php-transformer: add content round-trip hallucination check

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -39,6 +39,7 @@
     "static-parity": "php tools/static-parity/run.php",
     "live-wp-parity": "php tools/live-wp-parity/run.php",
     "corpus-diagnostics": "php tools/corpus-diagnostics/run.php",
+    "content-round-trip": "php tools/content-round-trip/run.php",
     "test": [
       "@test:canonical",
       "@test:parity",
@@ -56,6 +57,8 @@
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/custom-block-generator.php",
       "php tests/unit/css-value-splitter.php",
+      "php tests/unit/content-round-trip-reporter.php",
+      "php tests/unit/content-round-trip-form-echo.php",
       "php tests/unit/corpus-detectors.php",
       "php tests/unit/live-wp-parity-runner.php"
     ],

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/ContentRoundTripReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/ContentRoundTripReporter.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics;
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+
+/**
+ * Forward-direction content round-trip / hallucination check (#1, ported from
+ * the JS blocks-engine `output-verify.ts verifyComposedOutput()`).
+ *
+ * The structural validators ({@see \Automattic\BlocksEngine\PhpTransformer\WordPress\BlockValidityValidator})
+ * assert the OUTPUT is well-formed; the {@see SemanticParityReporter} compares
+ * landmarks and navigation menus. Neither checks that the visible COPY survived
+ * conversion intact. This reporter closes that gap: every visible text node in
+ * the serialized block output (>=3 alphanumeric characters, normalized) must
+ * appear as a substring of the normalized source plaintext. Output text that is
+ * absent from the source is "invented" copy — a sign that conversion mangled,
+ * synthesized, or duplicated content — and surfaces as a `content_not_in_source`
+ * finding.
+ *
+ * The check is deliberately one-directional (output ⊆ source). It mirrors the
+ * blocks-engine reference exactly: block-delimiter comments are stripped first,
+ * so text that lives only inside a dynamic block's JSON attributes (e.g. a
+ * core/navigation-link label) is NOT scanned as a visible node — that belongs to
+ * the navigation-parity check, not here.
+ *
+ * Pure: no DOM, no I/O, no global state; the same inputs always yield the same
+ * report.
+ */
+final class ContentRoundTripReporter
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/content-round-trip/v1';
+
+    /**
+     * Minimum alphanumeric character count for an output text node to be worth
+     * checking. Short fragments (punctuation, single glyphs, "&middot;") carry no
+     * meaningful copy and would only produce noise.
+     */
+    private const MIN_ALNUM = 3;
+
+    /**
+     * Maximum stored length of a finding's offending text snippet.
+     */
+    private const MAX_SNIPPET = 200;
+
+    /**
+     * @param array<int, string> $ignoredTexts Producer-declared text the transformer
+     *        SYNTHESIZED rather than extracted from visible source (e.g. form-control
+     *        echoes built from placeholder/value/required attributes). Such text is
+     *        legitimately absent from the source's visible copy, so flagging it would
+     *        be noise. Each entry is normalized with the same pipeline as output nodes.
+     * @return array<string, mixed>
+     */
+    public function report(string $serializedBlocks, string $sourceHtml, array $ignoredTexts = array()): array
+    {
+        $sourceText = $this->normalize($this->htmlToPlainText($sourceHtml));
+        $ignored = $this->normalizedIgnoreSet($ignoredTexts);
+        $findings = array();
+
+        foreach ( $this->extractTextNodes($serializedBlocks) as $node ) {
+            $needle = $this->normalize($node);
+            if ( '' === $needle ) {
+                continue;
+            }
+
+            if ( isset($ignored[$needle]) ) {
+                continue;
+            }
+
+            if ( ! str_contains($sourceText, $needle) ) {
+                $findings[] = ConversionFindingContract::withClassification(array(
+                    'code'     => 'content_not_in_source',
+                    'severity' => 'warning',
+                    'text'     => $this->boundedSnippet($node),
+                    'summary'  => 'Generated block text does not appear in the source content.',
+                ));
+            }
+        }
+
+        return array(
+            'schema'         => self::SCHEMA,
+            'finding_schema' => ConversionFindingContract::SCHEMA,
+            'status'         => array() === $findings ? 'pass' : 'warning',
+            'findings'       => $findings,
+        );
+    }
+
+    /**
+     * Visible text nodes from serialized block markup: drop the block-delimiter
+     * comments, split on tags, and keep fragments carrying at least
+     * {@see self::MIN_ALNUM} alphanumeric characters.
+     *
+     * @return array<int, string>
+     */
+    private function extractTextNodes(string $markup): array
+    {
+        $stripped = $this->stripBlockComments($markup);
+        $nodes = array();
+        foreach ( preg_split('/<[^>]+>/', $stripped) ?: array() as $raw ) {
+            $text = $this->htmlToPlainText($raw);
+            if ( '' === $text ) {
+                continue;
+            }
+
+            if ( strlen((string) preg_replace('/[^a-zA-Z0-9]/', '', $text)) < self::MIN_ALNUM ) {
+                continue;
+            }
+
+            $nodes[] = $text;
+        }
+
+        return $nodes;
+    }
+
+    private function stripBlockComments(string $markup): string
+    {
+        $markup = (string) preg_replace('/<!--\s*\/?wp:[^>]*-->/', ' ', $markup);
+
+        return (string) preg_replace('/<!--.*?-->/s', ' ', $markup);
+    }
+
+    private function htmlToPlainText(string $html): string
+    {
+        if ( '' === $html ) {
+            return '';
+        }
+
+        $text = (string) preg_replace('/<[^>]+>/', ' ', $html);
+
+        // Decode the FULL HTML entity set, not a hand-picked subset. The
+        // transformer parses the source DOM, so its output carries the literal
+        // glyph (©, →, —, ’) while raw-HTML sources still hold the entity
+        // (&copy;, &rarr;, &mdash;, &rsquo;). Decoding both sides identically is
+        // what keeps the substring comparison from drowning in false positives.
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // Fold non-breaking and other fixed-width Unicode spaces to a regular
+        // space; PCRE's \s does not match U+00A0 et al., so collapse them first.
+        $text = (string) preg_replace('/[\x{00A0}\x{2007}\x{202F}]/u', ' ', $text);
+
+        return trim((string) preg_replace('/\s+/u', ' ', $text));
+    }
+
+    private function normalize(string $text): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', strtolower($text)));
+    }
+
+    /**
+     * Normalize the producer-declared ignore list into a lookup keyed by the same
+     * representation output nodes are compared as, so membership tests are O(1)
+     * and tolerate the entity/whitespace/case differences the pipeline folds out.
+     *
+     * @param array<int, string> $ignoredTexts
+     * @return array<string, true>
+     */
+    private function normalizedIgnoreSet(array $ignoredTexts): array
+    {
+        $set = array();
+        foreach ( $ignoredTexts as $text ) {
+            $key = $this->normalize($this->htmlToPlainText((string) $text));
+            if ( '' !== $key ) {
+                $set[$key] = true;
+            }
+        }
+
+        return $set;
+    }
+
+    private function boundedSnippet(string $text): string
+    {
+        if ( strlen($text) <= self::MAX_SNIPPET ) {
+            return $text;
+        }
+
+        return rtrim(substr($text, 0, self::MAX_SNIPPET)) . '…';
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
@@ -28,6 +28,7 @@ final class DiagnosticsCollector
      * @param array<int, array<string, mixed>>  $runtimeIslands       Preserved runtime islands.
      * @param array<string, mixed>              $blockValidityReport  Block serialization validity report.
      * @param array<string, mixed>              $semanticParityReport Semantic parity report.
+     * @param array<string, mixed>              $contentRoundTripReport Content round-trip (hallucination) report.
      * @return array<int, array<string, mixed>>
      */
     public function collect(
@@ -36,7 +37,8 @@ final class DiagnosticsCollector
         array $fallbacks,
         array $runtimeIslands,
         array $blockValidityReport,
-        array $semanticParityReport
+        array $semanticParityReport,
+        array $contentRoundTripReport = array()
     ): array {
         $diagnostics = array(
             array(
@@ -141,6 +143,20 @@ final class DiagnosticsCollector
                 'source'   => $transformerSource,
                 'severity' => $finding['severity'] ?? 'warning',
                 'selector' => $finding['selector'] ?? null,
+            );
+        }
+
+        foreach ( $contentRoundTripReport['findings'] ?? array() as $finding ) {
+            if ( ! is_array($finding) ) {
+                continue;
+            }
+
+            $diagnostics[] = array(
+                'code'     => 'html_content_round_trip_' . (string) ($finding['code'] ?? 'warning'),
+                'message'  => (string) ($finding['summary'] ?? 'Generated block text does not appear in the source content.'),
+                'source'   => $transformerSource,
+                'severity' => $finding['severity'] ?? 'warning',
+                'text'     => $finding['text'] ?? null,
             );
         }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformationOptions;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\ContentRoundTripReporter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsCollector;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\SemanticParityReporter;
@@ -103,6 +104,18 @@ final class HtmlTransformer
     private readonly DiagnosticsCollector $diagnosticsCollector;
 
     private readonly SemanticParityReporter $semanticParityReporter;
+
+    private readonly ContentRoundTripReporter $contentRoundTripReporter;
+
+    /**
+     * Text the transformer SYNTHESIZES from form controls (label + value/
+     * placeholder/required state) rather than extracting from visible source.
+     * Declared to the content round-trip reporter so it is not mistaken for
+     * invented copy. Reset per transform().
+     *
+     * @var array<int, string>
+     */
+    private array $formControlEchoTexts = array();
 
     private readonly FallbackEmitter $fallbackEmitter;
 
@@ -259,6 +272,7 @@ final class HtmlTransformer
         ));
         $this->diagnosticsCollector = new DiagnosticsCollector();
         $this->semanticParityReporter = new SemanticParityReporter($this->runtime);
+        $this->contentRoundTripReporter = new ContentRoundTripReporter();
         $this->fallbackEmitter = new FallbackEmitter(
             $this->runtime,
             fn (DOMElement $element): array => $this->sourceContext($element)
@@ -282,6 +296,7 @@ final class HtmlTransformer
         $this->runtimeIslands = array();
         $this->nativeDisclosureRootIds = array();
         $this->generatedBlocks = array();
+        $this->formControlEchoTexts = array();
         $this->generatedBlockNamespace = $this->generatedBlockNamespaceFromOptions($options);
         $this->fallbackEmitter->resetGeneratedBlocks();
         $this->runtimeScriptMetadata = $this->runtimeScriptMetadataFromOptions($options);
@@ -367,13 +382,15 @@ final class HtmlTransformer
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
         $semanticParityReport = $this->semanticParityReporter->report($body, $blocks, $sourceProvenance, $html, (string) ($options['static_css'] ?? ''));
+        $contentRoundTripReport = $this->contentRoundTripReporter->report($serializedBlocks, $html, $this->formControlEchoTexts);
         $diagnostics = $this->diagnosticsCollector->collect(
             self::class,
             $this->scriptMetadata,
             $fallbacks,
             $this->runtimeIslands,
             $blockValidityReport,
-            $semanticParityReport
+            $semanticParityReport,
+            $contentRoundTripReport
         );
 
         $metrics = $this->metrics($html, $blocks, $serializedBlocks, $fallbacks, $diagnostics, $startedAt);
@@ -387,6 +404,7 @@ final class HtmlTransformer
             'superseded_selectors' => array_keys($this->supersededRuntimeSelectors),
             'wp_block_validity' => $blockValidityReport,
             'semantic_parity' => $semanticParityReport,
+            'content_round_trip' => $contentRoundTripReport,
             'html' => array(
                 'presentation_signals' => $this->presentationProvenance,
                 'frozen_hidden_state'  => $this->frozenHiddenStateFindings,
@@ -4594,6 +4612,7 @@ final class HtmlTransformer
     private function readableSelectBlockFromElement(DOMElement $select): ?array
     {
         $label = $this->readableFormControlLabel($select);
+        $this->registerFormControlEcho($label);
         $optionBlocks = array();
 
         foreach ( $this->selectOptions($select) as $option ) {
@@ -4606,6 +4625,7 @@ final class HtmlTransformer
                 $optionLabel .= ' (selected)';
             }
 
+            $this->registerFormControlEcho($optionLabel);
             $optionBlocks[] = $this->createBlock('core/list-item', array( 'content' => $this->runtime->escapeHtml($optionLabel) ));
         }
 
@@ -4948,7 +4968,25 @@ final class HtmlTransformer
             $text .= ' (required)';
         }
 
+        $this->registerFormControlEcho($text);
+
         return $this->runtime->escapeHtml($text);
+    }
+
+    /**
+     * Record text the transformer synthesizes from a form control (label plus
+     * value/placeholder/options/required state) so the content round-trip
+     * reporter does not flag it as invented copy — it is intentionally absent
+     * from the source's visible content. Harmless if a recorded string never
+     * reaches the output: the reporter only ever uses it to suppress an exact
+     * match.
+     */
+    private function registerFormControlEcho(string $text): void
+    {
+        $text = trim($text);
+        if ( '' !== $text ) {
+            $this->formControlEchoTexts[] = $text;
+        }
     }
 
     private function readableFormControlLabel(DOMElement $control): string

--- a/php-transformer/tests/unit/content-round-trip-form-echo.php
+++ b/php-transformer/tests/unit/content-round-trip-form-echo.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * End-to-end test for form-control echo suppression in the content round-trip
+ * check (step 1: precision tightening). The transformer flattens form controls
+ * into readable paragraphs whose text it SYNTHESIZES from label + value/
+ * placeholder/required/option state — text that is intentionally absent from
+ * the source's visible content. Without suppression the round-trip reporter
+ * floods on these; with it, only genuinely invented copy survives.
+ *
+ * Plain-PHP test script (no PHPUnit) — drives the real HtmlTransformer so it
+ * exercises the whole wire: collection in the transformer + exclusion in the
+ * reporter.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\ContentRoundTripReporter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$transformer = new HtmlTransformer();
+
+/**
+ * @return array{status: string, texts: array<int, string>}
+ */
+$roundTrip = static function (string $html) use ($transformer): array {
+    $report = $transformer->transform($html, array())->toArray()['source_reports']['content_round_trip'] ?? array();
+    $texts = array();
+    foreach ( $report['findings'] ?? array() as $finding ) {
+        $texts[] = (string) ($finding['text'] ?? '');
+    }
+
+    return array( 'status' => (string) ($report['status'] ?? ''), 'texts' => $texts );
+};
+
+// ---------------------------------------------------------------------------
+// 1. A required text input — placeholder + required are synthesized, NOT visible
+//    source text — must not be flagged.
+// ---------------------------------------------------------------------------
+$html = '<form>'
+    . '<label for="email">Email address</label>'
+    . '<input id="email" type="email" placeholder="your@email.com" required>'
+    . '</form>';
+$result = $roundTrip($html);
+$assert('pass' === $result['status'], '1: synthesized form-field echo is not flagged', implode(' | ', $result['texts']));
+
+// ---------------------------------------------------------------------------
+// 2. A <select> — option labels and the "(selected)" marker are synthesized.
+// ---------------------------------------------------------------------------
+$html = '<form><label for="topic">Topic</label>'
+    . '<select id="topic"><option>General</option><option selected>Billing question</option></select>'
+    . '</form>';
+$result = $roundTrip($html);
+$assert('pass' === $result['status'], '2: synthesized select option echoes are not flagged', implode(' | ', $result['texts']));
+
+// ---------------------------------------------------------------------------
+// 3. Suppression is load-bearing, not incidental: the synthesized placeholder
+//    value ("you@example.com") is genuinely absent from the source's visible
+//    text (it lives in a placeholder attribute). The transform passes, yet the
+//    SAME serialized output run through a reporter with NO ignore set DOES flag
+//    it — proving the transformer's declared echoes are what suppress it.
+// ---------------------------------------------------------------------------
+$html = '<form><label for="e2">Email</label><input id="e2" placeholder="you@example.com" required></form>';
+$arr = $transformer->transform($html, array())->toArray();
+$serialized = (string) ($arr['serialized_blocks'] ?? '');
+
+$result = $roundTrip($html);
+$assert('pass' === $result['status'], '3: placeholder echo suppressed in the wired transform', implode(' | ', $result['texts']));
+
+$unsuppressed = ( new ContentRoundTripReporter() )->report($serialized, $html);
+$assert('warning' === ($unsuppressed['status'] ?? ''), '3b: same output WOULD flag without the ignore set (suppression is load-bearing)');
+$unsuppressedText = strtolower(implode(' | ', array_map(static fn (array $f): string => (string) ($f['text'] ?? ''), $unsuppressed['findings'] ?? array())));
+$assert(str_contains($unsuppressedText, 'you@example.com'), '3c: the placeholder value is what the unsuppressed run flags', $unsuppressedText);
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+if ( $failures > 0 ) {
+    fwrite(STDERR, sprintf("content-round-trip-form-echo: %d passed, %d FAILED%s", $passes, $failures, PHP_EOL));
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf("content-round-trip-form-echo: %d assertions passed%s", $passes, PHP_EOL));

--- a/php-transformer/tests/unit/content-round-trip-reporter.php
+++ b/php-transformer/tests/unit/content-round-trip-reporter.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for the content round-trip / hallucination reporter (#1 ported
+ * from the JS blocks-engine `output-verify.ts verifyComposedOutput()`).
+ *
+ * Plain-PHP test script in the style of tests/unit/css-value-splitter.php — no
+ * PHPUnit. The reporter performs a FORWARD-direction parity check: every
+ * visible text node in the serialized block output (>=3 alphanumeric chars,
+ * normalized) must appear as a substring of the normalized source plaintext.
+ * Output text that is not present in the source is "invented" copy and surfaces
+ * as a `content_not_in_source` finding. Clean output produces zero findings and
+ * a `pass` status.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\ContentRoundTripReporter;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$reporter = new ContentRoundTripReporter();
+
+/**
+ * @param array<string, mixed> $report
+ * @return array<int, string>
+ */
+$codes = static function (array $report): array {
+    $codes = array();
+    foreach ( $report['findings'] ?? array() as $finding ) {
+        $codes[] = (string) ($finding['code'] ?? '');
+    }
+    return $codes;
+};
+
+// ---------------------------------------------------------------------------
+// 1. Faithful output (every text node present in source) -> pass, no findings.
+// ---------------------------------------------------------------------------
+$source = '<h2>Our Mission</h2><p>We build deterministic tools for the web.</p>';
+$output = "<!-- wp:heading -->\n<h2>Our Mission</h2>\n<!-- /wp:heading -->\n"
+    . "<!-- wp:paragraph -->\n<p>We build deterministic tools for the web.</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '1: faithful output reports pass', (string) ($report['status'] ?? ''));
+$assert(array() === ($report['findings'] ?? null), '1b: faithful output has no findings', implode(',', $codes($report)));
+$assert('blocks-engine/php-transformer/content-round-trip/v1' === ($report['schema'] ?? ''), '1c: report carries versioned schema');
+$assert(ConversionFindingContract::SCHEMA === ($report['finding_schema'] ?? ''), '1d: report advertises the finding schema');
+
+// ---------------------------------------------------------------------------
+// 2. Invented copy not in source -> warning + content_not_in_source finding.
+// ---------------------------------------------------------------------------
+$source = '<h2>Our Mission</h2>';
+$output = "<!-- wp:heading -->\n<h2>Our Mission</h2>\n<!-- /wp:heading -->\n"
+    . "<!-- wp:paragraph -->\n<p>Subscribe to our newsletter today.</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output, $source);
+$assert('warning' === ($report['status'] ?? ''), '2: invented copy reports warning', (string) ($report['status'] ?? ''));
+$assert(in_array('content_not_in_source', $codes($report), true), '2b: emits content_not_in_source', implode(',', $codes($report)));
+$assert(
+    'Subscribe to our newsletter today.' === ( ($report['findings'][0]['text'] ?? '') ),
+    '2c: finding carries the offending text node',
+    (string) ( $report['findings'][0]['text'] ?? '' )
+);
+$assert(
+    isset($report['findings'][0]['reason_code']),
+    '2d: finding is classified (reason_code stamped)'
+);
+
+// ---------------------------------------------------------------------------
+// 3. A standalone text node with <3 alphanumeric chars is ignored, even when
+//    it is absent from the source (e.g. a decorative separator glyph).
+// ---------------------------------------------------------------------------
+$source = '<p>Hello world</p>';
+$output = "<!-- wp:paragraph -->\n<p>Hello world</p>\n<!-- /wp:paragraph -->\n"
+    . "<!-- wp:separator -->\n<hr/><p>— · —</p>\n<!-- /wp:separator -->";
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '3: standalone punctuation-only node is ignored', implode(',', $codes($report)));
+
+// ---------------------------------------------------------------------------
+// 4. Whitespace + case differences must NOT count as hallucination.
+// ---------------------------------------------------------------------------
+$source = "<p>We   build\n  DETERMINISTIC tools.</p>";
+$output = "<!-- wp:paragraph -->\n<p>we build deterministic tools.</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '4: normalization tolerates case + whitespace', implode(',', $codes($report)));
+
+// ---------------------------------------------------------------------------
+// 5. HTML entities in output decode to source plaintext (no false positive).
+// ---------------------------------------------------------------------------
+$source = '<p>Tom & Jerry said "hi"</p>';
+$output = "<!-- wp:paragraph -->\n<p>Tom &amp; Jerry said &quot;hi&quot;</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '5: entity-decoded output matches source', implode(',', $codes($report)));
+
+// ---------------------------------------------------------------------------
+// 6. Block-delimiter comment attrs are NOT treated as visible output text.
+//    (A label living only in a dynamic block's JSON attrs must not be scanned
+//    as a text node — mirrors blocks-engine which strips wp: comments first.)
+// ---------------------------------------------------------------------------
+$source = '<nav><a href="/about">About</a></nav>';
+$output = '<!-- wp:navigation-link {"label":"Totally Invented","url":"/x"} /-->';
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '6: attr-only text inside wp: comments is not scanned', implode(',', $codes($report)));
+
+// ---------------------------------------------------------------------------
+// 6b. Named/numeric HTML entities in the SOURCE decode to the same glyph the
+//     transformer emits (it parses the DOM, so output carries literal © → —).
+//     The check must decode the full entity set on both sides, not a 7-entity
+//     subset — otherwise raw-HTML sources flag a flood of false positives on
+//     &copy;/&rarr;/&mdash;/&ndash;/&rsquo;.
+// ---------------------------------------------------------------------------
+$source = '<footer>&copy; 2026 Switchback Outfitters &mdash; Trail Kits &rarr; Shop</footer>';
+$output = "<!-- wp:paragraph -->\n<p>© 2026 Switchback Outfitters — Trail Kits → Shop</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '6b: full entity set decodes on both sides', implode(',', $codes($report)));
+
+$source = '<p>It&rsquo;s Milwaukee&rsquo;s independent voice&hellip;</p>';
+$output = "<!-- wp:paragraph -->\n<p>It’s Milwaukee’s independent voice…</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '6c: smart quotes and ellipsis decode', implode(',', $codes($report)));
+
+$source = '<p>Open&nbsp;7am&ndash;8pm</p>';
+$output = "<!-- wp:paragraph -->\n<p>Open 7am–8pm</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output, $source);
+$assert('pass' === ($report['status'] ?? ''), '6d: nbsp normalizes to a regular space', implode(',', $codes($report)));
+
+// ---------------------------------------------------------------------------
+// 6e. Producer-declared synthesized text (e.g. form-control echoes built from
+//     placeholder/value/required attributes — NOT visible source copy) is
+//     excluded from the check when passed in the ignore set, but still flagged
+//     when it is not declared. The reporter normalizes ignore entries with the
+//     same pipeline it uses for output nodes.
+// ---------------------------------------------------------------------------
+$source = '<form><label for="e">Email address</label><input id="e" placeholder="your@email.com" required></form>';
+$echo   = 'Email address: your@email.com (required)';
+$output = "<!-- wp:paragraph -->\n<p>Email address: your@email.com (required)</p>\n<!-- /wp:paragraph -->";
+
+$report = $reporter->report($output, $source);
+$assert('warning' === ($report['status'] ?? ''), '6e: undeclared synthesized text is still flagged', implode(',', $codes($report)));
+
+$report = $reporter->report($output, $source, array( $echo ));
+$assert('pass' === ($report['status'] ?? ''), '6e2: declared form-control echo is excluded', implode(',', $codes($report)));
+
+// A different invented node is NOT masked just because some echoes are declared.
+$output2 = $output . "\n<!-- wp:paragraph -->\n<p>Buy now and save fifty percent.</p>\n<!-- /wp:paragraph -->";
+$report = $reporter->report($output2, $source, array( $echo ));
+$assert(in_array('content_not_in_source', $codes($report), true), '6e3: ignore set does not mask genuine hallucinations');
+$assert(1 === count($report['findings'] ?? array()), '6e4: exactly the non-echo node is flagged', (string) count($report['findings'] ?? array()));
+
+// ---------------------------------------------------------------------------
+// 7. Empty output is trivially faithful.
+// ---------------------------------------------------------------------------
+$report = $reporter->report('', '<p>anything</p>');
+$assert('pass' === ($report['status'] ?? ''), '7: empty output passes');
+$assert(array() === ($report['findings'] ?? null), '7b: empty output has no findings');
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+if ( $failures > 0 ) {
+    fwrite(STDERR, sprintf("content-round-trip-reporter: %d passed, %d FAILED%s", $passes, $failures, PHP_EOL));
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf("content-round-trip-reporter: %d assertions passed%s", $passes, PHP_EOL));

--- a/php-transformer/tools/content-round-trip/run.php
+++ b/php-transformer/tools/content-round-trip/run.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Content round-trip harness.
+ *
+ * Runs the HTML transformer over a directory of real `.html` pages and reports
+ * the `content_round_trip` findings — output block text that does not appear in
+ * the source content (invented/mangled/merged copy). Pure PHP: no WordPress
+ * runtime, no browser, no network.
+ *
+ * Usage:
+ *   php tools/content-round-trip/run.php <dir> [--verbose] [--top <n>] [--output <file>]
+ *
+ * Options:
+ *   <dir>            Directory scanned recursively for *.html / *.htm (required).
+ *   --verbose        Print every flagged file with its offending text nodes.
+ *   --top <n>        How many ranked rows to print per table (default: 20).
+ *   --output <file>  Write the full machine-readable JSON report to this path.
+ *
+ * Example:
+ *   php tools/content-round-trip/run.php ~/Desktop/raw-html --verbose
+ */
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$opts = parseArgs($argv);
+$dir = $opts['dir'] ?? null;
+if ( null === $dir || ! is_dir($dir) ) {
+    fwrite(STDERR, "Usage: php tools/content-round-trip/run.php <dir> [--verbose] [--top <n>] [--output <file>]\n");
+    exit(1);
+}
+
+$top = (int) ($opts['top'] ?? 20);
+$verbose = isset($opts['verbose']);
+
+$files = htmlFiles($dir);
+if ( array() === $files ) {
+    fwrite(STDERR, "No .html files found under: {$dir}\n");
+    exit(1);
+}
+
+$transformer = new HtmlTransformer();
+$perFile = array();
+$snippetFreq = array();
+$totalFindings = 0;
+
+foreach ( $files as $path ) {
+    $html = (string) file_get_contents($path);
+    if ( '' === trim($html) ) {
+        continue;
+    }
+
+    $report = $transformer->transform($html, array())->toArray()['source_reports']['content_round_trip'] ?? array();
+    $findings = is_array($report['findings'] ?? null) ? $report['findings'] : array();
+    $rel = ltrim(substr($path, strlen($dir)), '/');
+    $perFile[$rel] = $findings;
+    $totalFindings += count($findings);
+
+    foreach ( $findings as $finding ) {
+        $text = trim((string) ($finding['text'] ?? ''));
+        $snippetFreq[$text] = ($snippetFreq[$text] ?? 0) + 1;
+    }
+}
+
+$flagged = array_filter($perFile, static fn (array $f): bool => array() !== $f);
+$counts = array_map('count', $flagged);
+arsort($counts);
+arsort($snippetFreq);
+
+if ( isset($opts['output']) ) {
+    $json = json_encode(array(
+        'corpus'             => $dir,
+        'files_scanned'      => count($perFile),
+        'files_with_findings' => count($flagged),
+        'total_findings'     => $totalFindings,
+        'per_file'           => $perFile,
+    ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    file_put_contents($opts['output'], (string) $json . "\n");
+    fwrite(STDOUT, "Wrote JSON report to: {$opts['output']}\n\n");
+}
+
+if ( $verbose ) {
+    foreach ( array_keys($counts) as $rel ) {
+        fwrite(STDOUT, "\n{$rel}  (" . count($flagged[$rel]) . " finding(s))\n");
+        foreach ( $flagged[$rel] as $finding ) {
+            fwrite(STDOUT, '   • ' . trim((string) ($finding['text'] ?? '')) . "\n");
+        }
+    }
+}
+
+$scanned = count($perFile);
+fwrite(STDOUT, "\n========== CONTENT ROUND-TRIP ==========\n");
+fwrite(STDOUT, sprintf("corpus:             %s\n", $dir));
+fwrite(STDOUT, sprintf("files scanned:      %d\n", $scanned));
+fwrite(STDOUT, sprintf("files w/ findings:  %d  (%.1f%%)\n", count($flagged), $scanned > 0 ? 100 * count($flagged) / $scanned : 0.0));
+fwrite(STDOUT, sprintf("total findings:     %d\n", $totalFindings));
+
+fwrite(STDOUT, "\n-- files with most findings --\n");
+printRows($counts, $top);
+
+fwrite(STDOUT, "\n-- most frequent flagged snippets --\n");
+printRows($snippetFreq, $top, 90);
+
+exit(0);
+
+/**
+ * @param array<int, string> $argv
+ * @return array<string, string>
+ */
+function parseArgs(array $argv): array
+{
+    $opts = array();
+    for ( $i = 1, $n = count($argv); $i < $n; $i++ ) {
+        $arg = $argv[$i];
+        if ( '--verbose' === $arg ) {
+            $opts['verbose'] = '1';
+        } elseif ( in_array($arg, array( '--top', '--output' ), true) && $i + 1 < $n ) {
+            $opts[substr($arg, 2)] = $argv[++$i];
+        } elseif ( ! str_starts_with($arg, '-') && ! isset($opts['dir']) ) {
+            $opts['dir'] = rtrim($arg, '/');
+        }
+    }
+
+    return $opts;
+}
+
+/**
+ * @return array<int, string>
+ */
+function htmlFiles(string $dir): array
+{
+    $files = array();
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS));
+    foreach ( $it as $entry ) {
+        if ( $entry->isFile() && preg_match('/\.html?$/i', $entry->getFilename()) ) {
+            $files[] = $entry->getPathname();
+        }
+    }
+    sort($files);
+
+    return $files;
+}
+
+/**
+ * @param array<string, int> $rows
+ */
+function printRows(array $rows, int $limit, int $width = 0): void
+{
+    $i = 0;
+    foreach ( $rows as $label => $count ) {
+        if ( $i++ >= $limit ) {
+            break;
+        }
+        $display = $width > 0 && mb_strlen($label) > $width ? mb_substr($label, 0, $width) . '…' : $label;
+        fwrite(STDOUT, sprintf("  %4d  %s\n", $count, $display));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a forward-direction **content round-trip** check: it flags generated block text that does not appear in the source content — invented, mangled, or merged copy. Ported from the JS blocks-engine `output-verify.ts verifyComposedOutput()` and adapted for raw-HTML input.

This is a technique being ported from the JS blocks-engine package. It complements what already exists:

- structural validators (`BlockValidityValidator`, `CanonicalSaveShapeValidator`) check that output is **well-formed**;
- `SemanticParityReporter` checks **landmarks and navigation**;
- neither verified that the **visible copy** survived conversion. This closes that gap.

## How it works

`ContentRoundTripReporter` strips block-delimiter comments, splits output into text nodes, and flags any node (≥3 alphanumeric chars, normalized) that is not a substring of the normalized source plaintext as `content_not_in_source`. It is wired into `HtmlTransformer::transform()` as an additive `source_reports.content_round_trip` report plus findings-gated diagnostics, so clean conversions remain byte-identical (the 187 parity fixtures are unaffected).

## Test corpus and findings

The two refinements in this PR were **driven by running the check against a real-world corpus** — 116 hand-built static HTML pages across 23 small sites (nonprofit, restaurant, SaaS, portfolio, docs, WooCommerce-style catalog, editorial magazine, local service business, event/conference, membership, etc.). These exercise entity usage, form markup, logo lockups, numbered lists, and stat counters the unit fixtures don't.

A dedicated harness was added to make this repeatable:

```
composer content-round-trip -- <dir-of-html> [--verbose] [--output report.json]
```

It walks `*.html` recursively, transforms each page, and prints a ranked worklist of flagged text.

**The numbers as the check was hardened:**

| Stage | Files flagged | Findings |
|-------|--------------:|---------:|
| Initial faithful port | 84.5% (98/116) | 624 |
| + full HTML-entity decode | 62.9% (73/116) | 301 |
| + form-control echo suppression | **20.7% (24/116)** | **72** |

That is an ~88% reduction in noise, and it came from fixing two real issues the corpus exposed:

1. **Entity-decoding asymmetry (false positive in the check).** Sources encode `©`/`→`/`—`/`’` as `&copy;`/`&rarr;`/`&mdash;`/`&rsquo;`; the transformer parses the DOM, so its output carries the literal glyph. The faithful port decoded only 7 named entities, so `©` never matched `&copy;`. Fixed by decoding the full entity set (`html_entity_decode`, `ENT_QUOTES | ENT_HTML5`) plus Unicode-space folding on both sides.

2. **Form-control echoes (expected transformer behavior, not a defect).** The transformer flattens form fields into readable paragraphs whose text it synthesizes from `label + value/placeholder/required/option` state (`Email address: your@email.com (required)`, `… (selected)`) — text legitimately absent from the source's visible content. The transformer (the only code that knows the text was synthesized) now declares those strings and the reporter excludes them. No serialized output changes; no brittle pattern/class-name matching.

**The residual 72 findings are genuine signal** — overwhelmingly one real transformer defect class: **lost inter-element whitespace when adjacent inline elements merge.** Examples surfaced by the corpus:
- `NORTHLINEPlumbing & Heating` (logo: `<span>NORTHLINE</span><span>Plumbing & Heating</span>`)
- `Civic SignalResource Library` (brand + sub-label lockup)
- `01Crushed San Marzano tomatoes` (number badge fused to list item text)
- `Error response shapejson` (label + code badge)

These are worth filing as a separate transformer fix; this check now provides a deduplicated, reproducible list of them.

## Testing

- `composer test` — 187 parity fixtures + contract/unit/packaging, all green; no regressions.
- `php tests/unit/content-round-trip-reporter.php` — 21 assertions (faithful output, hallucination detection, short-fragment skipping, full entity/whitespace/case normalization, producer-declared ignore set).
- `php tests/unit/content-round-trip-form-echo.php` — 5 assertions, end-to-end through the real transformer, proving form-echo suppression is load-bearing (the same output flags without the ignore set).
- `composer content-round-trip -- ~/path/to/html` — ad-hoc corpus runs.
