### PR TITLE
figma-transformer: summarize Kiwi variable bindings

### DIFF
--- a/figma-transformer/scripts/figma-parser-parity.php
+++ b/figma-transformer/scripts/figma-parser-parity.php
@@ -284,6 +284,8 @@ function blocks_engine_figma_parser_parity_report(string $input, array $source, 
     )));
     $rawVectorNodeIds = blocks_engine_figma_parser_parity_node_ids_by_type($rawNodes, array('VECTOR', 'BOOLEAN_OPERATION'));
     $rawComponentPropNodeIds = blocks_engine_figma_parser_parity_node_ids_with_paths($rawNodes, array('componentProperties', 'componentPropertyDefinitions', 'component_property_definitions', 'symbolData', 'derivedSymbolData'));
+    $rawVariableNodeIds = blocks_engine_figma_parser_parity_node_ids_with_paths($rawNodes, array('variableConsumptionMap', 'parameterConsumptionMap', 'variableDataValues', 'variableResolvedType', 'variableSetID', 'variableScopes', 'variableSetModes'));
+    $rawVariableFieldCounts = blocks_engine_figma_parser_parity_variable_field_counts($rawNodes);
     $rawAssetRefs = blocks_engine_figma_parser_parity_raw_asset_reference_node_ids($rawNodes);
     $emittedNodeIds = array_fill_keys(array_values(array_unique(array_merge($visualNodeIds, $htmlNodeIds))), true);
     $emittedNodeIdList = array_keys($emittedNodeIds);
@@ -311,6 +313,8 @@ function blocks_engine_figma_parser_parity_report(string $input, array $source, 
             'text_node_count' => count($rawTextNodeIds),
             'vector_node_count' => count($rawVectorNodeIds),
             'component_prop_node_count' => count($rawComponentPropNodeIds),
+            'variable_node_count' => count($rawVariableNodeIds),
+            'variable_field_counts' => $rawVariableFieldCounts,
         ),
         'normalized' => array(
             'node_count' => count($normalizedNodes),
@@ -321,6 +325,7 @@ function blocks_engine_figma_parser_parity_report(string $input, array $source, 
             'text_node_count' => count(is_array($normalized['text_inventory'] ?? null) ? $normalized['text_inventory'] : array()),
             'component_definition_count' => $normalized['source_report']['component_definition_count'] ?? null,
             'instance_node_count' => $normalized['source_report']['instance_node_count'] ?? null,
+            'variable_bindings' => $normalized['source_report']['variable_bindings'] ?? null,
             'diagnostic_count' => count(is_array($normalized['diagnostics'] ?? null) ? $normalized['diagnostics'] : array()),
         ),
         'emitted' => array(
@@ -364,6 +369,36 @@ function blocks_engine_figma_parser_parity_normalized_component_clone_node_ids(a
     }
 
     return array_values(array_unique($ids));
+}
+
+/**
+ * @param array<string, array<string, mixed>> $rawNodes
+ * @return array<string, int>
+ */
+function blocks_engine_figma_parser_parity_variable_field_counts(array $rawNodes): array
+{
+    $counts = array(
+        'variableConsumptionMap' => 0,
+        'parameterConsumptionMap' => 0,
+        'variableDataValues' => 0,
+        'variableResolvedType' => 0,
+        'variableSetID' => 0,
+        'variableScopes' => 0,
+        'variableSetModes' => 0,
+    );
+
+    foreach ( $rawNodes as $node ) {
+        if ( ! is_array($node) ) {
+            continue;
+        }
+        foreach ( array_keys($counts) as $field ) {
+            if ( array_key_exists($field, $node) ) {
+                $counts[$field]++;
+            }
+        }
+    }
+
+    return $counts;
 }
 
 /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -83,11 +83,12 @@ final class ScenegraphNormalizer
             }
         }
 
