### PR TITLE
figma-transformer: preserve clone child stacking order

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1358,7 +1358,10 @@ final class ScenegraphNormalizer
         $cloneType = strtoupper((string) ($clone['type'] ?? ''));
         $refreshedType = strtoupper((string) ($refreshed['type'] ?? ''));
 
-        return 'INSTANCE' === $cloneType || 'INSTANCE' === $refreshedType || true === ($clone['figma_component']['resolved'] ?? false) || true === ($refreshed['figma_component']['resolved'] ?? false);
+        return 'INSTANCE' === $cloneType
+            || 'INSTANCE' === $refreshedType
+            || true === ($clone['figma_component']['resolved'] ?? false)
+            || true === ($refreshed['figma_component']['resolved'] ?? false);
     }
 
     /**
@@ -1401,6 +1404,7 @@ final class ScenegraphNormalizer
 				$merged[$key] = $clone[$key];
 			}
 		}
+		$merged = $this->mergeComponentSourceCloneLayoutMetadata($merged, $clone, $refreshed);
 		if ( $preferRefreshedGeometry && is_array($refreshed['box'] ?? null) ) {
 			foreach ( array('x', 'y') as $dimension ) {
 				if ( isset($refreshed['box'][$dimension]) && is_numeric($refreshed['box'][$dimension]) ) {
@@ -1419,6 +1423,31 @@ final class ScenegraphNormalizer
 
 		return $this->markComponentSourceCloneGeometry($merged);
 	}
+
+    /**
+     * @param array<string, mixed> $merged
+     * @param array<string, mixed> $clone
+     * @param array<string, mixed> $refreshed
+     * @return array<string, mixed>
+     */
+    private function mergeComponentSourceCloneLayoutMetadata(array $merged, array $clone, array $refreshed): array
+    {
+        $refreshedLayout = is_array($refreshed['layout'] ?? null) ? $refreshed['layout'] : array();
+        if ( ! isset($refreshedLayout['z_index']) || ! is_numeric($refreshedLayout['z_index']) ) {
+            return $merged;
+        }
+
+        $cloneLayout = is_array($clone['layout'] ?? null) ? $clone['layout'] : array();
+        if ( isset($cloneLayout['z_index']) && is_numeric($cloneLayout['z_index']) ) {
+            return $merged;
+        }
+
+        $mergedLayout = is_array($merged['layout'] ?? null) ? $merged['layout'] : array();
+        $mergedLayout['z_index'] = (int) $refreshedLayout['z_index'];
+        $merged['layout'] = $mergedLayout;
+
+        return $merged;
+    }
 
 	/**
 	 * @param array<string, mixed> $clone
@@ -1916,12 +1945,44 @@ final class ScenegraphNormalizer
         if ( $this->instanceOverridesUseTransforms($overrides) ) {
             $resolved['layout'] = array('freeform' => true);
         }
-        $resolved['children'] = $this->namespaceResolvedInstanceChildren(
-            $this->applyInstanceOverridesToChildren($resolvedChildren, $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options),
-            $context['instance_id']
-        );
+        $resolvedChildren = $this->applyInstanceOverridesToChildren($resolvedChildren, $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
+        $resolvedChildren = $this->mergeComponentSourceCloneDescendantLayoutMetadata($resolvedChildren, $nodeMap);
+        $resolved['children'] = $this->namespaceResolvedInstanceChildren($resolvedChildren, $context['instance_id']);
 
         return $resolved;
+    }
+
+    /**
+     * @param array<int, mixed> $children
+     * @param array<string, array<string, mixed>> $nodeMap
+     * @return array<int, mixed>
+     */
+    private function mergeComponentSourceCloneDescendantLayoutMetadata(array $children, array $nodeMap): array
+    {
+        foreach ( $children as $index => $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $sourceId = isset($child['figma_component_source_id']) && is_scalar($child['figma_component_source_id'])
+                ? (string) $child['figma_component_source_id']
+                : (isset($child['id']) && is_scalar($child['id']) ? (string) $child['id'] : '');
+            if ( '' !== $sourceId && isset($nodeMap[$sourceId]['layout']['z_index']) && is_numeric($nodeMap[$sourceId]['layout']['z_index']) ) {
+                $layout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+                if ( ! isset($layout['z_index']) || ! is_numeric($layout['z_index']) ) {
+                    $layout['z_index'] = (int) $nodeMap[$sourceId]['layout']['z_index'];
+                    $child['layout'] = $layout;
+                }
+            }
+
+            if ( is_array($child['children'] ?? null) ) {
+                $child['children'] = $this->mergeComponentSourceCloneDescendantLayoutMetadata($child['children'], $nodeMap);
+            }
+
+            $children[$index] = $child;
+        }
+
+        return $children;
     }
 
     /**

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -76,6 +76,51 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $assert(str_contains($reverseZIndexCss, '.figma-node-reverse-z-first-first-top-child{width:80px;height:80px;z-index:2;flex-shrink:0}'), 'visual-map-reverse-z-first-child-on-top');
     $assert(str_contains($reverseZIndexCss, '.figma-node-reverse-z-second-second-lower-child{width:80px;height:80px;z-index:1;flex-shrink:0}'), 'visual-map-reverse-z-second-child-lower');
 
+    $componentCloneZIndexResult = blocks_engine_figma_transformer_contract_transform(
+        array(
+            'name'  => 'Component Clone Z Index Fixture',
+            'nodes' => array(
+                array(
+                    'id'                 => 'clone-z:component',
+                    'type'               => 'COMPONENT',
+                    'name'               => 'Layered component',
+                    'width'              => 240,
+                    'height'             => 120,
+                    'layoutMode'         => 'HORIZONTAL',
+                    'itemSpacing'        => -80,
+                    'stackReverseZIndex' => true,
+                    'children'           => array(
+                        array('id' => 'clone-z:component/front', 'type' => 'RECTANGLE', 'name' => 'Front panel', 'width' => 160, 'height' => 120),
+                        array('id' => 'clone-z:component/back', 'type' => 'RECTANGLE', 'name' => 'Back panel', 'width' => 160, 'height' => 120),
+                    ),
+                ),
+                array(
+                    'id'       => 'clone-z:page',
+                    'type'     => 'FRAME',
+                    'name'     => 'Page',
+                    'width'    => 320,
+                    'height'   => 180,
+                    'children' => array(
+                        array(
+                            'id'          => 'clone-z:instance',
+                            'type'        => 'INSTANCE',
+                            'name'        => 'Layered instance',
+                            'componentId' => 'clone-z:component',
+                            'x'           => 20,
+                            'y'           => 30,
+                            'width'       => 240,
+                            'height'      => 120,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array('frame_id' => 'clone-z:page')
+    );
+    $componentCloneZIndexCss = blocks_engine_figma_transformer_contract_file_content($componentCloneZIndexResult, 'style.css');
+    $assert(str_contains($componentCloneZIndexCss, '.back-panel{width:160px;height:120px;z-index:2;flex-shrink:0}'), 'visual-map-component-clone-preserves-back-z-index');
+    $assert(str_contains($componentCloneZIndexCss, '.front-panel{width:160px;height:120px;z-index:1;flex-shrink:0}'), 'visual-map-component-clone-preserves-front-z-index');
+
     $visualFlexOffCanvasResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Visual Flex Off Canvas Classification Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- Preserve source `z_index` layout metadata when component-source clones are refreshed.
- Carry source child `z_index` metadata into namespaced instance clone descendants.
- Add contract coverage for reverse-z component children inside an instance clone.

## Root cause
The FSE footer source has `Newsletter Signup` at `z_index:2` and the lower footer row at `z_index:1`, but instance clone normalization dropped that metadata on cloned descendants. The emitter then fell back to DOM order, letting the lower footer row/background paint over the newsletter card.

## Verification
- `php -l src/Scenegraph/ScenegraphNormalizer.php`
- `php -l tests/contract/VisualNodeMapContract.php`
- `composer test:contract` from `figma-transformer`
- Regenerated FSE site from the local `.fig` fixture with zstd: `success_with_warnings`, 5 pages, 34 files
- Footer trace now emits newsletter `z-index:2` and lower footer row `z-index:1`

Local verification output:
- `file:///var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-z-index-fix-20260701/site/index.html`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, implementation, contract coverage, and verification orchestration.