### PR TITLE
Fix runtime dependency parity data targets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -674,6 +674,20 @@ final class RuntimeDependencyParityReport
                     $targets['classes'][$class] = true;
                 }
             }
+
+            $tag = is_string($island['tag'] ?? null) ? strtolower(trim($island['tag'])) : '';
+            foreach ( $attributes as $name => $value ) {
+                $attributeName = strtolower((string) $name);
+                if ( ! str_starts_with($attributeName, 'data-') || ! preg_match('/^data-[a-z][a-z0-9_-]*$/', $attributeName) ) {
+                    continue;
+                }
+
+                $attributeSelector = '[' . $attributeName . ']';
+                $targets['selectors'][$attributeSelector] = true;
+                if ( '' !== $tag ) {
+                    $targets['selectors'][$tag . $attributeSelector] = true;
+                }
+            }
         }
 
         return $targets;
@@ -1175,7 +1189,7 @@ final class RuntimeDependencyParityReport
     private function scriptKind(string $path, string $script): string
     {
         $haystack = strtolower($path . "\n" . substr($script, 0, 2000));
-        if ( str_contains($haystack, 'netlify') || str_contains($haystack, 'rum') || str_contains($haystack, 'analytics') || str_contains($haystack, 'gtag') ) {
+        if ( preg_match('#(?:netlify|analytics|gtag|\brum\b|[-_./]rum[-_./])#', $haystack) ) {
             return 'telemetry';
         }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1713,6 +1713,7 @@ foreach ( array('canvas.preview', 'canvas', 'svg', '[data-tool]', '#mounted-app'
 $assert(true === ($expandedRuntimeDependencies['canvas.preview']['canvas_api'] ?? null), 'compound canvas selector records canvas API usage');
 $assert(str_contains($expandedRuntimeMarkup, '<canvas class="preview" aria-label="Preview"></canvas>'), 'compound canvas selector preserves canvas markup');
 $assert(str_contains($expandedRuntimeMarkup, 'data-tool'), 'data attribute runtime selector remains addressable in generated markup');
+$assert(true === ($expandedRuntimeDependencies['[data-tool]']['source_present'] ?? null), 'data attribute runtime selector is recorded as present in source markup');
 $assert(str_contains($expandedRuntimeMarkup, 'mounted-app'), 'app root receiving appended children remains addressable in generated markup');
 $assert(array() === ($expandedRuntimeReport['findings'] ?? array()), 'expanded runtime target selectors do not emit missing-target findings');
 
@@ -1772,6 +1773,32 @@ $assert(
 $assert(
     array() === array_values(array_filter($sharedScriptFindings, static fn (array $finding): bool => '.only-on-shop' === ($finding['selector'] ?? ''))),
     'runtime dependency parity does not fail entry output for selectors absent from that entry source'
+);
+
+$sharedDrumScriptSite = $compiler->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html'     => '<main><h1>Drum machine</h1><script src="js/site.js"></script></main>',
+            'patterns.html'  => '<main><button data-voice-demo="kick">Kick</button><button data-groove="classic">Classic</button><script src="js/site.js"></script></main>',
+            'js/site.js'     => 'document.querySelectorAll("[data-groove], [data-voice-demo]"); document.querySelectorAll(".is-playing").forEach(function (button) { button.classList.remove("is-playing"); });',
+        ),
+    )
+)->toArray();
+$sharedDrumScriptReport = $sharedDrumScriptSite['source_reports']['runtime_dependency_parity'] ?? array();
+$sharedDrumDependencies = $sharedDrumScriptReport['dependencies'] ?? array();
+$sharedDrumDependency = array_values(array_filter($sharedDrumDependencies, static fn (array $dependency): bool => '[data-voice-demo]' === ($dependency['selector'] ?? '')))[0] ?? null;
+$assert(
+    null !== $sharedDrumDependency,
+    'runtime dependency parity records shared data-attribute selectors absent from the entry source'
+);
+$assert(
+    'first_party' === ($sharedDrumDependency['script_kind'] ?? ''),
+    'runtime dependency parity does not classify drum scripts as RUM telemetry'
+);
+$assert(
+    array() === array_values(array_filter($sharedDrumScriptReport['findings'] ?? array(), static fn (array $finding): bool => in_array($finding['selector'] ?? '', array('.is-playing', '[data-voice-demo]', '[data-groove]'), true))),
+    'runtime dependency parity does not fail entry output for shared drum script selectors absent from that entry source'
 );
 
 $hamburgerOverlaySite = $compiler->compile(


### PR DESCRIPTION
## Summary
- Count preserved runtime island data attributes as generated parity targets.
- Avoid classifying ordinary drum-machine scripts as RUM telemetry.
- Add contract coverage for preserved data-attribute targets and shared drum scripts whose selectors belong to another page.

## Verification
- Local fixture repro: 48-desktop-os-sim and 68-drum-machine both pass runtime dependency parity with 0 findings.
- `php php-transformer/tests/contract/run.php`
- `php php-transformer/tests/parity/run.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed fixture parity failures, implemented the PHP parity fix, added regression coverage, and ran local verification.