### PR TITLE
figma-transformer: make text glyph path decoding opt-in

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -41,11 +41,11 @@ final class ScenegraphNormalizer
         }
         $paintStyles = $this->buildPaintStyleDefinitions($index['nodes'], $diagnostics);
         $textStyles  = $this->buildTextStyleDefinitions($index['nodes']);
-        $nodeMap     = $this->normalizeNodeMap($index['nodes'], $diagnostics, $blobs, $paintStyles, $textStyles);
+        $nodeMap     = $this->normalizeNodeMap($index['nodes'], $diagnostics, $blobs, $paintStyles, $textStyles, $options);
         $this->applyReverseChildZIndex($nodeMap);
         $components  = $this->buildComponentDefinitions($nodeMap);
         $componentDefinitionCount = $this->countComponentDefinitions($nodeMap);
-        $instanceReport = $this->resolveInstances($nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles);
+        $instanceReport = $this->resolveInstances($nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
         $this->applyReverseChildZIndex($nodeMap);
         $topLevelIds = $index['top_level_node_ids'];
         $frameIds    = $this->selectTopLevelFrameIds($topLevelIds, $nodeMap);
@@ -205,10 +205,17 @@ final class ScenegraphNormalizer
                 $nodeIds[$nodeId] = true;
             }
             if ( count($sampleGlyphs) < 10 ) {
-                $sampleGlyphs[] = array(
+                $sampleGlyph = array(
                     'node_id'     => $nodeId,
                     'glyph_index' => isset($context['glyph_index']) && is_numeric($context['glyph_index']) ? (int) $context['glyph_index'] : null,
                 );
+                if ( isset($context['byte_length']) && is_numeric($context['byte_length']) ) {
+                    $sampleGlyph['byte_length'] = (int) $context['byte_length'];
+                }
+                if ( isset($context['reason']) && is_scalar($context['reason']) ) {
+                    $sampleGlyph['reason'] = (string) $context['reason'];
+                }
+                $sampleGlyphs[] = $sampleGlyph;
             }
         }
 
@@ -382,10 +389,10 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>>    $diagnostics
      * @return array<string, array<string, mixed>>
      */
-    private function normalizeNodeMap(array $nodeMap, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
+    private function normalizeNodeMap(array $nodeMap, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array()): array
     {
         foreach ( $nodeMap as $id => $node ) {
-            $nodeMap[$id] = $this->normalizeNode($node, $diagnostics, $blobs, $paintStyles, $textStyles);
+            $nodeMap[$id] = $this->normalizeNode($node, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
         }
 
         return $nodeMap;
@@ -396,7 +403,7 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    private function normalizeNode(array $node, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
+    private function normalizeNode(array $node, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array()): array
     {
         $id = (string) ($node['id'] ?? '');
         $type = strtoupper((string) ($node['type'] ?? ''));
@@ -407,7 +414,7 @@ final class ScenegraphNormalizer
         }
 
         if ( 'TEXT' === $type ) {
-            $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics, $paintStyles, $textStyles);
+            $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics, $paintStyles, $textStyles, $options);
             if ( ! empty($text) ) {
                 $node['figma_text'] = $text;
             }
@@ -468,7 +475,7 @@ final class ScenegraphNormalizer
 
             foreach ( $node[$childrenKey] as $index => $child ) {
                 if ( is_array($child) ) {
-                    $normalizedChild = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles, $textStyles);
+                    $normalizedChild = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
                     $childLayout = is_array($normalizedChild['layout'] ?? null) ? $normalizedChild['layout'] : array();
                     $childLayout['source_order'] = isset($normalizedChild['_source_order']) && is_numeric($normalizedChild['_source_order'])
                         ? (int) $normalizedChild['_source_order']
@@ -622,7 +629,7 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array{instance_node_count: int, resolved_instance_count: int, unresolved_component_references: array<int, array<string, string>>}
      */
-    private function resolveInstances(array &$nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array()): array
+    private function resolveInstances(array &$nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array()): array
     {
         $instanceCount = 0;
         $resolvedCount = 0;
@@ -666,7 +673,7 @@ final class ScenegraphNormalizer
                 continue;
             }
 
-            $resolved = $this->cloneComponentForInstance($components[$reference['id']], $node, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, array($id));
+            $resolved = $this->cloneComponentForInstance($components[$reference['id']], $node, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options, array($id));
             $nodeMap[$id] = $resolved;
             $resolvedCount++;
         }
@@ -1266,7 +1273,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $nodeMap
      * @return array<string, mixed>
      */
-    private function cloneComponentForInstance(array $component, array $instance, string $componentId, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $resolutionTrail = array()): array
+    private function cloneComponentForInstance(array $component, array $instance, string $componentId, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array(), array $resolutionTrail = array()): array
     {
         $context = $this->buildInstanceCloneContext($component, $instance, $componentId, $overrides);
         $resolved = $component;
@@ -1296,7 +1303,7 @@ final class ScenegraphNormalizer
             )
         );
         $resolvedChildren = is_array($resolved['children'] ?? null) ? $resolved['children'] : array();
-        $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $resolutionTrail);
+        $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options, $resolutionTrail);
         $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
         $componentBox = is_array($component['box'] ?? null) ? $component['box'] : array();
         $componentSourceX = isset($componentBox['x']) && is_numeric($componentBox['x']) ? (float) $componentBox['x'] : null;