-        $textInventory   = $this->buildTextInventory($nodeMap);
-        $assetReferences = $this->buildAssetReferences($nodeMap);
-        $sourceName      = $this->readSourceName($source, $renderNodes);
-        $sourceMetadata  = $this->normalizeDocumentMetadata($source);
-        $diagnostics     = $this->vectorGeometryNormalizer->compactUnsupportedVectorNetworkBlobDiagnostics($this->compactGlyphCommandBlobDiagnostics($diagnostics));
+        $textInventory          = $this->buildTextInventory($nodeMap);
+        $assetReferences        = $this->buildAssetReferences($nodeMap);
+        $variableBindingSummary = $this->buildVariableBindingSummary($nodeMap);
+        $sourceMetadata         = $this->normalizeDocumentMetadata($source);
+        $sourceName             = $this->readSourceName($source, $renderNodes);
+        $diagnostics            = $this->vectorGeometryNormalizer->compactUnsupportedVectorNetworkBlobDiagnostics($this->compactGlyphCommandBlobDiagnostics($diagnostics));
 
         return array(
             'schema'              => 'blocks-engine/figma-transformer/scenegraph/v1',
@@ -120,6 +121,7 @@ final class ScenegraphNormalizer
                 'instance_node_count'   => $instanceReport['instance_node_count'],
                 'resolved_instance_count' => $instanceReport['resolved_instance_count'],
                 'unresolved_component_references' => $instanceReport['unresolved_component_references'],
+                'variable_bindings'     => $variableBindingSummary,
                 'diagnostic_count'      => count($diagnostics),
             ),
         );
@@ -595,9 +597,11 @@ final class ScenegraphNormalizer
                     continue;
                 }
 
-                $targetField = isset($entry['variableField']) && is_scalar($entry['variableField']) ? (string) $entry['variableField'] : null;
-                if ( null === $targetField && isset($entry['nodeField']) && is_scalar($entry['nodeField']) ) {
-                    $targetField = 'nodeField:' . (string) $entry['nodeField'];
+                $variableField = isset($entry['variableField']) && is_scalar($entry['variableField']) ? (string) $entry['variableField'] : null;
+                $nodeField = isset($entry['nodeField']) && is_scalar($entry['nodeField']) ? (string) $entry['nodeField'] : null;
+                $targetField = $variableField;
+                if ( null === $targetField && null !== $nodeField ) {
+                    $targetField = 'nodeField:' . $nodeField;
                 }
                 if ( null === $targetField || '' === $targetField ) {
                     continue;
@@ -607,16 +611,16 @@ final class ScenegraphNormalizer
                 $binding = array(
                     'source'             => $sourceKey,
                     'target_field'       => $targetField,
+                    'variable_field'     => $variableField,
+                    'node_field'         => $nodeField,
                     'target_role'        => $this->classifyVariableBindingTarget($targetField),
                     'data_type'          => isset($variableData['dataType']) && is_scalar($variableData['dataType']) ? (string) $variableData['dataType'] : null,
                     'resolved_data_type' => isset($variableData['resolvedDataType']) && is_scalar($variableData['resolvedDataType']) ? (string) $variableData['resolvedDataType'] : null,
                 );
 
                 $value = is_array($variableData['value'] ?? null) ? $variableData['value'] : array();
-                $variableId = $this->readGuidId($value['alias']['guid'] ?? null);
-                if ( null !== $variableId ) {
-                    $binding['variable_id'] = $variableId;
-                }
+                $valueMetadata = $this->normalizeVariableAnyValueMetadata($value);
+                $binding = array_merge($binding, $valueMetadata);
                 $directValue = $this->normalizeVariableAnyValue($value);
                 if ( null !== $directValue ) {
                     $binding['value'] = $directValue;
@@ -671,6 +675,13 @@ final class ScenegraphNormalizer
                         $normalizedMode[$key] = (string) $mode[$key];
                     }
                 }
+                foreach ( array('parentVariableSetId' => 'parent_variable_set_id', 'parentModeId' => 'parent_mode_id') as $sourceKey => $targetKey ) {
+                    $parentSource = $mode[$sourceKey] ?? null;
+                    $parentId = $this->readGuidId(is_array($parentSource) && array_key_exists('guid', $parentSource) ? $parentSource['guid'] : $parentSource);
+                    if ( null !== $parentId ) {
+                        $normalizedMode[$targetKey] = $parentId;
+                    }
+                }
                 $modes[] = $normalizedMode;
             }
             if ( ! empty($modes) ) {
@@ -686,16 +697,18 @@ final class ScenegraphNormalizer
                 }
                 $modeId = $this->readGuidId($entry['modeID'] ?? null);
                 $variableData = is_array($entry['variableData'] ?? null) ? $entry['variableData'] : array();
