### PR TITLE
Author commerce/forms capabilities on WooCommerce-bearing fixture manifests (19, 20)

### DIFF
--- a/fixtures/websites/19-product-catalog/fixture.json
+++ b/fixtures/websites/19-product-catalog/fixture.json
@@ -10,5 +10,8 @@
     "product-grid",
     "pricing"
   ],
+  "capabilities": [
+    "commerce-products"
+  ],
   "complexity": 2
 }

--- a/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
+++ b/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
@@ -12,5 +12,9 @@
     "bundles",
     "pricing"
   ],
+  "capabilities": [
+    "commerce-products",
+    "forms"
+  ],
   "complexity": 3
 }


### PR DESCRIPTION
## What

Authors `capabilities` on the two WooCommerce-bearing fixture manifests, per the SSI fixture-manifest contract (manifests are the sole source of truth — no runtime inference):

- `19-product-catalog`: `["commerce-products"]`
- `20-switchback-woocommerce-extra-hard`: `["commerce-products", "forms"]`

Human-intent judgments backed by the fixtures' existing `ecommerce`/`woocommerce`/`has-form` tags. No other manifest fields changed; no other fixtures touched.

## Why

Enables capability-driven dependency provisioning in the SSI fixture matrix (companion PR: Automattic/static-site-importer#547): fixtures declaring `commerce-products` get real WooCommerce installed in the test sandbox and exercise actual product seeding instead of the degraded `allow-missing-woocommerce` waiver path. Verified live: fixture 19 seeds 10 real products with WooCommerce 10.9.3 active.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 (claude-fable-5) via opencode, orchestrated agent workflow
- **Used for:** Manifest authoring and live verification. Reviewed by Chris Huber.