@@ -1319,7 +1326,7 @@ final class ScenegraphNormalizer
             $resolved['layout'] = array('freeform' => true);
         }
         $resolved['children'] = $this->namespaceResolvedInstanceChildren(
-            $this->applyInstanceOverridesToChildren($resolvedChildren, $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles),
+            $this->applyInstanceOverridesToChildren($resolvedChildren, $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options),
             $context['instance_id']
         );
 
@@ -1848,7 +1855,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $nodeMap
      * @return array<int, mixed>
      */
-    private function resolveClonedInstanceChildren(array $children, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $resolutionTrail = array()): array
+    private function resolveClonedInstanceChildren(array $children, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array(), array $resolutionTrail = array()): array
     {
         foreach ( $children as $index => $child ) {
             if ( ! is_array($child) ) {
@@ -1862,14 +1869,14 @@ final class ScenegraphNormalizer
                 if ( empty($refreshed['children']) && null !== $reference && isset($components[$reference['id']]) && ! in_array($id, $resolutionTrail, true) ) {
                     $overrides = $this->normalizeInstanceOverrides($refreshed, $id, $diagnostics);
                     if ( null !== $overrides ) {
-                        $refreshed = $this->cloneComponentForInstance($components[$reference['id']], $refreshed, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, array_merge($resolutionTrail, array($id)));
+                        $refreshed = $this->cloneComponentForInstance($components[$reference['id']], $refreshed, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options, array_merge($resolutionTrail, array($id)));
                     }
                 }
                 $child = $this->mergeRefreshedComponentSource($child, $refreshed, $id);
             }
 
             if ( is_array($child['children'] ?? null) ) {
-                $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $resolutionTrail);
+                $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options, $resolutionTrail);
             }
 
             $children[$index] = $child;
@@ -2031,7 +2038,7 @@ final class ScenegraphNormalizer
      * @param array<string, array<string, mixed>> $overrides
      * @return array<int, mixed>
      */
-    private function applyInstanceOverridesToChildren(array $children, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $parentSourcePaths = array()): array
+    private function applyInstanceOverridesToChildren(array $children, array $overrides, array $nodeMap, array $components, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array(), array $parentSourcePaths = array()): array
     {
 		foreach ( $children as $index => $child ) {
 			if ( ! is_array($child) ) {
@@ -2051,7 +2058,7 @@ final class ScenegraphNormalizer
             if ( null !== $swapComponentId && isset($components[$swapComponentId]) ) {
                 $child = $this->mergeRefreshedComponentSource($child, $components[$swapComponentId], $swapComponentId);
                 if ( is_array($child['children'] ?? null) ) {
-                    $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles);
+                    $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
                 }
                 $child['_figma_instance_override_applied'] = true;
             }
@@ -2071,12 +2078,12 @@ final class ScenegraphNormalizer
                 }
 			}
 			if ( $hasFieldOverride ) {
-				$child = $this->normalizeOverriddenInstanceChild($child, $id, $overrideFields, $diagnostics, $blobs, $paintStyles, $textStyles, $sourceChildBox);
+				$child = $this->normalizeOverriddenInstanceChild($child, $id, $overrideFields, $diagnostics, $blobs, $paintStyles, $textStyles, $options, $sourceChildBox);
 			}
 
             if ( is_array($child['children'] ?? null) ) {
                 $childOverrides = $this->descendantInstanceOverrideFieldsForChild($child, $overrides);
-                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], array_merge($overrides, $childOverrides, $nestedComponentPropertyOverrides), $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $sourcePaths);
+                $child['children'] = $this->applyInstanceOverridesToChildren($child['children'], array_merge($overrides, $childOverrides, $nestedComponentPropertyOverrides), $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options, $sourcePaths);
             }
 
             $children[$index] = $child;
