### PR TITLE
figma-transformer: preserve Kiwi prototype metadata

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -95,13 +95,14 @@ final class FigKiwiDecodePolicy
             // interactions as `PrototypeInteraction { event, actions }` whose
             // `PrototypeAction` carries `connectionType` (URL/INTERNAL_NODE),
             // `connectionURL`, `navigationType`, and the `transitionNodeID`
-            // GUID destination. Only the fields the normalizer needs to build a
-            // URL or node-navigation `figma_link` are whitelisted; animation,
-            // overlay, swap, and variable-mutation action data is left undecoded.
+            // GUID destination. Overlay/swap/open-url metadata is also decoded
+            // so generic normalization can surface prototype diagnostics without
+            // changing current anchor emission behavior. Animation and
+            // variable-mutation action data is left undecoded.
             'Hyperlink' => array('url', 'guid'),
             'PrototypeInteraction' => array('event', 'actions', 'id'),
             'PrototypeEvent' => array('interactionType'),
-            'PrototypeAction' => array('connectionType', 'connectionURL', 'transitionNodeID', 'navigationType'),
+            'PrototypeAction' => array('connectionType', 'connectionURL', 'transitionNodeID', 'navigationType', 'overlayPositionType', 'overlayRelativePosition', 'overlayBackground', 'overlayBackgroundInteraction', 'preserveScrollPosition', 'resetScrollPosition', 'resetVideoPosition', 'openUrlInNewTab', 'urlTarget'),
         );
     }
 
@@ -402,8 +403,8 @@ final class FigKiwiDecodePolicy
      */
     private function nodePrototypeLinkFields(): array
     {
-        // Link extraction only; richer animation/overlay/swap action data stays undecoded.
-        return array('hyperlink', 'prototypeInteractions', 'reactions', 'transitionNodeID');
+        // Link extraction plus prototype metadata needed for diagnostics; richer animation action data stays undecoded.
+        return array('hyperlink', 'prototypeInteractions', 'reactions', 'transitionNodeID', 'navigationType', 'connectionType', 'connectionURL');
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2833,6 +2833,7 @@ final class ScenegraphNormalizer
                 $link = $this->normalizeActionLink($action);
                 if ( null !== $link ) {
                     $link['source'] = 'reaction';
+                    $this->appendPrototypeLinkContext($link, $reaction, $action);
                     return $link;
                 }
             }
@@ -2861,7 +2862,9 @@ final class ScenegraphNormalizer
         $connectionType = strtoupper((string) ($action['connectionType'] ?? ''));
         $url = $this->readString($action, array('url', 'href', 'connectionURL'));
         if ( ( 'URL' === $type || 'URL' === $connectionType ) && null !== $url ) {
-            return array('type' => 'url', 'url' => $url);
+            $link = array('type' => 'url', 'url' => $url);
+            $this->appendActionLinkMetadata($link, $action, $type, $connectionType, '');
+            return $link;
         }
 
         $destination = $this->readString($action, array('destinationId', 'navigationDestinationId', 'transitionNodeID'))