-                $value = $this->normalizeVariableAnyValue(is_array($variableData['value'] ?? null) ? $variableData['value'] : array());
+                $rawValue = is_array($variableData['value'] ?? null) ? $variableData['value'] : array();
+                $value = $this->normalizeVariableAnyValue($rawValue);
+                $valueMetadata = $this->normalizeVariableAnyValueMetadata($rawValue);
                 if ( null === $modeId && null === $value ) {
                     continue;
                 }
-                $values[] = array_filter(array(
+                $values[] = array_filter(array_merge(array(
                     'mode_id'            => $modeId,
                     'value'              => $value,
                     'data_type'          => isset($variableData['dataType']) && is_scalar($variableData['dataType']) ? (string) $variableData['dataType'] : null,
                     'resolved_data_type' => isset($variableData['resolvedDataType']) && is_scalar($variableData['resolvedDataType']) ? (string) $variableData['resolvedDataType'] : null,
-                ), static fn (mixed $value): bool => null !== $value);
+                ), $valueMetadata), static fn (mixed $value): bool => null !== $value);
             }
             if ( ! empty($values) ) {
                 $normalized['values'] = $values;
@@ -814,6 +827,93 @@ final class ScenegraphNormalizer
     }
 
     /**
+     * @param array<string, array<string, mixed>> $nodeMap
+     * @return array<string, mixed>
+     */
+    private function buildVariableBindingSummary(array $nodeMap): array
+    {
+        $summary = array(
+            'schema'                      => 'blocks-engine/figma-transformer/variable-bindings/v1',
+            'node_count'                  => 0,
+            'binding_count'               => 0,
+            'value_count'                 => 0,
+            'variable_definition_count'   => 0,
+            'variable_set_count'          => 0,
+            'by_source'                   => array(),
+            'by_role'                     => array(),
+            'by_value_type'               => array(),
+            'by_resolved_data_type'       => array(),
+            'sample_nodes'                => array(),
+            'sample_limit'                => 10,
+            'sample_nodes_truncated'      => false,
+        );
+
+        foreach ( $nodeMap as $nodeId => $node ) {
+            $variableBindings = is_array($node['figma_variable_bindings'] ?? null) ? $node['figma_variable_bindings'] : array();
+            if ( empty($variableBindings) ) {
+                continue;
+            }
+
+            $summary['node_count']++;
+            $nodeSample = array(
+                'node_id' => (string) $nodeId,
+                'type'    => isset($node['type']) && is_scalar($node['type']) ? (string) $node['type'] : null,
+                'name'    => isset($node['name']) && is_scalar($node['name']) ? (string) $node['name'] : null,
+            );
+
+            if ( is_array($variableBindings['bindings'] ?? null) ) {
+                foreach ( $variableBindings['bindings'] as $binding ) {
+                    if ( ! is_array($binding) ) {
+                        continue;
+                    }
+                    $summary['binding_count']++;
+                    foreach ( array('source' => 'by_source', 'target_role' => 'by_role', 'value_type' => 'by_value_type', 'resolved_data_type' => 'by_resolved_data_type') as $sourceKey => $bucketKey ) {
+                        if ( isset($binding[$sourceKey]) && is_scalar($binding[$sourceKey]) ) {
+                            $bucket = (string) $binding[$sourceKey];
+                            $summary[$bucketKey][$bucket] = ($summary[$bucketKey][$bucket] ?? 0) + 1;
+                        }
+                    }
+                }
+                $nodeSample['binding_count'] = count($variableBindings['bindings']);
+            }
+
+            if ( is_array($variableBindings['values'] ?? null) ) {
+                $summary['value_count'] += count($variableBindings['values']);
+                $summary['variable_definition_count']++;
+                foreach ( $variableBindings['values'] as $value ) {
+                    if ( ! is_array($value) ) {
+                        continue;
+                    }
+                    foreach ( array('value_type' => 'by_value_type', 'resolved_data_type' => 'by_resolved_data_type') as $sourceKey => $bucketKey ) {
+                        if ( isset($value[$sourceKey]) && is_scalar($value[$sourceKey]) ) {
+                            $bucket = (string) $value[$sourceKey];
+                            $summary[$bucketKey][$bucket] = ($summary[$bucketKey][$bucket] ?? 0) + 1;
+                        }
+                    }
+                }
+                $nodeSample['value_count'] = count($variableBindings['values']);
+            }
+
+            if ( is_array($variableBindings['modes'] ?? null) ) {
+                $summary['variable_set_count']++;
+                $nodeSample['mode_count'] = count($variableBindings['modes']);
+            }
+
+            if ( count($summary['sample_nodes']) < $summary['sample_limit'] ) {
+                $summary['sample_nodes'][] = array_filter($nodeSample, static fn (mixed $value): bool => null !== $value);
+            } else {
+                $summary['sample_nodes_truncated'] = true;
+            }
+        }
+
+        foreach ( array('by_source', 'by_role', 'by_value_type', 'by_resolved_data_type') as $bucketKey ) {
+            arsort($summary[$bucketKey]);
+        }
+
+        return $summary;
+    }
+
+    /**
      * @param array<string, mixed> $value
      */
     private function normalizeVariableAnyValue(array $value): mixed
