### PR TITLE
figma-transformer: decode Kiwi text internals

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -35,11 +35,14 @@ final class FigKiwiDecodePolicy
             // already whitelists `styleID`/`fontName`/`fontSize`/`fillPaints`/etc.
             // Without these two names the per-character override data is dropped by
             // `skipField()` and every .fig text node emits flat, single-style text.
-            'TextData' => array('characters', 'layoutSize', 'characterStyleIDs', 'styleOverrideTable'),
-            'DerivedTextData' => array('layoutSize', 'baselines', 'fontMetaData'),
+            'TextData' => array('characters', 'layoutSize', 'characterStyleIDs', 'styleOverrideTable', 'layoutVersion', 'lines', 'minContentHeight', 'truncationStartIndex', 'truncatedHeight', 'logicalIndexToCharacterOffsetMap', 'derivedLines'),
+            'DerivedTextData' => array('layoutSize', 'baselines', 'fontMetaData', 'truncationStartIndex', 'truncatedHeight', 'logicalIndexToCharacterOffsetMap', 'derivedLines'),
+            'TextLineData' => array('lineType', 'styleId', 'indentationLevel', 'sourceDirectionality', 'directionality', 'directionalityIntent', 'downgradeStyleId', 'consistencyStyleId', 'listStartOffset', 'isFirstLineOfList'),
+            'DerivedTextLineData' => array('directionality'),
             'Baseline' => array('position', 'width', 'lineY', 'lineHeight', 'lineAscent', 'firstCharacter', 'endCharacter'),
             'Glyph' => array('position', 'fontSize', 'firstCharacter', 'endCharacter', 'advance', 'rotation', 'styleID'),
-            'FontMetaData' => array('key', 'fontLineHeight', 'fontWeight'),
+            'FontMetaData' => array('key', 'fontLineHeight', 'fontStyle', 'fontWeight'),
+            'FontVariation' => array('axisTag', 'axisName', 'value'),
             'Number' => array('value', 'units'),
             'Paint' => array('type', 'color', 'opacity', 'visible', 'blendMode', 'stops', 'transform', 'imageTransform', 'cropTransform', 'cropRect', 'image', 'imageThumbnail', 'imageScaleMode', 'originalImageWidth', 'originalImageHeight', 'scale', 'rotation', 'imageShouldColorManage', 'thumbHash', 'animationFrame', 'altText'),
             // Effect struct (#328). The Kiwi blur token is `FOREGROUND_BLUR`
@@ -117,6 +120,18 @@ final class FigKiwiDecodePolicy
             'export_metadata' => array('exportSettings', 'ExportSettings'),
             'document_metadata' => array('phase', 'autoRename', 'editInfo', 'pluginData', 'version', 'userFacingVersion', 'isPublishable', 'locked', 'isSoftDeleted', 'annotations', 'annotationCategories', 'publishID', 'sourceLibraryKey', 'ancestorPathBeforeDeletion', 'internalOnly', 'isPageDivider', 'pluginRelaunchData', 'slideThemeMap', 'ackID', 'originFileKey', 'sessionID'),
         );
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function scenegraphFieldPolicyWithTextGlyphs(): array
+    {
+        $policy = $this->defaultScenegraphFieldPolicy();
+        $policy['TextData'] = array_values(array_unique(array_merge($policy['TextData'] ?? array(), array('glyphs'))));
+        $policy['DerivedTextData'] = array_values(array_unique(array_merge($policy['DerivedTextData'] ?? array(), array('glyphs'))));
+        $policy['Glyph'] = array_values(array_unique(array_merge($policy['Glyph'] ?? array(), array('commandsBlob', 'emojiCodePoints', 'emojiImageSet'))));
+        return $policy;
     }
 
     /**
@@ -323,7 +338,15 @@ final class FigKiwiDecodePolicy
             'fontSize', 'fontName', 'textData', 'lineHeight', 'letterSpacing',
             'paragraphIndent', 'paragraphSpacing', 'styleID', 'textAlignHorizontal',
             'textAlignVertical', 'textCase', 'textDecoration', 'textAutoResize', 'listSpacing',
-            'derivedTextData',
+            'derivedTextData', 'styleIdForText', 'fontVariantCommonLigatures', 'fontVariantContextualLigatures',
+            'fontVariantDiscretionaryLigatures', 'fontVariantHistoricalLigatures',
+            'fontVariantOrdinal', 'fontVariantSlashedZero', 'fontVariantNumericFigure',
+            'fontVariantNumericSpacing', 'fontVariantNumericFraction', 'fontVariantCaps',
+            'fontVariantPosition', 'fontVersion', 'leadingTrim', 'hangingPunctuation',
+            'hangingList', 'fallbackGlyphs', 'maxLines', 'textUserLayoutVersion',
+            'textExplicitLayoutVersion', 'toggledOnOTFeatures', 'toggledOffOTFeatures',
+            'fontVariations', 'textBidiVersion', 'textTruncation', 'textWrapStyle',
+            'hasHadRTLText', 'textTracking',
         );
     }
 

--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -429,6 +429,14 @@ final class FigKiwiDecoder
     /**
      * @return array<string, array<int, string>>
      */
