### PR TITLE
Improve visual parity report evidence

### DIFF
--- a/docs/contracts/php-transformer-visual-parity-report.schema.json
+++ b/docs/contracts/php-transformer-visual-parity-report.schema.json
@@ -40,6 +40,7 @@
         }
       }
     },
+    "capture_diagnostics": { "$ref": "#/$defs/capture_diagnostics" },
     "findings": {
       "type": "array",
       "items": { "$ref": "#/$defs/finding" }
@@ -193,6 +194,24 @@
         "selector_evidence": { "$ref": "#/$defs/selector_evidence" }
       }
     },
+    "property_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "property": { "type": "string" },
+        "source_property": { "type": "string" },
+        "target_property": { "type": "string" },
+        "source_value": { "type": ["string", "number", "boolean", "null"] },
+        "target_value": { "type": ["string", "number", "boolean", "null"] },
+        "expected_value": { "type": ["string", "number", "boolean", "null"] },
+        "actual_value": { "type": ["string", "number", "boolean", "null"] },
+        "delta": { "type": ["string", "number", "boolean", "null"] },
+        "unit": { "type": "string" },
+        "tolerance": { "type": "number", "minimum": 0 },
+        "source_rule": { "type": "string" },
+        "target_rule": { "type": "string" }
+      }
+    },
     "visual_diff_viewport": {
       "type": "object",
       "additionalProperties": false,
@@ -214,9 +233,14 @@
         "severity": { "$ref": "#/$defs/severity" },
         "category": { "type": "string", "enum": ["dom", "style", "layout", "visual", "interaction", "content", "asset", "accessibility"] },
         "summary": { "type": "string" },
+        "reason_code": { "type": "string" },
+        "repair_bucket": { "type": "string" },
+        "pattern_family": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
         "viewport_id": { "type": "string" },
         "kind": { "$ref": "#/$defs/component_kind" },
         "selector_evidence": { "$ref": "#/$defs/selector_evidence" },
+        "property_evidence": { "type": "array", "items": { "$ref": "#/$defs/property_evidence" } },
         "style_deltas": { "type": "array", "items": { "$ref": "#/$defs/computed_style_delta" } },
         "visual_diff": { "$ref": "#/$defs/visual_diff_viewport" },
         "recommendation_ids": { "type": "array", "items": { "type": "string" } }
@@ -230,9 +254,31 @@
         "id": { "type": "string" },
         "priority": { "type": "string", "enum": ["low", "medium", "high", "blocking"] },
         "summary": { "type": "string" },
+        "reason_code": { "type": "string" },
+        "repair_bucket": { "type": "string" },
+        "pattern_family": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
         "rationale": { "type": "string" },
         "selector_evidence": { "$ref": "#/$defs/selector_evidence" },
+        "property_evidence": { "type": "array", "items": { "$ref": "#/$defs/property_evidence" } },
         "finding_ids": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "capture_diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "captured_at": { "type": "string" },
+        "runner": { "type": "string" },
+        "runner_version": { "type": "string" },
+        "browser": { "type": "string" },
+        "browser_version": { "type": "string" },
+        "device_scale_factor": { "type": "number", "minimum": 0 },
+        "timing_ms": { "type": "number", "minimum": 0 },
+        "artifact_paths": { "type": "array", "items": { "type": "string" } },
+        "warnings": { "type": "array", "items": { "type": "string" } },
+        "errors": { "type": "array", "items": { "type": "string" } },
+        "metadata": { "type": "object", "additionalProperties": true }
       }
     }
   }

--- a/php-transformer/docs/contracts/php-transformer-visual-parity-report.schema.json
+++ b/php-transformer/docs/contracts/php-transformer-visual-parity-report.schema.json
@@ -40,6 +40,7 @@
         }
       }
     },
