### PR TITLE
figma-transformer: apply derived symbol overrides by source path

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2031,7 +2031,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $overrides
      * @return array<int, mixed>
      */
-    private function applyInstanceOverridesToChildren(array $children, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
+    private function applyInstanceOverridesToChildren(array $children, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $parentSourcePaths = array()): array
     {
 		foreach ( $children as $index => $child ) {
 			if ( ! is_array($child) ) {
@@ -2042,7 +2042,8 @@ final class ScenegraphNormalizer
 			$sourceNode = '' !== $id && is_array($nodeMap[$id] ?? null) ? $nodeMap[$id] : array();
 			$sourceChildBox = is_array($sourceNode['box'] ?? null) ? $sourceNode['box'] : (is_array($child['box'] ?? null) ? $child['box'] : null);
 			$hasFieldOverride = false;
-            $overrideFields = $this->instanceOverrideFieldsForChild($child, $overrides);
+            $sourcePaths = $this->instanceChildOverrideSourcePaths($child, $parentSourcePaths);
+            $overrideFields = $this->instanceOverrideFieldsForChild($child, $overrides, $sourcePaths);
             $swapComponentId = isset($overrideFields['_figma_instance_swap_component_id']) && is_scalar($overrideFields['_figma_instance_swap_component_id']) ? (string) $overrideFields['_figma_instance_swap_component_id'] : null;
             unset($overrideFields['_figma_instance_swap_component_id']);
             $nestedComponentPropertyOverrides = $this->nestedComponentPropertyOverridesForChild($child, $overrideFields, $components);
@@ -2075,7 +2076,7 @@ final class ScenegraphNormalizer
 
             if ( is_array($child['children'] ?? null) ) {
                 $childOverrides = $this->descendantInstanceOverrideFieldsForChild($child, $overrides);
-                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], array_merge($overrides, $childOverrides, $nestedComponentPropertyOverrides), $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles);
+                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], array_merge($overrides, $childOverrides, $nestedComponentPropertyOverrides), $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $sourcePaths);
             }
 
             $children[$index] = $child;
@@ -2141,27 +2142,44 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $overrides
      * @return array<string, mixed>
      */
