### PR TITLE
figma-transformer: resolve Kiwi text style refs

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -37,10 +37,11 @@ final class ScenegraphNormalizer
             $index = $this->limitIndexNodes($index, (int) $options['max_nodes'], $diagnostics, $preferredRootId);
         }
         $paintStyles = $this->buildPaintStyleDefinitions($index['nodes'], $diagnostics);
-        $nodeMap     = $this->normalizeNodeMap($index['nodes'], $diagnostics, $blobs, $paintStyles);
+        $textStyles  = $this->buildTextStyleDefinitions($index['nodes']);
+        $nodeMap     = $this->normalizeNodeMap($index['nodes'], $diagnostics, $blobs, $paintStyles, $textStyles);
         $components  = $this->buildComponentDefinitions($nodeMap);
         $componentDefinitionCount = $this->countComponentDefinitions($nodeMap);
-        $instanceReport = $this->resolveInstances($nodeMap, $components, $diagnostics, $blobs, $paintStyles);
+        $instanceReport = $this->resolveInstances($nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles);
         $topLevelIds = $index['top_level_node_ids'];
         $frameIds    = $this->selectTopLevelFrameIds($topLevelIds, $nodeMap);
 
@@ -376,10 +377,10 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>>    $diagnostics
      * @return array<string, array<string, mixed>>
      */
-    private function normalizeNodeMap(array $nodeMap, array &$diagnostics, array $blobs = array(), array $paintStyles = array()): array
+    private function normalizeNodeMap(array $nodeMap, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
     {
         foreach ( $nodeMap as $id => $node ) {
-            $nodeMap[$id] = $this->normalizeNode($node, $diagnostics, $blobs, $paintStyles);
+            $nodeMap[$id] = $this->normalizeNode($node, $diagnostics, $blobs, $paintStyles, $textStyles);
         }
 
         return $nodeMap;
@@ -390,7 +391,7 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    private function normalizeNode(array $node, array &$diagnostics, array $blobs = array(), array $paintStyles = array()): array
+    private function normalizeNode(array $node, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
     {
         $id = (string) ($node['id'] ?? '');
         $type = strtoupper((string) ($node['type'] ?? ''));
@@ -401,7 +402,7 @@ final class ScenegraphNormalizer
         }
 
         if ( 'TEXT' === $type ) {
-            $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics, $paintStyles);
+            $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics, $paintStyles, $textStyles);
             if ( ! empty($text) ) {
                 $node['figma_text'] = $text;
             }
@@ -457,7 +458,7 @@ final class ScenegraphNormalizer
 
             foreach ( $node[$childrenKey] as $index => $child ) {
                 if ( is_array($child) ) {
-                    $normalizedChild = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles);
+                    $normalizedChild = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles, $textStyles);
                     $childLayout = is_array($normalizedChild['layout'] ?? null) ? $normalizedChild['layout'] : array();
                     $childLayout['source_order'] = isset($normalizedChild['_source_order']) && is_numeric($normalizedChild['_source_order'])
                         ? (int) $normalizedChild['_source_order']
@@ -564,11 +565,29 @@ final class ScenegraphNormalizer
 
     /**
      * @param array<string, array<string, mixed>> $nodeMap
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildTextStyleDefinitions(array $nodeMap): array
+    {
+        $styles = array();
+        foreach ( $nodeMap as $id => $node ) {
+            if ( 'TEXT' !== strtoupper((string) ($node['styleType'] ?? '')) || 'TEXT' !== strtoupper((string) ($node['type'] ?? '')) ) {
+                continue;
+            }
+
+            $styles[$id] = $node;
+        }
+
+        return $styles;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $nodeMap
      * @param array<string, array<string, mixed>> $components
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array{instance_node_count: int, resolved_instance_count: int, unresolved_component_references: array<int, array<string, string>>}
      */
-    private function resolveInstances(array &$nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array()): array
+    private function resolveInstances(array &$nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
     {
         $instanceCount = 0;
         $resolvedCount = 0;
@@ -612,7 +631,7 @@ final class ScenegraphNormalizer
                 continue;
             }
 
-            $resolved = $this->cloneComponentForInstance($components[$reference['id']], $node, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, array($id));
+            $resolved = $this->cloneComponentForInstance($components[$reference['id']], $node, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, array($id));
             $nodeMap[$id] = $resolved;
             $resolvedCount++;
         }
@@ -1245,7 +1264,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $nodeMap
      * @return array<string, mixed>
      */
-    private function cloneComponentForInstance(array $component, array $instance, string $componentId, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $resolutionTrail = array()): array
+    private function cloneComponentForInstance(array $component, array $instance, string $componentId, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $resolutionTrail = array()): array
     {
         $context = $this->buildInstanceCloneContext($component, $instance, $componentId, $overrides);
         $resolved = $component;
@@ -1275,7 +1294,7 @@ final class ScenegraphNormalizer
             )
         );
         $resolvedChildren = is_array($resolved['children'] ?? null) ? $resolved['children'] : array();
-        $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $resolutionTrail);
+        $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $resolutionTrail);
         $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
         $componentBox = is_array($component['box'] ?? null) ? $component['box'] : array();
         $componentSourceX = isset($componentBox['x']) && is_numeric($componentBox['x']) ? (float) $componentBox['x'] : null;