+    public function scenegraphFieldPolicyWithTextGlyphs(): array
+    {
+        return $this->decodePolicy->scenegraphFieldPolicyWithTextGlyphs();
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
     public function scenegraphFieldPolicyGroups(): array
     {
         return $this->decodePolicy->scenegraphFieldPolicyGroups();

--- a/figma-transformer/src/FigFile/FigKiwiParser.php
+++ b/figma-transformer/src/FigFile/FigKiwiParser.php
@@ -175,7 +175,8 @@ final class FigKiwiParser
             } else {
                 $maxMessageDecodeBytes = (int) ($options['max_kiwi_message_decode_bytes'] ?? self::DEFAULT_MAX_KIWI_MESSAGE_DECODE_BYTES);
                 if ( $maxMessageDecodeBytes > 0 && strlen($payload) > $maxMessageDecodeBytes ) {
-                    $messageResult = $this->kiwiDecoder->decodeMessageSelective($payload, $kiwiSchema);
+                    $fieldPolicy = true === ($options['render_text_glyph_paths'] ?? false) ? $this->kiwiDecoder->scenegraphFieldPolicyWithTextGlyphs() : array();
+                    $messageResult = $this->kiwiDecoder->decodeMessageSelective($payload, $kiwiSchema, 'Message', $fieldPolicy);
                     $diagnostics = array_merge($diagnostics, $messageResult['diagnostics']);
                     if ( null !== $messageResult['message'] ) {
                         $diagnostics[] = $this->diagnostic(

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -4644,6 +4644,30 @@ final class StaticHtmlEmitter
             $styles[] = 'font-weight:' . $this->number((float) $style['font_weight']);
         }
 
+        if ( is_array($style['font_variation_settings'] ?? null) ) {
+            $settings = array();
+            foreach ( $style['font_variation_settings'] as $axis => $value ) {
+                if ( is_string($axis) && 1 === preg_match('/^[A-Za-z0-9 ]{4}$/', $axis) && is_numeric($value) ) {
+                    $settings[] = '"' . $axis . '" ' . $this->number((float) $value);
+                }
+            }
+            if ( ! empty($settings) ) {
+                $styles[] = 'font-variation-settings:' . implode(',', $settings);
+            }
+        }
+
+        if ( is_array($style['font_feature_settings'] ?? null) ) {
+            $settings = array();
+            foreach ( $style['font_feature_settings'] as $feature => $enabled ) {
+                if ( is_string($feature) && 1 === preg_match('/^[A-Za-z0-9 ]{4}$/', $feature) && is_numeric($enabled) ) {
+                    $settings[] = '"' . $feature . '" ' . ((int) $enabled);
+                }
+            }
+            if ( ! empty($settings) ) {
+                $styles[] = 'font-feature-settings:' . implode(',', $settings);
+            }
+        }
+
         if ( isset($style['line_height_px']) && is_numeric($style['line_height_px']) && 0.0 < (float) $style['line_height_px'] ) {
             $styles[] = 'line-height:' . $this->number((float) $style['line_height_px']) . 'px';
         } elseif ( isset($style['line_height_raw']) && is_numeric($style['line_height_raw']) && 0.0 < (float) $style['line_height_raw'] ) {
@@ -4715,6 +4739,13 @@ final class StaticHtmlEmitter
             if ( 'small-caps' === $variant ) {
                 $styles[] = 'font-variant:' . $variant;
             }
+        }
+
+        if ( isset($style['max_lines']) && is_numeric($style['max_lines']) && 0 < (int) $style['max_lines'] ) {
+            $styles[] = '-webkit-line-clamp:' . ((int) $style['max_lines']);
+            $styles[] = 'display:-webkit-box';
+            $styles[] = '-webkit-box-orient:vertical';
+            $styles[] = 'overflow:hidden';
         }
 
         return $styles;

--- a/figma-transformer/src/Scenegraph/TextNormalizer.php
+++ b/figma-transformer/src/Scenegraph/TextNormalizer.php
@@ -215,6 +215,30 @@ final class TextNormalizer
             }
         }
 
+        foreach ( array('truncationStartIndex' => 'truncation_start_index', 'truncatedHeight' => 'truncated_height', 'minContentHeight' => 'min_content_height', 'layoutVersion' => 'layout_version') as $sourceKey => $targetKey ) {
+            if ( isset($source[$sourceKey]) && is_numeric($source[$sourceKey]) ) {
+                $layout[$targetKey] = (float) $source[$sourceKey];
+            }
+        }
+
+        if ( is_array($source['logicalIndexToCharacterOffsetMap'] ?? null) ) {
+            $offsets = array();
+            foreach ( $source['logicalIndexToCharacterOffsetMap'] as $offset ) {
+                if ( is_numeric($offset) ) {
+                    $offsets[] = (float) $offset;
+                }
+            }
+            if ( ! empty($offsets) ) {
+                $layout['logical_character_offsets'] = $offsets;
+            }
+        }
+
+        foreach ( array('lines' => 'line_count', 'derivedLines' => 'derived_line_count') as $sourceKey => $targetKey ) {
+            if ( is_array($source[$sourceKey] ?? null) ) {
+                $layout[$targetKey] = count($source[$sourceKey]);
+            }
+        }
+
         if ( is_array($source['glyphs'] ?? null) ) {
             $layout['glyph_count'] = count($source['glyphs']);
             if ( ! $decodeGlyphCommandBlobs ) {
@@ -362,6 +386,10 @@ final class TextNormalizer
             }
         }
 
+        if ( isset($source['textTracking']) && is_numeric($source['textTracking']) && ! isset($style['letter_spacing']) ) {
+            $style['letter_spacing'] = (float) $source['textTracking'];
+        }
+
         foreach ( array('fontSize' => 'font_size', 'lineHeightPx' => 'line_height_px', 'lineHeightPercent' => 'line_height_percent', 'letterSpacing' => 'letter_spacing') as $sourceKey => $targetKey ) {
             if ( isset($source[$sourceKey]) && is_numeric($source[$sourceKey]) ) {
                 $style[$targetKey] = (float) $source[$sourceKey];
@@ -388,6 +416,37 @@ final class TextNormalizer
             } elseif ( str_contains($letterSpacingUnits, 'PERCENT') ) {
                 $style['letter_spacing_em'] = (float) $source['letterSpacing']['value'] / 100;
             }
+        }
+
+        if ( is_array($source['fontVariations'] ?? null) ) {
+            $fontVariations = array();
+            foreach ( $source['fontVariations'] as $variation ) {
+                if ( ! is_array($variation) || ! isset($variation['value']) || ! is_numeric($variation['value']) ) {
+                    continue;
+                }
+                $axis = $this->fontVariationAxis($variation);
+                if ( null !== $axis ) {
+                    $fontVariations[$axis] = (float) $variation['value'];
+                }
+            }
+            if ( ! empty($fontVariations) ) {
+                $style['font_variation_settings'] = $fontVariations;
+            }
+        }
+
+        $fontFeatures = $this->normalizeFontFeatures($source);
+        if ( ! empty($fontFeatures) ) {
+            $style['font_feature_settings'] = $fontFeatures;
+        }
+
+        foreach ( array('leadingTrim' => 'leading_trim', 'textTruncation' => 'text_truncation', 'textWrapStyle' => 'text_wrap_style') as $sourceKey => $targetKey ) {
+            if ( isset($source[$sourceKey]) && is_scalar($source[$sourceKey]) && '' !== (string) $source[$sourceKey] ) {
+                $style[$targetKey] = strtolower((string) $source[$sourceKey]);
+            }
+        }
+
+        if ( isset($source['maxLines']) && is_numeric($source['maxLines']) ) {
+            $style['max_lines'] = (int) $source['maxLines'];
         }
 
         foreach ( array('color', 'textColor') as $sourceKey ) {
@@ -444,6 +503,66 @@ final class TextNormalizer
         }
 
         return $style;
+    }
+
+    /**
+     * @param array<string, mixed> $variation
+     */
+    private function fontVariationAxis(array $variation): ?string
+    {
+        if ( isset($variation['axisName']) && is_scalar($variation['axisName']) && 4 === strlen((string) $variation['axisName']) ) {
+            return (string) $variation['axisName'];
+        }
+        if ( isset($variation['axisTag']) && is_numeric($variation['axisTag']) ) {
+            $tag = (int) $variation['axisTag'];
+            $bytes = '';
+            for ( $shift = 24; $shift >= 0; $shift -= 8 ) {
+                $byte = ($tag >> $shift) & 0xff;
+                if ( $byte < 32 || $byte > 126 ) {
+                    return null;
+                }
+                $bytes .= chr($byte);
+            }
+            return $bytes;
+        }
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     * @return array<string, int>
+     */
+    private function normalizeFontFeatures(array $source): array
+    {
+        $features = array();
+        foreach ( array(
+            'fontVariantCommonLigatures' => 'liga',
+            'fontVariantContextualLigatures' => 'calt',
+            'fontVariantDiscretionaryLigatures' => 'dlig',
+            'fontVariantHistoricalLigatures' => 'hlig',
+            'fontVariantOrdinal' => 'ordn',
+            'fontVariantSlashedZero' => 'zero',
+        ) as $sourceKey => $feature ) {
+            if ( is_bool($source[$sourceKey] ?? null) ) {
+                $features[$feature] = true === $source[$sourceKey] ? 1 : 0;
+            }
+        }
+
+        foreach ( array('toggledOnOTFeatures' => 1, 'toggledOffOTFeatures' => 0) as $sourceKey => $enabled ) {
+            if ( ! is_array($source[$sourceKey] ?? null) ) {
+                continue;
+            }
+            foreach ( $source[$sourceKey] as $feature ) {
+                if ( is_scalar($feature) ) {
+                    $tag = strtolower((string) $feature);
+                    if ( 4 === strlen($tag) ) {
+                        $features[$tag] = $enabled;
+                    }
+                }
+            }
+        }
+
+        return $features;
     }
 
     private function fontWeightFromStyle(string $style): ?int

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -222,6 +222,17 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert(! array_key_exists('glyphs', $kiwiDerivedText), 'kiwi-selective-skips-derived-text-glyphs');
     $assert('Inter' === ($kiwiDerivedText['fontMetaData']['key']['family'] ?? null), 'kiwi-selective-decodes-derived-text-font-family');
     $assert(700 === ($kiwiDerivedText['fontMetaData']['fontWeight'] ?? null), 'kiwi-selective-decodes-derived-text-font-weight');
+    $assert(3 === ($kiwiDerivedText['truncationStartIndex'] ?? null), 'kiwi-selective-decodes-derived-text-truncation-start');
+    $assert(24.0 === ($kiwiDerivedText['truncatedHeight'] ?? null), 'kiwi-selective-decodes-derived-text-truncated-height');
+    $assert(array(0.0, 12.5) === ($kiwiDerivedText['logicalIndexToCharacterOffsetMap'] ?? null), 'kiwi-selective-decodes-derived-text-logical-offset-map');
+    $kiwiDerivedTextWithGlyphsMessage = $kiwiDecoder->decodeMessageSelective(
+        blocks_engine_figma_transformer_kiwi_derived_text_message_fixture(),
+        $kiwiDerivedTextSchema['schema'] ?? array(),
+        'Message',
+        $kiwiDecoder->scenegraphFieldPolicyWithTextGlyphs()
+    );
+    $kiwiDerivedTextWithGlyphs = $kiwiDerivedTextWithGlyphsMessage['message']['nodeChanges'][0]['derivedTextData'] ?? array();
+    $assert(7 === ($kiwiDerivedTextWithGlyphs['glyphs'][0]['commandsBlob'] ?? null), 'kiwi-selective-opt-in-decodes-derived-text-glyph-blob-ref');
 
     $kiwiStateGroupSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_state_group_schema_fixture());
     $kiwiStateGroupMessage = $kiwiDecoder->decodeMessageSelective(
@@ -769,14 +780,17 @@ function blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture(): str
         . blocks_engine_figma_transformer_kiwi_schema_field('key', 2, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('fontLineHeight', -5, false, 2)
         . blocks_engine_figma_transformer_kiwi_schema_field('fontWeight', -3, false, 3)
-        // def6: STRUCT DerivedTextData { layoutSize, baselines[], glyphs[], fontMetaData }
+        // def6: STRUCT DerivedTextData { layoutSize, baselines[], glyphs[], fontMetaData, truncationStartIndex, truncatedHeight, logicalIndexToCharacterOffsetMap[] }
         . blocks_engine_figma_transformer_kiwi_string('DerivedTextData')
         . chr(1)
-        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_wire_varint(7)
         . blocks_engine_figma_transformer_kiwi_schema_field('layoutSize', 1, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('baselines', 3, true, 2)
         . blocks_engine_figma_transformer_kiwi_schema_field('glyphs', 4, true, 3)
         . blocks_engine_figma_transformer_kiwi_schema_field('fontMetaData', 5, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('truncationStartIndex', -3, false, 5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('truncatedHeight', -5, false, 6)
+        . blocks_engine_figma_transformer_kiwi_schema_field('logicalIndexToCharacterOffsetMap', -5, true, 7)
         // def7: MESSAGE NodeChange { type, name, derivedTextData }
         . blocks_engine_figma_transformer_kiwi_string('NodeChange')
         . chr(2)
@@ -833,6 +847,12 @@ function blocks_engine_figma_transformer_kiwi_derived_text_message_fixture(): st
         . blocks_engine_figma_transformer_kiwi_string('Inter-Bold')
         . blocks_engine_figma_transformer_kiwi_varfloat(24.0)
         . blocks_engine_figma_transformer_wire_varint_signed(700)
+        // DerivedTextData.truncationStartIndex, truncatedHeight, logicalIndexToCharacterOffsetMap[].
+        . blocks_engine_figma_transformer_wire_varint_signed(3)
+        . blocks_engine_figma_transformer_kiwi_varfloat(24.0)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_varfloat(0.0)
+        . blocks_engine_figma_transformer_kiwi_varfloat(12.5)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
 }

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -545,6 +545,9 @@ function blocks_engine_figma_transformer_run_text_style_contract(callable $asser
                             'fontFamily'         => 'Example Sans',
                             'fontSize'           => 20,
                             'fontWeight'         => 600,
+                            'fontVariations'     => array(array('axisName' => 'wdth', 'value' => 85)),
+                            'fontVariantCommonLigatures' => false,
+                            'toggledOnOTFeatures' => array('kern'),
                             'lineHeightPercent'  => 125,
                             'letterSpacing'      => 0.5,
                             'textAlignHorizontal'=> 'CENTER',
@@ -627,7 +630,7 @@ function blocks_engine_figma_transformer_run_text_style_contract(callable $asser
     $assert(str_contains($metadataHtml, '<span style="font-weight:400">Hello </span><span style="font-weight:700;text-decoration:underline">World</span>'), 'styled-text-segments-emit');
     $assert(str_contains($metadataCss, 'p,h1,h2,h3,h4,h5,h6{margin:0}'), 'text-elements-reset-default-margins');
     $assert(str_contains($metadataCss, '.figma-node-4-1-metadata-frame{position:relative;background:rgba(51,102,153,0.5);opacity:0.75;border-radius:12px;border:2px solid #000000;box-shadow:0px 0px 0px 0px rgba(0,0,0,0.25)}'), 'normalized-frame-paint-box-style');
-    $assert(str_contains($metadataCss, '.figma-node-4-2-mixed-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:20px;font-weight:600;line-height:125%;letter-spacing:0.5px;color:rgba(255,128,0,0.8);text-align:center;vertical-align:top;text-decoration:underline}'), 'normalized-text-style');
+    $assert(str_contains($metadataCss, '.figma-node-4-2-mixed-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:20px;font-weight:600;font-variation-settings:"wdth" 85;font-feature-settings:"liga" 0,"kern" 1;line-height:125%;letter-spacing:0.5px;color:rgba(255,128,0,0.8);text-align:center;vertical-align:top;text-decoration:underline}'), 'normalized-text-style');
     $assert(str_contains($metadataCss, '.figma-node-4-3-uneven-radius{position:absolute;border-top-left-radius:4px;border-top-right-radius:8px;border-bottom-right-radius:12px;border-bottom-left-radius:16px}'), 'individual-radius-style');
     $assert(str_contains($metadataCss, '.figma-node-4-4-raw-line-height-text{position:absolute;font-family:"Example Sans", sans-serif;font-size:18px;font-weight:600;line-height:1.15}'), 'font-style-weight-and-raw-line-height');
     $assert(str_contains($metadataCss, '.figma-node-4-5-wp-cloud-text-metrics{position:absolute;font-family:"DM Sans", sans-serif;font-size:80px;font-weight:700;line-height:1.05;letter-spacing:-0.02em}'), 'wp-cloud-text-metrics-style');


### PR DESCRIPTION
## Summary
- Decode additional Kiwi text layout/style internals while keeping glyph command blobs opt-in.
- Preserve derived text truncation, logical offsets, line counts, font variations, and OpenType feature metadata.
- Emit font variation/feature CSS and max-line clamping only when normalized text metadata provides it.
- Extend parser and text layout contracts for the new text internals.

## Testing
- php -l src/FigFile/FigKiwiDecodePolicy.php
- php -l src/FigFile/FigKiwiDecoder.php
- php -l src/FigFile/FigKiwiParser.php
- php -l src/Html/StaticHtmlEmitter.php
- php -l src/Scenegraph/TextNormalizer.php
- php -l tests/contract/KiwiParserContract.php
- php -l tests/contract/TextLayoutContract.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Reviewing minion-authored text decoding, resolving rebase conflicts, running validation, committing, and preparing this PR description.