+    "capture_diagnostics": { "$ref": "#/$defs/capture_diagnostics" },
     "findings": {
       "type": "array",
       "items": { "$ref": "#/$defs/finding" }
@@ -193,6 +194,24 @@
         "selector_evidence": { "$ref": "#/$defs/selector_evidence" }
       }
     },
+    "property_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "property": { "type": "string" },
+        "source_property": { "type": "string" },
+        "target_property": { "type": "string" },
+        "source_value": { "type": ["string", "number", "boolean", "null"] },
+        "target_value": { "type": ["string", "number", "boolean", "null"] },
+        "expected_value": { "type": ["string", "number", "boolean", "null"] },
+        "actual_value": { "type": ["string", "number", "boolean", "null"] },
+        "delta": { "type": ["string", "number", "boolean", "null"] },
+        "unit": { "type": "string" },
+        "tolerance": { "type": "number", "minimum": 0 },
+        "source_rule": { "type": "string" },
+        "target_rule": { "type": "string" }
+      }
+    },
     "visual_diff_viewport": {
       "type": "object",
       "additionalProperties": false,
@@ -214,9 +233,14 @@
         "severity": { "$ref": "#/$defs/severity" },
         "category": { "type": "string", "enum": ["dom", "style", "layout", "visual", "interaction", "content", "asset", "accessibility"] },
         "summary": { "type": "string" },
+        "reason_code": { "type": "string" },
+        "repair_bucket": { "type": "string" },
+        "pattern_family": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
         "viewport_id": { "type": "string" },
         "kind": { "$ref": "#/$defs/component_kind" },
         "selector_evidence": { "$ref": "#/$defs/selector_evidence" },
+        "property_evidence": { "type": "array", "items": { "$ref": "#/$defs/property_evidence" } },
         "style_deltas": { "type": "array", "items": { "$ref": "#/$defs/computed_style_delta" } },
         "visual_diff": { "$ref": "#/$defs/visual_diff_viewport" },
         "recommendation_ids": { "type": "array", "items": { "type": "string" } }
@@ -230,9 +254,31 @@
         "id": { "type": "string" },
         "priority": { "type": "string", "enum": ["low", "medium", "high", "blocking"] },
         "summary": { "type": "string" },
+        "reason_code": { "type": "string" },
+        "repair_bucket": { "type": "string" },
+        "pattern_family": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
         "rationale": { "type": "string" },
         "selector_evidence": { "$ref": "#/$defs/selector_evidence" },
+        "property_evidence": { "type": "array", "items": { "$ref": "#/$defs/property_evidence" } },
         "finding_ids": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "capture_diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "captured_at": { "type": "string" },
+        "runner": { "type": "string" },
+        "runner_version": { "type": "string" },
+        "browser": { "type": "string" },
+        "browser_version": { "type": "string" },
+        "device_scale_factor": { "type": "number", "minimum": 0 },
+        "timing_ms": { "type": "number", "minimum": 0 },
+        "artifact_paths": { "type": "array", "items": { "type": "string" } },
+        "warnings": { "type": "array", "items": { "type": "string" } },
+        "errors": { "type": "array", "items": { "type": "string" } },
+        "metadata": { "type": "object", "additionalProperties": true }
       }
     }
   }

--- a/php-transformer/docs/contracts/visual-parity-report.md
+++ b/php-transformer/docs/contracts/visual-parity-report.md
@@ -61,9 +61,11 @@ Kind-specific fields are generic UI facts:
 
 `visual_diff` records optional image-diff metrics: mismatch percent, mismatch pixels, total pixels, SSIM, threshold, aggregate diff screenshot path, and per-viewport metrics. Omit metrics when a runner cannot produce them.
 
-`findings` is the reviewer-facing issue list. Findings carry severity, category, summary, viewport, component kind, selector evidence, style deltas, visual metrics, and linked recommendation IDs.
+`capture_diagnostics` records optional runner metadata such as runner/browser versions, capture timing, artifact paths, warnings, errors, and additional metadata. These fields describe how evidence was captured without encoding product persistence policy.
 
