### PR TITLE
figma-transformer: decode Kiwi component state metadata

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -55,8 +55,10 @@ final class FigKiwiDecodePolicy
             'DerivedSymbolData' => array('symbolID', 'symbolOverrides', 'uniformScaleFactor'),
             'GUIDPath' => array('guids'),
             'StyleId' => array('guid'),
+            'StateGroupPropertyValueOrder' => array('property', 'values'),
+            'VariantPropSpec' => array('propDefId', 'value'),
             'ComponentPropAssignment' => array('defID', 'value', 'varValue'),
-            'ComponentPropValue' => array('boolValue', 'textValue', 'guidValue', 'textDataValue', 'symbolIdValue'),
+            'ComponentPropValue' => array('boolValue', 'textValue', 'guidValue', 'floatValue', 'textDataValue', 'symbolIdValue'),
             'VariableData' => array('value', 'dataType', 'resolvedDataType'),
             'VariableAnyValue' => array('boolValue', 'textValue', 'floatValue', 'colorValue', 'symbolIdValue', 'textDataValue'),
             'SymbolId' => array('guid'),
@@ -124,6 +126,9 @@ final class FigKiwiDecodePolicy
         $name = strtolower($fieldName . ' ' . $type . ' ' . $parentMessage);
         if ( str_contains($name, 'variable') || str_contains($name, 'varvalue') || str_contains($name, 'parameter') || str_contains($name, 'consumption') ) {
             return 'variables_bindings';
+        }
+        if ( str_contains($name, 'stategroup') ) {
+            return 'component_overrides';
         }
         if ( str_contains($name, 'bound') || str_contains($name, 'layout') || str_contains($name, 'constraint') || str_contains($name, 'padding') || str_contains($name, 'size') || str_contains($name, 'transform') || str_contains($name, 'corner') || str_contains($name, 'stack') ) {
             return 'geometry_layout';
@@ -291,6 +296,7 @@ final class FigKiwiDecodePolicy
         return array(
             'key', 'componentKey', 'componentOrStateGroupKey', 'originComponentKey',
             'componentId', 'mainComponentId', 'componentPropAssignments', 'componentPropDefs', 'componentPropRefs',
+            'isStateGroup', 'stateGroupPropertyValueOrders', 'variantPropSpecs',
             'styleIdForEffect',
             'mainComponent', 'component', 'symbolData', 'derivedSymbolData', 'guidPath',
         );

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -539,11 +539,85 @@ final class ScenegraphNormalizer
             $metadata['component_properties'] = $node['componentProperties'];
         }
 
+        if ( true === ($node['isStateGroup'] ?? false) ) {
+            $metadata['state_group'] = true;
+        }
+
+        if ( is_array($node['stateGroupPropertyValueOrders'] ?? null) ) {
+            $orders = $this->normalizeStateGroupPropertyValueOrders($node['stateGroupPropertyValueOrders']);
+            if ( ! empty($orders) ) {
+                $metadata['state_group_property_value_orders'] = $orders;
+            }
+        }
+
+        if ( is_array($node['variantPropSpecs'] ?? null) ) {
+            $variantSpecs = $this->normalizeVariantPropSpecs($node['variantPropSpecs']);
+            if ( ! empty($variantSpecs) ) {
+                $metadata['variant_prop_specs'] = $variantSpecs;
+            }
+        }
+
         if ( is_array($node['overrides'] ?? null) ) {
             $metadata['overrides'] = $node['overrides'];
         }
 
         return $metadata;
