### PR TITLE
php-transformer: resolve nested telemetry script targets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -495,6 +495,9 @@ final class RuntimeDependencyParityReport
             }
             $tag = strtolower($element->tagName);
             $src = 'script' === $tag && $element->hasAttribute('src') ? trim($element->getAttribute('src')) : '';
+            if ( '' !== $src ) {
+                $src = ArtifactPath::resolveRelativePath($src, $sourcePath);
+            }
             $id = trim($element->hasAttribute('id') ? $element->getAttribute('id') : '');
             if ( '' !== $id ) {
                 $targets['#' . $id] = array_filter(array('tag' => $tag, 'source_path' => $sourcePath, 'id' => $id, 'src' => $src), static fn (string $value): bool => '' !== $value);

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1421,6 +1421,21 @@ $assert(null === $selfRumFinding, 'telemetry script self-target is not reported 
 $assert(null !== $selfRumDependency, 'runtime dependency parity records telemetry script self-target dependency');
 $assert('script' === ($selfRumDependency['target_kind'] ?? ''), 'runtime dependency parity identifies telemetry script self-target kind');
 
+$nestedSelfRumSite = $compiler->compile(
+    array(
+        'entrypoint' => 'website/index.html',
+        'files'      => array(
+            'website/index.html' => '<main><h1>Telemetry</h1><script id="netlify-rum-container" src="js/rum.js" data-netlify-cwv-token="token"></script></main>',
+            'website/js/rum.js' => 'document.querySelector("#netlify-rum-container")?.getAttribute("data-netlify-cwv-token");',
+        ),
+    )
+)->toArray();
+$nestedSelfRumFindings = $nestedSelfRumSite['source_reports']['runtime_dependency_parity']['findings'] ?? array();
+$assert(
+    array() === array_values(array_filter($nestedSelfRumFindings, static fn (array $finding): bool => '#netlify-rum-container' === ($finding['selector'] ?? ''))),
+    'nested telemetry script self-target is not reported as a missing block DOM target'
+);
+
 $decorativeCanvasSite = $compiler->compile(
     array(
         'entrypoint' => 'index.html',


### PR DESCRIPTION
## Summary
- Resolve source script paths relative to their owning source document before telemetry self-target classification.
- Add contract coverage for a nested entrypoint whose telemetry script reads its own script tag.

## Verification
- php php-transformer/tests/contract/run.php
- php php-transformer/tests/parity/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** diagnosing the nested telemetry self-target false positive, implementing the focused fix, and running verification.