### PR TITLE
figma-transformer: preserve Kiwi paint style metadata

### DIFF
--- a/figma-transformer/src/Html/VisualNodeMapBuilder.php
+++ b/figma-transformer/src/Html/VisualNodeMapBuilder.php
@@ -87,6 +87,7 @@ final class VisualNodeMapBuilder
                     'coordinate_space' => $box['coordinate_space'] ?? null,
                 ),
                 'image' => null === $imagePaint ? null : $this->visualImageMetadata($imagePaint),
+                'paints' => is_array($node['figma_paints'] ?? null) ? $node['figma_paints'] : null,
                 'text' => empty($text) ? null : $this->visualTextMetadata($text),
                 // Figma Dev Mode status (#280) surfaced for the diagnostics map.
                 'dev_status' => isset($node['dev_status']) && is_string($node['dev_status']) ? $node['dev_status'] : null,

--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -340,8 +340,11 @@ final class PaintNormalizer
                 if ( isset($paint['blendMode']) && is_scalar($paint['blendMode']) ) {
                     $normalized['blendMode'] = strtoupper((string) $paint['blendMode']);
                 }
-                if ( is_array($paint['gradientTransform'] ?? null) ) {
-                    $normalized['gradientTransform'] = $paint['gradientTransform'];
+                foreach ( array('gradientTransform', 'transform') as $transformKey ) {
+                    if ( is_array($paint[$transformKey] ?? null) ) {
+                        $normalized['gradientTransform'] = $paint[$transformKey];
+                        break;
+                    }
                 }
 
                 return $normalized;

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1877,7 +1877,7 @@ final class ScenegraphNormalizer
         // the definition's visibility and incorrectly emit to HTML.
         $resolved['visible'] = $instance['visible'] ?? true;
 
-        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'figma_variable_bindings', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'styleIdForEffect', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight', 'variableConsumptionMap', 'parameterConsumptionMap', 'variableDataValues', 'variableResolvedType', 'variableSetID', 'variableScopes', 'variableSetModes') as $key ) {
+        foreach ( array('box', 'figma_box', 'layout', 'figma_paints', 'figma_effects', 'figma_link', 'figma_vector_paths', 'figma_variable_bindings', 'componentProperties', 'fillPaints', 'effects', 'styleIdForFill', 'styleIdForStrokeFill', 'styleIdForStroke', 'styleIdForEffect', 'fillGeometry', 'strokeGeometry', 'vectorPaths', 'paths', 'pathData', 'path', 'd', 'strokeWeight', 'strokeAlign', 'dashPattern', 'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight', 'borderLeftWeight', 'borderRightWeight', 'variableConsumptionMap', 'parameterConsumptionMap', 'variableDataValues', 'variableResolvedType', 'variableSetID', 'variableScopes', 'variableSetModes') as $key ) {
             if ( array_key_exists($key, $instance) ) {
                 $resolved[$key] = $instance[$key];
             }

--- a/figma-transformer/tests/contract/ImagePaintContract.php
+++ b/figma-transformer/tests/contract/ImagePaintContract.php
@@ -305,4 +305,84 @@ function blocks_engine_figma_transformer_run_image_paint_contract(callable $asse
     $styleBackedImageOverrideCss = $fileContent($styleBackedImageOverrideResult, 'style.css');
     $assert(str_contains($styleBackedImageOverrideCss, 'background-image:url("assets/styled-override-image.bin")'), 'style-backed-image-override-replaces-style-image-paint');
     $assert(! str_contains($styleBackedImageOverrideCss, 'styled-default-image.bin'), 'style-backed-image-override-drops-stale-style-image-paint');
+
+    $paintMetadataResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Paint Metadata Fixture',
+        'nodes' => array(
+            array(
+                'id'         => 'paint-style:gradient-transform',
+                'type'       => 'RECTANGLE',
+                'name'       => 'Gradient Transform Style',
+                'styleType'  => 'FILL',
+                'fillPaints' => array(
+                    array(
+                        'type'      => 'GRADIENT_LINEAR',
+                        'opacity'   => 0.5,
+                        'blendMode' => 'MULTIPLY',
+                        'stops'     => array(
+                            array('position' => 0, 'color' => array('r' => 1, 'g' => 0, 'b' => 0, 'a' => 1)),
+                            array('position' => 1, 'color' => array('r' => 0, 'g' => 0, 'b' => 1, 'a' => 1)),
+                        ),
+                        'transform' => array(
+                            array(0, 1, 0),
+                            array(-1, 0, 1),
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                'id'         => 'paint-style:stroke-blue',
+                'type'       => 'RECTANGLE',
+                'name'       => 'Blue Stroke Style',
+                'styleType'  => 'FILL',
+                'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 1, 'a' => 1))),
+            ),
+            array(
+                'id'              => 'paint:metadata-frame',
+                'type'            => 'FRAME',
+                'name'            => 'Paint Metadata Frame',
+                'width'           => 80,
+                'height'          => 40,
+                'styleIdForFill'  => 'paint-style:gradient-transform',
+                'fillPaints'      => array(array('type' => 'SOLID', 'visible' => false, 'color' => array('r' => 0, 'g' => 1, 'b' => 0, 'a' => 1))),
+                'backgroundPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 0, 'a' => 1), 'opacity' => 0.25)),
+                'blendMode'       => 'PASS_THROUGH',
+            ),
+            array(
+                'guid'                  => array('sessionID' => 702, 'localID' => 1),
+                'type'                  => 'COMPONENT',
+                'name'                  => 'Stroke Style Component',
+                'children'              => array(
+                    array(
+                        'guid'                 => array('sessionID' => 702, 'localID' => 2),
+                        'type'                 => 'RECTANGLE',
+                        'name'                 => 'Stroke Style Child',
+                        'width'                => 20,
+                        'height'               => 20,
+                        'styleIdForStrokeFill' => 'paint-style:stroke-blue',
+                        'strokeWeight'         => 2,
+                        'strokeAlign'          => 'INSIDE',
+                    ),
+                ),
+            ),
+            array(
+                'id'         => 'instance:stroke-style',
+                'type'       => 'INSTANCE',
+                'name'       => 'Stroke Style Instance',
+                'symbolData' => array('symbolID' => array('sessionID' => 702, 'localID' => 1)),
+            ),
+        ),
+    ));
+    $paintMetadataCss = $fileContent($paintMetadataResult, 'style.css');
+    $paintMetadataFrame = blocks_engine_figma_transformer_contract_find_visual_node($paintMetadataResult, 'paint:metadata-frame');
+    $strokeStyleChild = blocks_engine_figma_transformer_contract_find_visual_node($paintMetadataResult, 'instance:stroke-style/702:2');
+    $assert(str_contains($paintMetadataCss, '.figma-node-paint-metadata-frame-paint-metadata-frame{width:80px;height:40px;background:linear-gradient(') && str_contains($paintMetadataCss, 'rgba(255,0,0,0.5) 0%,rgba(0,0,255,0.5) 100%'), 'style-gradient-transform-wins-over-invisible-local-fill');
+    $assert(! str_contains($paintMetadataCss, '#00ff00'), 'invisible-local-fill-omitted');
+    $assert(0.25 === ($paintMetadataFrame['paints']['background'][0]['opacity'] ?? null), 'visual-node-carries-background-paint-opacity');
+    $assert('GRADIENT_LINEAR' === ($paintMetadataFrame['paints']['fills'][0]['type'] ?? null), 'visual-node-carries-style-fill-paint-type');
+    $assert(0.5 === ($paintMetadataFrame['paints']['fills'][0]['opacity'] ?? null), 'visual-node-carries-style-fill-opacity');
+    $assert('MULTIPLY' === ($paintMetadataFrame['paints']['fills'][0]['blendMode'] ?? null), 'visual-node-carries-style-fill-blend-mode');
+    $assert(array(array(0, 1, 0), array(-1, 0, 1)) === ($paintMetadataFrame['paints']['fills'][0]['gradientTransform'] ?? null), 'visual-node-carries-gradient-transform-from-transform-field');
+    $assert('SOLID' === ($strokeStyleChild['paints']['strokes'][0]['type'] ?? null), 'cloned-instance-carries-stroke-style-paint');
+    $assert(str_contains($paintMetadataCss, 'border:2px solid #0000ff'), 'cloned-instance-stroke-style-emits-border');
 }


### PR DESCRIPTION
## Summary
- Preserve normalized paint metadata in visual node maps.
- Accept Kiwi gradient transform metadata from `transform` as well as `gradientTransform`.
- Carry stroke style IDs through cloned instances without changing the style-fill precedence fixed earlier.

## Testing
- `php -l src/Html/VisualNodeMapBuilder.php`
- `php -l src/Scenegraph/PaintNormalizer.php`
- `php -l src/Scenegraph/ScenegraphNormalizer.php`
- `php -l tests/contract/ImagePaintContract.php`
- `composer test:contract` from `figma-transformer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation review, branch integration, and verification orchestration.