### PR TITLE
php-transformer: classify inline semantic runtime islands

### DIFF
--- a/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
+++ b/php-transformer/src/HtmlToBlocks/FallbackDiagnostic.php
@@ -215,6 +215,10 @@ final class FallbackDiagnostic
         $tag = (string) ($fields['tag'] ?? '');
         $kind = (string) ($fields['kind'] ?? '');
 
+        if ( 'preserved_runtime_island' === $code && self::isInlineSemanticHtmlRuntimeIsland($fields) ) {
+            return 'inline_semantic_html';
+        }
+
         return match ( $code ) {
             'html_form_fallback' => 'interactive_form',
             'html_product_grid_fallback' => 'commerce_product_grid',
@@ -305,7 +309,7 @@ final class FallbackDiagnostic
             return (string) $fields['suggested_repair_class'];
         }
 
-        if ( str_starts_with($patternFamily, 'runtime_') || in_array($patternFamily, array('interactive_form', 'external_embed'), true) ) {
+        if ( str_starts_with($patternFamily, 'runtime_') || in_array($patternFamily, array('interactive_form', 'external_embed', 'inline_semantic_html'), true) ) {
             return 'preserve_runtime_island';
         }
 
@@ -318,5 +322,34 @@ final class FallbackDiagnostic
         }
 
         return 'review_generic_mapping';
+    }
+
+    /**
+     * Inline elements with semantic/ARIA/class hooks cannot be represented as
+     * editable RichText without risking attribute loss, so preserved runtime
+     * islands should cluster separately from generic raw-HTML fallbacks.
+     *
+     * @param array<string, mixed> $fields
+     */
+    private static function isInlineSemanticHtmlRuntimeIsland(array $fields): bool
+    {
+        if ( 'dom' !== (string) ($fields['kind'] ?? '') ) {
+            return false;
+        }
+
+        $tag = strtolower((string) ($fields['tag'] ?? ''));
+        if ( ! in_array($tag, array('a', 'abbr', 'b', 'cite', 'code', 'data', 'em', 'i', 'kbd', 'label', 'mark', 'q', 's', 'small', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var'), true) ) {
+            return false;
+        }
+
+        $attributes = is_array($fields['attributes'] ?? null) ? $fields['attributes'] : array();
+        foreach ( array_keys($attributes) as $name ) {
+            $attributeName = strtolower((string) $name);
+            if ( 'class' === $attributeName || 'id' === $attributeName || 'role' === $attributeName || str_starts_with($attributeName, 'aria-') || str_starts_with($attributeName, 'data-') ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -344,6 +344,17 @@ $assert(array() === ($runtimeCanvasResult['fallbacks'] ?? array()), 'runtime-tar
 $assert('core/html' === ($runtimeCanvasResult['blocks'][0]['blockName'] ?? null), 'runtime-targeted canvas is materialized as bounded raw HTML');
 $assert(str_contains((string) ($runtimeCanvasResult['serialized_blocks'] ?? ''), 'id="fixture-canvas"'), 'runtime-targeted canvas remains addressable in serialized blocks');
 
+$inlineSemanticRuntime = ( new HtmlTransformer() )->transform(
+    '<span class="qty-display" aria-live="polite">1</span>',
+    array('runtime_dom_selectors' => array('.qty-display'))
+)->toArray();
+$inlineSemanticIsland = $inlineSemanticRuntime['source_reports']['runtime_islands'][0] ?? array();
+$assert('core/html' === ($inlineSemanticRuntime['blocks'][0]['blockName'] ?? null), 'runtime-targeted inline semantic HTML remains a bounded core/html island to preserve attributes');
+$assert(str_contains((string) ($inlineSemanticRuntime['serialized_blocks'] ?? ''), 'aria-live="polite"'), 'runtime-targeted inline semantic HTML preserves aria-live in serialized markup');
+$assert('inline_semantic_html' === ($inlineSemanticIsland['pattern_family'] ?? ''), 'runtime-targeted inline semantic HTML reports a specific fallback pattern family');
+$assert('preserve_runtime_island' === ($inlineSemanticIsland['suggested_generic_repair_class'] ?? ''), 'runtime-targeted inline semantic HTML is classified as an attribute-preserving runtime island, not a generic unsupported span');
+$assert('preserved_runtime_island' === ($inlineSemanticIsland['reason_code'] ?? ''), 'runtime-targeted inline semantic HTML keeps the runtime-island reason code');
+
 $invalidStatus = $result;
 $invalidStatus['status'] = 'ok';
 $assertInvalidCanonicalEnvelope($invalidStatus, 'unsupported status', 'canonical validation rejects unsupported status values');


### PR DESCRIPTION
## Summary
- Classify preserved runtime-targeted inline semantic HTML as `inline_semantic_html` instead of a generic `html_span`/runtime-island family.
- Keep these elements as bounded `core/html` islands when attributes like `aria-live`/class are required for semantic or runtime preservation.
- Add deterministic contract coverage for `<span class="qty-display" aria-live="polite">1</span>` with `.qty-display` as a runtime DOM selector.

## Decision
This is better diagnostic/classification, not conversion to editable RichText. WordPress paragraph RichText cannot safely preserve arbitrary span attributes such as `aria-live`, class, role, id, or data hooks. Moving the hook to a paragraph/group wrapper would change the DOM target and accessibility/runtime semantics.

## Tests
- `composer run test:canonical`
- `composer run test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigated the php-transformer inline fallback path, implemented the focused classification/test change, and ran verification.