### PR TITLE
figma-transformer: decode Kiwi variable bindings

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -62,8 +62,16 @@ final class FigKiwiDecodePolicy
             'VariantPropSpec' => array('propDefId', 'value'),
             'ComponentPropAssignment' => array('defID', 'value', 'varValue'),
             'ComponentPropValue' => array('boolValue', 'textValue', 'guidValue', 'floatValue', 'textDataValue', 'symbolIdValue'),
+            'VariableDataMap' => array('entries'),
+            'VariableDataMapEntry' => array('nodeField', 'variableData', 'variableField'),
             'VariableData' => array('value', 'dataType', 'resolvedDataType'),
-            'VariableAnyValue' => array('boolValue', 'textValue', 'floatValue', 'colorValue', 'symbolIdValue', 'textDataValue'),
+            'VariableAnyValue' => array('boolValue', 'textValue', 'floatValue', 'alias', 'colorValue', 'symbolIdValue', 'textDataValue', 'vectorValue', 'linkValue', 'propRefValue'),
+            'VariableID' => array('guid', 'assetRef'),
+            'VariableOverrideId' => array('guid', 'assetRef'),
+            'VariableDataValues' => array('entries'),
+            'VariableDataValuesEntry' => array('modeID', 'variableData'),
+            'VariableSetMode' => array('id', 'name', 'sortPosition', 'parentVariableSetId', 'parentModeId'),
+            'VariableSetID' => array('guid', 'assetRef'),
             'SymbolId' => array('guid'),
             'ComponentPropDef' => array('id', 'parentPropDefId', 'name', 'initialValue', 'sortPosition', 'type', 'preferredValues', 'varValue'),
             'ComponentPropRef' => array('defID', 'componentPropNodeField'),
@@ -234,6 +242,7 @@ final class FigKiwiDecodePolicy
             $this->nodeTextFields(),
             $this->nodeLayoutFields(),
             $this->nodeEffectFields(),
+            $this->nodeVariableBindingFields(),
             $this->nodePrototypeLinkFields()
         );
     }
@@ -349,5 +358,13 @@ final class FigKiwiDecodePolicy
     {
         // Link extraction only; richer animation/overlay/swap action data stays undecoded.
         return array('hyperlink', 'prototypeInteractions', 'reactions', 'transitionNodeID');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function nodeVariableBindingFields(): array
+    {
+        return array('variableConsumptionMap', 'parameterConsumptionMap', 'variableDataValues', 'variableResolvedType', 'variableSetID', 'variableScopes', 'variableSetModes');
     }
 }

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -413,6 +413,11 @@ final class ScenegraphNormalizer
             $node['figma_component'] = $component;
         }
 
+        $variableBindings = $this->normalizeVariableBindings($node);
+        if ( ! empty($variableBindings) ) {
+            $node['figma_variable_bindings'] = $variableBindings;
+        }
+
         if ( 'TEXT' === $type ) {
             $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics, $paintStyles, $textStyles, $options);
             if ( ! empty($text) ) {
@@ -487,6 +492,174 @@ final class ScenegraphNormalizer
         }
 
         return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function normalizeVariableBindings(array $node): array
