### PR TITLE
figma-transformer: preserve Kiwi text line metadata

### DIFF
--- a/figma-transformer/src/Scenegraph/TextNormalizer.php
+++ b/figma-transformer/src/Scenegraph/TextNormalizer.php
@@ -12,6 +12,7 @@ final class TextNormalizer
     private const MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES = 262144;
     private const MAX_TEXT_GLYPH_COMMAND_BLOB_BYTES_PER_NODE = 262144;
     private const MAX_LOGICAL_CHARACTER_OFFSET_SAMPLES = 256;
+    private const MAX_TEXT_LINE_SAMPLES = 256;
 
     public function __construct(
         private readonly VectorGeometryNormalizer $vectorGeometryNormalizer = new VectorGeometryNormalizer()
@@ -169,7 +170,8 @@ final class TextNormalizer
      */
     private function normalizeDerivedTextLayout(array $node, array $blobs = array(), string $nodeId = '', array &$diagnostics = array(), bool $decodeGlyphCommandBlobs = false): array
     {
-        $source = is_array($node['derivedTextData'] ?? null) ? $node['derivedTextData'] : array();
+        $textDataSource = is_array($node['textData'] ?? null) ? $node['textData'] : array();
+        $source = is_array($node['derivedTextData'] ?? null) ? $node['derivedTextData'] : $textDataSource;
         if ( empty($source) ) {
             return array();
         }
@@ -217,8 +219,9 @@ final class TextNormalizer
         }
 
         foreach ( array('truncationStartIndex' => 'truncation_start_index', 'truncatedHeight' => 'truncated_height', 'minContentHeight' => 'min_content_height', 'layoutVersion' => 'layout_version') as $sourceKey => $targetKey ) {
-            if ( isset($source[$sourceKey]) && is_numeric($source[$sourceKey]) ) {
-                $layout[$targetKey] = (float) $source[$sourceKey];
+            $value = $source[$sourceKey] ?? $textDataSource[$sourceKey] ?? null;
+            if ( is_numeric($value) ) {
+                $layout[$targetKey] = (float) $value;
             }
         }
 
@@ -246,6 +249,30 @@ final class TextNormalizer
         foreach ( array('lines' => 'line_count', 'derivedLines' => 'derived_line_count') as $sourceKey => $targetKey ) {
             if ( is_array($source[$sourceKey] ?? null) ) {
                 $layout[$targetKey] = count($source[$sourceKey]);
+            }
+        }
+
+        $lineSource = is_array($textDataSource['lines'] ?? null) ? $textDataSource['lines'] : ( is_array($source['lines'] ?? null) ? $source['lines'] : array() );
+        if ( ! empty($lineSource) ) {
+            $layout['line_count'] = count($lineSource);
+            $lines = $this->normalizeTextLines($lineSource, false);
+            if ( ! empty($lines) ) {
+                $layout['lines'] = $lines;
+                if ( count($lineSource) > self::MAX_TEXT_LINE_SAMPLES ) {
+                    $layout['lines_truncated'] = true;
+                }
+            }
+        }
+
+        $derivedLineSource = is_array($source['derivedLines'] ?? null) ? $source['derivedLines'] : ( is_array($textDataSource['derivedLines'] ?? null) ? $textDataSource['derivedLines'] : array() );
+        if ( ! empty($derivedLineSource) ) {
+            $layout['derived_line_count'] = count($derivedLineSource);
+            $derivedLines = $this->normalizeTextLines($derivedLineSource, true);
+            if ( ! empty($derivedLines) ) {
+                $layout['derived_lines'] = $derivedLines;
+                if ( count($derivedLineSource) > self::MAX_TEXT_LINE_SAMPLES ) {
+                    $layout['derived_lines_truncated'] = true;
+                }
             }
         }
 
@@ -330,6 +357,47 @@ final class TextNormalizer
             }
         }
         return $this->appendDerivedTextFonts($layout, $source);