@@ -1298,7 +1317,7 @@ final class ScenegraphNormalizer
             $resolved['layout'] = array('freeform' => true);
         }
         $resolved['children'] = $this->namespaceResolvedInstanceChildren(
-            $this->applyInstanceOverridesToChildren($resolvedChildren, $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles),
+            $this->applyInstanceOverridesToChildren($resolvedChildren, $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles),
             $context['instance_id']
         );
 
@@ -1827,7 +1846,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $nodeMap
      * @return array<int, mixed>
      */
-    private function resolveClonedInstanceChildren(array $children, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $resolutionTrail = array()): array
+    private function resolveClonedInstanceChildren(array $children, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $resolutionTrail = array()): array
     {
         foreach ( $children as $index => $child ) {
             if ( ! is_array($child) ) {
@@ -1841,14 +1860,14 @@ final class ScenegraphNormalizer
                 if ( empty($refreshed['children']) && null !== $reference && isset($components[$reference['id']]) && ! in_array($id, $resolutionTrail, true) ) {
                     $overrides = $this->normalizeInstanceOverrides($refreshed, $id, $diagnostics);
                     if ( null !== $overrides ) {
-                        $refreshed = $this->cloneComponentForInstance($components[$reference['id']], $refreshed, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, array_merge($resolutionTrail, array($id)));
+                        $refreshed = $this->cloneComponentForInstance($components[$reference['id']], $refreshed, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, array_merge($resolutionTrail, array($id)));
                     }
                 }
                 $child = $this->mergeRefreshedComponentSource($child, $refreshed, $id);
             }
 
             if ( is_array($child['children'] ?? null) ) {
-                $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $resolutionTrail);
+                $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $resolutionTrail);
             }
 
             $children[$index] = $child;
@@ -2010,7 +2029,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $overrides
      * @return array<int, mixed>
      */
-    private function applyInstanceOverridesToChildren(array $children, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array()): array
+    private function applyInstanceOverridesToChildren(array $children, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
     {
 		foreach ( $children as $index => $child ) {
 			if ( ! is_array($child) ) {
@@ -2029,7 +2048,7 @@ final class ScenegraphNormalizer
             if ( null !== $swapComponentId && isset($components[$swapComponentId]) ) {
                 $child = $this->mergeRefreshedComponentSource($child, $components[$swapComponentId], $swapComponentId);
                 if ( is_array($child['children'] ?? null) ) {
-                    $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles);
+                    $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles);
                 }
                 $child['_figma_instance_override_applied'] = true;
             }
@@ -2049,12 +2068,12 @@ final class ScenegraphNormalizer
                 }
 			}
 			if ( $hasFieldOverride ) {
-				$child = $this->normalizeOverriddenInstanceChild($child, $id, $overrideFields, $diagnostics, $blobs, $paintStyles, $sourceChildBox);
+				$child = $this->normalizeOverriddenInstanceChild($child, $id, $overrideFields, $diagnostics, $blobs, $paintStyles, $textStyles, $sourceChildBox);
 			}
 
             if ( is_array($child['children'] ?? null) ) {
                 $childOverrides = $this->descendantInstanceOverrideFieldsForChild($child, $overrides);
-                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], array_merge($overrides, $childOverrides, $nestedComponentPropertyOverrides), $nodeMap, $components, $diagnostics, $blobs, $paintStyles);
+                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], array_merge($overrides, $childOverrides, $nestedComponentPropertyOverrides), $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles);
             }
 
             $children[$index] = $child;
@@ -2205,7 +2224,7 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-	private function normalizeOverriddenInstanceChild(array $child, string $id, array $overrideFields, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), ?array $sourceChildBox = null): array
+	private function normalizeOverriddenInstanceChild(array $child, string $id, array $overrideFields, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), ?array $sourceChildBox = null): array
 	{
 		$hasVectorGeometryOverride = array_key_exists('fillGeometry', $overrideFields) || array_key_exists('strokeGeometry', $overrideFields);
 		$hasExplicitSizeOverride = array_key_exists('size', $overrideFields);
@@ -2268,7 +2287,7 @@ final class ScenegraphNormalizer
         }
         unset($child['figma_vector_scale']);
 
