### PR TITLE
Keep multi-child hero stacks grouped

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -105,8 +105,10 @@ final class ColumnsPattern
             return false;
         }
 
+        // Split-layout names describe two-pane structures. Multi-child content
+        // stacks such as hero copy must stay groups so source CSS controls flow.
         return (bool) preg_match('/(?:^|[\s_-])columns?(?:$|[\s_-])/', $className)
-            || ( $this->looksLikeSplitLayout($element) && 1 < $this->directElementChildCount($element) )
+            || ( $this->looksLikeSplitLayout($element) && 2 === $this->directElementChildCount($element) )
             || ( $this->looksLikeDocumentationLayout($element) && $this->hasSidebarAndContentChildren($element) )
             || preg_match('/(?:^|;)\s*(?:display\s*:\s*(?:inline-)?flex|grid-template-columns\s*:)/', $style);
     }

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -54,6 +54,13 @@ $assert(str_contains($groupInnerHtml, 'is-layout-flex wp-block-columns-is-layout
 $assert(! str_contains($groupInnerHtml, 'gap:1rem'), '13: rendered wrapper omits blockGap when the core save shape does not reproduce it', $groupInnerHtml);
 $assert(! str_contains($groupInnerHtml, 'display:flex') && ! str_contains($groupInnerHtml, 'justify-content:center'), '14: rendered wrapper does not carry raw flex declarations', $groupInnerHtml);
 
+$stackHtml = '<div class="hero-content"><p>Eyebrow</p><h1>Low Tide Table</h1><div></div><p>Local shrimp.</p><div><p>Next Run</p></div><div><a href="#reserve">Reserve</a></div></div>';
+$stackResult = ( new HtmlTransformer() )->transform($stackHtml, array())->toArray();
+$stack = $stackResult['blocks'][0] ?? array();
+
+$assert('core/group' === ($stack['blockName'] ?? ''), '15: multi-child hero content stack stays a group, not columns', (string) ($stack['blockName'] ?? '(none)'));
+$assert('hero-content' === (($stack['attrs']['className'] ?? '')), '16: multi-child hero content stack keeps source class for stylesheet materialization', json_encode($stack['attrs'] ?? array()));
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Block style support conversion tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary
- Tightens `ColumnsPattern` so split-layout heuristics only emit `core/columns` for actual two-pane structures.
- Keeps multi-child content stacks such as `.hero-content` as `core/group` with the source class preserved, allowing the authored stylesheet to control flow.
- Adds regression coverage for the seafood-style hero content stack.

## Evidence
- Issue: Closes #486
- Baseline c1 ratios from SSI matrix (`8421204` / transformer `ebc3997`): `12-portfolio` `0.889`, `21-studio-web-seafood-popup` `0.759`.
- Single-fixture proof with this branch and current wp-codebox main:
  - `12-portfolio`: `0.087` visual mismatch, native `0.966`, fallback `0.035`.
  - `21-studio-web-seafood-popup`: `0.120` visual mismatch, native `1.000`, fallback `0.000`.
- Full c1 proof completed with 7/7 fixtures passing hard gate. The zero-threshold pixel ratios remain unstable for subtle full-page background/text differences (e.g. visually aligned seafood screenshots report high ratios in multi-fixture runs), so the PR is intentionally scoped to the concrete generic layout misclassification fixed here.

## Tests
- `php php-transformer/tests/unit/block-style-support-conversion.php`
- `php php-transformer/tests/unit/corpus-detectors.php`
- `php php-transformer/tests/contract/run.php`
- Direct SSI single-fixture matrix runs for `12-portfolio` and `21-studio-web-seafood-popup` passed.
- Direct SSI c1 matrix run with `--max-complexity 1` passed 7/7 hard gate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via opencode subagent, orchestrated by Claude (claude-fable-5)
- **Used for:** Diagnosis, implementation, tests, and PR drafting; reviewed by Chris Huber
