### PR TITLE
figma-transformer: honor Kiwi reverse z order

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3372,6 +3372,10 @@ final class StaticHtmlEmitter
             $styles[] = 'z-index:1';
         }
 
+        if ( isset($layout['z_index']) && is_numeric($layout['z_index']) && ! $this->stylesDeclareProperty($styles, 'z-index') ) {
+            $styles[] = 'z-index:' . (string) (int) $layout['z_index'];
+        }
+
         if ( 'TEXT' !== $type && ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE'), true) ) {
             $background = $this->backgroundColor($node);
             if ( null !== $background ) {

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -39,9 +39,11 @@ final class ScenegraphNormalizer
         $paintStyles = $this->buildPaintStyleDefinitions($index['nodes'], $diagnostics);
         $textStyles  = $this->buildTextStyleDefinitions($index['nodes']);
         $nodeMap     = $this->normalizeNodeMap($index['nodes'], $diagnostics, $blobs, $paintStyles, $textStyles);
+        $this->applyReverseChildZIndex($nodeMap);
         $components  = $this->buildComponentDefinitions($nodeMap);
         $componentDefinitionCount = $this->countComponentDefinitions($nodeMap);
         $instanceReport = $this->resolveInstances($nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles);
+        $this->applyReverseChildZIndex($nodeMap);
         $topLevelIds = $index['top_level_node_ids'];
         $frameIds    = $this->selectTopLevelFrameIds($topLevelIds, $nodeMap);
 
@@ -470,6 +472,31 @@ final class ScenegraphNormalizer
         }
 
         return $node;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $nodeMap
+     */
+    private function applyReverseChildZIndex(array &$nodeMap): void
+    {
+        foreach ( $nodeMap as $node ) {
+            if ( true !== ($node['layout']['reverse_z_index'] ?? false) || ! is_array($node['children'] ?? null) ) {
+                continue;
+            }
+
+            $children = array_values(array_filter($node['children'], 'is_array'));
+            $childCount = count($children);
+            foreach ( $children as $index => $child ) {
+                $childId = isset($child['id']) && is_scalar($child['id']) ? (string) $child['id'] : '';
+                if ( '' === $childId || ! isset($nodeMap[$childId]) ) {
+                    continue;
+                }
+
+                $layout = is_array($nodeMap[$childId]['layout'] ?? null) ? $nodeMap[$childId]['layout'] : array();
+                $layout['z_index'] = $childCount - (int) $index;
+                $nodeMap[$childId]['layout'] = $layout;
+            }
+        }
     }
 
     /**
@@ -3023,6 +3050,10 @@ final class ScenegraphNormalizer
             if ( 'WRAP' === $layout['wrap'] ) {
                 $layout['flex_wrap'] = 'wrap';
             }
+        }
+
+        if ( true === ($node['stackReverseZIndex'] ?? false) || 'true' === strtolower((string) ($node['stackReverseZIndex'] ?? '')) || 1 === ($node['stackReverseZIndex'] ?? null) || '1' === (string) ($node['stackReverseZIndex'] ?? '') ) {
+            $layout['reverse_z_index'] = true;
         }
 
         // REST `layoutPositioning`; Kiwi `stackPositioning`. Both encode the

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -52,6 +52,30 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $assert(100.0 === ($visualFlexCentered['rect']['x'] ?? null), 'visual-map-column-center-child-x');
     $assert(10.0 === ($visualFlexCentered['rect']['y'] ?? null), 'visual-map-column-padding-child-y');
 
+    $reverseZIndexResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Reverse Z Index Auto Layout Fixture',
+        'nodes' => array(
+            array(
+                'id'                 => 'reverse-z:row',
+                'type'               => 'FRAME',
+                'name'               => 'Overlapping reverse z row',
+                'width'              => 180,
+                'height'             => 80,
+                'layoutMode'         => 'HORIZONTAL',
+                'itemSpacing'        => -20,
+                'stackReverseZIndex' => true,
+                'children'           => array(
+                    array('id' => 'reverse-z:first', 'type' => 'RECTANGLE', 'name' => 'First top child', 'width' => 80, 'height' => 80),
+                    array('id' => 'reverse-z:second', 'type' => 'RECTANGLE', 'name' => 'Second lower child', 'width' => 80, 'height' => 80),
+                ),
+            ),
+        ),
+    ));
+    $reverseZIndexCss = blocks_engine_figma_transformer_contract_file_content($reverseZIndexResult, 'style.css');
+    $assert(str_contains($reverseZIndexCss, '.figma-node-reverse-z-row-overlapping-reverse-z-row{width:180px;height:80px;display:flex;flex-direction:row;gap:-20px}'), 'visual-map-reverse-z-parent-layout-order-preserved');
+    $assert(str_contains($reverseZIndexCss, '.figma-node-reverse-z-first-first-top-child{width:80px;height:80px;z-index:2;flex-shrink:0}'), 'visual-map-reverse-z-first-child-on-top');
+    $assert(str_contains($reverseZIndexCss, '.figma-node-reverse-z-second-second-lower-child{width:80px;height:80px;z-index:1;flex-shrink:0}'), 'visual-map-reverse-z-second-child-lower');
+
     $visualFlexOffCanvasResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Visual Flex Off Canvas Classification Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- Normalize Kiwi stackReverseZIndex into layout intent.
- Apply child z-index ordering so it survives resolved-tree refresh and instances.
- Add contract coverage for reverse z-order without changing DOM/layout order.

## Testing
- php -l touched PHP files
- composer test:contract
- focused/full FSE .fig transforms with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Kiwi layering investigation, implementation, rebase conflict resolution, and verification.