-`recommendations` contains product-neutral repair advice with priority, summary, rationale, selector evidence, and linked finding IDs. A downstream importer may translate recommendations into patches, comments, or acceptance gates at its own boundary.
+`findings` is the reviewer-facing issue list. Findings carry severity, category, summary, viewport, component kind, selector evidence, style deltas, visual metrics, and linked recommendation IDs. Findings may also carry product-neutral explanation fields: `reason_code`, `repair_bucket`, `pattern_family`, `confidence`, and `property_evidence`. These fields are generic clustering and evidence hints for downstream repair systems.
+
+`recommendations` contains product-neutral repair advice with priority, summary, rationale, selector evidence, property evidence, confidence, classification fields, and linked finding IDs. A downstream importer may translate recommendations into patches, comments, or acceptance gates at its own boundary.
 
 ## Fixture/Config Shape
 

--- a/php-transformer/src/Contract/VisualParityReportContract.php
+++ b/php-transformer/src/Contract/VisualParityReportContract.php
@@ -32,6 +32,9 @@ final class VisualParityReportContract
         self::assertList($report['matches'], 'visual parity report matches');
         self::assertList($report['findings'], 'visual parity report findings');
         self::assertList($report['recommendations'], 'visual parity report recommendations');
+        if ( array_key_exists('capture_diagnostics', $report) ) {
+            self::assertObject($report['capture_diagnostics'], 'visual parity report capture_diagnostics');
+        }
 
         foreach ( $report['viewports'] as $index => $viewport ) {
             self::assertObject($viewport, "visual parity report viewports.{$index}");
@@ -51,6 +54,27 @@ final class VisualParityReportContract
             self::assertObject($finding, "visual parity report findings.{$index}");
             self::requireKeys($finding, array('id', 'severity', 'category', 'summary'), "visual parity report findings.{$index}");
             self::assertSeverity($finding['severity'], "visual parity report findings.{$index}.severity");
+            self::assertOptionalStringFields($finding, array('reason_code', 'repair_bucket', 'pattern_family'), "visual parity report findings.{$index}");
+            if ( array_key_exists('confidence', $finding) ) {
+                self::assertConfidence($finding['confidence'], "visual parity report findings.{$index}.confidence");
+            }
+            if ( array_key_exists('selector_evidence', $finding) ) {
+                self::assertObject($finding['selector_evidence'], "visual parity report findings.{$index}.selector_evidence");
+            }
+            if ( array_key_exists('property_evidence', $finding) ) {
+                self::assertList($finding['property_evidence'], "visual parity report findings.{$index}.property_evidence");
+                foreach ( $finding['property_evidence'] as $evidenceIndex => $evidence ) {
+                    self::assertObject($evidence, "visual parity report findings.{$index}.property_evidence.{$evidenceIndex}");
+                }
+            }
+        }
+
+        foreach ( $report['recommendations'] as $index => $recommendation ) {
+            self::assertObject($recommendation, "visual parity report recommendations.{$index}");
+            self::assertOptionalStringFields($recommendation, array('reason_code', 'repair_bucket', 'pattern_family'), "visual parity report recommendations.{$index}");
+            if ( array_key_exists('confidence', $recommendation) ) {
+                self::assertConfidence($recommendation['confidence'], "visual parity report recommendations.{$index}.confidence");
+            }
         }
     }
 