@@ -2871,17 +2874,93 @@ final class ScenegraphNormalizer
             || 'INTERNAL_NODE' === $connectionType
             || in_array($navigation, array('NAVIGATE', 'OVERLAY', 'SWAP', 'SCROLL_TO'), true);
         if ( $navigatesToNode && null !== $destination && '' !== $destination ) {
-            return array('type' => 'node', 'target_node_id' => $destination);
+            $link = array('type' => 'node', 'target_node_id' => $destination);
+            $this->appendActionLinkMetadata($link, $action, $type, $connectionType, $navigation);
+            return $link;
         }
 
         if ( null !== $url ) {
-            return array('type' => 'url', 'url' => $url);
+            $link = array('type' => 'url', 'url' => $url);
+            $this->appendActionLinkMetadata($link, $action, $type, $connectionType, $navigation);
+            return $link;
         }
         if ( null !== $destination && '' !== $destination ) {
-            return array('type' => 'node', 'target_node_id' => $destination);
+            $link = array('type' => 'node', 'target_node_id' => $destination);
+            $this->appendActionLinkMetadata($link, $action, $type, $connectionType, $navigation);
+            return $link;
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, mixed> $link
+     * @param array<string, mixed> $reaction
+     * @param array<string, mixed> $action
+     */
+    private function appendPrototypeLinkContext(array &$link, array $reaction, array $action): void
+    {
+        $event = is_array($reaction['event'] ?? null) ? $reaction['event'] : array();
+        $eventType = $this->readString($event, array('interactionType', 'type'));
+        if ( null !== $eventType ) {
+            $link['prototype_event'] = strtoupper($eventType);
+        }
+
+        if ( isset($reaction['id']) && is_scalar($reaction['id']) && '' !== (string) $reaction['id'] ) {
+            $link['prototype_interaction_id'] = (string) $reaction['id'];
+        }
+
+        $this->appendPrototypeMetadataFields($link, $action);
+    }
+
+    /**
+     * @param array<string, mixed> $link
+     * @param array<string, mixed> $action
+     */
+    private function appendActionLinkMetadata(array &$link, array $action, string $type, string $connectionType, string $navigation): void
+    {
+        if ( '' !== $type ) {
+            $link['prototype_action_type'] = $type;
+        }
+        if ( '' !== $connectionType ) {
+            $link['prototype_connection_type'] = $connectionType;
+        }
+        if ( '' !== $navigation ) {
+            $link['prototype_navigation_type'] = $navigation;
+        }
+
+        $this->appendPrototypeMetadataFields($link, $action);
+    }
+
+    /**
+     * @param array<string, mixed> $link
+     * @param array<string, mixed> $action
+     */
+    private function appendPrototypeMetadataFields(array &$link, array $action): void
+    {
+        foreach ( array('overlayPositionType', 'overlayBackgroundInteraction', 'urlTarget') as $field ) {
+            if ( isset($action[$field]) && is_scalar($action[$field]) && '' !== (string) $action[$field] ) {
+                $link['prototype_' . $this->camelToSnake($field)] = strtoupper((string) $action[$field]);
+            }
+        }
+
+        foreach ( array('preserveScrollPosition', 'resetScrollPosition', 'resetVideoPosition', 'openUrlInNewTab') as $field ) {
+            if ( isset($action[$field]) && is_bool($action[$field]) ) {
+                $link['prototype_' . $this->camelToSnake($field)] = $action[$field];
+            }
+        }
+
+        if ( isset($action['overlayRelativePosition']) && is_array($action['overlayRelativePosition']) ) {
+            $link['prototype_overlay_relative_position'] = $action['overlayRelativePosition'];
+        }
+        if ( isset($action['overlayBackground']) && is_array($action['overlayBackground']) ) {
+            $link['prototype_overlay_background'] = $action['overlayBackground'];
+        }
+    }
+
+    private function camelToSnake(string $value): string
+    {
+        return strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $value));
     }
 
     /**

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -1443,18 +1443,25 @@ function blocks_engine_figma_transformer_kiwi_link_schema_fixture(): string
         . $field('NONE', 0, false, 0)
         . $field('INTERNAL_NODE', 0, false, 1)
         . $field('URL', 0, false, 2)
-        // def3: ENUM NavigationType { NAVIGATE = 0 }
-        . $str('NavigationType') . chr(0) . $varint(1)
+        // def3: ENUM NavigationType { NAVIGATE = 0, OVERLAY = 1, SWAP = 2 }
+        . $str('NavigationType') . chr(0) . $varint(3)
         . $field('NAVIGATE', 0, false, 0)
+        . $field('OVERLAY', 0, false, 1)
+        . $field('SWAP', 0, false, 2)
         // def4: MESSAGE PrototypeEvent { interactionType }
         . $str('PrototypeEvent') . chr(2) . $varint(1)
         . $field('interactionType', 1, false, 1)
-        // def5: MESSAGE PrototypeAction { transitionNodeID, connectionType, connectionURL, navigationType }
-        . $str('PrototypeAction') . chr(2) . $varint(4)
+        // def5: MESSAGE PrototypeAction { transitionNodeID, connectionType, connectionURL, navigationType, overlay/swap/open-url metadata }
+        . $str('PrototypeAction') . chr(2) . $varint(9)
         . $field('transitionNodeID', 0, false, 1)
         . $field('connectionType', 2, false, 7)
         . $field('connectionURL', -6, false, 8)
         . $field('navigationType', 3, false, 10)
+        . $field('overlayPositionType', -6, false, 11)
+        . $field('preserveScrollPosition', -1, false, 12)
+        . $field('openUrlInNewTab', -1, false, 13)
+        . $field('urlTarget', -6, false, 14)
+        . $field('resetScrollPosition', -1, false, 15)
         // def6: MESSAGE PrototypeInteraction { event, actions[] }
         . $str('PrototypeInteraction') . chr(2) . $varint(2)
         . $field('event', 4, false, 2)
@@ -1492,15 +1499,20 @@ function blocks_engine_figma_transformer_kiwi_link_message_fixture(): string
     // PrototypeEvent { interactionType = ON_CLICK (0) }
     $event = $v(1) . $v(0) . $v(0);
 
-    // PrototypeAction { connectionType = URL (2), connectionURL }
+    // PrototypeAction { connectionType = URL (2), connectionURL, openUrlInNewTab, urlTarget }
     $actionUrl = $v(7) . $v(2)
         . $v(8) . $str('https://example.com/cta')
+        . $v(13) . chr(1)
+        . $v(14) . $str('NEW_TAB')
         . $v(0);
 
-    // PrototypeAction { transitionNodeID = GUID{7,42}, connectionType = INTERNAL_NODE (1), navigationType = NAVIGATE (0) }
+    // PrototypeAction { transitionNodeID = GUID{7,42}, connectionType = INTERNAL_NODE (1), navigationType = OVERLAY (1), overlayPositionType }
     $actionNode = $v(1) . $v(7) . $v(42) // GUID struct body (sessionID, localID; structs carry no terminator)
         . $v(7) . $v(1)
-        . $v(10) . $v(0)
+        . $v(10) . $v(1)
+        . $v(11) . $str('CENTER')
+        . $v(12) . chr(1)
+        . $v(15) . chr(1)
         . $v(0);
 
     // PrototypeInteraction { event, actions = [actionUrl, actionNode] }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4260,8 +4260,58 @@ $linkInteraction = $linkNodeChanges[1]['prototypeInteractions'][0] ?? array();
 $assert('ON_CLICK' === ($linkInteraction['event']['interactionType'] ?? null), 'link-field-policy-carries-interaction-trigger');
 $assert('URL' === ($linkInteraction['actions'][0]['connectionType'] ?? null), 'link-field-policy-carries-connection-type');
 $assert('https://example.com/cta' === ($linkInteraction['actions'][0]['connectionURL'] ?? null), 'link-field-policy-carries-connection-url');
+$assert(true === ($linkInteraction['actions'][0]['openUrlInNewTab'] ?? null), 'link-field-policy-carries-open-url-new-tab');
+$assert('NEW_TAB' === ($linkInteraction['actions'][0]['urlTarget'] ?? null), 'link-field-policy-carries-url-target');
 $assert('INTERNAL_NODE' === ($linkInteraction['actions'][1]['connectionType'] ?? null), 'link-field-policy-carries-node-connection-type');
 $assert(array('sessionID' => 7, 'localID' => 42) === ($linkInteraction['actions'][1]['transitionNodeID'] ?? null), 'link-field-policy-carries-transition-node-guid');
+$assert('OVERLAY' === ($linkInteraction['actions'][1]['navigationType'] ?? null), 'link-field-policy-carries-overlay-navigation-type');
+$assert('CENTER' === ($linkInteraction['actions'][1]['overlayPositionType'] ?? null), 'link-field-policy-carries-overlay-position-type');
+$assert(true === ($linkInteraction['actions'][1]['preserveScrollPosition'] ?? null), 'link-field-policy-carries-preserve-scroll-position');
+$assert(true === ($linkInteraction['actions'][1]['resetScrollPosition'] ?? null), 'link-field-policy-carries-reset-scroll-position');
+
+$prototypeMetadataNormalizer = new ScenegraphNormalizer();
+$prototypeMetadataNormalized = $prototypeMetadataNormalizer->normalize(array(
+    'name'  => 'Kiwi Prototype Metadata Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'prototype-meta:home',
+            'type'     => 'FRAME',
+            'name'     => 'Home',
+            'children' => array(
+                array(
+                    'id'                    => 'prototype-meta:overlay-trigger',
+                    'type'                  => 'FRAME',
+                    'name'                  => 'Open Overlay',
+                    'prototypeInteractions' => array(
+                        array(
+                            'id'      => 'interaction:overlay',
+                            'event'   => array('interactionType' => 'ON_CLICK'),
+                            'actions' => array(
+                                array(
+                                    'connectionType'          => 'INTERNAL_NODE',
+                                    'transitionNodeID'        => array('sessionID' => 9, 'localID' => 77),
+                                    'navigationType'          => 'OVERLAY',
+                                    'overlayPositionType'     => 'CENTER',
+                                    'preserveScrollPosition'  => true,
+                                    'overlayRelativePosition' => array('x' => 24, 'y' => 32),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$prototypeMetadataLink = $prototypeMetadataNormalized['node_map']['prototype-meta:overlay-trigger']['figma_link'] ?? array();
+$assert('node' === ($prototypeMetadataLink['type'] ?? null), 'prototype-metadata-link-keeps-node-target');
+$assert('9:77' === ($prototypeMetadataLink['target_node_id'] ?? null), 'prototype-metadata-link-normalizes-transition-guid');
+$assert('OVERLAY' === ($prototypeMetadataLink['prototype_navigation_type'] ?? null), 'prototype-metadata-link-carries-navigation-type');
+$assert('CENTER' === ($prototypeMetadataLink['prototype_overlay_position_type'] ?? null), 'prototype-metadata-link-carries-overlay-position-type');
+$assert(true === ($prototypeMetadataLink['prototype_preserve_scroll_position'] ?? null), 'prototype-metadata-link-carries-preserve-scroll-position');
+$assert(array('x' => 24, 'y' => 32) === ($prototypeMetadataLink['prototype_overlay_relative_position'] ?? null), 'prototype-metadata-link-carries-overlay-relative-position');
+$assert('ON_CLICK' === ($prototypeMetadataLink['prototype_event'] ?? null), 'prototype-metadata-link-carries-event');
+$assert('interaction:overlay' === ($prototypeMetadataLink['prototype_interaction_id'] ?? null), 'prototype-metadata-link-carries-interaction-id');
 
 // ---------------------------------------------------------------------------
 // Figma Dev Mode status (#280): decode -> normalize -> select -> diagnose.


### PR DESCRIPTION
## Summary
- Decode additional Kiwi prototype/link fields.
- Preserve prototype metadata on normalized figma_link output without changing anchor behavior.
- Extend parser and normalizer contracts for URL/internal-node prototype metadata.

## Testing
- php -l src/FigFile/FigKiwiDecodePolicy.php
- php -l src/Scenegraph/ScenegraphNormalizer.php
- php -l tests/contract/KiwiParserContract.php
- php -l tests/contract/run.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Orchestrating the Kiwi parsing minion result, rebasing, validating, committing, and preparing this PR description.