### PR TITLE
figma-transformer: isolate multi-page shared classes

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -575,6 +575,7 @@ final class FigmaTransformer
         $files = array();
         $assetsByPath = array();
         $cssChunks = array();
+        $cssChunkIndexesByPath = array();
         $pageReports = array();
         $fontFamilies = array();
         $fontUsage = array();
@@ -633,6 +634,7 @@ final class FigmaTransformer
             $html = $this->fileContent($pageResult['files'] ?? array(), 'index.html');
             $css = $this->fileContent($pageResult['files'] ?? array(), 'style.css');
             if ( '' !== $css ) {
+                $cssChunkIndexesByPath[$path] = count($cssChunks);
                 $cssChunks[] = $css;
             }
 
@@ -673,7 +675,18 @@ final class FigmaTransformer
             );
         }
 
-        $css = $this->mergeCssChunks($cssChunks);
+        $mergedCss = $this->mergeCssChunks($cssChunks);
+        $css = $mergedCss['css'];
+        foreach ( $files as $fileIndex => $file ) {
+            if ( 'text/html' !== ($file['mime_type'] ?? '') || ! isset($file['content'], $file['path']) || ! is_scalar($file['path']) ) {
+                continue;
+            }
+            $chunkIndex = $cssChunkIndexesByPath[(string) $file['path']] ?? null;
+            if ( null === $chunkIndex || empty($mergedCss['class_maps'][$chunkIndex]) ) {
+                continue;
+            }
+            $files[$fileIndex]['content'] = $this->applyCssClassRenameMapToHtml((string) $file['content'], $mergedCss['class_maps'][$chunkIndex]);
+        }
         if ( '' !== $css ) {
             $files[] = array(
                 'path'      => 'style.css',
@@ -1418,13 +1431,15 @@ final class FigmaTransformer
      * breakpoints still win the cascade at their own viewport width.
      *
      * @param array<int, string> $chunks
+     * @return array{css: string, class_maps: array<int, array<string, string>>}
      */
-    private function mergeCssChunks(array $chunks): string
+    private function mergeCssChunks(array $chunks): array
     {
         $imports = array();
         $rules = array();
         $atBlocks = array();
-        foreach ( $chunks as $chunk ) {
+        $readableRules = array();
+        foreach ( $chunks as $chunkIndex => $chunk ) {
             foreach ( $this->splitCssStatements($chunk) as $statement ) {
                 $statement = trim($statement);
                 if ( '' === $statement ) {
@@ -1442,13 +1457,76 @@ final class FigmaTransformer
                     $atBlocks[$statement] = true;
                     continue;
                 }
+                $readableRule = $this->readableCssRule($statement);
+                if ( null !== $readableRule ) {
+                    $readableRules[$readableRule['class']][$readableRule['body']][] = $chunkIndex;
+                }
                 $rules[$statement] = true;
             }
         }
 
+        $classMaps = array();
+        $renamesByStatement = array();
+        foreach ( $readableRules as $class => $bodies ) {
+            if ( count($bodies) < 2 ) {
+                continue;
+            }
+            foreach ( $bodies as $body => $chunkIndexes ) {
+                $renamedClass = $class . '-' . substr(sha1($body), 0, 8);
+                $renamesByStatement['.' . $class . '{' . $body . '}'] = '.' . $renamedClass . '{' . $body . '}';
+                foreach ( $chunkIndexes as $chunkIndex ) {
+                    $classMaps[$chunkIndex][$class] = $renamedClass;
+                }
+            }
+        }
+
+        if ( ! empty($renamesByStatement) ) {
+            $renamedRules = array();
+            foreach ( array_keys($rules) as $statement ) {
+                $renamedRules[$renamesByStatement[$statement] ?? $statement] = true;
+            }
+            $rules = $renamedRules;
+        }
+
         $ordered = array_merge(array_keys($imports), array_keys($rules), array_keys($atBlocks));
 
-        return implode("\n", $ordered) . (empty($ordered) ? '' : "\n");
+        return array(
+            'css' => implode("\n", $ordered) . (empty($ordered) ? '' : "\n"),
+            'class_maps' => $classMaps,
+        );
+    }
+
+    /**
+     * @return array{class: string, body: string}|null
+     */
+    private function readableCssRule(string $statement): ?array
+    {
+        if ( 1 !== preg_match('/^\.([A-Za-z][A-Za-z0-9_-]*)\{(.*)\}$/s', $statement, $matches) ) {
+            return null;
+        }
+
+        $class = $matches[1];
+        if ( str_starts_with($class, 'figma-node-') || in_array($class, array('figma-root', 'figma-link', 'figma-text-glyphs', 'figma-vector-asset'), true) ) {
+            return null;
+        }
+
+        return array('class' => $class, 'body' => $matches[2]);
+    }
+
+    /**
+     * @param array<string, string> $classMap
+     */
+    private function applyCssClassRenameMapToHtml(string $html, array $classMap): string
+    {
+        if ( empty($classMap) ) {
+            return $html;
+        }
+
+        return (string) preg_replace_callback('/class="([^"]*)"/', static function (array $matches) use ($classMap): string {
+            $classes = preg_split('/\s+/', trim((string) $matches[1])) ?: array();
+            $classes = array_map(static fn (string $class): string => $classMap[$class] ?? $class, $classes);
+            return 'class="' . implode(' ', array_values(array_filter($classes, static fn (string $class): bool => '' !== $class))) . '"';
+        }, $html);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -390,7 +390,7 @@ final class StaticHtmlEmitter
 
         $assetFiles = array_merge($this->referencedAssetFiles($assetFiles), array_values($this->generatedAssetFiles));
 
-        $shared   = $this->applySharedStyleClasses($cssRules);
+        $shared   = $this->applySharedStyleClasses($cssRules, true);
         $cssRules = $shared['rules'];
         if ( ! empty($shared['class_map']) ) {
             foreach ( $files as $fileIndex => $file ) {
@@ -3438,7 +3438,16 @@ final class StaticHtmlEmitter
         foreach ( array('width', 'height') as $dimension ) {
             $sizingKey = 'width' === $dimension ? 'sizing_horizontal' : 'sizing_vertical';
             $sizing = strtoupper((string) ($layout[$sizingKey] ?? ''));
-            if ( 'HUG' === $sizing ) {
+            if ( 'width' === $dimension && $this->isFluidRootWidth($box, $parentNode) ) {
+                // Page root: centered fluid container. width:100% lets it shrink
+                // below the design width without forcing horizontal scroll, while
+                // max-width pins the intrinsic frame width so rendering stays
+                // pixel-faithful at and above the native canvas size.
+                $styles[] = 'width:100%';
+                $styles[] = 'max-width:' . $this->number((float) $box['width']) . 'px';
+                $styles[] = 'margin-left:auto';
+                $styles[] = 'margin-right:auto';
+            } elseif ( 'HUG' === $sizing ) {
                 $derivedTextSize = 'TEXT' === $type ? $this->derivedTextLayoutSize($node, $dimension) : null;
                 if ( null !== $derivedTextSize ) {
                     $styles[] = $dimension . ':' . $this->number($derivedTextSize) . 'px';
@@ -3451,20 +3460,9 @@ final class StaticHtmlEmitter
             } elseif ( 'FILL' === $sizing ) {
                 $styles[] = $dimension . ':100%';
             } elseif ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
-                if ( 'width' === $dimension && null === $parentNode && (float) $box['width'] >= self::FLUID_ROOT_MIN_WIDTH ) {
-                    // Page root: centered fluid container. width:100% lets it shrink
-                    // below the design width without forcing horizontal scroll, while
-                    // max-width pins the intrinsic frame width so rendering stays
-                    // pixel-faithful at and above the native canvas size.
-                    $styles[] = 'width:100%';
-                    $styles[] = 'max-width:' . $this->number((float) $box['width']) . 'px';
-                    $styles[] = 'margin-left:auto';
-                    $styles[] = 'margin-right:auto';
-                } else {
-                    $property = $dimension;
-                    $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
-                    $styles[] = $property . ':' . $this->number($value) . 'px';
-                }
+                $property = $dimension;
+                $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
+                $styles[] = $property . ':' . $this->number($value) . 'px';
             }
         }
 
@@ -3768,6 +3766,17 @@ final class StaticHtmlEmitter
         $intrinsicMainSpan = $childMainSpan + $paddingSpan + max(0, $childCount - 1) * $gap;
 
         return $intrinsicMainSpan > (float) $box[$dimension] + 1.0 ? 'max-content' : null;
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     */
+    private function isFluidRootWidth(array $box, ?array $parentNode): bool
+    {
+        return null === $parentNode
+            && isset($box['width'])
+            && is_numeric($box['width'])
+            && (float) $box['width'] >= self::FLUID_ROOT_MIN_WIDTH;
     }
 
     /**
@@ -5944,7 +5953,7 @@ final class StaticHtmlEmitter
      * @param array<int, string> $cssRules
      * @return array{rules: array<int, string>, class_map: array<string, string>}
      */
-    private function applySharedStyleClasses(array $cssRules): array
+    private function applySharedStyleClasses(array $cssRules, bool $hashReadableNames = false): array
     {
         $pattern = '/^\.(figma-node-[A-Za-z0-9_-]+)\{(.*)\}$/s';
 
@@ -5981,6 +5990,9 @@ final class StaticHtmlEmitter
         foreach ( array_keys($sharedOrder) as $body ) {
             $firstSelector = $bodyToSelectors[$body][0];
             $base = $this->nodeReadableNames[$firstSelector] ?? 'style';
+            if ( $hashReadableNames ) {
+                $base .= '-' . substr(sha1($body), 0, 8);
+            }
             $name = $base;
             $suffix = 2;
             while ( isset($usedNames[$name]) || isset($reserved[$name]) ) {

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -899,6 +899,8 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
                         'children' => array(
                             array('id' => 'text:home', 'type' => 'TEXT', 'name' => 'Home title', 'characters' => 'Home Hero', 'fontName' => array('family' => 'Example Sans', 'style' => 'Regular'), 'fontSize' => 20),
                             array('id' => 'image:home', 'type' => 'RECTANGLE', 'name' => 'Home image', 'width' => 100, 'height' => 60, 'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'home-image'))),
+                            array('id' => 'button:home:one', 'type' => 'TEXT', 'name' => 'Button', 'characters' => 'Read more', 'width' => 80, 'height' => 24, 'fontSize' => 16, 'fontWeight' => 700),
+                            array('id' => 'button:home:two', 'type' => 'TEXT', 'name' => 'Button', 'characters' => 'Subscribe', 'width' => 80, 'height' => 24, 'fontSize' => 16, 'fontWeight' => 700),
                             array('id' => 'vector:home-large', 'type' => 'VECTOR', 'name' => 'Home Large Vector', 'width' => 10, 'height' => 10, 'figma_vector_paths' => array(array('data' => $externalizedVectorPath, 'source' => 'strokeGeometry'))),
                         ),
                     ),
@@ -911,6 +913,8 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
                         'children' => array(
                             array('id' => 'text:about', 'type' => 'TEXT', 'name' => 'About title', 'characters' => 'About Hero', 'fontName' => array('family' => 'Example Sans', 'style' => 'Bold'), 'fontSize' => 20),
                             array('id' => 'image:about', 'type' => 'RECTANGLE', 'name' => 'About image', 'width' => 100, 'height' => 60, 'fillPaints' => array(array('type' => 'IMAGE', 'imageRef' => 'about-image'))),
+                            array('id' => 'button:about:one', 'type' => 'TEXT', 'name' => 'Button', 'characters' => 'Read more', 'width' => 96, 'height' => 28, 'fontSize' => 18, 'fontWeight' => 500),
+                            array('id' => 'button:about:two', 'type' => 'TEXT', 'name' => 'Button', 'characters' => 'Subscribe', 'width' => 96, 'height' => 28, 'fontSize' => 18, 'fontWeight' => 500),
                         ),
                     ),
                 ),
@@ -950,6 +954,9 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(str_contains($multiPageIndex, '<style data-figma-transformer-css="true">') && str_contains($multiPageIndex, '.figma-node-frame-home-home'), 'multi-page-index-inlines-page-css');
     $assert(str_contains($multiPageStyle, '.figma-node-frame-home-home'), 'multi-page-shared-css-home');
     $assert(str_contains($multiPageStyle, '.figma-node-frame-about-about'), 'multi-page-shared-css-about');
+    preg_match_all('/\.button-[0-9a-f]{8}\{/', $multiPageStyle, $multiPageButtonSharedClasses);
+    $assert(2 === count(array_unique($multiPageButtonSharedClasses[0] ?? array())), 'multi-page-shared-readable-classes-are-hashed');
+    $assert(! str_contains($multiPageStyle, '.button{'), 'multi-page-shared-readable-class-base-not-reused');
     $assert(2 === ($multiPageResult['metrics']['page_count'] ?? null), 'multi-page-page-count');
     $assert(2 === ($multiPageResult['source_reports']['compiled_site']['totals']['page_count'] ?? null), 'multi-page-compiled-site-page-count');
     $assert('about.html' === ($multiPageResult['source_reports']['compiled_site']['pages'][1]['path'] ?? null), 'multi-page-compiled-site-page-path');


### PR DESCRIPTION
## Summary
- hash shared readable CSS classes in responsive/site emission to prevent generic selector collisions
- rename colliding readable classes when normal multi-page CSS chunks are merged, and rewrite the matching page HTML class tokens
- make large page-root frames fluid with max-width even when Figma marks the root width as HUG sizing

## Verification
- `php -l src/FigmaTransformer.php`
- `php -l src/Html/StaticHtmlEmitter.php`
- `php -l tests/contract/SiteGenerationContract.php`
- `composer test:contract`
- Regenerated FSE Pilot bundle locally with zstd: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-layout-root-fix-20260701/site-v2`
- Verified generated FSE `style.css` uses `width:100%;max-width:1440px;margin-left:auto;margin-right:auto` for desktop page roots and hash-qualified readable classes such as `.heading-...`, `.content-...`, `.preview-...`, `.button-...`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, code changes, contract coverage, and local verification.