### PR TITLE
Fix presentational data hooks forcing HTML fallbacks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4348,6 +4348,10 @@ final class HtmlTransformer
         }
 
         foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
+            if ( $this->isPresentationalAnimationDataSelector((string) $selector) ) {
+                continue;
+            }
+
             if ( $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
@@ -4496,6 +4500,26 @@ final class HtmlTransformer
 
         foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
             if ( str_contains((string) $selector, '[') && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
+                if ( $this->isPresentationalAnimationDataSelector((string) $selector) ) {
+                    continue;
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPresentationalAnimationDataSelector(string $selector): bool
+    {
+        if ( ! preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match) ) {
+            return false;
+        }
+
+        $attribute = strtolower((string) $match[1]);
+        foreach ( preg_split('/[^a-z0-9]+/', substr($attribute, 5)) ?: array() as $token ) {
+            if ( in_array($token, array( 'animate', 'animation', 'appear', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'transition' ), true) ) {
                 return true;
             }
         }

--- a/php-transformer/tests/fixtures/parity/html-presentational-data-attributes-native.json
+++ b/php-transformer/tests/fixtures/parity/html-presentational-data-attributes-native.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-presentational-data-attributes-native",
+  "description": "Presentation-only animation data attributes such as data-reveal/data-delay do not force editable text and generic groups into core/html runtime preservation when callers provide matching runtime_dom_selectors.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-presentational-data-attributes-native.json",
+    "notes": "Generic regression for static marketing sections that use data-* reveal hooks on labels, headings, paragraphs, and wrappers."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Covers current PHP transformer generic data-attribute runtime selector behavior; no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"feature-section\" aria-label=\"Feature\"><div class=\"feature-header\" data-reveal><span class=\"section-label\" data-reveal>Feature Label</span><h2 class=\"feature-heading\" data-reveal data-delay=\"1\">Built on <em>care</em><br>and craft</h2><p class=\"feature-sub\" data-reveal data-delay=\"2\">Readable source copy.</p></div></section>",
+    "options": {
+      "runtime_dom_selectors": ["[data-reveal]", "[data-delay]"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-section", "tagName": "section" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature-header" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "<span class=\"section-label\" data-reveal>Feature Label</span>" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Built on <em>care</em><br>and craft", "level": 2, "className": "feature-heading" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "Readable source copy.", "className": "feature-sub" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:heading" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:paragraph" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Keep presentation-only animation data selectors such as `[data-reveal]` and `[data-delay]` out of runtime DOM target preservation.
- Adds a php-transformer parity fixture for static marketing sections that should remain editable native blocks.
- Reduces 14-restaurant HTML fallback pressure without changing inline SVG preservation semantics.

## Evidence
- `composer parity`: passed, 203 fixtures.
- `composer test`: passed, including contracts, units, parity, and install proof.
- Direct SSI 14-restaurant matrix after fix: 96.28% native, 3.72% core/html, 0 invalid editor blocks. Baseline from issue evidence: 71% native, 29% core/html.
- Direct SSI c1 matrix after fix: 7/7 fixtures succeeded, 97.40% native, 2.60% core/html, 0 invalid editor blocks.
- 2-onepager-coffee after fix: 90.82% native, 9.18% core/html, 0 invalid editor blocks.

## Fallback Taxonomy
- `div`, `p`, `h2`, `span`, and `section` fallbacks in 14-restaurant were static editorial content carrying reveal/delay data attributes; these now convert to core group/heading/paragraph output.
- Remaining 14-restaurant reported `core/html` findings are inline SVG artwork (`hero-flame-svg`, `chef-flame-art`, and a small icon SVG). Those remain raw HTML intentionally because arbitrary inline SVG has no safe core/native equivalent that preserves the vector artwork.
- Script fallback remains accepted runtime preservation.

Fixes #487.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated fallback evidence, implemented the transformer/test change, ran verification, and drafted this PR description.
