### PR TITLE
figma-transformer: preserve Kiwi document metadata

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -82,6 +82,10 @@ final class FigKiwiDecodePolicy
             // token string automatically, so only the struct/entry field names
             // that reach it need whitelisting. Over-listing plausible inner
             // field names is safe: unknown fields are skipped, not mis-read.
+            'EditInfo' => array('userID', 'userId', 'userName', 'timestamp', 'updatedAt'),
+            'PluginData' => array('pluginID', 'pluginId', 'data', 'name', 'key', 'value'),
+            'Annotation' => array('id', 'label', 'description', 'categoryID', 'categoryId'),
+            'AnnotationCategory' => array('id', 'label', 'name', 'color'),
             'SectionStatusInfo' => array('status', 'currentStatus', 'statusInfo', 'type', 'name', 'description'),
             'HandoffStatusMap' => array('entries', 'values', 'handoffStatuses'),
             'HandoffStatusMapEntry' => array('key', 'guid', 'nodeId', 'value', 'status', 'statusInfo', 'currentStatus'),
@@ -118,7 +122,7 @@ final class FigKiwiDecodePolicy
             'prototype_links' => $this->nodePrototypeLinkFields(),
             'variables_bindings' => array('variableConsumptionMap', 'parameterConsumptionMap', 'variableDataValues', 'variableResolvedType', 'variableSetID', 'variableScopes', 'variableSetModes', 'VariableDataMap', 'VariableDataValues', 'VariableResolvedDataType', 'VariableSetID', 'VariableScope', 'VariableSetMode'),
             'export_metadata' => array('exportSettings', 'ExportSettings'),
-            'document_metadata' => array('phase', 'autoRename', 'editInfo', 'pluginData', 'version', 'userFacingVersion', 'isPublishable', 'locked', 'isSoftDeleted', 'annotations', 'annotationCategories', 'publishID', 'sourceLibraryKey', 'ancestorPathBeforeDeletion', 'internalOnly', 'isPageDivider', 'pluginRelaunchData', 'slideThemeMap', 'ackID', 'originFileKey', 'sessionID'),
+            'document_metadata' => $this->documentMetadataFields(),
         );
     }
 
@@ -156,6 +160,9 @@ final class FigKiwiDecodePolicy
         if ( str_contains($name, 'stategroup') ) {
             return 'component_overrides';
         }
+        if ( str_contains($name, 'sectionstatus') || str_contains($name, 'handoffstatus') || str_contains($name, 'devstatus') || str_contains($name, 'currentstatus') || str_contains($name, 'statusinfo') ) {
+            return 'dev_status';
+        }
         if ( str_contains($name, 'arcdata') || str_contains($name, 'guide') || str_contains($name, 'bound') || str_contains($name, 'layout') || str_contains($name, 'constraint') || str_contains($name, 'padding') || str_contains($name, 'size') || str_contains($name, 'transform') || str_contains($name, 'corner') || str_contains($name, 'stack') ) {
             return 'geometry_layout';
         }
@@ -171,7 +178,7 @@ final class FigKiwiDecodePolicy
         if ( str_contains($name, 'export') ) {
             return 'export_metadata';
         }
