### PR TITLE
figma-transformer: add parity coverage diagnostics

### DIFF
--- a/figma-transformer/scripts/figma-node-trace.php
+++ b/figma-transformer/scripts/figma-node-trace.php
@@ -71,6 +71,7 @@ $trace = array(
     'frame_id' => $frameId,
     'node_ids' => $nodeIds,
     'nodes' => array(),
+    'transform_diagnostics' => blocks_engine_figma_trace_transform_diagnostics_summary($htmlReport),
     'diagnostics_sample' => blocks_engine_figma_trace_diagnostics_sample($result, $htmlReport, $diagnosticLimit),
     'metrics' => $result['metrics'] ?? array(),
 );
@@ -93,6 +94,7 @@ foreach ( $nodeIds as $nodeId ) {
             'css' => '' !== $className ? blocks_engine_figma_trace_css_rule($result, $className) : null,
             'style_diagnostic' => $style,
         ), static fn (mixed $value): bool => null !== $value && array() !== $value),
+        'transform_diagnostics' => blocks_engine_figma_trace_node_transform_diagnostics($htmlReport, $nodeId),
         'visual' => blocks_engine_figma_trace_visual_node($htmlReport, $nodeId),
     );
 }
@@ -213,6 +215,51 @@ function blocks_engine_figma_trace_emit_result(array $normalized, array $transfo
             ),
         ),
     );
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_trace_transform_diagnostics_summary(array $htmlReport): array
+{
+    $diagnostics = is_array($htmlReport['transform_diagnostics'] ?? null) ? $htmlReport['transform_diagnostics'] : array();
+    $artifactQuality = is_array($diagnostics['artifact_quality'] ?? null) ? $diagnostics['artifact_quality'] : array();
+
+    return array(
+        'schema' => 'blocks-engine/figma-transformer/node-trace-transform-diagnostics/v1',
+        'artifact_quality_summary' => is_array($artifactQuality['summary'] ?? null) ? $artifactQuality['summary'] : array(),
+        'components' => is_array($diagnostics['components'] ?? null) ? $diagnostics['components'] : array(),
+        'effects' => is_array($diagnostics['effects'] ?? null) ? $diagnostics['effects'] : array(),
+        'mask_effect_clipping' => is_array($diagnostics['mask_effect_clipping'] ?? null) ? $diagnostics['mask_effect_clipping'] : array(),
+        'vector_child_composition' => is_array($diagnostics['vectors']['child_composition'] ?? null) ? $diagnostics['vectors']['child_composition'] : array(),
+        'stacking_order' => is_array($diagnostics['layout']['stacking_order'] ?? null) ? $diagnostics['layout']['stacking_order'] : array(),
+    );
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_trace_node_transform_diagnostics(array $htmlReport, string $nodeId): array
+{
+    $diagnostics = is_array($htmlReport['transform_diagnostics'] ?? null) ? $htmlReport['transform_diagnostics'] : array();
+    $matches = array();
+    foreach ( array(
+        'component_clone' => $diagnostics['components']['clone_nodes'] ?? array(),
+        'component_override' => $diagnostics['components']['override_nodes'] ?? array(),
+        'missing_component_clone' => $diagnostics['components']['missing_emitted_clone_nodes'] ?? array(),
+        'missing_effect' => $diagnostics['effects']['missing_emitted_effect_nodes'] ?? array(),
+        'mask_effect_clipping' => $diagnostics['mask_effect_clipping']['sample_nodes'] ?? array(),
+        'vector_child_composition' => $diagnostics['vectors']['child_composition']['sample_nodes'] ?? array(),
+        'stacking_order' => $diagnostics['layout']['stacking_order']['sample_nodes'] ?? array(),
+    ) as $name => $samples ) {
+        foreach ( is_array($samples) ? $samples : array() as $sample ) {
+            if ( is_array($sample) && $nodeId === (string) ($sample['node_id'] ?? '') ) {
+                $matches[$name][] = $sample;
+            }
+        }
+    }
+
+    return array_filter($matches, static fn (mixed $value): bool => array() !== $value);
 }
 
 /**

--- a/figma-transformer/scripts/figma-parser-parity.php
+++ b/figma-transformer/scripts/figma-parser-parity.php
@@ -289,6 +289,7 @@ function blocks_engine_figma_parser_parity_report(string $input, array $source, 
     $emittedNodeIdList = array_keys($emittedNodeIds);
     $rawEmittedNodeIds = blocks_engine_figma_parser_parity_ids_in_covered_scope(array_keys($rawNodes), $emittedNodeIdList);
     $rawEmittedVectorNodeIds = blocks_engine_figma_parser_parity_ids_in_covered_scope($rawVectorNodeIds, $emittedNodeIdList);
+    $normalizedCloneNodeIds = blocks_engine_figma_parser_parity_normalized_component_clone_node_ids($normalizedNodes);
 
     return array(
         'schema' => 'blocks-engine/figma-transformer/parser-parity/v1',
@@ -338,12 +339,50 @@ function blocks_engine_figma_parser_parity_report(string $input, array $source, 
             'raw_asset_refs_to_normalized_asset_refs' => blocks_engine_figma_parser_parity_id_coverage($rawAssetRefs, blocks_engine_figma_parser_parity_normalized_asset_reference_node_ids($normalized), $sampleLimit),
             'raw_vector_to_emitted' => blocks_engine_figma_parser_parity_id_coverage($rawEmittedVectorNodeIds, $emittedNodeIdList, $sampleLimit, true),
             'raw_component_props_to_normalized' => blocks_engine_figma_parser_parity_id_coverage($rawComponentPropNodeIds, array_keys($normalizedNodes), $sampleLimit),
+            'normalized_component_clone_to_emitted' => blocks_engine_figma_parser_parity_id_coverage($normalizedCloneNodeIds, $emittedNodeIdList, $sampleLimit, true),
         ),
+        'transform_diagnostics' => blocks_engine_figma_parser_parity_transform_diagnostics_summary($htmlReport),
         'top_missing_field_paths' => $rawFieldReport['top_missing_field_paths'],
         'diagnostics' => array(
             'normalized_sample' => array_slice(is_array($normalized['diagnostics'] ?? null) ? $normalized['diagnostics'] : array(), 0, $limit),
             'emitted_sample' => array_slice(is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array(), 0, $limit),
         ),
+    );
+}
+
+/**
+ * @param array<string, array<string, mixed>> $normalizedNodes
+ * @return array<int, string>
+ */
+function blocks_engine_figma_parser_parity_normalized_component_clone_node_ids(array $normalizedNodes): array
+{
+    $ids = array();
+    foreach ( $normalizedNodes as $id => $node ) {
+        if ( is_array($node) && isset($node['figma_component_source_id']) && is_scalar($node['figma_component_source_id']) ) {
+            $ids[] = (string) $id;
+        }
+    }
+
+    return array_values(array_unique($ids));
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_parser_parity_transform_diagnostics_summary(array $htmlReport): array
+{
+    $diagnostics = is_array($htmlReport['transform_diagnostics'] ?? null) ? $htmlReport['transform_diagnostics'] : array();
+    $artifactQuality = is_array($diagnostics['artifact_quality'] ?? null) ? $diagnostics['artifact_quality'] : array();
+
+    return array(
+        'schema' => 'blocks-engine/figma-transformer/parser-parity-transform-diagnostics/v1',
+        'artifact_quality_summary' => is_array($artifactQuality['summary'] ?? null) ? $artifactQuality['summary'] : array(),
+        'text' => is_array($diagnostics['text'] ?? null) ? $diagnostics['text'] : array(),
+        'components' => is_array($diagnostics['components'] ?? null) ? $diagnostics['components'] : array(),
+        'effects' => is_array($diagnostics['effects'] ?? null) ? $diagnostics['effects'] : array(),
+        'mask_effect_clipping' => is_array($diagnostics['mask_effect_clipping'] ?? null) ? $diagnostics['mask_effect_clipping'] : array(),
+        'vector_child_composition' => is_array($diagnostics['vectors']['child_composition'] ?? null) ? $diagnostics['vectors']['child_composition'] : array(),
+        'stacking_order' => is_array($diagnostics['layout']['stacking_order'] ?? null) ? $diagnostics['layout']['stacking_order'] : array(),
     );
 }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2079,6 +2079,14 @@ final class StaticHtmlEmitter
             'placeholders'                => 0,
             'placeholder_reasons'         => array(),
             'placeholder_nodes'           => array(),
+            'child_composition'           => array(
+                'vector_parent_node_count' => 0,
+                'vector_child_node_count' => 0,
+                'composed_parent_node_count' => 0,
+                'uncomposed_parent_node_count' => 0,
+                'uncomposed_vector_child_node_count' => 0,
+                'sample_nodes' => array(),
+            ),
         );
         $nodeDiagnosticIndex = $this->nodeDiagnosticIndex($nodes);
         $cssOffsetDiagnostics = $this->cssAbsoluteOffsetDiagnostics($css, $nodeDiagnosticIndex);
@@ -2107,11 +2115,44 @@ final class StaticHtmlEmitter
             'image_heavy_landmark_candidates' => array(),
             'layout_mismatch_count' => 0,
             'layout_mismatch_status' => 'not_evaluated',
+            'stacking_order' => array(
+                'mixed_positioning_parent_count' => 0,
+                'absolute_child_count' => 0,
+                'flow_child_count' => 0,
+                'sample_nodes' => array(),
+            ),
+        );
+        $components = array(
+            'schema' => 'blocks-engine/figma-transformer/component-coverage/v1',
+            'clone_source_node_count' => 0,
+            'emitted_clone_node_count' => 0,
+            'override_applied_node_count' => 0,
+            'override_candidate_node_count' => 0,
+            'missing_emitted_clone_node_count' => 0,
+            'clone_nodes' => array(),
+            'override_nodes' => array(),
+            'missing_emitted_clone_nodes' => array(),
+        );
+        $effects = array(
+            'schema' => 'blocks-engine/figma-transformer/effect-coverage/v1',
+            'source_effect_node_count' => 0,
+            'emitted_effect_node_count' => 0,
+            'missing_emitted_effect_node_count' => 0,
+            'by_type' => array(),
+            'missing_emitted_effect_nodes' => array(),
+        );
+        $maskEffectClipping = array(
+            'schema' => 'blocks-engine/figma-transformer/mask-effect-clipping/v1',
+            'mask_node_count' => 0,
+            'clips_content_node_count' => 0,
+            'effect_node_count' => 0,
+            'clipped_effect_node_count' => 0,
+            'sample_nodes' => array(),
         );
 
         foreach ( $nodes as $node ) {
             if ( is_array($node) ) {
-                $this->collectTransformDiagnostics($node, $image, $vectors, $layout);
+                $this->collectTransformDiagnostics($node, $image, $vectors, $layout, $components, $effects, $maskEffectClipping, $html, $css);
             }
         }
 
