### PR TITLE
figma-transformer: improve FSE visual parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 **/docs/superpowers/
 node_modules/
+figma-transformer/tmp/

--- a/figma-transformer/scripts/figma-node-trace.php
+++ b/figma-transformer/scripts/figma-node-trace.php
@@ -87,6 +87,7 @@ foreach ( $nodeIds as $nodeId ) {
         'raw' => blocks_engine_figma_trace_node_summary($rawNodes[$nodeId] ?? (null !== $sourceId ? ($rawNodes[$sourceId] ?? null) : null), array(), isset($rawNodes[$nodeId]['id']) && is_scalar($rawNodes[$nodeId]['id']) ? (string) $rawNodes[$nodeId]['id'] : ($sourceId ?? $nodeId)),
         'source' => null !== $sourceId ? blocks_engine_figma_trace_node_summary($rawNodes[$sourceId] ?? ($normalizedNodes[$sourceId] ?? null), $normalized, $sourceId) : null,
         'normalized' => blocks_engine_figma_trace_node_summary($normalizedNode, $normalized, $nodeId),
+        'field_coverage' => blocks_engine_figma_trace_field_coverage($rawNodes[$nodeId] ?? (null !== $sourceId ? ($rawNodes[$sourceId] ?? null) : null), $normalizedNode),
         'emitted' => array_filter(array(
             'class' => '' !== $className ? $className : null,
             'tag' => is_array($style) ? ($style['node']['tag'] ?? null) : null,
@@ -349,7 +350,7 @@ function blocks_engine_figma_trace_find_raw_nodes(array $scenegraph, array $node
  */
 function blocks_engine_figma_trace_collect_raw_nodes(array $node, array $wanted, array &$found): void
 {
-    $nodeId = is_scalar($node['id'] ?? null) ? (string) $node['id'] : '';
+    $nodeId = blocks_engine_figma_trace_raw_node_id($node);
     if ( '' !== $nodeId && isset($wanted[$nodeId]) ) {
         $found[$nodeId] = $node;
     }
@@ -363,7 +364,10 @@ function blocks_engine_figma_trace_collect_raw_nodes(array $node, array $wanted,
             if ( ! is_array($candidate) ) {
                 continue;
             }
-            $id = is_scalar($candidate['id'] ?? null) ? (string) $candidate['id'] : (is_scalar($key) ? (string) $key : '');
+            $id = blocks_engine_figma_trace_raw_node_id($candidate);
+            if ( '' === $id && is_scalar($key) ) {
+                $id = (string) $key;
+            }
             if ( '' !== $id && isset($wanted[$id]) ) {
                 $found[$id] = $candidate;
             }
@@ -385,6 +389,20 @@ function blocks_engine_figma_trace_collect_raw_nodes(array $node, array $wanted,
             blocks_engine_figma_trace_collect_raw_nodes($children, $wanted, $found);
         }
     }
+}
+
+function blocks_engine_figma_trace_raw_node_id(array $node): string
+{
+    if ( isset($node['id']) && is_scalar($node['id']) && '' !== (string) $node['id'] ) {
+        return (string) $node['id'];
+    }
+
+    $guid = $node['guid'] ?? null;
+    if ( is_array($guid) && isset($guid['sessionID'], $guid['localID']) && is_scalar($guid['sessionID']) && is_scalar($guid['localID']) ) {
+        return (string) $guid['sessionID'] . ':' . (string) $guid['localID'];
+    }
+
+    return '';
 }
 
 /**
@@ -525,6 +543,118 @@ function blocks_engine_figma_trace_paint_summary(array $node): array
     return array_map(static function (mixed $paint): array {
         return is_array($paint) ? array_intersect_key($paint, array_flip(array('type', 'color', 'opacity', 'ref', 'imageHash', 'imageName'))) : array();
     }, array_values($paints));
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_trace_field_coverage(mixed $rawNode, mixed $normalizedNode): array
+{
+    $rawFields = is_array($rawNode) ? blocks_engine_figma_trace_node_field_names($rawNode) : array();
+    $normalizedFields = is_array($normalizedNode) ? blocks_engine_figma_trace_node_field_names($normalizedNode) : array();
+    $rawOnly = array_values(array_diff($rawFields, $normalizedFields));
+    $normalizedOnly = array_values(array_diff($normalizedFields, $rawFields));
+    $common = array_values(array_intersect($rawFields, $normalizedFields));
+
+    sort($rawOnly);
+    sort($normalizedOnly);
+    sort($common);
+
+    return array_filter(array(
+        'raw_count' => count($rawFields),
+        'normalized_count' => count($normalizedFields),
+        'common' => blocks_engine_figma_trace_limit_values($common, 80),
+        'raw_only' => blocks_engine_figma_trace_limit_values($rawOnly, 120),
+        'normalized_only' => blocks_engine_figma_trace_limit_values($normalizedOnly, 120),
+        'signal' => blocks_engine_figma_trace_signal_fields(is_array($rawNode) ? $rawNode : array(), is_array($normalizedNode) ? $normalizedNode : array()),
+    ), static fn (mixed $value): bool => array() !== $value);
+}
+
+/**
+ * @return array<int, string>
+ */
+function blocks_engine_figma_trace_node_field_names(array $node): array
+{
+    $fields = array();
+    foreach ( $node as $field => $_value ) {
+        if ( is_string($field) && ! in_array($field, array('children'), true) ) {
+            $fields[] = $field;
+        }
+    }
+    sort($fields);
+    return $fields;
+}
+
+/**
+ * @param array<int, string> $values
+ * @return array<int, string>
+ */
+function blocks_engine_figma_trace_limit_values(array $values, int $limit): array
+{
+    return array_slice($values, 0, max(0, $limit));
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_trace_signal_fields(array $rawNode, array $normalizedNode): array
+{
+    $fields = array(
+        'raw' => blocks_engine_figma_trace_interesting_fields($rawNode),
+        'normalized' => blocks_engine_figma_trace_interesting_fields($normalizedNode),
+    );
+    return array_filter($fields, static fn (mixed $value): bool => array() !== $value);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_trace_interesting_fields(array $node): array
+{
+    $interesting = array(
+        'id', 'type', 'name', 'visible', 'opacity', 'blendMode', 'blend_mode', 'isMask', 'mask', 'maskType', 'effects',
+        'constraints', 'horizontalConstraint', 'verticalConstraint', 'layoutMode', 'layoutPositioning', 'primaryAxisAlignItems',
+        'counterAxisAlignItems', 'primaryAxisSizingMode', 'counterAxisSizingMode', 'stackPrimarySizing', 'stackCounterSizing',
+        'itemSpacing', 'paddingLeft', 'paddingRight', 'paddingTop', 'paddingBottom', 'relativeTransform', 'absoluteTransform',
+        'absoluteBoundingBox', 'absoluteRenderBounds', 'size', 'x', 'y', 'width', 'height', 'rotation', 'fills', 'fillPaints',
+        'strokes', 'strokePaints', 'styles', 'styleIdForFill', 'styleIdForStroke', 'boundVariables', 'variableConsumptionMap',
+        'componentId', 'componentProperties', 'componentPropertyDefinitions', 'overrides', 'overrideTable', 'overrideMap',
+        'characters', 'text', 'figma_text', 'style', 'textStyleOverrides', 'lineTypes', 'lineIndentations', 'vectorNetwork',
+        'vectorPaths', 'vectorPath', 'arcData', 'cornerRadius', 'rectangleCornerRadii', 'figma_component_source_id',
+    );
+    $summary = array();
+    foreach ( $interesting as $field ) {
+        if ( array_key_exists($field, $node) ) {
+            $summary[$field] = blocks_engine_figma_trace_summarize_field_value($node[$field]);
+        }
+    }
+    return $summary;
+}
+
+function blocks_engine_figma_trace_summarize_field_value(mixed $value): mixed
+{
+    if ( is_scalar($value) || null === $value ) {
+        return $value;
+    }
+    if ( is_array($value) ) {
+        if ( array_is_list($value) ) {
+            return array(
+                'kind' => 'list',
+                'count' => count($value),
+                'sample' => array_slice(array_map('blocks_engine_figma_trace_summarize_field_value', $value), 0, 3),
+            );
+        }
+        $sample = array();
+        foreach ( array_slice($value, 0, 12, true) as $key => $item ) {
+            $sample[(string) $key] = blocks_engine_figma_trace_summarize_field_value($item);
+        }
+        return array(
+            'kind' => 'map',
+            'count' => count($value),
+            'sample' => $sample,
+        );
+    }
+    return get_debug_type($value);
 }
 
 function blocks_engine_figma_trace_style_diagnostic(array $htmlReport, string $nodeId): ?array

--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -625,6 +625,7 @@ final class FigKiwiDecoder
                 'occurrences'       => 0,
                 'node_types'        => array(),
                 'sample_node_ids'   => array(),
+                'sample_nodes'      => array(),
                 'sample_raw_values' => array(),
             );
         }
@@ -637,8 +638,20 @@ final class FigKiwiDecoder
             $inventory['fields'][$key]['sample_node_ids'][] = $nodeId;
         }
 
+        $normalized = $this->normalizeInventorySample($sample);
+        if ( count($inventory['fields'][$key]['sample_nodes']) < self::INVENTORY_SAMPLE_LIMIT ) {
+            $nodeSample = array_filter(array(
+                'node_id'   => '' !== $nodeId ? $nodeId : null,
+                'node_type' => $nodeType,
+                'path'      => $path,
+                'raw_value' => $normalized,
+            ), static fn (mixed $value): bool => null !== $value);
+            if ( ! in_array($nodeSample, $inventory['fields'][$key]['sample_nodes'], true) ) {
+                $inventory['fields'][$key]['sample_nodes'][] = $nodeSample;
+            }
+        }
+
         if ( count($inventory['fields'][$key]['sample_raw_values']) < self::INVENTORY_SAMPLE_LIMIT ) {
-            $normalized = $this->normalizeInventorySample($sample);
             if ( ! in_array($normalized, $inventory['fields'][$key]['sample_raw_values'], true) ) {
                 $inventory['fields'][$key]['sample_raw_values'][] = $normalized;
             }

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -979,6 +979,7 @@ final class FigmaTransformer
             'empty_visible_container_categories' => array(),
             'empty_visible_containers' => array(),
             'decorative_underlays' => array('count' => 0, 'nodes' => array()),
+            'sticky_ghosts' => array('count' => 0, 'candidates' => array()),
             'image_heavy_landmark_candidates' => array(),
             'layout_mismatch_count' => 0,
             'layout_mismatch_status' => 'not_evaluated',
@@ -1055,6 +1056,11 @@ final class FigmaTransformer
                     $layout['decorative_underlays']['nodes'][] = array_merge($pageContext, $item);
                 }
             }
+            foreach ( is_array($pageLayout['sticky_ghosts']['candidates'] ?? null) ? $pageLayout['sticky_ghosts']['candidates'] : array() as $item ) {
+                if ( is_array($item) ) {
+                    $layout['sticky_ghosts']['candidates'][] = array_merge($pageContext, $item);
+                }
+            }
             foreach ( is_array($pageLayout['image_heavy_landmark_candidates'] ?? null) ? $pageLayout['image_heavy_landmark_candidates'] : array() as $item ) {
                 if ( is_array($item) ) {
                     $layout['image_heavy_landmark_candidates'][] = array_merge($pageContext, $item);
@@ -1123,6 +1129,8 @@ final class FigmaTransformer
         }
 
         $layout['decorative_underlays']['count'] = count($layout['decorative_underlays']['nodes']);
+        $layout['sticky_ghosts']['candidates'] = array_values($layout['sticky_ghosts']['candidates']);
+        $layout['sticky_ghosts']['count'] = count($layout['sticky_ghosts']['candidates']);
         $layout['large_css_offset_nodes'] = array_values($layout['large_css_offset_nodes']);
         $layout['off_canvas_visual_nodes'] = array_values($layout['off_canvas_visual_nodes']);
         $layout['empty_visible_containers'] = array_values($layout['empty_visible_containers']);

--- a/figma-transformer/src/Html/CssPositioningResolver.php
+++ b/figma-transformer/src/Html/CssPositioningResolver.php
@@ -31,11 +31,18 @@ final class CssPositioningResolver
         $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
         $left = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'x', $parentNode);
         $top = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'y', $parentNode);
+        $centerInsetVisualChild = null !== $node && null !== $parentNode && $this->isInsetSingleVisualChild($node, $parentNode);
         if ( null !== $node && $this->hasComponentCloneGeometry($node) ) {
             $left = $this->componentCloneSourceOffset($node, $box, $parentBox, 'x', $left);
             $top = $this->componentCloneSourceOffset($node, $box, $parentBox, 'y', $top);
         }
         $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
+        if ( $centerInsetVisualChild ) {
+            $left = $this->centeredInsetOffset($box, $parentBox, 'width');
+            $top = $this->centeredInsetOffset($box, $parentBox, 'height');
+            $constraints['horizontal'] = 'CENTER';
+            $constraints['vertical'] = 'CENTER';
+        }
 
         foreach ( $this->axisConstraintStyles('horizontal', is_scalar($constraints['horizontal'] ?? null) ? (string) $constraints['horizontal'] : null, $left, $parentBox, $box) as $style ) {
             $styles[] = $style;
@@ -45,6 +52,69 @@ final class CssPositioningResolver
         }
 
         return $styles;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $parentNode
+     */
+    private function isInsetSingleVisualChild(array $node, array $parentNode): bool
+    {
+        $children = $this->nodeList($parentNode);
+        if ( 1 !== count($children) || ! is_array($children[0]) || (string) ($children[0]['id'] ?? '') !== (string) ($node['id'] ?? '') ) {
+            return false;
+        }
+
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE'), true) ) {
+            return false;
+        }
+
+        $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        if ( ! empty($parentLayout['display'] ?? null) ) {
+            return false;
+        }
+
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        foreach ( array('width', 'height') as $dimension ) {
+            if ( ! isset($parentBox[$dimension], $box[$dimension]) || ! is_numeric($parentBox[$dimension]) || ! is_numeric($box[$dimension]) ) {
+                return false;
+            }
+        }
+
+        $left = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'x', $parentNode);
+        $top = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'y', $parentNode);
+        if ( (null !== $left && abs($left) > 0.5) || (null !== $top && abs($top) > 0.5) ) {
+            return false;
+        }
+
+        $widthDelta = (float) $parentBox['width'] - (float) $box['width'];
+        $heightDelta = (float) $parentBox['height'] - (float) $box['height'];
+        return ($widthDelta > 0.5 && $widthDelta <= 32.0) || ($heightDelta > 0.5 && $heightDelta <= 32.0);
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     * @param array<string, mixed> $parentBox
+     */
+    private function centeredInsetOffset(array $box, array $parentBox, string $dimension): ?float
+    {
+        if ( ! isset($box[$dimension], $parentBox[$dimension]) || ! is_numeric($box[$dimension]) || ! is_numeric($parentBox[$dimension]) ) {
+            return null;
+        }
+
+        return ((float) $parentBox[$dimension] - (float) $box[$dimension]) / 2.0;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, mixed>
+     */
+    private function nodeList(array $node): array
+    {
+        $children = $node['children'] ?? array();
+        return is_array($children) && array_is_list($children) ? $children : array();
     }
 
     /**

--- a/figma-transformer/src/Html/CssPositioningResolver.php
+++ b/figma-transformer/src/Html/CssPositioningResolver.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Resolves CSS declarations for nodes that leave normal flow.
+ */
+final class CssPositioningResolver
+{
+    /**
+     * @param callable(float): string $numberFormatter
+     */
+    public function __construct(
+        private readonly LayoutIntentClassifier $layoutIntentClassifier,
+        private readonly mixed $numberFormatter,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     * @param array<string, mixed> $layout
+     * @param array<string, mixed>|null $parentNode
+     * @param array<string, mixed>|null $node
+     * @return array<int, string>
+     */
+    public function styles(array $box, array $layout, ?array $parentNode, ?array $node = null): array
+    {
+        $styles = array();
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        $left = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'x', $parentNode);
+        $top = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'y', $parentNode);
+        if ( null !== $node && $this->hasComponentCloneGeometry($node) ) {
+            $left = $this->componentCloneSourceOffset($node, $box, $parentBox, 'x', $left);
+            $top = $this->componentCloneSourceOffset($node, $box, $parentBox, 'y', $top);
+        }
+        $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
+
+        foreach ( $this->axisConstraintStyles('horizontal', is_scalar($constraints['horizontal'] ?? null) ? (string) $constraints['horizontal'] : null, $left, $parentBox, $box) as $style ) {
+            $styles[] = $style;
+        }
+        foreach ( $this->axisConstraintStyles('vertical', is_scalar($constraints['vertical'] ?? null) ? (string) $constraints['vertical'] : null, $top, $parentBox, $box) as $style ) {
+            $styles[] = $style;
+        }
+
+        return $styles;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasComponentCloneGeometry(array $node): bool
+    {
+        if ( true === ($node['_component_source_clone_geometry'] ?? false) ) {
+            return true;
+        }
+
+        foreach ( array('box', 'figma_box') as $boxKey ) {
+            $box = is_array($node[$boxKey] ?? null) ? $node[$boxKey] : array();
+            if ( 'component_source_clone' === ($box['geometry_semantics'] ?? null) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $box
+     * @param array<string, mixed> $parentBox
+     */
+    private function componentCloneSourceOffset(array $node, array $box, array $parentBox, string $dimension, ?float $offset): ?float
+    {
+        if ( null === $offset ) {
+            return null;
+        }
+
+        if ( 'local' === ($box['coordinate_space'] ?? null) ) {
+            return $offset;
+        }
+
+        $sizeKey = 'x' === $dimension ? 'width' : 'height';
+        if ( ! isset($parentBox[$sizeKey], $box[$sizeKey]) || ! is_numeric($parentBox[$sizeKey]) || ! is_numeric($box[$sizeKey]) ) {
+            return $offset;
+        }
+
+        $parentSize = (float) $parentBox[$sizeKey];
+        $boxSize = (float) $box[$sizeKey];
+        if ( $parentSize <= 0.0 || $boxSize <= 0.0 || ($offset >= -0.5 && $offset + $boxSize <= $parentSize + 0.5) ) {
+            return $offset;
+        }
+
+        $sourceBox = is_array($node['_component_source_clone_source_box'] ?? null) ? $node['_component_source_clone_source_box'] : array();
+        if ( isset($sourceBox[$dimension]) && is_numeric($sourceBox[$dimension]) ) {
+            return (float) $sourceBox[$dimension];
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * Resolve the absolute-position CSS for a single axis from its Figma pin
+     * constraint. The near edge (left/top) is the default; LEFT_RIGHT/TOP_BOTTOM
+     * pin both edges, RIGHT/BOTTOM pin only the far edge, and CENTER holds a fixed
+     * offset from the parent center without relying on `transform` (which the
+     * emitter reserves for the node's own matrix). SCALE is percentage-based and
+     * has no clean pixel translation, so it falls back to the deterministic near
+     * pin instead of emitting a wrong guess.
+     *
+     * @param array<string, mixed> $parentBox
+     * @param array<string, mixed> $box
+     * @return array<int, string>
+     */
+    private function axisConstraintStyles(string $axis, ?string $constraint, ?float $offset, array $parentBox, array $box): array
+    {
+        $isHorizontal = 'horizontal' === $axis;
+        $startProp = $isHorizontal ? 'left' : 'top';
+        $endProp = $isHorizontal ? 'right' : 'bottom';
+        $sizeKey = $isHorizontal ? 'width' : 'height';
+        $bothPin = $isHorizontal ? 'LEFT_RIGHT' : 'TOP_BOTTOM';
+        $farPin = $isHorizontal ? 'RIGHT' : 'BOTTOM';
+        $parentSize = isset($parentBox[$sizeKey]) && is_numeric($parentBox[$sizeKey]) ? (float) $parentBox[$sizeKey] : null;
+        $boxSize = isset($box[$sizeKey]) && is_numeric($box[$sizeKey]) ? (float) $box[$sizeKey] : null;
+        $constraint = null === $constraint ? null : strtoupper($constraint);
+
+        $styles = array();
+
+        // Far-edge-only pin (REST RIGHT/BOTTOM, Kiwi MAX): anchor to the trailing
+        // edge and drop the leading offset so the node stays glued on resize.
+        if ( $farPin === $constraint && null !== $offset && null !== $parentSize && null !== $boxSize ) {
+            $styles[] = $endProp . ':' . $this->number($parentSize - $offset - $boxSize) . 'px';
+            return $styles;
+        }
+
+        // Center pin: keep the child center at a constant offset from the parent
+        // center. Emit the leading edge directly so node transforms remain free.
+        if ( 'CENTER' === $constraint && null !== $offset && null !== $parentSize ) {
+            $halfBoxSize = null !== $boxSize ? $boxSize / 2.0 : 0.0;
+            $centerDelta = $offset + $halfBoxSize - ( $parentSize / 2.0 );
+            $leadingDelta = $centerDelta - $halfBoxSize;
+            $sign = $leadingDelta < 0 ? '-' : '+';
+            $styles[] = $startProp . ':calc(50% ' . $sign . ' ' . $this->number(abs($leadingDelta)) . 'px)';
+            return $styles;
+        }
+
+        // Near-edge pin (LEFT/TOP/default, also SCALE fallback) plus an optional
+        // far-edge pin for the both-side stretch constraint.
+        if ( null !== $offset ) {
+            $styles[] = $startProp . ':' . $this->number($offset) . 'px';
+        }
+        if ( $bothPin === $constraint && null !== $offset && null !== $parentSize && null !== $boxSize ) {
+            $styles[] = $endProp . ':' . $this->number($parentSize - $offset - $boxSize) . 'px';
+        }
+
+        return $styles;
+    }
+
+    private function number(float $value): string
+    {
+        return ($this->numberFormatter)($value);
+    }
+}

--- a/figma-transformer/src/Html/EffectOverflowPolicy.php
+++ b/figma-transformer/src/Html/EffectOverflowPolicy.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Decides when Figma content clipping can be represented as CSS overflow hidden.
+ */
+final class EffectOverflowPolicy
+{
+    /**
+     * @param array<string, mixed> $node
+     */
+    public function shouldHideOverflow(array $node, bool $containsStickyPrimary): bool
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+
+        return true === ($layout['clips_content'] ?? false) && ! $containsStickyPrimary && ! $this->clipsVisibleEffectOverflow($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function clipsVisibleEffectOverflow(array $node): bool
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            if ( $this->nodeEffectOverflowAmount($child) <= 0.0 ) {
+                if ( $this->clipsVisibleEffectOverflow($child) ) {
+                    return true;
+                }
+                continue;
+            }
+
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            $left = isset($childBox['x']) && is_numeric($childBox['x']) ? (float) $childBox['x'] : 0.0;
+            $top = isset($childBox['y']) && is_numeric($childBox['y']) ? (float) $childBox['y'] : 0.0;
+            $width = isset($childBox['width']) && is_numeric($childBox['width']) ? (float) $childBox['width'] : 0.0;
+            $height = isset($childBox['height']) && is_numeric($childBox['height']) ? (float) $childBox['height'] : 0.0;
+            $parentWidth = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
+            $parentHeight = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
+
+            if ( $left <= 0.0 || $top <= 0.0 || (null !== $parentWidth && $left + $width >= $parentWidth) || (null !== $parentHeight && $top + $height >= $parentHeight) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeEffectOverflowAmount(array $node): float
+    {
+        $amount = 0.0;
+        foreach ( is_array($node['figma_effects'] ?? null) ? $node['figma_effects'] : array() as $effect ) {
+            if ( ! is_array($effect) || false === ($effect['visible'] ?? true) ) {
+                continue;
+            }
+            $type = (string) ($effect['type'] ?? '');
+            if ( ! in_array($type, array('drop_shadow', 'layer_blur'), true) ) {
+                continue;
+            }
+            $radius = isset($effect['radius']) && is_numeric($effect['radius']) ? (float) $effect['radius'] : 0.0;
+            $spread = isset($effect['spread']) && is_numeric($effect['spread']) ? (float) $effect['spread'] : 0.0;
+            $offsetX = isset($effect['offset_x']) && is_numeric($effect['offset_x']) ? abs((float) $effect['offset_x']) : 0.0;
+            $offsetY = isset($effect['offset_y']) && is_numeric($effect['offset_y']) ? abs((float) $effect['offset_y']) : 0.0;
+            $amount = max($amount, $radius + $spread + $offsetX, $radius + $spread + $offsetY);
+        }
+
+        return $amount;
+    }
+
+    /**
+     * @param array<string, mixed> $container
+     * @return array<int, mixed>
+     */
+    private function nodeList(array $container): array
+    {
+        if ( is_array($container['nodes'] ?? null) ) {
+            return array_values($container['nodes']);
+        }
+
+        if ( is_array($container['children'] ?? null) ) {
+            return array_values($container['children']);
+        }
+
+        return array();
+    }
+}

--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -131,7 +131,7 @@ final class LayoutIntentClassifier
             return false;
         }
 
-        if ( ! $this->isDecorativeUnderlayVisualCandidate($node) || ! $this->parentHasTextOutsideNode($parentNode, $node) ) {
+        if ( ! $this->isDecorativeUnderlayVisualCandidate($node) || ! $this->parentHasTextOutsideNode($parentNode, $node) || ! $this->nodeIsBehindTextOutsideNode($parentNode, $node) ) {
             return false;
         }
 
@@ -372,6 +372,67 @@ final class LayoutIntentClassifier
         }
 
         return false;
+    }
+
+    /**
+     * @param array<string, mixed> $parentNode
+     * @param array<string, mixed> $node
+     */
+    private function nodeIsBehindTextOutsideNode(array $parentNode, array $node): bool
+    {
+        $nodeId = (string) ($node['id'] ?? '');
+        $nodeZIndex = $this->nodeZIndex($node);
+        $nodeSiblingIndex = null;
+        $siblings = $this->nodeList($parentNode);
+
+        foreach ( $siblings as $index => $sibling ) {
+            if ( is_array($sibling) && (string) ($sibling['id'] ?? '') === $nodeId ) {
+                $nodeSiblingIndex = (int) $index;
+                break;
+            }
+        }
+
+        foreach ( $siblings as $index => $sibling ) {
+            if ( ! is_array($sibling) || (string) ($sibling['id'] ?? '') === $nodeId || ! $this->treeHasText($sibling) ) {
+                continue;
+            }
+
+            $siblingZIndex = $this->nodeZIndex($sibling);
+            if ( null !== $nodeZIndex && null !== $siblingZIndex ) {
+                if ( $nodeZIndex < $siblingZIndex ) {
+                    return true;
+                }
+                continue;
+            }
+
+            $nodeOrder = $this->nodeSourceOrder($node) ?? $nodeSiblingIndex;
+            $siblingOrder = $this->nodeSourceOrder($sibling) ?? (int) $index;
+            if ( null !== $nodeOrder && $nodeOrder < $siblingOrder ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeZIndex(array $node): ?int
+    {
+        return isset($node['layout']['z_index']) && is_numeric($node['layout']['z_index']) ? (int) $node['layout']['z_index'] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeSourceOrder(array $node): ?int
+    {
+        if ( isset($node['layout']['source_order']) && is_numeric($node['layout']['source_order']) ) {
+            return (int) $node['layout']['source_order'];
+        }
+
+        return isset($node['_source_order']) && is_numeric($node['_source_order']) ? (int) $node['_source_order'] : null;
     }
 
     /**

--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -100,15 +100,11 @@ final class LayoutIntentClassifier
     public function isDecorativeFlexUnderlay(array $node, array $parentNode): bool
     {
         $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
-        if ( ! in_array((string) ($parentLayout['display'] ?? ''), array('flex', 'inline-flex'), true) ) {
+        if ( ! $this->isFlexDisplayLayout($parentLayout) ) {
             return false;
         }
 
-        if ( $this->treeHasText($node) || $this->treeHasImageReference($node) ) {
-            return false;
-        }
-
-        if ( ! $this->treeIsVectorShapeOnly($node) || ! $this->parentHasTextOutsideNode($parentNode, $node) ) {
+        if ( ! $this->isDecorativeUnderlayVisualCandidate($node) || ! $this->parentHasTextOutsideNode($parentNode, $node) ) {
             return false;
         }
 
@@ -172,6 +168,22 @@ final class LayoutIntentClassifier
      * @param array<string, mixed> $node
      */
     public function isClippableDecorativeVisualNode(array $node): bool
+    {
+        return $this->isDecorativeUnderlayVisualCandidate($node);
+    }
+
+    /**
+     * @param array<string, mixed> $layout
+     */
+    private function isFlexDisplayLayout(array $layout): bool
+    {
+        return in_array((string) ($layout['display'] ?? ''), array('flex', 'inline-flex'), true);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isDecorativeUnderlayVisualCandidate(array $node): bool
     {
         return ! $this->treeHasText($node) && ! $this->treeHasImageReference($node) && $this->treeIsVectorShapeOnly($node);
     }
@@ -420,7 +432,7 @@ final class LayoutIntentClassifier
      */
     private function treeHasImageReference(array $node): bool
     {
-        if ( null !== $this->nodeAssetPath($node) || ! empty($this->explicitNodeAssetReferences($node)) || ! empty($this->nodeImagePaints($node)) ) {
+        if ( $this->nodeHasImageReference($node) ) {
             return true;
         }
 
@@ -441,10 +453,10 @@ final class LayoutIntentClassifier
         $type = strtoupper((string) ($node['type'] ?? ''));
         $children = $this->nodeList($node);
         if ( empty($children) ) {
-            return in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON', 'RECTANGLE', 'ROUNDED_RECTANGLE'), true);
+            return $this->isPrimitiveVectorShapeType($type);
         }
 
-        if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'BOOLEAN_OPERATION'), true) ) {
+        if ( ! $this->isVectorShapeContainerType($type) ) {
             return false;
         }
 
@@ -455,6 +467,16 @@ final class LayoutIntentClassifier
         }
 
         return true;
+    }
+
+    private function isPrimitiveVectorShapeType(string $type): bool
+    {
+        return in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON', 'RECTANGLE', 'ROUNDED_RECTANGLE'), true);
+    }
+
+    private function isVectorShapeContainerType(string $type): bool
+    {
+        return in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'BOOLEAN_OPERATION'), true);
     }
 
     /**
@@ -507,6 +529,14 @@ final class LayoutIntentClassifier
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeHasImageReference(array $node): bool
+    {
+        return null !== $this->nodeAssetPath($node) || ! empty($this->explicitNodeAssetReferences($node)) || ! empty($this->nodeImagePaints($node));
     }
 
     /**

--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -112,7 +112,7 @@ final class LayoutIntentClassifier
             return false;
         }
 
-        return $this->isOversizedAgainstParent($node, $parentNode);
+        return $this->isOversizedAgainstParent($node, $parentNode) || $this->isAbsoluteBackgroundBleed($node, $parentNode, $parentLayout);
     }
 
     /**
@@ -357,6 +357,44 @@ final class LayoutIntentClassifier
         $areaRatio = ((float) $box['width'] * (float) $box['height']) / ((float) $parentBox['width'] * (float) $parentBox['height']);
 
         return 0.75 <= $widthRatio || 0.75 <= $heightRatio || 0.45 <= $areaRatio;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $parentNode
+     * @param array<string, mixed> $parentLayout
+     */
+    private function isAbsoluteBackgroundBleed(array $node, array $parentNode, array $parentLayout): bool
+    {
+        if ( 'absolute' !== ($node['layout']['positioning'] ?? null) ) {
+            return false;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        foreach ( array('width', 'height') as $dimension ) {
+            if ( ! isset($box[$dimension], $parentBox[$dimension]) || ! is_numeric($box[$dimension]) || ! is_numeric($parentBox[$dimension]) || 0.0 >= (float) $parentBox[$dimension] ) {
+                return false;
+            }
+        }
+
+        $isRow = 'row' === ($parentLayout['flex_direction'] ?? null);
+        $mainAxis = $isRow ? 'width' : 'height';
+        $crossAxis = $isRow ? 'height' : 'width';
+        $crossOrigin = $isRow ? 'y' : 'x';
+        $mainRatio = (float) $box[$mainAxis] / (float) $parentBox[$mainAxis];
+        if ( 0.95 > $mainRatio ) {
+            return false;
+        }
+
+        $crossOffset = $this->positionOffset($box, $parentBox, $crossOrigin, $parentNode);
+        if ( null === $crossOffset ) {
+            return false;
+        }
+
+        $crossSize = (float) $box[$crossAxis];
+        $parentCrossSize = (float) $parentBox[$crossAxis];
+        return 1.0 <= ($crossSize / $parentCrossSize) || ($crossOffset <= 0.0 && $crossOffset + $crossSize >= $parentCrossSize);
     }
 
     /**

--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -441,7 +441,7 @@ final class LayoutIntentClassifier
         $type = strtoupper((string) ($node['type'] ?? ''));
         $children = $this->nodeList($node);
         if ( empty($children) ) {
-            return in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON', 'RECTANGLE'), true);
+            return in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON', 'RECTANGLE', 'ROUNDED_RECTANGLE'), true);
         }
 
         if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'BOOLEAN_OPERATION'), true) ) {
@@ -516,7 +516,7 @@ final class LayoutIntentClassifier
     private function nodeAssetReferences(array $node): array
     {
         $references = array();
-        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref', 'id', 'name') as $key ) {
+        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
             if ( isset($node[$key]) && is_scalar($node[$key]) ) {
                 $references[] = (string) $node[$key];
             }

--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -104,7 +104,7 @@ final class LayoutIntentClassifier
             return false;
         }
 
-        if ( $this->isAbsoluteChild($node) || $this->treeHasText($node) || $this->treeHasImageReference($node) ) {
+        if ( $this->treeHasText($node) || $this->treeHasImageReference($node) ) {
             return false;
         }
 

--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -35,6 +35,10 @@ final class LayoutIntentClassifier
             return true;
         }
 
+        if ( empty($node['layout']['display'] ?? null) && $this->hasInsetSingleVisualChild($node, $children) ) {
+            return true;
+        }
+
         if ( 1 !== count($children) || ! is_array($children[0]) ) {
             return false;
         }
@@ -55,6 +59,29 @@ final class LayoutIntentClassifier
         }
 
         return (float) $childBox['width'] > (float) $box['width'] || (float) $childBox['height'] > (float) $box['height'];
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<int, mixed>    $children
+     */
+    private function hasInsetSingleVisualChild(array $node, array $children): bool
+    {
+        if ( 1 !== count($children) || ! is_array($children[0]) || ! $this->treeIsVectorShapeOnly($children[0]) ) {
+            return false;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $childBox = is_array($children[0]['box'] ?? null) ? $children[0]['box'] : array();
+        foreach ( array('width', 'height') as $dimension ) {
+            if ( ! isset($box[$dimension], $childBox[$dimension]) || ! is_numeric($box[$dimension]) || ! is_numeric($childBox[$dimension]) ) {
+                return false;
+            }
+        }
+
+        $widthDelta = (float) $box['width'] - (float) $childBox['width'];
+        $heightDelta = (float) $box['height'] - (float) $childBox['height'];
+        return ($widthDelta > 0.5 && $widthDelta <= 32.0) || ($heightDelta > 0.5 && $heightDelta <= 32.0);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -61,6 +61,8 @@ final class StaticHtmlEmitter
 
     private ?CssPositioningResolver $cssPositioningResolver = null;
 
+    private ?StickyLayoutCoordinator $stickyLayoutCoordinator = null;
+
     private function designSystemExtractor(): DesignSystemExtractor
     {
         return $this->designSystemExtractor ??= new DesignSystemExtractor();
@@ -103,6 +105,14 @@ final class StaticHtmlEmitter
         return $this->cssPositioningResolver ??= new CssPositioningResolver(
             $this->layoutIntentClassifier(),
             fn (float $value): string => $this->number($value),
+        );
+    }
+
+    private function stickyLayoutCoordinator(): StickyLayoutCoordinator
+    {
+        return $this->stickyLayoutCoordinator ??= new StickyLayoutCoordinator(
+            fn (array $node): array => $this->nodeList($node),
+            fn (array $node): string => $this->textContent($node),
         );
     }
 
@@ -161,26 +171,6 @@ final class StaticHtmlEmitter
     private array $nodeReadableNames = array();
 
     /**
-     * @var array<string, bool>
-     */
-    private array $stickyGhostNodeIds = array();
-
-    /**
-     * @var array<string, array<string, mixed>>
-     */
-    private array $stickyPrimaryNodeIds = array();
-
-    /**
-     * @var array<string, bool>
-     */
-    private array $stickyAncestorNodeIds = array();
-
-    /**
-     * @var array<int, array<string, mixed>>
-     */
-    private array $stickyGhostCandidates = array();
-
-    /**
      * @param array<string, mixed> $scenegraph Normalized Figma scenegraph.
      * @param array<string, mixed> $options Transformation options.
      * @return array<string, mixed>
@@ -192,15 +182,12 @@ final class StaticHtmlEmitter
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
         $this->nodeReadableNames = array();
-        $this->stickyGhostNodeIds = array();
-        $this->stickyPrimaryNodeIds = array();
-        $this->stickyAncestorNodeIds = array();
-        $this->stickyGhostCandidates = array();
+        $this->stickyLayoutCoordinator()->reset();
         $this->linkTargetPaths = $this->normalizeLinkTargetPaths($options);
         $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
         $nodes = $this->nodeList($scenegraph);
-        $this->detectStickyGhostCandidates($nodes);
+        $this->stickyLayoutCoordinator()->detectStickyGhostCandidates($nodes);
         $this->listItemIdCache = array();
         $this->prepareHeadingRanking($nodes);
         $diagnostics = array();
@@ -325,10 +312,7 @@ final class StaticHtmlEmitter
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
         $this->nodeReadableNames = array();
-        $this->stickyGhostNodeIds = array();
-        $this->stickyPrimaryNodeIds = array();
-        $this->stickyAncestorNodeIds = array();
-        $this->stickyGhostCandidates = array();
+        $this->stickyLayoutCoordinator()->reset();
         $this->linkTargetPaths = $this->linkTargetPathsFromPagePlan($pagePlan, $options);
         $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
@@ -383,7 +367,7 @@ final class StaticHtmlEmitter
                 }
             }
         }
-        $this->detectStickyGhostCandidates($stickyDetectionRoots);
+        $this->stickyLayoutCoordinator()->detectStickyGhostCandidates($stickyDetectionRoots);
 
         foreach ( $plannedPages as $index => $page ) {
             if ( ! is_array($page) ) {
@@ -641,7 +625,7 @@ final class StaticHtmlEmitter
      */
     private function collectVariantNodeStyles(array $node, int $depth, ?array $parentNode, string $pathKey, array &$map): void
     {
-        if ( $this->isSuppressedStickyGhost($node) ) {
+        if ( $this->stickyLayoutCoordinator()->isSuppressedStickyGhost($node) ) {
             return;
         }
 
@@ -649,12 +633,12 @@ final class StaticHtmlEmitter
         $name = (string) ($node['name'] ?? '');
         $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
         $className = 'figma-node-' . $this->slug($id . '-' . $name);
-        $styles = $this->stickyAwareStyleDeclarations($node, $type, $parentNode);
+        $styles = $this->stickyLayoutCoordinator()->stickyAwareStyleDeclarations($node, $this->styleDeclarations($node, $type, $parentNode));
 
         $map[$pathKey] = array(
             'class'           => $className,
             'styles'          => $styles,
-            'contains_sticky' => $this->containsStickyPrimary($node),
+            'contains_sticky' => $this->stickyLayoutCoordinator()->containsStickyPrimary($node),
         );
 
         $vectorSvg = $this->supportedVectorSvg($node, $type, $parentNode);
@@ -664,7 +648,7 @@ final class StaticHtmlEmitter
 
         $childOrdinal = 0;
         foreach ( $this->nodeList($node) as $child ) {
-            if ( ! is_array($child) || $this->isSuppressedStickyGhost($child) || $this->isFullyClippedDecorativeChild($child, $node) ) {
+            if ( ! is_array($child) || $this->stickyLayoutCoordinator()->isSuppressedStickyGhost($child) || $this->isFullyClippedDecorativeChild($child, $node) ) {
                 continue;
             }
 
@@ -751,7 +735,7 @@ final class StaticHtmlEmitter
      */
     private function emitNode(array $node, array &$cssRules, array &$diagnostics, array &$nodeStyleDiagnostics, int $depth, ?array $parentNode): string
     {
-        if ( $this->isSuppressedStickyGhost($node) ) {
+        if ( $this->stickyLayoutCoordinator()->isSuppressedStickyGhost($node) ) {
             return '';
         }
 
@@ -814,7 +798,7 @@ final class StaticHtmlEmitter
         }
 
         $styles = $this->styleDeclarations($node, $type, $parentNode);
-        $styles = $this->stickyAwareStyleDeclarations($node, $type, $parentNode, $styles);
+        $styles = $this->stickyLayoutCoordinator()->stickyAwareStyleDeclarations($node, $styles);
         if ( ! empty($styles) ) {
             $cssRules[] = '.' . $className . '{' . implode(';', $styles) . '}';
             $this->nodeReadableNames[$className] = $this->sharedClassBaseName($name, $type);
@@ -2209,8 +2193,8 @@ final class StaticHtmlEmitter
                 'sample_nodes' => array(),
             ),
             'sticky_ghosts' => array(
-                'count' => count($this->stickyGhostCandidates),
-                'candidates' => $this->stickyGhostCandidates,
+                'count' => count($this->stickyLayoutCoordinator()->stickyGhostCandidates()),
+                'candidates' => $this->stickyLayoutCoordinator()->stickyGhostCandidates(),
             ),
         );
         $components = array(
@@ -2471,7 +2455,7 @@ final class StaticHtmlEmitter
      */
     private function collectTransformDiagnostics(array $node, array &$image, array &$vectors, array &$layout, array &$components, array &$effects, array &$maskEffectClipping, string $html, string $css, ?array $parentNode = null): void
     {
-        if ( $this->isSuppressedStickyGhost($node) ) {
+        if ( $this->stickyLayoutCoordinator()->isSuppressedStickyGhost($node) ) {
             return;
         }
 
@@ -3520,286 +3504,6 @@ final class StaticHtmlEmitter
     }
 
     /**
-     * @param array<int, array<string, mixed>> $nodes
-     */
-    private function detectStickyGhostCandidates(array $nodes): void
-    {
-        foreach ( $nodes as $node ) {
-            if ( is_array($node) ) {
-                $this->detectStickyGhostCandidatesInNode($node);
-            }
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $parentNode
-     * @param array<int, string> $ancestorIds
-     */
-    private function detectStickyGhostCandidatesInNode(array $parentNode, array $ancestorIds = array()): void
-    {
-        $children = array_values(array_filter($this->nodeList($parentNode), 'is_array'));
-        $count = count($children);
-        $parentId = (string) ($parentNode['id'] ?? '');
-        $stickyAncestorIds = '' === $parentId ? $ancestorIds : array_merge($ancestorIds, array($parentId));
-        for ( $i = 0; $i < $count; $i++ ) {
-            for ( $j = $i + 1; $j < $count; $j++ ) {
-                $this->detectStickyGhostCandidatePair($parentNode, $children[$i], $children[$j], $stickyAncestorIds);
-            }
-        }
-
-        foreach ( $children as $child ) {
-            $this->detectStickyGhostCandidatesInNode($child, $stickyAncestorIds);
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $parentNode
-     * @param array<string, mixed> $a
-     * @param array<string, mixed> $b
-     * @param array<int, string> $stickyAncestorIds
-     */
-    private function detectStickyGhostCandidatePair(array $parentNode, array $a, array $b, array $stickyAncestorIds): void
-    {
-        $aAbsolute = $this->isAbsoluteLayoutNode($a);
-        $bAbsolute = $this->isAbsoluteLayoutNode($b);
-        if ( $aAbsolute === $bAbsolute ) {
-            return;
-        }
-
-        $flow = $aAbsolute ? $b : $a;
-        $ghost = $aAbsolute ? $a : $b;
-        if ( $this->nodeOpacity($ghost) > 0.25 || $this->nodeOpacity($flow) < 0.99 ) {
-            return;
-        }
-
-        $flowBox = is_array($flow['box'] ?? null) ? $flow['box'] : array();
-        $ghostBox = is_array($ghost['box'] ?? null) ? $ghost['box'] : array();
-        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
-        if ( ! $this->sameNodeSize($flowBox, $ghostBox) || ! $this->isFarVerticalEdgeDuplicate($ghost, $ghostBox, $parentBox) ) {
-            return;
-        }
-
-        $signature = $this->stickyGhostSemanticSignature($flow);
-        $ghostSignature = $this->stickyGhostSemanticSignature($ghost);
-        if ( '' === $signature || $signature !== $ghostSignature ) {
-            $signature = $this->stickyGhostContentSignature($flow);
-            if ( '' === $signature || $signature !== $this->stickyGhostContentSignature($ghost) ) {
-                return;
-            }
-        }
-
-        $primaryId = (string) ($flow['id'] ?? '');
-        $ghostId = (string) ($ghost['id'] ?? '');
-        if ( '' === $primaryId || '' === $ghostId || isset($this->stickyGhostNodeIds[$ghostId]) ) {
-            return;
-        }
-
-        $this->stickyPrimaryNodeIds[$primaryId] = array('ghost_id' => $ghostId, 'signature' => $signature);
-        foreach ( $stickyAncestorIds as $ancestorId ) {
-            if ( '' !== $ancestorId ) {
-                $this->stickyAncestorNodeIds[$ancestorId] = true;
-            }
-        }
-        $this->stickyGhostNodeIds[$ghostId] = true;
-        $this->stickyGhostCandidates[] = array(
-            'primary_id' => $primaryId,
-            'ghost_id' => $ghostId,
-            'parent_id' => (string) ($parentNode['id'] ?? ''),
-            'signature' => $signature,
-            'ghost_opacity' => $this->nodeOpacity($ghost),
-            'evidence' => array(
-                'primary_positioning' => 'flow',
-                'ghost_positioning' => 'absolute',
-                'ghost_vertical_constraint' => $this->verticalConstraint($ghost),
-                'same_size' => true,
-            ),
-        );
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function isSuppressedStickyGhost(array $node): bool
-    {
-        $id = (string) ($node['id'] ?? '');
-        return '' !== $id && isset($this->stickyGhostNodeIds[$id]);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function isStickyPrimary(array $node): bool
-    {
-        $id = (string) ($node['id'] ?? '');
-        return '' !== $id && isset($this->stickyPrimaryNodeIds[$id]);
-    }
-
-    /**
-     * @param array<string, mixed>|null $parentNode
-     * @param array<int, string>|null   $styles
-     * @return array<int, string>
-     */
-    private function stickyAwareStyleDeclarations(array $node, string $type, ?array $parentNode, ?array $styles = null): array
-    {
-        $styles = $styles ?? $this->styleDeclarations($node, $type, $parentNode);
-        if ( ! $this->isStickyPrimary($node) ) {
-            return $styles;
-        }
-
-        $styles = array_values(array_filter(
-            $styles,
-            static fn (string $style): bool => ! str_starts_with($style, 'position:') && ! str_starts_with($style, 'top:')
-        ));
-        $styles[] = 'position:sticky';
-        $styles[] = 'top:0';
-        $styles[] = 'align-self:flex-start';
-
-        return $styles;
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function containsStickyPrimary(array $node): bool
-    {
-        $id = (string) ($node['id'] ?? '');
-        return '' !== $id && isset($this->stickyAncestorNodeIds[$id]);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function isAbsoluteLayoutNode(array $node): bool
-    {
-        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        return 'absolute' === ($layout['positioning'] ?? null);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function nodeOpacity(array $node): float
-    {
-        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
-        if ( isset($box['opacity']) && is_numeric($box['opacity']) ) {
-            return (float) $box['opacity'];
-        }
-        if ( isset($node['opacity']) && is_numeric($node['opacity']) ) {
-            return (float) $node['opacity'];
-        }
-
-        return 1.0;
-    }
-
-    /**
-     * @param array<string, mixed> $flowBox
-     * @param array<string, mixed> $ghostBox
-     */
-    private function sameNodeSize(array $flowBox, array $ghostBox): bool
-    {
-        foreach ( array('width', 'height') as $dimension ) {
-            if ( ! isset($flowBox[$dimension], $ghostBox[$dimension]) || ! is_numeric($flowBox[$dimension]) || ! is_numeric($ghostBox[$dimension]) ) {
-                return false;
-            }
-            if ( abs((float) $flowBox[$dimension] - (float) $ghostBox[$dimension]) > 1.0 ) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param array<string, mixed> $ghost
-     * @param array<string, mixed> $ghostBox
-     * @param array<string, mixed> $parentBox
-     */
-    private function isFarVerticalEdgeDuplicate(array $ghost, array $ghostBox, array $parentBox): bool
-    {
-        if ( ! isset($ghostBox['y'], $ghostBox['height'], $parentBox['height']) || ! is_numeric($ghostBox['y']) || ! is_numeric($ghostBox['height']) || ! is_numeric($parentBox['height']) ) {
-            return false;
-        }
-
-        $bottomGap = (float) $parentBox['height'] - (float) $ghostBox['y'] - (float) $ghostBox['height'];
-        $constraint = $this->verticalConstraint($ghost);
-        $isFarPinned = in_array($constraint, array('BOTTOM', 'MAX'), true);
-
-        return $isFarPinned && (float) $ghostBox['y'] > (float) $ghostBox['height'] && $bottomGap >= -1.0 && $bottomGap <= 32.0;
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function verticalConstraint(array $node): string
-    {
-        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
-        if ( isset($constraints['vertical']) && is_scalar($constraints['vertical']) ) {
-            return strtoupper((string) $constraints['vertical']);
-        }
-        if ( isset($node['constraints']['vertical']) && is_scalar($node['constraints']['vertical']) ) {
-            return strtoupper((string) $node['constraints']['vertical']);
-        }
-
-        return '';
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function stickyGhostSemanticSignature(array $node): string
-    {
-        $sourceId = isset($node['figma_component_source_id']) && is_scalar($node['figma_component_source_id']) ? trim((string) $node['figma_component_source_id']) : '';
-        if ( '' !== $sourceId ) {
-            return 'component:' . $sourceId;
-        }
-
-        return $this->stickyGhostContentSignature($node);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function stickyGhostContentSignature(array $node): string
-    {
-        $textSequence = $this->descendantTextSequence($node);
-        if ( empty($textSequence) ) {
-            return '';
-        }
-
-        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
-        $type = strtoupper((string) ($node['type'] ?? ''));
-        $name = strtolower(trim(preg_replace('/\s+/', ' ', (string) ($node['name'] ?? '')) ?? ''));
-        $width = isset($box['width']) && is_numeric($box['width']) ? (string) round((float) $box['width']) : '';
-        $height = isset($box['height']) && is_numeric($box['height']) ? (string) round((float) $box['height']) : '';
-
-        return 'content:' . implode('|', array($type, $name, $width, $height, sha1(implode("\n", $textSequence))));
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     * @return array<int, string>
-     */
-    private function descendantTextSequence(array $node): array
-    {
-        $sequence = array();
-        if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
-            $text = trim(preg_replace('/\s+/', ' ', $this->textContent($node)) ?? '');
-            if ( '' !== $text ) {
-                $sequence[] = $text;
-            }
-        }
-
-        foreach ( $this->nodeList($node) as $child ) {
-            if ( is_array($child) ) {
-                array_push($sequence, ...$this->descendantTextSequence($child));
-            }
-        }
-
-        return $sequence;
-    }
-
-    /**
      * @param array<string, mixed> $node
      * @return array<int, string>
      */
@@ -3860,7 +3564,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        if ( $this->effectOverflowPolicy()->shouldHideOverflow($node, $this->containsStickyPrimary($node)) ) {
+        if ( $this->effectOverflowPolicy()->shouldHideOverflow($node, $this->stickyLayoutCoordinator()->containsStickyPrimary($node)) ) {
             $styles[] = 'overflow:hidden';
         }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3842,7 +3842,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        if ( true === ($layout['clips_content'] ?? false) && ! $this->containsStickyPrimary($node) ) {
+        if ( true === ($layout['clips_content'] ?? false) && ! $this->containsStickyPrimary($node) && ! $this->clipsVisibleEffectOverflow($node) ) {
             $styles[] = 'overflow:hidden';
         }
 
@@ -5246,6 +5246,63 @@ final class StaticHtmlEmitter
     private function effectStyles(array $node, string $type): array
     {
         return $this->styleDeclarationBuilder()->effectStyles($node, $type);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function clipsVisibleEffectOverflow(array $node): bool
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            if ( $this->nodeEffectOverflowAmount($child) <= 0.0 ) {
+                if ( $this->clipsVisibleEffectOverflow($child) ) {
+                    return true;
+                }
+                continue;
+            }
+
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            $left = isset($childBox['x']) && is_numeric($childBox['x']) ? (float) $childBox['x'] : 0.0;
+            $top = isset($childBox['y']) && is_numeric($childBox['y']) ? (float) $childBox['y'] : 0.0;
+            $width = isset($childBox['width']) && is_numeric($childBox['width']) ? (float) $childBox['width'] : 0.0;
+            $height = isset($childBox['height']) && is_numeric($childBox['height']) ? (float) $childBox['height'] : 0.0;
+            $parentWidth = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
+            $parentHeight = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
+
+            if ( $left <= 0.0 || $top <= 0.0 || (null !== $parentWidth && $left + $width >= $parentWidth) || (null !== $parentHeight && $top + $height >= $parentHeight) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeEffectOverflowAmount(array $node): float
+    {
+        $amount = 0.0;
+        foreach ( is_array($node['figma_effects'] ?? null) ? $node['figma_effects'] : array() as $effect ) {
+            if ( ! is_array($effect) || false === ($effect['visible'] ?? true) ) {
+                continue;
+            }
+            $type = (string) ($effect['type'] ?? '');
+            if ( ! in_array($type, array('drop_shadow', 'layer_blur'), true) ) {
+                continue;
+            }
+            $radius = isset($effect['radius']) && is_numeric($effect['radius']) ? (float) $effect['radius'] : 0.0;
+            $spread = isset($effect['spread']) && is_numeric($effect['spread']) ? (float) $effect['spread'] : 0.0;
+            $offsetX = isset($effect['offset_x']) && is_numeric($effect['offset_x']) ? abs((float) $effect['offset_x']) : 0.0;
+            $offsetY = isset($effect['offset_y']) && is_numeric($effect['offset_y']) ? abs((float) $effect['offset_y']) : 0.0;
+            $amount = max($amount, $radius + $spread + $offsetX, $radius + $spread + $offsetY);
+        }
+
+        return $amount;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -59,6 +59,8 @@ final class StaticHtmlEmitter
 
     private ?EffectOverflowPolicy $effectOverflowPolicy = null;
 
+    private ?CssPositioningResolver $cssPositioningResolver = null;
+
     private function designSystemExtractor(): DesignSystemExtractor
     {
         return $this->designSystemExtractor ??= new DesignSystemExtractor();
@@ -94,6 +96,14 @@ final class StaticHtmlEmitter
     private function effectOverflowPolicy(): EffectOverflowPolicy
     {
         return $this->effectOverflowPolicy ??= new EffectOverflowPolicy();
+    }
+
+    private function cssPositioningResolver(): CssPositioningResolver
+    {
+        return $this->cssPositioningResolver ??= new CssPositioningResolver(
+            $this->layoutIntentClassifier(),
+            fn (float $value): string => $this->number($value),
+        );
     }
 
     private function layoutIntentClassifier(): LayoutIntentClassifier
@@ -196,6 +206,7 @@ final class StaticHtmlEmitter
         $diagnostics = array();
         $nodeStyleDiagnostics = array();
         $assetFiles = $this->normalizeAssets($scenegraph['assets'] ?? array(), $diagnostics);
+        $this->cssPositioningResolver = null;
 
         $this->sectionDepth = $this->sectionDepthFor($nodes);
 
@@ -3859,21 +3870,21 @@ final class StaticHtmlEmitter
             $styles[] = 'position:relative';
         }
 
-		if ( $isDecorativeFlexUnderlay ) {
-			$styles[] = 'position:absolute';
-			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
-				$styles[] = $style;
-			}
-			$styles[] = 'z-index:0';
-			$styles[] = 'pointer-events:none';
-		} elseif ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
-			$styles[] = 'position:absolute';
-			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
-				$styles[] = $style;
-			}
-		} elseif ( 'absolute' === ($layout['positioning'] ?? null) ) {
+        if ( $isDecorativeFlexUnderlay ) {
             $styles[] = 'position:absolute';
-			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
+            foreach ( $this->cssPositioningResolver()->styles($box, $layout, $parentNode, $node) as $style ) {
+                $styles[] = $style;
+            }
+            $styles[] = 'z-index:0';
+            $styles[] = 'pointer-events:none';
+        } elseif ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
+            $styles[] = 'position:absolute';
+            foreach ( $this->cssPositioningResolver()->styles($box, $layout, $parentNode, $node) as $style ) {
+                $styles[] = $style;
+            }
+        } elseif ( 'absolute' === ($layout['positioning'] ?? null) ) {
+            $styles[] = 'position:absolute';
+            foreach ( $this->cssPositioningResolver()->styles($box, $layout, $parentNode, $node) as $style ) {
                 $styles[] = $style;
             }
         }
@@ -4161,124 +4172,6 @@ final class StaticHtmlEmitter
         }
 
         return false;
-    }
-
-    /**
-     * @param array<string, mixed> $box
-     * @param array<string, mixed> $layout
-     * @return array<int, string>
-     */
-    private function absolutePositionStyles(array $box, array $layout, ?array $parentNode, ?array $node = null): array
-    {
-        $styles = array();
-        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
-        $left = $this->positionOffset($box, $parentBox, 'x', $parentNode);
-        $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
-        if ( null !== $node && $this->hasComponentCloneGeometry($node) ) {
-            $left = $this->componentCloneSourceOffset($node, $box, $parentBox, 'x', $left);
-            $top = $this->componentCloneSourceOffset($node, $box, $parentBox, 'y', $top);
-        }
-        $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
-
-        foreach ( $this->axisConstraintStyles('horizontal', is_scalar($constraints['horizontal'] ?? null) ? (string) $constraints['horizontal'] : null, $left, $parentBox, $box) as $style ) {
-            $styles[] = $style;
-        }
-        foreach ( $this->axisConstraintStyles('vertical', is_scalar($constraints['vertical'] ?? null) ? (string) $constraints['vertical'] : null, $top, $parentBox, $box) as $style ) {
-            $styles[] = $style;
-        }
-
-        return $styles;
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     * @param array<string, mixed> $box
-     * @param array<string, mixed> $parentBox
-     */
-    private function componentCloneSourceOffset(array $node, array $box, array $parentBox, string $dimension, ?float $offset): ?float
-    {
-        if ( null === $offset ) {
-            return null;
-        }
-
-        if ( 'local' === ($box['coordinate_space'] ?? null) ) {
-            return $offset;
-        }
-
-        $sizeKey = 'x' === $dimension ? 'width' : 'height';
-        if ( ! isset($parentBox[$sizeKey], $box[$sizeKey]) || ! is_numeric($parentBox[$sizeKey]) || ! is_numeric($box[$sizeKey]) ) {
-            return $offset;
-        }
-
-        $parentSize = (float) $parentBox[$sizeKey];
-        $boxSize = (float) $box[$sizeKey];
-        if ( $parentSize <= 0.0 || $boxSize <= 0.0 || ($offset >= -0.5 && $offset + $boxSize <= $parentSize + 0.5) ) {
-            return $offset;
-        }
-
-        $sourceBox = is_array($node['_component_source_clone_source_box'] ?? null) ? $node['_component_source_clone_source_box'] : array();
-        if ( isset($sourceBox[$dimension]) && is_numeric($sourceBox[$dimension]) ) {
-            return (float) $sourceBox[$dimension];
-        }
-
-        return 0.0;
-    }
-
-    /**
-     * Resolve the absolute-position CSS for a single axis from its Figma pin
-     * constraint. The near edge (left/top) is the default; LEFT_RIGHT/TOP_BOTTOM
-     * pin both edges, RIGHT/BOTTOM pin only the far edge, and CENTER holds a fixed
-     * offset from the parent center without relying on `transform` (which the
-     * emitter reserves for the node's own matrix). SCALE is percentage-based and
-     * has no clean pixel translation, so it falls back to the deterministic near
-     * pin instead of emitting a wrong guess.
-     *
-     * @param array<string, mixed> $parentBox
-     * @param array<string, mixed> $box
-     * @return array<int, string>
-     */
-    private function axisConstraintStyles(string $axis, ?string $constraint, ?float $offset, array $parentBox, array $box): array
-    {
-        $isHorizontal = 'horizontal' === $axis;
-        $startProp = $isHorizontal ? 'left' : 'top';
-        $endProp = $isHorizontal ? 'right' : 'bottom';
-        $sizeKey = $isHorizontal ? 'width' : 'height';
-        $bothPin = $isHorizontal ? 'LEFT_RIGHT' : 'TOP_BOTTOM';
-        $farPin = $isHorizontal ? 'RIGHT' : 'BOTTOM';
-        $parentSize = isset($parentBox[$sizeKey]) && is_numeric($parentBox[$sizeKey]) ? (float) $parentBox[$sizeKey] : null;
-        $boxSize = isset($box[$sizeKey]) && is_numeric($box[$sizeKey]) ? (float) $box[$sizeKey] : null;
-        $constraint = null === $constraint ? null : strtoupper($constraint);
-
-        $styles = array();
-
-        // Far-edge-only pin (REST RIGHT/BOTTOM, Kiwi MAX): anchor to the trailing
-        // edge and drop the leading offset so the node stays glued on resize.
-        if ( $farPin === $constraint && null !== $offset && null !== $parentSize && null !== $boxSize ) {
-            $styles[] = $endProp . ':' . $this->number($parentSize - $offset - $boxSize) . 'px';
-            return $styles;
-        }
-
-        // Center pin: keep the child center at a constant offset from the parent
-        // center. Emit the leading edge directly so node transforms remain free.
-        if ( 'CENTER' === $constraint && null !== $offset && null !== $parentSize ) {
-            $halfBoxSize = null !== $boxSize ? $boxSize / 2.0 : 0.0;
-            $centerDelta = $offset + $halfBoxSize - ( $parentSize / 2.0 );
-            $leadingDelta = $centerDelta - $halfBoxSize;
-            $sign = $leadingDelta < 0 ? '-' : '+';
-            $styles[] = $startProp . ':calc(50% ' . $sign . ' ' . $this->number(abs($leadingDelta)) . 'px)';
-            return $styles;
-        }
-
-        // Near-edge pin (LEFT/TOP/default, also SCALE fallback) plus an optional
-        // far-edge pin for the both-side stretch constraint.
-        if ( null !== $offset ) {
-            $styles[] = $startProp . ':' . $this->number($offset) . 'px';
-        }
-        if ( $bothPin === $constraint && null !== $offset && null !== $parentSize && null !== $boxSize ) {
-            $styles[] = $endProp . ':' . $this->number($parentSize - $offset - $boxSize) . 'px';
-        }
-
-        return $styles;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -4222,12 +4222,14 @@ final class StaticHtmlEmitter
             return $styles;
         }
 
-        // Center pin: keep a constant offset from the parent center. Using calc()
-        // off the leading edge avoids touching transform.
+        // Center pin: keep the child center at a constant offset from the parent
+        // center. Emit the leading edge directly so node transforms remain free.
         if ( 'CENTER' === $constraint && null !== $offset && null !== $parentSize ) {
-            $delta = $offset + ((null !== $boxSize ? $boxSize : 0.0) / 2.0) - ( $parentSize / 2.0 );
-            $sign = $delta < 0 ? '-' : '+';
-            $styles[] = $startProp . ':calc(50% ' . $sign . ' ' . $this->number(abs($delta)) . 'px)';
+            $halfBoxSize = null !== $boxSize ? $boxSize / 2.0 : 0.0;
+            $centerDelta = $offset + $halfBoxSize - ( $parentSize / 2.0 );
+            $leadingDelta = $centerDelta - $halfBoxSize;
+            $sign = $leadingDelta < 0 ? '-' : '+';
+            $styles[] = $startProp . ':calc(50% ' . $sign . ' ' . $this->number(abs($leadingDelta)) . 'px)';
             return $styles;
         }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -144,6 +144,21 @@ final class StaticHtmlEmitter
     private array $nodeReadableNames = array();
 
     /**
+     * @var array<string, bool>
+     */
+    private array $stickyGhostNodeIds = array();
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $stickyPrimaryNodeIds = array();
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $stickyGhostCandidates = array();
+
+    /**
      * @param array<string, mixed> $scenegraph Normalized Figma scenegraph.
      * @param array<string, mixed> $options Transformation options.
      * @return array<string, mixed>
@@ -155,10 +170,14 @@ final class StaticHtmlEmitter
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
         $this->nodeReadableNames = array();
+        $this->stickyGhostNodeIds = array();
+        $this->stickyPrimaryNodeIds = array();
+        $this->stickyGhostCandidates = array();
         $this->linkTargetPaths = $this->normalizeLinkTargetPaths($options);
         $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
         $nodes = $this->nodeList($scenegraph);
+        $this->detectStickyGhostCandidates($nodes);
         $this->listItemIdCache = array();
         $this->prepareHeadingRanking($nodes);
         $diagnostics = array();
@@ -669,6 +688,10 @@ final class StaticHtmlEmitter
      */
     private function emitNode(array $node, array &$cssRules, array &$diagnostics, array &$nodeStyleDiagnostics, int $depth, ?array $parentNode): string
     {
+        if ( $this->isSuppressedStickyGhost($node) ) {
+            return '';
+        }
+
         // Designer-hidden layers carry an explicit `visible: false` from Figma.
         // Skip emitting them and their entire subtree. Absent/null `visible`
         // means visible, so only an explicit false is honored. A hidden node
@@ -728,6 +751,15 @@ final class StaticHtmlEmitter
         }
 
         $styles = $this->styleDeclarations($node, $type, $parentNode);
+        if ( $this->isStickyPrimary($node) ) {
+            $styles = array_values(array_filter(
+                $styles,
+                static fn (string $style): bool => ! str_starts_with($style, 'position:') && ! str_starts_with($style, 'top:')
+            ));
+            $styles[] = 'position:sticky';
+            $styles[] = 'top:0';
+            $styles[] = 'align-self:flex-start';
+        }
         if ( ! empty($styles) ) {
             $cssRules[] = '.' . $className . '{' . implode(';', $styles) . '}';
             $this->nodeReadableNames[$className] = $this->sharedClassBaseName($name, $type);
@@ -2121,6 +2153,10 @@ final class StaticHtmlEmitter
                 'flow_child_count' => 0,
                 'sample_nodes' => array(),
             ),
+            'sticky_ghosts' => array(
+                'count' => count($this->stickyGhostCandidates),
+                'candidates' => $this->stickyGhostCandidates,
+            ),
         );
         $components = array(
             'schema' => 'blocks-engine/figma-transformer/component-coverage/v1',
@@ -2380,6 +2416,10 @@ final class StaticHtmlEmitter
      */
     private function collectTransformDiagnostics(array $node, array &$image, array &$vectors, array &$layout, array &$components, array &$effects, array &$maskEffectClipping, string $html, string $css, ?array $parentNode = null): void
     {
+        if ( $this->isSuppressedStickyGhost($node) ) {
+            return;
+        }
+
         ++$image['total_node_count'];
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
@@ -3422,6 +3462,228 @@ final class StaticHtmlEmitter
         }
 
         return array('x' => $left, 'y' => $top, 'width' => $right - $left, 'height' => $bottom - $top);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $nodes
+     */
+    private function detectStickyGhostCandidates(array $nodes): void
+    {
+        foreach ( $nodes as $node ) {
+            if ( is_array($node) ) {
+                $this->detectStickyGhostCandidatesInNode($node);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $parentNode
+     */
+    private function detectStickyGhostCandidatesInNode(array $parentNode): void
+    {
+        $children = array_values(array_filter($this->nodeList($parentNode), 'is_array'));
+        $count = count($children);
+        for ( $i = 0; $i < $count; $i++ ) {
+            for ( $j = $i + 1; $j < $count; $j++ ) {
+                $this->detectStickyGhostCandidatePair($parentNode, $children[$i], $children[$j]);
+            }
+        }
+
+        foreach ( $children as $child ) {
+            $this->detectStickyGhostCandidatesInNode($child);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $parentNode
+     * @param array<string, mixed> $a
+     * @param array<string, mixed> $b
+     */
+    private function detectStickyGhostCandidatePair(array $parentNode, array $a, array $b): void
+    {
+        $aAbsolute = $this->isAbsoluteLayoutNode($a);
+        $bAbsolute = $this->isAbsoluteLayoutNode($b);
+        if ( $aAbsolute === $bAbsolute ) {
+            return;
+        }
+
+        $flow = $aAbsolute ? $b : $a;
+        $ghost = $aAbsolute ? $a : $b;
+        if ( $this->nodeOpacity($ghost) > 0.25 || $this->nodeOpacity($flow) < 0.99 ) {
+            return;
+        }
+
+        $flowBox = is_array($flow['box'] ?? null) ? $flow['box'] : array();
+        $ghostBox = is_array($ghost['box'] ?? null) ? $ghost['box'] : array();
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        if ( ! $this->sameNodeSize($flowBox, $ghostBox) || ! $this->isFarVerticalEdgeDuplicate($ghost, $ghostBox, $parentBox) ) {
+            return;
+        }
+
+        $signature = $this->stickyGhostSemanticSignature($flow);
+        if ( '' === $signature || $signature !== $this->stickyGhostSemanticSignature($ghost) ) {
+            return;
+        }
+
+        $primaryId = (string) ($flow['id'] ?? '');
+        $ghostId = (string) ($ghost['id'] ?? '');
+        if ( '' === $primaryId || '' === $ghostId || isset($this->stickyGhostNodeIds[$ghostId]) ) {
+            return;
+        }
+
+        $this->stickyPrimaryNodeIds[$primaryId] = array('ghost_id' => $ghostId, 'signature' => $signature);
+        $this->stickyGhostNodeIds[$ghostId] = true;
+        $this->stickyGhostCandidates[] = array(
+            'primary_id' => $primaryId,
+            'ghost_id' => $ghostId,
+            'parent_id' => (string) ($parentNode['id'] ?? ''),
+            'signature' => $signature,
+            'ghost_opacity' => $this->nodeOpacity($ghost),
+            'evidence' => array(
+                'primary_positioning' => 'flow',
+                'ghost_positioning' => 'absolute',
+                'ghost_vertical_constraint' => $this->verticalConstraint($ghost),
+                'same_size' => true,
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isSuppressedStickyGhost(array $node): bool
+    {
+        $id = (string) ($node['id'] ?? '');
+        return '' !== $id && isset($this->stickyGhostNodeIds[$id]);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isStickyPrimary(array $node): bool
+    {
+        $id = (string) ($node['id'] ?? '');
+        return '' !== $id && isset($this->stickyPrimaryNodeIds[$id]);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isAbsoluteLayoutNode(array $node): bool
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        return 'absolute' === ($layout['positioning'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeOpacity(array $node): float
+    {
+        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        if ( isset($box['opacity']) && is_numeric($box['opacity']) ) {
+            return (float) $box['opacity'];
+        }
+        if ( isset($node['opacity']) && is_numeric($node['opacity']) ) {
+            return (float) $node['opacity'];
+        }
+
+        return 1.0;
+    }
+
+    /**
+     * @param array<string, mixed> $flowBox
+     * @param array<string, mixed> $ghostBox
+     */
+    private function sameNodeSize(array $flowBox, array $ghostBox): bool
+    {
+        foreach ( array('width', 'height') as $dimension ) {
+            if ( ! isset($flowBox[$dimension], $ghostBox[$dimension]) || ! is_numeric($flowBox[$dimension]) || ! is_numeric($ghostBox[$dimension]) ) {
+                return false;
+            }
+            if ( abs((float) $flowBox[$dimension] - (float) $ghostBox[$dimension]) > 1.0 ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $ghost
+     * @param array<string, mixed> $ghostBox
+     * @param array<string, mixed> $parentBox
+     */
+    private function isFarVerticalEdgeDuplicate(array $ghost, array $ghostBox, array $parentBox): bool
+    {
+        if ( ! isset($ghostBox['y'], $ghostBox['height'], $parentBox['height']) || ! is_numeric($ghostBox['y']) || ! is_numeric($ghostBox['height']) || ! is_numeric($parentBox['height']) ) {
+            return false;
+        }
+
+        $bottomGap = (float) $parentBox['height'] - (float) $ghostBox['y'] - (float) $ghostBox['height'];
+        $constraint = $this->verticalConstraint($ghost);
+        $isFarPinned = in_array($constraint, array('BOTTOM', 'MAX'), true);
+
+        return $isFarPinned && (float) $ghostBox['y'] > (float) $ghostBox['height'] && $bottomGap >= -1.0 && $bottomGap <= 32.0;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function verticalConstraint(array $node): string
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
+        if ( isset($constraints['vertical']) && is_scalar($constraints['vertical']) ) {
+            return strtoupper((string) $constraints['vertical']);
+        }
+        if ( isset($node['constraints']['vertical']) && is_scalar($node['constraints']['vertical']) ) {
+            return strtoupper((string) $node['constraints']['vertical']);
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function stickyGhostSemanticSignature(array $node): string
+    {
+        $sourceId = isset($node['figma_component_source_id']) && is_scalar($node['figma_component_source_id']) ? trim((string) $node['figma_component_source_id']) : '';
+        if ( '' !== $sourceId ) {
+            return 'component:' . $sourceId;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        $name = strtolower(trim(preg_replace('/\s+/', ' ', (string) ($node['name'] ?? '')) ?? ''));
+        $width = isset($box['width']) && is_numeric($box['width']) ? (string) round((float) $box['width']) : '';
+        $height = isset($box['height']) && is_numeric($box['height']) ? (string) round((float) $box['height']) : '';
+
+        return implode('|', array($type, $name, $width, $height, sha1(implode("\n", $this->descendantTextSequence($node)))));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function descendantTextSequence(array $node): array
+    {
+        $sequence = array();
+        if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
+            $text = trim(preg_replace('/\s+/', ' ', $this->textContent($node)) ?? '');
+            if ( '' !== $text ) {
+                $sequence[] = $text;
+            }
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( is_array($child) ) {
+                array_push($sequence, ...$this->descendantTextSequence($child));
+            }
+        }
+
+        return $sequence;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3529,7 +3529,7 @@ final class StaticHtmlEmitter
             } elseif ( 'HUG' === $sizing ) {
                 $derivedTextSize = 'TEXT' === $type ? $this->derivedTextLayoutSize($node, $dimension) : null;
                 if ( null !== $derivedTextSize ) {
-                    if ( 'height' === $dimension && $this->textShouldAvoidTinyFixedHeight($node, $derivedTextSize) ) {
+                    if ( 'height' === $dimension && $this->textShouldAvoidTinyFixedHeight($node, $derivedTextSize) && ! $this->textShouldUseMeasuredFlexHeight($node, $parentNode) ) {
                         continue;
                     }
                     $styles[] = $dimension . ':' . $this->number($derivedTextSize) . 'px';
@@ -3544,7 +3544,7 @@ final class StaticHtmlEmitter
             } elseif ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
                 $property = $dimension;
                 $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
-                if ( 'height' === $dimension && 'TEXT' === $type && $this->textShouldAvoidTinyFixedHeight($node, $value) ) {
+                if ( 'height' === $dimension && 'TEXT' === $type && $this->textShouldAvoidTinyFixedHeight($node, $value) && ! $this->textShouldUseMeasuredFlexHeight($node, $parentNode) ) {
                     continue;
                 }
                 $styles[] = $property . ':' . $this->number($value) . 'px';
@@ -3661,6 +3661,9 @@ final class StaticHtmlEmitter
         if ( 'TEXT' === $type ) {
             foreach ( $this->textStyles($node) as $style ) {
                 $styles[] = $style;
+            }
+            if ( $this->textShouldUseMeasuredFlexHeight($node, $parentNode) ) {
+                $styles[] = 'overflow:visible';
             }
         }
 
@@ -4741,6 +4744,25 @@ final class StaticHtmlEmitter
         $lineY = (float) $baseline['lineY'];
 
         return 0.0 > $lineY && $lineHeight > $height + 0.5;
+    }
+
+    /**
+     * @param array<string, mixed>      $node
+     * @param array<string, mixed>|null $parentNode
+     */
+    private function textShouldUseMeasuredFlexHeight(array $node, ?array $parentNode): bool
+    {
+        if ( null === $parentNode || 'TEXT' !== strtoupper((string) ($node['type'] ?? '')) ) {
+            return false;
+        }
+
+        $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        if ( 'flex' !== ($parentLayout['display'] ?? null) ) {
+            return false;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        return isset($box['height']) && is_numeric($box['height']) && $this->textShouldAvoidTinyFixedHeight($node, (float) $box['height']);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -154,6 +154,11 @@ final class StaticHtmlEmitter
     private array $stickyPrimaryNodeIds = array();
 
     /**
+     * @var array<string, bool>
+     */
+    private array $stickyAncestorNodeIds = array();
+
+    /**
      * @var array<int, array<string, mixed>>
      */
     private array $stickyGhostCandidates = array();
@@ -172,6 +177,7 @@ final class StaticHtmlEmitter
         $this->nodeReadableNames = array();
         $this->stickyGhostNodeIds = array();
         $this->stickyPrimaryNodeIds = array();
+        $this->stickyAncestorNodeIds = array();
         $this->stickyGhostCandidates = array();
         $this->linkTargetPaths = $this->normalizeLinkTargetPaths($options);
         $this->linkCoverage = $this->newLinkCoverage();
@@ -303,6 +309,7 @@ final class StaticHtmlEmitter
         $this->nodeReadableNames = array();
         $this->stickyGhostNodeIds = array();
         $this->stickyPrimaryNodeIds = array();
+        $this->stickyAncestorNodeIds = array();
         $this->stickyGhostCandidates = array();
         $this->linkTargetPaths = $this->linkTargetPathsFromPagePlan($pagePlan, $options);
         $this->linkCoverage = $this->newLinkCoverage();
@@ -627,8 +634,9 @@ final class StaticHtmlEmitter
         $styles = $this->stickyAwareStyleDeclarations($node, $type, $parentNode);
 
         $map[$pathKey] = array(
-            'class'  => $className,
-            'styles' => $styles,
+            'class'           => $className,
+            'styles'          => $styles,
+            'contains_sticky' => $this->containsStickyPrimary($node),
         );
 
         $vectorSvg = $this->supportedVectorSvg($node, $type, $parentNode);
@@ -671,6 +679,7 @@ final class StaticHtmlEmitter
             $variantDeclarations = is_array($variantStyles[$pathKey]['styles'] ?? null) ? $variantStyles[$pathKey]['styles'] : array();
 
             $changed = array();
+            $baseContainsSticky = true === ($base['contains_sticky'] ?? false);
             foreach ( $variantDeclarations as $declaration ) {
                 $parts = explode(':', (string) $declaration, 2);
                 if ( 2 !== count($parts) ) {
@@ -679,6 +688,9 @@ final class StaticHtmlEmitter
 
                 $property = trim($parts[0]);
                 $value = trim($parts[1]);
+                if ( $baseContainsSticky && 'overflow' === $property ) {
+                    continue;
+                }
                 if ( ! array_key_exists($property, $baseMap) || $baseMap[$property] !== $value ) {
                     $changed[] = $property . ':' . $value;
                 }
@@ -3503,19 +3515,22 @@ final class StaticHtmlEmitter
 
     /**
      * @param array<string, mixed> $parentNode
+     * @param array<int, string> $ancestorIds
      */
-    private function detectStickyGhostCandidatesInNode(array $parentNode): void
+    private function detectStickyGhostCandidatesInNode(array $parentNode, array $ancestorIds = array()): void
     {
         $children = array_values(array_filter($this->nodeList($parentNode), 'is_array'));
         $count = count($children);
+        $parentId = (string) ($parentNode['id'] ?? '');
+        $stickyAncestorIds = '' === $parentId ? $ancestorIds : array_merge($ancestorIds, array($parentId));
         for ( $i = 0; $i < $count; $i++ ) {
             for ( $j = $i + 1; $j < $count; $j++ ) {
-                $this->detectStickyGhostCandidatePair($parentNode, $children[$i], $children[$j]);
+                $this->detectStickyGhostCandidatePair($parentNode, $children[$i], $children[$j], $stickyAncestorIds);
             }
         }
 
         foreach ( $children as $child ) {
-            $this->detectStickyGhostCandidatesInNode($child);
+            $this->detectStickyGhostCandidatesInNode($child, $stickyAncestorIds);
         }
     }
 
@@ -3523,8 +3538,9 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $parentNode
      * @param array<string, mixed> $a
      * @param array<string, mixed> $b
+     * @param array<int, string> $stickyAncestorIds
      */
-    private function detectStickyGhostCandidatePair(array $parentNode, array $a, array $b): void
+    private function detectStickyGhostCandidatePair(array $parentNode, array $a, array $b, array $stickyAncestorIds): void
     {
         $aAbsolute = $this->isAbsoluteLayoutNode($a);
         $bAbsolute = $this->isAbsoluteLayoutNode($b);
@@ -3561,6 +3577,11 @@ final class StaticHtmlEmitter
         }
 
         $this->stickyPrimaryNodeIds[$primaryId] = array('ghost_id' => $ghostId, 'signature' => $signature);
+        foreach ( $stickyAncestorIds as $ancestorId ) {
+            if ( '' !== $ancestorId ) {
+                $this->stickyAncestorNodeIds[$ancestorId] = true;
+            }
+        }
         $this->stickyGhostNodeIds[$ghostId] = true;
         $this->stickyGhostCandidates[] = array(
             'primary_id' => $primaryId,
@@ -3596,9 +3617,8 @@ final class StaticHtmlEmitter
     }
 
     /**
-     * @param array<string, mixed>      $node
-     * @param array<int, string>|null   $styles
      * @param array<string, mixed>|null $parentNode
+     * @param array<int, string>|null   $styles
      * @return array<int, string>
      */
     private function stickyAwareStyleDeclarations(array $node, string $type, ?array $parentNode, ?array $styles = null): array
@@ -3617,6 +3637,15 @@ final class StaticHtmlEmitter
         $styles[] = 'align-self:flex-start';
 
         return $styles;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function containsStickyPrimary(array $node): bool
+    {
+        $id = (string) ($node['id'] ?? '');
+        return '' !== $id && isset($this->stickyAncestorNodeIds[$id]);
     }
 
     /**
@@ -3813,7 +3842,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        if ( true === ($layout['clips_content'] ?? false) ) {
+        if ( true === ($layout['clips_content'] ?? false) && ! $this->containsStickyPrimary($node) ) {
             $styles[] = 'overflow:hidden';
         }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3757,18 +3757,18 @@ final class StaticHtmlEmitter
             $styles[] = 'position:relative';
         }
 
-		if ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
+		if ( $isDecorativeFlexUnderlay ) {
 			$styles[] = 'position:absolute';
 			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
 				$styles[] = $style;
 			}
-        } elseif ( $isDecorativeFlexUnderlay ) {
-            $styles[] = 'position:absolute';
+			$styles[] = 'z-index:0';
+			$styles[] = 'pointer-events:none';
+		} elseif ( null !== $parentNode && $this->isFreeformContainer($parentNode) ) {
+			$styles[] = 'position:absolute';
 			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {
-                $styles[] = $style;
-            }
-            $styles[] = 'z-index:0';
-            $styles[] = 'pointer-events:none';
+				$styles[] = $style;
+			}
 		} elseif ( 'absolute' === ($layout['positioning'] ?? null) ) {
             $styles[] = 'position:absolute';
 			foreach ( $this->absolutePositionStyles($box, $layout, $parentNode, $node) as $style ) {

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3891,7 +3891,7 @@ final class StaticHtmlEmitter
         // Center pin: keep a constant offset from the parent center. Using calc()
         // off the leading edge avoids touching transform.
         if ( 'CENTER' === $constraint && null !== $offset && null !== $parentSize ) {
-            $delta = $offset - ( $parentSize / 2.0 );
+            $delta = $offset + ((null !== $boxSize ? $boxSize : 0.0) / 2.0) - ( $parentSize / 2.0 );
             $sign = $delta < 0 ? '-' : '+';
             $styles[] = $startProp . ':calc(50% ' . $sign . ' ' . $this->number(abs($delta)) . 'px)';
             return $styles;

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3521,8 +3521,12 @@ final class StaticHtmlEmitter
         }
 
         $signature = $this->stickyGhostSemanticSignature($flow);
-        if ( '' === $signature || $signature !== $this->stickyGhostSemanticSignature($ghost) ) {
-            return;
+        $ghostSignature = $this->stickyGhostSemanticSignature($ghost);
+        if ( '' === $signature || $signature !== $ghostSignature ) {
+            $signature = $this->stickyGhostContentSignature($flow);
+            if ( '' === $signature || $signature !== $this->stickyGhostContentSignature($ghost) ) {
+                return;
+            }
         }
 
         $primaryId = (string) ($flow['id'] ?? '');
@@ -3654,13 +3658,26 @@ final class StaticHtmlEmitter
             return 'component:' . $sourceId;
         }
 
+        return $this->stickyGhostContentSignature($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function stickyGhostContentSignature(array $node): string
+    {
+        $textSequence = $this->descendantTextSequence($node);
+        if ( empty($textSequence) ) {
+            return '';
+        }
+
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $type = strtoupper((string) ($node['type'] ?? ''));
         $name = strtolower(trim(preg_replace('/\s+/', ' ', (string) ($node['name'] ?? '')) ?? ''));
         $width = isset($box['width']) && is_numeric($box['width']) ? (string) round((float) $box['width']) : '';
         $height = isset($box['height']) && is_numeric($box['height']) ? (string) round((float) $box['height']) : '';
 
-        return implode('|', array($type, $name, $width, $height, sha1(implode("\n", $this->descendantTextSequence($node)))));
+        return 'content:' . implode('|', array($type, $name, $width, $height, sha1(implode("\n", $textSequence))));
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -57,6 +57,8 @@ final class StaticHtmlEmitter
 
     private ?TransformDiagnosticsBuilder $transformDiagnosticsBuilder = null;
 
+    private ?EffectOverflowPolicy $effectOverflowPolicy = null;
+
     private function designSystemExtractor(): DesignSystemExtractor
     {
         return $this->designSystemExtractor ??= new DesignSystemExtractor();
@@ -87,6 +89,11 @@ final class StaticHtmlEmitter
     private function transformDiagnosticsBuilder(): TransformDiagnosticsBuilder
     {
         return $this->transformDiagnosticsBuilder ??= new TransformDiagnosticsBuilder();
+    }
+
+    private function effectOverflowPolicy(): EffectOverflowPolicy
+    {
+        return $this->effectOverflowPolicy ??= new EffectOverflowPolicy();
     }
 
     private function layoutIntentClassifier(): LayoutIntentClassifier
@@ -3842,7 +3849,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        if ( true === ($layout['clips_content'] ?? false) && ! $this->containsStickyPrimary($node) && ! $this->clipsVisibleEffectOverflow($node) ) {
+        if ( $this->effectOverflowPolicy()->shouldHideOverflow($node, $this->containsStickyPrimary($node)) ) {
             $styles[] = 'overflow:hidden';
         }
 
@@ -5246,63 +5253,6 @@ final class StaticHtmlEmitter
     private function effectStyles(array $node, string $type): array
     {
         return $this->styleDeclarationBuilder()->effectStyles($node, $type);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function clipsVisibleEffectOverflow(array $node): bool
-    {
-        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
-        foreach ( $this->nodeList($node) as $child ) {
-            if ( ! is_array($child) ) {
-                continue;
-            }
-            if ( $this->nodeEffectOverflowAmount($child) <= 0.0 ) {
-                if ( $this->clipsVisibleEffectOverflow($child) ) {
-                    return true;
-                }
-                continue;
-            }
-
-            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
-            $left = isset($childBox['x']) && is_numeric($childBox['x']) ? (float) $childBox['x'] : 0.0;
-            $top = isset($childBox['y']) && is_numeric($childBox['y']) ? (float) $childBox['y'] : 0.0;
-            $width = isset($childBox['width']) && is_numeric($childBox['width']) ? (float) $childBox['width'] : 0.0;
-            $height = isset($childBox['height']) && is_numeric($childBox['height']) ? (float) $childBox['height'] : 0.0;
-            $parentWidth = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : null;
-            $parentHeight = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
-
-            if ( $left <= 0.0 || $top <= 0.0 || (null !== $parentWidth && $left + $width >= $parentWidth) || (null !== $parentHeight && $top + $height >= $parentHeight) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function nodeEffectOverflowAmount(array $node): float
-    {
-        $amount = 0.0;
-        foreach ( is_array($node['figma_effects'] ?? null) ? $node['figma_effects'] : array() as $effect ) {
-            if ( ! is_array($effect) || false === ($effect['visible'] ?? true) ) {
-                continue;
-            }
-            $type = (string) ($effect['type'] ?? '');
-            if ( ! in_array($type, array('drop_shadow', 'layer_blur'), true) ) {
-                continue;
-            }
-            $radius = isset($effect['radius']) && is_numeric($effect['radius']) ? (float) $effect['radius'] : 0.0;
-            $spread = isset($effect['spread']) && is_numeric($effect['spread']) ? (float) $effect['spread'] : 0.0;
-            $offsetX = isset($effect['offset_x']) && is_numeric($effect['offset_x']) ? abs((float) $effect['offset_x']) : 0.0;
-            $offsetY = isset($effect['offset_y']) && is_numeric($effect['offset_y']) ? abs((float) $effect['offset_y']) : 0.0;
-            $amount = max($amount, $radius + $spread + $offsetX, $radius + $spread + $offsetY);
-        }
-
-        return $amount;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3450,6 +3450,9 @@ final class StaticHtmlEmitter
             } elseif ( 'HUG' === $sizing ) {
                 $derivedTextSize = 'TEXT' === $type ? $this->derivedTextLayoutSize($node, $dimension) : null;
                 if ( null !== $derivedTextSize ) {
+                    if ( 'height' === $dimension && $this->textShouldAvoidTinyFixedHeight($node, $derivedTextSize) ) {
+                        continue;
+                    }
                     $styles[] = $dimension . ':' . $this->number($derivedTextSize) . 'px';
                 } elseif ( 'flex' === ($layout['display'] ?? null) && isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
                     $intrinsicMainAxisSize = $this->flexHugMainAxisIntrinsicSizeStyle($node, $dimension);
@@ -3462,6 +3465,9 @@ final class StaticHtmlEmitter
             } elseif ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
                 $property = $dimension;
                 $value = 'height' === $dimension && null !== $zeroHeightVectorFallbackHeight ? $zeroHeightVectorFallbackHeight : (float) $box[$dimension];
+                if ( 'height' === $dimension && 'TEXT' === $type && $this->textShouldAvoidTinyFixedHeight($node, $value) ) {
+                    continue;
+                }
                 $styles[] = $property . ':' . $this->number($value) . 'px';
             }
         }
@@ -4632,6 +4638,11 @@ final class StaticHtmlEmitter
             return null;
         }
 
+        $baselineDeltaLineHeight = $this->textMedianPositiveBaselinePositionDelta($baselines);
+        if ( null !== $baselineDeltaLineHeight ) {
+            return $baselineDeltaLineHeight;
+        }
+
         $lineHeights = array();
         foreach ( $baselines as $baseline ) {
             if ( is_array($baseline) && isset($baseline['lineHeight']) && is_numeric($baseline['lineHeight']) && 0.0 < (float) $baseline['lineHeight'] ) {
@@ -4643,18 +4654,29 @@ final class StaticHtmlEmitter
             return $lineHeights[(int) floor(( count($lineHeights) - 1 ) / 2)];
         }
 
+        return null;
+    }
+
+    /**
+     * @param array<int, mixed> $baselines
+     */
+    private function textMedianPositiveBaselinePositionDelta(array $baselines): ?float
+    {
         $positions = array();
         foreach ( $baselines as $baseline ) {
             if ( is_array($baseline) && isset($baseline['position_y']) && is_numeric($baseline['position_y']) ) {
                 $positions[] = (float) $baseline['position_y'];
             }
         }
+        if ( 2 > count($positions) ) {
+            return null;
+        }
         sort($positions);
 
         $deltas = array();
         for ( $i = 1; $i < count($positions); $i++ ) {
             $delta = $positions[$i] - $positions[$i - 1];
-            if ( 0.0 < $delta ) {
+            if ( 0.001 < $delta && 10000.0 > $delta ) {
                 $deltas[] = $delta;
             }
         }
@@ -4664,6 +4686,37 @@ final class StaticHtmlEmitter
 
         sort($deltas);
         return $deltas[(int) floor(( count($deltas) - 1 ) / 2)];
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function textShouldAvoidTinyFixedHeight(array $node, float $height): bool
+    {
+        if ( 0.0 >= $height ) {
+            return false;
+        }
+
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        if ( '' === trim($this->nodePlainText($node)) || $this->textHasLineBreaks($node) || $this->textHasDerivedLineBreaks($node) ) {
+            return false;
+        }
+
+        $derivedLayout = is_array($text['derived_layout'] ?? null) ? $text['derived_layout'] : array();
+        $baselines = is_array($derivedLayout['baselines'] ?? null) ? array_values(array_filter($derivedLayout['baselines'], 'is_array')) : array();
+        if ( 1 !== count($baselines) ) {
+            return false;
+        }
+
+        $baseline = $baselines[0];
+        if ( ! isset($baseline['lineHeight'], $baseline['lineY']) || ! is_numeric($baseline['lineHeight']) || ! is_numeric($baseline['lineY']) ) {
+            return false;
+        }
+
+        $lineHeight = (float) $baseline['lineHeight'];
+        $lineY = (float) $baseline['lineY'];
+
+        return 0.0 > $lineY && $lineHeight > $height + 0.5;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3551,6 +3551,12 @@ final class StaticHtmlEmitter
             }
         }
 
+        $absoluteChildReserveHeight = $this->absoluteChildReserveHeight($node);
+        if ( null !== $absoluteChildReserveHeight && ! $this->stylesDeclareProperty($styles, 'min-height') ) {
+            $layoutMinHeight = isset($layout['min_height']) && is_numeric($layout['min_height']) ? (float) $layout['min_height'] : null;
+            $styles[] = 'min-height:' . $this->number(null === $layoutMinHeight ? $absoluteChildReserveHeight : max($layoutMinHeight, $absoluteChildReserveHeight)) . 'px';
+        }
+
         // Auto Layout min/max constraints (Kiwi minSize/maxSize). Skip a property
         // the width/height pass already emitted (e.g. the fluid root max-width).
         foreach ( array(
@@ -3901,6 +3907,61 @@ final class StaticHtmlEmitter
     private function isFreeformContainer(array $node): bool
     {
         return $this->layoutIntentClassifier()->isFreeformContainer($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function absoluteChildReserveHeight(array $node): ?float
+    {
+        $children = $this->nodeList($node);
+        if ( empty($children) || (! $this->isFreeformContainer($node) && ! $this->hasAbsoluteChild($node) && ! $this->hasDecorativeFlexUnderlayChild($node)) ) {
+            return null;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $parentHeight = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
+        $maxBottom = null;
+        $contributingChildren = 0;
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $layout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( ! $this->isFreeformContainer($node) && 'absolute' !== ($layout['positioning'] ?? null) && ! $this->isDecorativeFlexUnderlay($child, $node) ) {
+                continue;
+            }
+
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            if ( ! isset($childBox['height']) || ! is_numeric($childBox['height']) ) {
+                continue;
+            }
+
+            $top = $this->positionOffset($childBox, $box, 'y');
+            if ( null === $top ) {
+                continue;
+            }
+            if ( $top < -0.5 ) {
+                return null;
+            }
+
+            $bottom = $top + (float) $childBox['height'];
+            if ( null !== $parentHeight && $bottom > $parentHeight + 0.5 ) {
+                return null;
+            }
+            $maxBottom = null === $maxBottom ? $bottom : max($maxBottom, $bottom);
+            $contributingChildren++;
+        }
+
+        if ( $contributingChildren <= 1 || null === $maxBottom || $maxBottom <= 0.0 ) {
+            return null;
+        }
+        if ( null !== $parentHeight && abs($parentHeight - $maxBottom) > 0.5 ) {
+            return null;
+        }
+
+        return $maxBottom;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -301,6 +301,9 @@ final class StaticHtmlEmitter
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
         $this->nodeReadableNames = array();
+        $this->stickyGhostNodeIds = array();
+        $this->stickyPrimaryNodeIds = array();
+        $this->stickyGhostCandidates = array();
         $this->linkTargetPaths = $this->linkTargetPathsFromPagePlan($pagePlan, $options);
         $this->linkCoverage = $this->newLinkCoverage();
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
@@ -331,6 +334,31 @@ final class StaticHtmlEmitter
         $seenPaths = array();
         $mediaBlocks = array();
         $plannedPages = $this->plannedPages($pagePlan);
+
+        $stickyDetectionRoots = array();
+        foreach ( $plannedPages as $page ) {
+            if ( ! is_array($page) ) {
+                continue;
+            }
+
+            $frameIds = array();
+            $frameId = isset($page['frame_id']) && is_scalar($page['frame_id']) ? (string) $page['frame_id'] : '';
+            if ( '' !== $frameId ) {
+                $frameIds[] = $frameId;
+            }
+            foreach ( is_array($page['variants'] ?? null) ? $page['variants'] : array() as $variant ) {
+                if ( is_array($variant) && isset($variant['frame_id']) && is_scalar($variant['frame_id']) ) {
+                    $frameIds[] = (string) $variant['frame_id'];
+                }
+            }
+
+            foreach ( array_values(array_unique($frameIds)) as $candidateFrameId ) {
+                if ( isset($nodeMap[$candidateFrameId]) && is_array($nodeMap[$candidateFrameId]) ) {
+                    $stickyDetectionRoots[] = $nodeMap[$candidateFrameId];
+                }
+            }
+        }
+        $this->detectStickyGhostCandidates($stickyDetectionRoots);
 
         foreach ( $plannedPages as $index => $page ) {
             if ( ! is_array($page) ) {
@@ -588,14 +616,19 @@ final class StaticHtmlEmitter
      */
     private function collectVariantNodeStyles(array $node, int $depth, ?array $parentNode, string $pathKey, array &$map): void
     {
+        if ( $this->isSuppressedStickyGhost($node) ) {
+            return;
+        }
+
         $id = $this->sanitizeAttribute((string) ($node['id'] ?? ''));
         $name = (string) ($node['name'] ?? '');
         $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
         $className = 'figma-node-' . $this->slug($id . '-' . $name);
+        $styles = $this->stickyAwareStyleDeclarations($node, $type, $parentNode);
 
         $map[$pathKey] = array(
             'class'  => $className,
-            'styles' => $this->styleDeclarations($node, $type, $parentNode),
+            'styles' => $styles,
         );
 
         $vectorSvg = $this->supportedVectorSvg($node, $type, $parentNode);
@@ -605,7 +638,7 @@ final class StaticHtmlEmitter
 
         $childOrdinal = 0;
         foreach ( $this->nodeList($node) as $child ) {
-            if ( ! is_array($child) || $this->isFullyClippedDecorativeChild($child, $node) ) {
+            if ( ! is_array($child) || $this->isSuppressedStickyGhost($child) || $this->isFullyClippedDecorativeChild($child, $node) ) {
                 continue;
             }
 
@@ -751,15 +784,7 @@ final class StaticHtmlEmitter
         }
 
         $styles = $this->styleDeclarations($node, $type, $parentNode);
-        if ( $this->isStickyPrimary($node) ) {
-            $styles = array_values(array_filter(
-                $styles,
-                static fn (string $style): bool => ! str_starts_with($style, 'position:') && ! str_starts_with($style, 'top:')
-            ));
-            $styles[] = 'position:sticky';
-            $styles[] = 'top:0';
-            $styles[] = 'align-self:flex-start';
-        }
+        $styles = $this->stickyAwareStyleDeclarations($node, $type, $parentNode, $styles);
         if ( ! empty($styles) ) {
             $cssRules[] = '.' . $className . '{' . implode(';', $styles) . '}';
             $this->nodeReadableNames[$className] = $this->sharedClassBaseName($name, $type);
@@ -3568,6 +3593,30 @@ final class StaticHtmlEmitter
     {
         $id = (string) ($node['id'] ?? '');
         return '' !== $id && isset($this->stickyPrimaryNodeIds[$id]);
+    }
+
+    /**
+     * @param array<string, mixed>      $node
+     * @param array<int, string>|null   $styles
+     * @param array<string, mixed>|null $parentNode
+     * @return array<int, string>
+     */
+    private function stickyAwareStyleDeclarations(array $node, string $type, ?array $parentNode, ?array $styles = null): array
+    {
+        $styles = $styles ?? $this->styleDeclarations($node, $type, $parentNode);
+        if ( ! $this->isStickyPrimary($node) ) {
+            return $styles;
+        }
+
+        $styles = array_values(array_filter(
+            $styles,
+            static fn (string $style): bool => ! str_starts_with($style, 'position:') && ! str_starts_with($style, 'top:')
+        ));
+        $styles[] = 'position:sticky';
+        $styles[] = 'top:0';
+        $styles[] = 'align-self:flex-start';
+
+        return $styles;
     }
 
     /**

--- a/figma-transformer/src/Html/StickyLayoutCoordinator.php
+++ b/figma-transformer/src/Html/StickyLayoutCoordinator.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Coordinates sticky duplicate suppression and primary-node style adjustments.
+ */
+final class StickyLayoutCoordinator
+{
+    /**
+     * @var callable(array<string, mixed>): array<int, mixed>
+     */
+    private $nodeList;
+
+    /**
+     * @var callable(array<string, mixed>): string
+     */
+    private $textContent;
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $stickyGhostNodeIds = array();
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $stickyPrimaryNodeIds = array();
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $stickyAncestorNodeIds = array();
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $stickyGhostCandidates = array();
+
+    /**
+     * @param callable(array<string, mixed>): array<int, mixed> $nodeList
+     * @param callable(array<string, mixed>): string            $textContent
+     */
+    public function __construct(callable $nodeList, callable $textContent)
+    {
+        $this->nodeList = $nodeList;
+        $this->textContent = $textContent;
+    }
+
+    public function reset(): void
+    {
+        $this->stickyGhostNodeIds = array();
+        $this->stickyPrimaryNodeIds = array();
+        $this->stickyAncestorNodeIds = array();
+        $this->stickyGhostCandidates = array();
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $nodes
+     */
+    public function detectStickyGhostCandidates(array $nodes): void
+    {
+        foreach ( $nodes as $node ) {
+            if ( is_array($node) ) {
+                $this->detectStickyGhostCandidatesInNode($node);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    public function isSuppressedStickyGhost(array $node): bool
+    {
+        $id = (string) ($node['id'] ?? '');
+        return '' !== $id && isset($this->stickyGhostNodeIds[$id]);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    public function isStickyPrimary(array $node): bool
+    {
+        $id = (string) ($node['id'] ?? '');
+        return '' !== $id && isset($this->stickyPrimaryNodeIds[$id]);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    public function containsStickyPrimary(array $node): bool
+    {
+        $id = (string) ($node['id'] ?? '');
+        return '' !== $id && isset($this->stickyAncestorNodeIds[$id]);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<int, string>   $styles
+     * @return array<int, string>
+     */
+    public function stickyAwareStyleDeclarations(array $node, array $styles): array
+    {
+        if ( ! $this->isStickyPrimary($node) ) {
+            return $styles;
+        }
+
+        $styles = array_values(array_filter(
+            $styles,
+            static fn (string $style): bool => ! str_starts_with($style, 'position:') && ! str_starts_with($style, 'top:')
+        ));
+        $styles[] = 'position:sticky';
+        $styles[] = 'top:0';
+        $styles[] = 'align-self:flex-start';
+
+        return $styles;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function stickyGhostCandidates(): array
+    {
+        return $this->stickyGhostCandidates;
+    }
+
+    /**
+     * @param array<string, mixed> $parentNode
+     * @param array<int, string> $ancestorIds
+     */
+    private function detectStickyGhostCandidatesInNode(array $parentNode, array $ancestorIds = array()): void
+    {
+        $children = array_values(array_filter(($this->nodeList)($parentNode), 'is_array'));
+        $count = count($children);
+        $parentId = (string) ($parentNode['id'] ?? '');
+        $stickyAncestorIds = '' === $parentId ? $ancestorIds : array_merge($ancestorIds, array($parentId));
+        for ( $i = 0; $i < $count; $i++ ) {
+            for ( $j = $i + 1; $j < $count; $j++ ) {
+                $this->detectStickyGhostCandidatePair($parentNode, $children[$i], $children[$j], $stickyAncestorIds);
+            }
+        }
+
+        foreach ( $children as $child ) {
+            $this->detectStickyGhostCandidatesInNode($child, $stickyAncestorIds);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $parentNode
+     * @param array<string, mixed> $a
+     * @param array<string, mixed> $b
+     * @param array<int, string> $stickyAncestorIds
+     */
+    private function detectStickyGhostCandidatePair(array $parentNode, array $a, array $b, array $stickyAncestorIds): void
+    {
+        $aAbsolute = $this->isAbsoluteLayoutNode($a);
+        $bAbsolute = $this->isAbsoluteLayoutNode($b);
+        if ( $aAbsolute === $bAbsolute ) {
+            return;
+        }
+
+        $flow = $aAbsolute ? $b : $a;
+        $ghost = $aAbsolute ? $a : $b;
+        if ( $this->nodeOpacity($ghost) > 0.25 || $this->nodeOpacity($flow) < 0.99 ) {
+            return;
+        }
+
+        $flowBox = is_array($flow['box'] ?? null) ? $flow['box'] : array();
+        $ghostBox = is_array($ghost['box'] ?? null) ? $ghost['box'] : array();
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        if ( ! $this->sameNodeSize($flowBox, $ghostBox) || ! $this->isFarVerticalEdgeDuplicate($ghost, $ghostBox, $parentBox) ) {
+            return;
+        }
+
+        $signature = $this->stickyGhostSemanticSignature($flow);
+        $ghostSignature = $this->stickyGhostSemanticSignature($ghost);
+        if ( '' === $signature || $signature !== $ghostSignature ) {
+            $signature = $this->stickyGhostContentSignature($flow);
+            if ( '' === $signature || $signature !== $this->stickyGhostContentSignature($ghost) ) {
+                return;
+            }
+        }
+
+        $primaryId = (string) ($flow['id'] ?? '');
+        $ghostId = (string) ($ghost['id'] ?? '');
+        if ( '' === $primaryId || '' === $ghostId || isset($this->stickyGhostNodeIds[$ghostId]) ) {
+            return;
+        }
+
+        $this->stickyPrimaryNodeIds[$primaryId] = array('ghost_id' => $ghostId, 'signature' => $signature);
+        foreach ( $stickyAncestorIds as $ancestorId ) {
+            if ( '' !== $ancestorId ) {
+                $this->stickyAncestorNodeIds[$ancestorId] = true;
+            }
+        }
+        $this->stickyGhostNodeIds[$ghostId] = true;
+        $this->stickyGhostCandidates[] = array(
+            'primary_id' => $primaryId,
+            'ghost_id' => $ghostId,
+            'parent_id' => (string) ($parentNode['id'] ?? ''),
+            'signature' => $signature,
+            'ghost_opacity' => $this->nodeOpacity($ghost),
+            'evidence' => array(
+                'primary_positioning' => 'flow',
+                'ghost_positioning' => 'absolute',
+                'ghost_vertical_constraint' => $this->verticalConstraint($ghost),
+                'same_size' => true,
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isAbsoluteLayoutNode(array $node): bool
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        return 'absolute' === ($layout['positioning'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeOpacity(array $node): float
+    {
+        $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        if ( isset($box['opacity']) && is_numeric($box['opacity']) ) {
+            return (float) $box['opacity'];
+        }
+        if ( isset($node['opacity']) && is_numeric($node['opacity']) ) {
+            return (float) $node['opacity'];
+        }
+
+        return 1.0;
+    }
+
+    /**
+     * @param array<string, mixed> $flowBox
+     * @param array<string, mixed> $ghostBox
+     */
+    private function sameNodeSize(array $flowBox, array $ghostBox): bool
+    {
+        foreach ( array('width', 'height') as $dimension ) {
+            if ( ! isset($flowBox[$dimension], $ghostBox[$dimension]) || ! is_numeric($flowBox[$dimension]) || ! is_numeric($ghostBox[$dimension]) ) {
+                return false;
+            }
+            if ( abs((float) $flowBox[$dimension] - (float) $ghostBox[$dimension]) > 1.0 ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $ghost
+     * @param array<string, mixed> $ghostBox
+     * @param array<string, mixed> $parentBox
+     */
+    private function isFarVerticalEdgeDuplicate(array $ghost, array $ghostBox, array $parentBox): bool
+    {
+        if ( ! isset($ghostBox['y'], $ghostBox['height'], $parentBox['height']) || ! is_numeric($ghostBox['y']) || ! is_numeric($ghostBox['height']) || ! is_numeric($parentBox['height']) ) {
+            return false;
+        }
+
+        $bottomGap = (float) $parentBox['height'] - (float) $ghostBox['y'] - (float) $ghostBox['height'];
+        $constraint = $this->verticalConstraint($ghost);
+        $isFarPinned = in_array($constraint, array('BOTTOM', 'MAX'), true);
+
+        return $isFarPinned && (float) $ghostBox['y'] > (float) $ghostBox['height'] && $bottomGap >= -1.0 && $bottomGap <= 32.0;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function verticalConstraint(array $node): string
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
+        if ( isset($constraints['vertical']) && is_scalar($constraints['vertical']) ) {
+            return strtoupper((string) $constraints['vertical']);
+        }
+        if ( isset($node['constraints']['vertical']) && is_scalar($node['constraints']['vertical']) ) {
+            return strtoupper((string) $node['constraints']['vertical']);
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function stickyGhostSemanticSignature(array $node): string
+    {
+        $sourceId = isset($node['figma_component_source_id']) && is_scalar($node['figma_component_source_id']) ? trim((string) $node['figma_component_source_id']) : '';
+        if ( '' !== $sourceId ) {
+            return 'component:' . $sourceId;
+        }
+
+        return $this->stickyGhostContentSignature($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function stickyGhostContentSignature(array $node): string
+    {
+        $textSequence = $this->descendantTextSequence($node);
+        if ( empty($textSequence) ) {
+            return '';
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        $name = strtolower(trim(preg_replace('/\s+/', ' ', (string) ($node['name'] ?? '')) ?? ''));
+        $width = isset($box['width']) && is_numeric($box['width']) ? (string) round((float) $box['width']) : '';
+        $height = isset($box['height']) && is_numeric($box['height']) ? (string) round((float) $box['height']) : '';
+
+        return 'content:' . implode('|', array($type, $name, $width, $height, sha1(implode("\n", $textSequence))));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function descendantTextSequence(array $node): array
+    {
+        $sequence = array();
+        if ( 'TEXT' === strtoupper((string) ($node['type'] ?? '')) ) {
+            $text = trim(preg_replace('/\s+/', ' ', ($this->textContent)($node)) ?? '');
+            if ( '' !== $text ) {
+                $sequence[] = $text;
+            }
+        }
+
+        foreach ( ($this->nodeList)($node) as $child ) {
+            if ( is_array($child) ) {
+                array_push($sequence, ...$this->descendantTextSequence($child));
+            }
+        }
+
+        return $sequence;
+    }
+}

--- a/figma-transformer/src/Html/VectorSvgRenderer.php
+++ b/figma-transformer/src/Html/VectorSvgRenderer.php
@@ -312,10 +312,9 @@ final class VectorSvgRenderer
      */
     private function vectorPathElements(array $node): array
     {
-        $paint = $this->svgPaintAttributes($node);
         $elements = array();
         foreach ( $this->nodeVectorPathData($node) as $path ) {
-            $attributes = $paint;
+            $attributes = $this->svgPathPaintAttributes($node, $path);
             if ( null !== ($path['windingRule'] ?? null) ) {
                 $attributes[] = 'fill-rule="' . $path['windingRule'] . '"';
             }
@@ -330,7 +329,7 @@ final class VectorSvgRenderer
 
     /**
      * @param array<string, mixed> $node
-     * @return array<int, array{d: string, windingRule: string|null, styleID: string|null}>
+     * @return array<int, array{d: string, windingRule: string|null, styleID: string|null, source: string|null}>
      */
     private function nodeVectorPathData(array $node): array
     {
@@ -370,7 +369,12 @@ final class VectorSvgRenderer
                 $styleId = (string) $rawPath['styleID'];
             }
 
-            $paths[] = array('d' => $path, 'windingRule' => $rule, 'styleID' => $styleId);
+            $source = null;
+            if ( is_array($rawPath) && isset($rawPath['source']) && is_scalar($rawPath['source']) && '' !== trim((string) $rawPath['source']) ) {
+                $source = (string) $rawPath['source'];
+            }
+
+            $paths[] = array('d' => $path, 'windingRule' => $rule, 'styleID' => $styleId, 'source' => $source);
         }
 
         return $paths;
@@ -421,7 +425,7 @@ final class VectorSvgRenderer
 
     /**
      * @param array<string, mixed> $node
-     * @return array<int, array{paths: array<int, array{d: string, windingRule: string|null, styleID: string|null}>, paint: array<int, string>, dx: float, dy: float}>
+     * @return array<int, array{paths: array<int, array{d: string, windingRule: string|null, styleID: string|null, source: string|null}>, node: array<string, mixed>, dx: float, dy: float}>
      */
     private function booleanOperationChildVectors(array $node): array
     {
@@ -452,7 +456,7 @@ final class VectorSvgRenderer
             $dy = isset($box['y']) && is_numeric($box['y']) ? (float) $box['y'] - $originY : 0.0;
             $collected[] = array(
                 'paths' => $paths,
-                'paint' => $this->svgPaintAttributes($node),
+                'node'  => $node,
                 'dx'    => $dx,
                 'dy'    => $dy,
             );
@@ -472,10 +476,13 @@ final class VectorSvgRenderer
     {
         $body = '';
         foreach ( $children as $child ) {
-            $paint = is_array($child['paint'] ?? null) && ! empty($child['paint']) ? $child['paint'] : array('fill="currentColor"');
+            $node = is_array($child['node'] ?? null) ? $child['node'] : array();
             $elements = '';
             foreach ( is_array($child['paths'] ?? null) ? $child['paths'] : array() as $path ) {
-                $attributes = $paint;
+                $attributes = $this->svgPathPaintAttributes($node, $path);
+                if ( empty($attributes) ) {
+                    $attributes = array('fill="currentColor"');
+                }
                 if ( null !== ($path['windingRule'] ?? null) ) {
                     $attributes[] = 'fill-rule="' . $path['windingRule'] . '"';
                 }
@@ -904,10 +911,8 @@ final class VectorSvgRenderer
      */
     private function svgPaintAttributes(array $node): array
     {
-        $paints = is_array($node['figma_paints']['fills'] ?? null) ? $node['figma_paints']['fills'] : array();
-        $fill = $this->firstSolidPaint($paints);
-        $paints = is_array($node['figma_paints']['strokes'] ?? null) ? $node['figma_paints']['strokes'] : array();
-        $stroke = $this->firstSolidPaint($paints);
+        $fill = $this->nodeSolidPaint($node, 'fills');
+        $stroke = $this->nodeSolidPaint($node, 'strokes');
 
         $attributes = array('fill="' . ( null === $fill ? 'none' : $this->sanitizeAttribute($fill) ) . '"');
         if ( null !== $stroke ) {
@@ -919,6 +924,36 @@ final class VectorSvgRenderer
         }
 
         return $attributes;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array{source?: string|null} $path
+     * @return array<int, string>
+     */
+    private function svgPathPaintAttributes(array $node, array $path): array
+    {
+        $source = (string) ($path['source'] ?? '');
+        if ( str_starts_with($source, 'strokeGeometry') ) {
+            $stroke = $this->nodeSolidPaint($node, 'strokes');
+            return array('fill="' . ( null === $stroke ? 'none' : $this->sanitizeAttribute($stroke) ) . '"');
+        }
+
+        if ( str_starts_with($source, 'fillGeometry') ) {
+            $fill = $this->nodeSolidPaint($node, 'fills');
+            return array('fill="' . ( null === $fill ? 'none' : $this->sanitizeAttribute($fill) ) . '"');
+        }
+
+        return $this->svgPaintAttributes($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeSolidPaint(array $node, string $collection): ?string
+    {
+        $paints = is_array($node['figma_paints'][$collection] ?? null) ? $node['figma_paints'][$collection] : array();
+        return $this->firstSolidPaint($paints);
     }
 
     /**

--- a/figma-transformer/src/Html/VectorSvgRenderer.php
+++ b/figma-transformer/src/Html/VectorSvgRenderer.php
@@ -104,7 +104,7 @@ final class VectorSvgRenderer
         $scale = is_array($node['figma_vector_scale'] ?? null) ? $node['figma_vector_scale'] : array();
         $scaleX = isset($scale['x']) && is_numeric($scale['x']) ? (float) $scale['x'] : 1.0;
         $scaleY = isset($scale['y']) && is_numeric($scale['y']) ? (float) $scale['y'] : 1.0;
-        if ( abs($scaleX - 1.0) >= 0.0001 || abs($scaleY - 1.0) >= 0.0001 ) {
+        if ( ( abs($scaleX - 1.0) >= 0.0001 || abs($scaleY - 1.0) >= 0.0001 ) && $this->shouldApplyVectorScale($pathBounds, $width, $renderHeight) ) {
             $body = '<g transform="scale(' . $this->number($scaleX) . ' ' . $this->number($scaleY) . ')">' . $body . '</g>';
         }
 
@@ -282,6 +282,26 @@ final class VectorSvgRenderer
         }
 
         return array('x' => $minX, 'y' => $minY, 'width' => $maxX - $minX, 'height' => $maxY - $minY);
+    }
+
+    /**
+     * @param array{x: float, y: float, width: float, height: float}|null $pathBounds
+     */
+    private function shouldApplyVectorScale(?array $pathBounds, float $width, float $height): bool
+    {
+        if ( null === $pathBounds || $width <= 0.0 || $height <= 0.0 ) {
+            return true;
+        }
+
+        $tolerance = max(0.5, min($width, $height) * 0.05);
+        $fitsBox = $pathBounds['x'] >= -$tolerance
+            && $pathBounds['y'] >= -$tolerance
+            && $pathBounds['x'] + $pathBounds['width'] <= $width + $tolerance
+            && $pathBounds['y'] + $pathBounds['height'] <= $height + $tolerance;
+        $fillsBox = $pathBounds['width'] >= $width * 0.75
+            && $pathBounds['height'] >= $height * 0.75;
+
+        return ! ( $fitsBox && $fillsBox );
     }
 
     /**

--- a/figma-transformer/src/Html/VectorSvgRenderer.php
+++ b/figma-transformer/src/Html/VectorSvgRenderer.php
@@ -300,8 +300,10 @@ final class VectorSvgRenderer
             && $pathBounds['y'] + $pathBounds['height'] <= $height + $tolerance;
         $fillsBox = $pathBounds['width'] >= $width * 0.75
             && $pathBounds['height'] >= $height * 0.75;
+        $matchesBoxSpan = abs($pathBounds['width'] - $width) <= $tolerance
+            && abs($pathBounds['height'] - $height) <= $tolerance;
 
-        return ! ( $fitsBox && $fillsBox );
+        return ! ( ( $fitsBox && $fillsBox ) || $matchesBoxSpan );
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -157,7 +157,13 @@ final class PaintNormalizer
             ? array('strokeGeometry')
             : array('fillGeometry');
 
-        foreach ( array_merge($keys, array('vectorPaths', 'paths')) as $key ) {
+        foreach ( $keys as $key ) {
+            if ( $this->hasAuthoredVectorPathGeometry($node[$key] ?? null) ) {
+                return true;
+            }
+        }
+
+        foreach ( array('vectorPaths', 'paths') as $key ) {
             if ( ! empty($node[$key]) ) {
                 return true;
             }
@@ -170,6 +176,27 @@ final class PaintNormalizer
         }
 
         return isset($node['vectorData']) && is_array($node['vectorData']) && ! empty($node['vectorData']);
+    }
+
+    private function hasAuthoredVectorPathGeometry(mixed $geometry): bool
+    {
+        if ( ! is_array($geometry) ) {
+            return false;
+        }
+
+        foreach ( $geometry as $entry ) {
+            if ( ! is_array($entry) ) {
+                continue;
+            }
+
+            foreach ( array('path', 'pathData', 'd', 'data') as $key ) {
+                if ( isset($entry[$key]) && is_scalar($entry[$key]) && '' !== trim((string) $entry[$key]) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphIndex.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphIndex.php
@@ -323,12 +323,17 @@ final class ScenegraphIndex
 
     /**
      * @param array<string, mixed> $node
-     * @return array{0: int, 1: string|int, 2: string}
+     * @return array{0: int, 1: int|float, 2: string|int, 3?: string}
      */
     private static function layerOrderKey(array $node, string $id): array
     {
         if ( isset($node['_parent_sort_position']) && is_scalar($node['_parent_sort_position']) ) {
-            return array(0, (string) $node['_parent_sort_position'], $id);
+            $position = (string) $node['_parent_sort_position'];
+            if ( is_numeric($position) ) {
+                return array(0, 0, (float) $position, $id);
+            }
+
+            return array(0, 1, $position, $id);
         }
 
         return array(1, (int) ($node['_source_order'] ?? 0), $id);

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -1421,6 +1421,15 @@ final class ScenegraphNormalizer
             $merged = $this->rebaseComponentSourceCloneDescendants($merged, $sourceX, $sourceY, $sourceWidth, $sourceHeight);
         }
 
+        if ( is_array($clone['_component_source_clone_scale'] ?? null) && is_array($merged['children'] ?? null) ) {
+            $scaleX = isset($clone['_component_source_clone_scale']['x']) && is_numeric($clone['_component_source_clone_scale']['x']) ? (float) $clone['_component_source_clone_scale']['x'] : 1.0;
+            $scaleY = isset($clone['_component_source_clone_scale']['y']) && is_numeric($clone['_component_source_clone_scale']['y']) ? (float) $clone['_component_source_clone_scale']['y'] : 1.0;
+            if ( abs($scaleX - 1.0) >= 0.0001 || abs($scaleY - 1.0) >= 0.0001 ) {
+                $merged['children'] = $this->scaleVectorChildren($merged['children'], $scaleX, $scaleY);
+                $merged['_component_source_clone_scale'] = array('x' => $scaleX, 'y' => $scaleY);
+            }
+        }
+
 		return $this->markComponentSourceCloneGeometry($merged);
 	}
 
@@ -1932,7 +1941,6 @@ final class ScenegraphNormalizer
         );
         $resolvedChildren = is_array($resolved['children'] ?? null) ? $resolved['children'] : array();
         $resolvedChildren = $this->resolveClonedInstanceChildren($resolvedChildren, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options, $resolutionTrail);
-        $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
         $componentBox = is_array($component['box'] ?? null) ? $component['box'] : array();
         $componentSourceX = isset($componentBox['x']) && is_numeric($componentBox['x']) ? (float) $componentBox['x'] : null;
         $componentSourceY = isset($componentBox['y']) && is_numeric($componentBox['y']) ? (float) $componentBox['y'] : null;
@@ -1942,6 +1950,7 @@ final class ScenegraphNormalizer
             $rebasedSource = $this->rebaseComponentSourceCloneDescendants(array('children' => $resolvedChildren), $componentSourceX, $componentSourceY, $componentSourceWidth, $componentSourceHeight);
             $resolvedChildren = is_array($rebasedSource['children'] ?? null) ? $rebasedSource['children'] : $resolvedChildren;
         }
+        $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
         // Figma binds per-instance text content through component properties: each
         // master text node references a property definition (componentPropRefs ->
         // componentPropNodeField: TEXT_DATA) and the instance assigns the real value
@@ -2593,13 +2602,21 @@ final class ScenegraphNormalizer
                 }
             }
 
-            if ( is_array($child['figma_box']['transform'] ?? null) ) {
-                foreach ( array('m00' => $scaleX, 'm02' => $scaleX, 'm11' => $scaleY, 'm12' => $scaleY) as $key => $scale ) {
-                    if ( isset($child['figma_box']['transform'][$key]) && is_numeric($child['figma_box']['transform'][$key]) ) {
-                        $child['figma_box']['transform'][$key] = (float) $child['figma_box']['transform'][$key] * $scale;
+            if ( is_array($child['figma_box'] ?? null) ) {
+                foreach ( array('x' => $scaleX, 'width' => $scaleX, 'y' => $scaleY, 'height' => $scaleY) as $key => $scale ) {
+                    if ( isset($child['figma_box'][$key]) && is_numeric($child['figma_box'][$key]) ) {
+                        $child['figma_box'][$key] = (float) $child['figma_box'][$key] * $scale;
                     }
                 }
             }
+
+            foreach ( array('x' => $scaleX, 'width' => $scaleX, 'y' => $scaleY, 'height' => $scaleY) as $key => $scale ) {
+                if ( isset($child[$key]) && is_numeric($child[$key]) ) {
+                    $child[$key] = (float) $child[$key] * $scale;
+                }
+            }
+
+            $child['_component_source_clone_scale'] = array('x' => $scaleX, 'y' => $scaleY);
 
             if ( $this->isScalableVectorType(strtoupper((string) ($child['type'] ?? ''))) ) {
                 $child['figma_vector_scale'] = array('x' => $scaleX, 'y' => $scaleY);
@@ -2620,10 +2637,6 @@ final class ScenegraphNormalizer
      */
     private function isVectorOnlyComponent(array $component): bool
     {
-        if ( ! empty($component['layout']) ) {
-            return false;
-        }
-
         $children = is_array($component['children'] ?? null) ? $component['children'] : array();
         if ( empty($children) ) {
             return false;

--- a/figma-transformer/tests/contract/EffectsContract.php
+++ b/figma-transformer/tests/contract/EffectsContract.php
@@ -176,7 +176,7 @@ function blocks_engine_figma_transformer_run_effects_contract(callable $assert, 
     $clippedVectorGlowHtml = $fileContent($clippedVectorGlowResult, 'index.html');
     $clippedVectorGlowCss = $fileContent($clippedVectorGlowResult, 'style.css');
     $assert(str_contains($clippedVectorGlowHtml, 'data-figma-node-id="effects:vector-glow"') && str_contains($clippedVectorGlowHtml, 'data-figma-vector="true"'), 'effects-vector-glow-renders-inline-svg');
-    $assert(str_contains($clippedVectorGlowCss, '.figma-node-effects-clipped-frame-clipped-frame{width:96px;height:96px;overflow:hidden'), 'effects-vector-glow-parent-clips-content');
+    $assert(str_contains($clippedVectorGlowCss, '.figma-node-effects-clipped-frame-clipped-frame{width:96px;height:96px') && ! str_contains($clippedVectorGlowCss, '.figma-node-effects-clipped-frame-clipped-frame{width:96px;height:96px;overflow:hidden'), 'effects-vector-glow-parent-keeps-shadow-overflow-visible');
     $assert(str_contains($clippedVectorGlowCss, '.figma-node-effects-vector-glow-vector-glow{') && str_contains($clippedVectorGlowCss, 'filter:drop-shadow(0px 0px 16px rgba(255,207,0,0.5))'), 'effects-vector-glow-emits-alpha-drop-shadow-filter');
     $assert(! str_contains($clippedVectorGlowCss, '.figma-node-effects-vector-glow-vector-glow{width:96px;height:96px;box-shadow:'), 'effects-vector-glow-no-rectangular-box-shadow');
 
@@ -225,6 +225,7 @@ function blocks_engine_figma_transformer_run_effects_contract(callable $assert, 
         ),
     ));
     $componentCloneGlowCss = $fileContent($componentCloneGlowResult, 'style.css');
+    $assert(! str_contains($componentCloneGlowCss, '.figma-node-clone-clip-clone-clipped-glow-parent{width:96px;height:96px;overflow:hidden'), 'effects-component-clone-glow-parent-keeps-shadow-overflow-visible');
     $assert(str_contains($componentCloneGlowCss, '.figma-node-clone-glow-clone-glow-vector{width:106px;height:106px;position:absolute;left:0px;top:0px;') && str_contains($componentCloneGlowCss, 'filter:drop-shadow(0px 0px 16px '), 'effects-component-clone-local-glow-keeps-local-offset');
     $assert(! str_contains($componentCloneGlowCss, '.figma-node-clone-glow-clone-glow-vector{width:106px;height:106px;position:absolute;left:560px;top:0px'), 'effects-component-clone-local-glow-no-source-x-fallback');
 }

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -615,7 +615,43 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     ));
     $layerOrderHtml = $fileContent($layerOrderResult, 'index.html');
     $assert(strpos($layerOrderHtml, 'data-figma-node-id="layer:bottom"') < strpos($layerOrderHtml, 'data-figma-node-id="layer:top"'), 'freeform-layer-order-uses-parent-index-position');
-    
+
+    $numericLayerOrderResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'         => 'Numeric Layer Order Fixture',
+        'NODE_CHANGES' => array(
+            'numeric-layer:root' => array(
+                'node' => array(
+                    'id'          => 'numeric-layer:root',
+                    'type'        => 'FRAME',
+                    'name'        => 'Numeric layer root',
+                    'width'       => 300,
+                    'height'      => 200,
+                    'resizeToFit' => true,
+                    'children'    => array(
+                        array(
+                            'id'          => 'numeric-layer:front',
+                            'type'        => 'RECTANGLE',
+                            'name'        => 'Front',
+                            'width'       => 100,
+                            'height'      => 40,
+                            'parentIndex' => array('position' => '10'),
+                        ),
+                        array(
+                            'id'          => 'numeric-layer:back',
+                            'type'        => 'RECTANGLE',
+                            'name'        => 'Back',
+                            'width'       => 200,
+                            'height'      => 120,
+                            'parentIndex' => array('position' => '2'),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $numericLayerOrderHtml = $fileContent($numericLayerOrderResult, 'index.html');
+    $assert(strpos($numericLayerOrderHtml, 'data-figma-node-id="numeric-layer:back"') < strpos($numericLayerOrderHtml, 'data-figma-node-id="numeric-layer:front"'), 'freeform-layer-order-uses-numeric-parent-index-position');
+
     $overflowWrapperResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Overflow Wrapper Fixture',
         'nodes' => array(

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -33,6 +33,10 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('NodeChange' === ($layoutEntry['parent_message'] ?? null), 'kiwi-skipped-inventory-parent-message');
     $assert('FRAME' === array_key_first(is_array($layoutEntry['node_types'] ?? null) ? $layoutEntry['node_types'] : array()), 'kiwi-skipped-inventory-node-type');
     $assert(array('7:42') === ($layoutEntry['sample_node_ids'] ?? null), 'kiwi-skipped-inventory-node-id-sample');
+    $assert('7:42' === ($layoutEntry['sample_nodes'][0]['node_id'] ?? null), 'kiwi-skipped-inventory-node-sample-id');
+    $assert('FRAME' === ($layoutEntry['sample_nodes'][0]['node_type'] ?? null), 'kiwi-skipped-inventory-node-sample-type');
+    $assert('Message.nodeChanges[].layoutBoundsDebug' === ($layoutEntry['sample_nodes'][0]['path'] ?? null), 'kiwi-skipped-inventory-node-sample-path');
+    $assert('layout' === ($layoutEntry['sample_nodes'][0]['raw_value']['value'] ?? null), 'kiwi-skipped-inventory-node-sample-value');
     $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'maskType'), 'kiwi-skipped-inventory-mask-type-decoded');
     $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'arcData'), 'kiwi-skipped-inventory-arc-data-decoded');
     $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'guides'), 'kiwi-skipped-inventory-guides-decoded');

--- a/figma-transformer/tests/contract/NodeTraceContract.php
+++ b/figma-transformer/tests/contract/NodeTraceContract.php
@@ -58,6 +58,9 @@ function blocks_engine_figma_transformer_run_node_trace_contract(callable $asser
     $assert('TEXT' === ($titleTrace['raw']['type'] ?? null), 'node-trace-raw-type');
     $assert('Trace me' === ($titleTrace['raw']['text']['characters'] ?? null), 'node-trace-raw-text');
     $assert('TEXT' === ($titleTrace['normalized']['type'] ?? null), 'node-trace-normalized-type');
+    $assert(($titleTrace['field_coverage']['raw_count'] ?? 0) > 0, 'node-trace-field-coverage-raw-count');
+    $assert('Trace me' === ($titleTrace['field_coverage']['signal']['raw']['text'] ?? null), 'node-trace-field-coverage-raw-signal');
+    $assert('TEXT' === ($titleTrace['field_coverage']['signal']['normalized']['type'] ?? null), 'node-trace-field-coverage-normalized-signal');
     $assert('figma-node-trace-title-trace-title' === ($titleTrace['emitted']['class'] ?? null), 'node-trace-emitted-class');
     $assert(str_contains((string) ($titleTrace['emitted']['html'] ?? ''), 'data-figma-node-id="trace:title"'), 'node-trace-emitted-html-snippet');
     $assert(str_contains((string) ($titleTrace['emitted']['css'] ?? ''), '.figma-node-trace-title-trace-title{'), 'node-trace-emitted-css-rule');

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -139,6 +139,93 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     $assert(! in_array('off_canvas_visual_nodes', $normalLocalSignalCodes, true), 'quality-diagnostics-normal-local-no-visual-off-canvas-signal');
     $assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['large_absolute_offset_count'] ?? null), 'quality-diagnostics-normal-local-large-offset-count-zero');
     $assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['off_canvas_visual_node_count'] ?? null), 'quality-diagnostics-normal-local-visual-offset-count-zero');
+
+    $stickyGhostResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Sticky Ghost Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'sticky:root',
+                'type'     => 'FRAME',
+                'name'     => 'Sticky page',
+                'width'    => 960,
+                'height'   => 1800,
+                'children' => array(
+                    array(
+                        'id'         => 'sticky:row',
+                        'type'       => 'FRAME',
+                        'name'       => 'Article row',
+                        'width'      => 960,
+                        'height'     => 1600,
+                        'layoutMode' => 'HORIZONTAL',
+                        'itemSpacing' => 24,
+                        'children'   => array(
+                            array('id' => 'sticky:toc-primary', 'type' => 'FRAME', 'name' => 'Table of contents', 'width' => 240, 'height' => 320, 'children' => array(
+                                array('id' => 'sticky:toc-title', 'type' => 'TEXT', 'name' => 'TOC title', 'characters' => 'Contents', 'width' => 120, 'height' => 24, 'fontSize' => 18),
+                                array('id' => 'sticky:toc-link', 'type' => 'TEXT', 'name' => 'TOC link', 'characters' => 'Introduction', 'width' => 120, 'height' => 20, 'fontSize' => 14),
+                            )),
+                            array('id' => 'sticky:article', 'type' => 'FRAME', 'name' => 'Article body', 'width' => 696, 'height' => 1200, 'children' => array(
+                                array('id' => 'sticky:article-title', 'type' => 'TEXT', 'name' => 'Article title', 'characters' => 'Long article', 'width' => 320, 'height' => 48, 'fontSize' => 36),
+                            )),
+                            array('id' => 'sticky:toc-ghost', 'type' => 'FRAME', 'name' => 'Table of contents', 'x' => 0, 'y' => 1280, 'width' => 240, 'height' => 320, 'layoutPositioning' => 'ABSOLUTE', 'constraints' => array('horizontal' => 'LEFT', 'vertical' => 'BOTTOM'), 'opacity' => 0.1, 'children' => array(
+                                array('id' => 'sticky:toc-ghost-title', 'type' => 'TEXT', 'name' => 'TOC title', 'characters' => 'Contents', 'width' => 120, 'height' => 24, 'fontSize' => 18),
+                                array('id' => 'sticky:toc-ghost-link', 'type' => 'TEXT', 'name' => 'TOC link', 'characters' => 'Introduction', 'width' => 120, 'height' => 20, 'fontSize' => 14),
+                            )),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $stickyGhostHtml = $fileContent($stickyGhostResult, 'index.html');
+    $stickyGhostCss = $fileContent($stickyGhostResult, 'style.css');
+    $stickyGhostLayout = $stickyGhostResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+    $assert(str_contains($stickyGhostHtml, 'data-figma-node-id="sticky:toc-primary"'), 'sticky-ghost-primary-emitted');
+    $assert(! str_contains($stickyGhostHtml, 'data-figma-node-id="sticky:toc-ghost"'), 'sticky-ghost-duplicate-suppressed');
+    $assert(str_contains($stickyGhostCss, '.figma-node-sticky-toc-primary-table-of-contents{') && str_contains($stickyGhostCss, 'position:sticky;top:0;align-self:flex-start'), 'sticky-ghost-primary-css-sticky');
+    $assert(1 === ($stickyGhostLayout['sticky_ghosts']['count'] ?? null), 'sticky-ghost-diagnostic-count');
+    $assert('sticky:toc-primary' === ($stickyGhostLayout['sticky_ghosts']['candidates'][0]['primary_id'] ?? null), 'sticky-ghost-diagnostic-primary');
+    $assert('sticky:toc-ghost' === ($stickyGhostLayout['sticky_ghosts']['candidates'][0]['ghost_id'] ?? null), 'sticky-ghost-diagnostic-ghost');
+
+    $repeatedCardsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Repeated Cards Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'repeat:root',
+                'type'     => 'FRAME',
+                'name'     => 'Repeated cards root',
+                'width'    => 640,
+                'height'   => 900,
+                'children' => array(
+                    array(
+                        'id'         => 'repeat:row',
+                        'type'       => 'FRAME',
+                        'name'       => 'Cards row',
+                        'width'      => 640,
+                        'height'     => 720,
+                        'layoutMode' => 'HORIZONTAL',
+                        'itemSpacing' => 24,
+                        'children'   => array(
+                            array('id' => 'repeat:card-a', 'type' => 'FRAME', 'name' => 'Promo card', 'width' => 240, 'height' => 180, 'children' => array(
+                                array('id' => 'repeat:card-a-title', 'type' => 'TEXT', 'name' => 'Card title', 'characters' => 'Featured', 'width' => 120, 'height' => 24, 'fontSize' => 18),
+                            )),
+                            array('id' => 'repeat:card-b', 'type' => 'FRAME', 'name' => 'Promo card', 'width' => 240, 'height' => 180, 'children' => array(
+                                array('id' => 'repeat:card-b-title', 'type' => 'TEXT', 'name' => 'Card title', 'characters' => 'Featured', 'width' => 120, 'height' => 24, 'fontSize' => 18),
+                            )),
+                            array('id' => 'repeat:card-c', 'type' => 'FRAME', 'name' => 'Promo card', 'x' => 0, 'y' => 540, 'width' => 240, 'height' => 180, 'layoutPositioning' => 'ABSOLUTE', 'constraints' => array('horizontal' => 'LEFT', 'vertical' => 'BOTTOM'), 'opacity' => 1, 'children' => array(
+                                array('id' => 'repeat:card-c-title', 'type' => 'TEXT', 'name' => 'Card title', 'characters' => 'Featured', 'width' => 120, 'height' => 24, 'fontSize' => 18),
+                            )),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $repeatedCardsHtml = $fileContent($repeatedCardsResult, 'index.html');
+    $repeatedCardsLayout = $repeatedCardsResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+    $assert(str_contains($repeatedCardsHtml, 'data-figma-node-id="repeat:card-a"'), 'repeated-cards-flow-card-a-emitted');
+    $assert(str_contains($repeatedCardsHtml, 'data-figma-node-id="repeat:card-b"'), 'repeated-cards-flow-card-b-emitted');
+    $assert(str_contains($repeatedCardsHtml, 'data-figma-node-id="repeat:card-c"'), 'repeated-cards-full-opacity-absolute-emitted');
+    $assert(0 === ($repeatedCardsLayout['sticky_ghosts']['count'] ?? null), 'repeated-cards-no-sticky-ghost-diagnostic');
     
     $emptyVisibleContainerResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Empty Visible Container Classification Fixture',

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -186,6 +186,58 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     $assert('sticky:toc-primary' === ($stickyGhostLayout['sticky_ghosts']['candidates'][0]['primary_id'] ?? null), 'sticky-ghost-diagnostic-primary');
     $assert('sticky:toc-ghost' === ($stickyGhostLayout['sticky_ghosts']['candidates'][0]['ghost_id'] ?? null), 'sticky-ghost-diagnostic-ghost');
 
+    $stickyGhostSourceMismatchResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Sticky Ghost Source Mismatch Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'sticky-real:root',
+                'type'     => 'FRAME',
+                'name'     => 'Blog Post Desktop',
+                'width'    => 1440,
+                'height'   => 4800,
+                'children' => array(
+                    array(
+                        'id'         => '4194:2157',
+                        'type'       => 'FRAME',
+                        'name'       => 'Frame 51076550',
+                        'width'      => 1216,
+                        'height'     => 4163.5,
+                        'layoutMode' => 'HORIZONTAL',
+                        'itemSpacing' => 105,
+                        'children'   => array(
+                            array('id' => '4212:3087', 'figma_component_source_id' => '4212:3087', 'type' => 'INSTANCE', 'name' => 'Table of Contents', 'width' => 315, 'height' => 510, 'children' => array(
+                                array('id' => '4212:3087/4198:8360', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Table of Contents', 'width' => 180, 'height' => 24, 'fontSize' => 18),
+                                array('id' => '4212:3087/4188:11209', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Unboxing Experience', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                array('id' => '4212:3087/4188:11211', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Build Process', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                array('id' => '4212:3087/4188:11213', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Step-By-Step Construction', 'width' => 240, 'height' => 24, 'fontSize' => 16),
+                                array('id' => '4212:3087/4188:11220', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Conclusion', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                            )),
+                            array('id' => 'sticky-real:article', 'type' => 'FRAME', 'name' => 'Article body', 'width' => 796, 'height' => 3000, 'children' => array(
+                                array('id' => 'sticky-real:title', 'type' => 'TEXT', 'name' => 'Article title', 'characters' => 'Long article', 'width' => 420, 'height' => 56, 'fontSize' => 42),
+                            )),
+                            array('id' => '4210:12595', 'figma_component_source_id' => '4210:12595', 'type' => 'INSTANCE', 'name' => 'Table of Contents', 'x' => 0, 'y' => 3654, 'width' => 315, 'height' => 510, 'layoutPositioning' => 'ABSOLUTE', 'constraints' => array('horizontal' => 'LEFT', 'vertical' => 'BOTTOM'), 'opacity' => 0.1, 'children' => array(
+                                array('id' => '4210:12595/4198:8360', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Table of Contents', 'width' => 180, 'height' => 24, 'fontSize' => 18),
+                                array('id' => '4210:12595/4188:11209', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Unboxing Experience', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                array('id' => '4210:12595/4188:11211', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Build Process', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                array('id' => '4210:12595/4188:11213', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Step-By-Step Construction', 'width' => 240, 'height' => 24, 'fontSize' => 16),
+                                array('id' => '4210:12595/4188:11220', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Conclusion', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                            )),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $stickyGhostSourceMismatchHtml = $fileContent($stickyGhostSourceMismatchResult, 'index.html');
+    $stickyGhostSourceMismatchCss = $fileContent($stickyGhostSourceMismatchResult, 'style.css');
+    $stickyGhostSourceMismatchLayout = $stickyGhostSourceMismatchResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+    $assert(str_contains($stickyGhostSourceMismatchHtml, 'data-figma-node-id="4212:3087"'), 'sticky-ghost-source-mismatch-primary-emitted');
+    $assert(! str_contains($stickyGhostSourceMismatchHtml, 'data-figma-node-id="4210:12595"'), 'sticky-ghost-source-mismatch-duplicate-suppressed');
+    $assert(str_contains($stickyGhostSourceMismatchCss, '.figma-node-4212-3087-table-of-contents{') && str_contains($stickyGhostSourceMismatchCss, 'position:sticky;top:0;align-self:flex-start'), 'sticky-ghost-source-mismatch-primary-css-sticky');
+    $assert(1 === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['count'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-count');
+    $assert('4212:3087' === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['candidates'][0]['primary_id'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-primary');
+    $assert('4210:12595' === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['candidates'][0]['ghost_id'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-ghost');
+
     $repeatedCardsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Repeated Cards Fixture',
         'nodes' => array(

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -238,6 +238,98 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     $assert('4212:3087' === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['candidates'][0]['primary_id'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-primary');
     $assert('4210:12595' === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['candidates'][0]['ghost_id'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-ghost');
 
+    $stickyGhostMultiPageResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Sticky Ghost Multi Page Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'sticky-multi:canvas',
+                'type'     => 'CANVAS',
+                'name'     => 'Site',
+                'children' => array(
+                    array(
+                        'id'       => 'sticky-multi:home',
+                        'type'     => 'FRAME',
+                        'name'     => 'Home',
+                        'width'    => 1440,
+                        'height'   => 900,
+                        'children' => array(
+                            array('id' => 'sticky-multi:home-title', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Home', 'width' => 180, 'height' => 48, 'fontSize' => 36),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'sticky-multi:section',
+                        'type'     => 'SECTION',
+                        'name'     => 'Blog Post Section',
+                        'children' => array(
+                            array(
+                                'id'       => 'sticky-multi:blog-desktop',
+                                'type'     => 'FRAME',
+                                'name'     => 'Blog Post Desktop',
+                                'width'    => 1440,
+                                'height'   => 4800,
+                                'children' => array(
+                                    array(
+                                        'id'         => '4194:2157',
+                                        'type'       => 'FRAME',
+                                        'name'       => 'Frame 51076550',
+                                        'width'      => 1216,
+                                        'height'     => 4163.5,
+                                        'layoutMode' => 'HORIZONTAL',
+                                        'itemSpacing' => 105,
+                                        'children'   => array(
+                                            array('id' => '4212:3087', 'figma_component_source_id' => '4212:3087', 'type' => 'INSTANCE', 'name' => 'Table of Contents', 'width' => 315, 'height' => 510, 'children' => array(
+                                                array('id' => '4212:3087/4198:8360', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Table of Contents', 'width' => 180, 'height' => 24, 'fontSize' => 18),
+                                                array('id' => '4212:3087/4188:11209', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Unboxing Experience', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                                array('id' => '4212:3087/4188:11211', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Build Process', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                                array('id' => '4212:3087/4188:11213', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Step-By-Step Construction', 'width' => 240, 'height' => 24, 'fontSize' => 16),
+                                                array('id' => '4212:3087/4188:11220', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Conclusion', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                            )),
+                                            array('id' => 'sticky-multi:article', 'type' => 'FRAME', 'name' => 'Article body', 'width' => 796, 'height' => 3000, 'children' => array(
+                                                array('id' => 'sticky-multi:title', 'type' => 'TEXT', 'name' => 'Article title', 'characters' => 'Long article', 'width' => 420, 'height' => 56, 'fontSize' => 42),
+                                            )),
+                                            array('id' => '4210:12595', 'figma_component_source_id' => '4210:12595', 'type' => 'INSTANCE', 'name' => 'Table of Contents', 'x' => 0, 'y' => 3654, 'width' => 315, 'height' => 510, 'layoutPositioning' => 'ABSOLUTE', 'constraints' => array('horizontal' => 'LEFT', 'vertical' => 'BOTTOM'), 'opacity' => 0.1, 'children' => array(
+                                                array('id' => '4210:12595/4198:8360', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Table of Contents', 'width' => 180, 'height' => 24, 'fontSize' => 18),
+                                                array('id' => '4210:12595/4188:11209', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Unboxing Experience', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                                array('id' => '4210:12595/4188:11211', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'The Build Process', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                                array('id' => '4210:12595/4188:11213', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Step-By-Step Construction', 'width' => 240, 'height' => 24, 'fontSize' => 16),
+                                                array('id' => '4210:12595/4188:11220', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Conclusion', 'width' => 240, 'height' => 28, 'fontSize' => 20),
+                                            )),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            array(
+                                'id'       => 'sticky-multi:blog-mobile',
+                                'type'     => 'FRAME',
+                                'name'     => 'Blog Post Mobile',
+                                'width'    => 390,
+                                'height'   => 4200,
+                                'children' => array(
+                                    array('id' => 'sticky-multi:mobile-title', 'type' => 'TEXT', 'name' => 'Article title', 'characters' => 'Long article', 'width' => 320, 'height' => 44, 'fontSize' => 32),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ), array(
+        'multi_page'     => true,
+        'frame_ids'      => array('sticky-multi:home', 'sticky-multi:blog-desktop', 'sticky-multi:blog-mobile'),
+        'entry_frame_id' => 'sticky-multi:home',
+    ));
+    $stickyGhostMultiPageHtml = $fileContent($stickyGhostMultiPageResult, 'blog-post.html');
+    $stickyGhostMultiPageCss = $fileContent($stickyGhostMultiPageResult, 'style.css');
+    $stickyGhostMultiPageLayout = $stickyGhostMultiPageResult['source_reports']['figma']['html']['transform_diagnostics']['layout'] ?? array();
+    $assert('' !== $stickyGhostMultiPageHtml, 'sticky-ghost-multi-page-blog-post-emitted');
+    $assert(str_contains($stickyGhostMultiPageHtml, 'data-figma-node-id="4212:3087"'), 'sticky-ghost-multi-page-primary-emitted');
+    $assert(! str_contains($stickyGhostMultiPageHtml, 'data-figma-node-id="4210:12595"'), 'sticky-ghost-multi-page-ghost-absent-from-final-html');
+    $assert(str_contains($stickyGhostMultiPageCss, '.figma-node-4212-3087-table-of-contents{') && str_contains($stickyGhostMultiPageCss, 'position:sticky;top:0;align-self:flex-start'), 'sticky-ghost-multi-page-primary-sticky-in-final-css');
+    $assert(! str_contains($stickyGhostMultiPageCss, '.figma-node-4210-12595-table-of-contents'), 'sticky-ghost-multi-page-ghost-absent-from-final-css');
+    $assert(1 === ($stickyGhostMultiPageLayout['sticky_ghosts']['count'] ?? null), 'sticky-ghost-multi-page-diagnostic-count');
+    $assert('4212:3087' === ($stickyGhostMultiPageLayout['sticky_ghosts']['candidates'][0]['primary_id'] ?? null), 'sticky-ghost-multi-page-diagnostic-primary');
+    $assert('4210:12595' === ($stickyGhostMultiPageLayout['sticky_ghosts']['candidates'][0]['ghost_id'] ?? null), 'sticky-ghost-multi-page-diagnostic-ghost');
+
     $repeatedCardsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Repeated Cards Fixture',
         'nodes' => array(

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -195,6 +195,7 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
                 'name'     => 'Blog Post Desktop',
                 'width'    => 1440,
                 'height'   => 4800,
+                'clipsContent' => true,
                 'children' => array(
                     array(
                         'id'         => '4194:2157',
@@ -202,6 +203,7 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
                         'name'       => 'Frame 51076550',
                         'width'      => 1216,
                         'height'     => 4163.5,
+                        'clipsContent' => true,
                         'layoutMode' => 'HORIZONTAL',
                         'itemSpacing' => 105,
                         'children'   => array(
@@ -212,7 +214,7 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
                                 array('id' => '4212:3087/4188:11213', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Step-By-Step Construction', 'width' => 240, 'height' => 24, 'fontSize' => 16),
                                 array('id' => '4212:3087/4188:11220', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Conclusion', 'width' => 240, 'height' => 28, 'fontSize' => 20),
                             )),
-                            array('id' => 'sticky-real:article', 'type' => 'FRAME', 'name' => 'Article body', 'width' => 796, 'height' => 3000, 'children' => array(
+                            array('id' => 'sticky-real:article', 'type' => 'FRAME', 'name' => 'Article body', 'width' => 796, 'height' => 3000, 'clipsContent' => true, 'children' => array(
                                 array('id' => 'sticky-real:title', 'type' => 'TEXT', 'name' => 'Article title', 'characters' => 'Long article', 'width' => 420, 'height' => 56, 'fontSize' => 42),
                             )),
                             array('id' => '4210:12595', 'figma_component_source_id' => '4210:12595', 'type' => 'INSTANCE', 'name' => 'Table of Contents', 'x' => 0, 'y' => 3654, 'width' => 315, 'height' => 510, 'layoutPositioning' => 'ABSOLUTE', 'constraints' => array('horizontal' => 'LEFT', 'vertical' => 'BOTTOM'), 'opacity' => 0.1, 'children' => array(
@@ -234,6 +236,9 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     $assert(str_contains($stickyGhostSourceMismatchHtml, 'data-figma-node-id="4212:3087"'), 'sticky-ghost-source-mismatch-primary-emitted');
     $assert(! str_contains($stickyGhostSourceMismatchHtml, 'data-figma-node-id="4210:12595"'), 'sticky-ghost-source-mismatch-duplicate-suppressed');
     $assert(str_contains($stickyGhostSourceMismatchCss, '.figma-node-4212-3087-table-of-contents{') && str_contains($stickyGhostSourceMismatchCss, 'position:sticky;top:0;align-self:flex-start'), 'sticky-ghost-source-mismatch-primary-css-sticky');
+    $assert(! preg_match('/\.figma-node-sticky-real-root-blog-post-desktop\{[^}]*overflow:hidden/', $stickyGhostSourceMismatchCss), 'sticky-ghost-source-mismatch-root-no-overflow-hidden');
+    $assert(! preg_match('/\.figma-node-4194-2157-frame-51076550\{[^}]*overflow:hidden/', $stickyGhostSourceMismatchCss), 'sticky-ghost-source-mismatch-row-no-overflow-hidden');
+    $assert(1 === preg_match('/\.figma-node-sticky-real-article-article-body\{[^}]*overflow:hidden/', $stickyGhostSourceMismatchCss), 'sticky-ghost-source-mismatch-sibling-clipping-preserved');
     $assert(1 === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['count'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-count');
     $assert('4212:3087' === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['candidates'][0]['primary_id'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-primary');
     $assert('4210:12595' === ($stickyGhostSourceMismatchLayout['sticky_ghosts']['candidates'][0]['ghost_id'] ?? null), 'sticky-ghost-source-mismatch-diagnostic-ghost');

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -140,6 +140,42 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     $assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['large_absolute_offset_count'] ?? null), 'quality-diagnostics-normal-local-large-offset-count-zero');
     $assert(0 === ($normalLocalPlacementResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['off_canvas_visual_node_count'] ?? null), 'quality-diagnostics-normal-local-visual-offset-count-zero');
 
+    $absoluteChildReserveResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Absolute Child Flow Reserve Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'reserve:root',
+                'type'     => 'FRAME',
+                'name'     => 'Page root',
+                'width'    => 640,
+                'height'   => 700,
+                'children' => array(
+                    array(
+                        'id'       => 'reserve:footer',
+                        'type'     => 'FRAME',
+                        'name'     => 'Footer shell',
+                        'x'        => 0,
+                        'y'        => 120,
+                        'width'    => 640,
+                        'height'   => 483,
+                        'children' => array(
+                            array('id' => 'reserve:newsletter', 'type' => 'FRAME', 'name' => 'Promoted card', 'x' => 112, 'y' => 0, 'width' => 416, 'height' => 352, 'children' => array(
+                                array('id' => 'reserve:newsletter:text', 'type' => 'TEXT', 'name' => 'Card heading', 'characters' => 'Promoted content', 'width' => 240, 'height' => 32, 'fontSize' => 24),
+                            )),
+                            array('id' => 'reserve:bottom', 'type' => 'FRAME', 'name' => 'Bottom bar', 'x' => 0, 'y' => 352, 'width' => 640, 'height' => 131, 'children' => array(
+                                array('id' => 'reserve:bottom:text', 'type' => 'TEXT', 'name' => 'Bottom text', 'characters' => 'Footer links', 'width' => 120, 'height' => 24, 'fontSize' => 16),
+                            )),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $absoluteChildReserveCss = $fileContent($absoluteChildReserveResult, 'style.css');
+    $assert(str_contains($absoluteChildReserveCss, '.figma-node-reserve-footer-footer-shell{') && str_contains($absoluteChildReserveCss, 'height:483px;min-height:483px;'), 'absolute-child-reserve-parent-min-height');
+    $assert(str_contains($absoluteChildReserveCss, '.figma-node-reserve-newsletter-promoted-card{') && str_contains($absoluteChildReserveCss, 'width:416px;height:352px;position:absolute;left:112px;top:0px'), 'absolute-child-reserve-positioned-card-preserved');
+    $assert(str_contains($absoluteChildReserveCss, '.figma-node-reserve-bottom-bottom-bar{') && str_contains($absoluteChildReserveCss, 'width:640px;height:131px;position:absolute;left:0px;top:352px'), 'absolute-child-reserve-positioned-bottom-preserved');
+
     $stickyGhostResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Sticky Ghost Fixture',
         'nodes' => array(

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -583,6 +583,50 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     $singleLineButtonLabelCss = $fileContent($singleLineButtonLabelResult, 'style.css');
     $assert(str_contains($singleLineButtonLabelCss, '.figma-node-text-single-line-button-label-button-label{width:60px;font-size:16px;line-height:24px}'), 'single-line-button-label-avoids-fixed-tiny-height');
     $assert(! str_contains($singleLineButtonLabelCss, '.figma-node-text-single-line-button-label-button-label{width:60px;height:12px'), 'single-line-button-label-no-overflowing-fixed-height');
+
+    $hugButtonLabelResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Hug Button Label Fixture',
+        'nodes' => array(
+            array(
+                'id'              => 'text:hug-button',
+                'type'            => 'FRAME',
+                'name'            => 'Button',
+                'width'           => 73,
+                'height'          => 36,
+                'layoutMode'      => 'HORIZONTAL',
+                'paddingTop'      => 12,
+                'paddingRight'    => 16,
+                'paddingBottom'   => 12,
+                'paddingLeft'     => 16,
+                'itemSpacing'     => 8,
+                'cornerRadius'    => 999,
+                'fills'           => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                'children'        => array(
+                    array(
+                        'id'              => 'text:hug-button-label',
+                        'type'            => 'TEXT',
+                        'name'            => 'Reply',
+                        'characters'      => 'Reply',
+                        'x'               => 16,
+                        'y'               => 12,
+                        'width'           => 39,
+                        'height'          => 10,
+                        'fontSize'        => 14,
+                        'lineHeightPx'    => 22,
+                        'derivedTextData' => array(
+                            'layoutSize' => array('x' => 39, 'y' => 10),
+                            'baselines'  => array(
+                                array('firstCharacter' => 0, 'endCharacter' => 5, 'lineY' => -6.282, 'lineHeight' => 22, 'lineAscent' => 14, 'position' => array('x' => 0, 'y' => 10.43)),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $hugButtonLabelCss = $fileContent($hugButtonLabelResult, 'style.css');
+    $assert(str_contains($hugButtonLabelCss, '.figma-node-text-hug-button-button{width:73px;height:36px;'), 'hug-button-label-parent-keeps-figma-height');
+    $assert(str_contains($hugButtonLabelCss, '.figma-node-text-hug-button-label-reply{width:39px;height:10px;font-size:14px;line-height:22px;overflow:visible;flex-shrink:0}'), 'hug-button-label-flex-item-uses-measured-height');
 }
 
 function blocks_engine_figma_transformer_run_text_style_contract(callable $assert, callable $fileContent, callable $artifactQualitySignal, callable $artifactQualitySignalCodes): void

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -554,10 +554,35 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
             $derivedMeasuredLineHeightDiagnostic = $styleDiagnostic;
         }
     }
-    $assert(str_contains($derivedMeasuredLineHeightCss, '.figma-node-text-derived-measured-line-height-measured-line-height{width:120px;height:40px;line-height:20px;white-space:pre-line}'), 'derived-baselines-prefer-measured-line-height');
-    $assert('20px' === ($derivedMeasuredLineHeightDiagnostic['expected']['line_height'] ?? null), 'derived-baselines-measured-line-height-expected-diagnostic');
-    $assert('20px' === ($derivedMeasuredLineHeightDiagnostic['emitted']['line_height'] ?? null), 'derived-baselines-measured-line-height-emitted-diagnostic');
+    $assert(str_contains($derivedMeasuredLineHeightCss, '.figma-node-text-derived-measured-line-height-measured-line-height{width:120px;height:40px;line-height:23px;white-space:pre-line}'), 'derived-baselines-prefer-position-delta-line-height');
+    $assert('23px' === ($derivedMeasuredLineHeightDiagnostic['expected']['line_height'] ?? null), 'derived-baselines-measured-line-height-expected-diagnostic');
+    $assert('23px' === ($derivedMeasuredLineHeightDiagnostic['emitted']['line_height'] ?? null), 'derived-baselines-measured-line-height-emitted-diagnostic');
     $assert(array() === ($derivedMeasuredLineHeightDiagnostic['mismatches'] ?? null), 'derived-baselines-measured-line-height-no-diagnostic-mismatch');
+
+    $singleLineButtonLabelResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Single Line Button Label Fixture',
+        'nodes' => array(
+            array(
+                'id'              => 'text:single-line-button-label',
+                'type'            => 'TEXT',
+                'name'            => 'Button Label',
+                'characters'      => 'Submit',
+                'width'           => 60,
+                'height'          => 12,
+                'fontSize'        => 16,
+                'lineHeightPx'    => 24,
+                'derivedTextData' => array(
+                    'layoutSize' => array('x' => 60, 'y' => 12),
+                    'baselines'  => array(
+                        array('firstCharacter' => 0, 'endCharacter' => 6, 'lineY' => -6, 'lineHeight' => 24, 'lineAscent' => 18, 'position' => array('x' => 0, 'y' => 10)),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $singleLineButtonLabelCss = $fileContent($singleLineButtonLabelResult, 'style.css');
+    $assert(str_contains($singleLineButtonLabelCss, '.figma-node-text-single-line-button-label-button-label{width:60px;font-size:16px;line-height:24px}'), 'single-line-button-label-avoids-fixed-tiny-height');
+    $assert(! str_contains($singleLineButtonLabelCss, '.figma-node-text-single-line-button-label-button-label{width:60px;height:12px'), 'single-line-button-label-no-overflowing-fixed-height');
 }
 
 function blocks_engine_figma_transformer_run_text_style_contract(callable $assert, callable $fileContent, callable $artifactQualitySignal, callable $artifactQualitySignalCodes): void

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -98,9 +98,31 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
         ),
     ));
     $strokedGeometryStyleHtml = $fileContent($strokedGeometryStyleResult, 'index.html');
-    $assert(str_contains($strokedGeometryStyleHtml, 'stroke-linecap="round"') && str_contains($strokedGeometryStyleHtml, 'stroke-linejoin="bevel"'), 'stroke-geometry-cap-join-render');
-    $assert(str_contains($strokedGeometryStyleHtml, 'stroke-dasharray="4 2"'), 'stroke-geometry-dash-render');
+    $assert(str_contains($strokedGeometryStyleHtml, '<path d="M1 1L15 15" fill="#000000" data-figma-style-id="42"/>'), 'stroke-geometry-renders-expanded-outline-as-fill');
+    $assert(! str_contains($strokedGeometryStyleHtml, 'stroke-linecap="round"') && ! str_contains($strokedGeometryStyleHtml, 'stroke-dasharray="4 2"'), 'stroke-geometry-does-not-restroke-expanded-outline');
     $assert(str_contains($strokedGeometryStyleHtml, 'data-figma-style-id="42"'), 'vector-path-style-id-carry-through');
+
+    $mixedGeometryVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Mixed Fill And Stroke Geometry Fixture',
+        'nodes' => array(
+            array(
+                'id'             => 'vector:mixed-geometry',
+                'type'           => 'VECTOR',
+                'name'           => 'Mixed Geometry Icon',
+                'width'          => 16,
+                'height'         => 16,
+                'strokeWeight'   => 2,
+                'fillPaints'     => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
+                'strokePaints'   => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0, 'b' => 0, 'a' => 1))),
+                'fillGeometry'   => array(array('path' => 'M 0 0 L 4 0 L 4 4 L 0 4 Z')),
+                'strokeGeometry' => array(array('path' => 'M 6 6 L 10 6 L 10 10 L 6 10 Z')),
+            ),
+        ),
+    ));
+    $mixedGeometryVectorHtml = $fileContent($mixedGeometryVectorResult, 'index.html');
+    $assert(str_contains($mixedGeometryVectorHtml, '<path d="M0 0L4 0 4 4 0 4Z" fill="#000000"/>'), 'fill-geometry-uses-fill-paint-only');
+    $assert(str_contains($mixedGeometryVectorHtml, '<path d="M6 6L10 6 10 10 6 10Z" fill="#ff0000"/>'), 'stroke-geometry-uses-stroke-paint-as-fill');
+    $assert(! str_contains($mixedGeometryVectorHtml, 'stroke="#ff0000"'), 'mixed-geometry-does-not-restroke-stroke-geometry');
 
     $vectorNetworkObjectResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Vector Network Object Fixture',

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -137,7 +137,28 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
     $assert(str_contains($vectorNetworkObjectHtml, 'data-figma-node-id="vector:network-object"') && str_contains($vectorNetworkObjectHtml, 'data-figma-vector="true"'), 'vector-network-object-renders');
     $assert(str_contains($vectorNetworkObjectHtml, '<g transform="scale(2 2)"><path d="M0 0L10 0 10 10 0 10 0 0Z"'), 'vector-network-normalized-size-scales-path');
     $assert(str_contains($vectorNetworkObjectHtml, 'fill-rule="evenodd"'), 'vector-network-region-winding-rule-renders');
-     
+
+    $staleScaledIconResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Stale Vector Scale Icon Fixture',
+        'nodes' => array(
+            array(
+                'id'                 => 'vector:stale-scale-icon',
+                'type'               => 'VECTOR',
+                'name'               => 'Comment Icon',
+                'width'              => 17.355,
+                'height'             => 17.355,
+                'strokeWeight'       => 1.5,
+                'strokePaints'       => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
+                'figma_vector_scale' => array('x' => 0.078, 'y' => 0.078),
+                'figma_vector_paths' => array(array('data' => 'M1.25 2.25L16.105 2.25L16.105 12.75L8.6775 12.75L4.5 16.105L4.5 12.75L1.25 12.75Z')),
+            ),
+        ),
+    ));
+    $staleScaledIconHtml = $fileContent($staleScaledIconResult, 'index.html');
+    $assert(str_contains($staleScaledIconHtml, 'data-figma-node-id="vector:stale-scale-icon"') && str_contains($staleScaledIconHtml, 'data-figma-vector="true"'), 'stale-vector-scale-icon-renders');
+    $assert(! str_contains($staleScaledIconHtml, 'scale(0.078 0.078)'), 'stale-vector-scale-icon-skips-stale-scale');
+    $assert(str_contains($staleScaledIconHtml, '<path d="M1.25 2.25L16.105 2.25') && str_contains($staleScaledIconHtml, 'stroke="#000000"'), 'stale-vector-scale-icon-path-remains-visible');
+      
     $largeDecodedPath = 'M 0 0' . str_repeat(' L 10 10', 3000) . ' Z';
     $largeDecodedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Large Decoded Vector Fixture',

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -150,14 +150,15 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
                 'strokeWeight'       => 1.5,
                 'strokePaints'       => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
                 'figma_vector_scale' => array('x' => 0.078, 'y' => 0.078),
-                'figma_vector_paths' => array(array('data' => 'M1.25 2.25L16.105 2.25L16.105 12.75L8.6775 12.75L4.5 16.105L4.5 12.75L1.25 12.75Z')),
+                'figma_vector_paths' => array(array('data' => 'M-1.238 -1.116L16.117 -1.116L16.117 16.239L-1.238 16.239Z')),
             ),
         ),
     ));
     $staleScaledIconHtml = $fileContent($staleScaledIconResult, 'index.html');
     $assert(str_contains($staleScaledIconHtml, 'data-figma-node-id="vector:stale-scale-icon"') && str_contains($staleScaledIconHtml, 'data-figma-vector="true"'), 'stale-vector-scale-icon-renders');
+    $assert(str_contains($staleScaledIconHtml, 'viewBox="-1.238 -1.116 17.355 17.355"'), 'stale-vector-scale-icon-uses-real-fse-path-bounds');
     $assert(! str_contains($staleScaledIconHtml, 'scale(0.078 0.078)'), 'stale-vector-scale-icon-skips-stale-scale');
-    $assert(str_contains($staleScaledIconHtml, '<path d="M1.25 2.25L16.105 2.25') && str_contains($staleScaledIconHtml, 'stroke="#000000"'), 'stale-vector-scale-icon-path-remains-visible');
+    $assert(str_contains($staleScaledIconHtml, 'M-1.238-1.116') && str_contains($staleScaledIconHtml, 'stroke="#000000"'), 'stale-vector-scale-icon-path-remains-visible');
       
     $largeDecodedPath = 'M 0 0' . str_repeat(' L 10 10', 3000) . ' Z';
     $largeDecodedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -329,7 +329,38 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
     ));
     $assert(str_contains($containerPaintWithStyleCss, '.figma-node-frame-stale-local-with-style-stale-local-with-style{width:28px;height:3px;background:#ffcf00'), 'style-fill-wins-over-container-stale-local-fill');
     $assert('style' === ($containerPaintWithStyleDiagnostics[0]['context']['precedence'] ?? null), 'container-style-fill-conflict-diagnostic-precedence');
-     
+
+    $shapeCommandBlobPaintWithStyleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'        => 'Shape Command Blob Paint Style Fixture',
+        'figma_blobs' => array('M0 0L28 0 28 3 0 3Z'),
+        'nodes'       => array(
+            array(
+                'id'         => 'paint-style:accent-two',
+                'type'       => 'RECTANGLE',
+                'name'       => 'Accent - Two',
+                'styleType'  => 'FILL',
+                'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0.811764717, 'b' => 0, 'a' => 1))),
+            ),
+            array(
+                'id'             => 'shape:command-blob-stale-local-with-style',
+                'type'           => 'ROUNDED_RECTANGLE',
+                'name'           => 'Command Blob Stale Local With Style',
+                'width'          => 28,
+                'height'         => 3,
+                'styleIdForFill' => 'paint-style:accent-two',
+                'fillPaints'     => array(array('type' => 'SOLID', 'color' => array('r' => 0.850980401, 'g' => 0.850980401, 'b' => 0.850980401, 'a' => 1))),
+                'fillGeometry'   => array(array('commandsBlob' => 0, 'styleID' => 0, 'windingRule' => 'NONZERO')),
+            ),
+        ),
+    ));
+    $shapeCommandBlobPaintWithStyleCss = $fileContent($shapeCommandBlobPaintWithStyleResult, 'style.css');
+    $shapeCommandBlobPaintWithStyleDiagnostics = array_values(array_filter(
+        $shapeCommandBlobPaintWithStyleResult['diagnostics'] ?? array(),
+        static fn (array $diagnostic): bool => 'figma_local_style_paint_conflict' === ($diagnostic['code'] ?? null)
+    ));
+    $assert(str_contains($shapeCommandBlobPaintWithStyleCss, '.figma-node-shape-command-blob-stale-local-with-style-command-blob-stale-local-with-style{width:28px;height:3px;background:#ffcf00'), 'style-fill-wins-over-command-blob-shape-stale-local-fill');
+    $assert('style' === ($shapeCommandBlobPaintWithStyleDiagnostics[0]['context']['precedence'] ?? null), 'command-blob-shape-style-fill-conflict-diagnostic-precedence');
+
     $externalizedEquivalentVectorPath = 'M0,0' . str_repeat('L10,10', 12000) . 'Z';
     $externalizedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Externalized Vector Fixture',

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -371,6 +371,73 @@ $assert(array(
     'parent_height' => 600,
 ) === ($decorativeUnderlayDiagnostics['nodes'][0] ?? null), 'decorative-underlay-diagnostics-node-entry');
 
+$absoluteDecorativeUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Absolute Decorative Underlay Fixture',
+    'blobs' => array(array('bytes' => $vectorCommandBlob)),
+    'nodes' => array(
+        array(
+            'id'                  => 'abs-underlay:parent',
+            'type'                => 'FRAME',
+            'name'                => 'Footer row',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 600, 'height' => 120),
+            'layoutMode'          => 'HORIZONTAL',
+            'children'            => array(
+                array(
+                    'id'                  => 'abs-underlay:bg',
+                    'type'                => 'RECTANGLE',
+                    'name'                => 'Background plate',
+                    'absoluteBoundingBox' => array('x' => -20, 'y' => -30, 'width' => 660, 'height' => 180),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                    'fill'                => array('r' => 0.02, 'g' => 0.04, 'b' => 0.08),
+                    'fillGeometry'        => array(array('commandsBlob' => 0)),
+                ),
+                array(
+                    'id'       => 'abs-underlay:copy',
+                    'type'     => 'TEXT',
+                    'name'     => 'Footer copy',
+                    'text'     => 'Footer text stays clickable',
+                    'fontSize' => 16,
+                ),
+            ),
+        ),
+    ),
+));
+$absoluteDecorativeUnderlayCss = $fileContent($absoluteDecorativeUnderlayResult, 'style.css');
+$absoluteDecorativeUnderlays = $absoluteDecorativeUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
+$assert(str_contains($absoluteDecorativeUnderlayCss, '.figma-node-abs-underlay-parent-footer-row{width:600px;height:120px;position:relative;display:flex;flex-direction:row}'), 'absolute-decorative-underlay-parent-relative');
+$assert(str_contains($absoluteDecorativeUnderlayCss, '.figma-node-abs-underlay-bg-background-plate{width:660px;height:180px;position:absolute;left:0px;top:0px;z-index:0;pointer-events:none;background:#050a14}'), 'absolute-decorative-underlay-gets-underlay-z-index');
+$assert(str_contains($absoluteDecorativeUnderlayCss, '.figma-node-abs-underlay-copy-footer-copy{position:relative;z-index:1;font-size:16px;flex-shrink:0}'), 'absolute-decorative-underlay-flow-text-stacks-above');
+$assert(1 === ($absoluteDecorativeUnderlays['count'] ?? null), 'absolute-decorative-underlay-diagnostic-count');
+
+$absoluteTextContentGuardResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Absolute Text Content Guard Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'abs-textguard:parent',
+            'type'                => 'FRAME',
+            'name'                => 'Footer row',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 600, 'height' => 120),
+            'layoutMode'          => 'HORIZONTAL',
+            'children'            => array(
+                array(
+                    'id'                  => 'abs-textguard:callout',
+                    'type'                => 'TEXT',
+                    'name'                => 'Absolute callout',
+                    'absoluteBoundingBox' => array('x' => -20, 'y' => -30, 'width' => 660, 'height' => 180),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                    'text'                => 'Real absolute content',
+                ),
+                array('id' => 'abs-textguard:sibling', 'type' => 'TEXT', 'name' => 'Sibling copy', 'text' => 'Sibling'),
+            ),
+        ),
+    ),
+));
+$absoluteTextContentGuardCss = $fileContent($absoluteTextContentGuardResult, 'style.css');
+$absoluteTextContentGuardUnderlays = $absoluteTextContentGuardResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
+$assert(str_contains($absoluteTextContentGuardCss, '.figma-node-abs-textguard-callout-absolute-callout{width:660px;height:180px;position:absolute;left:0px;top:0px;flex-shrink:0}'), 'absolute-text-content-remains-absolute-content');
+$assert(! str_contains($absoluteTextContentGuardCss, '.figma-node-abs-textguard-callout-absolute-callout{width:660px;height:180px;position:absolute;left:0px;top:0px;z-index:0;pointer-events:none}'), 'absolute-text-content-not-hidden-as-underlay');
+$assert(0 === ($absoluteTextContentGuardUnderlays['count'] ?? null), 'absolute-text-content-not-decorative-underlay-diagnostic');
+
 $contentCardResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Content Card Fixture',
     'nodes' => array(
@@ -2255,11 +2322,38 @@ $assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-stretch-badg
 // Kiwi MAX (horizontal) == far-edge pin only; Kiwi MIN (vertical) == near pin.
 $assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-far-badge-far-badge{width:60px;height:40px;position:absolute;right:40px;top:10px}'), 'kiwi-constraint-max-pins-far-edge-only');
 // Kiwi CENTER == fixed offset from parent center via calc(), no transform.
-$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-center-badge-center-badge{width:50px;height:20px;position:absolute;left:calc(50% - 25px);top:calc(50% - 10px)}'), 'kiwi-constraint-center-uses-calc-offset');
+$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-center-badge-center-badge{width:50px;height:20px;position:absolute;left:calc(50% + 0px);top:calc(50% + 0px)}'), 'kiwi-constraint-center-uses-child-center-calc-offset');
 // stackChildPrimaryGrow -> flex-grow; minSize/maxSize -> min/max width/height.
 $assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-fill-item-fill-item{width:80px;height:40px;min-width:100px;max-width:200px;min-height:20px;max-height:60px;flex-grow:1}'), 'kiwi-grow-and-min-max-size');
 // stackPrimarySizing RESIZE_TO_FIT -> HUG main axis; stackCounterSizing FIXED -> fixed cross axis.
 $assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-hug-frame-hug-frame{width:max-content;height:40px;display:flex;flex-direction:row;flex-shrink:0}'), 'kiwi-stack-sizing-bridges-to-flex-sizing');
+
+$centerOversizedClippedResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Center Oversized Clipped Fixture',
+    'nodes' => array(
+        array(
+            'id'                  => 'center-clip:parent',
+            'type'                => 'FRAME',
+            'name'                => 'Clipped logo parent',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 0, 'width' => 200, 'height' => 80),
+            'isClip'              => true,
+            'children'            => array(
+                array(
+                    'id'                   => 'center-clip:logo-piece',
+                    'type'                 => 'RECTANGLE',
+                    'name'                 => 'Oversized logo piece',
+                    'absoluteBoundingBox'  => array('x' => -50, 'y' => -20, 'width' => 300, 'height' => 120),
+                    'stackPositioning'     => 'ABSOLUTE',
+                    'horizontalConstraint' => 'CENTER',
+                    'verticalConstraint'   => 'CENTER',
+                ),
+            ),
+        ),
+    ),
+));
+$centerOversizedClippedCss = $fileContent($centerOversizedClippedResult, 'style.css');
+$assert(str_contains($centerOversizedClippedCss, '.figma-node-center-clip-parent-clipped-logo-parent{width:200px;height:80px;overflow:hidden;position:relative}'), 'center-oversized-clipped-parent-overflow-hidden');
+$assert(str_contains($centerOversizedClippedCss, '.figma-node-center-clip-logo-piece-oversized-logo-piece{width:300px;height:120px;position:absolute;left:calc(50% + 50px);top:calc(50% + 20px)}'), 'center-oversized-clipped-child-uses-child-center-calc');
 
 $plainFrameLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Plain Frame Layout Fixture',

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -4231,6 +4231,49 @@ preg_match('/figma-node-cgoc-instance-cgoc-logo[^{]*\{[^}]*left:([\d.]+)px/', $c
 $canvasGlobalLogoLeftPx = isset($canvasGlobalLogoLeft[1]) ? (float) $canvasGlobalLogoLeft[1] : -1.0;
 $assert($canvasGlobalLogoLeftPx >= 0.0 && $canvasGlobalLogoLeftPx < 1440.0, 'overridden-instance-child-canvas-global-transform-localizes-x');
 
+// Header-like logo wrappers often contain a single vector/boolean mark whose
+// visual box is smaller than the wrapper. Keep that nested visual primitive
+// positioned against the wrapper instead of letting normal flow pin it to 0,0.
+$insetLogoVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Inset Logo Vector Fixture',
+    'nodes' => array(
+        array(
+            'id'       => 'ilv:page',
+            'type'     => 'FRAME',
+            'name'     => 'Page',
+            'width'    => 500,
+            'height'   => 120,
+            'children' => array(
+                array(
+                    'id'       => 'ilv:logo',
+                    'type'     => 'INSTANCE',
+                    'name'     => 'Logo',
+                    'x'        => 20,
+                    'y'        => 20,
+                    'width'    => 228,
+                    'height'   => 35,
+                    'children' => array(
+                        array(
+                            'id'           => 'ilv:mark',
+                            'type'         => 'BOOLEAN_OPERATION',
+                            'name'         => 'Union',
+                            'x'            => 0,
+                            'y'            => 0,
+                            'width'        => 227.682,
+                            'height'       => 30,
+                            'fillGeometry' => array(array('path' => 'M0 0L227.682 0L227.682 30L0 30Z', 'windingRule' => 'NONZERO')),
+                            'fills'        => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+));
+$insetLogoVectorCss = $fileContent($insetLogoVectorResult, 'style.css');
+$assert(str_contains($insetLogoVectorCss, '.figma-node-ilv-logo-logo{width:228px;height:35px;position:absolute;left:20px;top:20px'), 'inset-logo-wrapper-remains-positioned');
+$assert(str_contains($insetLogoVectorCss, '.figma-node-ilv-mark-union{width:227.682px;height:30px;position:absolute;left:calc(50% - 113.841px);top:calc(50% - 15px)'), 'inset-logo-vector-centers-within-wrapper');
+
 // DOCUMENT-MODE MULTI-PAGE ORIGIN REBASE (#360): emitSite resolves each page
 // frame from scenegraph['node_map'], so render_document normalization must write
 // page-localized frames back into node_map instead of only rebasing render nodes.

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -477,6 +477,56 @@ $assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-logo-logo{wi
 $assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-links-frame-29{width:265px;height:26px;position:relative;z-index:1;display:flex;flex-direction:row;flex-shrink:0}'), 'fse-footer-link-row-stacks-above-underlay');
 $assert(1 === ($fseFooterUnderlays['count'] ?? null), 'fse-footer-underlay-diagnostic-count');
 
+$yellowForegroundOverlapResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Yellow Foreground Overlap Fixture',
+    'nodes' => array(
+        array(
+            'id'         => 'paint-style:kiwi-yellow',
+            'type'       => 'RECTANGLE',
+            'name'       => 'Kiwi Yellow paint style',
+            'styleType'  => 'FILL',
+            'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0.811764717, 'b' => 0, 'a' => 1))),
+        ),
+        array(
+            'id'         => 'yellow-overlap:parent',
+            'type'       => 'FRAME',
+            'name'       => 'Featured overlap row',
+            'width'      => 1000,
+            'height'     => 600,
+            'layoutMode' => 'HORIZONTAL',
+            'children'   => array(
+                array(
+                    'id'       => 'yellow-overlap:title',
+                    'type'     => 'TEXT',
+                    'name'     => 'Featured title',
+                    'text'     => 'Featured copy stays behind accent',
+                    'fontSize' => 32,
+                ),
+                array(
+                    'id'             => 'yellow-overlap:accent',
+                    'type'           => 'FRAME',
+                    'name'           => 'Yellow overlap accent',
+                    'width'          => 900,
+                    'height'         => 520,
+                    'styleIdForFill' => 'paint-style:kiwi-yellow',
+                    'fillPaints'     => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                    'fillGeometry'   => array(array('path' => 'M 0 0 L 900 0 L 900 520 L 0 520 Z', 'windingRule' => 'NONZERO')),
+                ),
+            ),
+        ),
+    ),
+));
+$yellowForegroundOverlapCss = $fileContent($yellowForegroundOverlapResult, 'style.css');
+$yellowForegroundOverlapUnderlays = $yellowForegroundOverlapResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
+$yellowForegroundOverlapDiagnostics = array_values(array_filter(
+    $yellowForegroundOverlapResult['diagnostics'] ?? array(),
+    static fn (array $diagnostic): bool => 'figma_local_style_paint_conflict' === ($diagnostic['code'] ?? null)
+));
+$assert(str_contains($yellowForegroundOverlapCss, '.figma-node-yellow-overlap-accent-yellow-overlap-accent{width:900px;height:520px;background:#ffcf00;flex-shrink:0}'), 'yellow-overlap-style-paint-resolves-without-underlay');
+$assert(! str_contains($yellowForegroundOverlapCss, '.figma-node-yellow-overlap-accent-yellow-overlap-accent{width:900px;height:520px;position:absolute'), 'yellow-overlap-foreground-not-decorative-underlay');
+$assert(0 === ($yellowForegroundOverlapUnderlays['count'] ?? null), 'yellow-overlap-foreground-underlay-diagnostic-count');
+$assert('style' === ($yellowForegroundOverlapDiagnostics[0]['context']['precedence'] ?? null), 'yellow-overlap-style-fill-conflict-diagnostic-precedence');
+
 $multiPageFseFooterUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'   => 'Multi Page FSE Footer Underlay Fixture',
     'assets' => array(

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -409,6 +409,74 @@ $assert(str_contains($absoluteDecorativeUnderlayCss, '.figma-node-abs-underlay-b
 $assert(str_contains($absoluteDecorativeUnderlayCss, '.figma-node-abs-underlay-copy-footer-copy{position:relative;z-index:1;font-size:16px;flex-shrink:0}'), 'absolute-decorative-underlay-flow-text-stacks-above');
 $assert(1 === ($absoluteDecorativeUnderlays['count'] ?? null), 'absolute-decorative-underlay-diagnostic-count');
 
+$fseFooterUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'FSE Footer Underlay Fixture',
+    'blobs' => array(array('bytes' => $vectorCommandBlob)),
+    'nodes' => array(
+        array(
+            'id'                  => 'fse-footer:row',
+            'type'                => 'FRAME',
+            'name'                => 'Frame 19',
+            'absoluteBoundingBox' => array('x' => 0, 'y' => 352, 'width' => 1440, 'height' => 131),
+            'layoutMode'          => 'HORIZONTAL',
+            'primaryAxisAlignItems' => 'SPACE_BETWEEN',
+            'counterAxisAlignItems' => 'CENTER',
+            'paddingTop'          => 48,
+            'paddingRight'        => 112,
+            'paddingBottom'       => 48,
+            'paddingLeft'         => 112,
+            'children'            => array(
+                array(
+                    'id'                  => 'fse-footer:bg',
+                    'type'                => 'RECTANGLE',
+                    'name'                => 'Rectangle 3',
+                    'absoluteBoundingBox' => array('x' => 0, 'y' => 288, 'width' => 1440, 'height' => 195),
+                    'layoutPositioning'   => 'ABSOLUTE',
+                    'constraints'         => array('horizontal' => 'LEFT', 'vertical' => 'TOP_BOTTOM'),
+                    'fill'                => array('r' => 0.85, 'g' => 0.85, 'b' => 0.85),
+                ),
+                array(
+                    'id'       => 'fse-footer:logo',
+                    'type'     => 'FRAME',
+                    'name'     => 'Logo',
+                    'width'    => 228,
+                    'height'   => 35,
+                    'children' => array(
+                        array(
+                            'id'           => 'fse-footer:logo-mark',
+                            'type'         => 'VECTOR',
+                            'name'         => 'Union',
+                            'width'        => 228,
+                            'height'       => 35,
+                            'fillGeometry' => array(array('commandsBlob' => 0)),
+                        ),
+                    ),
+                ),
+                array(
+                    'id'         => 'fse-footer:links',
+                    'type'       => 'FRAME',
+                    'name'       => 'Frame 29',
+                    'width'      => 265,
+                    'height'     => 26,
+                    'layoutMode' => 'HORIZONTAL',
+                    'children'   => array(
+                        array('id' => 'fse-footer:about', 'type' => 'TEXT', 'name' => 'Footer text', 'text' => 'About', 'fontSize' => 16),
+                        array('id' => 'fse-footer:contact', 'type' => 'TEXT', 'name' => 'Footer text', 'text' => 'Contact', 'fontSize' => 16),
+                    ),
+                ),
+                array('id' => 'fse-footer:powered', 'type' => 'TEXT', 'name' => 'Footer text', 'text' => 'Proudly powered by WordPress.com', 'fontSize' => 16),
+            ),
+        ),
+    ),
+));
+$fseFooterUnderlayCss = $fileContent($fseFooterUnderlayResult, 'style.css');
+$fseFooterUnderlays = $fseFooterUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
+$assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-row-frame-19{width:100%;max-width:1440px;margin-left:auto;margin-right:auto;height:131px;position:relative;display:flex;flex-direction:row;justify-content:space-between;align-items:center;padding-top:48px;padding-right:112px;padding-bottom:48px;padding-left:112px}'), 'fse-footer-row-relative');
+$assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-bg-rectangle-3{width:1440px;height:195px;position:absolute;left:0px;top:-64px;bottom:0px;z-index:0;pointer-events:none;background:#d9d9d9}'), 'fse-footer-background-underlay-protected');
+$assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-logo-logo{width:228px;height:35px;position:relative;z-index:1;flex-shrink:0}'), 'fse-footer-logo-stacks-above-underlay');
+$assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-links-frame-29{width:265px;height:26px;position:relative;z-index:1;display:flex;flex-direction:row;flex-shrink:0}'), 'fse-footer-link-row-stacks-above-underlay');
+$assert(1 === ($fseFooterUnderlays['count'] ?? null), 'fse-footer-underlay-diagnostic-count');
+
 $absoluteTextContentGuardResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Absolute Text Content Guard Fixture',
     'nodes' => array(

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -2450,8 +2450,8 @@ $kiwiLayoutFieldsCss = $fileContent($kiwiLayoutFieldsResult, 'style.css');
 $assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-stretch-badge-stretch-badge{width:50px;height:20px;position:absolute;left:20px;right:330px;top:30px;bottom:250px;background:#000000}'), 'kiwi-constraint-stretch-pins-both-edges');
 // Kiwi MAX (horizontal) == far-edge pin only; Kiwi MIN (vertical) == near pin.
 $assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-far-badge-far-badge{width:60px;height:40px;position:absolute;right:40px;top:10px}'), 'kiwi-constraint-max-pins-far-edge-only');
-// Kiwi CENTER == fixed offset from parent center via calc(), no transform.
-$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-center-badge-center-badge{width:50px;height:20px;position:absolute;left:calc(50% + 0px);top:calc(50% + 0px)}'), 'kiwi-constraint-center-uses-child-center-calc-offset');
+// Kiwi CENTER == fixed child-center offset from parent center via calc(), no transform.
+$assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-center-badge-center-badge{width:50px;height:20px;position:absolute;left:calc(50% - 25px);top:calc(50% - 10px)}'), 'kiwi-constraint-center-uses-child-center-calc-offset');
 // stackChildPrimaryGrow -> flex-grow; minSize/maxSize -> min/max width/height.
 $assert(str_contains($kiwiLayoutFieldsCss, '.figma-node-kiwi-layout-fill-item-fill-item{width:80px;height:40px;min-width:100px;max-width:200px;min-height:20px;max-height:60px;flex-grow:1}'), 'kiwi-grow-and-min-max-size');
 // stackPrimarySizing RESIZE_TO_FIT -> HUG main axis; stackCounterSizing FIXED -> fixed cross axis.
@@ -2482,7 +2482,7 @@ $centerOversizedClippedResult = blocks_engine_figma_transformer_transform_sceneg
 ));
 $centerOversizedClippedCss = $fileContent($centerOversizedClippedResult, 'style.css');
 $assert(str_contains($centerOversizedClippedCss, '.figma-node-center-clip-parent-clipped-logo-parent{width:200px;height:80px;overflow:hidden;position:relative}'), 'center-oversized-clipped-parent-overflow-hidden');
-$assert(str_contains($centerOversizedClippedCss, '.figma-node-center-clip-logo-piece-oversized-logo-piece{width:300px;height:120px;position:absolute;left:calc(50% + 50px);top:calc(50% + 20px)}'), 'center-oversized-clipped-child-uses-child-center-calc');
+$assert(str_contains($centerOversizedClippedCss, '.figma-node-center-clip-logo-piece-oversized-logo-piece{width:300px;height:120px;position:absolute;left:calc(50% - 100px);top:calc(50% - 40px)}'), 'center-oversized-clipped-child-uses-child-center-calc');
 
 $plainFrameLayoutResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Plain Frame Layout Fixture',

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -3763,6 +3763,63 @@ $scaledVectorInstanceCss = $fileContent($scaledVectorInstanceResult, 'style.css'
 $assert(str_contains($scaledVectorInstanceCss, '.figma-node-scaled-icon-instance-scaled-icon-vector-vector{width:20px;height:20px'), 'scaled-vector-instance-child-css-scaled');
 $assert(str_contains($scaledVectorInstanceHtml, '<g transform="scale(2 2)">'), 'scaled-vector-instance-svg-transform');
 
+$nestedScaledVectorInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'  => 'Nested Scaled Vector Instance Fixture',
+    'blobs' => array(array('bytes' => $vectorCommandBlob)),
+    'nodes' => array(
+        array(
+            'id'       => 'nested-scaled-icon:source',
+            'type'     => 'COMPONENT',
+            'name'     => 'Nested scaled icon source',
+            'key'      => 'nested-scaled-icon-source-key',
+            'width'    => 80,
+            'height'   => 64,
+            'children' => array(
+                array(
+                    'id'           => 'nested-scaled-icon:vector',
+                    'type'         => 'VECTOR',
+                    'name'         => 'Vector',
+                    'width'        => 80,
+                    'height'       => 64,
+                    'fillGeometry' => array(array('commandsBlob' => 0, 'windingRule' => 'NONZERO')),
+                ),
+            ),
+        ),
+        array(
+            'id'       => 'nested-scaled-icon:wrapper',
+            'type'     => 'COMPONENT',
+            'name'     => 'Nested scaled icon wrapper',
+            'key'      => 'nested-scaled-icon-wrapper-key',
+            'width'    => 80,
+            'height'   => 64,
+            'layout'   => array('clips_content' => true),
+            'children' => array(
+                array(
+                    'id'          => 'nested-scaled-icon:nested-instance',
+                    'type'        => 'INSTANCE',
+                    'name'        => 'Nested icon instance',
+                    'componentId' => 'nested-scaled-icon-source-key',
+                    'width'       => 80,
+                    'height'      => 64,
+                ),
+            ),
+        ),
+        array(
+            'id'          => 'nested-scaled-icon:instance',
+            'type'        => 'INSTANCE',
+            'name'        => 'Nested scaled icon instance',
+            'componentId' => 'nested-scaled-icon-wrapper-key',
+            'width'       => 40,
+            'height'      => 32,
+        ),
+    ),
+));
+$nestedScaledVectorInstanceHtml = $fileContent($nestedScaledVectorInstanceResult, 'index.html');
+$nestedScaledVectorInstanceCss = $fileContent($nestedScaledVectorInstanceResult, 'style.css');
+$assert(str_contains($nestedScaledVectorInstanceHtml, 'data-figma-node-id="nested-scaled-icon:instance/nested-scaled-icon:nested-instance"') && str_contains($nestedScaledVectorInstanceCss, '.vector{width:40px;height:32px'), 'nested-scaled-vector-instance-child-css-scaled');
+$assert(str_contains($nestedScaledVectorInstanceHtml, 'data-figma-node-id="nested-scaled-icon:instance/nested-scaled-icon:nested-instance/nested-scaled-icon:vector"') && str_contains($nestedScaledVectorInstanceHtml, 'viewBox="0 0 40 32"'), 'nested-scaled-vector-instance-descendant-css-scaled');
+$assert(str_contains($nestedScaledVectorInstanceHtml, '<g transform="scale(0.5 0.5)">'), 'nested-scaled-vector-instance-svg-transform');
+
 blocks_engine_figma_transformer_run_effects_contract($assert, $fileContent);
 
 $symbolInstanceResult = blocks_engine_figma_transformer_transform_scenegraph(array(

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -477,6 +477,67 @@ $assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-logo-logo{wi
 $assert(str_contains($fseFooterUnderlayCss, '.figma-node-fse-footer-links-frame-29{width:265px;height:26px;position:relative;z-index:1;display:flex;flex-direction:row;flex-shrink:0}'), 'fse-footer-link-row-stacks-above-underlay');
 $assert(1 === ($fseFooterUnderlays['count'] ?? null), 'fse-footer-underlay-diagnostic-count');
 
+$multiPageFseFooterUnderlayResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name'   => 'Multi Page FSE Footer Underlay Fixture',
+    'assets' => array(
+        array(
+            'id'        => 'asset:rectangle-name-collision',
+            'name'      => 'Rectangle 3',
+            'content'   => 'asset-content',
+            'mime_type' => 'image/png',
+        ),
+    ),
+    'nodes'  => array(
+        array(
+            'id'       => 'multi-fse:canvas',
+            'type'     => 'CANVAS',
+            'name'     => 'Site',
+            'children' => array(
+                array(
+                    'id'       => 'multi-fse:home',
+                    'type'     => 'FRAME',
+                    'name'     => 'Home Desktop',
+                    'width'    => 1440,
+                    'height'   => 600,
+                    'children' => array(
+                        array(
+                            'id'                    => 'multi-fse:row',
+                            'type'                  => 'FRAME',
+                            'name'                  => 'Frame 19',
+                            'absoluteBoundingBox'   => array('x' => 0, 'y' => 352, 'width' => 1440, 'height' => 131),
+                            'layoutMode'            => 'HORIZONTAL',
+                            'primaryAxisAlignItems' => 'SPACE_BETWEEN',
+                            'counterAxisAlignItems' => 'CENTER',
+                            'paddingTop'            => 48,
+                            'paddingRight'          => 112,
+                            'paddingBottom'         => 48,
+                            'paddingLeft'           => 112,
+                            'children'              => array(
+                                array(
+                                    'id'                  => 'multi-fse:bg',
+                                    'type'                => 'RECTANGLE',
+                                    'name'                => 'Rectangle 3',
+                                    'absoluteBoundingBox' => array('x' => 0, 'y' => 288, 'width' => 1440, 'height' => 195),
+                                    'layoutPositioning'   => 'ABSOLUTE',
+                                    'constraints'         => array('horizontal' => 'LEFT', 'vertical' => 'TOP_BOTTOM'),
+                                    'fill'                => array('r' => 0.85, 'g' => 0.85, 'b' => 0.85),
+                                ),
+                                array('id' => 'multi-fse:logo', 'type' => 'VECTOR', 'name' => 'Logo', 'width' => 228, 'height' => 35, 'fillGeometry' => array(array('commandsBlob' => 0))),
+                                array('id' => 'multi-fse:about', 'type' => 'TEXT', 'name' => 'Footer text', 'text' => 'About', 'fontSize' => 16),
+                                array('id' => 'multi-fse:powered', 'type' => 'TEXT', 'name' => 'Footer text', 'text' => 'Proudly powered by WordPress.com', 'fontSize' => 16),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+), array('multi_page' => true, 'frame_ids' => array('multi-fse:home'), 'entry_frame_id' => 'multi-fse:home'));
+$multiPageFseFooterUnderlayCss = $fileContent($multiPageFseFooterUnderlayResult, 'style.css');
+$multiPageFseFooterUnderlays = $multiPageFseFooterUnderlayResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
+$assert(str_contains($multiPageFseFooterUnderlayCss, '.figma-node-multi-fse-bg-rectangle-3{') && str_contains($multiPageFseFooterUnderlayCss, 'z-index:0;pointer-events:none'), 'multi-page-fse-footer-background-underlay-protected-with-asset-name-collision');
+$assert(1 === ($multiPageFseFooterUnderlays['count'] ?? null), 'multi-page-fse-footer-underlay-diagnostic-count');
+
 $absoluteTextContentGuardResult = blocks_engine_figma_transformer_transform_scenegraph(array(
     'name'  => 'Absolute Text Content Guard Fixture',
     'nodes' => array(


### PR DESCRIPTION
## Summary
- improves deterministic FSE Pilot visual parity across sticky sidebars, nested vectors, stroke geometry, yellow style paint resolution, and stacked absolute layout reserves
- extracts focused helpers for CSS positioning, sticky layout coordination, and effect overflow policy
- expands Kiwi diagnostics/node trace field coverage for raw-to-normalized parser parity work

## Verification
- php -l on touched parser/emitter/contract files
- cd figma-transformer && composer test:contract
- full FSE generation: status=success_with_warnings, page_count=5, file_count=34

## Notes
- This is intentionally generic parser/emitter work: no FSE-specific runtime selectors or node-ID hacks.
- Header logo/site-title parity still needs deeper follow-up; diagnostics are now stronger for that next pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, with parallel coding subagents
- **Used for:** Root-cause investigation, implementation, refactoring, contract updates, and verification.