### PR TITLE
figma-transformer: apply Kiwi derived symbol overrides

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -64,6 +64,7 @@ final class FigKiwiDecodePolicy
             'Constraints' => array('horizontal', 'vertical'),
             'SymbolData' => array('symbolID', 'symbolOverrides', 'uniformScaleFactor'),
             'DerivedSymbolData' => array('symbolID', 'symbolOverrides', 'uniformScaleFactor'),
+            'SymbolOverride' => array('nodeId', 'node_id', 'id', 'guidPath', 'characters', 'text', 'name', 'textData', 'derivedTextData', 'fontName', 'fontFamily', 'fontPostScriptName', 'fontWeight', 'fontSize', 'lineHeight', 'lineHeightPx', 'lineHeightPercent', 'letterSpacing', 'listSpacing', 'styleIdForText', 'size', 'relativeTransform', 'absoluteTransform', 'transform', 'fillPaints', 'fills', 'strokes', 'strokePaints', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight', 'effects', 'styleIdForFill', 'styleIdForStrokeFill', 'styleIdForStroke', 'styleIdForEffect', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'arcData', 'cornerRadius', 'rectangleTopLeftCornerRadius', 'rectangleTopRightCornerRadius', 'rectangleBottomLeftCornerRadius', 'rectangleBottomRightCornerRadius', 'stackMode', 'stackPrimarySizing', 'stackCounterSizing', 'stackPositioning', 'stackChildAlignSelf', 'stackChildPrimaryGrow', 'componentPropAssignments'),
             'GUIDPath' => array('guids'),
             'StyleId' => array('guid'),
             'StateGroupPropertyValueOrder' => array('property', 'values'),

--- a/figma-transformer/src/Scenegraph/InstanceResolver.php
+++ b/figma-transformer/src/Scenegraph/InstanceResolver.php
@@ -16,16 +16,7 @@ final class InstanceResolver
      */
     public function normalizeInstanceOverrides(array $node, string $instanceId, array &$diagnostics): ?array
     {
-        $rawOverrides = array();
-        if ( is_array($node['overrides'] ?? null) ) {
-            $rawOverrides = array_merge($rawOverrides, $node['overrides']);
-        }
-        if ( is_array($node['symbolData']['symbolOverrides'] ?? null) ) {
-            $rawOverrides = array_merge($rawOverrides, $node['symbolData']['symbolOverrides']);
-        }
-        if ( is_array($node['derivedSymbolData'] ?? null) ) {
-            $rawOverrides = array_merge($rawOverrides, $node['derivedSymbolData']);
-        }
+        $rawOverrides = $this->collectRawOverrides($node);
 
         if ( empty($rawOverrides) ) {
             return array();
@@ -64,6 +55,41 @@ final class InstanceResolver
         }
 
         return $overrides;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int|string, mixed>
+     */
+    private function collectRawOverrides(array $node): array
+    {
+        $rawOverrides = array();
+        foreach ( array('overrides', 'symbolOverrides') as $key ) {
+            if ( is_array($node[$key] ?? null) ) {
+                $rawOverrides = array_merge($rawOverrides, $node[$key]);
+            }
+        }
+
+        foreach ( array('symbolData', 'derivedSymbolData') as $key ) {
+            $payload = $node[$key] ?? null;
+            if ( ! is_array($payload) ) {
+                continue;
+            }
+
+            if ( is_array($payload['symbolOverrides'] ?? null) ) {
+                $rawOverrides = array_merge($rawOverrides, $payload['symbolOverrides']);
+                continue;
+            }
+
+            // Older normalized fixtures stored DerivedSymbolData as the override
+            // list itself. Keep accepting that shape while preferring the real
+            // Kiwi struct shape above.
+            if ( 'derivedSymbolData' === $key && array_is_list($payload) ) {
+                $rawOverrides = array_merge($rawOverrides, $payload);
+            }
+        }
+
+        return $rawOverrides;
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1043,6 +1043,14 @@ final class ScenegraphNormalizer
             $metadata['component_properties'] = $node['componentProperties'];
         }
 
+        if ( is_array($node['componentPropDefs'] ?? null) ) {
+            $metadata['component_prop_defs'] = $node['componentPropDefs'];
+        }
+
+        if ( is_array($node['componentPropRefs'] ?? null) ) {
+            $metadata['component_prop_refs'] = $node['componentPropRefs'];
+        }
+
         if ( true === ($node['isStateGroup'] ?? false) ) {
             $metadata['state_group'] = true;
         }

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -1512,6 +1512,8 @@ function blocks_engine_figma_transformer_kiwi_document_metadata_message_fixture(
         . blocks_engine_figma_transformer_wire_varint(1)
         . $node
         . blocks_engine_figma_transformer_wire_varint(0);
+}
+
 function blocks_engine_figma_transformer_kiwi_derived_symbol_schema_fixture(): string
 {
     $field = 'blocks_engine_figma_transformer_kiwi_schema_field';

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -319,6 +319,20 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert(array('Desktop', 'Mobile') === ($kiwiStateGroupNode['stateGroupPropertyValueOrders'][0]['values'] ?? null), 'kiwi-selective-decodes-state-group-order-values');
     $assert('Desktop' === ($kiwiVariantNode['variantPropSpecs'][0]['value'] ?? null), 'kiwi-selective-decodes-variant-prop-spec-value');
 
+    $kiwiDerivedSymbolSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_derived_symbol_schema_fixture());
+    $kiwiDerivedSymbolMessage = $kiwiDecoder->decodeMessageSelective(
+        blocks_engine_figma_transformer_kiwi_derived_symbol_message_fixture(),
+        $kiwiDerivedSymbolSchema['schema'] ?? array()
+    );
+    $kiwiDerivedSymbolNode = $kiwiDerivedSymbolMessage['message']['nodeChanges'][0] ?? array();
+    $kiwiDerivedSymbolOverride = $kiwiDerivedSymbolNode['derivedSymbolData']['symbolOverrides'][0] ?? array();
+    $assert('40:1' === blocks_engine_figma_transformer_kiwi_format_guid($kiwiDerivedSymbolNode['derivedSymbolData']['symbolID']['guid'] ?? null), 'kiwi-selective-decodes-derived-symbol-id');
+    $assert('40:2' === blocks_engine_figma_transformer_kiwi_format_guid($kiwiDerivedSymbolOverride['guidPath']['guids'][0] ?? null), 'kiwi-selective-decodes-derived-symbol-override-guid-path');
+    $assert('Derived override' === ($kiwiDerivedSymbolOverride['textData']['characters'] ?? null), 'kiwi-selective-decodes-derived-symbol-override-text');
+    $kiwiDerivedSymbolResolverDiagnostics = array();
+    $kiwiDerivedSymbolResolverFields = ( new \Automattic\BlocksEngine\FigmaTransformer\Scenegraph\InstanceResolver() )->normalizeInstanceOverrides($kiwiDerivedSymbolNode, 'kiwi-derived-symbol:instance', $kiwiDerivedSymbolResolverDiagnostics);
+    $assert('Derived override' === ($kiwiDerivedSymbolResolverFields['40:2']['characters'] ?? null), 'kiwi-derived-symbol-resolver-reads-struct-overrides');
+
     $kiwiStateGroupNormalizer = new ScenegraphNormalizer();
     $kiwiStateGroupNormalized = $kiwiStateGroupNormalizer->normalize(array(
         'name'  => 'Kiwi State Group Metadata Fixture',
@@ -331,6 +345,9 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
                 'stateGroupPropertyValueOrders'  => array(
                     array('property' => 'Screen Size', 'values' => array('Desktop', 'Mobile')),
                 ),
+                'componentPropDefs'              => array(
+                    array('id' => array('sessionID' => 2422394609, 'localID' => 4048757538), 'name' => 'Screen Size'),
+                ),
             ),
             array(
                 'id'               => 'state-group:desktop',
@@ -338,6 +355,9 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
                 'name'             => 'Screen Size=Desktop',
                 'variantPropSpecs' => array(
                     array('propDefId' => array('sessionID' => 2422394609, 'localID' => 4048757538), 'value' => 'Desktop'),
+                ),
+                'componentPropRefs' => array(
+                    array('defID' => array('sessionID' => 2422394609, 'localID' => 4048757538), 'componentPropNodeField' => 'VARIANT'),
                 ),
             ),
         ),
@@ -347,8 +367,10 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert(true === ($kiwiStateGroupMetadata['state_group'] ?? null), 'kiwi-state-group-normalizes-component-flag');
     $assert('Screen Size' === ($kiwiStateGroupMetadata['state_group_property_value_orders'][0]['property'] ?? null), 'kiwi-state-group-normalizes-order-property');
     $assert(array('Desktop', 'Mobile') === ($kiwiStateGroupMetadata['state_group_property_value_orders'][0]['values'] ?? null), 'kiwi-state-group-normalizes-order-values');
+    $assert('Screen Size' === ($kiwiStateGroupMetadata['component_prop_defs'][0]['name'] ?? null), 'kiwi-component-prop-defs-preserved-in-metadata');
     $assert('2422394609:4048757538' === ($kiwiVariantMetadata['variant_prop_specs'][0]['prop_def_id'] ?? null), 'kiwi-variant-normalizes-prop-def-id');
     $assert('Desktop' === ($kiwiVariantMetadata['variant_prop_specs'][0]['value'] ?? null), 'kiwi-variant-normalizes-value');
+    $assert('VARIANT' === ($kiwiVariantMetadata['component_prop_refs'][0]['componentPropNodeField'] ?? null), 'kiwi-component-prop-refs-preserved-in-metadata');
 
     $kiwiDocumentMetadataSchema = $kiwiDecoder->decodeSchema(blocks_engine_figma_transformer_kiwi_document_metadata_schema_fixture());
     $kiwiDocumentMetadataMessage = $kiwiDecoder->decodeMessageSelective(
@@ -1490,6 +1512,68 @@ function blocks_engine_figma_transformer_kiwi_document_metadata_message_fixture(
         . blocks_engine_figma_transformer_wire_varint(1)
         . $node
         . blocks_engine_figma_transformer_wire_varint(0);
+function blocks_engine_figma_transformer_kiwi_derived_symbol_schema_fixture(): string
+{
+    $field = 'blocks_engine_figma_transformer_kiwi_schema_field';
+    $str = 'blocks_engine_figma_transformer_kiwi_string';
+    $v = 'blocks_engine_figma_transformer_wire_varint';
+
+    return $v(8)
+        . $str('GUID') . chr(1) . $v(2)
+        . $field('sessionID', -4, false, 1)
+        . $field('localID', -4, false, 2)
+        . $str('GUIDPath') . chr(1) . $v(1)
+        . $field('guids', 0, true, 1)
+        . $str('TextData') . chr(2) . $v(1)
+        . $field('characters', -6, false, 1)
+        . $str('SymbolId') . chr(1) . $v(1)
+        . $field('guid', 0, false, 1)
+        . $str('SymbolOverride') . chr(2) . $v(2)
+        . $field('guidPath', 1, false, 1)
+        . $field('textData', 2, false, 2)
+        . $str('DerivedSymbolData') . chr(1) . $v(3)
+        . $field('symbolID', 3, false, 1)
+        . $field('symbolOverrides', 4, true, 2)
+        . $field('uniformScaleFactor', -5, false, 3)
+        . $str('NodeChange') . chr(2) . $v(3)
+        . $field('type', -6, false, 1)
+        . $field('name', -6, false, 2)
+        . $field('derivedSymbolData', 5, false, 3)
+        . $str('Message') . chr(2) . $v(2)
+        . $field('type', -6, false, 1)
+        . $field('nodeChanges', 6, true, 2);
+}
+
+function blocks_engine_figma_transformer_kiwi_derived_symbol_message_fixture(): string
+{
+    $str = 'blocks_engine_figma_transformer_kiwi_string';
+    $v = 'blocks_engine_figma_transformer_wire_varint';
+    $symbolId = $v(40) . $v(1);
+    $guidPath = $v(1) . $v(40) . $v(2);
+    $textData = $v(1) . $str('Derived override') . $v(0);
+    $override = $v(1) . $guidPath
+        . $v(2) . $textData
+        . $v(0);
+    $derivedSymbolData = $symbolId
+        . $v(1) . $override
+        . blocks_engine_figma_transformer_kiwi_float(1.0);
+    $node = $v(1) . $str('INSTANCE')
+        . $v(2) . $str('Derived Symbol Instance')
+        . $v(3) . $derivedSymbolData
+        . $v(0);
+
+    return $v(1) . $str('NODE_CHANGES')
+        . $v(2) . $v(1) . $node
+        . $v(0);
+}
+
+function blocks_engine_figma_transformer_kiwi_format_guid(mixed $guid): ?string
+{
+    if ( ! is_array($guid) || ! isset($guid['sessionID'], $guid['localID']) ) {
+        return null;
+    }
+
+    return (string) $guid['sessionID'] . ':' . (string) $guid['localID'];
 }
 
 /**

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3736,6 +3736,48 @@ $assert(! str_contains($derivedSymbolInstanceHtml, '<g transform="scale'), 'deri
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-2-derived-label{width:90px;height:24px;position:absolute;left:12px;top:6px'), 'derived-symbol-instance-label-size-position');
 $assert(str_contains($derivedSymbolInstanceCss, '.figma-node-derived-instance-40-3-derived-icon{width:10px;height:10px;position:absolute;left:110px;top:10px'), 'derived-symbol-instance-icon-size-position');
 
+$derivedSymbolStructInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Derived Symbol Struct Overrides Fixture',
+    'nodes' => array(
+        array(
+            'guid'     => array('sessionID' => 43, 'localID' => 1),
+            'type'     => 'SYMBOL',
+            'name'     => 'Derived Symbol Struct',
+            'children' => array(
+                array(
+                    'guid'       => array('sessionID' => 43, 'localID' => 2),
+                    'type'       => 'TEXT',
+                    'name'       => 'Struct Label',
+                    'characters' => 'Default Struct',
+                    'width'      => 80,
+                    'height'     => 20,
+                ),
+            ),
+        ),
+        array(
+            'id'                => 'derived-struct:instance',
+            'type'              => 'INSTANCE',
+            'name'              => 'Derived Struct Instance',
+            'symbolData'        => array(
+                'symbolID' => array('sessionID' => 43, 'localID' => 1),
+            ),
+            'derivedSymbolData' => array(
+                'symbolID' => array('guid' => array('sessionID' => 43, 'localID' => 1)),
+                'symbolOverrides' => array(
+                    array(
+                        'guidPath' => array('guids' => array(array('sessionID' => 43, 'localID' => 2))),
+                        'textData' => array('characters' => 'Struct override'),
+                    ),
+                ),
+                'uniformScaleFactor' => 1.0,
+            ),
+        ),
+    ),
+));
+$derivedSymbolStructInstanceHtml = $fileContent($derivedSymbolStructInstanceResult, 'index.html');
+$assert(str_contains($derivedSymbolStructInstanceHtml, 'Struct override'), 'derived-symbol-struct-instance-text-override');
+$assert(str_contains($derivedSymbolStructInstanceHtml, 'data-figma-node-id="derived-struct:instance/43:2"'), 'derived-symbol-struct-instance-label-namespaced');
+
 $derivedSymbolPathOverrideResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Derived Symbol Path Override Fixture',
     'blobs' => array(array('bytes' => $vectorCommandBlob)),


### PR DESCRIPTION
## Summary
- Decode derived symbol override fields from Kiwi scenegraph messages.
- Normalize derived symbol overrides through instance resolution.
- Add contract coverage for derived symbol struct overrides and runner coverage.

## Testing
- `php -l figma-transformer/src/FigFile/FigKiwiDecodePolicy.php`
- `php -l figma-transformer/src/Scenegraph/InstanceResolver.php`
- `php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php`
- `php -l figma-transformer/tests/contract/KiwiParserContract.php`
- `php -l figma-transformer/tests/contract/run.php`
- `composer test:contract` from `figma-transformer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Conflict resolution, implementation review, and verification orchestration.