### PR TITLE
Decompose animated marketing sections into native blocks instead of core/html app-shell fallback

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2625,6 +2625,9 @@ final class HtmlTransformer
     private function dynamicTextContent(DOMElement $element): ?string
     {
         $target = trim($this->attr($element, 'data-target'));
+        if ( '' === $target ) {
+            $target = trim($this->attr($element, 'data-count'));
+        }
         if ( '' === $target || ! is_numeric($target) ) {
             return null;
         }
@@ -4337,18 +4340,18 @@ final class HtmlTransformer
     private function isRuntimeDomTarget(DOMElement $element): bool
     {
         $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && isset($this->runtimeDomSelectors['#' . $id]) ) {
+        if ( '' !== $id && isset($this->runtimeDomSelectors['#' . $id]) && ! $this->isPresentationalAnimationSelector('#' . $id) ) {
             return true;
         }
 
         foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class && isset($this->runtimeDomSelectors['.' . $class]) ) {
+            if ( '' !== $class && isset($this->runtimeDomSelectors['.' . $class]) && ! $this->isPresentationalAnimationSelector('.' . $class) ) {
                 return true;
             }
         }
 
         foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
-            if ( $this->isPresentationalAnimationDataSelector((string) $selector) ) {
+            if ( $this->isPresentationalAnimationSelector((string) $selector) ) {
                 continue;
             }
 
@@ -4500,7 +4503,7 @@ final class HtmlTransformer
 
         foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
             if ( str_contains((string) $selector, '[') && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
-                if ( $this->isPresentationalAnimationDataSelector((string) $selector) ) {
+                if ( $this->isPresentationalAnimationSelector((string) $selector) ) {
                     continue;
                 }
 
@@ -4511,15 +4514,23 @@ final class HtmlTransformer
         return false;
     }
 
-    private function isPresentationalAnimationDataSelector(string $selector): bool
+    private function isPresentationalAnimationSelector(string $selector): bool
     {
-        if ( ! preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match) ) {
+        $name = '';
+        if ( preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match) ) {
+            $name = substr(strtolower((string) $match[1]), 5);
+        } elseif ( preg_match('/^(?:[a-z][a-z0-9-]*\.|\.)([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
+            $name = strtolower((string) $match[1]);
+        } elseif ( preg_match('/^#([A-Za-z][A-Za-z0-9_-]*)$/', $selector, $match) ) {
+            $name = strtolower((string) $match[1]);
+        }
+
+        if ( '' === $name ) {
             return false;
         }
 
-        $attribute = strtolower((string) $match[1]);
-        foreach ( preg_split('/[^a-z0-9]+/', substr($attribute, 5)) ?: array() as $token ) {
-            if ( in_array($token, array( 'animate', 'animation', 'appear', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'transition' ), true) ) {
+        foreach ( preg_split('/[^a-z0-9]+/', $name) ?: array() as $token ) {
+            if ( in_array($token, array( 'animate', 'animation', 'appear', 'count', 'counter', 'delay', 'fade', 'motion', 'parallax', 'reveal', 'scroll', 'transition' ), true) ) {
                 return true;
             }
         }

--- a/php-transformer/tests/fixtures/parity/html-section-runtime-animation-native-decomposition.json
+++ b/php-transformer/tests/fixtures/parity/html-section-runtime-animation-native-decomposition.json
@@ -1,0 +1,44 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-section-runtime-animation-native-decomposition",
+  "description": "Artifact compilation keeps marketing sections with presentation-only reveal and counter scripts decomposed into native editable blocks instead of preserving the whole section as a runtime app shell.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-section-runtime-animation-native-decomposition.json",
+    "notes": "Distilled from SSI fixture-matrix section fallbacks: semantic section, header wrapper, repeated card grid, inline SVG artwork, reveal classes, and data-count animation selectors. The structure is generic and avoids fixture-specific class names."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream artifact primitive has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "html": "<main><section id=\"features\" aria-labelledby=\"features-title\"><div class=\"wrap\"><div class=\"reveal\"><span class=\"kicker\">Overview</span><h2 id=\"features-title\">Native sections</h2></div><div class=\"feature-grid\"><article class=\"feature-card reveal\"><svg viewBox=\"0 0 10 10\" aria-hidden=\"true\"><circle cx=\"5\" cy=\"5\" r=\"4\"></circle></svg><h3>One</h3><p><span class=\"metric\" data-count=\"42\" data-suffix=\"%\">0</span> faster.</p></article><article class=\"feature-card reveal\"><h3>Two</h3><p>Editable card text.</p></article></div></div></section><script>const io=new IntersectionObserver(entries=>entries.forEach(entry=>{if(entry.isIntersecting)entry.target.classList.add('visible');}));document.querySelectorAll('.reveal').forEach(el=>io.observe(el));document.querySelectorAll('[data-count]').forEach(el=>{el.textContent=el.dataset.count+(el.dataset.suffix||'');});</script></main>"
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "anchor": "features", "tagName": "section" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "wrap" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "reveal" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Native sections", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "feature-grid", "layout": { "type": "grid" } } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature-card reveal", "tagName": "article" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.0", "name": "core/html" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "One", "level": 3 } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/group", "attrs": { "className": "feature-card reveal", "tagName": "article" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 1 },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "script" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"anchor\":\"features\",\"tagName\":\"section\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"feature-grid\",\"layout\":{\"type\":\"grid\"}} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<article class=\"wp-block-group feature-card reveal\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<svg viewBox=\"0 0 10 10\" aria-hidden=\"true\">" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html {\"content\":\"\\u003csection" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "preservation_reason\":\"runtime_app_shell" }
+  ]
+}


### PR DESCRIPTION
## Problem

Ordinary marketing `<section>`s were preserved wholesale as a single `core/html` block whenever animation/counter scripts targeted elements inside them. `shouldPreserveRuntimeAppShell()` counted presentation-only selectors (`.reveal`, `[data-count]`, animate/motion/scroll classes) fed by `ArtifactCompiler::runtimeDomSelectors()` as runtime app-shell evidence, so any section with scroll-reveal animation looked like an interactive app and fell back — the single largest fallback family in the Static Site Importer fixture matrix (12 findings across 4 fixtures on the complexity-1 lane).

## Fix

- Filter presentation-only animation/counter selectors in `isRuntimeDomTarget()` and data-attribute preservation — generalizing the existing data-animation filter to class/id/data selectors. Structural decision only; no fixture- or class-name-specific matching beyond generic animation vocabulary.
- `data-count` support in `dynamicTextContent()` so counter text stays editable.
- New parity fixture: `html-section-runtime-animation-native-decomposition.json`.

## Verification

- Full suite green: `composer test` (canonical + 203 parity fixtures + packaging).
- Static Site Importer fixture matrix (complexity-1 lane, 7 fixtures, real WP sandbox with editor-side `wp.blocks.validateBlock`):
  - `fallback_block:core_html_block:section` family: **12 → 0**
  - Total blocks 917 → 1,142 (+225 real editable blocks from decomposed sections)
  - Editor-valid block rate stays 1.0; 7/7 fixtures pass the gate
  - Expected cascade: inner SVGs previously buried in section fallbacks now surface individually (svg family 8 → 19), tracked as follow-up work

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 (claude-fable-5) via opencode, orchestrated agent workflow
- **Used for:** Root-cause investigation, implementation, parity fixture, and fixture-matrix verification runs. Reviewed and verified by Chris Huber via the SSI fixture matrix quality gates.