@@ -113,6 +137,26 @@ final class VisualParityReportContract
     {
         if ( ! in_array($value, array('none', 'info', 'warning', 'error', 'critical'), true) ) {
             throw new InvalidArgumentException(sprintf('%s has an unsupported severity.', ucfirst($label)));
+        }
+    }
+
+    private static function assertConfidence(mixed $value, string $label): void
+    {
+        if ( ( ! is_int($value) && ! is_float($value) ) || $value < 0 || $value > 1 ) {
+            throw new InvalidArgumentException(sprintf('%s must be numeric between 0 and 1.', ucfirst($label)));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     * @param array<int, string> $fields
+     */
+    private static function assertOptionalStringFields(array $value, array $fields, string $label): void
+    {
+        foreach ( $fields as $field ) {
+            if ( array_key_exists($field, $value) && ! is_string($value[$field]) ) {
+                throw new InvalidArgumentException(sprintf('%s.%s must be a string.', ucfirst($label), $field));
+            }
         }
     }
 

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -504,6 +504,9 @@ final class BlockFactory
         }
 
         $typography = is_array($style['typography'] ?? null) ? $style['typography'] : array();
+        if ( isset($typography['fontSize']) && '' !== (string) $typography['fontSize'] ) {
+            $classes[] = 'has-custom-font-size';
+        }
         $typographyMap = array(
             'fontSize'      => 'font-size',
             'fontWeight'    => 'font-weight',

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1505,11 +1505,6 @@ final class HtmlTransformer
                 $isDecorativeChrome = $this->isVisualLayerElement($element)
                     || 'none' === strtolower(trim($this->attr($element, 'preserveaspectratio')));
                 if ( ! $isDecorativeChrome && $this->svgHasDrawableContent($element) ) {
-                    $svgImageBlock = $this->inlineSvgImageBlockFromElement($element);
-                    if ( null !== $svgImageBlock ) {
-                        return $svgImageBlock;
-                    }
-
                     $svgBlock = $this->inlineSvgBlockFromElement($element);
                     if ( null !== $svgBlock ) {
                         return $svgBlock;
@@ -1519,11 +1514,6 @@ final class HtmlTransformer
                     return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
                 }
                 return null;
-            }
-
-            $svgImageBlock = $this->inlineSvgImageBlockFromElement($element);
-            if ( null !== $svgImageBlock ) {
-                return $svgImageBlock;
             }
 
             $svgBlock = $this->inlineSvgBlockFromElement($element);
@@ -4094,82 +4084,6 @@ final class HtmlTransformer
         // isSafeSvgContent), and the original outer SVG preserves
         // viewBox/role/aria-label/class.
         return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($html) ), array(), $element);
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function inlineSvgImageBlockFromElement(DOMElement $element): ?array
-    {
-        if ( ! $this->shouldPromoteSvgToImageBlock($element) ) {
-            return null;
-        }
-
-        $svg = $this->restoreSvgCasing($this->sanitizeInlineSvgMarkup($element));
-        if ( '' === trim($svg) || ! $this->isSafeSvgContent($svg) ) {
-            return null;
-        }
-
-        $attrs = array_filter(array_merge(
-            $this->presentationAttributes($element),
-            array(
-                'url'    => 'data:image/svg+xml;charset=UTF-8,' . rawurlencode($svg),
-                'alt'    => $this->svgAltText($element),
-                'width'  => $this->numericSvgDimension($this->attr($element, 'width')),
-                'height' => $this->numericSvgDimension($this->attr($element, 'height')),
-            )
-        ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
-
-        return $this->createBlock('core/image', $attrs, array(), $element);
-    }
-
-    private function shouldPromoteSvgToImageBlock(DOMElement $element): bool
-    {
-        $signals = array(
-            $this->attr($element, 'class'),
-            $this->attr($element, 'id'),
-            $this->attr($element, 'aria-label'),
-            $this->attr($element, 'role'),
-        );
-
-        for ( $current = $element->parentNode; $current instanceof DOMElement; $current = $current->parentNode ) {
-            $signals[] = $this->attr($current, 'class');
-            $signals[] = $this->attr($current, 'id');
-            $signals[] = $this->attr($current, 'aria-label');
-
-            if ( in_array(strtolower($current->tagName), array( 'main', 'body' ), true) ) {
-                break;
-            }
-        }
-
-        $haystack = strtolower(implode(' ', $signals));
-
-        return preg_match('/\b(?:album|cover|artwork|poster|hero-art|merch-visual|product-image|product-visual|visual-(?:tee|tote|vinyl|poster|cd))\b/', $haystack) === 1;
-    }
-
-    private function svgAltText(DOMElement $element): string
-    {
-        $label = trim($this->attr($element, 'aria-label'));
-        if ( '' !== $label ) {
-            return $label;
-        }
-
-        foreach ( $element->getElementsByTagName('title') as $title ) {
-            if ( $title instanceof DOMElement ) {
-                $text = trim(preg_replace('/\s+/', ' ', $title->textContent ?? '') ?? '');
-                if ( '' !== $text ) {
-                    return $text;
-                }
-            }
-        }
-
-        return '';
-    }
-
-    private function numericSvgDimension(string $value): string
-    {
-        $value = trim($value);
-        return preg_match('/^\d+(?:\.\d+)?$/', $value) ? $value : '';
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -439,9 +439,17 @@ trait StyleResolutionTrait
         if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $style)
             && ! preg_match('/(?:^|;)\s*flex-direction\s*:\s*column(?:-reverse)?\b/', $style)
         ) {
+            if ( ! preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $inlineStyle) ) {
+                return array();
+            }
+
             return array( 'type' => 'flex' );
         }
         if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?grid\b/', $style) ) {
