### PR TITLE
figma-transformer: preserve Kiwi mask metadata

### DIFF
--- a/figma-transformer/scripts/figma-node-trace.php
+++ b/figma-transformer/scripts/figma-node-trace.php
@@ -7,7 +7,7 @@ use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCapability;
 use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiParser;
-use Automattic\BlocksEngine\FigmaTransformer\FigmaTransformer;
+use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphIndex;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer;
 
@@ -35,23 +35,21 @@ $nodeIds = $options['node_ids'];
 $zstdCommand = $options['zstd_command'] ?? (getenv('FIGMA_TRANSFORMER_ZSTD_COMMAND') ?: null);
 $diagnosticLimit = (int) ($options['diagnostic_limit'] ?? 20);
 $maxNodes = isset($options['max_nodes']) ? (int) $options['max_nodes'] : null;
+$archiveOptions = blocks_engine_figma_trace_archive_options($options);
 
 $archive = null;
-$source = blocks_engine_figma_trace_read_source($input, is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null, $archive);
-$transformer = blocks_engine_figma_trace_transformer(is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null);
+$source = blocks_engine_figma_trace_read_source($input, is_string($zstdCommand) && '' !== $zstdCommand ? $zstdCommand : null, $archiveOptions, $archive);
 
-$transformOptions = array('frame_id' => $frameId);
+$transformOptions = array_merge($archiveOptions, array('frame_id' => $frameId));
 if ( null !== $maxNodes ) {
     $transformOptions['max_nodes'] = max(0, $maxNodes);
 }
 
 $normalizer = new ScenegraphNormalizer();
 $normalized = $normalizer->normalize(is_array($source['scenegraph'] ?? null) ? $source['scenegraph'] : array(), $transformOptions);
-$result = str_ends_with(strtolower($input), '.json')
-    ? $transformer->transformScenegraph(is_array($source['scenegraph'] ?? null) ? $source['scenegraph'] : array(), $transformOptions)->toArray()
-    : $transformer->transformFile($input, $transformOptions)->toArray();
+$result = blocks_engine_figma_trace_emit_result($normalized, $transformOptions);
 