-		$child = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles);
+		$child = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles, $textStyles);
 		if ( $hasTransformGeometryOverride && is_array($sourceChildBox) ) {
 			$child = $this->preserveLocalSourceBoxForFarAbsoluteOverride($child, $sourceChildBox);
 		}

--- a/figma-transformer/src/Scenegraph/TextNormalizer.php
+++ b/figma-transformer/src/Scenegraph/TextNormalizer.php
@@ -20,7 +20,7 @@ final class TextNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    public function normalizeText(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array(), array $paintStyles = array()): array
+    public function normalizeText(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array(), array $paintStyles = array(), array $textStyles = array()): array
     {
         $text = array();
 
@@ -36,6 +36,11 @@ final class TextNormalizer
         }
 
         $style = array();
+        $styleId = $this->readStyleGuidId($node['styleIdForText'] ?? null);
+        if ( null !== $styleId && is_array($textStyles[$styleId] ?? null) ) {
+            $style = $this->normalizeTextStyle($textStyles[$styleId]);
+        }
+
         if ( is_array($node['style'] ?? null) ) {
             $style = $this->normalizeTextStyle($node['style']);
         }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4947,6 +4947,52 @@ $assert(str_contains($kiwiInlineTextStyleHtml, 'We&#039;re all about <span style
 // entry's bold `fontName` — and " plain text" stays unwrapped.
 $assert(str_contains($kiwiInlineTextStyleHtml, '<span style="font-weight:700">Bold</span> plain text'), 'kiwi-inline-style-mixed-weight-spans');
 
+// Kiwi text style references: production .fig payloads can carry stale inline
+// `fontName` data on a text node while `styleIdForText` points at the canonical
+// text style and `derivedTextData.fontMetaData` matches that style. Prefer the
+// referenced text style so cloned component text preserves direct Figma parity.
+$kiwiTextStyleReferenceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Kiwi Text Style Reference Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'kref:1',
+            'type'     => 'FRAME',
+            'name'     => 'Kiwi text style reference frame',
+            'width'    => 1200,
+            'height'   => 400,
+            'children' => array(
+                array(
+                    'id'        => '4166:11869',
+                    'type'      => 'TEXT',
+                    'styleType' => 'TEXT',
+                    'name'      => 'Desktop/Headings/H2',
+                    'fontName'  => array('family' => 'Barlow Condensed', 'style' => 'Bold'),
+                    'fontSize'  => 48,
+                    'lineHeight' => array('units' => 'PERCENT', 'value' => 120),
+                    'textData'  => array('characters' => 'Rag 123'),
+                ),
+                array(
+                    'id'             => 'kref:2',
+                    'type'           => 'TEXT',
+                    'name'           => 'Newsletter heading with stale inline font',
+                    'width'          => 544,
+                    'height'         => 48,
+                    'fontName'       => array('family' => 'Helvetica Neue', 'style' => 'Bold', 'postscript' => 'HelveticaNeue-Bold'),
+                    'fontSize'       => 24,
+                    'styleIdForText' => array('guid' => array('sessionID' => 4166, 'localID' => 11869)),
+                    'textData'       => array('characters' => 'Get the newsletter!'),
+                ),
+            ),
+        ),
+    ),
+));
+$kiwiTextStyleReferenceCss = $fileContent($kiwiTextStyleReferenceResult, 'style.css');
+$assert(str_contains($kiwiTextStyleReferenceCss, '.figma-node-kref-2-newsletter-heading-with-stale-inline-font{'), 'kiwi-text-style-reference-rule-emitted');
+$assert(str_contains($kiwiTextStyleReferenceCss, 'font-family:"Barlow Condensed", sans-serif'), 'kiwi-text-style-reference-font-family');
+$assert(str_contains($kiwiTextStyleReferenceCss, 'font-size:48px'), 'kiwi-text-style-reference-font-size');
+$assert(str_contains($kiwiTextStyleReferenceCss, 'font-weight:700'), 'kiwi-text-style-reference-font-weight');
+$assert(! str_contains($kiwiTextStyleReferenceCss, 'font-family:"Helvetica Neue", Helvetica, Arial, sans-serif'), 'kiwi-text-style-reference-stale-inline-font-not-emitted');
+
 // Font embedding: a known web font (Inter) resolves to a weight-aware Google Fonts
 // @font-face import, while an unknown family (Skolar Latin) stays actionable. This
 // mirrors the David Perell .fig matrix where Inter + Skolar Latin rendered in a


### PR DESCRIPTION
## Summary
- Index TEXT style definitions from raw Kiwi data.
- Prefer styleIdForText when normalizing text styles instead of stale inline font fields.
- Add contract coverage for canonical text style refs overriding stale inline font data.

## Testing
- composer test:contract
- focused/full FSE .fig transforms with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Kiwi data-parity investigation, implementation, and verification.