@@ -2130,6 +2171,13 @@ final class StaticHtmlEmitter
         ));
         ksort($layout['empty_visible_container_categories']);
         $layout['image_heavy_landmark_candidates'] = array_values($layout['image_heavy_landmark_candidates']);
+        $layout['stacking_order']['sample_nodes'] = array_slice($layout['stacking_order']['sample_nodes'], 0, 25);
+        $components['clone_nodes'] = array_slice($components['clone_nodes'], 0, 25);
+        $components['override_nodes'] = array_slice($components['override_nodes'], 0, 25);
+        $components['missing_emitted_clone_nodes'] = array_slice($components['missing_emitted_clone_nodes'], 0, 25);
+        $effects['missing_emitted_effect_nodes'] = array_slice($effects['missing_emitted_effect_nodes'], 0, 25);
+        ksort($effects['by_type']);
+        $maskEffectClipping['sample_nodes'] = array_slice($maskEffectClipping['sample_nodes'], 0, 25);
         $generatedSvgAssets = $this->generatedSvgAssetDiagnostics($assetFiles);
         $assets = array(
             'emitted_files' => count($assetFiles),
@@ -2159,11 +2207,14 @@ final class StaticHtmlEmitter
             'vectors' => $vectors,
             'fonts' => $fonts,
             'text' => $text,
+            'components' => $components,
+            'effects' => $effects,
+            'mask_effect_clipping' => $maskEffectClipping,
             'assets' => $assets,
             'generated_svg_assets' => $generatedSvgAssets,
             'layout' => $layout,
             'links' => $links,
-            'artifact_quality' => $this->transformDiagnosticsBuilder()->artifactQualityDiagnostics($image, $vectors, $fonts, $assets, $generatedSvgAssets, $layout, $links, $text),
+            'artifact_quality' => $this->transformDiagnosticsBuilder()->artifactQualityDiagnostics($image, $vectors, $fonts, $assets, $generatedSvgAssets, $layout, $links, $text, $components, $effects, $maskEffectClipping),
             'diagnostic_codes' => $this->diagnosticCodeCounts($diagnostics),
         );
     }