-$rawIndex = (new ScenegraphIndex())->build(is_array($source['scenegraph'] ?? null) ? $source['scenegraph'] : array());
+$rawNodes = blocks_engine_figma_trace_find_raw_nodes(is_array($source['scenegraph'] ?? null) ? $source['scenegraph'] : array(), $nodeIds);
 $htmlReport = is_array($result['source_reports']['figma']['html'] ?? null) ? $result['source_reports']['figma']['html'] : array();
 $trace = array(
     'schema' => 'blocks-engine/figma-transformer/node-trace/v1',
@@ -74,7 +72,7 @@ foreach ( $nodeIds as $nodeId ) {
     $className = is_array($style) ? (string) ($style['node']['class'] ?? '') : '';
     $trace['nodes'][] = array(
         'id' => $nodeId,
-        'raw' => blocks_engine_figma_trace_node_summary($rawIndex['nodes'][$nodeId] ?? null, $rawIndex, $nodeId),
+        'raw' => blocks_engine_figma_trace_node_summary($rawNodes[$nodeId] ?? null, array(), $nodeId),
         'normalized' => blocks_engine_figma_trace_node_summary($normalized['node_map'][$nodeId] ?? null, $normalized, $nodeId),
         'emitted' => array_filter(array(
             'class' => '' !== $className ? $className : null,
@@ -134,13 +132,24 @@ function blocks_engine_figma_trace_options(array $argv): array
 
 function blocks_engine_figma_trace_usage(mixed $stream): void
 {
-    fwrite($stream, "Usage: figma-node-trace.php <path-to-fig-or-scenegraph-json> --frame-id=<id> --node-ids=<id,id> [--zstd-command=/opt/homebrew/bin/zstd] [--max-nodes=5000] [--diagnostic-limit=20]\n");
+    fwrite($stream, "Usage: figma-node-trace.php <path-to-fig-or-scenegraph-json> --frame-id=<id> --node-ids=<id,id> [--zstd-command=/opt/homebrew/bin/zstd] [--max-kiwi-message-decode-bytes=1] [--max-nodes=5000] [--diagnostic-limit=20]\n");
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_trace_archive_options(array $options): array
+{
+    return array(
+        'include_asset_content' => false,
+        'max_kiwi_message_decode_bytes' => max(1, (int) ($options['max_kiwi_message_decode_bytes'] ?? 1)),
+    );
 }
 
 /**
  * @return array{scenegraph: array<string, mixed>, shape: string, decoded_scenegraph?: array<string, mixed>}
  */
-function blocks_engine_figma_trace_read_source(string $input, ?string $zstdCommand, ?array &$archive): array
+function blocks_engine_figma_trace_read_source(string $input, ?string $zstdCommand, array $archiveOptions, ?array &$archive): array
 {
     if ( str_ends_with(strtolower($input), '.json') ) {
         $decoded = is_readable($input) ? json_decode((string) file_get_contents($input), true) : null;
@@ -148,18 +157,13 @@ function blocks_engine_figma_trace_read_source(string $input, ?string $zstdComma
     }
 
     $archiveReader = blocks_engine_figma_trace_archive_reader($zstdCommand);
-    $archive = $archiveReader->read($input);
+    $archive = $archiveReader->read($input, $archiveOptions);
     $candidate = blocks_engine_figma_trace_decoded_scenegraph_candidate($archive);
     return array(
         'scenegraph' => is_array($candidate['payload'] ?? null) ? $candidate['payload'] : array(),
         'shape' => 'fig',
         'decoded_scenegraph' => is_array($candidate['report'] ?? null) ? $candidate['report'] : array(),
     );
-}
-
-function blocks_engine_figma_trace_transformer(?string $zstdCommand): FigmaTransformer
-{
-    return new FigmaTransformer(blocks_engine_figma_trace_archive_reader($zstdCommand));
 }
 
 function blocks_engine_figma_trace_archive_reader(?string $zstdCommand): FigArchiveReader
@@ -169,6 +173,34 @@ function blocks_engine_figma_trace_archive_reader(?string $zstdCommand): FigArch
     }
 
     return new FigArchiveReader(new FigKiwiParser(new ZstdCapability(new ZstdCommandDecoder(array($zstdCommand, '-dc')))));
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_trace_emit_result(array $normalized, array $transformOptions): array
+{
+    $artifact = (new StaticHtmlEmitter())->emit($normalized, $transformOptions);
+    $diagnostics = array_merge(
+        is_array($normalized['diagnostics'] ?? null) ? $normalized['diagnostics'] : array(),
+        is_array($artifact['diagnostics'] ?? null) ? $artifact['diagnostics'] : array()
+    );
+
+    return array(
+        'status' => $artifact['status'] ?? 'success_with_warnings',
+        'diagnostics' => $diagnostics,
+        'files' => is_array($artifact['files'] ?? null) ? $artifact['files'] : array(),
+        'assets' => is_array($artifact['assets'] ?? null) ? $artifact['assets'] : array(),
+        'metrics' => array(
+            'node_count' => is_array($normalized['node_map'] ?? null) ? count($normalized['node_map']) : 0,
+        ),
+        'source_reports' => array(
+            'figma' => array(
+                'scenegraph' => $normalized['source_report'] ?? array(),
+                'html' => is_array($artifact['source_report'] ?? null) ? $artifact['source_report'] : array(),
+            ),
+        ),
+    );
 }
 
 /**
@@ -238,6 +270,64 @@ function blocks_engine_figma_trace_scenegraph_score(array $payload, string $shap
     return $score + count(is_array($index['nodes'] ?? null) ? $index['nodes'] : array());
 }
 
+/**
+ * @param array<string, mixed> $scenegraph
+ * @param array<int, string>   $nodeIds
+ * @return array<string, array<string, mixed>>
+ */
+function blocks_engine_figma_trace_find_raw_nodes(array $scenegraph, array $nodeIds): array
+{
+    $wanted = array_fill_keys(array_map('strval', $nodeIds), true);
+    $found = array();
+    blocks_engine_figma_trace_collect_raw_nodes($scenegraph, $wanted, $found);
+    return $found;
+}
+
+/**
+ * @param array<string, mixed>                $node
+ * @param array<string, true>                 $wanted
+ * @param array<string, array<string, mixed>> $found
+ */
+function blocks_engine_figma_trace_collect_raw_nodes(array $node, array $wanted, array &$found): void
+{
+    $nodeId = is_scalar($node['id'] ?? null) ? (string) $node['id'] : '';
+    if ( '' !== $nodeId && isset($wanted[$nodeId]) ) {
+        $found[$nodeId] = $node;
+    }
+
+    foreach ( array('NODE_CHANGES', 'node_changes', 'nodeChanges') as $changesKey ) {
+        if ( ! is_array($node[$changesKey] ?? null) ) {
+            continue;
+        }
+        foreach ( $node[$changesKey] as $key => $change ) {
+            $candidate = is_array($change) && is_array($change['node'] ?? null) ? $change['node'] : $change;
+            if ( ! is_array($candidate) ) {
+                continue;
+            }
+            $id = is_scalar($candidate['id'] ?? null) ? (string) $candidate['id'] : (is_scalar($key) ? (string) $key : '');
+            if ( '' !== $id && isset($wanted[$id]) ) {
+                $found[$id] = $candidate;
+            }
+            blocks_engine_figma_trace_collect_raw_nodes($candidate, $wanted, $found);
+        }
+    }
+
+    foreach ( array('document', 'nodes', 'children') as $childrenKey ) {
+        $children = $node[$childrenKey] ?? null;
+        if ( is_array($children) && array_is_list($children) ) {
+            foreach ( $children as $child ) {
+                if ( is_array($child) ) {
+                    blocks_engine_figma_trace_collect_raw_nodes($child, $wanted, $found);
+                }
+            }
+            continue;
+        }
+        if ( is_array($children) ) {
+            blocks_engine_figma_trace_collect_raw_nodes($children, $wanted, $found);
+        }
+    }
+}
+
 function blocks_engine_figma_trace_node_summary(mixed $node, array $index, string $nodeId): ?array
 {
     if ( ! is_array($node) ) {
@@ -253,9 +343,23 @@ function blocks_engine_figma_trace_node_summary(mixed $node, array $index, strin
         'child_ids' => is_array($index['children_index'][$nodeId] ?? null) ? array_values($index['children_index'][$nodeId]) : array(),
         'box' => ! empty($box) ? $box : blocks_engine_figma_trace_raw_box($node),
         'layout' => ! empty($layout) ? $layout : blocks_engine_figma_trace_raw_layout($node),
+        'mask' => blocks_engine_figma_trace_mask_summary($node),
         'text' => blocks_engine_figma_trace_text_summary($node),
         'paints' => blocks_engine_figma_trace_paint_summary($node),
     ), static fn (mixed $value): bool => null !== $value && array() !== $value);
+}
+
+function blocks_engine_figma_trace_mask_summary(array $node): array
+{
+    if ( is_array($node['figma_mask'] ?? null) ) {
+        return $node['figma_mask'];
+    }
+
+    return array_filter(array(
+        'mask' => $node['mask'] ?? null,
+        'isMask' => $node['isMask'] ?? null,
+        'maskType' => $node['maskType'] ?? null,
+    ), static fn (mixed $value): bool => null !== $value);
 }
 
 function blocks_engine_figma_trace_raw_box(array $node): array

--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -97,7 +97,7 @@ final class FigKiwiDecodePolicy
             'fills_images' => array_values(array_unique(array_merge($this->nodePaintAndStrokeFields(), $this->nodeVectorAndImageFields(), array('Paint', 'Image', 'Blob', 'image', 'hash', 'bytes')))),
             'component_overrides' => $this->nodeComponentFields(),
             'text_style' => $this->nodeTextFields(),
-            'masks_effects' => array_values(array_unique(array_merge($this->nodeEffectFields(), array('isClip', 'frameMaskDisabled')))),
+            'masks_effects' => array_values(array_unique(array_merge($this->nodeEffectFields(), array('mask', 'isMask', 'maskType', 'isClip', 'frameMaskDisabled')))),
             'vectors' => array_values(array_unique(array_merge($this->nodeVectorAndImageFields(), array('Path', 'VectorPath', 'VectorData', 'commandsBlob', 'vectorNetworkBlob', 'vectorNetwork')))),
             'prototype_links' => $this->nodePrototypeLinkFields(),
         );
@@ -316,8 +316,9 @@ final class FigKiwiDecodePolicy
      */
     private function nodeEffectFields(): array
     {
-        // Visual effects (#328): shadows + blur.
-        return array('effects');
+        // Visual effects and mask-source metadata. `mask` is the Kiwi field name;
+        // `isMask` is the REST spelling seen in exported scenegraphs.
+        return array('effects', 'mask', 'isMask', 'maskType');
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -443,6 +443,11 @@ final class ScenegraphNormalizer
             $node['figma_effects'] = $effects;
         }
 
+        $mask = $this->normalizeMask($node);
+        if ( ! empty($mask) ) {
+            $node['figma_mask'] = $mask;
+        }
+
         $link = $this->normalizeLink($node, $type);
         if ( ! empty($link) ) {
             $node['figma_link'] = $link;
@@ -2650,6 +2655,49 @@ final class ScenegraphNormalizer
         }
 
         return $effects;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function normalizeMask(array $node): array
+    {
+        $isMask = $this->normalizeBoolean($node['isMask'] ?? $node['mask'] ?? null);
+        $maskType = isset($node['maskType']) && is_scalar($node['maskType']) ? strtoupper((string) $node['maskType']) : null;
+
+        if ( null === $isMask && null === $maskType ) {
+            return array();
+        }
+
+        return array_filter(
+            array(
+                'is_mask' => $isMask,
+                'type'    => $maskType,
+            ),
+            static fn (mixed $value): bool => null !== $value
+        );
+    }
+
+    private function normalizeBoolean(mixed $value): ?bool
+    {
+        if ( is_bool($value) ) {
+            return $value;
+        }
+
+        if ( is_int($value) || is_float($value) ) {
+            return 0 !== (int) $value;
+        }
+
+        if ( is_string($value) ) {
+            return match ( strtolower($value) ) {
+                '1', 'true', 'yes', 'on' => true,
+                '0', 'false', 'no', 'off' => false,
+                default => null,
+            };
+        }
+
+        return null;
     }
 
     /**

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiParser;
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer;
 
 function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $assert, callable $fileContent): void
 {
@@ -170,6 +171,28 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     );
     $kiwiFrameMaskNode = $kiwiFrameMaskMessage['message']['nodeChanges'][0] ?? array();
     $assert(false === ($kiwiFrameMaskNode['frameMaskDisabled'] ?? null), 'kiwi-selective-decodes-frame-mask-disabled');
+    $assert(true === ($kiwiFrameMaskNode['mask'] ?? null), 'kiwi-selective-decodes-mask');
+    $assert('ALPHA' === ($kiwiFrameMaskNode['maskType'] ?? null), 'kiwi-selective-decodes-mask-type');
+
+    $kiwiMaskNormalizer = new ScenegraphNormalizer();
+    $kiwiMaskNormalized = $kiwiMaskNormalizer->normalize(array(
+        'name'  => 'Kiwi Mask Metadata Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'kiwi:mask-source',
+                'type'     => 'VECTOR',
+                'name'     => 'Mask Source',
+                'width'    => 24,
+                'height'   => 24,
+                'mask'     => true,
+                'maskType' => 'ALPHA',
+            ),
+        ),
+    ));
+    $kiwiMaskNormalizedNode = $kiwiMaskNormalized['nodes'][0] ?? array();
+    $assert(true === ($kiwiMaskNormalizedNode['figma_mask']['is_mask'] ?? null), 'kiwi-mask-normalizes-mask-role');
+    $assert('ALPHA' === ($kiwiMaskNormalizedNode['figma_mask']['type'] ?? null), 'kiwi-mask-normalizes-mask-type');
+    $assert(! isset($kiwiMaskNormalizedNode['layout']['clips_content']), 'kiwi-mask-source-does-not-force-clips-content');
     
     $kiwiDerivedTextSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture());
     $kiwiDerivedTextMessage = $kiwiDecoder->decodeMessageSelective(
@@ -486,20 +509,29 @@ function blocks_engine_figma_transformer_kiwi_message_fixture(): string
 
 function blocks_engine_figma_transformer_kiwi_frame_mask_schema_fixture(): string
 {
-    return blocks_engine_figma_transformer_wire_varint(3)
+    return blocks_engine_figma_transformer_wire_varint(4)
         // def0: ENUM MessageType { NODE_CHANGES = 1 }
         . blocks_engine_figma_transformer_kiwi_string('MessageType')
         . chr(0)
         . blocks_engine_figma_transformer_wire_varint(1)
         . blocks_engine_figma_transformer_kiwi_schema_field('NODE_CHANGES', 0, false, 1)
-        // def1: MESSAGE NodeChange { type, name, frameMaskDisabled }
+        // def1: MESSAGE NodeChange { type, name, frameMaskDisabled, mask, maskType }
         . blocks_engine_figma_transformer_kiwi_string('NodeChange')
         . chr(2)
-        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_wire_varint(5)
         . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 2)
         . blocks_engine_figma_transformer_kiwi_schema_field('frameMaskDisabled', -1, false, 3)
-        // def2: MESSAGE Message { type, nodeChanges[] }
+        . blocks_engine_figma_transformer_kiwi_schema_field('mask', -1, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('maskType', 2, false, 5)
+        // def2: ENUM MaskType { ALPHA = 1, VECTOR = 2, LUMINANCE = 3 }
+        . blocks_engine_figma_transformer_kiwi_string('MaskType')
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('ALPHA', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('VECTOR', 0, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('LUMINANCE', 0, false, 3)
+        // def3: MESSAGE Message { type, nodeChanges[] }
         . blocks_engine_figma_transformer_kiwi_string('Message')
         . chr(2)
         . blocks_engine_figma_transformer_wire_varint(2)
@@ -519,6 +551,10 @@ function blocks_engine_figma_transformer_kiwi_frame_mask_message_fixture(): stri
         . blocks_engine_figma_transformer_kiwi_string('Masked Frame')
         . blocks_engine_figma_transformer_wire_varint(3)
         . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(5)
+        . blocks_engine_figma_transformer_wire_varint(1)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
 }

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -16,12 +16,12 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $fields = is_array($inventory['fields'] ?? null) ? $inventory['fields'] : array();
 
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1' === ($inventory['schema'] ?? null), 'kiwi-skipped-inventory-schema');
-    $assert(6 === ($inventory['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-field-count');
-    $assert(6 === ($inventory['summary']['occurrences'] ?? null), 'kiwi-skipped-inventory-occurrences');
+    $assert(5 === ($inventory['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-field-count');
+    $assert(5 === ($inventory['summary']['occurrences'] ?? null), 'kiwi-skipped-inventory-occurrences');
     $assert(1 === ($inventory['summary']['by_role']['geometry_layout'] ?? null), 'kiwi-skipped-inventory-geometry-role');
     $assert(1 === ($inventory['summary']['by_role']['component_overrides'] ?? null), 'kiwi-skipped-inventory-component-role');
     $assert(1 === ($inventory['summary']['by_role']['fills_images'] ?? null), 'kiwi-skipped-inventory-image-role');
-    $assert(1 === ($inventory['summary']['by_role']['masks_effects'] ?? null), 'kiwi-skipped-inventory-mask-role');
+    $assert(! isset($inventory['summary']['by_role']['masks_effects']), 'kiwi-skipped-inventory-mask-role');
     $assert(1 === ($inventory['summary']['by_role']['text_style'] ?? null), 'kiwi-skipped-inventory-text-role');
     $assert(1 === ($inventory['summary']['by_role']['vectors'] ?? null), 'kiwi-skipped-inventory-vector-role');
 
@@ -29,6 +29,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('NodeChange' === ($layoutEntry['parent_message'] ?? null), 'kiwi-skipped-inventory-parent-message');
     $assert('FRAME' === array_key_first(is_array($layoutEntry['node_types'] ?? null) ? $layoutEntry['node_types'] : array()), 'kiwi-skipped-inventory-node-type');
     $assert(array('7:42') === ($layoutEntry['sample_node_ids'] ?? null), 'kiwi-skipped-inventory-node-id-sample');
+    $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'maskType'), 'kiwi-skipped-inventory-mask-type-decoded');
 
     $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
         SyntheticFigKiwiFixtureBuilder::canvas(array(
@@ -45,7 +46,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
 
     $assert(is_array($cli), 'kiwi-skipped-inventory-cli-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-cli-schema');
-    $assert(6 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
+    $assert(5 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
 
     $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
         SyntheticFigKiwiFixtureBuilder::canvas(array(
@@ -69,7 +70,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-output/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-output-cli-schema');
     $assert(is_array($written), 'kiwi-skipped-inventory-output-file-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($written['schema'] ?? null), 'kiwi-skipped-inventory-output-file-schema');
-    $assert(6 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
+    $assert(5 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Decode Kiwi mask/isMask/maskType fields and normalize neutral figma_mask metadata.
- Preserve existing clipping behavior; mask source nodes no longer force overflow clipping.
- Update node trace to use bounded selective Kiwi decoding for large .fig traces.

## Testing
- php -l touched PHP files
- composer test:contract
- real FSE skipped-field inventory and node trace checks with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Raw Kiwi mask investigation, implementation, and verification.