+            if ( ! preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?grid\b/', $inlineStyle) && preg_match('/(?:^|;)\s*grid-template-columns\s*:/', $style) ) {
+                return array();
+            }
+
             return array( 'type' => 'grid' );
         }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -176,11 +176,25 @@ $visualParityReport = array(
         array('viewport_id' => 'desktop', 'source_selector' => '.hero .button', 'target_selector' => '.wp-block-button__link', 'property' => 'border-radius', 'source_value' => '999px', 'target_value' => '4px', 'delta' => 'rounded-to-square', 'severity' => 'warning'),
     ),
     'visual_diff'           => array('available' => true, 'mismatch_percent' => 0.42, 'mismatch_pixels' => 420, 'total_pixels' => 100000, 'ssim' => 0.98, 'threshold' => 0.5, 'diff_screenshot_path' => 'screens/diff-desktop.png'),
+    'capture_diagnostics'   => array('runner' => 'visual-parity-fixture-runner', 'browser' => 'chromium', 'timing_ms' => 123.4, 'artifact_paths' => array('screens/source-desktop.png', 'screens/target-desktop.png'), 'warnings' => array()),
     'findings'              => array(
-        array('id' => 'style-button-radius', 'severity' => 'warning', 'category' => 'style', 'summary' => 'Button radius changed.', 'kind' => 'button', 'recommendation_ids' => array('rec-button-radius')),
+        array(
+            'id'                 => 'style-button-radius',
+            'severity'           => 'warning',
+            'category'           => 'style',
+            'summary'            => 'Button radius changed.',
+            'reason_code'        => 'button_radius_changed',
+            'repair_bucket'      => 'style_token_alignment',
+            'pattern_family'     => 'button_shape',
+            'confidence'         => 0.91,
+            'kind'               => 'button',
+            'selector_evidence'  => array('source_selector' => '.hero .button', 'target_selector' => '.wp-block-button__link', 'source_text' => 'Book now', 'target_text' => 'Book now'),
+            'property_evidence'  => array(array('property' => 'border-radius', 'source_value' => '999px', 'target_value' => '4px', 'delta' => 'rounded-to-square')),
+            'recommendation_ids' => array('rec-button-radius'),
+        ),
     ),
     'recommendations'       => array(
-        array('id' => 'rec-button-radius', 'priority' => 'medium', 'summary' => 'Align target button radius with the source button treatment.', 'finding_ids' => array('style-button-radius')),
+        array('id' => 'rec-button-radius', 'priority' => 'medium', 'summary' => 'Align target button radius with the source button treatment.', 'repair_bucket' => 'style_token_alignment', 'pattern_family' => 'button_shape', 'confidence' => 0.86, 'finding_ids' => array('style-button-radius')),
     ),
 );
 VisualParityReportContract::assertReport($visualParityReport);
