### PR TITLE
figma-transformer: preserve Kiwi image paint metadata

### DIFF
--- a/figma-transformer/scripts/figma-parser-parity.php
+++ b/figma-transformer/scripts/figma-parser-parity.php
@@ -613,7 +613,7 @@ function blocks_engine_figma_parser_parity_raw_asset_reference_node_ids(array $n
             continue;
         }
         $encoded = json_encode($node, JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR);
-        if ( is_string($encoded) && preg_match('/("asset_id"|"imageHash"|"hash"|"ref")/', $encoded) ) {
+        if ( is_string($encoded) && preg_match('/("asset_id"|"imageRef"|"imageHash"|"hash"|"ref")/', $encoded) ) {
             $ids[] = (string) $id;
         }
     }

--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -41,7 +41,7 @@ final class FigKiwiDecodePolicy
             'Glyph' => array('position', 'fontSize', 'firstCharacter', 'endCharacter', 'advance', 'rotation', 'styleID'),
             'FontMetaData' => array('key', 'fontLineHeight', 'fontWeight'),
             'Number' => array('value', 'units'),
-            'Paint' => array('type', 'color', 'opacity', 'visible', 'blendMode', 'stops', 'transform', 'image', 'imageThumbnail', 'imageScaleMode', 'originalImageWidth', 'originalImageHeight', 'altText'),
+            'Paint' => array('type', 'color', 'opacity', 'visible', 'blendMode', 'stops', 'transform', 'imageTransform', 'cropTransform', 'cropRect', 'image', 'imageThumbnail', 'imageScaleMode', 'originalImageWidth', 'originalImageHeight', 'scale', 'rotation', 'imageShouldColorManage', 'thumbHash', 'animationFrame', 'altText'),
             // Effect struct (#328). The Kiwi blur token is `FOREGROUND_BLUR`
             // (REST calls it `LAYER_BLUR`); the normalizer bridges both. `offset`
             // resolves to the whitelisted `Vector` struct and `color` to `Color`.

--- a/figma-transformer/src/Html/VisualNodeMapBuilder.php
+++ b/figma-transformer/src/Html/VisualNodeMapBuilder.php
@@ -444,7 +444,7 @@ final class VisualNodeMapBuilder
             'has_transform' => null !== $transform && ! $this->isIdentityImageTransform($transform),
             'color_managed' => true === ($paint['imageShouldColorManage'] ?? false),
         );
-        foreach ( array('ref', 'imageHash', 'imageName', 'originalImageWidth', 'originalImageHeight', 'scale', 'rotation') as $key ) {
+        foreach ( array('ref', 'imageHash', 'imageName', 'originalImageWidth', 'originalImageHeight', 'scale', 'rotation', 'thumbHash', 'animationFrame') as $key ) {
             if ( isset($paint[$key]) && is_scalar($paint[$key]) ) {
                 $metadata[$key] = $paint[$key];
             }

--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -200,14 +200,23 @@ final class PaintNormalizer
                     $normalized[$key] = (float) $paint[$key];
                 }
             }
+            if ( isset($paint['animationFrame']) && is_numeric($paint['animationFrame']) ) {
+                $normalized['animationFrame'] = (int) $paint['animationFrame'];
+            }
             if ( isset($paint['imageShouldColorManage']) && is_bool($paint['imageShouldColorManage']) ) {
                 $normalized['imageShouldColorManage'] = $paint['imageShouldColorManage'];
             }
-            foreach ( array('transform', 'imageTransform') as $transformKey ) {
+            if ( isset($paint['thumbHash']) && is_scalar($paint['thumbHash']) && '' !== (string) $paint['thumbHash'] ) {
+                $normalized['thumbHash'] = $this->normalizeByteString((string) $paint['thumbHash']);
+            }
+            foreach ( array('transform', 'imageTransform', 'cropTransform') as $transformKey ) {
                 if ( is_array($paint[$transformKey] ?? null) ) {
                     $normalized['transform'] = $paint[$transformKey];
                     break;
                 }
+            }
+            if ( is_array($paint['cropRect'] ?? null) ) {
+                $normalized['cropRect'] = $paint['cropRect'];
             }
 
             return $normalized;
@@ -320,6 +329,11 @@ final class PaintNormalizer
         }
 
         return $hash;
+    }
+
+    private function normalizeByteString(string $value): string
+    {
+        return 1 === preg_match('//u', $value) ? $value : bin2hex($value);
     }
 
     private function readGuidId(mixed $guid): ?string

