### PR TITLE
figma-transformer: emit input-like controls as inputs

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -701,7 +701,7 @@ final class StaticHtmlEmitter
         $assetPath = $this->nodeAssetPath($node);
         $hasVectorAssetFallback = $this->isUnsupportedVectorType($type) && null !== $assetPath;
 
-        if ( ! ( 'BOOLEAN_OPERATION' === $type && null !== $vectorSvg ) ) {
+        if ( 'input' !== $tag && ! ( 'BOOLEAN_OPERATION' === $type && null !== $vectorSvg ) ) {
             foreach ( $children as $child ) {
                 if ( is_array($child) ) {
                     if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
@@ -742,6 +742,9 @@ final class StaticHtmlEmitter
         }
 
         $attributes = sprintf(' class="%1$s" data-figma-node-id="%2$s" data-figma-node-name="%3$s"', $className, $id, $attributeName);
+        if ( 'input' === $tag ) {
+            $attributes .= $this->inputControlAttributes($node);
+        }
         if ( 'RECTANGLE' === $type && '' === $content ) {
             $attributes .= ' aria-hidden="true"';
         }
@@ -751,7 +754,11 @@ final class StaticHtmlEmitter
             $attributes .= ' role="img" aria-label="' . $this->sanitizeAttribute('' !== $name ? $name : $type) . '"';
         }
 
-        $element = sprintf("<%1\$s%2\$s>%3\$s</%1\$s>\n", $tag, $attributes, $content);
+        if ( 'input' === $tag ) {
+            $element = sprintf("<input%1\$s>\n", $attributes);
+        } else {
+            $element = sprintf("<%1\$s%2\$s>%3\$s</%1\$s>\n", $tag, $attributes, $content);
+        }
 
         return $this->wrapWithLink($node, $element, $diagnostics, $this->isButtonLike($node));
     }
@@ -790,6 +797,10 @@ final class StaticHtmlEmitter
         // List items: a repeated, structurally-similar child of a list container.
         if ( null !== $parentNode && $this->isListItemOf($node, $parentNode) ) {
             return 'li';
+        }
+
+        if ( $this->isInputLike($node) ) {
+            return 'input';
         }
 
         // A standalone button-like control (no link) becomes a real <button>.
@@ -1086,6 +1097,9 @@ final class StaticHtmlEmitter
      */
     private function isButtonLike(array $node): bool
     {
+        if ( $this->isInputLike($node) ) {
+            return false;
+        }
         if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
             return false;
         }
@@ -1106,6 +1120,90 @@ final class StaticHtmlEmitter
         $nameHint = str_contains($name, 'button') || str_contains($name, 'btn') || str_contains($name, 'cta');
 
         return $nameHint || null !== $this->backgroundColor($node) || $this->cornerRadius($node) > 0.0;
+    }
+
+    /**
+     * Identifies input-like control chrome before generic button heuristics see a
+     * rounded, filled single-text frame and emit it as a button.
+     *
+     * @param array<string, mixed> $node
+     */
+    private function isInputLike(array $node): bool
+    {
+        if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
+            return false;
+        }
+
+        $name = strtolower((string) ($node['name'] ?? ''));
+        if ( str_contains($name, 'button') || str_contains($name, 'btn') || str_contains($name, 'cta') ) {
+            return false;
+        }
+
+        $hasInputName = str_contains($name, 'input')
+            || str_contains($name, 'text field')
+            || str_contains($name, 'textfield')
+            || str_contains($name, 'form field')
+            || preg_match('/(^|[^a-z])field([^a-z]|$)/', $name);
+        if ( ! $hasInputName ) {
+            return false;
+        }
+
+        $textCount = $this->textDescendantCount($node);
+        if ( $textCount < 1 || $textCount > 2 ) {
+            return false;
+        }
+
+        $width = $this->boxValue($node, 'width');
+        $height = $this->boxValue($node, 'height');
+        if ( (null !== $width && $width > 640.0) || (null !== $height && $height > 120.0) ) {
+            return false;
+        }
+
+        return null !== $this->backgroundColor($node) || $this->cornerRadius($node) > 0.0 || $this->hasStrokePaint($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasStrokePaint(array $node): bool
+    {
+        foreach ( array('figma_paints', 'strokes', 'strokePaints') as $key ) {
+            $paints = $node[$key] ?? null;
+            if ( ! is_array($paints) ) {
+                continue;
+            }
+
+            if ( 'figma_paints' === $key ) {
+                $paints = $paints['strokes'] ?? array();
+            }
+
+            if ( ! empty($paints) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function inputControlAttributes(array $node): string
+    {
+        $placeholder = trim($this->subtreePlainText($node));
+        $name = (string) ($node['name'] ?? '');
+        $haystack = strtolower($name . ' ' . $placeholder);
+        $type = str_contains($haystack, 'email') || str_contains($haystack, 'e-mail') ? 'email' : 'text';
+
+        $attributes = ' type="' . $type . '"';
+        if ( '' !== $placeholder ) {
+            $attributes .= ' placeholder="' . $this->sanitizeAttribute($placeholder) . '"';
+            $attributes .= ' aria-label="' . $this->sanitizeAttribute($placeholder) . '"';
+        } elseif ( '' !== $name ) {
+            $attributes .= ' aria-label="' . $this->sanitizeAttribute($name) . '"';
+        }
+
+        return $attributes;
     }
 
     /**
@@ -2700,6 +2798,10 @@ final class StaticHtmlEmitter
     private function appendTextCoverageDiagnostics(array $node, string $html, array &$coverage, array $page, bool $isRoot): void
     {
         if ( ! $isRoot && false === ($node['visible'] ?? null) ) {
+            return;
+        }
+
+        if ( $this->isInputLike($node) && $this->htmlContainsNodeId($html, (string) ($node['id'] ?? '')) ) {
             return;
         }
 

--- a/figma-transformer/tests/contract/FormControlContract.php
+++ b/figma-transformer/tests/contract/FormControlContract.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_form_control_contract(callable $assert, callable $fileContent): void
+{
+    $result = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Form Control Fixture',
+        'nodes' => array(
+            array(
+                'id'         => 'form:root',
+                'type'       => 'FRAME',
+                'name'       => 'Newsletter section',
+                'width'      => 640,
+                'height'     => 160,
+                'layoutMode' => 'HORIZONTAL',
+                'itemSpacing' => 16,
+                'children'   => array(
+                    array(
+                        'id'              => 'form:input',
+                        'type'            => 'FRAME',
+                        'name'            => 'Input',
+                        'width'           => 280,
+                        'height'          => 46,
+                        'layoutMode'      => 'HORIZONTAL',
+                        'primaryAxisAlignItems' => 'CENTER',
+                        'counterAxisAlignItems' => 'CENTER',
+                        'paddingTop'      => 12,
+                        'paddingRight'    => 18,
+                        'paddingBottom'   => 12,
+                        'paddingLeft'     => 18,
+                        'cornerRadius'    => 4,
+                        'fills'           => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                        'children'        => array(
+                            array(
+                                'id'         => 'form:input:text',
+                                'type'       => 'TEXT',
+                                'name'       => 'Text',
+                                'characters' => 'Your email address',
+                                'fontSize'   => 16,
+                            ),
+                        ),
+                    ),
+                    array(
+                        'id'           => 'form:button',
+                        'type'         => 'FRAME',
+                        'name'         => 'Button',
+                        'width'        => 108,
+                        'height'       => 46,
+                        'cornerRadius' => 999,
+                        'fills'        => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0.8, 'b' => 0, 'a' => 1))),
+                        'children'     => array(
+                            array(
+                                'id'         => 'form:button:text',
+                                'type'       => 'TEXT',
+                                'name'       => 'Subscribe',
+                                'characters' => 'Sign Up',
+                                'fontSize'   => 16,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+
+    $html = $fileContent($result, 'index.html');
+    $css = $fileContent($result, 'style.css');
+
+    $assert(str_contains($html, '<input class="figma-node-form-input-input"'), 'form-control-input-emits-input-tag');
+    $assert(str_contains($html, 'type="email"'), 'form-control-input-infers-email-type');
+    $assert(str_contains($html, 'placeholder="Your email address"'), 'form-control-input-uses-placeholder');
+    $assert(! str_contains($html, '<button class="figma-node-form-input-input"'), 'form-control-input-does-not-emit-button');
+    $assert(! str_contains($html, 'data-figma-node-id="form:input:text"'), 'form-control-input-suppresses-presentational-text-child');
+    $assert(str_contains($html, '<button class="figma-node-form-button-button"'), 'form-control-button-still-emits-button');
+    $assert(str_contains($css, '.figma-node-form-input-input{width:280px;height:46px;'), 'form-control-input-preserves-visual-css');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/ContractHelpers.php';
 require_once __DIR__ . '/DiagnosticsEvidenceContract.php';
 require_once __DIR__ . '/EffectsContract.php';
 require_once __DIR__ . '/FixtureMatrixContract.php';
+require_once __DIR__ . '/FormControlContract.php';
 require_once __DIR__ . '/GeometryBoxContract.php';
 require_once __DIR__ . '/ImagePaintContract.php';
 require_once __DIR__ . '/KiwiSkippedFieldInventoryContract.php';
@@ -185,6 +186,8 @@ $assert(str_contains($css, '.figma-node-1-1-hero-section{width:100%;max-width:12
 $assert(str_contains($css, '.figma-node-1-2-hero-title{font-size:48px;font-weight:700;color:#1a334d;flex-shrink:0}'), 'css-text-style');
 
 blocks_engine_figma_transformer_run_image_paint_contract($assert, $result, $css, $fileContent);
+
+blocks_engine_figma_transformer_run_form_control_contract($assert, $fileContent);
 
 blocks_engine_figma_transformer_run_vector_command_blob_contract($assert, $oversizedCommandBlob, $longStrokeCommandBlob);
 


### PR DESCRIPTION
## Summary
- Classify input-like Figma control chrome before button heuristics.
- Emit input-like frames as styled <input> elements with placeholder, aria-label, and email type inference.
- Add contract coverage proving sibling button controls still emit as buttons.

## Testing
- php -l src/Html/StaticHtmlEmitter.php
- php -l tests/contract/FormControlContract.php
- php -l tests/contract/run.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Form control parity investigation, implementation, and verification.