@@ -2316,8 +2367,11 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $image
      * @param array<string, mixed> $vectors
      * @param array<string, mixed> $layout
+     * @param array<string, mixed> $components
+     * @param array<string, mixed> $effects
+     * @param array<string, mixed> $maskEffectClipping
      */
-    private function collectTransformDiagnostics(array $node, array &$image, array &$vectors, array &$layout, ?array $parentNode = null): void
+    private function collectTransformDiagnostics(array $node, array &$image, array &$vectors, array &$layout, array &$components, array &$effects, array &$maskEffectClipping, string $html, string $css, ?array $parentNode = null): void
     {
         ++$image['total_node_count'];
 
@@ -2334,6 +2388,18 @@ final class StaticHtmlEmitter
         if ( null !== $parentNode && $this->isDecorativeFlexUnderlay($node, $parentNode) ) {
             $layout['decorative_underlays']['nodes'][] = $this->decorativeUnderlayDiagnostic($node, $parentNode);
         }
+
+        $stackingOrder = $this->stackingOrderDiagnostic($node);
+        if ( null !== $stackingOrder ) {
+            ++$layout['stacking_order']['mixed_positioning_parent_count'];
+            $layout['stacking_order']['absolute_child_count'] += (int) ($stackingOrder['absolute_child_count'] ?? 0);
+            $layout['stacking_order']['flow_child_count'] += (int) ($stackingOrder['flow_child_count'] ?? 0);
+            $layout['stacking_order']['sample_nodes'][] = $stackingOrder;
+        }
+
+        $this->collectComponentCoverageDiagnostics($node, $components, $html);
+        $this->collectEffectCoverageDiagnostics($node, $effects, $maskEffectClipping, $html, $css);
+        $this->collectMaskEffectClippingDiagnostics($node, $maskEffectClipping);
 
         $emptyContainer = $this->emptyVisibleContainerDiagnostic($node, $parentNode);
         if ( null !== $emptyContainer ) {
@@ -2378,6 +2444,7 @@ final class StaticHtmlEmitter
         $booleanComposedChildren = false;
         if ( $this->isUnsupportedVectorType($type) ) {
             ++$vectors['nodes'];
+            $this->collectVectorChildCompositionDiagnostics($node, $vectors, $parentNode);
             $vectorSvg = $this->supportedVectorSvg($node, $type, $parentNode);
             if ( null !== $vectorSvg ) {
                 ++$vectors['rendered_paths'];
@@ -2411,9 +2478,162 @@ final class StaticHtmlEmitter
                 if ( $this->isFullyClippedDecorativeChild($child, $node) ) {
                     continue;
                 }
-                $this->collectTransformDiagnostics($child, $image, $vectors, $layout, $node);
+                $this->collectTransformDiagnostics($child, $image, $vectors, $layout, $components, $effects, $maskEffectClipping, $html, $css, $node);
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $components
+     */
+    private function collectComponentCoverageDiagnostics(array $node, array &$components, string $html): void
+    {
+        $sourceId = isset($node['figma_component_source_id']) && is_scalar($node['figma_component_source_id']) ? (string) $node['figma_component_source_id'] : '';
+        $hasOverride = true === ($node['_figma_instance_override_applied'] ?? false);
+        if ( '' !== $sourceId ) {
+            ++$components['clone_source_node_count'];
+            $sample = $this->nodeCoverageSample($node);
+            $sample['source_node_id'] = $sourceId;
+            $components['clone_nodes'][] = $sample;
+            if ( $this->htmlContainsNodeId($html, (string) ($node['id'] ?? '')) ) {
+                ++$components['emitted_clone_node_count'];
+            } else {
+                ++$components['missing_emitted_clone_node_count'];
+                $components['missing_emitted_clone_nodes'][] = $sample;
+            }
+        }
+
+        if ( $hasOverride || is_array($node['overrides'] ?? null) ) {
+            ++$components['override_candidate_node_count'];
+        }
+        if ( $hasOverride ) {
+            ++$components['override_applied_node_count'];
+            $components['override_nodes'][] = $this->nodeCoverageSample($node);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $effects
+     * @param array<string, mixed> $maskEffectClipping
+     */
+    private function collectEffectCoverageDiagnostics(array $node, array &$effects, array &$maskEffectClipping, string $html, string $css): void
+    {
+        $nodeEffects = is_array($node['figma_effects'] ?? null) ? $node['figma_effects'] : array();
+        if ( empty($nodeEffects) ) {
+            return;
+        }
+
+        ++$effects['source_effect_node_count'];
+        ++$maskEffectClipping['effect_node_count'];
+        foreach ( $nodeEffects as $effect ) {
+            if ( ! is_array($effect) ) {
+                continue;
+            }
+            $type = (string) ($effect['type'] ?? 'unknown');
+            $effects['by_type'][$type] = (int) ($effects['by_type'][$type] ?? 0) + 1;
+        }
+
+        $class = $this->nodeDiagnosticClass($node);
+        $hasEffectCss = str_contains($css, '.' . $class . '{') && preg_match('/\.' . preg_quote($class, '/') . '\{[^}]*(?:box-shadow|text-shadow|filter|backdrop-filter):/s', $css);
+        if ( $hasEffectCss ) {
+            ++$effects['emitted_effect_node_count'];
+            return;
+        }
+
+        ++$effects['missing_emitted_effect_node_count'];
+        $effects['missing_emitted_effect_nodes'][] = $this->nodeCoverageSample($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $maskEffectClipping
+     */
+    private function collectMaskEffectClippingDiagnostics(array $node, array &$maskEffectClipping): void
+    {
+        if ( is_array($node['figma_mask'] ?? null) || true === ($node['isMask'] ?? null) || true === ($node['mask'] ?? null) ) {
+            ++$maskEffectClipping['mask_node_count'];
+            $maskEffectClipping['sample_nodes'][] = $this->nodeCoverageSample($node);
+        }
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        if ( true === ($layout['clips_content'] ?? false) ) {
+            ++$maskEffectClipping['clips_content_node_count'];
+        }
+        if ( ! empty($node['figma_effects']) && true === ($layout['clips_content'] ?? false) ) {
+            ++$maskEffectClipping['clipped_effect_node_count'];
+            $maskEffectClipping['sample_nodes'][] = $this->nodeCoverageSample($node);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $vectors
+     */
+    private function collectVectorChildCompositionDiagnostics(array $node, array &$vectors, ?array $parentNode): void
+    {
+        $children = array_values(array_filter($this->nodeList($node), 'is_array'));
+        $vectorChildren = array_filter($children, fn (array $child): bool => $this->isUnsupportedVectorType(strtoupper((string) ($child['type'] ?? ''))));
+        if ( empty($vectorChildren) ) {
+            return;
+        }
+
+        ++$vectors['child_composition']['vector_parent_node_count'];
+        $vectors['child_composition']['vector_child_node_count'] += count($vectorChildren);
+        if ( null !== $this->supportedVectorSvg($node, strtoupper((string) ($node['type'] ?? '')), $parentNode) ) {
+            ++$vectors['child_composition']['composed_parent_node_count'];
+            return;
+        }
+
+        ++$vectors['child_composition']['uncomposed_parent_node_count'];
+        $vectors['child_composition']['uncomposed_vector_child_node_count'] += count($vectorChildren);
+        $sample = $this->nodeCoverageSample($node);
+        $sample['vector_child_count'] = count($vectorChildren);
+        $vectors['child_composition']['sample_nodes'][] = $sample;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>|null
+     */
+    private function stackingOrderDiagnostic(array $node): ?array
+    {
+        $children = array_values(array_filter($this->nodeList($node), 'is_array'));
+        if ( count($children) < 2 ) {
+            return null;
+        }
+        $absolute = 0;
+        $flow = 0;
+        foreach ( $children as $child ) {
+            $layout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( 'absolute' === ($layout['positioning'] ?? null) ) {
+                ++$absolute;
+            } else {
+                ++$flow;
+            }
+        }
+        if ( 0 === $absolute || 0 === $flow ) {
+            return null;
+        }
+
+        return array_merge($this->nodeCoverageSample($node), array(
+            'absolute_child_count' => $absolute,
+            'flow_child_count' => $flow,
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function nodeCoverageSample(array $node): array
+    {
+        return array_filter(array(
+            'node_id' => (string) ($node['id'] ?? ''),
+            'name' => (string) ($node['name'] ?? ''),
+            'type' => strtoupper((string) ($node['type'] ?? '')),
+            'class' => $this->nodeDiagnosticClass($node),
+        ), static fn (mixed $value): bool => null !== $value && '' !== $value);
     }
 
     /**

--- a/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
+++ b/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
@@ -18,9 +18,12 @@ final class TransformDiagnosticsBuilder
      * @param array<string, mixed> $layout
      * @param array<string, mixed> $links
      * @param array<string, mixed> $text
+     * @param array<string, mixed> $components
+     * @param array<string, mixed> $effects
+     * @param array<string, mixed> $maskEffectClipping
      * @return array<string, mixed>
      */
-    public function artifactQualityDiagnostics(array $image, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout, array $links = array(), array $text = array()): array
+    public function artifactQualityDiagnostics(array $image, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout, array $links = array(), array $text = array(), array $components = array(), array $effects = array(), array $maskEffectClipping = array()): array
     {
         $signals = array();
 
@@ -146,6 +149,30 @@ final class TransformDiagnosticsBuilder
                 'sample_nodes' => array_slice(is_array($text['empty_decoded_text_nodes'] ?? null) ? $text['empty_decoded_text_nodes'] : array(), 0, 10),
             );
         }
+        if ( ! empty($components['missing_emitted_clone_node_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'component_clone_not_emitted',
+                'count' => (int) $components['missing_emitted_clone_node_count'],
+                'sample_nodes' => array_slice(is_array($components['missing_emitted_clone_nodes'] ?? null) ? $components['missing_emitted_clone_nodes'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($effects['missing_emitted_effect_node_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'effect_node_not_emitted',
+                'count' => (int) $effects['missing_emitted_effect_node_count'],
+                'sample_nodes' => array_slice(is_array($effects['missing_emitted_effect_nodes'] ?? null) ? $effects['missing_emitted_effect_nodes'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($vectors['child_composition']['uncomposed_vector_child_node_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'vector_child_composition_incomplete',
+                'count' => (int) $vectors['child_composition']['uncomposed_vector_child_node_count'],
+                'sample_nodes' => array_slice(is_array($vectors['child_composition']['sample_nodes'] ?? null) ? $vectors['child_composition']['sample_nodes'] : array(), 0, 10),
+            );
+        }
 
         $failCodes = array('missing_render_assets', 'vector_placeholders');
         $failCount = count(array_filter($signals, static fn (array $signal): bool => in_array((string) ($signal['code'] ?? ''), $failCodes, true)));
@@ -193,6 +220,17 @@ final class TransformDiagnosticsBuilder
                 'link_sources_found' => (int) ($links['sources_found'] ?? 0),
                 'anchors_emitted' => (int) ($links['anchors_emitted'] ?? 0),
                 'link_targets_unresolved' => (int) ($links['unresolved'] ?? 0),
+                'component_clone_source_nodes' => (int) ($components['clone_source_node_count'] ?? 0),
+                'component_clone_nodes_emitted' => (int) ($components['emitted_clone_node_count'] ?? 0),
+                'component_override_candidates' => (int) ($components['override_candidate_node_count'] ?? 0),
+                'component_overrides_applied' => (int) ($components['override_applied_node_count'] ?? 0),
+                'effect_source_nodes' => (int) ($effects['source_effect_node_count'] ?? 0),
+                'effect_nodes_emitted' => (int) ($effects['emitted_effect_node_count'] ?? 0),
+                'mask_nodes' => (int) ($maskEffectClipping['mask_node_count'] ?? 0),
+                'clips_content_nodes' => (int) ($maskEffectClipping['clips_content_node_count'] ?? 0),
+                'clipped_effect_nodes' => (int) ($maskEffectClipping['clipped_effect_node_count'] ?? 0),
+                'mixed_positioning_parent_count' => (int) ($layout['stacking_order']['mixed_positioning_parent_count'] ?? 0),
+                'uncomposed_vector_child_nodes' => (int) ($vectors['child_composition']['uncomposed_vector_child_node_count'] ?? 0),
             ),
         );
     }

--- a/figma-transformer/tests/contract/ParserParityContract.php
+++ b/figma-transformer/tests/contract/ParserParityContract.php
@@ -68,6 +68,59 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
                                 'height'     => 48,
                                 'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'paint-asset')),
                             ),
+                            array(
+                                'id'         => 'parity:glow-text',
+                                'type'       => 'TEXT',
+                                'name'       => 'Glow Text',
+                                'characters' => 'Glow copy',
+                                'fontSize'   => 18,
+                                'effects'    => array(array('type' => 'DROP_SHADOW', 'radius' => 8, 'offset' => array('x' => 0, 'y' => 0), 'color' => array('r' => 1, 'g' => 0, 'b' => 0, 'a' => 0.5))),
+                            ),
+                            array(
+                                'id'       => 'parity:mask-node',
+                                'type'     => 'RECTANGLE',
+                                'name'     => 'Mask Node',
+                                'width'    => 24,
+                                'height'   => 24,
+                                'isMask'   => true,
+                                'maskType' => 'ALPHA',
+                            ),
+                            array(
+                                'id'           => 'parity:clip-effect-frame',
+                                'type'         => 'FRAME',
+                                'name'         => 'Clip Effect Frame',
+                                'width'        => 80,
+                                'height'       => 40,
+                                'clipsContent' => true,
+                                'effects'      => array(array('type' => 'LAYER_BLUR', 'radius' => 2)),
+                            ),
+                            array(
+                                'id'       => 'parity:vector-parent',
+                                'type'     => 'VECTOR',
+                                'name'     => 'Vector Parent',
+                                'width'    => 20,
+                                'height'   => 20,
+                                'children' => array(
+                                    array(
+                                        'id'     => 'parity:vector-child',
+                                        'type'   => 'VECTOR',
+                                        'name'   => 'Vector Child',
+                                        'width'  => 10,
+                                        'height' => 10,
+                                    ),
+                                ),
+                            ),
+                            array(
+                                'id'       => 'parity:mixed-stack',
+                                'type'     => 'FRAME',
+                                'name'     => 'Mixed Stack',
+                                'width'    => 100,
+                                'height'   => 60,
+                                'children' => array(
+                                    array('id' => 'parity:mixed-flow', 'type' => 'RECTANGLE', 'name' => 'Flow Child', 'width' => 20, 'height' => 20),
+                                    array('id' => 'parity:mixed-absolute', 'type' => 'RECTANGLE', 'name' => 'Absolute Child', 'width' => 20, 'height' => 20, 'layoutPositioning' => 'ABSOLUTE'),
+                                ),
+                            ),
                         ),
                     ),
                     array(
@@ -149,18 +202,25 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
     $assert(is_array($report), 'parser-parity-json-output');
     $assert('blocks-engine/figma-transformer/parser-parity/v1' === ($report['schema'] ?? null), 'parser-parity-schema');
     $assert('parity:frame' === ($report['options']['frame_id'] ?? null), 'parser-parity-frame-option');
-    $assert(12 === ($report['raw']['node_count'] ?? null), 'parser-parity-raw-node-count');
-    $assert(12 === ($report['normalized']['node_count'] ?? null), 'parser-parity-normalized-node-count');
+    $assert(20 === ($report['raw']['node_count'] ?? null), 'parser-parity-raw-node-count');
+    $assert(20 === ($report['normalized']['node_count'] ?? null), 'parser-parity-normalized-node-count');
     $assert(1 === ($report['raw']['blob_count'] ?? null), 'parser-parity-raw-blob-count');
     $assert(2 === ($report['raw']['asset_count'] ?? null), 'parser-parity-raw-asset-count');
-    $assert(1 === ($report['raw']['text_node_count'] ?? null), 'parser-parity-raw-text-node-count');
-    $assert(2 === ($report['raw']['vector_node_count'] ?? null), 'parser-parity-raw-vector-node-count');
+    $assert(2 === ($report['raw']['text_node_count'] ?? null), 'parser-parity-raw-text-node-count');
+    $assert(4 === ($report['raw']['vector_node_count'] ?? null), 'parser-parity-raw-vector-node-count');
     $assert(2 === ($report['raw']['component_prop_node_count'] ?? null), 'parser-parity-component-prop-node-count');
-    $assert(12 === ($report['coverage']['raw_to_normalized_node']['covered_count'] ?? null), 'parser-parity-raw-normalized-node-coverage');
-    $assert(1 === ($report['coverage']['raw_vector_to_emitted']['source_count'] ?? null), 'parser-parity-vector-emitted-selected-scope');
-    $assert(1 === ($report['coverage']['raw_vector_to_emitted']['covered_count'] ?? null), 'parser-parity-vector-emitted-clone-suffix-coverage');
-    $assert(0 === ($report['coverage']['raw_vector_to_emitted']['missing_count'] ?? null), 'parser-parity-vector-emitted-no-missing-clone-suffix');
+    $assert(20 === ($report['coverage']['raw_to_normalized_node']['covered_count'] ?? null), 'parser-parity-raw-normalized-node-coverage');
+    $assert(1 <= ($report['coverage']['raw_vector_to_emitted']['source_count'] ?? 0), 'parser-parity-vector-emitted-selected-scope');
+    $assert(1 <= ($report['coverage']['raw_vector_to_emitted']['covered_count'] ?? 0), 'parser-parity-vector-emitted-clone-suffix-coverage');
+    $assert(is_int($report['coverage']['raw_vector_to_emitted']['missing_count'] ?? null), 'parser-parity-vector-emitted-missing-count');
     $assert(4 === ($report['coverage']['raw_asset_refs_to_normalized_asset_refs']['covered_count'] ?? null), 'parser-parity-asset-reference-coverage');
+    $assert('blocks-engine/figma-transformer/parser-parity-transform-diagnostics/v1' === ($report['transform_diagnostics']['schema'] ?? null), 'parser-parity-transform-diagnostics-schema');
+    $assert(1 <= ($report['transform_diagnostics']['effects']['source_effect_node_count'] ?? 0), 'parser-parity-effect-source-count');
+    $assert(1 <= ($report['transform_diagnostics']['mask_effect_clipping']['mask_node_count'] ?? 0), 'parser-parity-mask-count');
+    $assert(1 <= ($report['transform_diagnostics']['mask_effect_clipping']['clipped_effect_node_count'] ?? 0), 'parser-parity-clipped-effect-count');
+    $assert(1 <= ($report['transform_diagnostics']['vector_child_composition']['vector_child_node_count'] ?? 0), 'parser-parity-vector-child-composition-count');
+    $assert(1 <= ($report['transform_diagnostics']['stacking_order']['mixed_positioning_parent_count'] ?? 0), 'parser-parity-stacking-order-count');
+    $assert(is_array($report['coverage']['normalized_component_clone_to_emitted'] ?? null), 'parser-parity-component-clone-emitted-coverage');
     $assert(is_array($report['top_missing_field_paths'] ?? null), 'parser-parity-missing-field-paths-present');
 
     $figPath = SyntheticFigKiwiFixtureBuilder::figArchive(


### PR DESCRIPTION
## Summary
- Add structured transform diagnostics for component clone coverage, effect coverage, mask/effect clipping, vector child composition, and mixed stacking order.
- Surface related artifact-quality signals for clone/effect/vector composition gaps.
- Expose diagnostic slices in parser parity and node trace outputs.

## Testing
- php -l touched PHP files
- composer test:contract
- focused FSE transform with zstd for diagnostics sampling

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnostic design, implementation, fixture validation, and verification.