--- a/figma-transformer/tests/contract/ImagePaintContract.php
+++ b/figma-transformer/tests/contract/ImagePaintContract.php
@@ -222,7 +222,20 @@ function blocks_engine_figma_transformer_run_image_paint_contract(callable $asse
                             'guidPath'   => array('guids' => array(array('sessionID' => 700, 'localID' => 4), array('sessionID' => 700, 'localID' => 2))),
                             'fillPaints' => array(
                                 array('type' => 'IMAGE', 'imageRef' => 'default-image'),
-                                array('type' => 'IMAGE', 'imageRef' => 'override-image'),
+                                array(
+                                    'type'                   => 'IMAGE',
+                                    'imageRef'               => 'override-image',
+                                    'imageScaleMode'         => 'STRETCH',
+                                    'imageShouldColorManage' => false,
+                                    'rotation'               => 15,
+                                    'scale'                  => 2,
+                                    'animationFrame'         => 3,
+                                    'thumbHash'              => 'thumbhash-bytes',
+                                    'imageTransform'         => array(
+                                        array(0.5, 0, 0.25),
+                                        array(0, 0.5, 0.25),
+                                    ),
+                                ),
                             ),
                         ),
                     ),
@@ -235,8 +248,14 @@ function blocks_engine_figma_transformer_run_image_paint_contract(callable $asse
         ),
     ));
     $nestedImageOverrideCss = $fileContent($nestedImageOverrideResult, 'style.css');
+    $nestedImageOverrideVisualNode = blocks_engine_figma_transformer_contract_find_visual_node($nestedImageOverrideResult, 'instance:preview/700:4/700:2');
     $assert(str_contains($nestedImageOverrideCss, '.figma-node-instance-preview-700-4-700-2-image'), 'nested-image-override-emits-nested-image-node');
     $assert(str_contains($nestedImageOverrideCss, 'background-image:url("assets/override-image.bin")'), 'nested-image-override-replaces-source-image-paint');
