### PR TITLE
figma-transformer: restore styled FSE colors and text spacing

### DIFF
--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -32,10 +32,11 @@ final class PaintNormalizer
         $styleFillId = $this->readStyleGuidId($node['styleIdForFill'] ?? null);
         if ( null !== $styleFillId && ! empty($paintStyles[$styleFillId]['fills']) ) {
             $styleFills = $paintStyles[$styleFillId]['fills'];
+            $localFillPrecedence = $this->hasLocalVectorPaintSource($node, 'fills');
             if ( ! empty($collections['fills']) && $collections['fills'] !== $styleFills ) {
-                $this->appendLocalStylePaintConflictDiagnostic($diagnostics, $nodeId, 'fills', $styleFillId, $collections['fills'], $styleFills, $this->hasGeometryPaintSource($node));
+                $this->appendLocalStylePaintConflictDiagnostic($diagnostics, $nodeId, 'fills', $styleFillId, $collections['fills'], $styleFills, $localFillPrecedence);
             }
-            if ( empty($collections['fills']) || ! $this->hasGeometryPaintSource($node) ) {
+            if ( empty($collections['fills']) || ! $localFillPrecedence ) {
                 $collections['fills'] = $styleFills;
             }
         }
@@ -43,10 +44,11 @@ final class PaintNormalizer
         $styleStrokeId = $this->readStyleGuidId($node['styleIdForStrokeFill'] ?? $node['styleIdForStroke'] ?? null);
         if ( null !== $styleStrokeId && ! empty($paintStyles[$styleStrokeId]['fills']) ) {
             $styleStrokes = $paintStyles[$styleStrokeId]['fills'];
+            $localStrokePrecedence = $this->hasLocalVectorPaintSource($node, 'strokes');
             if ( ! empty($collections['strokes']) && $collections['strokes'] !== $styleStrokes ) {
-                $this->appendLocalStylePaintConflictDiagnostic($diagnostics, $nodeId, 'strokes', $styleStrokeId, $collections['strokes'], $styleStrokes, $this->hasGeometryPaintSource($node));
+                $this->appendLocalStylePaintConflictDiagnostic($diagnostics, $nodeId, 'strokes', $styleStrokeId, $collections['strokes'], $styleStrokes, $localStrokePrecedence);
             }
-            if ( empty($collections['strokes']) || ! $this->hasGeometryPaintSource($node) ) {
+            if ( empty($collections['strokes']) || ! $localStrokePrecedence ) {
                 $collections['strokes'] = $styleStrokes;
             }
         }
@@ -144,9 +146,18 @@ final class PaintNormalizer
     /**
      * @param array<string, mixed> $node
      */
-    private function hasGeometryPaintSource(array $node): bool
+    private function hasLocalVectorPaintSource(array $node, string $collection): bool
     {
-        foreach ( array('fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths') as $key ) {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION', 'CANVAS', 'DOCUMENT'), true) ) {
+            return false;
+        }
+
+        $keys = 'strokes' === $collection
+            ? array('strokeGeometry')
+            : array('fillGeometry');
+
+        foreach ( array_merge($keys, array('vectorPaths', 'paths')) as $key ) {
             if ( ! empty($node[$key]) ) {
                 return true;
             }

--- a/figma-transformer/src/Scenegraph/TextNormalizer.php
+++ b/figma-transformer/src/Scenegraph/TextNormalizer.php
@@ -400,10 +400,14 @@ final class TextNormalizer
             $style['letter_spacing'] = (float) $source['textTracking'];
         }
 
-        foreach ( array('fontSize' => 'font_size', 'lineHeightPx' => 'line_height_px', 'lineHeightPercent' => 'line_height_percent', 'letterSpacing' => 'letter_spacing') as $sourceKey => $targetKey ) {
+        foreach ( array('fontSize' => 'font_size', 'lineHeightPx' => 'line_height_px', 'lineHeightPercent' => 'line_height_percent') as $sourceKey => $targetKey ) {
             if ( isset($source[$sourceKey]) && is_numeric($source[$sourceKey]) ) {
                 $style[$targetKey] = (float) $source[$sourceKey];
             }
+        }
+
+        if ( isset($source['letterSpacing']) && is_numeric($source['letterSpacing']) ) {
+            $style['letter_spacing'] = (float) $source['letterSpacing'];
         }
 
         if ( isset($source['lineHeight']) && is_array($source['lineHeight']) && isset($source['lineHeight']['value']) && is_numeric($source['lineHeight']['value']) ) {
@@ -421,10 +425,13 @@ final class TextNormalizer
             $letterSpacingUnits = strtoupper((string) ($source['letterSpacing']['units'] ?? 'PIXELS'));
             if ( 'PIXELS' === $letterSpacingUnits ) {
                 $style['letter_spacing'] = (float) $source['letterSpacing']['value'];
+                unset($style['letter_spacing_em']);
             } elseif ( 'RAW' === $letterSpacingUnits ) {
                 $style['letter_spacing_em'] = (float) $source['letterSpacing']['value'];
+                unset($style['letter_spacing']);
             } elseif ( str_contains($letterSpacingUnits, 'PERCENT') ) {
                 $style['letter_spacing_em'] = (float) $source['letterSpacing']['value'] / 100;
+                unset($style['letter_spacing']);
             }
         }
 

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -196,6 +196,36 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
     $assert(str_contains($localPaintWithStyleCss, '.figma-node-vector-local-paint-with-style-local-paint-with-style{width:28px;height:3px;background:#d9d9d9'), 'local-fill-paint-wins-over-style-fill');
     $assert(! str_contains($localPaintWithStyleCss, '.figma-node-vector-local-paint-with-style-local-paint-with-style{width:28px;height:3px;background:#ffffff'), 'style-fill-does-not-overwrite-local-fill-paint');
     $assert('local' === ($localPaintWithStyleDiagnostics[0]['context']['precedence'] ?? null), 'local-style-fill-conflict-diagnostic-precedence');
+
+    $containerPaintWithStyleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Container Paint With Style Fixture',
+        'nodes' => array(
+            array(
+                'id'         => 'paint-style:yellow',
+                'type'       => 'RECTANGLE',
+                'name'       => 'Yellow paint style',
+                'styleType'  => 'FILL',
+                'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0.811764717, 'b' => 0, 'a' => 1))),
+            ),
+            array(
+                'id'             => 'frame:stale-local-with-style',
+                'type'           => 'FRAME',
+                'name'           => 'Stale Local With Style',
+                'width'          => 28,
+                'height'         => 3,
+                'styleIdForFill' => 'paint-style:yellow',
+                'fillPaints'     => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                'fillGeometry'   => array(array('path' => 'M 0 0 L 28 0 L 28 3 L 0 3 Z', 'windingRule' => 'NONZERO')),
+            ),
+        ),
+    ));
+    $containerPaintWithStyleCss = $fileContent($containerPaintWithStyleResult, 'style.css');
+    $containerPaintWithStyleDiagnostics = array_values(array_filter(
+        $containerPaintWithStyleResult['diagnostics'] ?? array(),
+        static fn (array $diagnostic): bool => 'figma_local_style_paint_conflict' === ($diagnostic['code'] ?? null)
+    ));
+    $assert(str_contains($containerPaintWithStyleCss, '.figma-node-frame-stale-local-with-style-stale-local-with-style{width:28px;height:3px;background:#ffcf00'), 'style-fill-wins-over-container-stale-local-fill');
+    $assert('style' === ($containerPaintWithStyleDiagnostics[0]['context']['precedence'] ?? null), 'container-style-fill-conflict-diagnostic-precedence');
      
     $externalizedEquivalentVectorPath = 'M0,0' . str_repeat('L10,10', 12000) . 'Z';
     $externalizedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary
- Keep local paint precedence for vector/shape geometry, but let styled container fills use the style paint even when decoded geometry metadata is present.
- Preserve unit-aware letter spacing from Kiwi text payloads so RAW/PERCENT values emit as em instead of being overridden by textTracking px fallback.
- Add contract coverage for a styled frame with stale local paint and existing vector local-paint precedence.

## Testing
- php -l src/Scenegraph/PaintNormalizer.php
- php -l src/Scenegraph/TextNormalizer.php
- php -l tests/contract/VectorRenderingContract.php
- php -l tests/contract/TextLayoutContract.php
- composer test:contract
- Regenerated FSE Pilot site at /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-paint-text-fix-20260701b/site

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the FSE visual regression, implementing transformer fixes, running contracts, regenerating verification output, and preparing this PR description.