### PR TITLE
figma-transformer: preserve derived text box sizing

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3296,7 +3296,10 @@ final class StaticHtmlEmitter
             $sizingKey = 'width' === $dimension ? 'sizing_horizontal' : 'sizing_vertical';
             $sizing = strtoupper((string) ($layout[$sizingKey] ?? ''));
             if ( 'HUG' === $sizing ) {
-                if ( 'flex' === ($layout['display'] ?? null) && isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
+                $derivedTextSize = 'TEXT' === $type ? $this->derivedTextLayoutSize($node, $dimension) : null;
+                if ( null !== $derivedTextSize ) {
+                    $styles[] = $dimension . ':' . $this->number($derivedTextSize) . 'px';
+                } elseif ( 'flex' === ($layout['display'] ?? null) && isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
                     $intrinsicMainAxisSize = $this->flexHugMainAxisIntrinsicSizeStyle($node, $dimension);
                     $styles[] = $dimension . ':' . (null === $intrinsicMainAxisSize ? $this->number((float) $box[$dimension]) . 'px' : $intrinsicMainAxisSize);
                 } else {
@@ -3509,6 +3512,21 @@ final class StaticHtmlEmitter
         }
 
         return $merged;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function derivedTextLayoutSize(array $node, string $dimension): ?float
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $derivedLayout = is_array($text['derived_layout'] ?? null) ? $text['derived_layout'] : array();
+        $size = is_array($derivedLayout['size'] ?? null) ? $derivedLayout['size'] : array();
+        if ( isset($size[$dimension]) && is_numeric($size[$dimension]) && 0.0 <= (float) $size[$dimension] ) {
+            return (float) $size[$dimension];
+        }
+
+        return null;
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3225,6 +3225,53 @@ $assert(str_contains($derivedLineBreakHtml, "First line\nSecond line"), 'derived
 $assert(str_contains($derivedLineBreakCss, '.figma-node-text-derived-lines-measured-lines{width:120px;height:44px;line-height:22px;white-space:pre-line}'), 'derived-baselines-enable-pre-line');
 $assert(! str_contains($derivedLineBreakCss, 'line-height:40px;line-height:22px'), 'derived-baselines-replace-source-line-height');
 
+$derivedHugTextHeightResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Derived Hug Text Height Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'frame:derived-hug-text-height',
+            'type'     => 'FRAME',
+            'name'     => 'Measured Text Stack',
+            'width'    => 320,
+            'height'   => 140,
+            'layoutMode' => 'VERTICAL',
+            'itemSpacing' => 32,
+            'children' => array(
+                array(
+                    'id'              => 'text:derived-hug-text-height',
+                    'type'            => 'TEXT',
+                    'name'            => 'Trimmed Heading',
+                    'characters'      => 'PAge not found',
+                    'width'           => 320,
+                    'height'          => 86,
+                    'fontSize'        => 128,
+                    'lineHeight'      => array('value' => 0.9, 'units' => 'RAW'),
+                    'textAutoResize'  => 'HEIGHT',
+                    'derivedTextData' => array(
+                        'layoutSize' => array('x' => 320, 'y' => 86),
+                        'baselines'  => array(
+                            array('firstCharacter' => 0, 'endCharacter' => 14, 'lineHeight' => 115.2, 'lineAscent' => 96, 'position' => array('x' => 0, 'y' => 81.4)),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'         => 'text:derived-hug-copy',
+                    'type'       => 'TEXT',
+                    'name'       => 'Copy',
+                    'characters' => 'Follow-up copy',
+                    'width'      => 320,
+                    'height'     => 20,
+                    'fontSize'   => 16,
+                ),
+            ),
+        ),
+    ),
+));
+$derivedHugTextHeightCss = $fileContent($derivedHugTextHeightResult, 'style.css');
+$assert(str_contains($derivedHugTextHeightCss, '.figma-node-text-derived-hug-text-height-trimmed-heading{') && str_contains($derivedHugTextHeightCss, 'width:320px;height:86px') && str_contains($derivedHugTextHeightCss, 'font-size:128px;line-height:0.9'), 'derived-hug-text-height-preserves-measured-box');
+$assert(! str_contains($derivedHugTextHeightCss, '.figma-node-text-derived-hug-text-height-trimmed-heading{width:320px;height:fit-content'), 'derived-hug-text-height-not-fit-content');
+$assert(str_contains($derivedHugTextHeightCss, '.figma-node-frame-derived-hug-text-height-measured-text-stack{width:320px;height:140px;display:flex;flex-direction:column;gap:32px}'), 'derived-hug-text-height-parent-gap-preserved');
+
 $derivedMeasuredLineHeightResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Derived Measured Line Height Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- Use decoded derived text layout dimensions for HUG text sizing instead of browser fit-content.
- Preserve measured Figma text boxes where line-height exceeds source bounds.
- Add contract coverage for auto-height display text spacing.

## Testing
- composer test:contract
- focused/full FSE .fig transforms with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Kiwi text micro-layout investigation, implementation, and verification.