### PR TITLE
figma-transformer: reset overflowing clone offsets

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3350,19 +3350,19 @@ final class StaticHtmlEmitter
 
 		if ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
 			$styles[] = 'position:absolute';
-			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode) as $style ) {
+			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
 				$styles[] = $style;
 			}
         } elseif ( $isDecorativeFlexUnderlay ) {
             $styles[] = 'position:absolute';
-            foreach ( $this->absolutePositionStyles($box, $layout, $parentNode) as $style ) {
+			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
                 $styles[] = $style;
             }
             $styles[] = 'z-index:0';
             $styles[] = 'pointer-events:none';
 		} elseif ( 'absolute' === ($layout['positioning'] ?? null) ) {
             $styles[] = 'position:absolute';
-            foreach ( $this->absolutePositionStyles($box, $layout, $parentNode) as $style ) {
+			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
                 $styles[] = $style;
             }
         }
@@ -3644,12 +3644,16 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $layout
      * @return array<int, string>
      */
-    private function absolutePositionStyles(array $box, array $layout, ?array $parentNode): array
+    private function absolutePositionStyles(array $box, array $layout, ?array $parentNode, ?array $node = null): array
     {
         $styles = array();
         $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
         $left = $this->positionOffset($box, $parentBox, 'x', $parentNode);
         $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
+        if ( null !== $node && $this->hasComponentCloneGeometry($node) ) {
+            $left = $this->componentCloneSourceOffset($node, $box, $parentBox, 'x', $left);
+            $top = $this->componentCloneSourceOffset($node, $box, $parentBox, 'y', $top);
+        }
         $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
 
         foreach ( $this->axisConstraintStyles('horizontal', is_scalar($constraints['horizontal'] ?? null) ? (string) $constraints['horizontal'] : null, $left, $parentBox, $box) as $style ) {
@@ -3660,6 +3664,36 @@ final class StaticHtmlEmitter
         }
 
         return $styles;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $box
+     * @param array<string, mixed> $parentBox
+     */
+    private function componentCloneSourceOffset(array $node, array $box, array $parentBox, string $dimension, ?float $offset): ?float
+    {
+        if ( null === $offset ) {
+            return null;
+        }
+
+        $sizeKey = 'x' === $dimension ? 'width' : 'height';
+        if ( ! isset($parentBox[$sizeKey], $box[$sizeKey]) || ! is_numeric($parentBox[$sizeKey]) || ! is_numeric($box[$sizeKey]) ) {
+            return $offset;
+        }
+
+        $parentSize = (float) $parentBox[$sizeKey];
+        $boxSize = (float) $box[$sizeKey];
+        if ( $parentSize <= 0.0 || $boxSize <= 0.0 || ($offset >= -0.5 && $offset + $boxSize <= $parentSize + 0.5) ) {
+            return $offset;
+        }
+
+        $sourceBox = is_array($node['_component_source_clone_source_box'] ?? null) ? $node['_component_source_clone_source_box'] : array();
+        if ( isset($sourceBox[$dimension]) && is_numeric($sourceBox[$dimension]) ) {
+            return (float) $sourceBox[$dimension];
+        }
+
+        return 0.0;
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -969,6 +969,10 @@ final class ScenegraphNormalizer
                 continue;
             }
 
+			if ( 'box' === $boxKey && ! isset($node['_component_source_clone_source_box']) ) {
+				$node['_component_source_clone_source_box'] = $node[$boxKey];
+			}
+
 			$sourceKind = GeometryBox::sourceKind($node[$boxKey]);
 			foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
 				$hasRebasedLocalCoordinate = in_array($dimension, array('x', 'y'), true)
@@ -1096,6 +1100,18 @@ final class ScenegraphNormalizer
         }
 
         $box = $node[$boxKey];
