### PR TITLE
figma-transformer: clear stale instance clone geometry

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1912,6 +1912,14 @@ final class ScenegraphNormalizer
             }
         }
 
+		foreach ( array('size', 'transform', 'relativeTransform', 'absoluteTransform', 'absoluteBoundingBox') as $key ) {
+			if ( array_key_exists($key, $instance) ) {
+				$resolved[$key] = $instance[$key];
+			} else {
+				unset($resolved[$key]);
+			}
+		}
+
         $resolved['figma_component'] = array_merge(
             is_array($instance['figma_component'] ?? null) ? $instance['figma_component'] : array(),
             array(

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -603,4 +603,97 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     $staleCanvasImage = blocks_engine_figma_transformer_contract_find_visual_node($staleCanvasTransformResult, 'instance:card/source:card/image');
     $assert(str_contains($staleCanvasImageCss, '.image{width:376px;height:282px;position:absolute;left:0px;top:0px}'), 'visual-map-component-source-stale-canvas-transform-css-parent-local');
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $staleCanvasImage, array('x' => 112.0, 'y' => 198.0, 'width' => 376.0, 'height' => 282.0), 'visual-map-component-source-stale-canvas-transform-rect-parent-local');
+
+    $staleNestedInstanceGeometryResult = blocks_engine_figma_transformer_contract_transform(
+        array(
+            'name'  => 'Nested Instance Stale Definition Geometry Fixture',
+            'nodes' => array(
+                array(
+                    'id'       => 'source:image-component',
+                    'type'     => 'COMPONENT',
+                    'name'     => 'Aspect Ratio=4:3',
+                    'x'        => 16,
+                    'y'        => 480,
+                    'width'    => 240,
+                    'height'   => 180,
+                    'children' => array(
+                        array(
+                            'id'     => 'source:image-component/fill',
+                            'type'   => 'RECTANGLE',
+                            'name'   => 'Fill',
+                            'x'      => 0,
+                            'y'      => 0,
+                            'width'  => 240,
+                            'height' => 180,
+                        ),
+                    ),
+                ),
+                array(
+                    'id'       => 'source:nested-card',
+                    'type'     => 'COMPONENT',
+                    'name'     => 'Post card',
+                    'width'    => 376,
+                    'height'   => 477,
+                    'children' => array(
+                        array(
+                            'id'          => 'source:nested-card/image',
+                            'type'        => 'INSTANCE',
+                            'name'        => 'Image',
+                            'componentId' => 'source:image-component',
+                            'x'           => 0,
+                            'y'           => 0,
+                            'width'       => 376,
+                            'height'      => 282,
+                        ),
+                        array(
+                            'id'     => 'source:nested-card/content',
+                            'type'   => 'FRAME',
+                            'name'   => 'Content',
+                            'x'      => 0,
+                            'y'      => 314,
+                            'width'  => 376,
+                            'height' => 163,
+                        ),
+                    ),
+                ),
+                array(
+                    'id'       => 'source:nested-page',
+                    'type'     => 'FRAME',
+                    'name'     => 'Page',
+                    'width'    => 600,
+                    'height'   => 800,
+                    'children' => array(
+                        array(
+                            'id'                => 'instance:nested-card',
+                            'type'              => 'INSTANCE',
+                            'name'              => 'Placed card',
+                            'componentId'       => 'source:nested-card',
+                            'x'                 => 112,
+                            'y'                 => 198,
+                            'width'             => 376,
+                            'height'            => 477,
+                            'derivedSymbolData' => array(
+                                array(
+                                    'nodeId'     => 'source:nested-card/image',
+                                    'size'       => array('x' => 376, 'y' => 282),
+                                    'fillPaints' => array(
+                                        array(
+                                            'type'    => 'SOLID',
+                                            'color'   => array('r' => 1, 'g' => 0, 'b' => 0),
+                                            'opacity' => 1,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        array('frame_id' => 'source:nested-page')
+    );
+    $staleNestedInstanceGeometryCss = blocks_engine_figma_transformer_contract_file_content($staleNestedInstanceGeometryResult, 'style.css');
+    $staleNestedInstanceImage = blocks_engine_figma_transformer_contract_find_visual_node($staleNestedInstanceGeometryResult, 'instance:nested-card/source:nested-card/image');
+    $assert(str_contains($staleNestedInstanceGeometryCss, 'width:376px;height:282px;position:absolute;left:0px;top:0px'), 'visual-map-nested-instance-stale-definition-transform-css-parent-local');
+    blocks_engine_figma_transformer_contract_assert_node_rect($assert, $staleNestedInstanceImage, array('x' => 112.0, 'y' => 198.0, 'width' => 376.0, 'height' => 282.0), 'visual-map-nested-instance-stale-definition-transform-rect-parent-local');
 }


### PR DESCRIPTION
## Summary
- clear component-definition raw geometry fields from cloned instance roots when the placed instance does not provide them
- prevent later instance override re-normalization from reusing stale nested component transforms as placement
- add contract coverage for a nested image instance whose component definition lives at a different local coordinate than the card slot

## Verification
- `php -l src/Scenegraph/ScenegraphNormalizer.php`
- `php -l tests/contract/VisualNodeMapContract.php`
- `composer test:contract`
- Regenerated FSE Pilot bundle locally with zstd: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-stale-instance-geometry-fix-20260701/site`
- Verified affected All Updates image selectors now emit `left:0px;top:0px` for `3468:1074/4181:993` and `3468:1075/4181:993` instead of the stale `left:16px;top:480px`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, code changes, contract coverage, and local verification.