### PR TITLE
figma-transformer: preserve local paints on geometry vectors

### DIFF
--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -30,12 +30,12 @@ final class PaintNormalizer
         }
 
         $styleFillId = $this->readStyleGuidId($node['styleIdForFill'] ?? null);
-        if ( null !== $styleFillId && ! empty($paintStyles[$styleFillId]['fills']) ) {
+        if ( null !== $styleFillId && ( empty($collections['fills']) || ! $this->hasGeometryPaintSource($node) ) && ! empty($paintStyles[$styleFillId]['fills']) ) {
             $collections['fills'] = $paintStyles[$styleFillId]['fills'];
         }
 
         $styleStrokeId = $this->readStyleGuidId($node['styleIdForStrokeFill'] ?? $node['styleIdForStroke'] ?? null);
-        if ( null !== $styleStrokeId && ! empty($paintStyles[$styleStrokeId]['fills']) ) {
+        if ( null !== $styleStrokeId && ( empty($collections['strokes']) || ! $this->hasGeometryPaintSource($node) ) && ! empty($paintStyles[$styleStrokeId]['fills']) ) {
             $collections['strokes'] = $paintStyles[$styleStrokeId]['fills'];
         }
 
@@ -127,6 +127,26 @@ final class PaintNormalizer
         }
 
         return $this->readGuidId($style);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasGeometryPaintSource(array $node): bool
+    {
+        foreach ( array('fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths') as $key ) {
+            if ( ! empty($node[$key]) ) {
+                return true;
+            }
+        }
+
+        foreach ( array('pathData', 'path', 'd') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== trim((string) $node[$key]) ) {
+                return true;
+            }
+        }
+
+        return isset($node['vectorData']) && is_array($node['vectorData']) && ! empty($node['vectorData']);
     }
 
     /**

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -147,7 +147,33 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
     $assert(1 === (int) ($readyGeometryCoverage['placeholders'] ?? 0), 'ready-geometry-decode-coverage-placeholder-count');
     $assert(0.5 === ($readyGeometryCoverage['coverage_ratio'] ?? null), 'ready-geometry-decode-coverage-ratio');
     $assert(1 === (int) ($readyGeometryCoverage['placeholder_reason_categories']['no_geometry_available'] ?? 0), 'ready-geometry-decode-coverage-no-geometry-category');
-    
+
+    $localPaintWithStyleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Local Paint With Style Fixture',
+        'nodes' => array(
+            array(
+                'id'         => 'paint-style:white',
+                'type'       => 'RECTANGLE',
+                'name'       => 'White paint style',
+                'styleType'  => 'FILL',
+                'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+            ),
+            array(
+                'id'             => 'vector:local-paint-with-style',
+                'type'           => 'ROUNDED_RECTANGLE',
+                'name'           => 'Local Paint With Style',
+                'width'          => 28,
+                'height'         => 3,
+                'styleIdForFill' => 'paint-style:white',
+                'fillPaints'     => array(array('type' => 'SOLID', 'color' => array('r' => 0.850980401, 'g' => 0.850980401, 'b' => 0.850980401, 'a' => 1))),
+                'fillGeometry'   => array(array('path' => 'M 0 0 L 28 0 L 28 3 L 0 3 Z', 'windingRule' => 'NONZERO')),
+            ),
+        ),
+    ));
+    $localPaintWithStyleCss = $fileContent($localPaintWithStyleResult, 'style.css');
+    $assert(str_contains($localPaintWithStyleCss, '.figma-node-vector-local-paint-with-style-local-paint-with-style{width:28px;height:3px;background:#d9d9d9'), 'local-fill-paint-wins-over-style-fill');
+    $assert(! str_contains($localPaintWithStyleCss, '.figma-node-vector-local-paint-with-style-local-paint-with-style{width:28px;height:3px;background:#ffffff'), 'style-fill-does-not-overwrite-local-fill-paint');
+     
     $externalizedEquivalentVectorPath = 'M0,0' . str_repeat('L10,10', 12000) . 'Z';
     $externalizedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Externalized Vector Fixture',


### PR DESCRIPTION
## Summary
- Preserve explicit local paints on geometry-backed vector/detail nodes instead of overriding them with style paint refs.
- Keep style paint references overriding stale inline paints for ordinary styled shapes.
- Add contract coverage for geometry-backed local paint parity, matching the newsletter icon failure mode.

## Testing
- php -l figma-transformer/src/Scenegraph/PaintNormalizer.php
- php -l figma-transformer/tests/contract/VectorRenderingContract.php
- composer test:contract
- focused node traces and frame transform with zstd

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Raw Kiwi icon/vector paint investigation, implementation, and verification.