-    private function instanceOverrideFieldsForChild(array $child, array $overrides): array
+    private function instanceOverrideFieldsForChild(array $child, array $overrides, array $sourcePaths = array()): array
     {
         $fields = array();
         foreach ( $this->instanceChildOverrideAliases($child) as $alias ) {
             if ( isset($overrides[$alias]) && is_array($overrides[$alias]) ) {
                 $fields = array_merge($fields, $overrides[$alias]);
             }
+        }
 
-            foreach ( $overrides as $target => $overrideFields ) {
-                if ( ! is_string($target) || ! is_array($overrideFields) || ! str_contains($target, '/') ) {
-                    continue;
-                }
-
-                $parts = explode('/', $target);
-                if ( $alias === end($parts) ) {
-                    $fields = array_merge($fields, $overrideFields);
-                }
+        foreach ( $sourcePaths as $sourcePath ) {
+            if ( isset($overrides[$sourcePath]) && is_array($overrides[$sourcePath]) ) {
+                $fields = array_merge($fields, $overrides[$sourcePath]);
             }
         }
 
         return $fields;
+    }
+
+    /**
+     * @param array<string, mixed> $child
+     * @param array<int, string>   $parentSourcePaths
+     * @return array<int, string>
+     */
+    private function instanceChildOverrideSourcePaths(array $child, array $parentSourcePaths = array()): array
+    {
+        $aliases = $this->instanceChildOverrideAliases($child);
+        if ( empty($parentSourcePaths) ) {
+            return $aliases;
+        }
+
+        $paths = array();
+        foreach ( $parentSourcePaths as $parentSourcePath ) {
+            foreach ( $aliases as $alias ) {
+                $paths[] = $parentSourcePath . '/' . $alias;
+            }
+        }
+
+        return array_values(array_unique($paths));
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3730,6 +3730,72 @@ $assert(! str_contains($derivedSymbolInstanceHtml, '<g transform="scale'), 'deri
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-2-derived-label{width:90px;height:24px;position:absolute;left:12px;top:6px'), 'derived-symbol-instance-label-size-position');
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-3-derived-icon{width:10px;height:10px;position:absolute;left:110px;top:10px'), 'derived-symbol-instance-icon-size-position');
 
+$derivedSymbolPathOverrideResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Derived Symbol Path Override Fixture',
+    'blobs' => array(array('bytes' => $vectorCommandBlob)),
+    'nodes' => array(
+        array(
+            'guid'     => array('sessionID' => 42, 'localID' => 1),
+            'type'     => 'SYMBOL',
+            'name'     => 'Path Matched Symbol',
+            'children' => array(
+                array(
+                    'id'       => 'left',
+                    'type'     => 'FRAME',
+                    'name'     => 'Left Branch',
+                    'children' => array(
+                        array(
+                            'id'     => 'left/shared',
+                            'type'   => 'VECTOR',
+                            'name'   => 'Shared Leaf',
+                            'width'  => 5,
+                            'height' => 5,
+                        ),
+                    ),
+                ),
+                array(
+                    'id'       => 'right',
+                    'type'     => 'FRAME',
+                    'name'     => 'Right Branch',
+                    'children' => array(
+                        array(
+                            'id'     => 'right/shared',
+                            'type'   => 'VECTOR',
+                            'name'   => 'Shared Leaf',
+                            'width'  => 5,
+                            'height' => 5,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'         => 'path-match:instance',
+            'type'       => 'INSTANCE',
+            'name'       => 'Path Matched Instance',
+            'symbolData' => array(
+                'symbolID' => array('sessionID' => 42, 'localID' => 1),
+            ),
+            'derivedSymbolData' => array(
+                array(
+                    'guidPath'       => array('guids' => array('left', 'shared')),
+                    'size'           => array('x' => 10, 'y' => 10),
+                    'transform'      => array('m00' => 1, 'm01' => 0, 'm02' => 7, 'm10' => 0, 'm11' => 1, 'm12' => 8),
+                    'fillGeometry'   => array(array('commandsBlob' => 0)),
+                    'strokeGeometry' => array(array('commandsBlob' => 0)),
+                ),
+            ),
+        ),
+    ),
+));
+$derivedSymbolPathOverrideHtml = $fileContent($derivedSymbolPathOverrideResult, 'index.html');
+$derivedSymbolPathOverrideCss = $fileContent($derivedSymbolPathOverrideResult, 'style.css');
+$assert(str_contains($derivedSymbolPathOverrideHtml, 'data-figma-node-id="path-match:instance/left/shared"'), 'derived-symbol-path-override-left-leaf-namespaced');
+$assert(str_contains($derivedSymbolPathOverrideHtml, 'data-figma-node-id="path-match:instance/right/shared"'), 'derived-symbol-path-override-right-leaf-namespaced');
+$assert(str_contains($derivedSymbolPathOverrideHtml, 'd="M0 0L10 0 10 10Z"'), 'derived-symbol-path-override-left-geometry');
+$assert(str_contains($derivedSymbolPathOverrideCss, '.figma-node-path-match-instance-left-shared-shared-leaf{width:10px;height:10px;position:absolute;left:7px;top:8px'), 'derived-symbol-path-override-left-size-position');
+$assert(str_contains($derivedSymbolPathOverrideCss, '.shared-leaf{width:5px;height:5px}') && ! str_contains($derivedSymbolPathOverrideCss, '.figma-node-path-match-instance-right-shared-shared-leaf{width:10px;height:10px'), 'derived-symbol-path-override-does-not-bleed-to-sibling-leaf');
+
 $kiwiStackOverrideInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Kiwi Stack Override Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- Track source-path aliases while applying instance overrides to cloned descendants.
- Apply slash-qualified derivedSymbolData/symbolOverrides geometry overrides to exact cloned source paths instead of matching only terminal IDs.
- Add coverage preventing same-leaf sibling override bleed for fill/stroke geometry, transform, and size overrides.

## Testing
- php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
- php -l figma-transformer/tests/contract/run.php
- composer test:contract
- parser parity/focused FSE matrix with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Derived symbol geometry investigation, implementation, and verification.