### PR TITLE
figma-transformer: refactor parser and emitter collaborators

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecoder.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecoder.php
@@ -9,17 +9,18 @@ namespace Automattic\BlocksEngine\FigmaTransformer\FigFile;
  */
 final class FigKiwiDecoder
 {
-    private const TYPES = array('bool', 'byte', 'int', 'uint', 'float', 'string', 'int64', 'uint64');
     private const KINDS = array('ENUM', 'STRUCT', 'MESSAGE');
     private const INVENTORY_SAMPLE_LIMIT = 3;
     private const INVENTORY_SAMPLE_STRING_BYTES = 120;
     private const INVENTORY_SAMPLE_ARRAY_ITEMS = 8;
 
     private FigKiwiDecodePolicy $decodePolicy;
+    private FigKiwiSchemaFields $schemaFields;
 
-    public function __construct(?FigKiwiDecodePolicy $decodePolicy = null)
+    public function __construct(?FigKiwiDecodePolicy $decodePolicy = null, ?FigKiwiSchemaFields $schemaFields = null)
     {
         $this->decodePolicy = $decodePolicy ?? new FigKiwiDecodePolicy();
+        $this->schemaFields = $schemaFields ?? new FigKiwiSchemaFields();
     }
 
     /**
@@ -60,7 +61,7 @@ final class FigKiwiDecoder
                 foreach ( $definition['fields'] as $fieldIndex => $field ) {
                     $type = $field['type'];
                     if ( null !== $type && $type < 0 ) {
-                        $definitions[$definitionIndex]['fields'][$fieldIndex]['type'] = self::TYPES[~$type] ?? null;
+                        $definitions[$definitionIndex]['fields'][$fieldIndex]['type'] = FigKiwiSchemaFields::PRIMITIVE_TYPES[~$type] ?? null;
                     } elseif ( null !== $type ) {
                         $definitions[$definitionIndex]['fields'][$fieldIndex]['type'] = $definitions[$type]['name'] ?? null;
                     }
@@ -83,7 +84,7 @@ final class FigKiwiDecoder
     public function decodeMessage(string $payload, array $schema, string $rootType = 'Message'): array
     {
         try {
-            $definitions = $this->definitionsByName($schema);
+            $definitions = $this->schemaFields->definitionsByName($schema);
             if ( ! isset($definitions[$rootType]) ) {
                 return array('message' => null, 'diagnostics' => array($this->diagnostic('figma_transformer_kiwi_message_schema_missing', 'Kiwi schema does not define the expected root message.', $rootType)));
             }
@@ -107,7 +108,7 @@ final class FigKiwiDecoder
     public function decodeMessageSelective(string $payload, array $schema, string $rootType = 'Message', array $fieldPolicy = array()): array
     {
         try {
-            $definitions = $this->definitionsByName($schema);
+            $definitions = $this->schemaFields->definitionsByName($schema);
             if ( ! isset($definitions[$rootType]) ) {
                 return array('message' => null, 'diagnostics' => array($this->diagnostic('figma_transformer_kiwi_message_schema_missing', 'Kiwi schema does not define the expected root message.', $rootType)));
             }
@@ -133,7 +134,7 @@ final class FigKiwiDecoder
     public function inventorySkippedFieldsSelective(string $payload, array $schema, string $rootType = 'Message', array $fieldPolicy = array()): array
     {
         try {
-            $definitions = $this->definitionsByName($schema);
+            $definitions = $this->schemaFields->definitionsByName($schema);
             if ( ! isset($definitions[$rootType]) ) {
                 return array('inventory' => null, 'diagnostics' => array($this->diagnostic('figma_transformer_kiwi_message_schema_missing', 'Kiwi schema does not define the expected root message.', $rootType)));
             }
@@ -143,7 +144,7 @@ final class FigKiwiDecoder
                 'schema'             => 'blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1',
                 'root_type'          => $rootType,
                 'policy_groups'      => $this->decodePolicy->scenegraphFieldPolicyGroups(),
-                'schema_definitions' => $this->schemaDefinitionInventory($schema),
+                'schema_definitions' => $this->schemaFields->schemaDefinitionInventory($schema),
                 'fields'             => array(),
             );
             $context = $this->decodePolicy->initialInventoryContext($rootType);
@@ -160,22 +161,6 @@ final class FigKiwiDecoder
     }
 
     /**
-     * @param array<string, mixed> $schema
-     * @return array<string, array<string, mixed>>
-     */
-    private function definitionsByName(array $schema): array
-    {
-        $definitions = array();
-        foreach ( $schema['definitions'] ?? array() as $definition ) {
-            if ( is_array($definition) && isset($definition['name']) ) {
-                $definitions[(string) $definition['name']] = $definition;
-            }
-        }
-
-        return $definitions;
-    }
-
-    /**
      * @param array<string, mixed>                $definition
      * @param array<string, array<string, mixed>> $definitions
      */
@@ -183,12 +168,7 @@ final class FigKiwiDecoder
     {
         $result = array();
         if ( 'MESSAGE' === ($definition['kind'] ?? null) ) {
-            $fieldsByValue = array();
-            foreach ( $definition['fields'] ?? array() as $field ) {
-                if ( is_array($field) ) {
-                    $fieldsByValue[(int) ($field['value'] ?? 0)] = $field;
-                }
-            }
+            $fieldsByValue = $this->schemaFields->fieldsByValue($definition);
 
             while ( true ) {
                 $fieldValue = $reader->readVarUint();
@@ -202,10 +182,8 @@ final class FigKiwiDecoder
             }
         }
 
-        foreach ( $definition['fields'] ?? array() as $field ) {
-            if ( is_array($field) ) {
-                $this->decodeField($reader, $field, $definitions, $result);
-            }
+        foreach ( $this->schemaFields->fields($definition) as $field ) {
+            $this->decodeField($reader, $field, $definitions, $result);
         }
 
         return $result;
@@ -223,12 +201,7 @@ final class FigKiwiDecoder
         $allowed = array_flip($fieldPolicy[$typeName] ?? array());
 
         if ( 'MESSAGE' === ($definition['kind'] ?? null) ) {
-            $fieldsByValue = array();
-            foreach ( $definition['fields'] ?? array() as $field ) {
-                if ( is_array($field) ) {
-                    $fieldsByValue[(int) ($field['value'] ?? 0)] = $field;
-                }
-            }
+            $fieldsByValue = $this->schemaFields->fieldsByValue($definition);
 
             while ( true ) {
                 $fieldValue = $reader->readVarUint();
@@ -240,7 +213,7 @@ final class FigKiwiDecoder
                 }
 
                 $field = $fieldsByValue[$fieldValue];
-                $fieldName = (string) ($field['name'] ?? '');
+                $fieldName = $this->schemaFields->fieldName($field);
                 if ( isset($allowed[$fieldName]) ) {
                     $this->decodeFieldSelective($reader, $field, $definitions, $fieldPolicy, $result);
                 } else {
@@ -249,12 +222,8 @@ final class FigKiwiDecoder
             }
         }
 
-        foreach ( $definition['fields'] ?? array() as $field ) {
-            if ( ! is_array($field) ) {
-                continue;
-            }
-
-            $fieldName = (string) ($field['name'] ?? '');
+        foreach ( $this->schemaFields->fields($definition) as $field ) {
+            $fieldName = $this->schemaFields->fieldName($field);
             if ( isset($allowed[$fieldName]) ) {
                 $this->decodeFieldSelective($reader, $field, $definitions, $fieldPolicy, $result);
             } else {
@@ -273,8 +242,8 @@ final class FigKiwiDecoder
      */
     private function decodeFieldSelective(FigKiwiByteReader $reader, array $field, array $definitions, array $fieldPolicy, array &$result): void
     {
-        $type = (string) ($field['type'] ?? '');
-        if ( true === ($field['is_array'] ?? false) ) {
+        $type = $this->schemaFields->fieldType($field);
+        if ( $this->schemaFields->isArrayField($field) ) {
             if ( 'byte' === $type ) {
                 $value = $reader->readByteArray();
             } else {
@@ -288,8 +257,8 @@ final class FigKiwiDecoder
             $value = $this->decodeValueSelective($reader, $type, $definitions, $fieldPolicy);
         }
 
-        if ( true !== ($field['is_deprecated'] ?? false) && isset($field['name']) ) {
-            $result[(string) $field['name']] = $value;
+        if ( ! $this->schemaFields->isDeprecatedField($field) && isset($field['name']) ) {
+            $result[$this->schemaFields->fieldName($field)] = $value;
         }
     }
 
@@ -342,8 +311,8 @@ final class FigKiwiDecoder
      */
     private function skipField(FigKiwiByteReader $reader, array $field, array $definitions): void
     {
-        $type = (string) ($field['type'] ?? '');
-        if ( true === ($field['is_array'] ?? false) ) {
+        $type = $this->schemaFields->fieldType($field);
+        if ( $this->schemaFields->isArrayField($field) ) {
             if ( 'byte' === $type ) {
                 $reader->skipByteArray();
                 return;
@@ -392,12 +361,7 @@ final class FigKiwiDecoder
         }
 
         if ( 'MESSAGE' === ($definition['kind'] ?? null) ) {
-            $fieldsByValue = array();
-            foreach ( $definition['fields'] ?? array() as $field ) {
-                if ( is_array($field) ) {
-                    $fieldsByValue[(int) ($field['value'] ?? 0)] = $field;
-                }
-            }
+            $fieldsByValue = $this->schemaFields->fieldsByValue($definition);
 
             while ( true ) {
                 $fieldValue = $reader->readVarUint();
@@ -411,10 +375,8 @@ final class FigKiwiDecoder
             }
         }
 
-        foreach ( $definition['fields'] ?? array() as $field ) {
-            if ( is_array($field) ) {
-                $this->skipField($reader, $field, $definitions);
-            }
+        foreach ( $this->schemaFields->fields($definition) as $field ) {
+            $this->skipField($reader, $field, $definitions);
         }
     }
 
@@ -456,12 +418,7 @@ final class FigKiwiDecoder
         $context['parent_type'] = $typeName;
 
         if ( 'MESSAGE' === ($definition['kind'] ?? null) ) {
-            $fieldsByValue = array();
-            foreach ( $definition['fields'] ?? array() as $field ) {
-                if ( is_array($field) ) {
-                    $fieldsByValue[(int) ($field['value'] ?? 0)] = $field;
-                }
-            }
+            $fieldsByValue = $this->schemaFields->fieldsByValue($definition);
 
             while ( true ) {
                 $fieldValue = $reader->readVarUint();
@@ -473,7 +430,7 @@ final class FigKiwiDecoder
                 }
 
                 $field = $fieldsByValue[$fieldValue];
-                $fieldName = (string) ($field['name'] ?? '');
+                $fieldName = $this->schemaFields->fieldName($field);
                 if ( isset($allowed[$fieldName]) ) {
                     $this->inventoryDecodeFieldSelective($reader, $field, $definitions, $fieldPolicy, $inventory, $context);
                 } else {
@@ -483,12 +440,8 @@ final class FigKiwiDecoder
             }
         }
 
-        foreach ( $definition['fields'] ?? array() as $field ) {
-            if ( ! is_array($field) ) {
-                continue;
-            }
-
-            $fieldName = (string) ($field['name'] ?? '');
+        foreach ( $this->schemaFields->fields($definition) as $field ) {
+            $fieldName = $this->schemaFields->fieldName($field);
             if ( isset($allowed[$fieldName]) ) {
                 $this->inventoryDecodeFieldSelective($reader, $field, $definitions, $fieldPolicy, $inventory, $context);
             } else {
@@ -507,11 +460,11 @@ final class FigKiwiDecoder
      */
     private function inventoryDecodeFieldSelective(FigKiwiByteReader $reader, array $field, array $definitions, array $fieldPolicy, array &$inventory, array &$context): void
     {
-        $fieldName = (string) ($field['name'] ?? '');
-        $type = (string) ($field['type'] ?? '');
-        $fieldPath = (string) ($context['path'] ?? '') . '.' . $fieldName;
+        $fieldName = $this->schemaFields->fieldName($field);
+        $type = $this->schemaFields->fieldType($field);
+        $fieldPath = $this->schemaFields->fieldPath((string) ($context['path'] ?? ''), $fieldName);
 
-        if ( true === ($field['is_array'] ?? false) ) {
+        if ( $this->schemaFields->isArrayField($field) ) {
             if ( 'byte' === $type ) {
                 $value = $reader->readByteArray();
             } else {
@@ -602,13 +555,13 @@ final class FigKiwiDecoder
      */
     private function recordSkippedField(array &$inventory, array $field, array $definitions, array $context, mixed $sample): void
     {
-        $fieldName = (string) ($field['name'] ?? '');
-        $type = (string) ($field['type'] ?? '');
+        $fieldName = $this->schemaFields->fieldName($field);
+        $type = $this->schemaFields->fieldType($field);
         $parentType = (string) ($context['parent_type'] ?? '');
-        $path = (string) ($context['path'] ?? $parentType) . '.' . $fieldName;
+        $path = $this->schemaFields->fieldPath((string) ($context['path'] ?? $parentType), $fieldName);
         $role = $this->decodePolicy->classifySkippedFieldRole($fieldName, $type, $parentType);
-        $key = $parentType . '|' . $path . '|' . $fieldName . '|' . $type;
-        $typeDefinition = $this->fieldTypeDefinition($type, $definitions);
+        $key = $this->schemaFields->inventoryKey($parentType, $path, $fieldName, $type);
+        $typeDefinition = $this->schemaFields->typeDefinition($type, $definitions);
 
         if ( ! isset($inventory['fields'][$key]) ) {
             $inventory['fields'][$key] = array(
@@ -616,12 +569,12 @@ final class FigKiwiDecoder
                 'field'             => $fieldName,
                 'type'              => $type,
                 'type_kind'         => $typeDefinition['kind'] ?? 'PRIMITIVE',
-                'wire_type'         => $this->fieldWireType($field, $definitions),
+                'wire_type'         => $this->schemaFields->wireType($field, $definitions),
                 'type_definition'   => $typeDefinition,
                 'parent_message'    => $parentType,
                 'field_role'        => $role,
-                'is_array'          => true === ($field['is_array'] ?? false),
-                'field_number'      => (int) ($field['value'] ?? 0),
+                'is_array'          => $this->schemaFields->isArrayField($field),
+                'field_number'      => $this->schemaFields->fieldNumber($field),
                 'occurrences'       => 0,
                 'node_types'        => array(),
                 'sample_node_ids'   => array(),
@@ -664,8 +617,8 @@ final class FigKiwiDecoder
      */
     private function readFieldValue(FigKiwiByteReader $reader, array $field, array $definitions): mixed
     {
-        $type = (string) ($field['type'] ?? '');
-        if ( true === ($field['is_array'] ?? false) ) {
+        $type = $this->schemaFields->fieldType($field);
+        if ( $this->schemaFields->isArrayField($field) ) {
             if ( 'byte' === $type ) {
                 return $reader->readByteArray();
             }
@@ -679,97 +632,6 @@ final class FigKiwiDecoder
         }
 
         return $this->decodeValue($reader, $type, $definitions);
-    }
-
-    /**
-     * @param array<string, mixed>                $field
-     * @param array<string, array<string, mixed>> $definitions
-     */
-    private function fieldWireType(array $field, array $definitions): string
-    {
-        $type = (string) ($field['type'] ?? '');
-        if ( true === ($field['is_array'] ?? false) ) {
-            return 'length_delimited_array';
-        }
-
-        if ( in_array($type, array('bool', 'byte', 'int', 'uint', 'int64', 'uint64'), true) ) {
-            return 'varint';
-        }
-        if ( 'float' === $type ) {
-            return 'varfloat';
-        }
-        if ( 'string' === $type ) {
-            return 'null_terminated_string';
-        }
-
-        $definition = $definitions[$type] ?? null;
-        if ( ! is_array($definition) ) {
-            return 'unknown';
-        }
-
-        return match ( $definition['kind'] ?? null ) {
-            'ENUM' => 'varint_enum',
-            'STRUCT' => 'kiwi_struct',
-            'MESSAGE' => 'kiwi_message',
-            default => 'unknown',
-        };
-    }
-
-    /**
-     * @param array<string, array<string, mixed>> $definitions
-     * @return array<string, mixed>
-     */
-    private function fieldTypeDefinition(string $type, array $definitions): array
-    {
-        if ( in_array($type, self::TYPES, true) ) {
-            return array('name' => $type, 'kind' => 'PRIMITIVE');
-        }
-
-        $definition = $definitions[$type] ?? null;
-        return is_array($definition) ? $this->normalizeSchemaDefinition($definition) : array('name' => $type, 'kind' => 'UNKNOWN');
-    }
-
-    /**
-     * @param array<string, mixed> $schema
-     * @return array<string, array<string, mixed>>
-     */
-    private function schemaDefinitionInventory(array $schema): array
-    {
-        $inventory = array();
-        foreach ( $schema['definitions'] ?? array() as $definition ) {
-            if ( is_array($definition) && isset($definition['name']) ) {
-                $inventory[(string) $definition['name']] = $this->normalizeSchemaDefinition($definition);
-            }
-        }
-        ksort($inventory);
-        return $inventory;
-    }
-
-    /**
-     * @param array<string, mixed> $definition
-     * @return array<string, mixed>
-     */
-    private function normalizeSchemaDefinition(array $definition): array
-    {
-        $fields = array();
-        foreach ( $definition['fields'] ?? array() as $field ) {
-            if ( ! is_array($field) ) {
-                continue;
-            }
-            $fields[] = array(
-                'name'       => (string) ($field['name'] ?? ''),
-                'type'       => (string) ($field['type'] ?? ''),
-                'is_array'   => true === ($field['is_array'] ?? false),
-                'number'     => (int) ($field['value'] ?? 0),
-                'deprecated' => true === ($field['is_deprecated'] ?? false),
-            );
-        }
-
-        return array(
-            'name'   => (string) ($definition['name'] ?? ''),
-            'kind'   => (string) ($definition['kind'] ?? 'UNKNOWN'),
-            'fields' => $fields,
-        );
     }
 
     /**
@@ -830,8 +692,8 @@ final class FigKiwiDecoder
      */
     private function decodeField(FigKiwiByteReader $reader, array $field, array $definitions, array &$result): void
     {
-        $type = (string) ($field['type'] ?? '');
-        if ( true === ($field['is_array'] ?? false) ) {
+        $type = $this->schemaFields->fieldType($field);
+        if ( $this->schemaFields->isArrayField($field) ) {
             if ( 'byte' === $type ) {
                 $value = $reader->readByteArray();
             } else {
@@ -845,8 +707,8 @@ final class FigKiwiDecoder
             $value = $this->decodeValue($reader, $type, $definitions);
         }
 
-        if ( true !== ($field['is_deprecated'] ?? false) && isset($field['name']) ) {
-            $result[(string) $field['name']] = $value;
+        if ( ! $this->schemaFields->isDeprecatedField($field) && isset($field['name']) ) {
+            $result[$this->schemaFields->fieldName($field)] = $value;
         }
     }
 

--- a/figma-transformer/src/FigFile/FigKiwiSchemaFields.php
+++ b/figma-transformer/src/FigFile/FigKiwiSchemaFields.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\FigFile;
+
+/**
+ * Normalized accessors for raw Kiwi schema field metadata.
+ */
+final class FigKiwiSchemaFields
+{
+    public const PRIMITIVE_TYPES = array('bool', 'byte', 'int', 'uint', 'float', 'string', 'int64', 'uint64');
+
+    /**
+     * @param array<string, mixed> $schema
+     * @return array<string, array<string, mixed>>
+     */
+    public function definitionsByName(array $schema): array
+    {
+        $definitions = array();
+        foreach ( $schema['definitions'] ?? array() as $definition ) {
+            if ( is_array($definition) && isset($definition['name']) ) {
+                $definitions[(string) $definition['name']] = $definition;
+            }
+        }
+
+        return $definitions;
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     * @return array<int, array<string, mixed>>
+     */
+    public function fieldsByValue(array $definition): array
+    {
+        $fields = array();
+        foreach ( $definition['fields'] ?? array() as $field ) {
+            if ( is_array($field) ) {
+                $fields[$this->fieldNumber($field)] = $field;
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     * @return array<int, array<string, mixed>>
+     */
+    public function fields(array $definition): array
+    {
+        $fields = array();
+        foreach ( $definition['fields'] ?? array() as $field ) {
+            if ( is_array($field) ) {
+                $fields[] = $field;
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param array<string, mixed> $field
+     */
+    public function fieldName(array $field): string
+    {
+        return (string) ($field['name'] ?? '');
+    }
+
+    /**
+     * @param array<string, mixed> $field
+     */
+    public function fieldType(array $field): string
+    {
+        return (string) ($field['type'] ?? '');
+    }
+
+    /**
+     * @param array<string, mixed> $field
+     */
+    public function isArrayField(array $field): bool
+    {
+        return true === ($field['is_array'] ?? false);
+    }
+
+    /**
+     * @param array<string, mixed> $field
+     */
+    public function isDeprecatedField(array $field): bool
+    {
+        return true === ($field['is_deprecated'] ?? false);
+    }
+
+    /**
+     * @param array<string, mixed> $field
+     */
+    public function fieldNumber(array $field): int
+    {
+        return (int) ($field['value'] ?? 0);
+    }
+
+    public function fieldPath(string $parentPath, string $fieldName): string
+    {
+        return $parentPath . '.' . $fieldName;
+    }
+
+    public function inventoryKey(string $parentType, string $path, string $fieldName, string $type): string
+    {
+        return $parentType . '|' . $path . '|' . $fieldName . '|' . $type;
+    }
+
+    /**
+     * @param array<string, mixed>                $field
+     * @param array<string, array<string, mixed>> $definitions
+     */
+    public function wireType(array $field, array $definitions): string
+    {
+        $type = $this->fieldType($field);
+        if ( $this->isArrayField($field) ) {
+            return 'length_delimited_array';
+        }
+
+        if ( in_array($type, array('bool', 'byte', 'int', 'uint', 'int64', 'uint64'), true) ) {
+            return 'varint';
+        }
+        if ( 'float' === $type ) {
+            return 'varfloat';
+        }
+        if ( 'string' === $type ) {
+            return 'null_terminated_string';
+        }
+
+        $definition = $definitions[$type] ?? null;
+        if ( ! is_array($definition) ) {
+            return 'unknown';
+        }
+
+        return match ( $definition['kind'] ?? null ) {
+            'ENUM' => 'varint_enum',
+            'STRUCT' => 'kiwi_struct',
+            'MESSAGE' => 'kiwi_message',
+            default => 'unknown',
+        };
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $definitions
+     * @return array<string, mixed>
+     */
+    public function typeDefinition(string $type, array $definitions): array
+    {
+        if ( in_array($type, self::PRIMITIVE_TYPES, true) ) {
+            return array('name' => $type, 'kind' => 'PRIMITIVE');
+        }
+
+        $definition = $definitions[$type] ?? null;
+        return is_array($definition) ? $this->normalizeDefinition($definition) : array('name' => $type, 'kind' => 'UNKNOWN');
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @return array<string, array<string, mixed>>
+     */
+    public function schemaDefinitionInventory(array $schema): array
+    {
+        $inventory = array();
+        foreach ( $schema['definitions'] ?? array() as $definition ) {
+            if ( is_array($definition) && isset($definition['name']) ) {
+                $inventory[(string) $definition['name']] = $this->normalizeDefinition($definition);
+            }
+        }
+        ksort($inventory);
+        return $inventory;
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     * @return array<string, mixed>
+     */
+    public function normalizeDefinition(array $definition): array
+    {
+        $fields = array();
+        foreach ( $this->fields($definition) as $field ) {
+            $fields[] = array(
+                'name'       => $this->fieldName($field),
+                'type'       => $this->fieldType($field),
+                'is_array'   => $this->isArrayField($field),
+                'number'     => $this->fieldNumber($field),
+                'deprecated' => $this->isDeprecatedField($field),
+            );
+        }
+
+        return array(
+            'name'   => (string) ($definition['name'] ?? ''),
+            'kind'   => (string) ($definition['kind'] ?? 'UNKNOWN'),
+            'fields' => $fields,
+        );
+    }
+}

--- a/figma-transformer/src/Html/HtmlArtifactAssembler.php
+++ b/figma-transformer/src/Html/HtmlArtifactAssembler.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Assembles static HTML artifact wrappers and shared stylesheet scaffolding.
+ */
+final class HtmlArtifactAssembler
+{
+    /**
+     * @param callable(string): string $attributeSanitizer
+     */
+    public function __construct(
+        private readonly mixed $attributeSanitizer,
+    ) {
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function baseCssRules(bool $renderTextGlyphPaths): array
+    {
+        $rules = array(
+            'html{box-sizing:border-box}',
+            '*,*::before,*::after{box-sizing:inherit}',
+            'body{margin:0}',
+            '.figma-root{position:relative;width:100%}',
+            'p,h1,h2,h3,h4,h5,h6{margin:0}',
+            'ul,ol{margin:0;padding:0;list-style:none}',
+            'img{display:block;max-width:100%;height:auto}',
+            'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',
+            '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
+        );
+        if ( $renderTextGlyphPaths ) {
+            $rules[] = '.figma-text-glyphs{display:block;width:100%;height:100%;overflow:visible}';
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @param array<int, string> $cssRules
+     * @param array<int, string> $mediaBlocks
+     */
+    public function stylesheet(string $fontCss, string $designSystemCss, array $cssRules, array $mediaBlocks = array(), bool $dedupeRules = false): string
+    {
+        if ( $dedupeRules ) {
+            $cssRules = array_values(array_unique($cssRules));
+        }
+
+        $css = ('' !== $fontCss ? $fontCss . "\n" : '')
+            . ('' !== $designSystemCss ? $designSystemCss : '')
+            . implode("\n", $cssRules) . "\n";
+        if ( ! empty($mediaBlocks) ) {
+            // Responsive overrides cascade after the widest-first base rules so
+            // narrower breakpoints win at their own viewport width.
+            $css .= implode("\n", $mediaBlocks) . "\n";
+        }
+
+        return $css;
+    }
+
+    public function htmlDocument(string $title, string $stylesheetHref, string $body): string
+    {
+        return "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>" . $title . "</title>\n<link rel=\"stylesheet\" href=\"" . $this->sanitizeAttribute($stylesheetHref) . "\">\n</head>\n<body>\n<main class=\"figma-root\" data-figma-root=\"true\">\n" . $body . "</main>\n</body>\n</html>\n";
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     */
+    public function htmlFilesContent(array $files): string
+    {
+        $html = '';
+        foreach ( $files as $file ) {
+            if ( is_array($file) && 'text/html' === ($file['mime_type'] ?? null) && isset($file['content']) && is_scalar($file['content']) ) {
+                $html .= "\n" . (string) $file['content'];
+            }
+        }
+
+        return $html;
+    }
+
+    private function sanitizeAttribute(string $value): string
+    {
+        $sanitizeAttribute = $this->attributeSanitizer;
+        return $sanitizeAttribute($value);
+    }
+}

--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -9,6 +9,24 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
  */
 final class LayoutIntentClassifier
 {
+    /** @var array<int, string> */
+    private const FREEFORM_CONTAINER_TYPES = array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION');
+
+    /** @var array<int, string> */
+    private const PRIMITIVE_VECTOR_SHAPE_TYPES = array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON', 'RECTANGLE', 'ROUNDED_RECTANGLE');
+
+    /** @var array<int, string> */
+    private const VECTOR_SHAPE_CONTAINER_TYPES = array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'BOOLEAN_OPERATION');
+
+    /** @var array<int, string> */
+    private const ASSET_REFERENCE_KEYS = array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref');
+
+    /** @var array<int, string> */
+    private const PAINT_ASSET_REFERENCE_KEYS = array('imageRef', 'imageHash', 'ref', 'asset_id', 'assetId', 'image_ref');
+
+    /** @var array<int, string> */
+    private const PAINT_COLLECTION_KEYS = array('fills', 'strokes', 'background');
+
     /**
      * @param array<string, array<string, mixed>> $assetsById
      */
@@ -27,38 +45,82 @@ final class LayoutIntentClassifier
         }
 
         $children = $this->nodeList($node);
-        if ( true === ($node['figma_component']['resolved'] ?? false) && ! empty($children) && empty($node['layout']['display'] ?? null) ) {
+        if ( true === ($node['figma_component']['resolved'] ?? false) && ! empty($children) && $this->hasNoDeclaredDisplay($node) ) {
             return true;
         }
 
-        if ( empty($node['layout']['display'] ?? null) && $this->hasPositionedSourceChild($node, $children) ) {
+        if ( $this->hasNoDeclaredDisplay($node) && $this->hasPositionedSourceChild($node, $children) ) {
             return true;
         }
 
-        if ( empty($node['layout']['display'] ?? null) && $this->hasInsetSingleVisualChild($node, $children) ) {
+        if ( $this->hasNoDeclaredDisplay($node) && $this->hasInsetSingleVisualChild($node, $children) ) {
             return true;
         }
 
+        return $this->hasSingleChildOverflowingLayoutBox($node, $children);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasNoDeclaredDisplay(array $node): bool
+    {
+        return empty($node['layout']['display'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<int, mixed>    $children
+     */
+    private function hasSingleChildOverflowingLayoutBox(array $node, array $children): bool
+    {
         if ( 1 !== count($children) || ! is_array($children[0]) ) {
             return false;
         }
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $childBox = is_array($children[0]['box'] ?? null) ? $children[0]['box'] : array();
-        if ( ! isset($box['width'], $box['height'], $childBox['width'], $childBox['height']) || ! is_numeric($box['width']) || ! is_numeric($box['height']) || ! is_numeric($childBox['width']) || ! is_numeric($childBox['height']) ) {
+        if ( ! $this->boxesHaveDimensions($box, $childBox, array('width', 'height')) ) {
             return false;
         }
 
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
         if ( ! empty($layout['display'] ?? null) ) {
-            if ( 'flex' !== ($layout['display'] ?? null) ) {
-                return false;
-            }
-            $mainAxis = 'row' === ($layout['flex_direction'] ?? null) ? 'width' : 'height';
-            return (float) $childBox[$mainAxis] > (float) $box[$mainAxis];
+            return $this->flexChildOverflowsMainAxis($layout, $box, $childBox);
         }
 
         return (float) $childBox['width'] > (float) $box['width'] || (float) $childBox['height'] > (float) $box['height'];
+    }
+
+    /**
+     * @param array<string, mixed> $layout
+     * @param array<string, mixed> $box
+     * @param array<string, mixed> $childBox
+     */
+    private function flexChildOverflowsMainAxis(array $layout, array $box, array $childBox): bool
+    {
+        if ( 'flex' !== ($layout['display'] ?? null) ) {
+            return false;
+        }
+
+        $mainAxis = 'row' === ($layout['flex_direction'] ?? null) ? 'width' : 'height';
+        return (float) $childBox[$mainAxis] > (float) $box[$mainAxis];
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     * @param array<string, mixed> $childBox
+     * @param array<int, string>   $dimensions
+     */
+    private function boxesHaveDimensions(array $box, array $childBox, array $dimensions): bool
+    {
+        foreach ( $dimensions as $dimension ) {
+            if ( ! isset($box[$dimension], $childBox[$dimension]) || ! is_numeric($box[$dimension]) || ! is_numeric($childBox[$dimension]) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -73,10 +135,8 @@ final class LayoutIntentClassifier
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $childBox = is_array($children[0]['box'] ?? null) ? $children[0]['box'] : array();
-        foreach ( array('width', 'height') as $dimension ) {
-            if ( ! isset($box[$dimension], $childBox[$dimension]) || ! is_numeric($box[$dimension]) || ! is_numeric($childBox[$dimension]) ) {
-                return false;
-            }
+        if ( ! $this->boxesHaveDimensions($box, $childBox, array('width', 'height')) ) {
+            return false;
         }
 
         $widthDelta = (float) $box['width'] - (float) $childBox['width'];
@@ -127,11 +187,11 @@ final class LayoutIntentClassifier
     public function isDecorativeFlexUnderlay(array $node, array $parentNode): bool
     {
         $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
-        if ( ! $this->isFlexDisplayLayout($parentLayout) ) {
+        if ( ! $this->parentSupportsDecorativeFlexUnderlay($parentLayout) ) {
             return false;
         }
 
-        if ( ! $this->isDecorativeUnderlayVisualCandidate($node) || ! $this->parentHasTextOutsideNode($parentNode, $node) || ! $this->nodeIsBehindTextOutsideNode($parentNode, $node) ) {
+        if ( ! $this->hasDecorativeUnderlayForegroundEvidence($node, $parentNode) ) {
             return false;
         }
 
@@ -202,9 +262,20 @@ final class LayoutIntentClassifier
     /**
      * @param array<string, mixed> $layout
      */
-    private function isFlexDisplayLayout(array $layout): bool
+    private function parentSupportsDecorativeFlexUnderlay(array $layout): bool
     {
         return in_array((string) ($layout['display'] ?? ''), array('flex', 'inline-flex'), true);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $parentNode
+     */
+    private function hasDecorativeUnderlayForegroundEvidence(array $node, array $parentNode): bool
+    {
+        return $this->isDecorativeUnderlayVisualCandidate($node)
+            && $this->parentHasTextOutsideNode($parentNode, $node)
+            && $this->nodeIsBehindTextOutsideNode($parentNode, $node);
     }
 
     /**
@@ -212,7 +283,7 @@ final class LayoutIntentClassifier
      */
     private function isDecorativeUnderlayVisualCandidate(array $node): bool
     {
-        return ! $this->treeHasText($node) && ! $this->treeHasImageReference($node) && $this->treeIsVectorShapeOnly($node);
+        return ! $this->treeHasText($node) && ! $this->treeHasImageReference($node) && $this->treeIsShapeOnlyPrimitiveVisual($node);
     }
 
     /**
@@ -222,7 +293,7 @@ final class LayoutIntentClassifier
     private function hasPositionedSourceChild(array $node, array $children): bool
     {
         $type = strtoupper((string) ($node['type'] ?? ''));
-        if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION'), true) ) {
+        if ( ! in_array($type, self::FREEFORM_CONTAINER_TYPES, true) ) {
             return false;
         }
 
@@ -352,7 +423,15 @@ final class LayoutIntentClassifier
      */
     private function isContainingBlockOriginCandidate(array $node): bool
     {
-        return $this->treeHasText($node) || $this->treeHasImageReference($node) || ! $this->treeIsVectorShapeOnly($node);
+        return $this->treeHasText($node) || $this->isImageBackedLandmark($node) || ! $this->treeIsShapeOnlyPrimitiveVisual($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isImageBackedLandmark(array $node): bool
+    {
+        return $this->treeHasImageReference($node);
     }
 
     /**
@@ -382,37 +461,50 @@ final class LayoutIntentClassifier
     {
         $nodeId = (string) ($node['id'] ?? '');
         $nodeZIndex = $this->nodeZIndex($node);
-        $nodeSiblingIndex = null;
         $siblings = $this->nodeList($parentNode);
-
-        foreach ( $siblings as $index => $sibling ) {
-            if ( is_array($sibling) && (string) ($sibling['id'] ?? '') === $nodeId ) {
-                $nodeSiblingIndex = (int) $index;
-                break;
-            }
-        }
+        $nodeSiblingIndex = $this->nodeSiblingIndex($siblings, $nodeId);
 
         foreach ( $siblings as $index => $sibling ) {
             if ( ! is_array($sibling) || (string) ($sibling['id'] ?? '') === $nodeId || ! $this->treeHasText($sibling) ) {
                 continue;
             }
 
-            $siblingZIndex = $this->nodeZIndex($sibling);
-            if ( null !== $nodeZIndex && null !== $siblingZIndex ) {
-                if ( $nodeZIndex < $siblingZIndex ) {
-                    return true;
-                }
-                continue;
-            }
-
-            $nodeOrder = $this->nodeSourceOrder($node) ?? $nodeSiblingIndex;
-            $siblingOrder = $this->nodeSourceOrder($sibling) ?? (int) $index;
-            if ( null !== $nodeOrder && $nodeOrder < $siblingOrder ) {
+            if ( $this->nodeHasPaintOrderEvidenceBehindSibling($node, $sibling, $nodeZIndex, $nodeSiblingIndex, (int) $index) ) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @param array<int, mixed> $siblings
+     */
+    private function nodeSiblingIndex(array $siblings, string $nodeId): ?int
+    {
+        foreach ( $siblings as $index => $sibling ) {
+            if ( is_array($sibling) && (string) ($sibling['id'] ?? '') === $nodeId ) {
+                return (int) $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $sibling
+     */
+    private function nodeHasPaintOrderEvidenceBehindSibling(array $node, array $sibling, ?int $nodeZIndex, ?int $nodeSiblingIndex, int $siblingIndex): bool
+    {
+        $siblingZIndex = $this->nodeZIndex($sibling);
+        if ( null !== $nodeZIndex && null !== $siblingZIndex ) {
+            return $nodeZIndex < $siblingZIndex;
+        }
+
+        $nodeOrder = $this->nodeSourceOrder($node) ?? $nodeSiblingIndex;
+        $siblingOrder = $this->nodeSourceOrder($sibling) ?? $siblingIndex;
+        return null !== $nodeOrder && $nodeOrder < $siblingOrder;
     }
 
     /**
@@ -557,14 +649,22 @@ final class LayoutIntentClassifier
         return true;
     }
 
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function treeIsShapeOnlyPrimitiveVisual(array $node): bool
+    {
+        return $this->treeIsVectorShapeOnly($node);
+    }
+
     private function isPrimitiveVectorShapeType(string $type): bool
     {
-        return in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON', 'RECTANGLE', 'ROUNDED_RECTANGLE'), true);
+        return in_array($type, self::PRIMITIVE_VECTOR_SHAPE_TYPES, true);
     }
 
     private function isVectorShapeContainerType(string $type): bool
     {
-        return in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'BOOLEAN_OPERATION'), true);
+        return in_array($type, self::VECTOR_SHAPE_CONTAINER_TYPES, true);
     }
 
     /**
@@ -634,17 +734,17 @@ final class LayoutIntentClassifier
     private function nodeAssetReferences(array $node): array
     {
         $references = array();
-        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+        foreach ( self::ASSET_REFERENCE_KEYS as $key ) {
             if ( isset($node[$key]) && is_scalar($node[$key]) ) {
                 $references[] = (string) $node[$key];
             }
         }
-        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+        foreach ( self::PAINT_COLLECTION_KEYS as $paintKey ) {
             foreach ( is_array($node[$paintKey] ?? null) ? $node[$paintKey] : array() as $paint ) {
                 if ( ! is_array($paint) ) {
                     continue;
                 }
-                foreach ( array('imageRef', 'imageHash', 'ref', 'asset_id', 'assetId', 'image_ref') as $key ) {
+                foreach ( self::PAINT_ASSET_REFERENCE_KEYS as $key ) {
                     if ( isset($paint[$key]) && is_scalar($paint[$key]) ) {
                         $references[] = (string) $paint[$key];
                     }
@@ -662,13 +762,13 @@ final class LayoutIntentClassifier
     private function explicitNodeAssetReferences(array $node): array
     {
         $references = array();
-        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+        foreach ( self::ASSET_REFERENCE_KEYS as $key ) {
             if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
                 $references[] = (string) $node[$key];
             }
         }
         if ( is_array($node['image'] ?? null) ) {
-            foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+            foreach ( self::ASSET_REFERENCE_KEYS as $key ) {
                 if ( isset($node['image'][$key]) && is_scalar($node['image'][$key]) && '' !== (string) $node['image'][$key] ) {
                     $references[] = (string) $node['image'][$key];
                 }
@@ -685,7 +785,7 @@ final class LayoutIntentClassifier
     private function nodeImagePaints(array $node): array
     {
         $imagePaints = array();
-        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+        foreach ( self::PAINT_COLLECTION_KEYS as $paintKey ) {
             $paintCollections = array();
             if ( is_array($node[$paintKey] ?? null) ) {
                 $paintCollections[] = $node[$paintKey];

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -63,6 +63,8 @@ final class StaticHtmlEmitter
 
     private ?StickyLayoutCoordinator $stickyLayoutCoordinator = null;
 
+    private ?HtmlArtifactAssembler $htmlArtifactAssembler = null;
+
     private function designSystemExtractor(): DesignSystemExtractor
     {
         return $this->designSystemExtractor ??= new DesignSystemExtractor();
@@ -113,6 +115,13 @@ final class StaticHtmlEmitter
         return $this->stickyLayoutCoordinator ??= new StickyLayoutCoordinator(
             fn (array $node): array => $this->nodeList($node),
             fn (array $node): string => $this->textContent($node),
+        );
+    }
+
+    private function htmlArtifactAssembler(): HtmlArtifactAssembler
+    {
+        return $this->htmlArtifactAssembler ??= new HtmlArtifactAssembler(
+            fn (string $value): string => $this->sanitizeAttribute($value),
         );
     }
 
@@ -198,20 +207,7 @@ final class StaticHtmlEmitter
         $this->sectionDepth = $this->sectionDepthFor($nodes);
 
         $body = '';
-        $cssRules = array(
-            'html{box-sizing:border-box}',
-            '*,*::before,*::after{box-sizing:inherit}',
-            'body{margin:0}',
-            '.figma-root{position:relative;width:100%}',
-            'p,h1,h2,h3,h4,h5,h6{margin:0}',
-            'ul,ol{margin:0;padding:0;list-style:none}',
-            'img{display:block;max-width:100%;height:auto}',
-            'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',
-            '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
-        );
-        if ( $this->renderTextGlyphPaths ) {
-            $cssRules[] = '.figma-text-glyphs{display:block;width:100%;height:100%;overflow:visible}';
-        }
+        $cssRules = $this->htmlArtifactAssembler()->baseCssRules($this->renderTextGlyphPaths);
         $operatorFontCss = $this->fontCss($options);
         $familyOverrides = $this->fontFamilyOverrides($options);
 
@@ -238,15 +234,13 @@ final class StaticHtmlEmitter
             $diagnostics[] = $diagnostic;
         }
 
-        $css = ('' !== $fontCss ? $fontCss . "\n" : '')
-            . ('' !== $designSystem['css'] ? $designSystem['css'] : '')
-            . implode("\n", $cssRules) . "\n";
+        $css = $this->htmlArtifactAssembler()->stylesheet($fontCss, (string) $designSystem['css'], $cssRules);
         $files = array(
             array(
                 'path'      => 'index.html',
                 'role'      => 'entrypoint',
                 'mime_type' => 'text/html',
-                'content'   => "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>" . $title . "</title>\n<link rel=\"stylesheet\" href=\"style.css\">\n</head>\n<body>\n<main class=\"figma-root\" data-figma-root=\"true\">\n" . $body . "</main>\n</body>\n</html>\n",
+                'content'   => $this->htmlArtifactAssembler()->htmlDocument($title, 'style.css', $body),
             ),
             array(
                 'path'      => 'style.css',
@@ -321,20 +315,7 @@ final class StaticHtmlEmitter
         $assetFiles = $this->normalizeAssets($scenegraph['assets'] ?? array(), $diagnostics);
         $nodeMap = $this->nodeMap($scenegraph);
 
-        $cssRules = array(
-            'html{box-sizing:border-box}',
-            '*,*::before,*::after{box-sizing:inherit}',
-            'body{margin:0}',
-            '.figma-root{position:relative;width:100%}',
-            'p,h1,h2,h3,h4,h5,h6{margin:0}',
-            'ul,ol{margin:0;padding:0;list-style:none}',
-            'img{display:block;max-width:100%;height:auto}',
-            'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',
-            '.figma-vector-asset{display:block;width:100%;height:100%;object-fit:fill}',
-        );
-        if ( $this->renderTextGlyphPaths ) {
-            $cssRules[] = '.figma-text-glyphs{display:block;width:100%;height:100%;overflow:visible}';
-        }
+        $cssRules = $this->htmlArtifactAssembler()->baseCssRules($this->renderTextGlyphPaths);
         $operatorFontCss = $this->fontCss($options);
         $familyOverrides = $this->fontFamilyOverrides($options);
         $files = array();
@@ -410,7 +391,7 @@ final class StaticHtmlEmitter
                 'path'      => $path,
                 'role'      => true === ($page['entrypoint'] ?? false) ? 'entrypoint' : 'document',
                 'mime_type' => 'text/html',
-                'content'   => $this->htmlDocument($this->sanitizeText($pageName), $this->stylesheetHref($path), $body),
+                'content'   => $this->htmlArtifactAssembler()->htmlDocument($this->sanitizeText($pageName), $this->stylesheetHref($path), $body),
             );
             $renderedNodes[] = $frameNode;
 
@@ -438,7 +419,7 @@ final class StaticHtmlEmitter
                     'path'      => 'index.html',
                     'role'      => 'entrypoint',
                     'mime_type' => 'text/html',
-                    'content'   => $this->htmlDocument($title, 'style.css', $body),
+                    'content'   => $this->htmlArtifactAssembler()->htmlDocument($title, 'style.css', $body),
                 );
                 $renderedNodes[] = $node;
             }
@@ -464,14 +445,7 @@ final class StaticHtmlEmitter
         foreach ( $this->designSystemDiagnostics($designSystem) as $diagnostic ) {
             $diagnostics[] = $diagnostic;
         }
-        $css = ('' !== $fontCss ? $fontCss . "\n" : '')
-            . ('' !== $designSystem['css'] ? $designSystem['css'] : '')
-            . implode("\n", array_values(array_unique($cssRules))) . "\n";
-        if ( ! empty($mediaBlocks) ) {
-            // Responsive overrides cascade AFTER the widest-first base rules so
-            // narrower breakpoints win at their own viewport width.
-            $css .= implode("\n", $mediaBlocks) . "\n";
-        }
+        $css = $this->htmlArtifactAssembler()->stylesheet($fontCss, (string) $designSystem['css'], $cssRules, $mediaBlocks, true);
         $files[] = array(
             'path'      => 'style.css',
             'role'      => 'stylesheet',
@@ -486,7 +460,7 @@ final class StaticHtmlEmitter
         $files = (new InlineCssFileInjector())->inject($files, $css);
 
         $visualNodeMap = $this->visualNodeMap($renderedNodes);
-        $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $visualNodeMap, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics, $this->htmlFilesContent($files));
+        $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $visualNodeMap, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics, $this->htmlArtifactAssembler()->htmlFilesContent($files));
         foreach ( $this->unresolvedSourceFontDiagnostics($fontResolution) as $diagnostic ) {
             $diagnostics[] = $diagnostic;
         }
@@ -706,26 +680,6 @@ final class StaticHtmlEmitter
         }
 
         return $rules;
-    }
-
-    private function htmlDocument(string $title, string $stylesheetHref, string $body): string
-    {
-        return "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>" . $title . "</title>\n<link rel=\"stylesheet\" href=\"" . $this->sanitizeAttribute($stylesheetHref) . "\">\n</head>\n<body>\n<main class=\"figma-root\" data-figma-root=\"true\">\n" . $body . "</main>\n</body>\n</html>\n";
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $files
-     */
-    private function htmlFilesContent(array $files): string
-    {
-        $html = '';
-        foreach ( $files as $file ) {
-            if ( is_array($file) && 'text/html' === ($file['mime_type'] ?? null) && isset($file['content']) && is_scalar($file['content']) ) {
-                $html .= "\n" . (string) $file['content'];
-            }
-        }
-
-        return $html;
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ComponentSourceCloneGeometry.php
+++ b/figma-transformer/src/Scenegraph/ComponentSourceCloneGeometry.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Refreshes namespaced component-source clone geometry while preserving instance placement.
+ */
+final class ComponentSourceCloneGeometry
+{
+    private const GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE = 'component_source_clone';
+
+    public function __construct(
+        private readonly ScenegraphVectorInstanceScaler $vectorInstanceScaler = new ScenegraphVectorInstanceScaler()
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $clone
+     * @param array<string, mixed> $refreshed
+     */
+    public function isRefreshable(array $clone, array $refreshed): bool
+    {
+        $cloneType = strtoupper((string) ($clone['type'] ?? ''));
+        $refreshedType = strtoupper((string) ($refreshed['type'] ?? ''));
+
+        return 'INSTANCE' === $cloneType
+            || 'INSTANCE' === $refreshedType
+            || true === ($clone['figma_component']['resolved'] ?? false)
+            || true === ($refreshed['figma_component']['resolved'] ?? false);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    public function subtreeHasInstanceOverrideApplied(array $node): bool
+    {
+        if ( true === ($node['_figma_instance_override_applied'] ?? false) ) {
+            return true;
+        }
+
+        foreach ( is_array($node['children'] ?? null) ? $node['children'] : array() as $child ) {
+            if ( is_array($child) && $this->subtreeHasInstanceOverrideApplied($child) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, array<string, mixed>> $nodeMap
+     * @return array<string, mixed>
+     */
+    public function repairFarGeometry(array $node, array $nodeMap): array
+    {
+        $sourceId = isset($node['figma_component_source_id']) && is_scalar($node['figma_component_source_id']) ? (string) $node['figma_component_source_id'] : '';
+        if ( '' === $sourceId || ! is_array($nodeMap[$sourceId]['box'] ?? null) || ! is_array($node['box'] ?? null) ) {
+            return $node;
+        }
+
+        $sourceBox = $nodeMap[$sourceId]['box'];
+        if ( GeometryBox::COORDINATE_SPACE_PARENT_LOCAL !== GeometryBox::coordinateSpace($sourceBox) ) {
+            return $node;
+        }
+
+        $repaired = false;
+        foreach ( array('x', 'y') as $dimension ) {
+            if ( isset($sourceBox[$dimension], $node['box'][$dimension]) && is_numeric($sourceBox[$dimension]) && is_numeric($node['box'][$dimension]) && abs((float) $node['box'][$dimension] - (float) $sourceBox[$dimension]) >= 1000.0 ) {
+                $node[$dimension] = (float) $sourceBox[$dimension];
+                $node['box'][$dimension] = (float) $sourceBox[$dimension];
+                if ( is_array($node['figma_box'] ?? null) && isset($node['figma_box'][$dimension]) && is_numeric($node['figma_box'][$dimension]) ) {
+                    $node['figma_box'][$dimension] = (float) $sourceBox[$dimension];
+                }
+                $repaired = true;
+            }
+        }
+
+        if ( $repaired ) {
+            $node['box']['coordinate_space'] = GeometryBox::COORDINATE_SPACE_PARENT_LOCAL;
+            if ( is_array($node['figma_box'] ?? null) ) {
+                $node['figma_box']['coordinate_space'] = GeometryBox::COORDINATE_SPACE_PARENT_LOCAL;
+            }
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $clone
+     * @param array<string, mixed> $refreshed
+     * @return array<string, mixed>
+     */
+    public function mergeRefreshed(array $clone, array $refreshed, string $sourceId): array
+    {
+        $cloneId = (string) ($clone['id'] ?? '');
+        $sourceBox = is_array($refreshed['box'] ?? null) ? $refreshed['box'] : array();
+        $merged = '' !== $cloneId ? $this->retargetSourceIds($refreshed, $sourceId, $cloneId) : $refreshed;
+
+        $preferRefreshedGeometry = $this->shouldUseRefreshedGeometry($clone, $refreshed);
+        foreach ( array('id', 'figma_component_source_id', 'box', 'figma_box', 'layout', 'x', 'y', 'width', 'height') as $key ) {
+            if ( $preferRefreshedGeometry && in_array($key, array('box', 'figma_box', 'x', 'y'), true) ) {
+                continue;
+            }
+            if ( array_key_exists($key, $clone) ) {
+                $merged[$key] = $clone[$key];
+            }
+        }
+        $merged = $this->mergeLayoutMetadata($merged, $clone, $refreshed);
+        if ( $preferRefreshedGeometry && is_array($refreshed['box'] ?? null) ) {
+            foreach ( array('x', 'y') as $dimension ) {
+                if ( isset($refreshed['box'][$dimension]) && is_numeric($refreshed['box'][$dimension]) ) {
+                    $merged[$dimension] = (float) $refreshed['box'][$dimension];
+                }
+            }
+        }
+
+        $sourceX = isset($sourceBox['x']) && is_numeric($sourceBox['x']) ? (float) $sourceBox['x'] : null;
+        $sourceY = isset($sourceBox['y']) && is_numeric($sourceBox['y']) ? (float) $sourceBox['y'] : null;
+        $sourceWidth = isset($sourceBox['width']) && is_numeric($sourceBox['width']) ? (float) $sourceBox['width'] : null;
+        $sourceHeight = isset($sourceBox['height']) && is_numeric($sourceBox['height']) ? (float) $sourceBox['height'] : null;
+        if ( null !== $sourceX || null !== $sourceY ) {
+            $merged = $this->rebaseDescendants($merged, $sourceX, $sourceY, $sourceWidth, $sourceHeight);
+        }
+
+        if ( is_array($clone['_component_source_clone_scale'] ?? null) && is_array($merged['children'] ?? null) ) {
+            $scaleX = isset($clone['_component_source_clone_scale']['x']) && is_numeric($clone['_component_source_clone_scale']['x']) ? (float) $clone['_component_source_clone_scale']['x'] : 1.0;
+            $scaleY = isset($clone['_component_source_clone_scale']['y']) && is_numeric($clone['_component_source_clone_scale']['y']) ? (float) $clone['_component_source_clone_scale']['y'] : 1.0;
+            if ( abs($scaleX - 1.0) >= 0.0001 || abs($scaleY - 1.0) >= 0.0001 ) {
+                $merged['children'] = $this->vectorInstanceScaler->scaleVectorChildren($merged['children'], $scaleX, $scaleY);
+                $merged['_component_source_clone_scale'] = array('x' => $scaleX, 'y' => $scaleY);
+            }
+        }
+
+        return $this->markGeometry($merged);
+    }
+
+    /**
+     * @param array<string, mixed> $merged
+     * @param array<string, mixed> $clone
+     * @param array<string, mixed> $refreshed
+     * @return array<string, mixed>
+     */
+    private function mergeLayoutMetadata(array $merged, array $clone, array $refreshed): array
+    {
+        $refreshedLayout = is_array($refreshed['layout'] ?? null) ? $refreshed['layout'] : array();
+        if ( ! isset($refreshedLayout['z_index']) || ! is_numeric($refreshedLayout['z_index']) ) {
+            return $merged;
+        }
+
+        $cloneLayout = is_array($clone['layout'] ?? null) ? $clone['layout'] : array();
+        if ( isset($cloneLayout['z_index']) && is_numeric($cloneLayout['z_index']) ) {
+            return $merged;
+        }
+
+        $mergedLayout = is_array($merged['layout'] ?? null) ? $merged['layout'] : array();
+        $mergedLayout['z_index'] = (int) $refreshedLayout['z_index'];
+        $merged['layout'] = $mergedLayout;
+
+        return $merged;
+    }
+
+    /**
+     * @param array<string, mixed> $clone
+     * @param array<string, mixed> $refreshed
+     */
+    private function shouldUseRefreshedGeometry(array $clone, array $refreshed): bool
+    {
+        $cloneBox = is_array($clone['box'] ?? null) ? $clone['box'] : array();
+        $refreshedBox = is_array($refreshed['box'] ?? null) ? $refreshed['box'] : array();
+        if ( GeometryBox::COORDINATE_SPACE_PARENT_LOCAL !== GeometryBox::coordinateSpace($refreshedBox) ) {
+            return false;
+        }
+
+        $hasComponentSource = isset($clone['figma_component_source_id']) && is_scalar($clone['figma_component_source_id']) && '' !== (string) $clone['figma_component_source_id'];
+        if ( ! $hasComponentSource && empty($clone['_component_source_clone_geometry']) && self::GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE !== ($cloneBox['geometry_semantics'] ?? null) ) {
+            return false;
+        }
+
+        foreach ( array('x', 'y') as $dimension ) {
+            if ( isset($cloneBox[$dimension], $refreshedBox[$dimension]) && is_numeric($cloneBox[$dimension]) && is_numeric($refreshedBox[$dimension]) && abs((float) $cloneBox[$dimension] - (float) $refreshedBox[$dimension]) >= 1000.0 ) {
+                return true;
+            }
+            if ( isset($clone[$dimension], $refreshedBox[$dimension]) && is_numeric($clone[$dimension]) && is_numeric($refreshedBox[$dimension]) && abs((float) $clone[$dimension] - (float) $refreshedBox[$dimension]) >= 1000.0 ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    public function rebaseDescendants(array $node, ?float $parentSourceX, ?float $parentSourceY, ?float $parentSourceWidth = null, ?float $parentSourceHeight = null): array
+    {
+        if ( ! is_array($node['children'] ?? null) ) {
+            return $node;
+        }
+
+        foreach ( $node['children'] as $index => $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $childSourceX = $this->boxCoordinate($child, 'x');
+            $childSourceY = $this->boxCoordinate($child, 'y');
+            $childSourceWidth = $this->boxCoordinate($child, 'width');
+            $childSourceHeight = $this->boxCoordinate($child, 'height');
+            $child = $this->rebaseBox($child, 'box', $parentSourceX, $parentSourceY, $parentSourceWidth, $parentSourceHeight);
+            $child = $this->rebaseBox($child, 'figma_box', $parentSourceX, $parentSourceY, $parentSourceWidth, $parentSourceHeight);
+            $node['children'][$index] = $this->rebaseDescendants(
+                $child,
+                null !== $childSourceX ? $childSourceX : $parentSourceX,
+                null !== $childSourceY ? $childSourceY : $parentSourceY,
+                null !== $childSourceWidth ? $childSourceWidth : $parentSourceWidth,
+                null !== $childSourceHeight ? $childSourceHeight : $parentSourceHeight
+            );
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function boxCoordinate(array $node, string $dimension): ?float
+    {
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        return isset($box[$dimension]) && is_numeric($box[$dimension]) ? (float) $box[$dimension] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function rebaseBox(array $node, string $boxKey, ?float $parentSourceX, ?float $parentSourceY, ?float $parentSourceWidth = null, ?float $parentSourceHeight = null): array
+    {
+        if ( ! is_array($node[$boxKey] ?? null) ) {
+            return $node;
+        }
+
+        $box = $node[$boxKey];
+        if ( 'page' !== ($box['local_origin'] ?? null) && GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE !== GeometryBox::coordinateSpace($box) ) {
+            return $node;
+        }
+
+        foreach ( array('x' => array($parentSourceX, $parentSourceWidth), 'y' => array($parentSourceY, $parentSourceHeight)) as $dimension => $parentSource ) {
+            [$parentSourceCoordinate, $parentSourceSize] = $parentSource;
+            if ( null === $parentSourceCoordinate || ! isset($node[$boxKey][$dimension]) || ! is_numeric($node[$boxKey][$dimension]) ) {
+                continue;
+            }
+            if ( GeometryBox::COORDINATE_SPACE_CANVAS_ABSOLUTE === GeometryBox::coordinateSpace($box) && ! $this->coordinateOverlapsParent((float) $node[$boxKey][$dimension], $parentSourceCoordinate, $parentSourceSize) ) {
+                continue;
+            }
+
+            $node[$boxKey][$dimension] = (float) $node[$boxKey][$dimension] - $parentSourceCoordinate;
+        }
+
+        unset($node[$boxKey]['local_origin']);
+        $node[$boxKey]['coordinate_space'] = GeometryBox::COORDINATE_SPACE_PARENT_LOCAL;
+
+        return $node;
+    }
+
+    private function coordinateOverlapsParent(float $coordinate, float $parentSourceCoordinate, ?float $parentSourceSize): bool
+    {
+        if ( null === $parentSourceSize ) {
+            return $coordinate >= $parentSourceCoordinate - 0.5;
+        }
+
+        return $coordinate >= $parentSourceCoordinate - 0.5 && $coordinate <= $parentSourceCoordinate + $parentSourceSize + 0.5;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function retargetSourceIds(array $node, string $sourceId, string $cloneId): array
+    {
+        foreach ( array('id', 'figma_component_source_id') as $key ) {
+            if ( ! isset($node[$key]) || ! is_scalar($node[$key]) ) {
+                continue;
+            }
+
+            $id = (string) $node[$key];
+            if ( $sourceId === $id ) {
+                $node[$key] = 'id' === $key ? $cloneId : $sourceId;
+            } elseif ( str_starts_with($id, $sourceId . '/') ) {
+                $node[$key] = ('id' === $key ? $cloneId : $sourceId) . substr($id, strlen($sourceId));
+            }
+        }
+
+        if ( is_array($node['children'] ?? null) ) {
+            foreach ( $node['children'] as $index => $child ) {
+                if ( is_array($child) ) {
+                    $node['children'][$index] = $this->retargetSourceIds($child, $sourceId, $cloneId);
+                }
+            }
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    private function markGeometry(array $node): array
+    {
+        $node['_component_source_clone_geometry'] = true;
+        foreach ( array('box', 'figma_box') as $boxKey ) {
+            if ( ! is_array($node[$boxKey] ?? null) ) {
+                continue;
+            }
+
+            if ( 'box' === $boxKey && ! isset($node['_component_source_clone_source_box']) ) {
+                $node['_component_source_clone_source_box'] = $node[$boxKey];
+            }
+
+            $sourceKind = GeometryBox::sourceKind($node[$boxKey]);
+            foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
+                $hasRebasedLocalCoordinate = in_array($dimension, array('x', 'y'), true)
+                    && isset($node[$boxKey][$dimension])
+                    && GeometryBox::COORDINATE_SPACE_PARENT_LOCAL === GeometryBox::coordinateSpace($node[$boxKey]);
+                if ( ! $hasRebasedLocalCoordinate && isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
+                    $node[$boxKey][$dimension] = (float) $node[$dimension];
+                }
+            }
+
+            $node[$boxKey] = GeometryBox::withoutProvenance(GeometryBox::withProvenance($node[$boxKey], GeometryBox::SOURCE_COMPONENT_CLONE));
+            $node[$boxKey]['geometry_semantics'] = self::GEOMETRY_SEMANTICS_COMPONENT_SOURCE_CLONE;
+            if ( null !== $sourceKind ) {
+                $node[$boxKey]['component_clone_source_kind'] = $sourceKind;
+            }
+        }
+
+        if ( is_array($node['children'] ?? null) ) {
+            foreach ( $node['children'] as $index => $child ) {
+                if ( is_array($child) ) {
+                    $node['children'][$index] = $this->markGeometry($child);
+                }
+            }
+        }
+
+        return $node;
+    }
+}

--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -9,6 +9,41 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
  */
 final class PaintNormalizer
 {
+    private const PAINT_COLLECTION_SOURCES = array(
+        'fills'            => 'fills',
+        'fillPaints'       => 'fills',
+        'strokes'          => 'strokes',
+        'strokePaints'     => 'strokes',
+        'background'       => 'background',
+        'backgroundPaints' => 'background',
+    );
+
+    private const FALLBACK_COLOR_SOURCES = array(
+        'fill'            => 'fills',
+        'backgroundColor' => 'background',
+    );
+
+    private const STYLE_REFERENCE_FIELDS = array(
+        'fills'   => array('styleIdForFill'),
+        'strokes' => array('styleIdForStrokeFill', 'styleIdForStroke'),
+    );
+
+    private const STYLE_PAINT_COLLECTION = array(
+        'fills'   => 'fills',
+        'strokes' => 'fills',
+    );
+
+    private const NON_VECTOR_PAINT_SOURCE_NODE_TYPES = array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION', 'CANVAS', 'DOCUMENT');
+
+    private const VECTOR_GEOMETRY_FIELDS = array(
+        'fills'   => array('fillGeometry'),
+        'strokes' => array('strokeGeometry'),
+    );
+
+    private const VECTOR_PATH_COLLECTION_FIELDS = array('vectorPaths', 'paths');
+
+    private const VECTOR_PATH_SCALAR_FIELDS = array('pathData', 'path', 'd');
+
     /**
      * @param array<string, mixed>             $node
      * @param array<int, array<string, mixed>> $diagnostics
@@ -16,44 +51,12 @@ final class PaintNormalizer
      */
     public function normalizePaintCollections(array $node, string $nodeId, array &$diagnostics, array $paintStyles = array()): array
     {
-        $collections = array();
-        foreach ( array('fills' => 'fills', 'fillPaints' => 'fills', 'strokes' => 'strokes', 'strokePaints' => 'strokes', 'background' => 'background', 'backgroundPaints' => 'background') as $sourceKey => $targetKey ) {
-            if ( ! is_array($node[$sourceKey] ?? null) ) {
-                continue;
-            }
-
-            $paints = $this->normalizePaintList($node[$sourceKey], $nodeId, $sourceKey, $diagnostics);
-
-            if ( ! empty($paints) ) {
-                $collections[$targetKey] = $paints;
-            }
+        $collections = $this->normalizeLocalPaintCollections($node, $nodeId, $diagnostics);
+        foreach ( array_keys(self::STYLE_REFERENCE_FIELDS) as $collection ) {
+            $this->applyReferencedPaintStyle($collections, $node, $nodeId, $collection, $paintStyles, $diagnostics);
         }
 
-        $styleFillId = $this->readStyleGuidId($node['styleIdForFill'] ?? null);
-        if ( null !== $styleFillId && ! empty($paintStyles[$styleFillId]['fills']) ) {
-            $styleFills = $paintStyles[$styleFillId]['fills'];
-            $localFillPrecedence = $this->hasLocalVectorPaintSource($node, 'fills');
-            if ( ! empty($collections['fills']) && $collections['fills'] !== $styleFills ) {
-                $this->appendLocalStylePaintConflictDiagnostic($diagnostics, $nodeId, 'fills', $styleFillId, $collections['fills'], $styleFills, $localFillPrecedence);
-            }
-            if ( empty($collections['fills']) || ! $localFillPrecedence ) {
-                $collections['fills'] = $styleFills;
-            }
-        }
-
-        $styleStrokeId = $this->readStyleGuidId($node['styleIdForStrokeFill'] ?? $node['styleIdForStroke'] ?? null);
-        if ( null !== $styleStrokeId && ! empty($paintStyles[$styleStrokeId]['fills']) ) {
-            $styleStrokes = $paintStyles[$styleStrokeId]['fills'];
-            $localStrokePrecedence = $this->hasLocalVectorPaintSource($node, 'strokes');
-            if ( ! empty($collections['strokes']) && $collections['strokes'] !== $styleStrokes ) {
-                $this->appendLocalStylePaintConflictDiagnostic($diagnostics, $nodeId, 'strokes', $styleStrokeId, $collections['strokes'], $styleStrokes, $localStrokePrecedence);
-            }
-            if ( empty($collections['strokes']) || ! $localStrokePrecedence ) {
-                $collections['strokes'] = $styleStrokes;
-            }
-        }
-
-        foreach ( array('fill' => 'fills', 'backgroundColor' => 'background') as $sourceKey => $targetKey ) {
+        foreach ( self::FALLBACK_COLOR_SOURCES as $sourceKey => $targetKey ) {
             if ( ! isset($node[$sourceKey]) ) {
                 continue;
             }
@@ -65,6 +68,98 @@ final class PaintNormalizer
         }
 
         return $collections;
+    }
+
+    /**
+     * @param array<string, mixed>             $node
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function normalizeLocalPaintCollections(array $node, string $nodeId, array &$diagnostics): array
+    {
+        $collections = array();
+        foreach ( self::PAINT_COLLECTION_SOURCES as $sourceKey => $targetKey ) {
+            if ( ! is_array($node[$sourceKey] ?? null) ) {
+                continue;
+            }
+
+            $paints = $this->normalizePaintList($node[$sourceKey], $nodeId, $sourceKey, $diagnostics);
+            if ( ! empty($paints) ) {
+                $collections[$targetKey] = $paints;
+            }
+        }
+
+        return $collections;
+    }
+
+    /**
+     * @param array<string, array<int, array<string, mixed>>> $collections
+     * @param array<string, mixed>                            $node
+     * @param array<string, array<string, mixed>>             $paintStyles
+     * @param array<int, array<string, mixed>>                $diagnostics
+     */
+    private function applyReferencedPaintStyle(array &$collections, array $node, string $nodeId, string $collection, array $paintStyles, array &$diagnostics): void
+    {
+        $styleId = $this->readStyleReferenceId($node, $collection);
+        if ( null === $styleId ) {
+            return;
+        }
+
+        $stylePaints = $this->readStylePaints($paintStyles, $styleId, $collection);
+        if ( empty($stylePaints) ) {
+            return;
+        }
+
+        $precedence = $this->resolveLocalStylePaintPrecedence($node, $collection, ! empty($collections[$collection]));
+        if ( ! empty($collections[$collection]) && $collections[$collection] !== $stylePaints ) {
+            $this->appendLocalStylePaintConflictDiagnostic($diagnostics, $nodeId, $collection, $styleId, $collections[$collection], $stylePaints, $precedence);
+        }
+
+        if ( empty($collections[$collection]) || 'style' === $precedence['winner'] ) {
+            $collections[$collection] = $stylePaints;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function readStyleReferenceId(array $node, string $collection): ?string
+    {
+        foreach ( self::STYLE_REFERENCE_FIELDS[$collection] ?? array() as $field ) {
+            $id = $this->readStyleGuidId($node[$field] ?? null);
+            if ( null !== $id ) {
+                return $id;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $paintStyles
+     * @return array<int, array<string, mixed>>
+     */
+    private function readStylePaints(array $paintStyles, string $styleId, string $collection): array
+    {
+        $styleCollection = self::STYLE_PAINT_COLLECTION[$collection] ?? $collection;
+        $paints = $paintStyles[$styleId][$styleCollection] ?? null;
+
+        return is_array($paints) ? $paints : array();
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array{winner: string, local_vector_source: bool, reason: string}
+     */
+    private function resolveLocalStylePaintPrecedence(array $node, string $collection, bool $hasLocalPaints): array
+    {
+        $hasLocalVectorSource = $hasLocalPaints && $this->hasLocalVectorPaintSource($node, $collection);
+
+        return array(
+            'winner'              => $hasLocalVectorSource ? 'local' : 'style',
+            'local_vector_source' => $hasLocalVectorSource,
+            'reason'              => $hasLocalVectorSource ? 'local_vector_geometry' : 'style_reference',
+        );
     }
 
     /**
@@ -149,27 +244,23 @@ final class PaintNormalizer
     private function hasLocalVectorPaintSource(array $node, string $collection): bool
     {
         $type = strtoupper((string) ($node['type'] ?? ''));
-        if ( in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION', 'CANVAS', 'DOCUMENT'), true) ) {
+        if ( in_array($type, self::NON_VECTOR_PAINT_SOURCE_NODE_TYPES, true) ) {
             return false;
         }
 
-        $keys = 'strokes' === $collection
-            ? array('strokeGeometry')
-            : array('fillGeometry');
-
-        foreach ( $keys as $key ) {
+        foreach ( self::VECTOR_GEOMETRY_FIELDS[$collection] ?? array() as $key ) {
             if ( $this->hasAuthoredVectorPathGeometry($node[$key] ?? null) ) {
                 return true;
             }
         }
 
-        foreach ( array('vectorPaths', 'paths') as $key ) {
+        foreach ( self::VECTOR_PATH_COLLECTION_FIELDS as $key ) {
             if ( ! empty($node[$key]) ) {
                 return true;
             }
         }
 
-        foreach ( array('pathData', 'path', 'd') as $key ) {
+        foreach ( self::VECTOR_PATH_SCALAR_FIELDS as $key ) {
             if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== trim((string) $node[$key]) ) {
                 return true;
             }
@@ -203,17 +294,17 @@ final class PaintNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @param array<int, array<string, mixed>> $localPaints
      * @param array<int, array<string, mixed>> $stylePaints
+     * @param array{winner: string, local_vector_source: bool, reason: string} $precedence
      */
-    private function appendLocalStylePaintConflictDiagnostic(array &$diagnostics, string $nodeId, string $collection, string $styleId, array $localPaints, array $stylePaints, bool $geometryBacked): void
+    private function appendLocalStylePaintConflictDiagnostic(array &$diagnostics, string $nodeId, string $collection, string $styleId, array $localPaints, array $stylePaints, array $precedence): void
     {
-        $precedence = $geometryBacked ? 'local' : 'style';
         foreach ( $diagnostics as $diagnostic ) {
             if ( 'figma_local_style_paint_conflict' !== ($diagnostic['code'] ?? null) || ! is_array($diagnostic['context'] ?? null) ) {
                 continue;
             }
 
             $context = $diagnostic['context'];
-            if ( $nodeId === ($context['node_id'] ?? null) && $collection === ($context['collection'] ?? null) && $styleId === ($context['style_id'] ?? null) && $precedence === ($context['precedence'] ?? null) ) {
+            if ( $nodeId === ($context['node_id'] ?? null) && $collection === ($context['collection'] ?? null) && $styleId === ($context['style_id'] ?? null) && $precedence['winner'] === ($context['precedence'] ?? null) ) {
                 return;
             }
         }
@@ -227,8 +318,9 @@ final class PaintNormalizer
                 'node_id'         => $nodeId,
                 'collection'      => $collection,
                 'style_id'        => $styleId,
-                'geometry_backed' => $geometryBacked,
-                'precedence'      => $precedence,
+                'geometry_backed' => $precedence['local_vector_source'],
+                'precedence'      => $precedence['winner'],
+                'precedence_rule' => $precedence['reason'],
                 'local_paints'    => $localPaints,
                 'style_paints'    => $stylePaints,
             ),

--- a/figma-transformer/src/Scenegraph/ScenegraphDiagnostics.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphDiagnostics.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Normalizes diagnostic volume without changing diagnostic semantics.
+ */
+final class ScenegraphDiagnostics
+{
+    public function __construct(
+        private readonly VectorGeometryNormalizer $vectorGeometryNormalizer = new VectorGeometryNormalizer()
+    ) {
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    public function compact(array $diagnostics): array
+    {
+        return $this->vectorGeometryNormalizer->compactUnsupportedVectorNetworkBlobDiagnostics($this->compactGlyphCommandBlobDiagnostics($diagnostics));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $diagnostics
+     * @return array<int, array<string, mixed>>
+     */
+    private function compactGlyphCommandBlobDiagnostics(array $diagnostics): array
+    {
+        $compacted = array();
+        $count = 0;
+        $nodeIds = array();
+        $sampleGlyphs = array();
+
+        foreach ( $diagnostics as $diagnostic ) {
+            if ( ! is_array($diagnostic) || 'unsupported_text_glyph_command_blob' !== ($diagnostic['code'] ?? null) ) {
+                $compacted[] = $diagnostic;
+                continue;
+            }
+
+            $count++;
+            $context = is_array($diagnostic['context'] ?? null) ? $diagnostic['context'] : array();
+            $nodeId = isset($context['node_id']) && is_scalar($context['node_id']) ? (string) $context['node_id'] : '';
+            if ( '' !== $nodeId ) {
+                $nodeIds[$nodeId] = true;
+            }
+            if ( count($sampleGlyphs) < 10 ) {
+                $sampleGlyph = array(
+                    'node_id'     => $nodeId,
+                    'glyph_index' => isset($context['glyph_index']) && is_numeric($context['glyph_index']) ? (int) $context['glyph_index'] : null,
+                );
+                if ( isset($context['byte_length']) && is_numeric($context['byte_length']) ) {
+                    $sampleGlyph['byte_length'] = (int) $context['byte_length'];
+                }
+                if ( isset($context['reason']) && is_scalar($context['reason']) ) {
+                    $sampleGlyph['reason'] = (string) $context['reason'];
+                }
+                $sampleGlyphs[] = $sampleGlyph;
+            }
+        }
+
+        if ( 0 === $count ) {
+            return $compacted;
+        }
+
+        $compacted[] = array(
+            'severity' => 'warning',
+            'code'     => 'unsupported_text_glyph_command_blob',
+            'message'  => 'Unsupported Figma text glyph command blobs were omitted from derived glyph metadata.',
+            'source'   => 'ScenegraphNormalizer',
+            'context'  => array(
+                'total_count'         => $count,
+                'affected_node_count' => count($nodeIds),
+                'sample_node_ids'     => array_slice(array_keys($nodeIds), 0, 10),
+                'sample_glyphs'       => $sampleGlyphs,
+            ),
+        );
+
+        return $compacted;
+    }
+}

--- a/figma-transformer/src/Scenegraph/ScenegraphLayoutNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphLayoutNormalizer.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Normalizes Figma geometry boxes and Auto Layout metadata.
+ */
+final class ScenegraphLayoutNormalizer
+{
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    public function normalizeLayoutBox(array $node): array
+    {
+        $box = array();
+        $sourceKind = null;
+
+        foreach ( array('absoluteBoundingBox', 'absoluteRenderBounds') as $boundsKey ) {
+            if ( ! is_array($node[$boundsKey] ?? null) ) {
+                continue;
+            }
+
+            foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
+                if ( ! array_key_exists($dimension, $box) && isset($node[$boundsKey][$dimension]) && is_numeric($node[$boundsKey][$dimension]) ) {
+                    $box[$dimension] = (float) $node[$boundsKey][$dimension];
+                }
+            }
+
+            if ( isset($node[$boundsKey]['x']) || isset($node[$boundsKey]['y']) ) {
+                $sourceKind = GeometryBox::SOURCE_ABSOLUTE_BOUNDS;
+            }
+        }
+
+        foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
+            if ( ! array_key_exists($dimension, $box) && isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
+                $box[$dimension] = (float) $node[$dimension];
+                if ( 'x' === $dimension || 'y' === $dimension ) {
+                    $sourceKind = isset($node[GeometryBox::PROVENANCE_KEY]) && is_scalar($node[GeometryBox::PROVENANCE_KEY])
+                        ? (string) $node[GeometryBox::PROVENANCE_KEY]
+                        : GeometryBox::SOURCE_EXPLICIT_LOCAL;
+                }
+            }
+        }
+
+        if ( is_array($node['size'] ?? null) ) {
+            foreach ( array('x' => 'width', 'y' => 'height') as $source => $target ) {
+                if ( ! array_key_exists($target, $box) && isset($node['size'][$source]) && is_numeric($node['size'][$source]) ) {
+                    $box[$target] = (float) $node['size'][$source];
+                    $sourceKind ??= GeometryBox::SOURCE_SIZE_ONLY;
+                }
+            }
+        }
+
+        foreach ( array('stackWidth' => 'width', 'stackHeight' => 'height') as $source => $target ) {
+            if ( ! array_key_exists($target, $box) && isset($node[$source]) && is_numeric($node[$source]) ) {
+                $box[$target] = (float) $node[$source];
+                $sourceKind ??= GeometryBox::SOURCE_SIZE_ONLY;
+            }
+        }
+
+        $transformBox = $this->layoutBoxFromTransform($node);
+        foreach ( array('x', 'y') as $dimension ) {
+            if ( ! array_key_exists($dimension, $box) && isset($transformBox[$dimension]) ) {
+                $box[$dimension] = $transformBox[$dimension];
+                $sourceKind = $transformBox[GeometryBox::PROVENANCE_KEY];
+            }
+        }
+
+        if ( null !== $sourceKind ) {
+            $box = GeometryBox::withProvenance($box, $sourceKind);
+        }
+
+        return GeometryBox::withoutProvenance($box);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array{x?: float, y?: float, _geometry_provenance?: string}
+     */
+    private function layoutBoxFromTransform(array $node): array
+    {
+        foreach ( array(
+            'relativeTransform' => GeometryBox::SOURCE_TRANSFORM,
+            'transform'         => GeometryBox::SOURCE_TRANSFORM,
+            'absoluteTransform' => GeometryBox::SOURCE_ABSOLUTE_TRANSFORM,
+        ) as $sourceKey => $sourceKind ) {
+            if ( ! is_array($node[$sourceKey] ?? null) ) {
+                continue;
+            }
+
+            $box = array(GeometryBox::PROVENANCE_KEY => $sourceKind);
+            foreach ( array('m02' => 'x', 'm12' => 'y') as $source => $target ) {
+                if ( isset($node[$sourceKey][$source]) && is_numeric($node[$sourceKey][$source]) ) {
+                    $box[$target] = (float) $node[$sourceKey][$source];
+                }
+            }
+
+            if ( isset($box['x']) || isset($box['y']) ) {
+                return $box;
+            }
+        }
+
+        return array();
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    public function normalizeLayout(array $node): array
+    {
+        $layout = array();
+
+        if ( isset($node['layoutMode']) && is_scalar($node['layoutMode']) ) {
+            $mode = strtoupper((string) $node['layoutMode']);
+            $layout['mode'] = $mode;
+        } elseif ( isset($node['stackMode']) && is_scalar($node['stackMode']) ) {
+            $mode = strtoupper((string) $node['stackMode']);
+            $layout['mode'] = $mode;
+        }
+        if ( isset($layout['mode']) ) {
+            if ( 'HORIZONTAL' === $layout['mode'] ) {
+                $layout['display'] = 'flex';
+                $layout['flex_direction'] = 'row';
+            } elseif ( 'VERTICAL' === $layout['mode'] ) {
+                $layout['display'] = 'flex';
+                $layout['flex_direction'] = 'column';
+            }
+        }
+
+        foreach ( array(
+            'layoutSizingHorizontal' => 'sizing_horizontal',
+            'layoutSizingVertical' => 'sizing_vertical',
+            'horizontalSizing' => 'sizing_horizontal',
+            'verticalSizing' => 'sizing_vertical',
+        ) as $source => $target ) {
+            if ( isset($node[$source]) && is_scalar($node[$source]) ) {
+                $layout[$target] = strtoupper((string) $node[$source]);
+            }
+        }
+
+        foreach ( array(
+            'primary_axis_sizing' => array('rest' => 'primaryAxisSizingMode', 'kiwi' => 'stackPrimarySizing'),
+            'counter_axis_sizing' => array('rest' => 'counterAxisSizingMode', 'kiwi' => 'stackCounterSizing'),
+        ) as $target => $sources ) {
+            $raw = null;
+            if ( isset($node[$sources['rest']]) && is_scalar($node[$sources['rest']]) ) {
+                $raw = (string) $node[$sources['rest']];
+            } elseif ( isset($node[$sources['kiwi']]) && is_scalar($node[$sources['kiwi']]) ) {
+                $raw = (string) $node[$sources['kiwi']];
+            }
+            if ( null !== $raw ) {
+                $layout[$target] = $this->normalizeAxisSizingValue($raw);
+            }
+        }
+
+        $flexDirection = $layout['flex_direction'] ?? null;
+        if ( 'row' === $flexDirection || 'column' === $flexDirection ) {
+            $primaryAxisKey = 'row' === $flexDirection ? 'sizing_horizontal' : 'sizing_vertical';
+            $counterAxisKey = 'row' === $flexDirection ? 'sizing_vertical' : 'sizing_horizontal';
+            if ( isset($layout['primary_axis_sizing']) && ! isset($layout[$primaryAxisKey]) ) {
+                $layout[$primaryAxisKey] = $layout['primary_axis_sizing'];
+            }
+            if ( isset($layout['counter_axis_sizing']) && ! isset($layout[$counterAxisKey]) ) {
+                $layout[$counterAxisKey] = $layout['counter_axis_sizing'];
+            }
+        }
+
+        if ( isset($node['textAutoResize']) && is_scalar($node['textAutoResize']) && '' !== (string) $node['textAutoResize'] ) {
+            $autoResize = strtoupper((string) $node['textAutoResize']);
+            $layout['text_auto_resize'] = $autoResize;
+            [$autoResizeHorizontal, $autoResizeVertical] = match ( $autoResize ) {
+                'WIDTH_AND_HEIGHT' => array('HUG', 'HUG'),
+                'HEIGHT'           => array(null, 'HUG'),
+                default            => array(null, null),
+            };
+            if ( null !== $autoResizeHorizontal && ! isset($layout['sizing_horizontal']) ) {
+                $layout['sizing_horizontal'] = $autoResizeHorizontal;
+            }
+            if ( null !== $autoResizeVertical && ! isset($layout['sizing_vertical']) ) {
+                $layout['sizing_vertical'] = $autoResizeVertical;
+            }
+            if ( 'TRUNCATE' === $autoResize ) {
+                $layout['clips_content'] = true;
+            }
+        }
+
+        foreach ( array(
+            'primaryAxisAlignItems' => 'primary_axis_alignment',
+            'counterAxisAlignItems' => 'counter_axis_alignment',
+            'stackPrimaryAlignItems' => 'primary_axis_alignment',
+            'stackCounterAlignItems' => 'counter_axis_alignment',
+        ) as $source => $target ) {
+            if ( isset($node[$source]) && is_scalar($node[$source]) ) {
+                $layout[$target] = strtoupper((string) $node[$source]);
+            }
+        }
+
+        if ( isset($layout['primary_axis_alignment']) ) {
+            $layout['justify_content'] = $this->cssAxisAlignment((string) $layout['primary_axis_alignment']);
+        }
+        if ( isset($layout['counter_axis_alignment']) ) {
+            $layout['align_items'] = $this->cssAxisAlignment((string) $layout['counter_axis_alignment']);
+        }
+
+        $padding = array();
+        if ( isset($node['stackPadding']) && is_numeric($node['stackPadding']) ) {
+            foreach ( array('top', 'right', 'bottom', 'left') as $edge ) {
+                $padding[$edge] = (float) $node['stackPadding'];
+            }
+        }
+        foreach ( array('top' => 'paddingTop', 'right' => 'paddingRight', 'bottom' => 'paddingBottom', 'left' => 'paddingLeft') as $edge => $source ) {
+            if ( isset($node[$source]) && is_numeric($node[$source]) ) {
+                $padding[$edge] = (float) $node[$source];
+            }
+        }
+        foreach ( array('left' => 'stackPaddingLeft', 'right' => 'stackPaddingRight', 'top' => 'stackPaddingTop', 'bottom' => 'stackPaddingBottom') as $edge => $source ) {
+            if ( isset($node[$source]) && is_numeric($node[$source]) ) {
+                $padding[$edge] = (float) $node[$source];
+            }
+        }
+        foreach ( array('left', 'right') as $edge ) {
+            if ( ! array_key_exists($edge, $padding) && isset($node['paddingHorizontal']) && is_numeric($node['paddingHorizontal']) ) {
+                $padding[$edge] = (float) $node['paddingHorizontal'];
+            } elseif ( ! array_key_exists($edge, $padding) && isset($node['stackHorizontalPadding']) && is_numeric($node['stackHorizontalPadding']) ) {
+                $padding[$edge] = (float) $node['stackHorizontalPadding'];
+            }
+        }
+        foreach ( array('top', 'bottom') as $edge ) {
+            if ( ! array_key_exists($edge, $padding) && isset($node['paddingVertical']) && is_numeric($node['paddingVertical']) ) {
+                $padding[$edge] = (float) $node['paddingVertical'];
+            } elseif ( ! array_key_exists($edge, $padding) && isset($node['stackVerticalPadding']) && is_numeric($node['stackVerticalPadding']) ) {
+                $padding[$edge] = (float) $node['stackVerticalPadding'];
+            }
+        }
+        if ( ! empty($padding) ) {
+            $layout['padding'] = $padding;
+        }
+
+        if ( isset($node['itemSpacing']) && is_numeric($node['itemSpacing']) ) {
+            $layout['item_spacing'] = (float) $node['itemSpacing'];
+        } elseif ( isset($node['stackSpacing']) && is_numeric($node['stackSpacing']) ) {
+            $layout['item_spacing'] = (float) $node['stackSpacing'];
+        }
+        if ( isset($node['counterAxisSpacing']) && is_numeric($node['counterAxisSpacing']) ) {
+            $layout['counter_axis_spacing'] = (float) $node['counterAxisSpacing'];
+        } elseif ( isset($node['stackCounterSpacing']) && is_numeric($node['stackCounterSpacing']) ) {
+            $layout['counter_axis_spacing'] = (float) $node['stackCounterSpacing'];
+        }
+
+        if ( isset($node['layoutWrap']) && is_scalar($node['layoutWrap']) ) {
+            $layout['wrap'] = strtoupper((string) $node['layoutWrap']);
+        } elseif ( isset($node['stackWrap']) && is_scalar($node['stackWrap']) ) {
+            $layout['wrap'] = strtoupper((string) $node['stackWrap']);
+        }
+        if ( 'WRAP' === ($layout['wrap'] ?? null) ) {
+            $layout['flex_wrap'] = 'wrap';
+        }
+
+        if ( true === ($node['stackReverseZIndex'] ?? false) || 'true' === strtolower((string) ($node['stackReverseZIndex'] ?? '')) || 1 === ($node['stackReverseZIndex'] ?? null) || '1' === (string) ($node['stackReverseZIndex'] ?? '') ) {
+            $layout['reverse_z_index'] = true;
+        }
+
+        $positioning = null;
+        if ( isset($node['layoutPositioning']) && is_scalar($node['layoutPositioning']) ) {
+            $positioning = strtoupper((string) $node['layoutPositioning']);
+        } elseif ( isset($node['stackPositioning']) && is_scalar($node['stackPositioning']) ) {
+            $positioning = strtoupper((string) $node['stackPositioning']);
+        }
+        if ( 'ABSOLUTE' === $positioning ) {
+            $layout['positioning'] = 'absolute';
+        }
+
+        if ( isset($node['layoutGrow']) && is_numeric($node['layoutGrow']) ) {
+            $layout['grow'] = (float) $node['layoutGrow'];
+        } elseif ( isset($node['stackChildPrimaryGrow']) && is_numeric($node['stackChildPrimaryGrow']) ) {
+            $layout['grow'] = (float) $node['stackChildPrimaryGrow'];
+        }
+        if ( isset($node['layoutAlign']) && is_scalar($node['layoutAlign']) ) {
+            $layout['align'] = strtoupper((string) $node['layoutAlign']);
+        } elseif ( isset($node['stackChildAlignSelf']) && is_scalar($node['stackChildAlignSelf']) ) {
+            $layout['align'] = strtoupper((string) $node['stackChildAlignSelf']);
+        }
+        if ( true === ($node['clipsContent'] ?? false) || true === ($node['isClip'] ?? false) || false === ($node['frameMaskDisabled'] ?? null) ) {
+            $layout['clips_content'] = true;
+        }
+
+        $constraints = array();
+        if ( is_array($node['constraints'] ?? null) ) {
+            foreach ( array('horizontal', 'vertical') as $axis ) {
+                if ( isset($node['constraints'][$axis]) && is_scalar($node['constraints'][$axis]) ) {
+                    $constraints[$axis] = strtoupper((string) $node['constraints'][$axis]);
+                }
+            }
+        }
+        foreach ( array('horizontal' => 'horizontalConstraint', 'vertical' => 'verticalConstraint') as $axis => $kiwiKey ) {
+            if ( isset($constraints[$axis]) || ! isset($node[$kiwiKey]) || ! is_scalar($node[$kiwiKey]) ) {
+                continue;
+            }
+            $translated = $this->normalizeKiwiConstraint(strtoupper((string) $node[$kiwiKey]), $axis);
+            if ( null !== $translated ) {
+                $constraints[$axis] = $translated;
+            }
+        }
+        if ( ! empty($constraints) ) {
+            $layout['constraints'] = $constraints;
+        }
+
+        foreach ( array('minSize' => 'min', 'maxSize' => 'max') as $source => $prefix ) {
+            if ( ! is_array($node[$source] ?? null) ) {
+                continue;
+            }
+            foreach ( array('x' => 'width', 'y' => 'height') as $axis => $dimension ) {
+                if ( isset($node[$source][$axis]) && is_numeric($node[$source][$axis]) ) {
+                    $value = (float) $node[$source][$axis];
+                    if ( is_finite($value) && $value >= 0.0 ) {
+                        $layout[$prefix . '_' . $dimension] = $value;
+                    }
+                }
+            }
+        }
+        foreach ( array('minWidth' => 'min_width', 'maxWidth' => 'max_width', 'minHeight' => 'min_height', 'maxHeight' => 'max_height') as $source => $target ) {
+            if ( isset($node[$source]) && is_numeric($node[$source]) ) {
+                $value = (float) $node[$source];
+                if ( is_finite($value) && $value >= 0.0 ) {
+                    $layout[$target] = $value;
+                }
+            }
+        }
+
+        if ( ! isset($layout['display']) && is_array($node['children'] ?? null) && count($node['children']) > 1 ) {
+            $type = strtoupper((string) ($node['type'] ?? ''));
+            if ( true === ($node['resizeToFit'] ?? false) || in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION'), true) ) {
+                $layout['freeform'] = true;
+            }
+        }
+
+        return $layout;
+    }
+
+    private function normalizeAxisSizingValue(string $value): string
+    {
+        return match ( strtoupper($value) ) {
+            'AUTO', 'HUG', 'RESIZE_TO_FIT', 'RESIZE_TO_FIT_WITH_IMPLICIT_SIZE' => 'HUG',
+            'FILL', 'STRETCH' => 'FILL',
+            default => 'FIXED',
+        };
+    }
+
+    private function normalizeKiwiConstraint(string $value, string $axis): ?string
+    {
+        $isHorizontal = 'horizontal' === $axis;
+
+        return match ( strtoupper($value) ) {
+            'MIN' => $isHorizontal ? 'LEFT' : 'TOP',
+            'MAX' => $isHorizontal ? 'RIGHT' : 'BOTTOM',
+            'STRETCH' => $isHorizontal ? 'LEFT_RIGHT' : 'TOP_BOTTOM',
+            'CENTER' => 'CENTER',
+            'SCALE' => 'SCALE',
+            default => null,
+        };
+    }
+
+    private function cssAxisAlignment(string $alignment): ?string
+    {
+        return match ( strtoupper($alignment) ) {
+            'MIN' => 'flex-start',
+            'CENTER' => 'center',
+            'MAX' => 'flex-end',
+            'SPACE_BETWEEN' => 'space-between',
+            'SPACE_EVENLY' => 'space-between',
+            'BASELINE' => 'baseline',
+            'STRETCH' => 'stretch',
+            default => null,
+        };
+    }
+}

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -15,14 +15,34 @@ final class ScenegraphNormalizer
 
     private readonly InstanceResolver $instanceResolver;
 
+    private readonly ScenegraphDiagnostics $diagnosticsNormalizer;
+
+    private readonly ScenegraphLayoutNormalizer $layoutNormalizer;
+
+    private readonly ScenegraphSourceOrderPropagator $sourceOrderPropagator;
+
+    private readonly ScenegraphVectorInstanceScaler $vectorInstanceScaler;
+
+    private readonly ComponentSourceCloneGeometry $componentSourceCloneGeometry;
+
     public function __construct(
         private readonly ScenegraphIndex $index = new ScenegraphIndex(),
         private readonly VectorGeometryNormalizer $vectorGeometryNormalizer = new VectorGeometryNormalizer(),
         private readonly PaintNormalizer $paintNormalizer = new PaintNormalizer(),
-        ?TextNormalizer $textNormalizer = null
+        ?TextNormalizer $textNormalizer = null,
+        ?ScenegraphDiagnostics $diagnosticsNormalizer = null,
+        ?ScenegraphLayoutNormalizer $layoutNormalizer = null,
+        ?ScenegraphSourceOrderPropagator $sourceOrderPropagator = null,
+        ?ScenegraphVectorInstanceScaler $vectorInstanceScaler = null,
+        ?ComponentSourceCloneGeometry $componentSourceCloneGeometry = null
     ) {
         $this->textNormalizer = $textNormalizer ?? new TextNormalizer($this->vectorGeometryNormalizer);
         $this->instanceResolver = new InstanceResolver();
+        $this->diagnosticsNormalizer = $diagnosticsNormalizer ?? new ScenegraphDiagnostics($this->vectorGeometryNormalizer);
+        $this->layoutNormalizer = $layoutNormalizer ?? new ScenegraphLayoutNormalizer();
+        $this->sourceOrderPropagator = $sourceOrderPropagator ?? new ScenegraphSourceOrderPropagator();
+        $this->vectorInstanceScaler = $vectorInstanceScaler ?? new ScenegraphVectorInstanceScaler();
+        $this->componentSourceCloneGeometry = $componentSourceCloneGeometry ?? new ComponentSourceCloneGeometry($this->vectorInstanceScaler);
     }
 
     /**
@@ -88,7 +108,7 @@ final class ScenegraphNormalizer
         $variableBindingSummary = $this->buildVariableBindingSummary($nodeMap);
         $sourceMetadata         = $this->normalizeDocumentMetadata($source);
         $sourceName             = $this->readSourceName($source, $renderNodes);
-        $diagnostics            = $this->vectorGeometryNormalizer->compactUnsupportedVectorNetworkBlobDiagnostics($this->compactGlyphCommandBlobDiagnostics($diagnostics));
+        $diagnostics            = $this->diagnosticsNormalizer->compact($diagnostics);
 
         return array(
             'schema'              => 'blocks-engine/figma-transformer/scenegraph/v1',
@@ -500,11 +520,7 @@ final class ScenegraphNormalizer
             foreach ( $node[$childrenKey] as $index => $child ) {
                 if ( is_array($child) ) {
                     $normalizedChild = $this->normalizeNode($child, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
-                    $childLayout = is_array($normalizedChild['layout'] ?? null) ? $normalizedChild['layout'] : array();
-                    $childLayout['source_order'] = isset($normalizedChild['_source_order']) && is_numeric($normalizedChild['_source_order'])
-                        ? (int) $normalizedChild['_source_order']
-                        : (int) $index;
-                    $normalizedChild['layout'] = $childLayout;
+                    $normalizedChild = $this->sourceOrderPropagator->apply($normalizedChild, (int) $index);
                     $node[$childrenKey][$index] = $normalizedChild;
                 }
             }
@@ -1287,11 +1303,11 @@ final class ScenegraphNormalizer
         $id = (string) ($node['id'] ?? '');
         $sourceId = (string) ($node['figma_component_source_id'] ?? '');
         $refreshId = '' !== $id && isset($nodeMap[$id]) ? $id : $sourceId;
-        $refreshesComponentSourceClone = '' !== $sourceId && $refreshId === $sourceId && $this->isRefreshableComponentSourceClone($node, $nodeMap[$refreshId] ?? array());
-        if ( '' !== $refreshId && isset($nodeMap[$refreshId]) && ! in_array($refreshId, $trail, true) && ($refreshId === $id || ($refreshesComponentSourceClone && ! $this->subtreeHasInstanceOverrideApplied($node))) ) {
+        $refreshesComponentSourceClone = '' !== $sourceId && $refreshId === $sourceId && $this->componentSourceCloneGeometry->isRefreshable($node, $nodeMap[$refreshId] ?? array());
+        if ( '' !== $refreshId && isset($nodeMap[$refreshId]) && ! in_array($refreshId, $trail, true) && ($refreshId === $id || ($refreshesComponentSourceClone && ! $this->componentSourceCloneGeometry->subtreeHasInstanceOverrideApplied($node))) ) {
             $node = $refreshId === $id
                 ? $nodeMap[$refreshId]
-                : $this->mergeRefreshedComponentSource($node, $nodeMap[$refreshId], $refreshId);
+                : $this->componentSourceCloneGeometry->mergeRefreshed($node, $nodeMap[$refreshId], $refreshId);
             $trail[] = $refreshId;
         }
 
@@ -1307,7 +1323,7 @@ final class ScenegraphNormalizer
 			$node['children'][$index] = $this->refreshResolvedTree($child, $nodeMap, $trail);
 		}
 
-		return $this->repairFarComponentSourceCloneGeometry($node, $nodeMap);
+		return $this->componentSourceCloneGeometry->repairFarGeometry($node, $nodeMap);
 	}
 
 	/**
@@ -1425,7 +1441,7 @@ final class ScenegraphNormalizer
             $scaleX = isset($clone['_component_source_clone_scale']['x']) && is_numeric($clone['_component_source_clone_scale']['x']) ? (float) $clone['_component_source_clone_scale']['x'] : 1.0;
             $scaleY = isset($clone['_component_source_clone_scale']['y']) && is_numeric($clone['_component_source_clone_scale']['y']) ? (float) $clone['_component_source_clone_scale']['y'] : 1.0;
             if ( abs($scaleX - 1.0) >= 0.0001 || abs($scaleY - 1.0) >= 0.0001 ) {
-                $merged['children'] = $this->scaleVectorChildren($merged['children'], $scaleX, $scaleY);
+            $merged['children'] = $this->vectorInstanceScaler->scaleVectorChildren($merged['children'], $scaleX, $scaleY);
                 $merged['_component_source_clone_scale'] = array('x' => $scaleX, 'y' => $scaleY);
             }
         }
@@ -1947,10 +1963,10 @@ final class ScenegraphNormalizer
         $componentSourceWidth = isset($componentBox['width']) && is_numeric($componentBox['width']) ? (float) $componentBox['width'] : null;
         $componentSourceHeight = isset($componentBox['height']) && is_numeric($componentBox['height']) ? (float) $componentBox['height'] : null;
         if ( null !== $componentSourceX || null !== $componentSourceY ) {
-            $rebasedSource = $this->rebaseComponentSourceCloneDescendants(array('children' => $resolvedChildren), $componentSourceX, $componentSourceY, $componentSourceWidth, $componentSourceHeight);
+            $rebasedSource = $this->componentSourceCloneGeometry->rebaseDescendants(array('children' => $resolvedChildren), $componentSourceX, $componentSourceY, $componentSourceWidth, $componentSourceHeight);
             $resolvedChildren = is_array($rebasedSource['children'] ?? null) ? $rebasedSource['children'] : $resolvedChildren;
         }
-        $resolvedChildren = $this->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
+        $resolvedChildren = $this->vectorInstanceScaler->scaleVectorOnlyInstanceChildren($resolvedChildren, $component, $instance);
         // Figma binds per-instance text content through component properties: each
         // master text node references a property definition (componentPropRefs ->
         // componentPropNodeField: TEXT_DATA) and the instance assigns the real value
@@ -2541,7 +2557,7 @@ final class ScenegraphNormalizer
                         $refreshed = $this->cloneComponentForInstance($components[$reference['id']], $refreshed, $reference['id'], $overrides, $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options, array_merge($resolutionTrail, array($id)));
                     }
                 }
-                $child = $this->mergeRefreshedComponentSource($child, $refreshed, $id);
+                $child = $this->componentSourceCloneGeometry->mergeRefreshed($child, $refreshed, $id);
             }
 
             if ( is_array($child['children'] ?? null) ) {
@@ -2729,7 +2745,7 @@ final class ScenegraphNormalizer
             $nestedComponentPropertyOverrides = $this->nestedComponentPropertyOverridesForChild($child, $overrideFields, $components);
             unset($overrideFields['componentPropAssignments']);
             if ( null !== $swapComponentId && isset($components[$swapComponentId]) ) {
-                $child = $this->mergeRefreshedComponentSource($child, $components[$swapComponentId], $swapComponentId);
+                $child = $this->componentSourceCloneGeometry->mergeRefreshed($child, $components[$swapComponentId], $swapComponentId);
                 if ( is_array($child['children'] ?? null) ) {
                     $child['children'] = $this->resolveClonedInstanceChildren($child['children'], $nodeMap, $components, $diagnostics, $blobs, $paintStyles, $textStyles, $options);
                 }
@@ -3601,65 +3617,7 @@ final class ScenegraphNormalizer
      */
     private function normalizeLayoutBox(array $node): array
     {
-        $box = array();
-        $sourceKind = null;
-
-        foreach ( array('absoluteBoundingBox', 'absoluteRenderBounds') as $boundsKey ) {
-            if ( ! is_array($node[$boundsKey] ?? null) ) {
-                continue;
-            }
-
-            foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
-                if ( ! array_key_exists($dimension, $box) && isset($node[$boundsKey][$dimension]) && is_numeric($node[$boundsKey][$dimension]) ) {
-                    $box[$dimension] = (float) $node[$boundsKey][$dimension];
-                }
-            }
-
-            if ( isset($node[$boundsKey]['x']) || isset($node[$boundsKey]['y']) ) {
-                $sourceKind = GeometryBox::SOURCE_ABSOLUTE_BOUNDS;
-            }
-        }
-
-        foreach ( array('x', 'y', 'width', 'height') as $dimension ) {
-            if ( ! array_key_exists($dimension, $box) && isset($node[$dimension]) && is_numeric($node[$dimension]) ) {
-                $box[$dimension] = (float) $node[$dimension];
-                if ( 'x' === $dimension || 'y' === $dimension ) {
-                    $sourceKind = isset($node[GeometryBox::PROVENANCE_KEY]) && is_scalar($node[GeometryBox::PROVENANCE_KEY])
-                        ? (string) $node[GeometryBox::PROVENANCE_KEY]
-                        : GeometryBox::SOURCE_EXPLICIT_LOCAL;
-                }
-            }
-        }
-
-        if ( is_array($node['size'] ?? null) ) {
-            foreach ( array('x' => 'width', 'y' => 'height') as $source => $target ) {
-                if ( ! array_key_exists($target, $box) && isset($node['size'][$source]) && is_numeric($node['size'][$source]) ) {
-                    $box[$target] = (float) $node['size'][$source];
-                    $sourceKind ??= GeometryBox::SOURCE_SIZE_ONLY;
-                }
-            }
-        }
-
-        foreach ( array('stackWidth' => 'width', 'stackHeight' => 'height') as $source => $target ) {
-            if ( ! array_key_exists($target, $box) && isset($node[$source]) && is_numeric($node[$source]) ) {
-                $box[$target] = (float) $node[$source];
-                $sourceKind ??= GeometryBox::SOURCE_SIZE_ONLY;
-            }
-        }
-
-        $transformBox = $this->layoutBoxFromTransform($node);
-        foreach ( array('x', 'y') as $dimension ) {
-            if ( ! array_key_exists($dimension, $box) && isset($transformBox[$dimension]) ) {
-                $box[$dimension] = $transformBox[$dimension];
-                $sourceKind = $transformBox[GeometryBox::PROVENANCE_KEY];
-            }
-        }
-
-        if ( null !== $sourceKind ) {
-            $box = GeometryBox::withProvenance($box, $sourceKind);
-        }
-
-        return GeometryBox::withoutProvenance($box);
+        return $this->layoutNormalizer->normalizeLayoutBox($node);
     }
 
     /**
@@ -3698,285 +3656,7 @@ final class ScenegraphNormalizer
      */
     private function normalizeLayout(array $node): array
     {
-        $layout = array();
-
-        if ( isset($node['layoutMode']) && is_scalar($node['layoutMode']) ) {
-            $mode = strtoupper((string) $node['layoutMode']);
-            $layout['mode'] = $mode;
-
-            if ( 'HORIZONTAL' === $mode ) {
-                $layout['display'] = 'flex';
-                $layout['flex_direction'] = 'row';
-            } elseif ( 'VERTICAL' === $mode ) {
-                $layout['display'] = 'flex';
-                $layout['flex_direction'] = 'column';
-            }
-        } elseif ( isset($node['stackMode']) && is_scalar($node['stackMode']) ) {
-            $mode = strtoupper((string) $node['stackMode']);
-            $layout['mode'] = $mode;
-
-            if ( 'HORIZONTAL' === $mode ) {
-                $layout['display'] = 'flex';
-                $layout['flex_direction'] = 'row';
-            } elseif ( 'VERTICAL' === $mode ) {
-                $layout['display'] = 'flex';
-                $layout['flex_direction'] = 'column';
-            }
-        }
-
-        foreach ( array(
-            'layoutSizingHorizontal' => 'sizing_horizontal',
-            'layoutSizingVertical' => 'sizing_vertical',
-            'horizontalSizing' => 'sizing_horizontal',
-            'verticalSizing' => 'sizing_vertical',
-        ) as $source => $target ) {
-            if ( isset($node[$source]) && is_scalar($node[$source]) ) {
-                $layout[$target] = strtoupper((string) $node[$source]);
-            }
-        }
-
-        // REST exposes `primaryAxisSizingMode`/`counterAxisSizingMode`; the .fig
-        // Kiwi schema carries the same intent as flat `stackPrimarySizing`/
-        // `stackCounterSizing` enums. Read REST first, fall back to Kiwi, and
-        // normalize both vocabularies to canonical HUG/FIXED tokens.
-        foreach ( array(
-            'primary_axis_sizing' => array('rest' => 'primaryAxisSizingMode', 'kiwi' => 'stackPrimarySizing'),
-            'counter_axis_sizing' => array('rest' => 'counterAxisSizingMode', 'kiwi' => 'stackCounterSizing'),
-        ) as $target => $sources ) {
-            $raw = null;
-            if ( isset($node[$sources['rest']]) && is_scalar($node[$sources['rest']]) ) {
-                $raw = (string) $node[$sources['rest']];
-            } elseif ( isset($node[$sources['kiwi']]) && is_scalar($node[$sources['kiwi']]) ) {
-                $raw = (string) $node[$sources['kiwi']];
-            }
-            if ( null !== $raw ) {
-                $layout[$target] = $this->normalizeAxisSizingValue($raw);
-            }
-        }
-
-        // Bridge axis sizing onto the horizontal/vertical sizing fields the HTML
-        // emitter consumes, mapping primary/counter to physical axes by stack
-        // orientation. .fig input never sets `layoutSizingHorizontal`, so without
-        // this bridge HUG/FIXED intent from the Kiwi stack enums is pure data loss.
-        $flexDirection = $layout['flex_direction'] ?? null;
-        if ( 'row' === $flexDirection || 'column' === $flexDirection ) {
-            $primaryAxisKey = 'row' === $flexDirection ? 'sizing_horizontal' : 'sizing_vertical';
-            $counterAxisKey = 'row' === $flexDirection ? 'sizing_vertical' : 'sizing_horizontal';
-            if ( isset($layout['primary_axis_sizing']) && ! isset($layout[$primaryAxisKey]) ) {
-                $layout[$primaryAxisKey] = $layout['primary_axis_sizing'];
-            }
-            if ( isset($layout['counter_axis_sizing']) && ! isset($layout[$counterAxisKey]) ) {
-                $layout[$counterAxisKey] = $layout['counter_axis_sizing'];
-            }
-        }
-
-        // Figma `textAutoResize` (TEXT auto-resize behaviour) governs whether a
-        // text box hugs its content. WIDTH_AND_HEIGHT hugs both axes, HEIGHT keeps
-        // a fixed width while the height hugs content, NONE is a fixed box, and
-        // TRUNCATE is a fixed box that clips overflow. It is decoded by the Kiwi
-        // parser but was never read, so the intent was dropped for .fig input.
-        // Bridge it onto the HUG/FIXED sizing fields and clip flag the emitter
-        // already consumes rather than inventing a parallel sizing channel.
-        if ( isset($node['textAutoResize']) && is_scalar($node['textAutoResize']) && '' !== (string) $node['textAutoResize'] ) {
-            $autoResize = strtoupper((string) $node['textAutoResize']);
-            $layout['text_auto_resize'] = $autoResize;
-            [$autoResizeHorizontal, $autoResizeVertical] = match ( $autoResize ) {
-                'WIDTH_AND_HEIGHT' => array('HUG', 'HUG'),
-                'HEIGHT'           => array(null, 'HUG'),
-                default            => array(null, null),
-            };
-            if ( null !== $autoResizeHorizontal && ! isset($layout['sizing_horizontal']) ) {
-                $layout['sizing_horizontal'] = $autoResizeHorizontal;
-            }
-            if ( null !== $autoResizeVertical && ! isset($layout['sizing_vertical']) ) {
-                $layout['sizing_vertical'] = $autoResizeVertical;
-            }
-            if ( 'TRUNCATE' === $autoResize ) {
-                $layout['clips_content'] = true;
-            }
-        }
-
-        foreach ( array(
-            'primaryAxisAlignItems' => 'primary_axis_alignment',
-            'counterAxisAlignItems' => 'counter_axis_alignment',
-            'stackPrimaryAlignItems' => 'primary_axis_alignment',
-            'stackCounterAlignItems' => 'counter_axis_alignment',
-        ) as $source => $target ) {
-            if ( isset($node[$source]) && is_scalar($node[$source]) ) {
-                $layout[$target] = strtoupper((string) $node[$source]);
-            }
-        }
-
-        if ( isset($layout['primary_axis_alignment']) ) {
-            $layout['justify_content'] = $this->cssAxisAlignment((string) $layout['primary_axis_alignment']);
-        }
-
-        if ( isset($layout['counter_axis_alignment']) ) {
-            $layout['align_items'] = $this->cssAxisAlignment((string) $layout['counter_axis_alignment']);
-        }
-
-        $padding = array();
-        if ( isset($node['stackPadding']) && is_numeric($node['stackPadding']) ) {
-            foreach ( array('top', 'right', 'bottom', 'left') as $edge ) {
-                $padding[$edge] = (float) $node['stackPadding'];
-            }
-        }
-        foreach ( array('top' => 'paddingTop', 'right' => 'paddingRight', 'bottom' => 'paddingBottom', 'left' => 'paddingLeft') as $edge => $source ) {
-            if ( isset($node[$source]) && is_numeric($node[$source]) ) {
-                $padding[$edge] = (float) $node[$source];
-            }
-        }
-        foreach ( array('left' => 'stackPaddingLeft', 'right' => 'stackPaddingRight', 'top' => 'stackPaddingTop', 'bottom' => 'stackPaddingBottom') as $edge => $source ) {
-            if ( isset($node[$source]) && is_numeric($node[$source]) ) {
-                $padding[$edge] = (float) $node[$source];
-            }
-        }
-        foreach ( array('left', 'right') as $edge ) {
-            if ( ! array_key_exists($edge, $padding) && isset($node['paddingHorizontal']) && is_numeric($node['paddingHorizontal']) ) {
-                $padding[$edge] = (float) $node['paddingHorizontal'];
-            } elseif ( ! array_key_exists($edge, $padding) && isset($node['stackHorizontalPadding']) && is_numeric($node['stackHorizontalPadding']) ) {
-                $padding[$edge] = (float) $node['stackHorizontalPadding'];
-            }
-        }
-        foreach ( array('top', 'bottom') as $edge ) {
-            if ( ! array_key_exists($edge, $padding) && isset($node['paddingVertical']) && is_numeric($node['paddingVertical']) ) {
-                $padding[$edge] = (float) $node['paddingVertical'];
-            } elseif ( ! array_key_exists($edge, $padding) && isset($node['stackVerticalPadding']) && is_numeric($node['stackVerticalPadding']) ) {
-                $padding[$edge] = (float) $node['stackVerticalPadding'];
-            }
-        }
-        if ( ! empty($padding) ) {
-            $layout['padding'] = $padding;
-        }
-
-        if ( isset($node['itemSpacing']) && is_numeric($node['itemSpacing']) ) {
-            $layout['item_spacing'] = (float) $node['itemSpacing'];
-        } elseif ( isset($node['stackSpacing']) && is_numeric($node['stackSpacing']) ) {
-            $layout['item_spacing'] = (float) $node['stackSpacing'];
-        }
-
-        // REST `counterAxisSpacing`; Kiwi `stackCounterSpacing`. The cross-axis gap
-        // between wrapped rows/columns in a wrapping Auto Layout, distinct from the
-        // main-axis `item_spacing`. Decoded by the Kiwi parser but never read, so
-        // the wrap gap was dropped for .fig input. The emitter folds it into the
-        // two-value CSS `gap` shorthand when it differs from the main spacing.
-        if ( isset($node['counterAxisSpacing']) && is_numeric($node['counterAxisSpacing']) ) {
-            $layout['counter_axis_spacing'] = (float) $node['counterAxisSpacing'];
-        } elseif ( isset($node['stackCounterSpacing']) && is_numeric($node['stackCounterSpacing']) ) {
-            $layout['counter_axis_spacing'] = (float) $node['stackCounterSpacing'];
-        }
-
-        if ( isset($node['layoutWrap']) && is_scalar($node['layoutWrap']) ) {
-            $layout['wrap'] = strtoupper((string) $node['layoutWrap']);
-            if ( 'WRAP' === $layout['wrap'] ) {
-                $layout['flex_wrap'] = 'wrap';
-            }
-        } elseif ( isset($node['stackWrap']) && is_scalar($node['stackWrap']) ) {
-            $layout['wrap'] = strtoupper((string) $node['stackWrap']);
-            if ( 'WRAP' === $layout['wrap'] ) {
-                $layout['flex_wrap'] = 'wrap';
-            }
-        }
-
-        if ( true === ($node['stackReverseZIndex'] ?? false) || 'true' === strtolower((string) ($node['stackReverseZIndex'] ?? '')) || 1 === ($node['stackReverseZIndex'] ?? null) || '1' === (string) ($node['stackReverseZIndex'] ?? '') ) {
-            $layout['reverse_z_index'] = true;
-        }
-
-        // REST `layoutPositioning`; Kiwi `stackPositioning`. Both encode the
-        // absolute-in-auto-layout escape with an `ABSOLUTE` enum token.
-        $positioning = null;
-        if ( isset($node['layoutPositioning']) && is_scalar($node['layoutPositioning']) ) {
-            $positioning = strtoupper((string) $node['layoutPositioning']);
-        } elseif ( isset($node['stackPositioning']) && is_scalar($node['stackPositioning']) ) {
-            $positioning = strtoupper((string) $node['stackPositioning']);
-        }
-        if ( 'ABSOLUTE' === $positioning ) {
-            $layout['positioning'] = 'absolute';
-        }
-
-        // REST `layoutGrow`; Kiwi `stackChildPrimaryGrow`. Flex-grow factor.
-        if ( isset($node['layoutGrow']) && is_numeric($node['layoutGrow']) ) {
-            $layout['grow'] = (float) $node['layoutGrow'];
-        } elseif ( isset($node['stackChildPrimaryGrow']) && is_numeric($node['stackChildPrimaryGrow']) ) {
-            $layout['grow'] = (float) $node['stackChildPrimaryGrow'];
-        }
-
-        if ( isset($node['layoutAlign']) && is_scalar($node['layoutAlign']) ) {
-            $layout['align'] = strtoupper((string) $node['layoutAlign']);
-        } elseif ( isset($node['stackChildAlignSelf']) && is_scalar($node['stackChildAlignSelf']) ) {
-            $layout['align'] = strtoupper((string) $node['stackChildAlignSelf']);
-        }
-
-        if ( true === ($node['clipsContent'] ?? false) || true === ($node['isClip'] ?? false) || false === ($node['frameMaskDisabled'] ?? null) ) {
-            $layout['clips_content'] = true;
-        }
-
-        // REST exposes a nested `constraints` object with LEFT/RIGHT/LEFT_RIGHT/
-        // CENTER/SCALE (and TOP/BOTTOM/TOP_BOTTOM) tokens. The .fig Kiwi schema
-        // instead carries flat `horizontalConstraint`/`verticalConstraint` enums
-        // whose token vocabulary is MIN/CENTER/MAX/STRETCH/SCALE. Read the REST
-        // shape first, then fall back to the Kiwi scalars, translating the Kiwi
-        // enum onto the REST vocabulary so the emitter sees a single language.
-        $constraints = array();
-        if ( is_array($node['constraints'] ?? null) ) {
-            foreach ( array('horizontal', 'vertical') as $axis ) {
-                if ( isset($node['constraints'][$axis]) && is_scalar($node['constraints'][$axis]) ) {
-                    $constraints[$axis] = strtoupper((string) $node['constraints'][$axis]);
-                }
-            }
-        }
-        foreach ( array('horizontal' => 'horizontalConstraint', 'vertical' => 'verticalConstraint') as $axis => $kiwiKey ) {
-            if ( isset($constraints[$axis]) || ! isset($node[$kiwiKey]) || ! is_scalar($node[$kiwiKey]) ) {
-                continue;
-            }
-            $translated = $this->normalizeKiwiConstraint(strtoupper((string) $node[$kiwiKey]), $axis);
-            if ( null !== $translated ) {
-                $constraints[$axis] = $translated;
-            }
-        }
-        if ( ! empty($constraints) ) {
-            $layout['constraints'] = $constraints;
-        }
-
-        // Auto Layout min/max width/height. Kiwi decodes `minSize`/`maxSize` as
-        // OptionalVector {x, y} objects (x = width, y = height) but nothing ever
-        // referenced them, so they were decoded-and-dropped for .fig input.
-        foreach ( array('minSize' => 'min', 'maxSize' => 'max') as $source => $prefix ) {
-            if ( ! is_array($node[$source] ?? null) ) {
-                continue;
-            }
-            foreach ( array('x' => 'width', 'y' => 'height') as $axis => $dimension ) {
-                if ( ! isset($node[$source][$axis]) || ! is_numeric($node[$source][$axis]) ) {
-                    continue;
-                }
-                $value = (float) $node[$source][$axis];
-                if ( is_finite($value) && $value >= 0.0 ) {
-                    $layout[$prefix . '_' . $dimension] = $value;
-                }
-            }
-        }
-        foreach ( array(
-            'minWidth'  => 'min_width',
-            'maxWidth'  => 'max_width',
-            'minHeight' => 'min_height',
-            'maxHeight' => 'max_height',
-        ) as $source => $target ) {
-            if ( isset($node[$source]) && is_numeric($node[$source]) ) {
-                $value = (float) $node[$source];
-                if ( is_finite($value) && $value >= 0.0 ) {
-                    $layout[$target] = $value;
-                }
-            }
-        }
-
-        if ( ! isset($layout['display']) && is_array($node['children'] ?? null) && count($node['children']) > 1 ) {
-            $type = strtoupper((string) ($node['type'] ?? ''));
-            if ( true === ($node['resizeToFit'] ?? false) || in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE', 'SECTION'), true) ) {
-                $layout['freeform'] = true;
-            }
-        }
-
-        return $layout;
+        return $this->layoutNormalizer->normalizeLayout($node);
     }
 
     /**

--- a/figma-transformer/src/Scenegraph/ScenegraphSourceOrderPropagator.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphSourceOrderPropagator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Carries source sibling order into normalized child layout metadata.
+ */
+final class ScenegraphSourceOrderPropagator
+{
+    /**
+     * @param array<string, mixed> $node
+     * @return array<string, mixed>
+     */
+    public function apply(array $node, int $fallbackOrder): array
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $layout['source_order'] = isset($node['_source_order']) && is_numeric($node['_source_order'])
+            ? (int) $node['_source_order']
+            : $fallbackOrder;
+        $node['layout'] = $layout;
+
+        return $node;
+    }
+}

--- a/figma-transformer/src/Scenegraph/ScenegraphVectorInstanceScaler.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphVectorInstanceScaler.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Scenegraph;
+
+/**
+ * Applies instance-size scaling to vector-only component clone children.
+ */
+final class ScenegraphVectorInstanceScaler
+{
+    /**
+     * @param array<int, mixed> $children
+     * @param array<string, mixed> $component
+     * @param array<string, mixed> $instance
+     * @return array<int, mixed>
+     */
+    public function scaleVectorOnlyInstanceChildren(array $children, array $component, array $instance): array
+    {
+        if ( ! $this->isVectorOnlyComponent($component) ) {
+            return $children;
+        }
+
+        $componentBox = is_array($component['box'] ?? null) ? $component['box'] : array();
+        $instanceBox  = is_array($instance['box'] ?? null) ? $instance['box'] : array();
+        $componentWidth = isset($componentBox['width']) && is_numeric($componentBox['width']) ? (float) $componentBox['width'] : 0.0;
+        $componentHeight = isset($componentBox['height']) && is_numeric($componentBox['height']) ? (float) $componentBox['height'] : 0.0;
+        $instanceWidth = isset($instanceBox['width']) && is_numeric($instanceBox['width']) ? (float) $instanceBox['width'] : 0.0;
+        $instanceHeight = isset($instanceBox['height']) && is_numeric($instanceBox['height']) ? (float) $instanceBox['height'] : 0.0;
+        if ( $componentWidth <= 0.0 || $componentHeight <= 0.0 || $instanceWidth <= 0.0 || $instanceHeight <= 0.0 ) {
+            return $children;
+        }
+
+        $scaleX = $instanceWidth / $componentWidth;
+        $scaleY = $instanceHeight / $componentHeight;
+        if ( abs($scaleX - 1.0) < 0.0001 && abs($scaleY - 1.0) < 0.0001 ) {
+            return $children;
+        }
+
+        return $this->scaleVectorChildren($children, $scaleX, $scaleY);
+    }
+
+    /**
+     * @param array<int, mixed> $children
+     * @return array<int, mixed>
+     */
+    public function scaleVectorChildren(array $children, float $scaleX, float $scaleY): array
+    {
+        foreach ( $children as $index => $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            foreach ( array('box', 'figma_box') as $boxKey ) {
+                if ( ! is_array($child[$boxKey] ?? null) ) {
+                    continue;
+                }
+                foreach ( array('x' => $scaleX, 'width' => $scaleX, 'y' => $scaleY, 'height' => $scaleY) as $key => $scale ) {
+                    if ( isset($child[$boxKey][$key]) && is_numeric($child[$boxKey][$key]) ) {
+                        $child[$boxKey][$key] = (float) $child[$boxKey][$key] * $scale;
+                    }
+                }
+            }
+
+            foreach ( array('x' => $scaleX, 'width' => $scaleX, 'y' => $scaleY, 'height' => $scaleY) as $key => $scale ) {
+                if ( isset($child[$key]) && is_numeric($child[$key]) ) {
+                    $child[$key] = (float) $child[$key] * $scale;
+                }
+            }
+
+            $child['_component_source_clone_scale'] = array('x' => $scaleX, 'y' => $scaleY);
+
+            if ( $this->isScalableVectorType(strtoupper((string) ($child['type'] ?? ''))) ) {
+                $child['figma_vector_scale'] = array('x' => $scaleX, 'y' => $scaleY);
+            }
+
+            if ( is_array($child['children'] ?? null) ) {
+                $child['children'] = $this->scaleVectorChildren($child['children'], $scaleX, $scaleY);
+            }
+
+            $children[$index] = $child;
+        }
+
+        return $children;
+    }
+
+    /**
+     * @param array<string, mixed> $component
+     */
+    private function isVectorOnlyComponent(array $component): bool
+    {
+        $children = is_array($component['children'] ?? null) ? $component['children'] : array();
+        if ( empty($children) ) {
+            return false;
+        }
+
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) || ! $this->isVectorOnlyNode($child) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isVectorOnlyNode(array $node): bool
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        if ( 'INSTANCE' !== $type && ! $this->isScalableVectorType($type) ) {
+            return false;
+        }
+
+        foreach ( is_array($node['children'] ?? null) ? $node['children'] : array() as $child ) {
+            if ( ! is_array($child) || ! $this->isVectorOnlyNode($child) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isScalableVectorType(string $type): bool
+    {
+        return in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'RECTANGLE', 'STAR', 'POLYGON', 'REGULAR_POLYGON'), true);
+    }
+}

--- a/figma-transformer/tests/contract/ContractHelpers.php
+++ b/figma-transformer/tests/contract/ContractHelpers.php
@@ -81,6 +81,113 @@ function blocks_engine_figma_transformer_contract_artifact_quality_signal(array 
 }
 
 /**
+ * @param array<string, mixed> $result
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_transformer_contract_transform_diagnostics(array $result): array
+{
+    $diagnostics = $result['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    return is_array($diagnostics) ? $diagnostics : array();
+}
+
+/**
+ * @param callable(bool, string): void $assert
+ * @param array<string, mixed> $diagnostics
+ */
+function blocks_engine_figma_transformer_contract_assert_diagnostic_envelope(callable $assert, array $diagnostics, string $schema, string $messagePrefix): void
+{
+    $assert($schema === ($diagnostics['schema'] ?? null), $messagePrefix . '-schema');
+    $assert(is_array($diagnostics['artifact_quality'] ?? null), $messagePrefix . '-artifact-quality-envelope');
+    $assert(is_array($diagnostics['diagnostic_codes'] ?? null), $messagePrefix . '-diagnostic-codes-envelope');
+}
+
+/**
+ * @param callable(bool, string): void $assert
+ * @param array<string, mixed> $diagnostics
+ */
+function blocks_engine_figma_transformer_contract_assert_diagnostic_summary_envelope(callable $assert, array $diagnostics, string $schema, string $messagePrefix): void
+{
+    $assert($schema === ($diagnostics['schema'] ?? null), $messagePrefix . '-schema');
+    $assert(is_array($diagnostics['artifact_quality_summary'] ?? null), $messagePrefix . '-artifact-quality-summary-envelope');
+}
+
+/**
+ * @param array<string, mixed> $payload
+ */
+function blocks_engine_figma_transformer_contract_json_fixture(string $prefix, array $payload): string
+{
+    $path = sys_get_temp_dir() . '/' . $prefix . '-' . getmypid() . '-' . bin2hex(random_bytes(4)) . '.json';
+    file_put_contents($path, json_encode($payload, JSON_THROW_ON_ERROR));
+
+    return $path;
+}
+
+/**
+ * @param array<int, string> $args
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_transformer_contract_run_json_script(string $script, string $inputPath, array $args = array()): ?array
+{
+    $command = escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg($script)
+        . ' ' . escapeshellarg($inputPath);
+
+    foreach ( $args as $arg ) {
+        $command .= ' ' . $arg;
+    }
+
+    $output = shell_exec($command);
+    $decoded = is_string($output) ? json_decode($output, true) : null;
+
+    return is_array($decoded) ? $decoded : null;
+}
+
+/**
+ * @param array<string, mixed> $payload
+ * @param array<int, string>  $args
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_transformer_contract_run_json_fixture_script(string $prefix, string $script, array $payload, array $args = array()): ?array
+{
+    $fixturePath = blocks_engine_figma_transformer_contract_json_fixture($prefix, $payload);
+    try {
+        return blocks_engine_figma_transformer_contract_run_json_script($script, $fixturePath, $args);
+    } finally {
+        @unlink($fixturePath);
+    }
+}
+
+/**
+ * @param array<int, mixed> $nodeTraces
+ * @return array<string, mixed>|null
+ */
+function blocks_engine_figma_transformer_contract_find_trace_node(array $nodeTraces, string $id): ?array
+{
+    foreach ( $nodeTraces as $nodeTrace ) {
+        if ( is_array($nodeTrace) && $id === ($nodeTrace['id'] ?? null) ) {
+            return $nodeTrace;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @param array<string, array<string, mixed>> $fields
+ * @return array<string, mixed>
+ */
+function blocks_engine_figma_transformer_contract_find_named_field(array $fields, string $fieldName): array
+{
+    foreach ( $fields as $field ) {
+        if ( $fieldName === ($field['field'] ?? null) ) {
+            return $field;
+        }
+    }
+
+    return array();
+}
+
+/**
  * @param callable(bool, string): void $assert
  * @param array<string, mixed>|null $node
  * @param array<string, float> $expectedRect

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -22,8 +22,9 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
             ),
         ),
     ));
-    $normalDiagnostics = $normalResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $normalDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($normalResult);
     $normalSignalCodes = blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($normalResult);
+    blocks_engine_figma_transformer_contract_assert_diagnostic_envelope($assert, $normalDiagnostics, 'blocks-engine/figma-transformer/transform-diagnostics/v1', 'diagnostics-evidence-normal-envelope');
     $assert(1 === ($normalDiagnostics['text']['decoded_text_node_count'] ?? null), 'diagnostics-evidence-normal-decoded-text-count');
     $assert(1 === ($normalDiagnostics['text']['emitted_text_node_count'] ?? null), 'diagnostics-evidence-normal-emitted-text-count');
     $assert(0 === ($normalDiagnostics['text']['missing_emitted_text_node_count'] ?? null), 'diagnostics-evidence-normal-missing-text-zero');
@@ -48,7 +49,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
             ),
         ),
     ));
-    $clippedDiagnostics = $clippedResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $clippedDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($clippedResult);
     $clippedSignalCodes = blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($clippedResult);
     $assert(1 === ($clippedDiagnostics['layout']['clipped_visual_node_count'] ?? null), 'diagnostics-evidence-clipped-count');
     $assert(0.5 === ($clippedDiagnostics['layout']['clipped_visual_area_ratio'] ?? null), 'diagnostics-evidence-clipped-area-ratio');
@@ -70,7 +71,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
             ),
         ),
     ));
-    $largeOffsetDiagnostics = $largeOffsetResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $largeOffsetDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($largeOffsetResult);
     $largeOffsetNodes = $largeOffsetDiagnostics['layout']['large_css_offset_nodes'] ?? array();
     $assert('empty_visible_container' === ($largeOffsetNodes[0]['classification'] ?? null), 'diagnostics-evidence-large-css-offset-classification');
 
@@ -89,7 +90,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
             ),
         ),
     ));
-    $emptyTextDiagnostics = $emptyTextResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $emptyTextDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($emptyTextResult);
     $emptyTextSignalCodes = blocks_engine_figma_transformer_contract_artifact_quality_signal_codes($emptyTextResult);
     $assert(1 === ($emptyTextDiagnostics['text']['empty_decoded_text_node_count'] ?? null), 'diagnostics-evidence-empty-text-count');
     $assert('diag:empty-text' === ($emptyTextDiagnostics['text']['empty_decoded_text_nodes'][0]['node_id'] ?? null), 'diagnostics-evidence-empty-text-sample-node');
@@ -128,7 +129,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
             ),
         ),
     ));
-    $maskMetadataDiagnostics = $maskMetadataResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $maskMetadataDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($maskMetadataResult);
     $maskEffectClipping = $maskMetadataDiagnostics['mask_effect_clipping'] ?? array();
     $assert(1 === ($maskEffectClipping['mask_node_count'] ?? null), 'diagnostics-evidence-mask-node-count');
     $assert(3 === ($maskEffectClipping['mask_metadata_node_count'] ?? null), 'diagnostics-evidence-mask-metadata-node-count');
@@ -175,7 +176,8 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
             ),
         ),
     ), array('multi_page' => true, 'frame_ids' => array('diag:aggregation-home', 'diag:aggregation-about'), 'entry_frame_id' => 'diag:aggregation-home'));
-    $multiPageDiagnostics = $multiPageResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $multiPageDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($multiPageResult);
+    blocks_engine_figma_transformer_contract_assert_diagnostic_envelope($assert, $multiPageDiagnostics, 'blocks-engine/figma-transformer/transform-diagnostics/v1', 'diagnostics-evidence-multi-page-envelope');
     $missingAssets = $multiPageDiagnostics['images']['missing_assets'] ?? array();
     $placeholderNodes = $multiPageDiagnostics['vectors']['placeholder_nodes'] ?? array();
     $assert('multi_page' === ($multiPageDiagnostics['scope'] ?? null), 'diagnostics-evidence-multi-page-scope');

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -29,7 +29,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert(1 === ($inventory['summary']['by_role']['document_metadata'] ?? null), 'kiwi-skipped-inventory-document-role');
     $assert(1 === ($inventory['summary']['by_role']['dev_status'] ?? null), 'kiwi-skipped-inventory-dev-status-role');
 
-    $layoutEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'layoutBoundsDebug');
+    $layoutEntry = blocks_engine_figma_transformer_contract_find_named_field($fields, 'layoutBoundsDebug');
     $assert('NodeChange' === ($layoutEntry['parent_message'] ?? null), 'kiwi-skipped-inventory-parent-message');
     $assert('FRAME' === array_key_first(is_array($layoutEntry['node_types'] ?? null) ? $layoutEntry['node_types'] : array()), 'kiwi-skipped-inventory-node-type');
     $assert(array('7:42') === ($layoutEntry['sample_node_ids'] ?? null), 'kiwi-skipped-inventory-node-id-sample');
@@ -37,25 +37,25 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('FRAME' === ($layoutEntry['sample_nodes'][0]['node_type'] ?? null), 'kiwi-skipped-inventory-node-sample-type');
     $assert('Message.nodeChanges[].layoutBoundsDebug' === ($layoutEntry['sample_nodes'][0]['path'] ?? null), 'kiwi-skipped-inventory-node-sample-path');
     $assert('layout' === ($layoutEntry['sample_nodes'][0]['raw_value']['value'] ?? null), 'kiwi-skipped-inventory-node-sample-value');
-    $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'maskType'), 'kiwi-skipped-inventory-mask-type-decoded');
-    $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'arcData'), 'kiwi-skipped-inventory-arc-data-decoded');
-    $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'guides'), 'kiwi-skipped-inventory-guides-decoded');
-    $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'listSpacing'), 'kiwi-skipped-inventory-list-spacing-decoded');
-    $assert(array() === blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'phase'), 'kiwi-skipped-inventory-phase-decoded');
-    $documentEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'metadataAuditTrail');
+    $assert(array() === blocks_engine_figma_transformer_contract_find_named_field($fields, 'maskType'), 'kiwi-skipped-inventory-mask-type-decoded');
+    $assert(array() === blocks_engine_figma_transformer_contract_find_named_field($fields, 'arcData'), 'kiwi-skipped-inventory-arc-data-decoded');
+    $assert(array() === blocks_engine_figma_transformer_contract_find_named_field($fields, 'guides'), 'kiwi-skipped-inventory-guides-decoded');
+    $assert(array() === blocks_engine_figma_transformer_contract_find_named_field($fields, 'listSpacing'), 'kiwi-skipped-inventory-list-spacing-decoded');
+    $assert(array() === blocks_engine_figma_transformer_contract_find_named_field($fields, 'phase'), 'kiwi-skipped-inventory-phase-decoded');
+    $documentEntry = blocks_engine_figma_transformer_contract_find_named_field($fields, 'metadataAuditTrail');
     $assert('document_metadata' === ($documentEntry['field_role'] ?? null), 'kiwi-skipped-inventory-metadata-document-role');
-    $handoffEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'handoffStatusHistory');
+    $handoffEntry = blocks_engine_figma_transformer_contract_find_named_field($fields, 'handoffStatusHistory');
     $assert('dev_status' === ($handoffEntry['field_role'] ?? null), 'kiwi-skipped-inventory-handoff-dev-role');
-    $glyphEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'glyphs');
+    $glyphEntry = blocks_engine_figma_transformer_contract_find_named_field($fields, 'glyphs');
     $assert('text_style' === ($glyphEntry['field_role'] ?? null), 'kiwi-skipped-inventory-glyph-text-role');
     $assert('null_terminated_string' === ($glyphEntry['wire_type'] ?? null), 'kiwi-skipped-inventory-string-wire-type');
     $assert('glyphs' === ($glyphEntry['sample_raw_values'][0]['value'] ?? null), 'kiwi-skipped-inventory-string-sample-value');
-    $statusEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'inventoryStatus');
+    $statusEntry = blocks_engine_figma_transformer_contract_find_named_field($fields, 'inventoryStatus');
     $assert('ENUM' === ($statusEntry['type_kind'] ?? null), 'kiwi-skipped-inventory-enum-kind');
     $assert('varint_enum' === ($statusEntry['wire_type'] ?? null), 'kiwi-skipped-inventory-enum-wire-type');
     $assert('READY' === ($statusEntry['sample_raw_values'][0]['value'] ?? null), 'kiwi-skipped-inventory-enum-sample-value');
     $assert('READY' === ($statusEntry['type_definition']['fields'][1]['name'] ?? null), 'kiwi-skipped-inventory-enum-definition');
-    $guidEntry = blocks_engine_figma_transformer_kiwi_inventory_find_field($fields, 'extraGuid');
+    $guidEntry = blocks_engine_figma_transformer_contract_find_named_field($fields, 'extraGuid');
     $assert('STRUCT' === ($guidEntry['type_kind'] ?? null), 'kiwi-skipped-inventory-struct-kind');
     $assert('kiwi_struct' === ($guidEntry['wire_type'] ?? null), 'kiwi-skipped-inventory-struct-wire-type');
     $assert(99 === ($guidEntry['sample_raw_values'][0]['items']['localID']['value'] ?? null), 'kiwi-skipped-inventory-struct-sample-value');
@@ -72,12 +72,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $message = $decoder->decodeMessageSelective(blocks_engine_figma_transformer_kiwi_inventory_message_fixture(), $schema)['message'] ?? array();
     $assert('variables' === ($message['nodeChanges'][0]['variableConsumptionMap'] ?? null), 'kiwi-selective-decodes-variable-consumption-map');
 
-    $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
-        SyntheticFigKiwiFixtureBuilder::canvas(array(
-            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_schema_fixture()),
-            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_message_fixture()),
-        ))
-    );
+    $fixture = blocks_engine_figma_transformer_kiwi_inventory_fixture();
     $command = escapeshellarg(PHP_BINARY)
         . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-kiwi-skipped-field-inventory.php')
         . ' ' . escapeshellarg($fixture);
@@ -89,12 +84,7 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($cli['schema'] ?? null), 'kiwi-skipped-inventory-cli-schema');
     $assert(11 === ($cli['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-cli-field-count');
 
-    $fixture = SyntheticFigKiwiFixtureBuilder::figArchive(
-        SyntheticFigKiwiFixtureBuilder::canvas(array(
-            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_schema_fixture()),
-            SyntheticFigKiwiFixtureBuilder::zlibChunk(blocks_engine_figma_transformer_kiwi_inventory_message_fixture()),
-        ))
-    );
+    $fixture = blocks_engine_figma_transformer_kiwi_inventory_fixture();
     $outputPath = tempnam(sys_get_temp_dir(), 'blocks-engine-kiwi-inventory-output-');
     $command = escapeshellarg(PHP_BINARY)
         . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-kiwi-skipped-field-inventory.php')
@@ -114,18 +104,12 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert(11 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
 }
 
-/**
- * @param array<string, array<string, mixed>> $fields
- * @return array<string, mixed>
- */
-function blocks_engine_figma_transformer_kiwi_inventory_find_field(array $fields, string $fieldName): array
+function blocks_engine_figma_transformer_kiwi_inventory_fixture(): string
 {
-    foreach ( $fields as $field ) {
-        if ( $fieldName === ($field['field'] ?? null) ) {
-            return $field;
-        }
-    }
-    return array();
+    return SyntheticFigKiwiFixtureBuilder::zlibFigArchive(array(
+        blocks_engine_figma_transformer_kiwi_inventory_schema_fixture(),
+        blocks_engine_figma_transformer_kiwi_inventory_message_fixture(),
+    ));
 }
 
 function blocks_engine_figma_transformer_kiwi_inventory_schema_fixture(): string

--- a/figma-transformer/tests/contract/NodeTraceContract.php
+++ b/figma-transformer/tests/contract/NodeTraceContract.php
@@ -7,8 +7,10 @@ declare(strict_types=1);
  */
 function blocks_engine_figma_transformer_run_node_trace_contract(callable $assert): void
 {
-    $traceFixturePath = sys_get_temp_dir() . '/figma-node-trace-contract-' . getmypid() . '-' . bin2hex(random_bytes(4)) . '.json';
-    file_put_contents($traceFixturePath, json_encode(array(
+    $trace = blocks_engine_figma_transformer_contract_run_json_fixture_script(
+        'figma-node-trace-contract',
+        __DIR__ . '/../../scripts/figma-node-trace.php',
+        array(
         'name'  => 'Node Trace Fixture',
         'nodes' => array(
             array(
@@ -31,28 +33,18 @@ function blocks_engine_figma_transformer_run_node_trace_contract(callable $asser
                 ),
             ),
         ),
-    ), JSON_THROW_ON_ERROR));
-
-    $command = escapeshellarg(PHP_BINARY)
-        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-node-trace.php')
-        . ' ' . escapeshellarg($traceFixturePath)
-        . ' --frame-id=' . escapeshellarg('trace:frame')
-        . ' --node-ids=' . escapeshellarg('trace:frame,trace:title');
-    $output = shell_exec($command);
-    @unlink($traceFixturePath);
-
-    $trace = is_string($output) ? json_decode($output, true) : null;
+        ),
+        array(
+            '--frame-id=' . escapeshellarg('trace:frame'),
+            '--node-ids=' . escapeshellarg('trace:frame,trace:title'),
+        )
+    );
     $assert(is_array($trace), 'node-trace-json-output');
     $assert('blocks-engine/figma-transformer/node-trace/v1' === ($trace['schema'] ?? null), 'node-trace-schema');
     $assert('trace:frame' === ($trace['frame_id'] ?? null), 'node-trace-frame-id');
     $assert(2 === count(is_array($trace['nodes'] ?? null) ? $trace['nodes'] : array()), 'node-trace-node-count');
 
-    $titleTrace = null;
-    foreach ( is_array($trace['nodes'] ?? null) ? $trace['nodes'] : array() as $nodeTrace ) {
-        if ( is_array($nodeTrace) && 'trace:title' === ($nodeTrace['id'] ?? null) ) {
-            $titleTrace = $nodeTrace;
-        }
-    }
+    $titleTrace = blocks_engine_figma_transformer_contract_find_trace_node(is_array($trace['nodes'] ?? null) ? $trace['nodes'] : array(), 'trace:title');
 
     $assert(is_array($titleTrace), 'node-trace-title-present');
     $assert('TEXT' === ($titleTrace['raw']['type'] ?? null), 'node-trace-raw-type');
@@ -67,8 +59,10 @@ function blocks_engine_figma_transformer_run_node_trace_contract(callable $asser
     $assert(is_array($titleTrace['visual']['rect'] ?? null), 'node-trace-visual-rect');
     $assert(is_array($trace['diagnostics_sample']['transform'] ?? null), 'node-trace-transform-diagnostics-sample');
 
-    $cloneTraceFixturePath = sys_get_temp_dir() . '/figma-node-trace-clone-contract-' . getmypid() . '-' . bin2hex(random_bytes(4)) . '.json';
-    file_put_contents($cloneTraceFixturePath, json_encode(array(
+    $cloneTrace = blocks_engine_figma_transformer_contract_run_json_fixture_script(
+        'figma-node-trace-clone-contract',
+        __DIR__ . '/../../scripts/figma-node-trace.php',
+        array(
         'name'  => 'Node Trace Clone Fixture',
         'nodes' => array(
             array(
@@ -108,17 +102,12 @@ function blocks_engine_figma_transformer_run_node_trace_contract(callable $asser
                 ),
             ),
         ),
-    ), JSON_THROW_ON_ERROR));
-
-    $cloneCommand = escapeshellarg(PHP_BINARY)
-        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-node-trace.php')
-        . ' ' . escapeshellarg($cloneTraceFixturePath)
-        . ' --frame-id=' . escapeshellarg('trace-clone:frame')
-        . ' --node-ids=' . escapeshellarg('trace-clone:instance/trace-clone:component/title');
-    $cloneOutput = shell_exec($cloneCommand);
-    @unlink($cloneTraceFixturePath);
-
-    $cloneTrace = is_string($cloneOutput) ? json_decode($cloneOutput, true) : null;
+        ),
+        array(
+            '--frame-id=' . escapeshellarg('trace-clone:frame'),
+            '--node-ids=' . escapeshellarg('trace-clone:instance/trace-clone:component/title'),
+        )
+    );
     $assert(is_array($cloneTrace), 'node-trace-clone-json-output');
     $cloneTitleTrace = is_array($cloneTrace['nodes'][0] ?? null) ? $cloneTrace['nodes'][0] : array();
     $assert('trace-clone:instance/trace-clone:component/title' === ($cloneTitleTrace['id'] ?? null), 'node-trace-clone-generated-id');

--- a/figma-transformer/tests/contract/ParserParityContract.php
+++ b/figma-transformer/tests/contract/ParserParityContract.php
@@ -7,8 +7,10 @@ declare(strict_types=1);
  */
 function blocks_engine_figma_transformer_run_parser_parity_contract(callable $assert): void
 {
-    $fixturePath = sys_get_temp_dir() . '/figma-parser-parity-contract-' . getmypid() . '-' . bin2hex(random_bytes(4)) . '.json';
-    file_put_contents($fixturePath, json_encode(array(
+    $report = blocks_engine_figma_transformer_contract_run_json_fixture_script(
+        'figma-parser-parity-contract',
+        __DIR__ . '/../../scripts/figma-parser-parity.php',
+        array(
         'name'   => 'Parser Parity Fixture',
         'blobs'  => array(array('bytes' => 'synthetic-vector-blob')),
         'assets' => array(
@@ -188,17 +190,13 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
                 ),
             ),
         ),
-    ), JSON_THROW_ON_ERROR));
-
-    $command = escapeshellarg(PHP_BINARY)
-        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-parser-parity.php')
-        . ' ' . escapeshellarg($fixturePath)
-        . ' --frame-id=' . escapeshellarg('parity:frame')
-        . ' --limit=10 --sample-limit=3';
-    $output = shell_exec($command);
-    @unlink($fixturePath);
-
-    $report = is_string($output) ? json_decode($output, true) : null;
+        ),
+        array(
+            '--frame-id=' . escapeshellarg('parity:frame'),
+            '--limit=10',
+            '--sample-limit=3',
+        )
+    );
     $assert(is_array($report), 'parser-parity-json-output');
     $assert('blocks-engine/figma-transformer/parser-parity/v1' === ($report['schema'] ?? null), 'parser-parity-schema');
     $assert('parity:frame' === ($report['options']['frame_id'] ?? null), 'parser-parity-frame-option');
@@ -214,41 +212,39 @@ function blocks_engine_figma_transformer_run_parser_parity_contract(callable $as
     $assert(1 <= ($report['coverage']['raw_vector_to_emitted']['covered_count'] ?? 0), 'parser-parity-vector-emitted-clone-suffix-coverage');
     $assert(is_int($report['coverage']['raw_vector_to_emitted']['missing_count'] ?? null), 'parser-parity-vector-emitted-missing-count');
     $assert(4 === ($report['coverage']['raw_asset_refs_to_normalized_asset_refs']['covered_count'] ?? null), 'parser-parity-asset-reference-coverage');
-    $assert('blocks-engine/figma-transformer/parser-parity-transform-diagnostics/v1' === ($report['transform_diagnostics']['schema'] ?? null), 'parser-parity-transform-diagnostics-schema');
-    $assert(1 <= ($report['transform_diagnostics']['effects']['source_effect_node_count'] ?? 0), 'parser-parity-effect-source-count');
-    $assert(1 <= ($report['transform_diagnostics']['mask_effect_clipping']['mask_node_count'] ?? 0), 'parser-parity-mask-count');
-    $assert(1 <= ($report['transform_diagnostics']['mask_effect_clipping']['clipped_effect_node_count'] ?? 0), 'parser-parity-clipped-effect-count');
-    $assert(1 <= ($report['transform_diagnostics']['vector_child_composition']['vector_child_node_count'] ?? 0), 'parser-parity-vector-child-composition-count');
-    $assert(1 <= ($report['transform_diagnostics']['stacking_order']['mixed_positioning_parent_count'] ?? 0), 'parser-parity-stacking-order-count');
+    $transformDiagnostics = is_array($report['transform_diagnostics'] ?? null) ? $report['transform_diagnostics'] : array();
+    blocks_engine_figma_transformer_contract_assert_diagnostic_summary_envelope($assert, $transformDiagnostics, 'blocks-engine/figma-transformer/parser-parity-transform-diagnostics/v1', 'parser-parity-transform-diagnostics');
+    $assert(1 <= ($transformDiagnostics['effects']['source_effect_node_count'] ?? 0), 'parser-parity-effect-source-count');
+    $assert(1 <= ($transformDiagnostics['mask_effect_clipping']['mask_node_count'] ?? 0), 'parser-parity-mask-count');
+    $assert(1 <= ($transformDiagnostics['mask_effect_clipping']['clipped_effect_node_count'] ?? 0), 'parser-parity-clipped-effect-count');
+    $assert(1 <= ($transformDiagnostics['vector_child_composition']['vector_child_node_count'] ?? 0), 'parser-parity-vector-child-composition-count');
+    $assert(1 <= ($transformDiagnostics['stacking_order']['mixed_positioning_parent_count'] ?? 0), 'parser-parity-stacking-order-count');
     $assert(is_array($report['coverage']['normalized_component_clone_to_emitted'] ?? null), 'parser-parity-component-clone-emitted-coverage');
     $assert(is_array($report['top_missing_field_paths'] ?? null), 'parser-parity-missing-field-paths-present');
 
-    $figPath = SyntheticFigKiwiFixtureBuilder::figArchive(
-        SyntheticFigKiwiFixtureBuilder::canvas(array(
-            SyntheticFigKiwiFixtureBuilder::jsonZlibChunk(array(
-                'nodes' => array(
-                    array(
-                        'id'       => 'parity:fig-frame',
-                        'type'     => 'FRAME',
-                        'name'     => 'Parser Parity Fig Frame',
-                        'width'    => 320,
-                        'height'   => 180,
-                        'children' => array(),
-                    ),
+    $figPath = SyntheticFigKiwiFixtureBuilder::jsonFigArchive(
+        array(
+            'nodes' => array(
+                array(
+                    'id'       => 'parity:fig-frame',
+                    'type'     => 'FRAME',
+                    'name'     => 'Parser Parity Fig Frame',
+                    'width'    => 320,
+                    'height'   => 180,
+                    'children' => array(),
                 ),
-            )),
-        )),
+            ),
+        ),
         array('images/fixture.png' => str_repeat('asset-bytes', 128))
     );
 
-    $figCommand = escapeshellarg(PHP_BINARY)
-        . ' ' . escapeshellarg(__DIR__ . '/../../scripts/figma-parser-parity.php')
-        . ' ' . escapeshellarg($figPath)
-        . ' --limit=1 --sample-limit=1';
-    $figOutput = shell_exec($figCommand);
+    $figReport = blocks_engine_figma_transformer_contract_run_json_script(
+        __DIR__ . '/../../scripts/figma-parser-parity.php',
+        $figPath,
+        array('--limit=1', '--sample-limit=1')
+    );
     @unlink($figPath);
 
-    $figReport = is_string($figOutput) ? json_decode($figOutput, true) : null;
     $assert(is_array($figReport), 'parser-parity-fig-json-output');
     $assert(false === ($figReport['input']['archive_options']['include_asset_content'] ?? null), 'parser-parity-fig-omits-asset-content-by-default');
     $assert(1 === ($figReport['input']['archive_options']['max_kiwi_message_decode_bytes'] ?? null), 'parser-parity-fig-forces-selective-kiwi-decode-by-default');

--- a/figma-transformer/tests/contract/SyntheticFigKiwiFixtureBuilder.php
+++ b/figma-transformer/tests/contract/SyntheticFigKiwiFixtureBuilder.php
@@ -68,6 +68,34 @@ final class SyntheticFigKiwiFixtureBuilder
     }
 
     /**
+     * @param array<int, string>     $payloads
+     * @param array<string, string>  $images
+     * @param array<string, mixed>   $meta
+     */
+    public static function zlibFigArchive(array $payloads, array $images = array(), array $meta = array('name' => 'Synthetic Fixture')): string
+    {
+        return self::figArchive(
+            self::canvas(array_map(static fn (string $payload): string => self::zlibChunk($payload), $payloads)),
+            $images,
+            $meta
+        );
+    }
+
+    /**
+     * @param array<string, mixed>  $payload
+     * @param array<string, string> $images
+     * @param array<string, mixed>  $meta
+     */
+    public static function jsonFigArchive(array $payload, array $images = array(), array $meta = array('name' => 'Synthetic Fixture')): string
+    {
+        return self::figArchive(
+            self::canvas(array(self::jsonZlibChunk($payload))),
+            $images,
+            $meta
+        );
+    }
+
+    /**
      * @param array<string, string> $images
      */
     public static function wrapperArchive(string $canvas, array $images = array('images/synthetic' => 'asset')): string


### PR DESCRIPTION
## Summary
- extracts Kiwi schema field metadata handling from the decoder
- extracts scenegraph normalization collaborators for clone geometry, layout normalization, source-order propagation, vector instance scaling, and diagnostics
- clarifies paint/style precedence and layout-intent rule helpers
- extracts HTML artifact assembly from the static emitter
- refactors contract helpers for parser diagnostics and evidence fixtures

## Verification
- php -l on touched parser, scenegraph, HTML, and contract files
- cd figma-transformer && composer test:contract
- full FSE generation: status=success_with_warnings, page_count=5, file_count=34

## Notes
- Refactor-focused follow-up to #476.
- No FSE-specific runtime logic; extraction is intended to keep .fig/Kiwi parser and HTML translation primitives generic and easier to extend.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, with parallel coding subagents
- **Used for:** Coordinated refactoring, contract helper cleanup, verification, and PR preparation.