+    $assert(true === ($nestedImageOverrideVisualNode['image']['has_transform'] ?? null), 'nested-image-override-carries-image-transform-metadata');
+    $assert(15.0 === ($nestedImageOverrideVisualNode['image']['rotation'] ?? null), 'nested-image-override-carries-image-rotation');
+    $assert(2.0 === ($nestedImageOverrideVisualNode['image']['scale'] ?? null), 'nested-image-override-carries-image-scale');
+    $assert(3 === ($nestedImageOverrideVisualNode['image']['animationFrame'] ?? null), 'nested-image-override-carries-animation-frame');
+    $assert('thumbhash-bytes' === ($nestedImageOverrideVisualNode['image']['thumbHash'] ?? null), 'nested-image-override-carries-thumb-hash');
     $assert(! str_contains($nestedImageOverrideCss, 'background-image:url("assets/override-image.bin"),url("assets/default-image.bin")'), 'nested-image-override-drops-stale-source-image-paint');
 
     $styleBackedImageOverrideResult = blocks_engine_figma_transformer_transform_scenegraph(array(

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -193,6 +193,22 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert(true === ($kiwiMaskNormalizedNode['figma_mask']['is_mask'] ?? null), 'kiwi-mask-normalizes-mask-role');
     $assert('ALPHA' === ($kiwiMaskNormalizedNode['figma_mask']['type'] ?? null), 'kiwi-mask-normalizes-mask-type');
     $assert(! isset($kiwiMaskNormalizedNode['layout']['clips_content']), 'kiwi-mask-source-does-not-force-clips-content');
+
+    $kiwiImagePaintSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_image_paint_schema_fixture());
+    $kiwiImagePaintMessage = $kiwiDecoder->decodeMessageSelective(
+        blocks_engine_figma_transformer_kiwi_image_paint_message_fixture(),
+        $kiwiImagePaintSchema['schema'] ?? array()
+    );
+    $kiwiDirectImagePaint = $kiwiImagePaintMessage['message']['nodeChanges'][0]['fillPaints'][0] ?? array();
+    $kiwiOverrideImagePaint = $kiwiImagePaintMessage['message']['nodeChanges'][0]['symbolData']['symbolOverrides'][0]['fillPaints'][0] ?? array();
+    $assert(true === ($kiwiDirectImagePaint['imageShouldColorManage'] ?? null), 'kiwi-selective-decodes-image-color-management');
+    $assert(15.0 === round((float) ($kiwiDirectImagePaint['rotation'] ?? 0.0), 4), 'kiwi-selective-decodes-image-rotation');
+    $assert(2.0 === round((float) ($kiwiDirectImagePaint['scale'] ?? 0.0), 4), 'kiwi-selective-decodes-image-scale');
+    $assert(7 === ($kiwiDirectImagePaint['animationFrame'] ?? null), 'kiwi-selective-decodes-image-animation-frame');
+    $assert('abc' === ($kiwiDirectImagePaint['thumbHash'] ?? null), 'kiwi-selective-decodes-image-thumb-hash');
+    $assert(0.5 === round((float) ($kiwiDirectImagePaint['imageTransform']['m00'] ?? 0.0), 4), 'kiwi-selective-decodes-image-transform');
+    $assert(false === ($kiwiOverrideImagePaint['imageShouldColorManage'] ?? null), 'kiwi-selective-decodes-override-image-color-management');
+    $assert(9 === ($kiwiOverrideImagePaint['animationFrame'] ?? null), 'kiwi-selective-decodes-override-image-animation-frame');
     
     $kiwiDerivedTextSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture());
     $kiwiDerivedTextMessage = $kiwiDecoder->decodeMessageSelective(
@@ -557,6 +573,106 @@ function blocks_engine_figma_transformer_kiwi_frame_mask_message_fixture(): stri
         . blocks_engine_figma_transformer_wire_varint(1)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
+}
+
+function blocks_engine_figma_transformer_kiwi_image_paint_schema_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(7)
+        // def0: ENUM MessageType { NODE_CHANGES = 1 }
+        . blocks_engine_figma_transformer_kiwi_string('MessageType')
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('NODE_CHANGES', 0, false, 1)
+        // def1: STRUCT Matrix { m00, m01, m02, m10, m11, m12 }
+        . blocks_engine_figma_transformer_kiwi_string('Matrix')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(6)
+        . blocks_engine_figma_transformer_kiwi_schema_field('m00', -5, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('m01', -5, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('m02', -5, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('m10', -5, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('m11', -5, false, 5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('m12', -5, false, 6)
+        // def2: STRUCT Image { hash, name }
+        . blocks_engine_figma_transformer_kiwi_string('Image')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('hash', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 2)
+        // def3: STRUCT Paint with image metadata fields observed in raw Kiwi fills and symbol overrides.
+        . blocks_engine_figma_transformer_kiwi_string('Paint')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(9)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('image', 2, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('imageScaleMode', -6, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('imageShouldColorManage', -1, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('rotation', -5, false, 5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('scale', -5, false, 6)
+        . blocks_engine_figma_transformer_kiwi_schema_field('animationFrame', -4, false, 7)
+        . blocks_engine_figma_transformer_kiwi_schema_field('thumbHash', -2, true, 8)
+        . blocks_engine_figma_transformer_kiwi_schema_field('imageTransform', 1, false, 9)
+        // def4: STRUCT SymbolData { symbolOverrides[] }
+        . blocks_engine_figma_transformer_kiwi_string('SymbolData')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('symbolOverrides', 5, true, 1)
+        // def5: MESSAGE NodeChange { type, fillPaints[], symbolData }
+        . blocks_engine_figma_transformer_kiwi_string('NodeChange')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('fillPaints', 3, true, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('symbolData', 4, false, 3)
+        // def6: MESSAGE Message { type, nodeChanges[] }
+        . blocks_engine_figma_transformer_kiwi_string('Message')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 5, true, 2);
+}
+
+function blocks_engine_figma_transformer_kiwi_image_paint_message_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('INSTANCE')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_image_paint_bytes('direct-hash', true, 15.0, 2.0, 7, 'abc', 0.5)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('RECTANGLE')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_image_paint_bytes('override-hash', false, 30.0, 1.25, 9, 'xyz', 0.25)
+        . blocks_engine_figma_transformer_wire_varint(0)
+        . blocks_engine_figma_transformer_wire_varint(0)
+        . blocks_engine_figma_transformer_wire_varint(0);
+}
+
+function blocks_engine_figma_transformer_kiwi_image_paint_bytes(string $hash, bool $colorManaged, float $rotation, float $scale, int $animationFrame, string $thumbHash, float $m00): string
+{
+    return blocks_engine_figma_transformer_kiwi_string('IMAGE')
+        . blocks_engine_figma_transformer_kiwi_string($hash)
+        . blocks_engine_figma_transformer_kiwi_string($hash . '.png')
+        . blocks_engine_figma_transformer_kiwi_string('STRETCH')
+        . chr($colorManaged ? 1 : 0)
+        . blocks_engine_figma_transformer_kiwi_varfloat($rotation)
+        . blocks_engine_figma_transformer_kiwi_varfloat($scale)
+        . blocks_engine_figma_transformer_wire_varint($animationFrame)
+        . blocks_engine_figma_transformer_wire_varint(strlen($thumbHash))
+        . $thumbHash
+        . blocks_engine_figma_transformer_kiwi_varfloat($m00)
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.1)
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.75)
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.2);
 }
 
 function blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture(): string

--- a/figma-transformer/tests/contract/ParserParityContract.php
+++ b/figma-transformer/tests/contract/ParserParityContract.php
@@ -17,6 +17,11 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
                 'mime_type' => 'image/svg+xml',
                 'content'   => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>',
             ),
+            'paint-asset' => array(
+                'name'      => 'Paint Asset',
+                'mime_type' => 'image/png',
+                'content'   => 'paint asset',
+            ),
         ),
         'nodes'  => array(
             array(
@@ -50,6 +55,14 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
                         'height'       => 20,
                         'fillGeometry' => array(array('commandsBlob' => 0)),
                     ),
+                    array(
+                        'id'         => 'parity:image-ref',
+                        'type'       => 'RECTANGLE',
+                        'name'       => 'Parity Image Ref',
+                        'width'      => 64,
+                        'height'     => 48,
+                        'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'paint-asset')),
+                    ),
                 ),
             ),
         ),
