### PR TITLE
figma-transformer: bound text offset map normalization

### DIFF
--- a/figma-transformer/src/Scenegraph/TextNormalizer.php
+++ b/figma-transformer/src/Scenegraph/TextNormalizer.php
@@ -11,6 +11,7 @@ final class TextNormalizer
 {
     private const MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES = 262144;
     private const MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES_PER_NODE = 262144;
+    private const MAX_LOGICAL_CHARACTER_OFFSET_SAMPLES = 256;
 
     public function __construct(
         private readonly VectorGeometryNormalizer $vectorGeometryNormalizer = new VectorGeometryNormalizer()
@@ -223,13 +224,22 @@ final class TextNormalizer
 
         if ( is_array($source['logicalIndexToCharacterOffsetMap'] ?? null) ) {
             $offsets = array();
+            $offsetCount = 0;
             foreach ( $source['logicalIndexToCharacterOffsetMap'] as $offset ) {
                 if ( is_numeric($offset) ) {
+                    $offsetCount++;
+                    if ( $offsetCount > self::MAX_LOGICAL_CHARACTER_OFFSET_SAMPLES ) {
+                        continue;
+                    }
                     $offsets[] = (float) $offset;
                 }
             }
             if ( ! empty($offsets) ) {
                 $layout['logical_character_offsets'] = $offsets;
+                $layout['logical_character_offset_count'] = $offsetCount;
+                if ( $offsetCount > self::MAX_LOGICAL_CHARACTER_OFFSET_SAMPLES ) {
+                    $layout['logical_character_offsets_truncated'] = true;
+                }
             }
         }
 

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -59,6 +59,7 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
                             'fontWeight'     => 400,
                         ),
                     ),
+                    'logicalIndexToCharacterOffsetMap' => range(0, 299),
                 ),
             ),
         ),
@@ -76,6 +77,9 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     $assert(1 === ($derivedTextVisualNode['text']['baseline_count'] ?? null), 'visual-node-derived-text-baseline-count');
     $assert(3 === ($derivedTextVisualNode['text']['glyph_count'] ?? null), 'visual-node-derived-text-glyph-count');
     $assert(146.5 === ($derivedTextVisualNode['text']['derived_layout']['size']['width'] ?? null), 'visual-node-derived-text-layout-width');
+    $assert(300 === ($derivedTextVisualNode['text']['derived_layout']['logical_character_offset_count'] ?? null), 'visual-node-derived-text-logical-offset-count');
+    $assert(256 === count($derivedTextVisualNode['text']['derived_layout']['logical_character_offsets'] ?? array()), 'visual-node-derived-text-logical-offset-sample-count');
+    $assert(true === ($derivedTextVisualNode['text']['derived_layout']['logical_character_offsets_truncated'] ?? null), 'visual-node-derived-text-logical-offset-truncated');
     $assert(! isset($derivedTextVisualNode['text']['derived_layout']['glyph_paths']), 'visual-node-derived-text-default-omits-glyph-paths');
     $assert('dom_text' === ($derivedTextVisualNode['text']['glyph_rendering'] ?? null), 'visual-node-derived-text-default-dom-rendering');
     $derivedTextLayoutCss = $fileContent($derivedTextLayoutResult, 'style.css');


### PR DESCRIPTION
## Summary
- Bound normalized logical character offset maps to a 256-value sample.
- Preserve total offset count and truncation metadata for diagnostics.
- Add contract coverage proving large offset maps are summarized instead of duplicated.

## Testing
- php -l src/Scenegraph/TextNormalizer.php
- php -l tests/contract/TextLayoutContract.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the default-memory parser parity regression, implementing the bounded normalization fix, running validation, and preparing this PR description.