+    }
+
+    /**
+     * @param array<int, mixed> $lines
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeTextLines(array $lines, bool $derived): array
+    {
+        $normalizedLines = array();
+        foreach ( $lines as $line ) {
+            if ( count($normalizedLines) >= self::MAX_TEXT_LINE_SAMPLES ) {
+                break;
+            }
+            if ( ! is_array($line) ) {
+                continue;
+            }
+
+            $normalized = array();
+            foreach ( array('lineType' => 'line_type', 'sourceDirectionality' => 'source_directionality', 'directionality' => 'directionality', 'directionalityIntent' => 'directionality_intent') as $sourceKey => $targetKey ) {
+                if ( isset($line[$sourceKey]) && is_scalar($line[$sourceKey]) && '' !== (string) $line[$sourceKey] ) {
+                    $normalized[$targetKey] = (string) $line[$sourceKey];
+                }
+            }
+
+            if ( ! $derived ) {
+                foreach ( array('styleId' => 'style_id', 'indentationLevel' => 'indentation_level', 'downgradeStyleId' => 'downgrade_style_id', 'consistencyStyleId' => 'consistency_style_id', 'listStartOffset' => 'list_start_offset') as $sourceKey => $targetKey ) {
+                    if ( isset($line[$sourceKey]) && is_numeric($line[$sourceKey]) ) {
+                        $normalized[$targetKey] = (int) $line[$sourceKey];
+                    }
+                }
+                if ( isset($line['isFirstLineOfList']) && is_bool($line['isFirstLineOfList']) ) {
+                    $normalized['is_first_line_of_list'] = $line['isFirstLineOfList'];
+                }
+            }
+
+            if ( ! empty($normalized) ) {
+                $normalizedLines[] = $normalized;
+            }
+        }
+
+        return $normalizedLines;
     }
 
     /**
@@ -464,6 +532,22 @@ final class TextNormalizer
 
         if ( isset($source['maxLines']) && is_numeric($source['maxLines']) ) {
             $style['max_lines'] = (int) $source['maxLines'];
+        }
+
+        foreach ( array('textBidiVersion' => 'text_bidi_version') as $sourceKey => $targetKey ) {
+            if ( isset($source[$sourceKey]) && is_numeric($source[$sourceKey]) ) {
+                $style[$targetKey] = (int) $source[$sourceKey];
+            }
+        }
+
+        foreach ( array('hangingPunctuation' => 'hanging_punctuation', 'hangingList' => 'hanging_list', 'hasHadRTLText' => 'has_had_rtl_text') as $sourceKey => $targetKey ) {
+            if ( isset($source[$sourceKey]) && is_bool($source[$sourceKey]) ) {
+                $style[$targetKey] = $source[$sourceKey];
+            }
+        }
+
+        if ( isset($source['listSpacing']) && is_numeric($source['listSpacing']) ) {
+            $style['list_spacing'] = (float) $source['listSpacing'];
         }
 
         foreach ( array('color', 'textColor') as $sourceKey ) {

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -265,6 +265,7 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert(3 === ($kiwiDerivedText['truncationStartIndex'] ?? null), 'kiwi-selective-decodes-derived-text-truncation-start');
     $assert(24.0 === ($kiwiDerivedText['truncatedHeight'] ?? null), 'kiwi-selective-decodes-derived-text-truncated-height');
     $assert(array(0.0, 12.5) === ($kiwiDerivedText['logicalIndexToCharacterOffsetMap'] ?? null), 'kiwi-selective-decodes-derived-text-logical-offset-map');
+    $assert('RTL' === ($kiwiDerivedText['derivedLines'][0]['directionality'] ?? null), 'kiwi-selective-decodes-derived-text-line-directionality');
     $kiwiDerivedTextWithGlyphsMessage = $kiwiDecoder->decodeMessageSelective(
         blocks_engine_figma_transformer_kiwi_derived_text_message_fixture(),
         $kiwiDerivedTextSchema['schema'] ?? array(),
@@ -993,7 +994,7 @@ function blocks_engine_figma_transformer_kiwi_export_settings_bytes(string $form
 
 function blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture(): string
 {
-    return blocks_engine_figma_transformer_wire_varint(9)
+    return blocks_engine_figma_transformer_wire_varint(11)
         // def0: ENUM MessageType { NODE_CHANGES = 1 }
         . blocks_engine_figma_transformer_kiwi_string('MessageType')
         . chr(0)
@@ -1042,10 +1043,22 @@ function blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture(): str
         . blocks_engine_figma_transformer_kiwi_schema_field('key', 2, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('fontLineHeight', -5, false, 2)
         . blocks_engine_figma_transformer_kiwi_schema_field('fontWeight', -3, false, 3)
-        // def6: STRUCT DerivedTextData { layoutSize, baselines[], glyphs[], fontMetaData, truncationStartIndex, truncatedHeight, logicalIndexToCharacterOffsetMap[] }
+        // def6: ENUM Directionality { UNKNOWN, LTR, RTL }
+        . blocks_engine_figma_transformer_kiwi_string('Directionality')
+        . chr(0)
+        . blocks_engine_figma_transformer_wire_varint(3)
+        . blocks_engine_figma_transformer_kiwi_schema_field('UNKNOWN', 0, false, 0)
+        . blocks_engine_figma_transformer_kiwi_schema_field('LTR', 0, false, 1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('RTL', 0, false, 2)
+        // def7: MESSAGE DerivedTextLineData { directionality }
+        . blocks_engine_figma_transformer_kiwi_string('DerivedTextLineData')
+        . chr(2)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_schema_field('directionality', 6, false, 1)
+        // def8: STRUCT DerivedTextData { layoutSize, baselines[], glyphs[], fontMetaData, truncationStartIndex, truncatedHeight, logicalIndexToCharacterOffsetMap[], derivedLines[] }
         . blocks_engine_figma_transformer_kiwi_string('DerivedTextData')
         . chr(1)
-        . blocks_engine_figma_transformer_wire_varint(7)
+        . blocks_engine_figma_transformer_wire_varint(8)
         . blocks_engine_figma_transformer_kiwi_schema_field('layoutSize', 1, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('baselines', 3, true, 2)
         . blocks_engine_figma_transformer_kiwi_schema_field('glyphs', 4, true, 3)
@@ -1053,19 +1066,20 @@ function blocks_engine_figma_transformer_kiwi_derived_text_schema_fixture(): str
         . blocks_engine_figma_transformer_kiwi_schema_field('truncationStartIndex', -3, false, 5)
         . blocks_engine_figma_transformer_kiwi_schema_field('truncatedHeight', -5, false, 6)
         . blocks_engine_figma_transformer_kiwi_schema_field('logicalIndexToCharacterOffsetMap', -5, true, 7)
-        // def7: MESSAGE NodeChange { type, name, derivedTextData }
+        . blocks_engine_figma_transformer_kiwi_schema_field('derivedLines', 7, true, 8)
+        // def9: MESSAGE NodeChange { type, name, derivedTextData }
         . blocks_engine_figma_transformer_kiwi_string('NodeChange')
         . chr(2)
         . blocks_engine_figma_transformer_wire_varint(3)
         . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('name', -6, false, 2)
-        . blocks_engine_figma_transformer_kiwi_schema_field('derivedTextData', 6, false, 3)
-        // def8: MESSAGE Message { type, nodeChanges[] }
+        . blocks_engine_figma_transformer_kiwi_schema_field('derivedTextData', 8, false, 3)
+        // def10: MESSAGE Message { type, nodeChanges[] }
         . blocks_engine_figma_transformer_kiwi_string('Message')
         . chr(2)
         . blocks_engine_figma_transformer_wire_varint(2)
         . blocks_engine_figma_transformer_kiwi_schema_field('type', 0, false, 1)
-        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 7, true, 2);
+        . blocks_engine_figma_transformer_kiwi_schema_field('nodeChanges', 9, true, 2);
 }
 
 function blocks_engine_figma_transformer_kiwi_derived_text_message_fixture(): string
@@ -1115,6 +1129,11 @@ function blocks_engine_figma_transformer_kiwi_derived_text_message_fixture(): st
         . blocks_engine_figma_transformer_wire_varint(2)
         . blocks_engine_figma_transformer_kiwi_varfloat(0.0)
         . blocks_engine_figma_transformer_kiwi_varfloat(12.5)
+        // DerivedTextData.derivedLines[].
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);
 }

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -34,6 +34,30 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
                 'height'          => 32.25,
                 'fontSize'        => 10,
                 'fontName'        => array('family' => 'Example Sans', 'style' => 'Regular'),
+                'textTruncation'  => 'ENDING',
+                'textWrapStyle'   => 'BALANCE',
+                'maxLines'        => 2,
+                'hangingList'     => true,
+                'hangingPunctuation' => false,
+                'hasHadRTLText'   => true,
+                'textBidiVersion' => 3,
+                'listSpacing'     => 8,
+                'textData'        => array(
+                    'lines' => array(
+                        array(
+                            'lineType'             => 'BULLET',
+                            'styleId'              => 4,
+                            'indentationLevel'     => 1,
+                            'sourceDirectionality' => 'AUTO',
+                            'directionality'       => 'LTR',
+                            'directionalityIntent' => 'EXPLICIT',
+                            'downgradeStyleId'     => 2,
+                            'consistencyStyleId'   => 3,
+                            'listStartOffset'      => 1,
+                            'isFirstLineOfList'    => true,
+                        ),
+                    ),
+                ),
                 'derivedTextData' => array(
                     'layoutSize' => array('x' => 146.5, 'y' => 32.25),
                     'baselines'  => array(
@@ -60,11 +84,16 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
                         ),
                     ),
                     'logicalIndexToCharacterOffsetMap' => range(0, 299),
+                    'derivedLines' => array(
+                        array('directionality' => 'RTL'),
+                    ),
                 ),
             ),
         ),
     );
     $derivedTextLayoutResult = blocks_engine_figma_transformer_transform_scenegraph($derivedTextLayoutScenegraph);
+    $derivedTextNormalized = ( new \Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer() )->normalize($derivedTextLayoutScenegraph);
+    $derivedTextNormalizedNode = $derivedTextNormalized['nodes'][0] ?? array();
     $derivedTextVisualNodes = $derivedTextLayoutResult['source_reports']['figma']['html']['visual_node_map'] ?? array();
     $derivedTextVisualNode = null;
     foreach ( is_array($derivedTextVisualNodes) ? $derivedTextVisualNodes : array() as $visualNode ) {
@@ -80,6 +109,20 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     $assert(300 === ($derivedTextVisualNode['text']['derived_layout']['logical_character_offset_count'] ?? null), 'visual-node-derived-text-logical-offset-count');
     $assert(256 === count($derivedTextVisualNode['text']['derived_layout']['logical_character_offsets'] ?? array()), 'visual-node-derived-text-logical-offset-sample-count');
     $assert(true === ($derivedTextVisualNode['text']['derived_layout']['logical_character_offsets_truncated'] ?? null), 'visual-node-derived-text-logical-offset-truncated');
+    $assert(1 === ($derivedTextVisualNode['text']['derived_layout']['line_count'] ?? null), 'visual-node-text-line-count');
+    $assert('BULLET' === ($derivedTextVisualNode['text']['derived_layout']['lines'][0]['line_type'] ?? null), 'visual-node-text-line-type');
+    $assert(1 === ($derivedTextVisualNode['text']['derived_layout']['lines'][0]['indentation_level'] ?? null), 'visual-node-text-line-indentation');
+    $assert('LTR' === ($derivedTextVisualNode['text']['derived_layout']['lines'][0]['directionality'] ?? null), 'visual-node-text-line-directionality');
+    $assert(true === ($derivedTextVisualNode['text']['derived_layout']['lines'][0]['is_first_line_of_list'] ?? null), 'visual-node-text-line-list-first');
+    $assert(1 === ($derivedTextVisualNode['text']['derived_layout']['derived_line_count'] ?? null), 'visual-node-derived-text-line-count');
+    $assert('RTL' === ($derivedTextVisualNode['text']['derived_layout']['derived_lines'][0]['directionality'] ?? null), 'visual-node-derived-text-line-directionality');
+    $assert('ending' === ($derivedTextNormalizedNode['figma_text']['style']['text_truncation'] ?? null), 'normalized-text-style-truncation');
+    $assert('balance' === ($derivedTextNormalizedNode['figma_text']['style']['text_wrap_style'] ?? null), 'normalized-text-style-wrap');
+    $assert(true === ($derivedTextNormalizedNode['figma_text']['style']['hanging_list'] ?? null), 'normalized-text-style-hanging-list');
+    $assert(false === ($derivedTextNormalizedNode['figma_text']['style']['hanging_punctuation'] ?? null), 'normalized-text-style-hanging-punctuation');
+    $assert(true === ($derivedTextNormalizedNode['figma_text']['style']['has_had_rtl_text'] ?? null), 'normalized-text-style-had-rtl');
+    $assert(3 === ($derivedTextNormalizedNode['figma_text']['style']['text_bidi_version'] ?? null), 'normalized-text-style-bidi-version');
+    $assert(8.0 === ($derivedTextNormalizedNode['figma_text']['style']['list_spacing'] ?? null), 'normalized-text-style-list-spacing');
     $assert(! isset($derivedTextVisualNode['text']['derived_layout']['glyph_paths']), 'visual-node-derived-text-default-omits-glyph-paths');
     $assert('dom_text' === ($derivedTextVisualNode['text']['glyph_rendering'] ?? null), 'visual-node-derived-text-default-dom-rendering');
     $derivedTextLayoutCss = $fileContent($derivedTextLayoutResult, 'style.css');


### PR DESCRIPTION
## Summary
- Preserve bounded Kiwi text line and derived-line metadata in normalized text layout.
- Normalize truncation, wrap, list, hanging, bidi, and directionality metadata.
- Add parser and text layout contracts for line-level text parity.

## Testing
- php -l src/Scenegraph/TextNormalizer.php
- php -l tests/contract/KiwiParserContract.php
- php -l tests/contract/TextLayoutContract.php
- composer test:contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Orchestrating the Kiwi parsing minion result, rebasing, validating, committing, and preparing this PR description.