+        if ( ! $isRoot && $this->isComponentSourceCloneTransformDescendant($node, $box) ) {
+            $sourceBox = $node['_component_source_clone_source_box'];
+            foreach ( array('x', 'y') as $dimension ) {
+                if ( isset($sourceBox[$dimension]) && is_numeric($sourceBox[$dimension]) ) {
+                    $box[$dimension] = (float) $sourceBox[$dimension];
+                }
+            }
+            $box = GeometryBox::withoutProvenance($box);
+            $box['coordinate_space'] = GeometryBox::COORDINATE_SPACE_PARENT_LOCAL;
+            $node[$boxKey] = $box;
+            return $node;
+        }
         if ( ! $isRoot && $this->isComponentSourceCloneDescendant($node, $box) ) {
             $box = GeometryBox::withoutProvenance($box);
             $box['coordinate_space'] = GeometryBox::COORDINATE_SPACE_PARENT_LOCAL;
@@ -1144,6 +1160,26 @@ final class ScenegraphNormalizer
         $x = isset($box['x']) && is_numeric($box['x']) ? abs((float) $box['x']) : 0.0;
         $y = isset($box['y']) && is_numeric($box['y']) ? abs((float) $box['y']) : 0.0;
         return $x < 1000.0 && $y < 1000.0;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $box
+     */
+    private function isComponentSourceCloneTransformDescendant(array $node, array $box): bool
+    {
+        $sourceKind = isset($box['component_clone_source_kind']) && is_scalar($box['component_clone_source_kind']) ? (string) $box['component_clone_source_kind'] : null;
+        if ( ! in_array($sourceKind, array(GeometryBox::SOURCE_TRANSFORM, GeometryBox::SOURCE_ABSOLUTE_TRANSFORM, GeometryBox::SOURCE_OVERRIDE_TRANSFORM), true) ) {
+            return false;
+        }
+
+        if ( empty($node['_component_source_clone_geometry']) && self::GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE !== ($box['geometry_semantics'] ?? null) ) {
+            return false;
+        }
+
+        $sourceBox = is_array($node['_component_source_clone_source_box'] ?? null) ? $node['_component_source_clone_source_box'] : array();
+        return GeometryBox::COORDINATE_SPACE_PARENT_LOCAL === GeometryBox::coordinateSpace($sourceBox)
+            && (isset($sourceBox['x']) || isset($sourceBox['y']));
     }
 
     /**
@@ -2348,12 +2384,24 @@ final class ScenegraphNormalizer
 		}
 
 		$box = $child['box'];
+		$shouldPreserveSourcePosition = false;
 		foreach ( array('x', 'y') as $dimension ) {
 			if ( ! isset($sourceChildBox[$dimension], $box[$dimension]) || ! is_numeric($sourceChildBox[$dimension]) || ! is_numeric($box[$dimension]) ) {
 				continue;
 			}
 
-			if ( abs((float) $box[$dimension] - (float) $sourceChildBox[$dimension]) >= 1000.0 ) {
+			if ( abs((float) $box[$dimension] - (float) $sourceChildBox[$dimension]) >= 100.0 ) {
+				$shouldPreserveSourcePosition = true;
+				break;
+			}
+		}
+
+		if ( $shouldPreserveSourcePosition ) {
+			foreach ( array('x', 'y') as $dimension ) {
+				if ( ! isset($sourceChildBox[$dimension]) || ! is_numeric($sourceChildBox[$dimension]) ) {
+					continue;
+				}
+
 				$child[$dimension] = (float) $sourceChildBox[$dimension];
 				$child['box'][$dimension] = (float) $sourceChildBox[$dimension];
 				if ( is_array($child['figma_box'] ?? null) && isset($child['figma_box'][$dimension]) && is_numeric($child['figma_box'][$dimension]) ) {

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -493,4 +493,69 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $assert(str_contains($nestedVectorSourceCss, '.source-union{width:20px;height:6px;position:absolute;left:4px;top:30px}'), 'visual-map-component-source-boolean-css-parent-local');
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedVectorSourceVector, array('x' => 42.0, 'y' => 48.0, 'width' => 16.0, 'height' => 16.0), 'visual-map-component-source-vector-rect-parent-local');
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $nestedVectorSourceUnion, array('x' => 34.0, 'y' => 70.0, 'width' => 20.0, 'height' => 6.0), 'visual-map-component-source-boolean-rect-parent-local');
+
+    $staleCanvasTransformResult = blocks_engine_figma_transformer_contract_transform(
+        array(
+            'name'  => 'Component Clone Stale Canvas Transform Fixture',
+            'nodes' => array(
+                array(
+                    'id'       => 'source:card',
+                    'type'     => 'COMPONENT',
+                    'name'     => 'Post card',
+                    'width'    => 376,
+                    'height'   => 477,
+                    'children' => array(
+                        array(
+                            'id'     => 'source:card/image',
+                            'type'   => 'RECTANGLE',
+                            'name'   => 'Image',
+                            'x'      => 0,
+                            'y'      => 0,
+                            'width'  => 376,
+                            'height' => 282,
+                        ),
+                        array(
+                            'id'     => 'source:card/content',
+                            'type'   => 'FRAME',
+                            'name'   => 'Content',
+                            'x'      => 0,
+                            'y'      => 314,
+                            'width'  => 376,
+                            'height' => 163,
+                        ),
+                    ),
+                ),
+                array(
+                    'id'       => 'source:page',
+                    'type'     => 'FRAME',
+                    'name'     => 'Page',
+                    'width'    => 600,
+                    'height'   => 800,
+                    'children' => array(
+                        array(
+                            'id'                => 'instance:card',
+                            'type'              => 'INSTANCE',
+                            'name'              => 'Placed card',
+                            'componentId'       => 'source:card',
+                            'x'                 => 112,
+                            'y'                 => 198,
+                            'width'             => 376,
+                            'height'            => 477,
+                            'derivedSymbolData' => array(
+                                array(
+                                    'nodeId'    => 'source:card/image',
+                                    'transform' => array('m02' => 128, 'm12' => 678),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array('frame_id' => 'source:page')
+    );
+    $staleCanvasImageCss = blocks_engine_figma_transformer_contract_file_content($staleCanvasTransformResult, 'style.css');
+    $staleCanvasImage = blocks_engine_figma_transformer_contract_find_visual_node($staleCanvasTransformResult, 'instance:card/source:card/image');
+    $assert(str_contains($staleCanvasImageCss, '.image{width:376px;height:282px;position:absolute;left:0px;top:0px}'), 'visual-map-component-source-stale-canvas-transform-css-parent-local');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $staleCanvasImage, array('x' => 112.0, 'y' => 198.0, 'width' => 376.0, 'height' => 282.0), 'visual-map-component-source-stale-canvas-transform-rect-parent-local');
 }


### PR DESCRIPTION
## Summary
- Preserve source-local component clone boxes for absolute descendants.
- Reset component-clone offsets that overflow their freeform instance container to source-local placement.
- Add contract coverage for stale canvas transform geometry on card image clones.

## Testing
- composer test:contract
- full FSE .fig transform with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Recent Posts placement investigation, implementation, and verification.