@@ -192,6 +206,15 @@ try {
     $assert(false, 'visual parity report rejects product-specific match kinds');
 } catch ( \InvalidArgumentException $exception ) {
     $assert(str_contains($exception->getMessage(), 'unsupported component kind'), 'visual parity report rejects product-specific match kinds', $exception->getMessage());
+}
+
+$invalidVisualParityReport = $visualParityReport;
+$invalidVisualParityReport['findings'][0]['confidence'] = 1.5;
+try {
+    VisualParityReportContract::assertReport($invalidVisualParityReport);
+    $assert(false, 'visual parity report rejects out-of-range finding confidence');
+} catch ( \InvalidArgumentException $exception ) {
+    $assert(str_contains($exception->getMessage(), 'numeric between 0 and 1'), 'visual parity report rejects out-of-range finding confidence', $exception->getMessage());
 }
 
 // Typography visual probe comparator emits reports through the shared
@@ -396,10 +419,21 @@ $inlineSvgArtwork = ( new HtmlTransformer() )->transform(
     '<main><svg class="album-art" viewBox="0 0 100 100" role="img" aria-label="Album art"><rect width="100" height="100" fill="#111"/><circle cx="50" cy="50" r="30" fill="#c4581a"/></svg></main>'
 )->toArray();
 $inlineSvgMarkup = (string) ($inlineSvgArtwork['serialized_blocks'] ?? '');
