### PR TITLE
figma-transformer: avoid duplicate SVG wrapper strokes

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3407,8 +3407,10 @@ final class StaticHtmlEmitter
             $styles[] = $style;
         }
 
-        foreach ( $this->strokeStyles($node) as $style ) {
-            $styles[] = $style;
+        if ( ! $this->rendersStrokeInsideInlineSvg($node, $type, $parentNode) ) {
+            foreach ( $this->strokeStyles($node) as $style ) {
+                $styles[] = $style;
+            }
         }
 
         $assetPaths = $this->nodeAssetPaths($node);
@@ -4695,6 +4697,22 @@ final class StaticHtmlEmitter
         }
 
         return $styles;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function rendersStrokeInsideInlineSvg(array $node, string $type, ?array $parentNode): bool
+    {
+        if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON'), true) ) {
+            return false;
+        }
+
+        if ( empty($this->strokeStyles($node)) ) {
+            return false;
+        }
+
+        return null !== $this->supportedVectorSvg($node, $type, $parentNode);
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1061,6 +1061,26 @@ $edgeAlignedFilledVectorHtml = $fileContent($edgeAlignedFilledVectorResult, 'ind
 $assert(str_contains($edgeAlignedFilledVectorHtml, 'viewBox="0 0 10 10"'), 'edge-aligned-filled-vector-viewbox-keeps-intrinsic-bounds');
 $assert(! str_contains($edgeAlignedFilledVectorHtml, 'viewBox="-0.5 -0.5 11 11"'), 'edge-aligned-filled-vector-no-stroke-padding');
 
+$strokedInlineVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Stroked Inline Vector Fixture',
+    'nodes' => array(
+        array(
+            'id'                 => 'vector:stroked-inline',
+            'type'               => 'VECTOR',
+            'name'               => 'Stroked Inline Icon',
+            'width'              => 16,
+            'height'             => 16,
+            'strokeWeight'       => 2,
+            'strokePaints'       => array(array('type' => 'SOLID', 'color' => array('r' => 0.1215686275, 'g' => 0.1215686275, 'b' => 0.1215686275, 'a' => 1))),
+            'figma_vector_paths' => array(array('data' => 'M4 4L12 12')),
+        ),
+    ),
+));
+$strokedInlineVectorHtml = $fileContent($strokedInlineVectorResult, 'index.html');
+$strokedInlineVectorCss = $fileContent($strokedInlineVectorResult, 'style.css');
+$assert(str_contains($strokedInlineVectorHtml, 'stroke="#1f1f1f"') && str_contains($strokedInlineVectorHtml, 'stroke-width="2"'), 'stroked-inline-vector-svg-carries-stroke');
+$assert(! str_contains($strokedInlineVectorCss, 'border:2px solid #1f1f1f'), 'stroked-inline-vector-wrapper-no-css-border');
+
 $largeDecodedPath = 'M 0 0' . str_repeat(' L 10 10', 3000) . ' Z';
 $largeDecodedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Large Decoded Vector Fixture',


### PR DESCRIPTION
## Summary
- Keep vector stroke styling inside inline SVG geometry when a vector-like node renders as SVG.
- Preserve CSS border/stroke fallback behavior for non-SVG shapes such as frames and rectangles.
- Add contract coverage proving stroked inline vectors do not also emit wrapper borders.

## Testing
- composer test:contract
- full FSE .fig transform with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Raw Kiwi parity investigation, vector/icon stroke implementation, and verification.