### PR TITLE
figma-transformer: account for resolved instance asset refs

### DIFF
--- a/figma-transformer/scripts/figma-parser-parity.php
+++ b/figma-transformer/scripts/figma-parser-parity.php
@@ -631,7 +631,76 @@ function blocks_engine_figma_parser_parity_normalized_asset_reference_node_ids(a
             $ids[] = (string) $reference['node_id'];
         }
     }
+
+    foreach ( is_array($normalized['node_map'] ?? null) ? $normalized['node_map'] : array() as $nodeId => $node ) {
+        if ( ! is_array($node) || 'INSTANCE' !== strtoupper((string) ($node['type'] ?? '')) ) {
+            continue;
+        }
+        if ( blocks_engine_figma_parser_parity_normalized_node_has_child_asset_reference($node) ) {
+            $ids[] = (string) $nodeId;
+        }
+    }
+
     return array_values(array_unique($ids));
+}
+
+function blocks_engine_figma_parser_parity_normalized_node_has_child_asset_reference(array $node): bool
+{
+    foreach ( is_array($node['children'] ?? null) ? $node['children'] : array() as $child ) {
+        if ( ! is_array($child) ) {
+            continue;
+        }
+        if ( blocks_engine_figma_parser_parity_normalized_node_has_direct_asset_reference($child) || blocks_engine_figma_parser_parity_normalized_node_has_child_asset_reference($child) ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function blocks_engine_figma_parser_parity_normalized_node_has_direct_asset_reference(array $node): bool
+{
+    foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+        if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
+            return true;
+        }
+    }
+
+    foreach ( array('fills', 'strokes', 'background', 'fillPaints', 'strokePaints') as $paintKey ) {
+        if ( blocks_engine_figma_parser_parity_normalized_paints_have_asset_reference(is_array($node[$paintKey] ?? null) ? $node[$paintKey] : array()) ) {
+            return true;
+        }
+    }
+
+    foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+        if ( blocks_engine_figma_parser_parity_normalized_paints_have_asset_reference(is_array($node['figma_paints'][$paintKey] ?? null) ? $node['figma_paints'][$paintKey] : array()) ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function blocks_engine_figma_parser_parity_normalized_paints_have_asset_reference(array $paints): bool
+{
+    foreach ( $paints as $paint ) {
+        if ( ! is_array($paint) ) {
+            continue;
+        }
+        if ( 'IMAGE' !== strtoupper((string) ($paint['type'] ?? '')) ) {
+            continue;
+        }
+        foreach ( array('ref', 'imageRef', 'imageHash', 'asset_id', 'image_ref') as $key ) {
+            if ( isset($paint[$key]) && is_scalar($paint[$key]) && '' !== (string) $paint[$key] ) {
+                return true;
+            }
+        }
+        if ( isset($paint['image']['hash']) && is_scalar($paint['image']['hash']) && '' !== (string) $paint['image']['hash'] ) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**

--- a/figma-transformer/tests/contract/ParserParityContract.php
+++ b/figma-transformer/tests/contract/ParserParityContract.php
@@ -63,6 +63,34 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
                         'height'     => 48,
                         'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'paint-asset')),
                     ),
+                    array(
+                        'id'         => 'parity:instance-ref',
+                        'type'       => 'INSTANCE',
+                        'name'       => 'Parity Instance Ref',
+                        'symbolData' => array(
+                            'symbolOverrides' => array(
+                                array(
+                                    'fillPaints' => array(array(
+                                        'type'  => 'IMAGE',
+                                        'image' => array('hash' => 'instance-paint-asset'),
+                                    )),
+                                ),
+                            ),
+                        ),
+                        'children'   => array(
+                            array(
+                                'id'         => 'parity:instance-child-ref',
+                                'type'       => 'RECTANGLE',
+                                'name'       => 'Parity Instance Child Ref',
+                                'width'      => 32,
+                                'height'     => 32,
+                                'fillPaints' => array(array(
+                                    'type'  => 'IMAGE',
+                                    'image' => array('hash' => 'instance-paint-asset'),
+                                )),
+                            ),
+                        ),
+                    ),
                 ),
             ),
         ),
@@ -80,15 +108,15 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
     $assert(is_array($report), 'parser-parity-json-output');
     $assert('blocks-engine/figma-transformer/parser-parity/v1' === ($report['schema'] ?? null), 'parser-parity-schema');
     $assert('parity:frame' === ($report['options']['frame_id'] ?? null), 'parser-parity-frame-option');
-    $assert(5 === ($report['raw']['node_count'] ?? null), 'parser-parity-raw-node-count');
-    $assert(5 === ($report['normalized']['node_count'] ?? null), 'parser-parity-normalized-node-count');
+    $assert(7 === ($report['raw']['node_count'] ?? null), 'parser-parity-raw-node-count');
+    $assert(7 === ($report['normalized']['node_count'] ?? null), 'parser-parity-normalized-node-count');
     $assert(1 === ($report['raw']['blob_count'] ?? null), 'parser-parity-raw-blob-count');
     $assert(2 === ($report['raw']['asset_count'] ?? null), 'parser-parity-raw-asset-count');
     $assert(1 === ($report['raw']['text_node_count'] ?? null), 'parser-parity-raw-text-node-count');
     $assert(1 === ($report['raw']['vector_node_count'] ?? null), 'parser-parity-raw-vector-node-count');
-    $assert(1 === ($report['raw']['component_prop_node_count'] ?? null), 'parser-parity-component-prop-node-count');
-    $assert(5 === ($report['coverage']['raw_to_normalized_node']['covered_count'] ?? null), 'parser-parity-raw-normalized-node-coverage');
-    $assert(2 === ($report['coverage']['raw_asset_refs_to_normalized_asset_refs']['covered_count'] ?? null), 'parser-parity-asset-reference-coverage');
+    $assert(2 === ($report['raw']['component_prop_node_count'] ?? null), 'parser-parity-component-prop-node-count');
+    $assert(7 === ($report['coverage']['raw_to_normalized_node']['covered_count'] ?? null), 'parser-parity-raw-normalized-node-coverage');
+    $assert(4 === ($report['coverage']['raw_asset_refs_to_normalized_asset_refs']['covered_count'] ?? null), 'parser-parity-asset-reference-coverage');
     $assert(is_array($report['top_missing_field_paths'] ?? null), 'parser-parity-missing-field-paths-present');
 
     $figPath = SyntheticFigKiwiFixtureBuilder::figArchive(


### PR DESCRIPTION
## Summary
- Update parser parity asset coverage to count raw instance refs covered by resolved child subtree image paints.
- Preserve normalized asset inventory counts; this is parity accounting, not emitted output behavior.
- Add contract coverage for an instance source ref represented through child asset paint output.

## Testing
- php -l scripts/figma-parser-parity.php
- php -l tests/contract/ParserParityContract.php
- composer test:contract
- parser parity against FSE .fig with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Raw/parser parity investigation, implementation, and verification.