### PR TITLE
figma-transformer: render vector glows as drop shadows

### DIFF
--- a/figma-transformer/src/Html/StyleDeclarationBuilder.php
+++ b/figma-transformer/src/Html/StyleDeclarationBuilder.php
@@ -133,6 +133,11 @@ final class StyleDeclarationBuilder
 
             $effectType = (string) ($effect['type'] ?? '');
             if ( in_array($effectType, array('drop_shadow', 'inner_shadow'), true) ) {
+                if ( 'drop_shadow' === $effectType && $this->shouldEmitVectorDropShadowFilter($effect, $type) ) {
+                    $filters[] = $this->dropShadowFilterValue($effect);
+                    continue;
+                }
+
                 $shadow = $this->shadowValue($effect, 'inner_shadow' === $effectType);
                 if ( null === $shadow ) {
                     continue;
@@ -240,6 +245,36 @@ final class StyleDeclarationBuilder
             . $this->number((float) ($effect['radius'] ?? 0)) . 'px '
             . $this->number((float) ($effect['spread'] ?? 0)) . 'px '
             . $color;
+    }
+
+    /**
+     * @param array<string, mixed> $effect
+     */
+    private function shouldEmitVectorDropShadowFilter(array $effect, string $type): bool
+    {
+        if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON'), true) ) {
+            return false;
+        }
+
+        return abs((float) ($effect['spread'] ?? 0)) < 0.0001;
+    }
+
+    /**
+     * @param array<string, mixed> $effect
+     */
+    private function dropShadowFilterValue(array $effect): string
+    {
+        $color = $this->color($effect['color'] ?? null);
+        if ( null === $color ) {
+            $color = 'rgba(0,0,0,0.25)';
+        }
+
+        return 'drop-shadow('
+            . $this->number((float) ($effect['offset_x'] ?? 0)) . 'px '
+            . $this->number((float) ($effect['offset_y'] ?? 0)) . 'px '
+            . $this->number((float) ($effect['radius'] ?? 0)) . 'px '
+            . $color
+            . ')';
     }
 
     /**

--- a/figma-transformer/tests/contract/EffectsContract.php
+++ b/figma-transformer/tests/contract/EffectsContract.php
@@ -126,6 +126,46 @@ function blocks_engine_figma_transformer_run_effects_contract(callable $assert, 
     $assert(str_contains($kiwiEffectsCss, 'box-shadow:0px 6px 6px 0px rgba(0,0,0,0.5)'), 'kiwi-effects-emits-drop-shadow-css');
     $assert(str_contains($kiwiEffectsCss, 'filter:blur(8px)'), 'kiwi-effects-emits-foreground-blur-css');
     $assert(! in_array('unsupported_figma_effect_type', $kiwiEffectsDiagnosticCodes, true), 'kiwi-effects-foreground-blur-no-diagnostic');
+
+    $clippedVectorGlowResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Clipped Vector Glow Fixture',
+        'nodes' => array(
+            array(
+                'id'                => 'effects:clipped-frame',
+                'type'              => 'FRAME',
+                'name'              => 'Clipped frame',
+                'width'             => 96,
+                'height'            => 96,
+                'frameMaskDisabled' => false,
+                'children'          => array(
+                    array(
+                        'id'                 => 'effects:vector-glow',
+                        'type'               => 'VECTOR',
+                        'name'               => 'Vector glow',
+                        'width'              => 96,
+                        'height'             => 96,
+                        'fillPaints'         => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0.8117647059, 'b' => 0, 'a' => 1))),
+                        'figma_vector_paths' => array(array('data' => 'M48 0A48 48 0 1 1 47.99 0M48 24A24 24 0 1 0 48.01 24Z', 'windingRule' => 'EVENODD')),
+                        'effects'            => array(array(
+                            'type'                 => 'DROP_SHADOW',
+                            'offset'               => array('x' => 0, 'y' => 0),
+                            'radius'               => 16,
+                            'spread'               => 0,
+                            'visible'              => true,
+                            'showShadowBehindNode' => false,
+                            'color'                => array('r' => 1, 'g' => 0.8117647059, 'b' => 0, 'a' => 0.5),
+                        )),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $clippedVectorGlowHtml = $fileContent($clippedVectorGlowResult, 'index.html');
+    $clippedVectorGlowCss = $fileContent($clippedVectorGlowResult, 'style.css');
+    $assert(str_contains($clippedVectorGlowHtml, 'data-figma-node-id="effects:vector-glow"') && str_contains($clippedVectorGlowHtml, 'data-figma-vector="true"'), 'effects-vector-glow-renders-inline-svg');
+    $assert(str_contains($clippedVectorGlowCss, '.figma-node-effects-clipped-frame-clipped-frame{width:96px;height:96px;overflow:hidden'), 'effects-vector-glow-parent-clips-content');
+    $assert(str_contains($clippedVectorGlowCss, '.figma-node-effects-vector-glow-vector-glow{') && str_contains($clippedVectorGlowCss, 'filter:drop-shadow(0px 0px 16px rgba(255,207,0,0.5))'), 'effects-vector-glow-emits-alpha-drop-shadow-filter');
+    $assert(! str_contains($clippedVectorGlowCss, '.figma-node-effects-vector-glow-vector-glow{width:96px;height:96px;box-shadow:'), 'effects-vector-glow-no-rectangular-box-shadow');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Emit zero-spread drop shadows on vector-like SVG nodes as CSS drop-shadow filters.
- Keep rectangular box-shadow behavior for frames and non-vector elements, and preserve spread/inner shadow behavior.
- Add coverage for clipped vector glow rendering.

## Testing
- php -l figma-transformer/src/Html/StyleDeclarationBuilder.php
- php -l figma-transformer/tests/contract/EffectsContract.php
- composer test:contract
- focused FSE transform for footer glow frame with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Footer effect parity investigation, implementation, and verification.