### PR TITLE
figma-transformer: decode Kiwi vector network geometry

### DIFF
--- a/figma-transformer/src/Html/VectorSvgRenderer.php
+++ b/figma-transformer/src/Html/VectorSvgRenderer.php
@@ -297,6 +297,9 @@ final class VectorSvgRenderer
             if ( null !== ($path['windingRule'] ?? null) ) {
                 $attributes[] = 'fill-rule="' . $path['windingRule'] . '"';
             }
+            if ( null !== ($path['styleID'] ?? null) ) {
+                $attributes[] = 'data-figma-style-id="' . $this->sanitizeAttribute($path['styleID']) . '"';
+            }
             $elements[] = '<path d="' . $this->sanitizeAttribute($path['d']) . '" ' . implode(' ', $attributes) . '/>';
         }
 
@@ -305,7 +308,7 @@ final class VectorSvgRenderer
 
     /**
      * @param array<string, mixed> $node
-     * @return array<int, array{d: string, windingRule: string|null}>
+     * @return array<int, array{d: string, windingRule: string|null, styleID: string|null}>
      */
     private function nodeVectorPathData(array $node): array
     {
@@ -340,7 +343,12 @@ final class VectorSvgRenderer
                 }
             }
 
-            $paths[] = array('d' => $path, 'windingRule' => $rule);
+            $styleId = null;
+            if ( is_array($rawPath) && isset($rawPath['styleID']) && is_scalar($rawPath['styleID']) && '' !== trim((string) $rawPath['styleID']) ) {
+                $styleId = (string) $rawPath['styleID'];
+            }
+
+            $paths[] = array('d' => $path, 'windingRule' => $rule, 'styleID' => $styleId);
         }
 
         return $paths;
@@ -391,7 +399,7 @@ final class VectorSvgRenderer
 
     /**
      * @param array<string, mixed> $node
-     * @return array<int, array{paths: array<int, array{d: string, windingRule: string|null}>, paint: array<int, string>, dx: float, dy: float}>
+     * @return array<int, array{paths: array<int, array{d: string, windingRule: string|null, styleID: string|null}>, paint: array<int, string>, dx: float, dy: float}>
      */
     private function booleanOperationChildVectors(array $node): array
     {
@@ -448,6 +456,9 @@ final class VectorSvgRenderer
                 $attributes = $paint;
                 if ( null !== ($path['windingRule'] ?? null) ) {
                     $attributes[] = 'fill-rule="' . $path['windingRule'] . '"';
+                }
+                if ( null !== ($path['styleID'] ?? null) ) {
+                    $attributes[] = 'data-figma-style-id="' . $this->sanitizeAttribute($path['styleID']) . '"';
                 }
                 $elements .= '<path d="' . $this->sanitizeAttribute((string) $path['d']) . '" ' . implode(' ', $attributes) . '/>';
             }