+    {
+        $normalized = array();
+        $bindings = array();
+        $byRole = array();
+
+        foreach ( array('variableConsumptionMap', 'parameterConsumptionMap') as $sourceKey ) {
+            if ( ! is_array($node[$sourceKey]['entries'] ?? null) ) {
+                continue;
+            }
+
+            foreach ( $node[$sourceKey]['entries'] as $entry ) {
+                if ( ! is_array($entry) ) {
+                    continue;
+                }
+
+                $targetField = isset($entry['variableField']) && is_scalar($entry['variableField']) ? (string) $entry['variableField'] : null;
+                if ( null === $targetField && isset($entry['nodeField']) && is_scalar($entry['nodeField']) ) {
+                    $targetField = 'nodeField:' . (string) $entry['nodeField'];
+                }
+                if ( null === $targetField || '' === $targetField ) {
+                    continue;
+                }
+
+                $variableData = is_array($entry['variableData'] ?? null) ? $entry['variableData'] : array();
+                $binding = array(
+                    'source'             => $sourceKey,
+                    'target_field'       => $targetField,
+                    'target_role'        => $this->classifyVariableBindingTarget($targetField),
+                    'data_type'          => isset($variableData['dataType']) && is_scalar($variableData['dataType']) ? (string) $variableData['dataType'] : null,
+                    'resolved_data_type' => isset($variableData['resolvedDataType']) && is_scalar($variableData['resolvedDataType']) ? (string) $variableData['resolvedDataType'] : null,
+                );
+
+                $value = is_array($variableData['value'] ?? null) ? $variableData['value'] : array();
+                $variableId = $this->readGuidId($value['alias']['guid'] ?? null);
+                if ( null !== $variableId ) {
+                    $binding['variable_id'] = $variableId;
+                }
+                $directValue = $this->normalizeVariableAnyValue($value);
+                if ( null !== $directValue ) {
+                    $binding['value'] = $directValue;
+                }
+
+                $bindings[] = array_filter($binding, static fn (mixed $value): bool => null !== $value);
+                $role = (string) $binding['target_role'];
+                $byRole[$role] = ($byRole[$role] ?? 0) + 1;
+            }
+        }
+
+        if ( ! empty($bindings) ) {
+            arsort($byRole);
+            $normalized['bindings'] = $bindings;
+            $normalized['summary'] = array(
+                'binding_count' => count($bindings),
+                'by_role'       => $byRole,
+            );
+        }
+
+        if ( isset($node['variableResolvedType']) && is_scalar($node['variableResolvedType']) ) {
+            $normalized['resolved_type'] = (string) $node['variableResolvedType'];
+        }
+
+        if ( is_array($node['variableSetID'] ?? null) ) {
+            $setId = $this->readGuidId($node['variableSetID']['guid'] ?? null);
+            if ( null !== $setId ) {
+                $normalized['variable_set_id'] = $setId;
+            }
+        }
+
+        if ( is_array($node['variableScopes'] ?? null) ) {
+            $scopes = array_values(array_filter($node['variableScopes'], 'is_scalar'));
+            if ( ! empty($scopes) ) {
+                $normalized['scopes'] = array_map('strval', $scopes);
+            }
+        }
+
+        if ( is_array($node['variableSetModes'] ?? null) ) {
+            $modes = array();
+            foreach ( $node['variableSetModes'] as $mode ) {
+                if ( ! is_array($mode) ) {
+                    continue;
+                }
+                $modeId = $this->readGuidId($mode['id'] ?? null);
+                if ( null === $modeId ) {
+                    continue;
+                }
+                $normalizedMode = array('id' => $modeId);
+                foreach ( array('name', 'sortPosition') as $key ) {
+                    if ( isset($mode[$key]) && is_scalar($mode[$key]) ) {
+                        $normalizedMode[$key] = (string) $mode[$key];
+                    }
+                }
+                $modes[] = $normalizedMode;
+            }
+            if ( ! empty($modes) ) {
+                $normalized['modes'] = $modes;
+            }
+        }
+
+        if ( is_array($node['variableDataValues']['entries'] ?? null) ) {
+            $values = array();
+            foreach ( $node['variableDataValues']['entries'] as $entry ) {
+                if ( ! is_array($entry) ) {
+                    continue;
+                }
+                $modeId = $this->readGuidId($entry['modeID'] ?? null);
+                $variableData = is_array($entry['variableData'] ?? null) ? $entry['variableData'] : array();
+                $value = $this->normalizeVariableAnyValue(is_array($variableData['value'] ?? null) ? $variableData['value'] : array());
+                if ( null === $modeId && null === $value ) {
+                    continue;
+                }
+                $values[] = array_filter(array(
+                    'mode_id'            => $modeId,
+                    'value'              => $value,
+                    'data_type'          => isset($variableData['dataType']) && is_scalar($variableData['dataType']) ? (string) $variableData['dataType'] : null,
+                    'resolved_data_type' => isset($variableData['resolvedDataType']) && is_scalar($variableData['resolvedDataType']) ? (string) $variableData['resolvedDataType'] : null,
+                ), static fn (mixed $value): bool => null !== $value);
+            }
+            if ( ! empty($values) ) {
+                $normalized['values'] = $values;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function classifyVariableBindingTarget(string $targetField): string
+    {
+        return match ($targetField) {
+            'TEXT_DATA', 'FONT_FAMILY', 'FONT_STYLE', 'FONT_VARIATIONS', 'FONT_SIZE', 'LETTER_SPACING', 'LINE_HEIGHT', 'PARAGRAPH_SPACING', 'PARAGRAPH_INDENT' => 'text',
+            'STACK_SPACING', 'STACK_COUNTER_SPACING', 'STACK_PADDING_LEFT', 'STACK_PADDING_TOP', 'STACK_PADDING_RIGHT', 'STACK_PADDING_BOTTOM', 'WIDTH', 'HEIGHT', 'MIN_WIDTH', 'MAX_WIDTH', 'MIN_HEIGHT', 'MAX_HEIGHT', 'X_POSITION', 'Y_POSITION', 'ROTATION' => 'layout',
+            'CORNER_RADIUS', 'RECTANGLE_TOP_LEFT_CORNER_RADIUS', 'RECTANGLE_TOP_RIGHT_CORNER_RADIUS', 'RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS', 'RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS' => 'geometry',
+            'VISIBLE' => 'visibility',
+            'OPACITY', 'ALL_FILLS', 'FRAME_FILL', 'SHAPE_FILL', 'TEXT_FILL', 'STROKE', 'STROKE_FLOAT', 'COLOR_OPACITY' => 'paint',
+            'VARIANT_PROPERTIES', 'OVERRIDDEN_SYMBOL_ID', 'SLOT_CONTENT_ID' => 'component',
+            'HYPERLINK' => 'link',
+            default => 'unknown',
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     */
+    private function normalizeVariableAnyValue(array $value): mixed
+    {
+        foreach ( array('boolValue', 'textValue', 'floatValue') as $key ) {
+            if ( array_key_exists($key, $value) && is_scalar($value[$key]) ) {
+                return $value[$key];
+            }
+        }
+
+        if ( is_array($value['colorValue'] ?? null) ) {
+            return $value['colorValue'];
+        }
+        if ( is_array($value['textDataValue'] ?? null) ) {
+            return $value['textDataValue'];
+        }
+        if ( is_array($value['symbolIdValue']['guid'] ?? null) ) {
+            return $this->readGuidId($value['symbolIdValue']['guid']);
+        }
+
+        return null;
     }
 
     /**
@@ -1360,7 +1533,7 @@ final class ScenegraphNormalizer
         // the definition's visibility and incorrectly emit to HTML.
         $resolved['visible'] = $instance['visible'] ?? true;
 
-        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'styleIdForEffect', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight') as $key ) {
+        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'figma_variable_bindings', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'styleIdForEffect', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight', 'variableConsumptionMap', 'parameterConsumptionMap', 'variableDataValues', 'variableResolvedType', 'variableSetID', 'variableScopes', 'variableSetModes') as $key ) {
             if ( array_key_exists($key, $instance) ) {
                 $resolved[$key] = $instance[$key];
             }

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -16,15 +16,15 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $fields = is_array($inventory['fields'] ?? null) ? $inventory['fields'] : array();
 
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1' === ($inventory['schema'] ?? null), 'kiwi-skipped-inventory-schema');
-    $assert(11 === ($inventory['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-field-count');
-    $assert(11 === ($inventory['summary']['occurrences'] ?? null), 'kiwi-skipped-inventory-occurrences');
+    $assert(10 === ($inventory['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-field-count');
+    $assert(10 === ($inventory['summary']['occurrences'] ?? null), 'kiwi-skipped-inventory-occurrences');
     $assert(1 === ($inventory['summary']['by_role']['geometry_layout'] ?? null), 'kiwi-skipped-inventory-geometry-role');
     $assert(1 === ($inventory['summary']['by_role']['component_overrides'] ?? null), 'kiwi-skipped-inventory-component-role');
     $assert(1 === ($inventory['summary']['by_role']['fills_images'] ?? null), 'kiwi-skipped-inventory-image-role');
     $assert(! isset($inventory['summary']['by_role']['masks_effects']), 'kiwi-skipped-inventory-mask-role');
     $assert(2 === ($inventory['summary']['by_role']['text_style'] ?? null), 'kiwi-skipped-inventory-text-role');
     $assert(1 === ($inventory['summary']['by_role']['vectors'] ?? null), 'kiwi-skipped-inventory-vector-role');
-    $assert(1 === ($inventory['summary']['by_role']['variables_bindings'] ?? null), 'kiwi-skipped-inventory-variables-role');
+    $assert(! isset($inventory['summary']['by_role']['variables_bindings']), 'kiwi-skipped-inventory-variables-role-decoded');
     $assert(1 === ($inventory['summary']['by_role']['export_metadata'] ?? null), 'kiwi-skipped-inventory-export-role');
     $assert(1 === ($inventory['summary']['by_role']['document_metadata'] ?? null), 'kiwi-skipped-inventory-document-role');
 
@@ -61,6 +61,9 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('7:99' === blocks_engine_figma_transformer_kiwi_inventory_format_guid($node['guides'][0]['guid'] ?? null), 'kiwi-selective-guide-guid');
     $assert(6.0 === ($node['listSpacing'] ?? null), 'kiwi-selective-list-spacing');
 
+    $message = $decoder->decodeMessageSelective(blocks_engine_figma_transformer_kiwi_inventory_message_fixture(), $schema)['message'] ?? array();
+    $assert('variables' === ($message['nodeChanges'][0]['variableConsumptionMap'] ?? null), 'kiwi-selective-decodes-variable-consumption-map');
+
     $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
         SyntheticFigKiwiFixtureBuilder::canvas(array(
             SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_schema_fixture()),
@@ -76,7 +79,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
 
     $assert(is_array($cli), 'kiwi-skipped-inventory-cli-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-cli-schema');
-    $assert(11 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
+    $assert(10 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
 
     $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
         SyntheticFigKiwiFixtureBuilder::canvas(array(
@@ -100,7 +103,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-output/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-output-cli-schema');
     $assert(is_array($written), 'kiwi-skipped-inventory-output-file-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($written['schema'] ?? null), 'kiwi-skipped-inventory-output-file-schema');
-    $assert(11 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
+    $assert(10 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
 }
 
 /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -29,6 +29,7 @@ use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\ParityReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\VisualAttributionReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphFrameClassifier;
+use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphPagePlanner;
 
 $failures = array();
@@ -5205,6 +5206,74 @@ $rootLevelBandsResult = blocks_engine_figma_transformer_transform_scenegraph(arr
 ));
 $rootLevelHtml = $fileContent($rootLevelBandsResult, 'index.html');
 $assert(2 === substr_count($rootLevelHtml, '<section'), 'section-refinement-root-level-bands-are-sections');
+
+$variableBindingNormalizer = new ScenegraphNormalizer();
+$variableBindingResult = $variableBindingNormalizer->normalize(array(
+    'name'  => 'Variable Binding Fixture',
+    'nodes' => array(
+        array(
+            'id'        => 'variable-node-gap',
+            'type'      => 'VARIABLE',
+            'name'      => 'Gap / Medium',
+            'variableResolvedType' => 'FLOAT',
+            'variableSetID' => array('guid' => array('sessionID' => 9, 'localID' => 1)),
+            'variableScopes' => array('GAP'),
+            'variableDataValues' => array(
+                'entries' => array(
+                    array(
+                        'modeID' => array('sessionID' => 9, 'localID' => 2),
+                        'variableData' => array(
+                            'dataType' => 'FLOAT',
+                            'resolvedDataType' => 'FLOAT',
+                            'value' => array('floatValue' => 16.0),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'        => 'variable-frame',
+            'type'      => 'FRAME',
+            'name'      => 'Variable Frame',
+            'width'     => 320,
+            'height'    => 200,
+            'stackMode' => 'VERTICAL',
+            'stackSpacing' => 16,
+            'variableConsumptionMap' => array(
+                'entries' => array(
+                    array(
+                        'variableField' => 'STACK_SPACING',
+                        'variableData' => array(
+                            'dataType' => 'ALIAS',
+                            'resolvedDataType' => 'FLOAT',
+                            'value' => array('alias' => array('guid' => array('sessionID' => 9, 'localID' => 3))),
+                        ),
+                    ),
+                ),
+            ),
+            'parameterConsumptionMap' => array(
+                'entries' => array(
+                    array(
+                        'variableField' => 'TEXT_DATA',
+                        'variableData' => array(
+                            'dataType' => 'PROP_REF',
+                            'resolvedDataType' => 'TEXT_DATA',
+                            'value' => array(),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$variableFrameBindings = $variableBindingResult['node_map']['variable-frame']['figma_variable_bindings'] ?? array();
+$assert(2 === ($variableFrameBindings['summary']['binding_count'] ?? null), 'variable-bindings-normalized-count');
+$assert(1 === ($variableFrameBindings['summary']['by_role']['layout'] ?? null), 'variable-bindings-layout-role');
+$assert(1 === ($variableFrameBindings['summary']['by_role']['text'] ?? null), 'variable-bindings-text-role');
+$assert('9:3' === ($variableFrameBindings['bindings'][0]['variable_id'] ?? null), 'variable-bindings-alias-guid-normalized');
+$variableDefinition = $variableBindingResult['node_map']['variable-node-gap']['figma_variable_bindings'] ?? array();
+$assert('FLOAT' === ($variableDefinition['resolved_type'] ?? null), 'variable-definition-resolved-type');
+$assert(16.0 === ($variableDefinition['values'][0]['value'] ?? null), 'variable-definition-mode-value');
 
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 blocks_engine_figma_transformer_run_node_trace_contract($assert);


### PR DESCRIPTION
## Summary
- Decode Kiwi variable binding structs and variable set/value metadata.
- Preserve normalized figma_variable_bindings metadata on nodes without applying variable values to output layout or paint.
- Add contract coverage for binding summaries, alias IDs, variable definitions, and skipped-field inventory changes.

## Testing
- php -l src/FigFile/FigKiwiDecodePolicy.php
- php -l src/Scenegraph/ScenegraphNormalizer.php
- php -l tests/contract/KiwiSkippedFieldInventoryContract.php
- php -l tests/contract/run.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Reviewing minion-authored variable-binding decoding, resolving rebase conflicts, running validation, committing, and preparing this PR description.