@@ -67,15 +80,15 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
     $assert(is_array($report), 'parser-parity-json-output');
     $assert('blocks-engine/figma-transformer/parser-parity/v1' === ($report['schema'] ?? null), 'parser-parity-schema');
     $assert('parity:frame' === ($report['options']['frame_id'] ?? null), 'parser-parity-frame-option');
-    $assert(4 === ($report['raw']['node_count'] ?? null), 'parser-parity-raw-node-count');
-    $assert(4 === ($report['normalized']['node_count'] ?? null), 'parser-parity-normalized-node-count');
+    $assert(5 === ($report['raw']['node_count'] ?? null), 'parser-parity-raw-node-count');
+    $assert(5 === ($report['normalized']['node_count'] ?? null), 'parser-parity-normalized-node-count');
     $assert(1 === ($report['raw']['blob_count'] ?? null), 'parser-parity-raw-blob-count');
-    $assert(1 === ($report['raw']['asset_count'] ?? null), 'parser-parity-raw-asset-count');
+    $assert(2 === ($report['raw']['asset_count'] ?? null), 'parser-parity-raw-asset-count');
     $assert(1 === ($report['raw']['text_node_count'] ?? null), 'parser-parity-raw-text-node-count');
     $assert(1 === ($report['raw']['vector_node_count'] ?? null), 'parser-parity-raw-vector-node-count');
     $assert(1 === ($report['raw']['component_prop_node_count'] ?? null), 'parser-parity-component-prop-node-count');
-    $assert(4 === ($report['coverage']['raw_to_normalized_node']['covered_count'] ?? null), 'parser-parity-raw-normalized-node-coverage');
-    $assert(($report['coverage']['raw_asset_refs_to_normalized_asset_refs']['covered_count'] ?? 0) >= 1, 'parser-parity-asset-reference-coverage');
+    $assert(5 === ($report['coverage']['raw_to_normalized_node']['covered_count'] ?? null), 'parser-parity-raw-normalized-node-coverage');
+    $assert(2 === ($report['coverage']['raw_asset_refs_to_normalized_asset_refs']['covered_count'] ?? null), 'parser-parity-asset-reference-coverage');
     $assert(is_array($report['top_missing_field_paths'] ?? null), 'parser-parity-missing-field-paths-present');
 
     $figPath = SyntheticFigKiwiFixtureBuilder::figArchive(


### PR DESCRIPTION
## Summary
- Decode and normalize additional Kiwi image paint metadata, including scale, rotation, color management, thumbHash, animationFrame, and transform aliases.
- Expose selected image metadata in visual node maps and improve parser parity raw asset reference detection for imageRef.
- Add coverage for direct fills, nested symbol override paints, and parser parity image refs.

## Testing
- php -l touched PHP files
- composer test:contract
- real FSE skipped-field inventory/parser parity checks with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Raw Kiwi image metadata investigation, implementation, rebase conflict resolution, and verification.