@@ -2244,7 +2251,7 @@ final class ScenegraphNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-	private function normalizeOverriddenInstanceChild(array $child, string $id, array $overrideFields, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), ?array $sourceChildBox = null): array
+	private function normalizeOverriddenInstanceChild(array $child, string $id, array $overrideFields, array &$diagnostics, array $blobs = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array(), ?array $sourceChildBox = null): array
 	{
 		$hasVectorGeometryOverride = array_key_exists('fillGeometry', $overrideFields) || array_key_exists('strokeGeometry', $overrideFields);
 		$hasExplicitSizeOverride = array_key_exists('size', $overrideFields);
@@ -2307,7 +2314,7 @@ final class ScenegraphNormalizer
         }
         unset($child['figma_vector_scale']);
 
-		$child = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles, $textStyles);
+		$child = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
 		if ( $hasTransformGeometryOverride && is_array($sourceChildBox) ) {
 			$child = $this->preserveLocalSourceBoxForFarAbsoluteOverride($child, $sourceChildBox);
 		}

--- a/figma-transformer/src/Scenegraph/TextNormalizer.php
+++ b/figma-transformer/src/Scenegraph/TextNormalizer.php
@@ -9,6 +9,9 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
  */
 final class TextNormalizer
 {
+    private const MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES = 262144;
+    private const MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES_PER_NODE = 262144;
+
     public function __construct(
         private readonly VectorGeometryNormalizer $vectorGeometryNormalizer = new VectorGeometryNormalizer()
     ) {
@@ -20,7 +23,7 @@ final class TextNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    public function normalizeText(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array(), array $paintStyles = array(), array $textStyles = array()): array
+    public function normalizeText(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array(), array $paintStyles = array(), array $textStyles = array(), array $options = array()): array
     {
         $text = array();
 
@@ -64,7 +67,7 @@ final class TextNormalizer
             }
         }
 
-        $derivedLayout = $this->normalizeDerivedTextLayout($node, $blobs, $nodeId, $diagnostics);
+        $derivedLayout = $this->normalizeDerivedTextLayout($node, $blobs, $nodeId, $diagnostics, true === ($options['render_text_glyph_paths'] ?? false));
         if ( ! empty($derivedLayout) ) {
             $text['derived_layout'] = $derivedLayout;
             $style = $this->fillMissingStyleFromDerivedFonts($style, $derivedLayout);
@@ -163,7 +166,7 @@ final class TextNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<string, mixed>
      */
-    private function normalizeDerivedTextLayout(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array()): array
+    private function normalizeDerivedTextLayout(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array(), bool $decodeGlyphCommandBlobs = false): array
     {
         $source = is_array($node['derivedTextData'] ?? null) ? $node['derivedTextData'] : array();
         if ( empty($source) ) {
@@ -214,12 +217,17 @@ final class TextNormalizer
 
         if ( is_array($source['glyphs'] ?? null) ) {
             $layout['glyph_count'] = count($source['glyphs']);
+            if ( ! $decodeGlyphCommandBlobs ) {
+                return $this->appendDerivedTextFonts($layout, $source);
+            }
+
             $glyphPaths = array();
             $characters = isset($node['textData']['characters']) && is_scalar($node['textData']['characters']) ? (string) $node['textData']['characters'] : ( isset($node['characters']) && is_scalar($node['characters']) ? (string) $node['characters'] : '' );
             $characterList = '' !== $characters ? preg_split('//u', $characters, -1, PREG_SPLIT_NO_EMPTY) : array();
             if ( ! is_array($characterList) ) {
                 $characterList = array();
             }
+            $decodedGlyphCommandBlobBytes = 0;
             foreach ( $source['glyphs'] as $index => $glyph ) {
                 if ( ! is_array($glyph) ) {
                     continue;
@@ -242,9 +250,26 @@ final class TextNormalizer
                     }
                 }
 
-                if ( isset($glyph['commandsBlob']) ) {
+                if ( $decodeGlyphCommandBlobs && isset($glyph['commandsBlob']) ) {
                     $bytes = $this->vectorGeometryNormalizer->readCommandBlobBytes($glyph['commandsBlob'], $blobs);
                     if ( null !== $bytes ) {
+                        $byteLength = strlen($bytes);
+                        if ( $byteLength > self::MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES || $decodedGlyphCommandBlobBytes + $byteLength > self::MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES_PER_NODE ) {
+                            $diagnostics[] = array(
+                                'severity' => 'warning',
+                                'code'     => 'unsupported_text_glyph_command_blob',
+                                'message'  => 'Oversized Figma text glyph command blob was omitted from derived glyph metadata.',
+                                'context'  => array(
+                                    'node_id'     => $nodeId,
+                                    'glyph_index' => $index,
+                                    'byte_length' => $byteLength,
+                                    'reason'      => $byteLength > self::MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES ? 'byte_limit_exceeded' : 'node_byte_budget_exceeded',
+                                ),
+                            );
+                            continue;
+                        }
+                        $decodedGlyphCommandBlobBytes += $byteLength;
+
                         $decoded = $this->vectorGeometryNormalizer->classifyVectorCommandBlob($bytes);
                         if ( 'path' === $decoded['status'] ) {
                             $glyphPath['data'] = $decoded['path'];
@@ -270,6 +295,16 @@ final class TextNormalizer
                 $layout['glyph_paths'] = $glyphPaths;
             }
         }
+        return $this->appendDerivedTextFonts($layout, $source);
+    }
+
+    /**
+     * @param array<string, mixed> $layout
+     * @param array<string, mixed> $source
+     * @return array<string, mixed>
+     */
+    private function appendDerivedTextFonts(array $layout, array $source): array
+    {
         if ( is_array($source['fontMetaData'] ?? null) ) {
             $fonts = array();
             foreach ( $source['fontMetaData'] as $font ) {

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -76,8 +76,7 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     $assert(1 === ($derivedTextVisualNode['text']['baseline_count'] ?? null), 'visual-node-derived-text-baseline-count');
     $assert(3 === ($derivedTextVisualNode['text']['glyph_count'] ?? null), 'visual-node-derived-text-glyph-count');
     $assert(146.5 === ($derivedTextVisualNode['text']['derived_layout']['size']['width'] ?? null), 'visual-node-derived-text-layout-width');
-    $assert('M 0 0 Q 4 8 8 0 Z' === ($derivedTextVisualNode['text']['derived_layout']['glyph_paths'][0]['data'] ?? null), 'visual-node-derived-text-glyph-quadratic-path');
-    $assert(2.0 === ($derivedTextVisualNode['text']['derived_layout']['glyph_paths'][0]['x'] ?? null), 'visual-node-derived-text-glyph-position');
+    $assert(! isset($derivedTextVisualNode['text']['derived_layout']['glyph_paths']), 'visual-node-derived-text-default-omits-glyph-paths');
     $assert('dom_text' === ($derivedTextVisualNode['text']['glyph_rendering'] ?? null), 'visual-node-derived-text-default-dom-rendering');
     $assert(false === ($derivedTextLayoutResult['source_reports']['figma']['html']['render_text_glyph_paths'] ?? null), 'derived-text-glyph-rendering-default-disabled');
     $assert(! str_contains($fileContent($derivedTextLayoutResult, 'index.html'), 'data-figma-text-glyphs="true"'), 'derived-text-default-avoids-glyph-svg');
@@ -111,7 +110,7 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
             ),
         ),
     );
-    $unsupportedGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($unsupportedGlyphScenegraph);
+    $unsupportedGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($unsupportedGlyphScenegraph, array('render_text_glyph_paths' => true));
     $unsupportedGlyphDiagnostics = array_values(array_filter(
         $unsupportedGlyphResult['diagnostics'] ?? array(),
         static fn (array $diagnostic): bool => 'unsupported_text_glyph_command_blob' === ($diagnostic['code'] ?? null)
@@ -122,7 +121,45 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     $assert(array('text:unsupported-glyph-a', 'text:unsupported-glyph-b') === ($unsupportedGlyphDiagnostics[0]['context']['sample_node_ids'] ?? null), 'unsupported-glyph-diagnostics-sample-node-ids');
     $assert(str_contains($fileContent($unsupportedGlyphResult, 'index.html'), 'Unsupported glyph A'), 'unsupported-glyph-diagnostics-preserve-text-a');
     $assert(str_contains($fileContent($unsupportedGlyphResult, 'index.html'), 'Unsupported glyph B'), 'unsupported-glyph-diagnostics-preserve-text-b');
-    
+
+    $oversizedGlyphCommandBlob = str_repeat(chr(1) . pack('g', 0.0) . pack('g', 0.0), 32769);
+    $oversizedGlyphScenegraph = array(
+        'name'  => 'Oversized Glyph Diagnostic Fixture',
+        'blobs' => array(array('bytes' => $oversizedGlyphCommandBlob)),
+        'nodes' => array(
+            array(
+                'id'              => 'text:oversized-glyph',
+                'type'            => 'TEXT',
+                'name'            => 'Oversized Glyph Text',
+                'characters'      => 'Text remains renderable',
+                'derivedTextData' => array(
+                    'glyphs' => array(
+                        array('firstCharacter' => 0, 'commandsBlob' => 0),
+                    ),
+                ),
+            ),
+        ),
+    );
+    $oversizedGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($oversizedGlyphScenegraph, array('render_text_glyph_paths' => true));
+    $oversizedGlyphDiagnostics = array_values(array_filter(
+        $oversizedGlyphResult['diagnostics'] ?? array(),
+        static fn (array $diagnostic): bool => 'unsupported_text_glyph_command_blob' === ($diagnostic['code'] ?? null)
+    ));
+    $oversizedGlyphVisualNodes = $oversizedGlyphResult['source_reports']['figma']['html']['visual_node_map'] ?? array();
+    $oversizedGlyphVisualNode = null;
+    foreach ( is_array($oversizedGlyphVisualNodes) ? $oversizedGlyphVisualNodes : array() as $visualNode ) {
+        if ( is_array($visualNode) && 'text:oversized-glyph' === ($visualNode['id'] ?? null) ) {
+            $oversizedGlyphVisualNode = $visualNode;
+            break;
+        }
+    }
+    $assert(str_contains($fileContent($oversizedGlyphResult, 'index.html'), 'Text remains renderable'), 'oversized-glyph-preserves-dom-text');
+    $assert(1 === count($oversizedGlyphDiagnostics), 'oversized-glyph-diagnostics-bounded');
+    $assert(1 === ($oversizedGlyphDiagnostics[0]['context']['total_count'] ?? null), 'oversized-glyph-diagnostics-total-count');
+    $assert('byte_limit_exceeded' === ($oversizedGlyphDiagnostics[0]['context']['sample_glyphs'][0]['reason'] ?? null), 'oversized-glyph-diagnostics-reason');
+    $assert(strlen($oversizedGlyphCommandBlob) === ($oversizedGlyphDiagnostics[0]['context']['sample_glyphs'][0]['byte_length'] ?? null), 'oversized-glyph-diagnostics-byte-length');
+    $assert(array() === ($oversizedGlyphVisualNode['text']['derived_layout']['glyph_paths'] ?? array()), 'oversized-glyph-omits-derived-path-data');
+     
     // Whitespace glyphs are emitted by Figma as a single 0x00 (empty-path) command
     // blob: well-formed, but carrying no drawable outline. These are valid, not
     // unsupported, and must NOT raise unsupported_text_glyph_command_blob warnings
@@ -156,7 +193,7 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
             ),
         ),
     );
-    $whitespaceGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($whitespaceGlyphScenegraph);
+    $whitespaceGlyphResult = blocks_engine_figma_transformer_transform_scenegraph($whitespaceGlyphScenegraph, array('render_text_glyph_paths' => true));
     $whitespaceGlyphDiagnostics = array_values(array_filter(
         $whitespaceGlyphResult['diagnostics'] ?? array(),
         static fn (array $diagnostic): bool => 'unsupported_text_glyph_command_blob' === ($diagnostic['code'] ?? null)


### PR DESCRIPTION
## Summary
- Avoid materializing derived text glyph command blobs by default when DOM text rendering is used.
- Keep glyph path extraction available behind render_text_glyph_paths and add bounds/diagnostics for oversized glyph blobs.
- Preserve derived symbol override source-path logic while threading the glyph-rendering option through normalization.

## Testing
- php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
- php -l figma-transformer/src/Scenegraph/TextNormalizer.php
- php -l figma-transformer/tests/contract/TextLayoutContract.php
- composer test:contract
- focused footer transform with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Raw fixture runtime investigation, rebase conflict resolution, implementation, and verification.