-        if ( str_contains($name, 'phase') || str_contains($name, 'autorename') || str_contains($name, 'editinfo') || str_contains($name, 'plugindata') || str_contains($name, 'version') || str_contains($name, 'publish') || str_contains($name, 'locked') || str_contains($name, 'softdeleted') || str_contains($name, 'annotation') || str_contains($name, 'librarykey') || str_contains($name, 'internalonly') || str_contains($name, 'pagedivider') || str_contains($name, 'relaunch') || str_contains($name, 'slidetheme') || str_contains($name, 'ackid') || str_contains($name, 'originfilekey') || str_contains($name, 'sessionid') ) {
+        if ( str_contains($name, 'metadata') || str_contains($name, 'phase') || str_contains($name, 'autorename') || str_contains($name, 'editinfo') || str_contains($name, 'plugindata') || str_contains($name, 'version') || str_contains($name, 'publish') || str_contains($name, 'locked') || str_contains($name, 'softdeleted') || str_contains($name, 'annotation') || str_contains($name, 'librarykey') || str_contains($name, 'internalonly') || str_contains($name, 'pagedivider') || str_contains($name, 'relaunch') || str_contains($name, 'slidetheme') || str_contains($name, 'ackid') || str_contains($name, 'originfilekey') || str_contains($name, 'filekey') || str_contains($name, 'sessionid') || str_contains($name, 'ancestorpath') ) {
             return 'document_metadata';
         }
         if ( str_contains($name, 'component') || str_contains($name, 'symbol') || str_contains($name, 'override') || str_contains($name, 'prop') || str_contains($name, 'variant') ) {
@@ -239,7 +246,7 @@ final class FigKiwiDecodePolicy
     private function scenegraphRootFields(): array
     {
         // `handoffStatus`/`sectionStatus` may also surface at the file root as a handoff map.
-        return array('type', 'nodeChanges', 'blobs', 'blobBaseIndex', 'fileVersion', 'sectionStatus', 'handoffStatus');
+        return array_values(array_unique(array_merge(array('type', 'nodeChanges', 'blobs', 'blobBaseIndex', 'fileVersion', 'sectionStatus', 'handoffStatus'), $this->documentMetadataFields())));
     }
 
     /**
@@ -258,7 +265,22 @@ final class FigKiwiDecodePolicy
             $this->nodeLayoutFields(),
             $this->nodeEffectFields(),
             $this->nodeVariableBindingFields(),
-            $this->nodePrototypeLinkFields()
+            $this->nodePrototypeLinkFields(),
+            $this->documentMetadataFields()
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function documentMetadataFields(): array
+    {
+        return array(
+            'phase', 'autoRename', 'editInfo', 'pluginData', 'version', 'userFacingVersion',
+            'fileVersion', 'isPublishable', 'locked', 'isSoftDeleted', 'annotations',
+            'annotationCategories', 'categories', 'publishID', 'publishId', 'sourceLibraryKey',
+            'ancestorPathBeforeDeletion', 'internalOnly', 'isPageDivider', 'pluginRelaunchData',
+            'slideThemeMap', 'ackID', 'ackId', 'originFileKey', 'fileKey', 'sessionID', 'sessionId',
         );
     }
 

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -86,6 +86,7 @@ final class ScenegraphNormalizer
         $textInventory   = $this->buildTextInventory($nodeMap);
         $assetReferences = $this->buildAssetReferences($nodeMap);
         $sourceName      = $this->readSourceName($source, $renderNodes);
+        $sourceMetadata  = $this->normalizeDocumentMetadata($source);
         $diagnostics     = $this->vectorGeometryNormalizer->compactUnsupportedVectorNetworkBlobDiagnostics($this->compactGlyphCommandBlobDiagnostics($diagnostics));
 
         return array(
@@ -114,6 +115,7 @@ final class ScenegraphNormalizer
                 'text_node_count'       => count($textInventory),
                 'asset_reference_count' => count($assetReferences),
                 'asset_references'      => $assetReferences,
+                'figma_metadata'        => $sourceMetadata,
                 'component_definition_count' => $componentDefinitionCount,
                 'instance_node_count'   => $instanceReport['instance_node_count'],
                 'resolved_instance_count' => $instanceReport['resolved_instance_count'],
@@ -418,6 +420,11 @@ final class ScenegraphNormalizer
             $node['figma_variable_bindings'] = $variableBindings;
         }
 
+        $metadata = $this->normalizeDocumentMetadata($node);
+        if ( ! empty($metadata) ) {
+            $node['figma_metadata'] = $metadata;
+        }
+
         if ( 'TEXT' === $type ) {
             $text = $this->textNormalizer->normalizeText($node, $blobs, $id, $diagnostics, $paintStyles, $textStyles, $options);
             if ( ! empty($text) ) {
@@ -619,6 +626,100 @@ final class ScenegraphNormalizer
             if ( ! empty($values) ) {
                 $normalized['values'] = $values;
             }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function normalizeDocumentMetadata(array $node): array
+    {
+        $metadata = array();
+
+        foreach ( array('phase', 'autoRename', 'version', 'userFacingVersion', 'fileVersion', 'publishID', 'publishId', 'sourceLibraryKey', 'ancestorPathBeforeDeletion', 'ackID', 'ackId') as $key ) {
+            if ( array_key_exists($key, $node) && is_scalar($node[$key]) ) {
+                $metadata[$this->normalizeMetadataKey($key)] = $node[$key];
+            }
+        }
+
+        foreach ( array('isPublishable', 'locked', 'isSoftDeleted', 'internalOnly', 'isPageDivider') as $key ) {
+            if ( array_key_exists($key, $node) && is_bool($node[$key]) ) {
+                $metadata[$this->normalizeMetadataKey($key)] = $node[$key];
+            }
+        }
+
+        foreach ( array('originFileKey', 'fileKey', 'sessionID', 'sessionId') as $key ) {
+            if ( ! array_key_exists($key, $node) ) {
+                continue;
+            }
+            $value = $this->readGuidId($node[$key]);
+            if ( null !== $value ) {
+                $metadata[$this->normalizeMetadataKey($key)] = $value;
+            }
+        }
+
+        foreach ( array('editInfo', 'pluginData', 'annotations', 'annotationCategories', 'categories', 'pluginRelaunchData', 'slideThemeMap') as $key ) {
+            if ( ! array_key_exists($key, $node) ) {
+                continue;
+            }
+            $value = $this->normalizeMetadataValue($node[$key]);
+            if ( null !== $value && array() !== $value ) {
+                $metadata[$this->normalizeMetadataKey($key)] = $value;
+            }
+        }
+
+        return $metadata;
+    }
+
+    private function normalizeMetadataKey(string $key): string
+    {
+        return match ($key) {
+            'autoRename' => 'auto_rename',
+            'userFacingVersion' => 'user_facing_version',
+            'fileVersion' => 'file_version',
+            'publishID', 'publishId' => 'publish_id',
+            'sourceLibraryKey' => 'source_library_key',
+            'ancestorPathBeforeDeletion' => 'ancestor_path_before_deletion',
+            'isPublishable' => 'is_publishable',
+            'isSoftDeleted' => 'is_soft_deleted',
+            'internalOnly' => 'internal_only',
+            'isPageDivider' => 'is_page_divider',
+            'originFileKey' => 'origin_file_key',
+            'fileKey' => 'file_key',
+            'sessionID', 'sessionId' => 'session_id',
+            'ackID', 'ackId' => 'ack_id',
+            'userID', 'userId' => 'user_id',
+            'pluginID', 'pluginId' => 'plugin_id',
+            'categoryID', 'categoryId' => 'category_id',
+            'editInfo' => 'edit_info',
+            'pluginData' => 'plugin_data',
+            'annotationCategories' => 'annotation_categories',
+            'pluginRelaunchData' => 'plugin_relaunch_data',
+            'slideThemeMap' => 'slide_theme_map',
+            default => $key,
+        };
+    }
+
+    private function normalizeMetadataValue(mixed $value): mixed
+    {
+        if ( is_scalar($value) || null === $value ) {
+            return $value;
+        }
+
+        if ( ! is_array($value) ) {
+            return null;
+        }
+
+        $normalized = array();
+        foreach ( $value as $key => $item ) {
+            $normalizedItem = $this->normalizeMetadataValue($item);
+            if ( null === $normalizedItem ) {
+                continue;
+            }
+            $normalized[is_int($key) ? $key : $this->normalizeMetadataKey((string) $key)] = $normalizedItem;
         }
 
         return $normalized;

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -284,7 +284,71 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert(array('Desktop', 'Mobile') === ($kiwiStateGroupMetadata['state_group_property_value_orders'][0]['values'] ?? null), 'kiwi-state-group-normalizes-order-values');
     $assert('2422394609:4048757538' === ($kiwiVariantMetadata['variant_prop_specs'][0]['prop_def_id'] ?? null), 'kiwi-variant-normalizes-prop-def-id');
     $assert('Desktop' === ($kiwiVariantMetadata['variant_prop_specs'][0]['value'] ?? null), 'kiwi-variant-normalizes-value');
-    
+
+    $kiwiDocumentMetadataSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_document_metadata_schema_fixture());
+    $kiwiDocumentMetadataMessage = $kiwiDecoder->decodeMessageSelective(
+        blocks_engine_figma_transformer_kiwi_document_metadata_message_fixture(),
+        $kiwiDocumentMetadataSchema['schema'] ?? array()
+    );
+    $kiwiDocumentMetadataRoot = $kiwiDocumentMetadataMessage['message'] ?? array();
+    $kiwiDocumentMetadataNode = $kiwiDocumentMetadataRoot['nodeChanges'][0] ?? array();
+    $assert(42 === ($kiwiDocumentMetadataRoot['fileVersion'] ?? null), 'kiwi-document-metadata-decodes-root-file-version');
+    $assert('COMPLETED' === ($kiwiDocumentMetadataRoot['sectionStatus']['status'] ?? null), 'kiwi-document-metadata-decodes-root-section-status');
+    $assert('DESIGN' === ($kiwiDocumentMetadataNode['phase'] ?? null), 'kiwi-document-metadata-decodes-phase');
+    $assert(false === ($kiwiDocumentMetadataNode['autoRename'] ?? null), 'kiwi-document-metadata-decodes-auto-rename');
+    $assert('editor-1' === ($kiwiDocumentMetadataNode['editInfo']['userID'] ?? null), 'kiwi-document-metadata-decodes-edit-info');
+    $assert('plugin-1' === ($kiwiDocumentMetadataNode['pluginData']['pluginID'] ?? null), 'kiwi-document-metadata-decodes-plugin-data');
+    $assert(7 === ($kiwiDocumentMetadataNode['version'] ?? null), 'kiwi-document-metadata-decodes-version');
+    $assert('v7-public' === ($kiwiDocumentMetadataNode['userFacingVersion'] ?? null), 'kiwi-document-metadata-decodes-user-facing-version');
+    $assert('pub-123' === ($kiwiDocumentMetadataNode['publishID'] ?? null), 'kiwi-document-metadata-decodes-publish-id');
+    $assert('library-key-1' === ($kiwiDocumentMetadataNode['sourceLibraryKey'] ?? null), 'kiwi-document-metadata-decodes-source-library-key');
+    $assert('annotation-1' === ($kiwiDocumentMetadataNode['annotations'][0]['id'] ?? null), 'kiwi-document-metadata-decodes-annotations');
+    $assert('category-1' === ($kiwiDocumentMetadataNode['annotationCategories'][0]['id'] ?? null), 'kiwi-document-metadata-decodes-annotation-categories');
+    $assert('BUILD' === ($kiwiDocumentMetadataNode['sectionStatus'] ?? null), 'kiwi-document-metadata-decodes-section-status');
+    $assert('COMPLETED' === ($kiwiDocumentMetadataNode['sectionStatusInfo']['status'] ?? null), 'kiwi-document-metadata-decodes-section-status-info');
+    $assert('BUILD' === ($kiwiDocumentMetadataNode['handoffStatus']['status'] ?? null), 'kiwi-document-metadata-decodes-handoff-status');
+    $assert(true === ($kiwiDocumentMetadataNode['internalOnly'] ?? null), 'kiwi-document-metadata-decodes-internal-only');
+    $assert(true === ($kiwiDocumentMetadataNode['isPageDivider'] ?? null), 'kiwi-document-metadata-decodes-page-divider');
+    $assert('origin-file-1' === ($kiwiDocumentMetadataNode['originFileKey'] ?? null), 'kiwi-document-metadata-decodes-origin-file-key');
+    $assert('session-1' === ($kiwiDocumentMetadataNode['sessionID'] ?? null), 'kiwi-document-metadata-decodes-session-id');
+
+    $kiwiDocumentMetadataNormalizer = new ScenegraphNormalizer();
+    $kiwiDocumentMetadataNormalized = $kiwiDocumentMetadataNormalizer->normalize(array(
+        'name'          => 'Kiwi Document Metadata Fixture',
+        'fileVersion'   => 42,
+        'sectionStatus' => array('status' => 'COMPLETED', 'description' => 'File complete'),
+        'nodes'         => array(
+            array_merge($kiwiDocumentMetadataNode, array('id' => 'metadata:page', 'width' => 320, 'height' => 180)),
+        ),
+    ));
+    $kiwiDocumentMetadata = $kiwiDocumentMetadataNormalized['nodes'][0]['figma_metadata'] ?? array();
+    $kiwiDocumentMetadataReport = $kiwiDocumentMetadataNormalized['source_report']['figma_metadata'] ?? array();
+    $assert(42 === ($kiwiDocumentMetadataReport['file_version'] ?? null), 'kiwi-document-metadata-normalizes-root-file-version');
+    $assert('DESIGN' === ($kiwiDocumentMetadata['phase'] ?? null), 'kiwi-document-metadata-normalizes-phase');
+    $assert(false === ($kiwiDocumentMetadata['auto_rename'] ?? null), 'kiwi-document-metadata-normalizes-auto-rename');
+    $assert('editor-1' === ($kiwiDocumentMetadata['edit_info']['user_id'] ?? null), 'kiwi-document-metadata-normalizes-edit-info');
+    $assert('plugin-1' === ($kiwiDocumentMetadata['plugin_data']['plugin_id'] ?? null), 'kiwi-document-metadata-normalizes-plugin-data');
+    $assert('v7-public' === ($kiwiDocumentMetadata['user_facing_version'] ?? null), 'kiwi-document-metadata-normalizes-user-facing-version');
+    $assert('pub-123' === ($kiwiDocumentMetadata['publish_id'] ?? null), 'kiwi-document-metadata-normalizes-publish-id');
+    $assert('library-key-1' === ($kiwiDocumentMetadata['source_library_key'] ?? null), 'kiwi-document-metadata-normalizes-source-library-key');
+    $assert('annotation-1' === ($kiwiDocumentMetadata['annotations'][0]['id'] ?? null), 'kiwi-document-metadata-normalizes-annotations');
+    $assert('category-1' === ($kiwiDocumentMetadata['annotation_categories'][0]['id'] ?? null), 'kiwi-document-metadata-normalizes-annotation-categories');
+    $assert(true === ($kiwiDocumentMetadata['internal_only'] ?? null), 'kiwi-document-metadata-normalizes-internal-only');
+    $assert(true === ($kiwiDocumentMetadata['is_page_divider'] ?? null), 'kiwi-document-metadata-normalizes-page-divider');
+    $assert('origin-file-1' === ($kiwiDocumentMetadata['origin_file_key'] ?? null), 'kiwi-document-metadata-normalizes-origin-file-key');
+    $assert('session-1' === ($kiwiDocumentMetadata['session_id'] ?? null), 'kiwi-document-metadata-normalizes-session-id');
+
+    $metadataVisualBaseline = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Metadata Visual Baseline',
+        'nodes' => array(array('id' => 'metadata:visual', 'type' => 'FRAME', 'name' => 'Metadata Visual', 'width' => 320, 'height' => 180)),
+    ));
+    $metadataVisualWithFields = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Metadata Visual Baseline',
+        'nodes' => array(array_merge($kiwiDocumentMetadataNode, array('id' => 'metadata:visual', 'type' => 'FRAME', 'name' => 'Metadata Visual', 'width' => 320, 'height' => 180))),
+    ));
+    $assert($fileContent($metadataVisualBaseline, 'index.html') === $fileContent($metadataVisualWithFields, 'index.html'), 'kiwi-document-metadata-does-not-change-html');
+    $assert($fileContent($metadataVisualBaseline, 'style.css') === $fileContent($metadataVisualWithFields, 'style.css'), 'kiwi-document-metadata-does-not-change-css');
+
     $kiwiFrameMaskResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'document' => array(
             'id'       => 'kiwi-mask:document',
@@ -975,6 +1039,145 @@ function blocks_engine_figma_transformer_kiwi_state_group_message_fixture(): str
         . blocks_engine_figma_transformer_wire_varint(2)
         . $stateGroupNode
         . $variantNode
+        . blocks_engine_figma_transformer_wire_varint(0);
+}
+
+function blocks_engine_figma_transformer_kiwi_document_metadata_schema_fixture(): string
+{
+    return blocks_engine_figma_transformer_wire_varint(9)
+        . blocks_engine_figma_transformer_kiwi_string('GUID')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sessionID', -4, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('localID', -4, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('EditInfo')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('userID', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('userName', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('PluginData')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('pluginID', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('data', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('Annotation')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('id', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('label', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('AnnotationCategory')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('id', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('SectionStatus')
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('BUILD', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('COMPLETED', 0, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('SectionStatusInfo')
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('status', 5, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('description', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_string('NodeChange')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(20)
+        . blocks_engine_figma_transformer_kiwi_schema_field('guid', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('phase', -6, false, 4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('autoRename', -1, false, 5)
+        . blocks_engine_figma_transformer_kiwi_schema_field('editInfo', 1, false, 6)
+        . blocks_engine_figma_transformer_kiwi_schema_field('pluginData', 2, false, 7)
+        . blocks_engine_figma_transformer_kiwi_schema_field('version', -4, false, 8)
+        . blocks_engine_figma_transformer_kiwi_schema_field('userFacingVersion', -6, false, 9)
+        . blocks_engine_figma_transformer_kiwi_schema_field('publishID', -6, false, 10)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sourceLibraryKey', -6, false, 11)
+        . blocks_engine_figma_transformer_kiwi_schema_field('annotations', 3, true, 12)
+        . blocks_engine_figma_transformer_kiwi_schema_field('annotationCategories', 4, true, 13)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sectionStatus', 5, false, 14)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sectionStatusInfo', 6, false, 15)
+        . blocks_engine_figma_transformer_kiwi_schema_field('handoffStatus', 6, false, 16)
+        . blocks_engine_figma_transformer_kiwi_schema_field('internalOnly', -1, false, 17)
+        . blocks_engine_figma_transformer_kiwi_schema_field('isPageDivider', -1, false, 18)
+        . blocks_engine_figma_transformer_kiwi_schema_field('originFileKey', -6, false, 19)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sessionID', -6, false, 20)
+        . blocks_engine_figma_transformer_kiwi_string('Message')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('fileVersion', -4, false, 2)
+        . blocks_engine_figma_transformer_kiwi_schema_field('sectionStatus', 6, false, 3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 7, true, 4);
+}
+
+function blocks_engine_figma_transformer_kiwi_document_metadata_message_fixture(): string
+{
+    $annotation = blocks_engine_figma_transformer_kiwi_string('annotation-1')
+        . blocks_engine_figma_transformer_kiwi_string('Primary annotation');
+    $category = blocks_engine_figma_transformer_kiwi_string('category-1')
+        . blocks_engine_figma_transformer_kiwi_string('Accessibility');
+    $completedInfo = blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('Complete');
+    $buildInfo = blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('Ready');
+    $node = blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(10)
+        . blocks_engine_figma_transformer_wire_varint(20)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_kiwi_string('FRAME')
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_string('Metadata Page')
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_kiwi_string('DESIGN')
+        . blocks_engine_figma_transformer_wire_varint(5)
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(6)
+        . blocks_engine_figma_transformer_kiwi_string('editor-1')
+        . blocks_engine_figma_transformer_kiwi_string('Editor One')
+        . blocks_engine_figma_transformer_wire_varint(7)
+        . blocks_engine_figma_transformer_kiwi_string('plugin-1')
+        . blocks_engine_figma_transformer_kiwi_string('{"ok":true}')
+        . blocks_engine_figma_transformer_wire_varint(8)
+        . blocks_engine_figma_transformer_wire_varint(7)
+        . blocks_engine_figma_transformer_wire_varint(9)
+        . blocks_engine_figma_transformer_kiwi_string('v7-public')
+        . blocks_engine_figma_transformer_wire_varint(10)
+        . blocks_engine_figma_transformer_kiwi_string('pub-123')
+        . blocks_engine_figma_transformer_wire_varint(11)
+        . blocks_engine_figma_transformer_kiwi_string('library-key-1')
+        . blocks_engine_figma_transformer_wire_varint(12)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . $annotation
+        . blocks_engine_figma_transformer_wire_varint(13)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . $category
+        . blocks_engine_figma_transformer_wire_varint(14)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(15)
+        . $completedInfo
+        . blocks_engine_figma_transformer_wire_varint(16)
+        . $buildInfo
+        . blocks_engine_figma_transformer_wire_varint(17)
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(18)
+        . chr(1)
+        . blocks_engine_figma_transformer_wire_varint(19)
+        . blocks_engine_figma_transformer_kiwi_string('origin-file-1')
+        . blocks_engine_figma_transformer_wire_varint(20)
+        . blocks_engine_figma_transformer_kiwi_string('session-1')
+        . blocks_engine_figma_transformer_wire_varint(0);
+
+    return blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_string('NODE_CHANGES')
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(42)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . $completedInfo
+        . blocks_engine_figma_transformer_wire_varint(4)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . $node
         . blocks_engine_figma_transformer_wire_varint(0);
 }
 

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -16,8 +16,8 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $fields = is_array($inventory['fields'] ?? null) ? $inventory['fields'] : array();
 
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1' === ($inventory['schema'] ?? null), 'kiwi-skipped-inventory-schema');
-    $assert(10 === ($inventory['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-field-count');
-    $assert(10 === ($inventory['summary']['occurrences'] ?? null), 'kiwi-skipped-inventory-occurrences');
+    $assert(11 === ($inventory['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-field-count');
+    $assert(11 === ($inventory['summary']['occurrences'] ?? null), 'kiwi-skipped-inventory-occurrences');
     $assert(1 === ($inventory['summary']['by_role']['geometry_layout'] ?? null), 'kiwi-skipped-inventory-geometry-role');
     $assert(1 === ($inventory['summary']['by_role']['component_overrides'] ?? null), 'kiwi-skipped-inventory-component-role');
     $assert(1 === ($inventory['summary']['by_role']['fills_images'] ?? null), 'kiwi-skipped-inventory-image-role');
@@ -27,6 +27,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert(! isset($inventory['summary']['by_role']['variables_bindings']), 'kiwi-skipped-inventory-variables-role-decoded');
     $assert(1 === ($inventory['summary']['by_role']['export_metadata'] ?? null), 'kiwi-skipped-inventory-export-role');
     $assert(1 === ($inventory['summary']['by_role']['document_metadata'] ?? null), 'kiwi-skipped-inventory-document-role');
+    $assert(1 === ($inventory['summary']['by_role']['dev_status'] ?? null), 'kiwi-skipped-inventory-dev-status-role');
 
     $layoutEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'layoutBoundsDebug');
     $assert('NodeChange' === ($layoutEntry['parent_message'] ?? null), 'kiwi-skipped-inventory-parent-message');
@@ -36,8 +37,11 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'arcData'), 'kiwi-skipped-inventory-arc-data-decoded');
     $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'guides'), 'kiwi-skipped-inventory-guides-decoded');
     $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'listSpacing'), 'kiwi-skipped-inventory-list-spacing-decoded');
-    $phaseEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'phase');
-    $assert('document_metadata' === ($phaseEntry['field_role'] ?? null), 'kiwi-skipped-inventory-phase-document-role');
+    $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'phase'), 'kiwi-skipped-inventory-phase-decoded');
+    $documentEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'metadataAuditTrail');
+    $assert('document_metadata' === ($documentEntry['field_role'] ?? null), 'kiwi-skipped-inventory-metadata-document-role');
+    $handoffEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'handoffStatusHistory');
+    $assert('dev_status' === ($handoffEntry['field_role'] ?? null), 'kiwi-skipped-inventory-handoff-dev-role');
     $glyphEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'glyphs');
     $assert('text_style' === ($glyphEntry['field_role'] ?? null), 'kiwi-skipped-inventory-glyph-text-role');
     $assert('null_terminated_string' === ($glyphEntry['wire_type'] ?? null), 'kiwi-skipped-inventory-string-wire-type');
@@ -79,7 +83,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
 
     $assert(is_array($cli), 'kiwi-skipped-inventory-cli-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-cli-schema');
-    $assert(10 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
+    $assert(11 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
 
     $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
         SyntheticFigKiwiFixtureBuilder::canvas(array(
@@ -103,7 +107,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-output/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-output-cli-schema');
     $assert(is_array($written), 'kiwi-skipped-inventory-output-file-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($written['schema'] ?? null), 'kiwi-skipped-inventory-output-file-schema');
-    $assert(10 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
+    $assert(11 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
 }
 
 /**
@@ -142,7 +146,7 @@ function blocks_engine_figma_transformer_kiwi_inventory_schema_fixture(): string
         . blocks_engine_figma_transformer_kiwi_schema_field('guid', 0, false, 3)
         . blocks_engine_figma_transformer_kiwi_string('NodeChange')
         . chr(2)
-        . blocks_engine_figma_transformer_wire_varint(18)
+        . blocks_engine_figma_transformer_wire_varint(20)
         . blocks_engine_figma_transformer_kiwi_schema_field('guid', 0, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 2)
         . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 3)
@@ -161,6 +165,8 @@ function blocks_engine_figma_transformer_kiwi_inventory_schema_fixture(): string
         . blocks_engine_figma_transformer_kiwi_schema_field('listSpacing', -5, false, 16)
         . blocks_engine_figma_transformer_kiwi_schema_field('inventoryStatus', 5, false, 17)
         . blocks_engine_figma_transformer_kiwi_schema_field('extraGuid', 0, false, 18)
+        . blocks_engine_figma_transformer_kiwi_schema_field('metadataAuditTrail', -6, false, 19)
+        . blocks_engine_figma_transformer_kiwi_schema_field('handoffStatusHistory', -6, false, 20)
         . blocks_engine_figma_transformer_kiwi_string('Message')
         . chr(2)
         . blocks_engine_figma_transformer_wire_varint(2)
@@ -231,6 +237,10 @@ function blocks_engine_figma_transformer_kiwi_inventory_message_fixture(): strin
         . blocks_engine_figma_transformer_wire_varint(18)
         . blocks_engine_figma_transformer_wire_varint(9)
         . blocks_engine_figma_transformer_wire_varint(99)
+        . blocks_engine_figma_transformer_wire_varint(19)
+        . blocks_engine_figma_transformer_kiwi_string('metadata-audit')
+        . blocks_engine_figma_transformer_wire_varint(20)
+        . blocks_engine_figma_transformer_kiwi_string('handoff-history')
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
 }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4318,7 +4318,7 @@ $assert('Selected label' === ($componentPropAssignment['value']['textValue']['ch
 $assert('Selected label via variable' === ($componentPropAssignment['varValue']['value']['textDataValue']['characters'] ?? null), 'component-prop-field-policy-carries-var-value-text-data');
 $assert(array('sessionID' => 9, 'localID' => 10) === ($componentPropRef['defID'] ?? null), 'component-prop-field-policy-carries-ref-def-id');
 $assert('TEXT_DATA' === ($componentPropRef['componentPropNodeField'] ?? null), 'component-prop-field-policy-carries-text-ref-field');
-$assert(! array_key_exists('pluginData', $componentPropNodeChange), 'component-prop-field-policy-skips-adjacent-plugin-data');
+$assert('raw' === ($componentPropNodeChange['pluginData'] ?? null), 'component-prop-field-policy-carries-adjacent-plugin-data');
 
 // NORMALIZE: raw sectionStatus tokens map onto a clean dev_status with the raw
 // value carried for auditability.


### PR DESCRIPTION
## Summary
- Decode and preserve Kiwi document/page/dev-status metadata as non-visual figma_metadata.
- Add parser and normalizer contracts for metadata preservation and no visual output changes.
- Update skipped-field inventory expectations now that more document metadata is decoded.

## Testing
- php -l src/FigFile/FigKiwiDecodePolicy.php
- php -l src/Scenegraph/ScenegraphNormalizer.php
- php -l tests/contract/KiwiParserContract.php
- php -l tests/contract/KiwiSkippedFieldInventoryContract.php
- php -l tests/contract/run.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Orchestrating the Kiwi parsing minion result, validating, committing, and preparing this PR description.