@@ -835,6 +935,62 @@ final class ScenegraphNormalizer
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     * @return array<string, mixed>
+     */
+    private function normalizeVariableAnyValueMetadata(array $value): array
+    {
+        foreach ( array('boolValue' => 'bool', 'textValue' => 'text', 'floatValue' => 'float') as $key => $type ) {
+            if ( array_key_exists($key, $value) && is_scalar($value[$key]) ) {
+                return array('value_type' => $type);
+            }
+        }
+
+        if ( is_array($value['alias'] ?? null) ) {
+            $variableId = $this->readGuidId($value['alias']['guid'] ?? null);
+            return array_filter(array(
+                'value_type'  => 'alias',
+                'variable_id' => $variableId,
+            ), static fn (mixed $value): bool => null !== $value);
+        }
+
+        if ( is_array($value['colorValue'] ?? null) ) {
+            return array('value_type' => 'color');
+        }
+        if ( is_array($value['symbolIdValue']['guid'] ?? null) ) {
+            return array(
+                'value_type' => 'symbol_id',
+                'symbol_id'  => $this->readGuidId($value['symbolIdValue']['guid']),
+            );
+        }
+        if ( is_array($value['textDataValue'] ?? null) ) {
+            return array('value_type' => 'text_data');
+        }
+        if ( is_array($value['vectorValue'] ?? null) ) {
+            return array('value_type' => 'vector');
+        }
+        if ( is_array($value['linkValue'] ?? null) ) {
+            return array('value_type' => 'link');
+        }
+        if ( is_array($value['propRefValue'] ?? null) ) {
+            $propRefId = $this->readGuidId($value['propRefValue']['defId'] ?? null);
+            return array_filter(array(
+                'value_type'  => 'prop_ref',
+                'prop_ref_id' => $propRefId,
+            ), static fn (mixed $value): bool => null !== $value);
+        }
+
+        if ( ! empty($value) ) {
+            return array(
+                'value_type' => 'unresolved',
+                'value_keys' => array_values(array_filter(array_keys($value), 'is_string')),
+            );
+        }
+
+        return array();
     }
 
     /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -5287,6 +5287,40 @@ $variableBindingResult = $variableBindingNormalizer->normalize(array(
             ),
         ),
         array(
+            'id'        => 'variable-node-color',
+            'type'      => 'VARIABLE',
+            'name'      => 'Color / Brand',
+            'variableResolvedType' => 'COLOR',
+            'variableSetID' => array('guid' => array('sessionID' => 9, 'localID' => 1)),
+            'variableScopes' => array('ALL_FILLS', 'STROKE'),
+            'variableDataValues' => array(
+                'entries' => array(
+                    array(
+                        'modeID' => array('sessionID' => 9, 'localID' => 2),
+                        'variableData' => array(
+                            'dataType' => 'COLOR',
+                            'resolvedDataType' => 'COLOR',
+                            'value' => array('colorValue' => array('r' => 0.1, 'g' => 0.2, 'b' => 0.3, 'a' => 1.0)),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array(
+            'id'        => 'variable-set-spacing',
+            'type'      => 'VARIABLE_SET',
+            'name'      => 'Spacing',
+            'variableSetModes' => array(
+                array(
+                    'id' => array('sessionID' => 9, 'localID' => 2),
+                    'name' => 'Desktop',
+                    'sortPosition' => '!',
+                    'parentVariableSetId' => array('guid' => array('sessionID' => 9, 'localID' => 1)),
+                    'parentModeId' => array('sessionID' => 9, 'localID' => 2),
+                ),
+            ),
+        ),
+        array(
             'id'        => 'variable-frame',
             'type'      => 'FRAME',
             'name'      => 'Variable Frame',
@@ -5313,7 +5347,15 @@ $variableBindingResult = $variableBindingNormalizer->normalize(array(
                         'variableData' => array(
                             'dataType' => 'PROP_REF',
                             'resolvedDataType' => 'TEXT_DATA',
-                            'value' => array(),
+                            'value' => array('propRefValue' => array('defId' => array('sessionID' => 7, 'localID' => 4))),
+                        ),
+                    ),
+                    array(
+                        'nodeField' => 17,
+                        'variableData' => array(
+                            'dataType' => 'ALIAS',
+                            'resolvedDataType' => 'FLOAT',
+                            'value' => array('alias' => array('guid' => array('sessionID' => 9, 'localID' => 3))),
                         ),
                     ),
                 ),
@@ -5322,13 +5364,41 @@ $variableBindingResult = $variableBindingNormalizer->normalize(array(
     ),
 ));
 $variableFrameBindings = $variableBindingResult['node_map']['variable-frame']['figma_variable_bindings'] ?? array();
-$assert(2 === ($variableFrameBindings['summary']['binding_count'] ?? null), 'variable-bindings-normalized-count');
+$assert(3 === ($variableFrameBindings['summary']['binding_count'] ?? null), 'variable-bindings-normalized-count');
 $assert(1 === ($variableFrameBindings['summary']['by_role']['layout'] ?? null), 'variable-bindings-layout-role');
 $assert(1 === ($variableFrameBindings['summary']['by_role']['text'] ?? null), 'variable-bindings-text-role');
+$assert(1 === ($variableFrameBindings['summary']['by_role']['unknown'] ?? null), 'variable-bindings-node-field-unknown-role');
 $assert('9:3' === ($variableFrameBindings['bindings'][0]['variable_id'] ?? null), 'variable-bindings-alias-guid-normalized');
+$assert('alias' === ($variableFrameBindings['bindings'][0]['value_type'] ?? null), 'variable-bindings-alias-value-type');
+$assert('TEXT_DATA' === ($variableFrameBindings['bindings'][1]['variable_field'] ?? null), 'variable-bindings-variable-field-preserved');
+$assert('prop_ref' === ($variableFrameBindings['bindings'][1]['value_type'] ?? null), 'variable-bindings-prop-ref-value-type');
+$assert('7:4' === ($variableFrameBindings['bindings'][1]['prop_ref_id'] ?? null), 'variable-bindings-prop-ref-id-normalized');
+$assert('17' === ($variableFrameBindings['bindings'][2]['node_field'] ?? null), 'variable-bindings-node-field-preserved');
+$assert('nodeField:17' === ($variableFrameBindings['bindings'][2]['target_field'] ?? null), 'variable-bindings-node-field-target-normalized');
 $variableDefinition = $variableBindingResult['node_map']['variable-node-gap']['figma_variable_bindings'] ?? array();
 $assert('FLOAT' === ($variableDefinition['resolved_type'] ?? null), 'variable-definition-resolved-type');
 $assert(16.0 === ($variableDefinition['values'][0]['value'] ?? null), 'variable-definition-mode-value');
+$assert('float' === ($variableDefinition['values'][0]['value_type'] ?? null), 'variable-definition-float-value-type');
+$assert('9:1' === ($variableDefinition['variable_set_id'] ?? null), 'variable-definition-set-id-normalized');
+$assert(array('GAP') === ($variableDefinition['scopes'] ?? null), 'variable-definition-scopes-normalized');
+$variableColorDefinition = $variableBindingResult['node_map']['variable-node-color']['figma_variable_bindings'] ?? array();
+$assert('color' === ($variableColorDefinition['values'][0]['value_type'] ?? null), 'variable-definition-color-value-type');
+$assert(array('r' => 0.1, 'g' => 0.2, 'b' => 0.3, 'a' => 1.0) === ($variableColorDefinition['values'][0]['value'] ?? null), 'variable-definition-color-value-preserved');
+$variableSetDefinition = $variableBindingResult['node_map']['variable-set-spacing']['figma_variable_bindings'] ?? array();
+$assert('9:2' === ($variableSetDefinition['modes'][0]['id'] ?? null), 'variable-set-mode-id-normalized');
+$assert('Desktop' === ($variableSetDefinition['modes'][0]['name'] ?? null), 'variable-set-mode-name-preserved');
+$assert('9:1' === ($variableSetDefinition['modes'][0]['parent_variable_set_id'] ?? null), 'variable-set-mode-parent-set-id-normalized');
+$assert('9:2' === ($variableSetDefinition['modes'][0]['parent_mode_id'] ?? null), 'variable-set-mode-parent-mode-id-normalized');
+$variableSourceSummary = $variableBindingResult['source_report']['variable_bindings'] ?? array();
+$assert(4 === ($variableSourceSummary['node_count'] ?? null), 'variable-source-summary-node-count');
+$assert(3 === ($variableSourceSummary['binding_count'] ?? null), 'variable-source-summary-binding-count');
+$assert(2 === ($variableSourceSummary['value_count'] ?? null), 'variable-source-summary-value-count');
+$assert(2 === ($variableSourceSummary['variable_definition_count'] ?? null), 'variable-source-summary-definition-count');
+$assert(1 === ($variableSourceSummary['variable_set_count'] ?? null), 'variable-source-summary-set-count');
+$assert(2 === ($variableSourceSummary['by_value_type']['alias'] ?? null), 'variable-source-summary-alias-count');
+$assert(1 === ($variableSourceSummary['by_value_type']['prop_ref'] ?? null), 'variable-source-summary-prop-ref-count');
+$assert(1 === ($variableSourceSummary['by_value_type']['float'] ?? null), 'variable-source-summary-float-count');
+$assert(1 === ($variableSourceSummary['by_value_type']['color'] ?? null), 'variable-source-summary-color-count');
 
 blocks_engine_figma_transformer_run_fixture_matrix_contract($assert);
 blocks_engine_figma_transformer_run_node_trace_contract($assert);


### PR DESCRIPTION
## Summary
- Preserve richer Kiwi variable binding metadata and value types.
- Add normalized variable-binding source report summaries for parser parity.
- Extend contracts for alias, prop-ref, direct values, modes, scopes, and summaries.

## Testing
- php -l src/Scenegraph/ScenegraphNormalizer.php
- php -l scripts/figma-parser-parity.php
- php -l tests/contract/run.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Orchestrating the Kiwi parsing minion result, resolving rebase conflicts, validating, committing, and preparing this PR description.