@@ -857,7 +868,7 @@ final class VectorSvgRenderer
     {
         if ( is_array($rawPath) && isset($rawPath['source']) && is_scalar($rawPath['source']) ) {
             $source = (string) $rawPath['source'];
-            if ( str_starts_with($source, 'fillGeometry') || str_starts_with($source, 'strokeGeometry') || 'vectorData.vectorNetworkBlob' === $source ) {
+            if ( str_starts_with($source, 'fillGeometry') || str_starts_with($source, 'strokeGeometry') || str_starts_with($source, 'vectorData.vectorNetwork') ) {
                 return self::MAX_DECODED_FIGMA_SVG_PATH_DATA_BYTES;
             }
         }
@@ -880,6 +891,47 @@ final class VectorSvgRenderer
         if ( null !== $stroke ) {
             $attributes[] = 'stroke="' . $this->sanitizeAttribute($stroke) . '"';
             $attributes[] = 'stroke-width="' . $this->number($this->strokeWeight($node)) . '"';
+            foreach ( $this->strokeGeometryAttributes($node) as $attribute ) {
+                $attributes[] = $attribute;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function strokeGeometryAttributes(array $node): array
+    {
+        $attributes = array();
+
+        $cap = strtoupper((string) ($node['strokeCap'] ?? ''));
+        $capMap = array('ROUND' => 'round', 'SQUARE' => 'square', 'BUTT' => 'butt', 'NONE' => 'butt');
+        if ( isset($capMap[$cap]) ) {
+            $attributes[] = 'stroke-linecap="' . $capMap[$cap] . '"';
+        }
+
+        $join = strtoupper((string) ($node['strokeJoin'] ?? ''));
+        $joinMap = array('ROUND' => 'round', 'BEVEL' => 'bevel', 'MITER' => 'miter');
+        if ( isset($joinMap[$join]) ) {
+            $attributes[] = 'stroke-linejoin="' . $joinMap[$join] . '"';
+        }
+
+        $dashPattern = is_array($node['dashPattern'] ?? null) ? $node['dashPattern'] : array();
+        $dashes = array();
+        foreach ( $dashPattern as $dash ) {
+            if ( ! is_numeric($dash) ) {
+                return $attributes;
+            }
+            $value = max(0.0, (float) $dash);
+            if ( $value > 0.0 ) {
+                $dashes[] = $this->number($value);
+            }
+        }
+        if ( ! empty($dashes) ) {
+            $attributes[] = 'stroke-dasharray="' . implode(' ', $dashes) . '"';
         }
 
         return $attributes;

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -444,6 +444,11 @@ final class ScenegraphNormalizer
             $node['figma_vector_paths'] = $vectorPaths;
         }
 
+        $vectorScale = $this->vectorGeometryNormalizer->normalizedVectorScale($node);
+        if ( null !== $vectorScale ) {
+            $node['figma_vector_scale'] = $vectorScale;
+        }
+
         $box = $this->normalizeVisualBox($node);
         if ( ! empty($box) ) {
             $node['figma_box'] = $box;

--- a/figma-transformer/src/Scenegraph/VectorGeometryNormalizer.php
+++ b/figma-transformer/src/Scenegraph/VectorGeometryNormalizer.php
@@ -11,6 +11,37 @@ final class VectorGeometryNormalizer
 {
     private const MAX_VECTOR_COMMAND_BLOB_COMMANDS = 5000;
     private const MAX_VECTOR_COMMAND_BLOB_PATH_BYTES = 131072;
+    private const MAX_VECTOR_NETWORK_OBJECT_VERTICES = 20000;
+    private const MAX_VECTOR_NETWORK_OBJECT_SEGMENTS = 40000;
+    private const MAX_VECTOR_NETWORK_OBJECT_REGIONS = 20000;
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array{x: float, y: float}|null
+     */
+    public function normalizedVectorScale(array $node): ?array
+    {
+        $size = is_array($node['vectorData']['normalizedSize'] ?? null) ? $node['vectorData']['normalizedSize'] : array();
+        $normalizedWidth = $this->readPointCoordinate($size, 'x') ?? $this->readPointCoordinate($size, 'width');
+        $normalizedHeight = $this->readPointCoordinate($size, 'y') ?? $this->readPointCoordinate($size, 'height');
+        if ( null === $normalizedWidth || null === $normalizedHeight || $normalizedWidth <= 0.0 || $normalizedHeight <= 0.0 ) {
+            return null;
+        }
+
+        $width = $this->rawNodeDimension($node, 'width');
+        $height = $this->rawNodeDimension($node, 'height');
+        if ( $width <= 0.0 || $height <= 0.0 ) {
+            return null;
+        }
+
+        $scaleX = $width / $normalizedWidth;
+        $scaleY = $height / $normalizedHeight;
+        if ( ! is_finite($scaleX) || ! is_finite($scaleY) || ( abs($scaleX - 1.0) < 0.0001 && abs($scaleY - 1.0) < 0.0001 ) ) {
+            return null;
+        }
+
+        return array('x' => $scaleX, 'y' => $scaleY);
+    }
 
     /**
      * @param array<int, array<string, mixed>> $diagnostics
@@ -155,6 +186,17 @@ final class VectorGeometryNormalizer
                 if ( isset($geometry['windingRule']) && is_scalar($geometry['windingRule']) ) {
                     $normalized['windingRule'] = (string) $geometry['windingRule'];
                 }
+                $styleId = $this->readStyleId($geometry['styleID'] ?? $geometry['styleId'] ?? null);
+                if ( null !== $styleId ) {
+                    $normalized['styleID'] = $styleId;
+                }
+                $paths[] = $normalized;
+            }
+        }
+
+        if ( empty($paths) && is_array($node['vectorData']['vectorNetwork'] ?? null) ) {
+            $normalized = $this->normalizeVectorNetwork($node['vectorData']['vectorNetwork']);
+            if ( null !== $normalized ) {
                 $paths[] = $normalized;
             }
         }
@@ -167,6 +209,159 @@ final class VectorGeometryNormalizer
         }
 
         return $paths;
+    }
+
+    /**
+     * @param array<string, mixed> $network
+     * @return array<string, mixed>|null
+     */
+    private function normalizeVectorNetwork(array $network): ?array
+    {
+        $vertices = $this->normalizeVectorNetworkObjectVertices($network['vertices'] ?? null);
+        $segments = $this->normalizeVectorNetworkObjectSegments($network['segments'] ?? null, count($vertices));
+        if ( empty($vertices) || empty($segments) ) {
+            return null;
+        }
+
+        $regions = is_array($network['regions'] ?? null) ? $network['regions'] : array();
+        if ( count($regions) > self::MAX_VECTOR_NETWORK_OBJECT_REGIONS ) {
+            return null;
+        }
+
+        $subpaths = array();
+        $windingRule = 'NONZERO';
+        foreach ( $regions as $region ) {
+            if ( ! is_array($region) ) {
+                return null;
+            }
+            $entries = $this->normalizeVectorNetworkRegionEntries($region['segments'] ?? $region['segmentIndices'] ?? $region['loop'] ?? null, count($segments));
+            if ( empty($entries) ) {
+                return null;
+            }
+            $subpath = $this->vectorNetworkRegionSubpath($vertices, $segments, $entries);
+            if ( null === $subpath ) {
+                return null;
+            }
+            $subpaths[] = $subpath;
+            $rule = strtoupper((string) ($region['windingRule'] ?? $region['fillRule'] ?? ''));
+            if ( in_array($rule, array('EVENODD', 'EVEN_ODD'), true) ) {
+                $windingRule = 'EVENODD';
+            }
+        }
+
+        if ( empty($subpaths) ) {
+            $subpath = $this->vectorNetworkObjectClosedLoopSubpath($vertices, $segments);
+            if ( null === $subpath ) {
+                return null;
+            }
+            $subpaths[] = $subpath;
+        }
+
+        return array(
+            'data'        => implode(' ', $subpaths),
+            'source'      => 'vectorData.vectorNetwork',
+            'windingRule' => $windingRule,
+        );
+    }
+
+    /**
+     * @return array<int, array{0: float, 1: float}>
+     */
+    private function normalizeVectorNetworkObjectVertices(mixed $rawVertices): array
+    {
+        if ( ! is_array($rawVertices) || count($rawVertices) > self::MAX_VECTOR_NETWORK_OBJECT_VERTICES ) {
+            return array();
+        }
+
+        $vertices = array();
+        foreach ( $rawVertices as $vertex ) {
+            if ( ! is_array($vertex) ) {
+                return array();
+            }
+            $point = is_array($vertex['position'] ?? null) ? $vertex['position'] : $vertex;
+            $x = $this->readPointCoordinate($point, 'x') ?? $this->readPointCoordinate($point, 0);
+            $y = $this->readPointCoordinate($point, 'y') ?? $this->readPointCoordinate($point, 1);
+            if ( null === $x || null === $y || ! is_finite($x) || ! is_finite($y) ) {
+                return array();
+            }
+            $vertices[] = array($x, $y);
+        }
+
+        return $vertices;
+    }
+
+    /**
+     * @return array<int, array{start: int, end: int, tangentStart: array{0: float, 1: float}, tangentEnd: array{0: float, 1: float}}>
+     */
+    private function normalizeVectorNetworkObjectSegments(mixed $rawSegments, int $vertexCount): array
+    {
+        if ( ! is_array($rawSegments) || count($rawSegments) > self::MAX_VECTOR_NETWORK_OBJECT_SEGMENTS ) {
+            return array();
+        }
+
+        $segments = array();
+        foreach ( $rawSegments as $segment ) {
+            if ( ! is_array($segment) ) {
+                return array();
+            }
+            $start = $this->readIndex($segment['start'] ?? $segment['startVertex'] ?? $segment[0] ?? null);
+            $end = $this->readIndex($segment['end'] ?? $segment['endVertex'] ?? $segment[1] ?? null);
+            if ( null === $start || null === $end || $start < 0 || $end < 0 || $start >= $vertexCount || $end >= $vertexCount || $start === $end ) {
+                return array();
+            }
+
+            $segments[] = array(
+                'start' => $start,
+                'end' => $end,
+                'tangentStart' => $this->readTangent($segment['tangentStart'] ?? $segment['startTangent'] ?? null),
+                'tangentEnd' => $this->readTangent($segment['tangentEnd'] ?? $segment['endTangent'] ?? null),
+            );
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @return array<int, array{0: int, 1: int}>
+     */
+    private function normalizeVectorNetworkRegionEntries(mixed $rawEntries, int $segmentCount): array
+    {
+        if ( ! is_array($rawEntries) || empty($rawEntries) || count($rawEntries) > $segmentCount ) {
+            return array();
+        }
+
+        $entries = array();
+        foreach ( $rawEntries as $entry ) {
+            $segmentIndex = is_array($entry) ? $this->readIndex($entry['segment'] ?? $entry['segmentIndex'] ?? $entry['index'] ?? $entry[0] ?? null) : $this->readIndex($entry);
+            $direction = 0;
+            if ( is_array($entry) ) {
+                if ( isset($entry['direction']) && is_numeric($entry['direction']) ) {
+                    $direction = (int) $entry['direction'];
+                } elseif ( false === ($entry['forward'] ?? true) || true === ($entry['reverse'] ?? false) ) {
+                    $direction = 1;
+                }
+            }
+            if ( null === $segmentIndex || $segmentIndex < 0 || $segmentIndex >= $segmentCount || ( 0 !== $direction && 1 !== $direction ) ) {
+                return array();
+            }
+            $entries[] = array($segmentIndex, $direction);
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param array<int, array{0: float, 1: float}> $vertices
+     * @param array<int, array{start: int, end: int, tangentStart: array{0: float, 1: float}, tangentEnd: array{0: float, 1: float}}> $segments
+     */
+    private function vectorNetworkObjectClosedLoopSubpath(array $vertices, array $segments): ?string
+    {
+        if ( count($segments) < 3 ) {
+            return null;
+        }
+
+        $entries = array_map(static fn (int $index): array => array($index, 0), array_keys($segments));
+        return $this->vectorNetworkRegionSubpath($vertices, $segments, $entries);
     }
 
     /**
@@ -969,6 +1164,52 @@ final class VectorGeometryNormalizer
 
         $value = unpack('V', substr($bytes, $offset, 4));
         return false === $value ? null : (int) $value[1];
+    }
+
+    private function readPointCoordinate(array $point, string|int $key): ?float
+    {
+        return isset($point[$key]) && is_numeric($point[$key]) ? (float) $point[$key] : null;
+    }
+
+    private function readIndex(mixed $value): ?int
+    {
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * @return array{0: float, 1: float}
+     */
+    private function readTangent(mixed $value): array
+    {
+        if ( ! is_array($value) ) {
+            return array(0.0, 0.0);
+        }
+
+        $x = $this->readPointCoordinate($value, 'x') ?? $this->readPointCoordinate($value, 0) ?? 0.0;
+        $y = $this->readPointCoordinate($value, 'y') ?? $this->readPointCoordinate($value, 1) ?? 0.0;
+        return is_finite($x) && is_finite($y) ? array($x, $y) : array(0.0, 0.0);
+    }
+
+    private function readStyleId(mixed $value): ?string
+    {
+        if ( is_scalar($value) && '' !== trim((string) $value) ) {
+            return (string) $value;
+        }
+
+        if ( ! is_array($value) ) {
+            return null;
+        }
+
+        if ( is_array($value['guid'] ?? null) ) {
+            $value = $value['guid'];
+        }
+        $session = $value['sessionID'] ?? null;
+        $local = $value['localID'] ?? null;
+        if ( is_scalar($session) && is_scalar($local) ) {
+            return (string) $session . ':' . (string) $local;
+        }
+
+        return is_scalar($local) ? (string) $local : null;
     }
 
     private function svgNumber(float $value): string

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -78,7 +78,66 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
     $strokedInlineVectorCss = $fileContent($strokedInlineVectorResult, 'style.css');
     $assert(str_contains($strokedInlineVectorHtml, 'stroke="#1f1f1f"') && str_contains($strokedInlineVectorHtml, 'stroke-width="2"'), 'stroked-inline-vector-svg-carries-stroke');
     $assert(! str_contains($strokedInlineVectorCss, 'border:2px solid #1f1f1f'), 'stroked-inline-vector-wrapper-no-css-border');
-    
+
+    $strokedGeometryStyleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Stroked Geometry Style Fixture',
+        'nodes' => array(
+            array(
+                'id'             => 'vector:stroke-geometry-style',
+                'type'           => 'VECTOR',
+                'name'           => 'Stroked Geometry Style',
+                'width'          => 16,
+                'height'         => 16,
+                'strokeWeight'   => 3,
+                'strokeCap'      => 'ROUND',
+                'strokeJoin'     => 'BEVEL',
+                'dashPattern'    => array(4, 2),
+                'strokePaints'   => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
+                'strokeGeometry' => array(array('path' => 'M 1 1 L 15 15', 'styleID' => 42)),
+            ),
+        ),
+    ));
+    $strokedGeometryStyleHtml = $fileContent($strokedGeometryStyleResult, 'index.html');
+    $assert(str_contains($strokedGeometryStyleHtml, 'stroke-linecap="round"') && str_contains($strokedGeometryStyleHtml, 'stroke-linejoin="bevel"'), 'stroke-geometry-cap-join-render');
+    $assert(str_contains($strokedGeometryStyleHtml, 'stroke-dasharray="4 2"'), 'stroke-geometry-dash-render');
+    $assert(str_contains($strokedGeometryStyleHtml, 'data-figma-style-id="42"'), 'vector-path-style-id-carry-through');
+
+    $vectorNetworkObjectResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Vector Network Object Fixture',
+        'nodes' => array(
+            array(
+                'id'         => 'vector:network-object',
+                'type'       => 'VECTOR',
+                'name'       => 'Network Object',
+                'width'      => 20,
+                'height'     => 20,
+                'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
+                'vectorData' => array(
+                    'normalizedSize' => array('x' => 10, 'y' => 10),
+                    'vectorNetwork'  => array(
+                        'vertices' => array(
+                            array('x' => 0, 'y' => 0),
+                            array('x' => 10, 'y' => 0),
+                            array('x' => 10, 'y' => 10),
+                            array('x' => 0, 'y' => 10),
+                        ),
+                        'segments' => array(
+                            array('start' => 0, 'end' => 1),
+                            array('start' => 1, 'end' => 2),
+                            array('start' => 2, 'end' => 3),
+                            array('start' => 3, 'end' => 0),
+                        ),
+                        'regions' => array(array('segments' => array(0, 1, 2, 3), 'windingRule' => 'EVENODD')),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $vectorNetworkObjectHtml = $fileContent($vectorNetworkObjectResult, 'index.html');
+    $assert(str_contains($vectorNetworkObjectHtml, 'data-figma-node-id="vector:network-object"') && str_contains($vectorNetworkObjectHtml, 'data-figma-vector="true"'), 'vector-network-object-renders');
+    $assert(str_contains($vectorNetworkObjectHtml, '<g transform="scale(2 2)"><path d="M0 0L10 0 10 10 0 10 0 0Z"'), 'vector-network-normalized-size-scales-path');
+    $assert(str_contains($vectorNetworkObjectHtml, 'fill-rule="evenodd"'), 'vector-network-region-winding-rule-renders');
+     
     $largeDecodedPath = 'M 0 0' . str_repeat(' L 10 10', 3000) . ' Z';
     $largeDecodedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Large Decoded Vector Fixture',


### PR DESCRIPTION
## Summary
- Normalize Kiwi vector network object geometry into deterministic SVG paths.
- Preserve vector path style IDs and normalized-size scaling metadata.
- Render stroke cap, join, and dash geometry attributes for inline vectors.

## Testing
- `php -l src/Html/VectorSvgRenderer.php`
- `php -l src/Scenegraph/ScenegraphNormalizer.php`
- `php -l src/Scenegraph/VectorGeometryNormalizer.php`
- `php -l tests/contract/VectorRenderingContract.php`
- `composer test:contract` from `figma-transformer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation review, branch integration, and verification orchestration.