+    }
+
+    /**
+     * @param array<int, mixed> $orders
+     * @return array<int, array{property: string, values: array<int, string>}>
+     */
+    private function normalizeStateGroupPropertyValueOrders(array $orders): array
+    {
+        $normalized = array();
+
+        foreach ( $orders as $order ) {
+            if ( ! is_array($order) || ! isset($order['property']) || ! is_scalar($order['property']) ) {
+                continue;
+            }
+
+            $values = array();
+            foreach ( is_array($order['values'] ?? null) ? $order['values'] : array() as $value ) {
+                if ( is_scalar($value) ) {
+                    $values[] = (string) $value;
+                }
+            }
+
+            $normalized[] = array(
+                'property' => (string) $order['property'],
+                'values'   => $values,
+            );
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<int, mixed> $specs
+     * @return array<int, array{prop_def_id: string, value: string}>
+     */
+    private function normalizeVariantPropSpecs(array $specs): array
+    {
+        $normalized = array();
+
+        foreach ( $specs as $spec ) {
+            if ( ! is_array($spec) || ! isset($spec['value']) || ! is_scalar($spec['value']) ) {
+                continue;
+            }
+
+            $propDefId = $this->readGuidId($spec['propDefId'] ?? null);
+            if ( null === $propDefId ) {
+                continue;
+            }
+
+            $normalized[] = array(
+                'prop_def_id' => $propDefId,
+                'value'       => (string) $spec['value'],
+            );
+        }
+
+        return $normalized;
     }
 
     /**

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -222,6 +222,49 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert(! array_key_exists('glyphs', $kiwiDerivedText), 'kiwi-selective-skips-derived-text-glyphs');
     $assert('Inter' === ($kiwiDerivedText['fontMetaData']['key']['family'] ?? null), 'kiwi-selective-decodes-derived-text-font-family');
     $assert(700 === ($kiwiDerivedText['fontMetaData']['fontWeight'] ?? null), 'kiwi-selective-decodes-derived-text-font-weight');
+
+    $kiwiStateGroupSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_state_group_schema_fixture());
+    $kiwiStateGroupMessage = $kiwiDecoder->decodeMessageSelective(
+        blocks_engine_figma_transformer_kiwi_state_group_message_fixture(),
+        $kiwiStateGroupSchema['schema'] ?? array()
+    );
+    $kiwiStateGroupNode = $kiwiStateGroupMessage['message']['nodeChanges'][0] ?? array();
+    $kiwiVariantNode = $kiwiStateGroupMessage['message']['nodeChanges'][1] ?? array();
+    $assert(true === ($kiwiStateGroupNode['isStateGroup'] ?? null), 'kiwi-selective-decodes-state-group-flag');
+    $assert('Screen Size' === ($kiwiStateGroupNode['stateGroupPropertyValueOrders'][0]['property'] ?? null), 'kiwi-selective-decodes-state-group-order-property');
+    $assert(array('Desktop', 'Mobile') === ($kiwiStateGroupNode['stateGroupPropertyValueOrders'][0]['values'] ?? null), 'kiwi-selective-decodes-state-group-order-values');
+    $assert('Desktop' === ($kiwiVariantNode['variantPropSpecs'][0]['value'] ?? null), 'kiwi-selective-decodes-variant-prop-spec-value');
+
+    $kiwiStateGroupNormalizer = new ScenegraphNormalizer();
+    $kiwiStateGroupNormalized = $kiwiStateGroupNormalizer->normalize(array(
+        'name'  => 'Kiwi State Group Metadata Fixture',
+        'nodes' => array(
+            array(
+                'id'                             => 'state-group:root',
+                'type'                           => 'FRAME',
+                'name'                           => 'Newsletter Signup',
+                'isStateGroup'                   => true,
+                'stateGroupPropertyValueOrders'  => array(
+                    array('property' => 'Screen Size', 'values' => array('Desktop', 'Mobile')),
+                ),
+            ),
+            array(
+                'id'               => 'state-group:desktop',
+                'type'             => 'SYMBOL',
+                'name'             => 'Screen Size=Desktop',
+                'variantPropSpecs' => array(
+                    array('propDefId' => array('sessionID' => 2422394609, 'localID' => 4048757538), 'value' => 'Desktop'),
+                ),
+            ),
+        ),
+    ));
+    $kiwiStateGroupMetadata = $kiwiStateGroupNormalized['nodes'][0]['figma_component'] ?? array();
+    $kiwiVariantMetadata = $kiwiStateGroupNormalized['nodes'][1]['figma_component'] ?? array();
+    $assert(true === ($kiwiStateGroupMetadata['state_group'] ?? null), 'kiwi-state-group-normalizes-component-flag');
+    $assert('Screen Size' === ($kiwiStateGroupMetadata['state_group_property_value_orders'][0]['property'] ?? null), 'kiwi-state-group-normalizes-order-property');
+    $assert(array('Desktop', 'Mobile') === ($kiwiStateGroupMetadata['state_group_property_value_orders'][0]['values'] ?? null), 'kiwi-state-group-normalizes-order-values');
+    $assert('2422394609:4048757538' === ($kiwiVariantMetadata['variant_prop_specs'][0]['prop_def_id'] ?? null), 'kiwi-variant-normalizes-prop-def-id');
+    $assert('Desktop' === ($kiwiVariantMetadata['variant_prop_specs'][0]['value'] ?? null), 'kiwi-variant-normalizes-value');
     
     $kiwiFrameMaskResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'document' => array(
@@ -791,6 +834,92 @@ function blocks_engine_figma_transformer_kiwi_derived_text_message_fixture(): st
         . blocks_engine_figma_transformer_kiwi_varfloat(24.0)
         . blocks_engine_figma_transformer_wire_varint_signed(700)
         . blocks_engine_figma_transformer_wire_varint(0)
+        . blocks_engine_figma_transformer_wire_varint(0);
+}
+
+function blocks_engine_figma_transformer_kiwi_state_group_schema_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(5)
+        . blocks_engine_figma_transformer_kiwi_string('GUID')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sessionID', -4, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('localID', -4, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('StateGroupPropertyValueOrder')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('property', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('values', -6, true, 2)
+        . blocks_engine_figma_transformer_kiwi_string('VariantPropSpec')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('propDefId', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('value', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('NodeChange')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(6)
+        . blocks_engine_figma_transformer_kiwi_schema_field('guid', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('isStateGroup', -1, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('stateGroupPropertyValueOrders', 1, true, 5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('variantPropSpecs', 2, true, 6)
+        . blocks_engine_figma_transformer_kiwi_string('Message')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 3, true, 2);
+}
+
+function blocks_engine_figma_transformer_kiwi_state_group_message_fixture(): string
+{
+    $stateGroupOrder = blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('Screen Size')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('Desktop')
+        . blocks_engine_figma_transformer_kiwi_string('Mobile')
+        . blocks_engine_figma_transformer_wire_varint(0);
+
+    $stateGroupNode = blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(4166)
+        . blocks_engine_figma_transformer_wire_varint(11733)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('FRAME')
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_string('Newsletter Signup')
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(5)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . $stateGroupOrder
+        . blocks_engine_figma_transformer_wire_varint(0);
+
+    $variantPropSpec = blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(2422394609)
+        . blocks_engine_figma_transformer_wire_varint(4048757538)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('Desktop')
+        . blocks_engine_figma_transformer_wire_varint(0);
+
+    $variantNode = blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(3266)
+        . blocks_engine_figma_transformer_wire_varint(75449)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('SYMBOL')
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_string('Screen Size=Desktop')
+        . blocks_engine_figma_transformer_wire_varint(6)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . $variantPropSpec
+        . blocks_engine_figma_transformer_wire_varint(0);
+
+    return blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('NODE_CHANGES')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . $stateGroupNode
+        . $variantNode
         . blocks_engine_figma_transformer_wire_varint(0);
 }
 


### PR DESCRIPTION
## Summary
- Decode Kiwi state-group and variant-property metadata.
- Preserve normalized component state-group orders and variant prop specs in scenegraph metadata.
- Add parser contract coverage for state-group and variant metadata decoding.

## Testing
- php -l src/FigFile/FigKiwiDecodePolicy.php
- php -l src/Scenegraph/ScenegraphNormalizer.php
- php -l tests/contract/KiwiParserContract.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Reviewing the minion-authored parser changes, rebasing, running validation, committing, and preparing this PR description.