### PR TITLE
Preserve whole-element links: propagate wrapper hrefs onto native link-bearing blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -40,6 +40,35 @@ final class HtmlTransformer
     private const MAX_INTERACTION_CANDIDATES = 100;
 
     /**
+     * Blocks that manage their own link destination and must never receive a
+     * propagated card-link wrapper href (core/button owns its `url`,
+     * core/navigation-link owns its `url`, core/html is opaque markup, …).
+     *
+     * @var array<int, string>
+     */
+    private const LINK_SELF_MANAGING_BLOCKS = array(
+        'core/button',
+        'core/buttons',
+        'core/file',
+        'core/html',
+        'core/navigation',
+        'core/navigation-link',
+        'core/navigation-submenu',
+    );
+
+    /**
+     * RichText content blocks whose stored `content` can carry an inline `<a>`
+     * when a whole-element link wrapper is propagated onto them (#260).
+     *
+     * @var array<int, string>
+     */
+    private const LINK_BEARING_TEXT_BLOCKS = array(
+        'core/heading',
+        'core/paragraph',
+        'core/list-item',
+    );
+
+    /**
      * @var array<int, string>
      */
     private const SUPPORTED_BLOCKS = array(
@@ -139,9 +168,10 @@ final class HtmlTransformer
 
     /**
      * Whole-element link wrappers (an <a> wrapping block-level content) whose
-     * link was dropped because the resulting core/group has no native link
-     * attribute (#260). Surfaced for diagnostics so navigation loss is
-     * detectable rather than emitted as an unsupported attribute.
+     * link could not be propagated onto any native link-bearing inner block, so
+     * the resulting content is no longer navigable (#260). Surfaced for
+     * diagnostics so the navigation loss is detectable and a downstream repair
+     * loop can act on it, rather than emitted as an unsupported attribute.
      *
      * @var array<int, array<string, mixed>>
      */
@@ -1451,15 +1481,9 @@ final class HtmlTransformer
             }
 
             if ( $this->hasBlockContentChildren($element) ) {
-                $children = $this->convertChildren($element, $fallbacks, true);
-                if ( array() !== $children ) {
-                    // core/group has no native link attribute, so the wrapping
-                    // anchor's href/target/rel cannot live on the group without
-                    // becoming an unsupported attribute WordPress silently drops
-                    // (#260). Preserve the children as a valid group and surface
-                    // the dropped link wrapper for diagnostics instead.
-                    $this->recordDroppedLinkWrapper($element);
-                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+                $linkWrapper = $this->convertLinkWrapperGroup($element, $fallbacks);
+                if ( null !== $linkWrapper ) {
+                    return $linkWrapper;
                 }
             }
 
@@ -5737,10 +5761,12 @@ final class HtmlTransformer
     }
 
     /**
-     * Record a content-wrapping anchor whose link was dropped because the
-     * resulting core/group exposes no native link attribute (#260). The link
-     * details are captured for diagnostics so the navigation loss is detectable
-     * rather than silently emitted as an unsupported attribute on the group.
+     * Record a content-wrapping anchor whose link could not be preserved on any
+     * native link-bearing inner block, because the resulting core/group exposes
+     * no native link attribute of its own (#260). The link details (selector +
+     * href) are captured for diagnostics so the navigation loss is detectable
+     * and a downstream repair loop can act on it, rather than the link being
+     * silently dropped.
      */
     private function recordDroppedLinkWrapper(DOMElement $anchor): void
     {
@@ -5751,11 +5777,235 @@ final class HtmlTransformer
 
         $this->droppedLinkWrapperFindings[] = array_merge(
             array(
+                'kind'     => 'source link wrapper dropped / content no longer navigable',
                 'tag'      => strtolower($anchor->tagName),
                 'selector' => $this->elementSelector($anchor),
             ),
             $link
         );
+    }
+
+    /**
+     * Convert a whole-element link wrapper (an `<a href>` wrapping block-level
+     * content) into a core/group whose layout/className is preserved while the
+     * anchor's href is propagated onto native link-bearing inner blocks, so the
+     * card content stays navigable instead of carrying a dead href on the group
+     * (#260).
+     *
+     * Mapping is chosen deterministically from the wrapped content:
+     *  - Button-like anchors (carrying a button signal) are routed to
+     *    core/button/core/buttons upstream of this method, so they never arrive
+     *    here.
+     *  - Otherwise (card/tile with heading, image, text) the link is propagated
+     *    onto core/image (native link attributes) and core/heading /
+     *    core/paragraph / core/list-item (inline `<a>` around the text content),
+     *    recursing through layout containers (group/columns/column/…). The
+     *    container never carries a bogus href.
+     *
+     * When the link cannot be preserved on any inner block (e.g. the card holds
+     * only non-link-bearing content), a structured finding is emitted instead.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertLinkWrapperGroup(DOMElement $anchor, array &$fallbacks): ?array
+    {
+        $children = $this->convertChildren($anchor, $fallbacks, true);
+        if ( array() === $children ) {
+            return null;
+        }
+
+        $linkAttrs = $this->linkPropagationAttributes($anchor);
+        if ( array() !== $linkAttrs && ! $this->propagateLinkWrapper($children, $linkAttrs) ) {
+            $this->recordDroppedLinkWrapper($anchor);
+        }
+
+        return $this->createBlock('core/group', $this->presentationAttributes($anchor), $children, $anchor);
+    }
+
+    /**
+     * The subset of a card-link wrapper's attributes used to propagate the link
+     * onto inner blocks: href (sanitized), target, and rel. The wrapper's own
+     * class/aria-label stay on the container group, not on each inner block.
+     *
+     * @return array<string, string>
+     */
+    private function linkPropagationAttributes(DOMElement $anchor): array
+    {
+        $href = $this->safeLinkUrl($this->attr($anchor, 'href'));
+        if ( '' === $href ) {
+            return array();
+        }
+
+        return array_filter(array(
+            'href'   => $href,
+            'target' => $this->attr($anchor, 'target'),
+            'rel'    => $this->attr($anchor, 'rel'),
+        ), static fn (string $value): bool => '' !== trim($value));
+    }
+
+    /**
+     * Walk the converted inner blocks of a link wrapper and propagate the
+     * anchor's link onto every native link-bearing descendant so the content
+     * remains navigable. core/image receives native link attributes;
+     * {@see self::LINK_BEARING_TEXT_BLOCKS} get an inline `<a>` around their text
+     * content. Layout containers (group/columns/column/…) are recursed into so a
+     * card whose heading/image/text lives behind wrapper `<div>`s is still
+     * covered. Blocks that manage their own link
+     * ({@see self::LINK_SELF_MANAGING_BLOCKS}) are skipped.
+     *
+     * Returns true when the link was carried onto at least one inner block.
+     *
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<string, string> $linkAttrs
+     */
+    private function propagateLinkWrapper(array &$blocks, array $linkAttrs): bool
+    {
+        $preserved = false;
+        foreach ( $blocks as $index => $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            $name = (string) ($block['blockName'] ?? '');
+
+            if ( in_array($name, self::LINK_SELF_MANAGING_BLOCKS, true) ) {
+                continue;
+            }
+
+            if ( 'core/image' === $name ) {
+                if ( $this->propagateLinkOntoImage($blocks[$index], $linkAttrs) ) {
+                    $preserved = true;
+                }
+                continue;
+            }
+
+            if ( in_array($name, self::LINK_BEARING_TEXT_BLOCKS, true) ) {
+                if ( $this->propagateInlineLink($blocks[$index], $linkAttrs) ) {
+                    $preserved = true;
+                }
+                continue;
+            }
+
+            if ( isset($blocks[$index]['innerBlocks']) && is_array($blocks[$index]['innerBlocks']) ) {
+                if ( $this->propagateLinkWrapper($blocks[$index]['innerBlocks'], $linkAttrs) ) {
+                    $preserved = true;
+                }
+            }
+        }
+
+        return $preserved;
+    }
+
+    /**
+     * Propagate a card-link wrapper's href onto a core/image block via its
+     * native link attributes (href/linkDestination/linkTarget/rel). An image
+     * that already carries its own link is left untouched.
+     *
+     * @param array<string, mixed> $block
+     * @param array<string, string> $linkAttrs
+     */
+    private function propagateLinkOntoImage(array &$block, array $linkAttrs): bool
+    {
+        $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+        if ( '' !== (string) ($attrs['href'] ?? '') ) {
+            return false;
+        }
+
+        $href = (string) ($linkAttrs['href'] ?? '');
+        if ( '' === $href ) {
+            return false;
+        }
+
+        $imageLink = array_filter(array(
+            'href'            => $href,
+            'linkDestination' => 'custom',
+            'linkTarget'      => (string) ($linkAttrs['target'] ?? ''),
+            'rel'             => (string) ($linkAttrs['rel'] ?? ''),
+        ), static fn (string $value): bool => '' !== trim($value));
+
+        $block = $this->rebuildBlock($block, array_merge($attrs, $imageLink));
+        return true;
+    }
+
+    /**
+     * Propagate a card-link wrapper's href onto a RichText content block
+     * (heading/paragraph/list-item) by wrapping its text content in an inline
+     * `<a>`. Content that is empty or already carries a link is left untouched.
+     *
+     * @param array<string, mixed> $block
+     * @param array<string, string> $linkAttrs
+     */
+    private function propagateInlineLink(array &$block, array $linkAttrs): bool
+    {
+        $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+        $content = (string) ($attrs['content'] ?? '');
+        if ( '' === trim($content) ) {
+            return false;
+        }
+
+        $href = (string) ($linkAttrs['href'] ?? '');
+        if ( '' === $href ) {
+            return false;
+        }
+
+        if ( preg_match('/<a\b/i', $content) ) {
+            return false;
+        }
+
+        $wrapped = $this->wrapInlineLink($content, $linkAttrs);
+        if ( $wrapped === $content ) {
+            return false;
+        }
+
+        $block = $this->rebuildBlock($block, array_merge($attrs, array( 'content' => $wrapped )));
+        return true;
+    }
+
+    /**
+     * Wrap a RichText content string in an inline `<a>` carrying the propagated
+     * href/target/rel.
+     *
+     * @param array<string, string> $linkAttrs
+     */
+    private function wrapInlineLink(string $content, array $linkAttrs): string
+    {
+        $href = (string) ($linkAttrs['href'] ?? '');
+        if ( '' === $href || '' === trim($content) ) {
+            return $content;
+        }
+
+        $attributes = ' href="' . htmlspecialchars($href, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        if ( '' !== trim((string) ($linkAttrs['target'] ?? '')) ) {
+            $attributes .= ' target="' . htmlspecialchars($linkAttrs['target'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+        if ( '' !== trim((string) ($linkAttrs['rel'] ?? '')) ) {
+            $attributes .= ' rel="' . htmlspecialchars($linkAttrs['rel'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+
+        return '<a' . $attributes . '>' . $content . '</a>';
+    }
+
+    /**
+     * Rebuild a converted block with updated attributes so its innerHTML and
+     * innerContent stay consistent with the stored attrs after an in-place edit
+     * (e.g. a propagated link). Source-provenance linkage is preserved; no new
+     * provenance is recorded for the rebuild.
+     *
+     * @param array<string, mixed> $block
+     * @param array<string, mixed> $attrs
+     * @return array<string, mixed>
+     */
+    private function rebuildBlock(array $block, array $attrs): array
+    {
+        $name = (string) ($block['blockName'] ?? '');
+        $innerBlocks = is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array();
+        $rebuilt = $this->blockFactory->create($name, $attrs, $innerBlocks);
+        if ( isset($block['_source_provenance_id']) ) {
+            $rebuilt['_source_provenance_id'] = $block['_source_provenance_id'];
+        }
+
+        return $rebuilt;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-linked-card-anchor-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-card-anchor-grid.json
@@ -21,7 +21,7 @@
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-card featured" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-thumb" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "article-card-body" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/heading", "attrs": { "className": "article-headline", "content": "City Hall Rewrites the Map", "level": 3 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/heading", "attrs": { "className": "article-headline", "content": "<a href=\"/story-one\">City Hall Rewrites the Map</a>", "level": 3 } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "article-card" } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/buttons", "attrs": { "className": "link-row" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "text": "Start", "url": "/start" } },

--- a/php-transformer/tests/fixtures/parity/html-linked-overlay-category-card.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-overlay-category-card.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-linked-overlay-category-card",
-  "description": "Whole-card overlay/category anchors wrapping background and content regions become valid core/group blocks with children preserved and no unsupported href attribute on the group (#260).",
+  "description": "Whole-card overlay/category anchors wrapping background and content regions become valid core/group blocks with the link propagated onto inner image/heading/paragraph blocks so the card stays navigable. The group itself never carries an unsupported href attribute (#260).",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-linked-overlay-category-card.json",
-    "notes": "Generic coverage for overlay cards with card__bg and category-card content."
+    "notes": "Generic coverage for overlay cards with card__bg and category-card content. The wrapping anchor's href is propagated to the inner core/image (native link attrs) and to the heading/paragraph (inline <a>), never onto the group."
   },
   "legacy_comparison": {
     "skip": true,
@@ -32,8 +32,9 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "Sharp Visual Systems" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Production Workflows" },
     { "path": "serialized_blocks", "assert": "contains", "value": "card__bg" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/category/design\"" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/category/build\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/category/design\">Sharp Visual Systems</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/category/build\">Production Workflows</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/category/design\"><img" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "\"ariaLabel\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }

--- a/php-transformer/tests/fixtures/parity/html-linked-resource-card-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-resource-card-grid.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-linked-resource-card-grid",
-  "description": "Whole-card anchors wrapping resource-card content become valid core/group blocks with their children preserved and no unsupported href attribute on the group (#260).",
+  "description": "Whole-card anchors wrapping resource-card content become valid core/group blocks with the link propagated onto inner image/heading/paragraph blocks so the card stays navigable. The group itself never carries an unsupported href attribute (#260).",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-linked-resource-card-grid.json",
-    "notes": "Product-neutral coverage for resource/card grids where the whole card is an anchor. core/group has no native link attribute, so the wrapping anchor's href/target/rel are not emitted on the group; the card children are preserved as valid blocks."
+    "notes": "Product-neutral coverage for resource/card grids where the whole card is an anchor. The wrapping anchor's href is propagated to the inner core/image (native link attrs) and to the heading/paragraph (inline <a>), never onto the group."
   },
   "legacy_comparison": {
     "skip": true,
@@ -31,8 +31,9 @@
     { "path": "blocks.0.innerBlocks.1.blockName", "assert": "equals", "value": "core/group" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Block Pattern Basics" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Launch Review" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/resources/block-patterns\"" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/resources/site-launch\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/resources/block-patterns\">Block Pattern Basics</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/resources/site-launch\" target=\"_blank\" rel=\"noopener\">Launch Review</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/resources/block-patterns\"><img" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<p><a class=\"resource-card\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }

--- a/php-transformer/tests/fixtures/parity/html-whole-element-link-button-like.json
+++ b/php-transformer/tests/fixtures/parity/html-whole-element-link-button-like.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-whole-element-link-button-like",
+  "description": "A whole-element link whose content is button-like (a button signal on a short-text anchor wrapping block-level markup) routes to core/button/core/buttons with the href preserved, rather than collapsing to a link-dropped core/group (#260).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-whole-element-link-button-like.json",
+    "notes": "Generic structural coverage: an <a> carrying a button class signal wraps a single short-text block element. The button recognizer fires upstream of the link-wrapper group path, so the href is preserved natively on core/button."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"btn-primary\" href=\"/signup\"><div>Sign Up Free</div></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Sign Up Free", "url": "/signup" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/buttons" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/button" },
+    { "path": "blocks.0.innerBlocks.0.attrs.text", "assert": "equals", "value": "Sign Up Free" },
+    { "path": "blocks.0.innerBlocks.0.attrs.url", "assert": "equals", "value": "/signup" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "href=\"/signup\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "core/group" },
+    { "path": "source_reports.html.dropped_link_wrappers", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-whole-element-link-card-propagated.json
+++ b/php-transformer/tests/fixtures/parity/html-whole-element-link-card-propagated.json
@@ -1,0 +1,43 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-whole-element-link-card-propagated",
+  "description": "A whole-element link wrapping a card (image + heading + paragraph) propagates the href onto native link-bearing inner blocks: core/image receives its link attribute, and the heading/paragraph carry an inline <a> around their text. The container core/group keeps its className/layout but never carries a dead href (#260).",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-whole-element-link-card-propagated.json",
+    "notes": "Generic structural coverage for a card/tile anchor wrapping media + heading + body text. The wrapping <a>'s href is propagated deterministically rather than dropped or emitted as an unsupported group attribute."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"feature-card\" href=\"https://example.com/feature/\"><img src=\"/img/feature.jpg\" alt=\"Feature\"><h3>Feature Title</h3><p>Feature description text.</p></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-card" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "url": "/img/feature.jpg", "alt": "Feature", "href": "https://example.com/feature/", "linkDestination": "custom" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "<a href=\"https://example.com/feature/\">Feature Title</a>", "level": 3 } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.attrs.href", "assert": "equals", "value": null },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/image" },
+    { "path": "blocks.0.innerBlocks.0.attrs.href", "assert": "equals", "value": "https://example.com/feature/" },
+    { "path": "blocks.0.innerBlocks.0.attrs.linkDestination", "assert": "equals", "value": "custom" },
+    { "path": "blocks.0.innerBlocks.1.attrs.content", "assert": "contains", "value": "<a href=\"https://example.com/feature/\">Feature Title</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"https://example.com/feature/\"><img" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"https://example.com/feature/\">Feature Title</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"https://example.com/feature/\">Feature description text.</a>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"className\":\"feature-card\",\"href\"" },
+    { "path": "source_reports.html.dropped_link_wrappers", "assert": "count", "count": 0 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-whole-element-link-dropped-finding.json
+++ b/php-transformer/tests/fixtures/parity/html-whole-element-link-dropped-finding.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-whole-element-link-dropped-finding",
+  "description": "A whole-element link wrapping content that has no native link-bearing inner block (a media-only card) emits a structured 'source link wrapper dropped / content no longer navigable' finding carrying the source selector and href so a downstream repair loop can act on it (#260). The group never carries a dead href.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-whole-element-link-dropped-finding.json",
+    "notes": "Generic structural coverage: an <a href> wrapping a core/video (no text/image/heading inner block can receive the link). The link is non-preservable natively, so the finding is emitted rather than a dead href."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a href=\"/watch\" class=\"video-card\"><video src=\"/clip.mp4\">Transcript</video></a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "video-card" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/video", "attrs": { "src": "/clip.mp4" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.attrs.href", "assert": "equals", "value": null },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.blockName", "assert": "equals", "value": "core/video" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"/watch\"" },
+    { "path": "source_reports.html.dropped_link_wrappers", "assert": "count", "count": 1 },
+    { "path": "source_reports.html.dropped_link_wrappers.0.kind", "assert": "equals", "value": "source link wrapper dropped / content no longer navigable" },
+    { "path": "source_reports.html.dropped_link_wrappers.0.href", "assert": "equals", "value": "/watch" },
+    { "path": "source_reports.html.dropped_link_wrappers.0.selector", "assert": "contains", "value": "a:nth-of-type(1)" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-whole-element-link-group-no-href.json
+++ b/php-transformer/tests/fixtures/parity/html-whole-element-link-group-no-href.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-whole-element-link-group-no-href",
-  "description": "A whole-element link (an <a> wrapping block-level content) converts to a valid core/group with its children preserved and no unsupported href/target/rel/ariaLabel attribute on the group (#260).",
+  "description": "A whole-element link (an <a> wrapping block-level content) converts to a valid core/group whose layout/className is preserved while the href is propagated onto native link-bearing inner blocks (inline <a> around heading/paragraph text). The group itself never carries a dead href/target/rel/ariaLabel attribute (#260).",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-whole-element-link-group-no-href.json",
-    "notes": "Generic structural coverage: any anchor wrapping block-level content. core/group has no native link attribute, so the link wrapper's href/target/rel are not emitted on the group; the children are kept as valid, editable blocks."
+    "notes": "Generic structural coverage: any anchor wrapping block-level content. core/group has no native link attribute, so the link wrapper's href/target/rel are propagated onto the inner heading/paragraph as inline <a> instead of being dropped or emitted as an unsupported group attribute."
   },
   "legacy_comparison": {
     "skip": true,
@@ -17,20 +17,21 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "panel-link" } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Quarterly Review", "level": 2 } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "A summary of the latest reporting period." } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "<a href=\"https://example.com/details/\" target=\"_blank\" rel=\"noopener\">Quarterly Review</a>", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph" }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.blockName", "assert": "equals", "value": "core/group" },
+    { "path": "blocks.0.attrs.href", "assert": "equals", "value": null },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"https://example.com/details/\" target=\"_blank\" rel=\"noopener\">Quarterly Review</a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"https://example.com/details/\" target=\"_blank\" rel=\"noopener\">A summary of the latest reporting period.</a>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "Quarterly Review" },
     { "path": "serialized_blocks", "assert": "contains", "value": "A summary of the latest reporting period." },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\"" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"target\"" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"rel\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"href\":\"https://example.com/details/\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "\"ariaLabel\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }


### PR DESCRIPTION
Fixes #260

## Problem
`<a href>` wrapping block-level content (linked cards/tiles) converted to `core/group` with an unsupported `href` attribute that WordPress silently drops — the card was no longer clickable, and the loss was undetected.

## Change
- Propagate the wrapper link deterministically onto native link-bearing inner blocks: `core/image` gets native link attributes; `core/heading`/`core/paragraph`/`core/list-item` get an inline `<a>` around text content; propagation recurses through layout containers.
- Blocks that manage their own link destination (`core/button`, `core/navigation*`, ...) are never overwritten; the container keeps layout/className and never carries a bogus `href`.
- When no inner block can carry the link, a structured **source link wrapper dropped / content no longer navigable** finding is emitted with source selector and href for downstream repair loops.

## Coverage
Parity fixtures: propagated card link, button-like anchor, no-href group contract, dropped-link finding. `composer test` (canonical + parity + packaging) green locally.

## Provenance
Implemented by an autonomous cook on Homeboy Lab; the patch was salvaged from the lab workspace after an infrastructure gap (Extra-Chill/homeboy#7370) prevented normal artifact capture, then verified locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GLM 5.2) via Homeboy agent-task cook
- **Used for:** Drafted the implementation and fixtures autonomously from a task brief; Chris reviewed, verified gates locally, and owns the change.