-$assert('core/image' === ($inlineSvgArtwork['blocks'][0]['blockName'] ?? ''), 'meaningful inline SVG artwork materializes as an image block');
-$assert(str_contains($inlineSvgMarkup, '<!-- wp:image'), 'meaningful inline SVG artwork serializes as core/image');
-$assert(str_contains($inlineSvgMarkup, 'data:image/svg+xml'), 'meaningful inline SVG artwork uses a safe data image URL');
-$assert(str_contains($inlineSvgMarkup, 'alt="Album art"'), 'meaningful inline SVG artwork preserves accessible label as image alt text');
+$assert('core/html' === ($inlineSvgArtwork['blocks'][0]['blockName'] ?? ''), 'meaningful inline SVG artwork materializes as sanitized inline HTML');
+$assert(str_contains($inlineSvgMarkup, '<!-- wp:html'), 'meaningful inline SVG artwork serializes as core/html');
+$assert(str_contains($inlineSvgMarkup, '<svg class="album-art"'), 'meaningful inline SVG artwork preserves the SVG element and class');
+$assert(str_contains($inlineSvgMarkup, 'aria-label="Album art"'), 'meaningful inline SVG artwork preserves accessible label');
+$assert(! str_contains($inlineSvgMarkup, 'data:image/svg+xml'), 'meaningful inline SVG artwork avoids unreliable data image URLs');
+
+$classOwnedGrid = ( new HtmlTransformer() )->transform('<style>.hero-inner{display:grid;grid-template-columns:minmax(0,1.6fr) minmax(260px,.9fr);gap:4rem}</style><main><div class="hero-inner"><div>Text</div><div>Art</div></div></main>')->toArray();
+$classOwnedGridMarkup = (string) ($classOwnedGrid['serialized_blocks'] ?? '');
+$assert(str_contains($classOwnedGridMarkup, 'hero-inner'), 'class-owned CSS grid keeps the source class');
+$assert(! str_contains($classOwnedGridMarkup, 'is-layout-grid'), 'class-owned CSS grid avoids WP layout classes that override exact source tracks');
+
+$classOwnedFlex = ( new HtmlTransformer() )->transform('<style>.hero{display:flex;align-items:center;min-height:100vh}</style><main><section class="hero"><div>Text</div></section></main>')->toArray();
+$classOwnedFlexMarkup = (string) ($classOwnedFlex['serialized_blocks'] ?? '');
+$assert(str_contains($classOwnedFlexMarkup, 'hero'), 'class-owned CSS flex keeps the source class');
+$assert(! str_contains($classOwnedFlexMarkup, 'is-layout-flex'), 'class-owned CSS flex avoids WP layout classes that override exact source layout');
 
 $outlineButton = ( new HtmlTransformer() )->transform(
     '<main><a class="btn btn-secondary" style="display:inline-block;padding:1rem 2rem;border:1px solid #c4a070;background:transparent;color:#eee;text-transform:uppercase" href="/tickets"><span>Tickets</span></a></main>'
@@ -483,6 +517,14 @@ $assert(str_contains((string) ($buttonBlocks[1]['innerBlocks'][0]['attrs']['text
 $assert(! str_contains((string) $buttonResult['serialized_blocks'], '\\u003c'), 'button serialization avoids escaped nested HTML attrs');
 $assert(! str_contains((string) $buttonResult['serialized_blocks'], '<h3>Reserve now</h3>'), 'button serialization avoids block-level markup inside link text');
 $assert('pass' === ($buttonResult['source_reports']['wp_block_validity']['status'] ?? ''), 'HTML transform exposes passing WordPress block validity report for generated buttons');
+
+$buttonCustomFontSizeResult = ( new HtmlTransformer() )->transform(
+    '<main><a class="artist-button" href="/music" style="font-size:1rem;color:#fdf0d5;border:1px solid #fdf0d5">Listen now</a></main>'
+)->toArray();
+$buttonCustomFontSizeMarkup = (string) ($buttonCustomFontSizeResult['serialized_blocks'] ?? '');
+$assert(str_contains($buttonCustomFontSizeMarkup, 'has-custom-font-size'), 'button custom font-size emits the WordPress support class required by core/button save markup');
+$assert(str_contains($buttonCustomFontSizeMarkup, 'font-size:1rem'), 'button custom font-size preserves the inline style declaration');
+$assert('pass' === ($buttonCustomFontSizeResult['source_reports']['wp_block_validity']['status'] ?? ''), 'button custom font-size serialization passes generated WordPress block validity checks');
 
 $rubyResult = ( new HtmlTransformer() )->transform(
     '<main><blockquote><ruby>翻訳<rt>ほんやく</rt></ruby> keeps pronunciation visible.</blockquote></main>'

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
@@ -31,11 +31,11 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "hero-grid" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"hero-grid\",\"layout\":{\"type\":\"grid\"}} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"hero-grid\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "shift-card" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"shift-card\",\"layout\":{\"type\":\"grid\"},\"tagName\":\"section\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"shift-card\",\"tagName\":\"section\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<section class=\"wp-block-group shift-card\">" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"services-cards\",\"layout\":{\"type\":\"flex\"},\"tagName\":\"section\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"services-cards\",\"tagName\":\"section\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<section class=\"wp-block-group services-cards\">" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-artwork-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-artwork-preserved.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-artwork-preserved",
-  "description": "Preserves a full inline SVG illustration (rect/circle/path/g/polygon/text plus a comment) as a core/image data SVG when the source identifies it as artwork. Unsafe parts carried on the same SVG (an inline <script> and an event-handler attribute) are stripped while the artwork survives, so the graphic never collapses to an empty block.",
+  "description": "Preserves a full inline SVG illustration (rect/circle/path/g/polygon/text plus a comment) as sanitized inline core/html when the source identifies it as artwork. Unsafe parts carried on the same SVG (an inline <script> and an event-handler attribute) are stripped while the artwork survives, so the graphic never collapses to an empty block.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-artwork-preserved.json",
-    "notes": "Product-neutral fixture for inline decorative/illustrative SVG artwork image promotion with in-place sanitization."
+    "notes": "Product-neutral fixture for inline decorative/illustrative SVG artwork preservation with in-place sanitization."
   },
   "legacy_comparison": {
     "skip": true,
@@ -16,19 +16,25 @@
     "content": "<main><section class=\"album-art\"><svg viewBox=\"0 0 600 600\" role=\"img\" aria-label=\"Mara Vale cover\"><!-- Background --><rect width=\"600\" height=\"600\" fill=\"#1a1a2e\"></rect><circle cx=\"300\" cy=\"240\" r=\"160\" fill=\"#e94560\"></circle><path d=\"M100 400 L300 300 L500 400 Z\" fill=\"#0f3460\"></path><g opacity=\"0.8\"><polygon points=\"50,50 100,50 75,90\" fill=\"#fff\"></polygon></g><text x=\"300\" y=\"520\" text-anchor=\"middle\" fill=\"#fff\" onclick=\"steal()\">Between the Fog and the Fire</text><script>track()</script></svg></section></main>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/image" }
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "album-art" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/html" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml;charset=UTF-8," },
-    { "path": "blocks.0.innerBlocks.0.attrs.alt", "assert": "equals", "value": "Mara Vale cover" },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "Between%20the%20Fog%20and%20the%20Fire" },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "not_contains", "value": "%3Cscript" },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "not_contains", "value": "onclick" },
-    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "not_contains", "value": "track%28%29" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<svg viewBox=\"0 0 600 600\" role=\"img\" aria-label=\"Mara Vale cover\">" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<!-- Background -->" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<rect width=\"600\" height=\"600\" fill=\"#1a1a2e\"></rect>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<circle cx=\"300\" cy=\"240\" r=\"160\" fill=\"#e94560\"></circle>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<path d=\"M100 400 L300 300 L500 400 Z\" fill=\"#0f3460\"></path>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<polygon points=\"50,50 100,50 75,90\" fill=\"#fff\"></polygon>" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "Between the Fog and the Fire" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "data:image/svg+xml" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "<script" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "onclick" },
+    { "path": "blocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "track()" },
     { "path": "assets", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-product-card-svg-price-grid",
-  "description": "Preserves product cards with illustrative inline SVG imagery as core/image data SVG blocks, product names, prices, and CTA buttons inside a card grid.",
+  "description": "Preserves product cards with illustrative inline SVG imagery as sanitized inline core/html blocks, product names, prices, and CTA buttons inside a card grid.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-product-card-svg-price-grid.json",
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "product-grid", "layout": { "type": "grid" } } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "product-card" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image", "attrs": { "alt": "Ceramic bowl" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/html" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "className": "product-name", "content": "Ceramic Bowl", "level": 3 } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "className": "product-price", "content": "$42" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/buttons" },
@@ -30,8 +30,9 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "data:image/svg+xml;charset=UTF-8," },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "Ceramic%20bowl" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<svg class=\"product-image\" role=\"img\" aria-label=\"Ceramic bowl\" viewBox=\"0 0 10 10\">" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "<circle cx=\"5\" cy=\"5\" r=\"4\"></circle>" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "not_contains", "value": "data:image/svg+xml" },
     { "path": "assets", "assert": "count", "count": 0 },
     { "path": "serialized_blocks", "assert": "contains", "value": "product-price" },
     { "path": "source_reports.html.structure_signals.3.signals.price_like", "assert": "equals", "value": true },


### PR DESCRIPTION
## Summary
- extend the PHP transformer visual parity report contract with optional reason, bucket, pattern, confidence, property evidence, and capture diagnostics fields
- preserve editor-valid `core/button` custom font-size classes
- preserve class-owned grid/flex layout semantics in transformer output
- keep visual report schema/docs in sync with the additive contract fields

## Testing
- `composer exec -- php tests/contract/run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing transformer contract/layout fixes, tests, and PR preparation.