### PR TITLE
Corpus taxonomy audit: normalize fixture_class keys, classify commerce fixtures with reviewed capabilities

### DIFF
--- a/fixtures/websites/10-nonprofit/fixture.json
+++ b/fixtures/websites/10-nonprofit/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "nonprofit",
     "has-nav",

--- a/fixtures/websites/11-nonprofit-campaign/fixture.json
+++ b/fixtures/websites/11-nonprofit-campaign/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "nonprofit",
     "campaign",

--- a/fixtures/websites/12-portfolio/fixture.json
+++ b/fixtures/websites/12-portfolio/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "portfolio",
     "creative",

--- a/fixtures/websites/13-realistic-small-business/fixture.json
+++ b/fixtures/websites/13-realistic-small-business/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "small-business",
     "retail",

--- a/fixtures/websites/14-restaurant/fixture.json
+++ b/fixtures/websites/14-restaurant/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "restaurant",
     "food",

--- a/fixtures/websites/15-saas/fixture.json
+++ b/fixtures/websites/15-saas/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "saas",
     "landing",

--- a/fixtures/websites/16-astro-docs-content-collection/fixture.json
+++ b/fixtures/websites/16-astro-docs-content-collection/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "docs",
     "documentation",

--- a/fixtures/websites/17-markdown-blog-launch-site/fixture.json
+++ b/fixtures/websites/17-markdown-blog-launch-site/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "blog",
     "markdown",

--- a/fixtures/websites/18-static-content-library/fixture.json
+++ b/fixtures/websites/18-static-content-library/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "content-library",
     "resources",

--- a/fixtures/websites/19-product-catalog/fixture.json
+++ b/fixtures/websites/19-product-catalog/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "ecommerce/catalog",
+  "fixture_class": "ecommerce/catalog",
   "tags": [
     "ecommerce",
     "catalog",

--- a/fixtures/websites/19-product-catalog/fixture.json
+++ b/fixtures/websites/19-product-catalog/fixture.json
@@ -10,5 +10,8 @@
     "product-grid",
     "pricing"
   ],
+  "capabilities": [
+    "commerce-products"
+  ],
   "complexity": 2
 }

--- a/fixtures/websites/2-onepager-coffee/fixture.json
+++ b/fixtures/websites/2-onepager-coffee/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "restaurant",
     "cafe",

--- a/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
+++ b/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "ecommerce/catalog",
+  "fixture_class": "ecommerce/catalog",
   "tags": [
     "ecommerce",
     "woocommerce",

--- a/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
+++ b/fixtures/websites/20-switchback-woocommerce-extra-hard/fixture.json
@@ -12,5 +12,9 @@
     "bundles",
     "pricing"
   ],
+  "capabilities": [
+    "commerce-products",
+    "forms"
+  ],
   "complexity": 3
 }

--- a/fixtures/websites/21-studio-web-seafood-popup/fixture.json
+++ b/fixtures/websites/21-studio-web-seafood-popup/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "restaurant",
     "pop-up",

--- a/fixtures/websites/22-fast-beautiful-website/fixture.json
+++ b/fixtures/websites/22-fast-beautiful-website/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "marketing",
     "landing",

--- a/fixtures/websites/23-recipe-blog/fixture.json
+++ b/fixtures/websites/23-recipe-blog/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "blog",
     "recipes",

--- a/fixtures/websites/24-podcast-show/fixture.json
+++ b/fixtures/websites/24-podcast-show/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "podcast",
     "audio",

--- a/fixtures/websites/25-real-estate/fixture.json
+++ b/fixtures/websites/25-real-estate/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "real-estate",
     "listings",

--- a/fixtures/websites/26-government-municipal/fixture.json
+++ b/fixtures/websites/26-government-municipal/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "government",
     "municipal",

--- a/fixtures/websites/27-university-department/fixture.json
+++ b/fixtures/websites/27-university-department/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "education",
     "university",

--- a/fixtures/websites/28-enterprise-b2b/fixture.json
+++ b/fixtures/websites/28-enterprise-b2b/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "b2b",
     "enterprise",

--- a/fixtures/websites/29-multilingual-i18n/fixture.json
+++ b/fixtures/websites/29-multilingual-i18n/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "nonprofit",
     "multilingual",

--- a/fixtures/websites/3-artist-music/fixture.json
+++ b/fixtures/websites/3-artist-music/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "music",
     "artist",

--- a/fixtures/websites/31-personal-cv-academic/fixture.json
+++ b/fixtures/websites/31-personal-cv-academic/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "cv",
     "resume",

--- a/fixtures/websites/32-wedding-microsite/fixture.json
+++ b/fixtures/websites/32-wedding-microsite/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "wedding",
     "microsite",

--- a/fixtures/websites/33-sports-team-league/fixture.json
+++ b/fixtures/websites/33-sports-team-league/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "sports",
     "league",

--- a/fixtures/websites/34-comparison-review-site/fixture.json
+++ b/fixtures/websites/34-comparison-review-site/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "review",
     "comparison",

--- a/fixtures/websites/35-hyper-minimal-blog/fixture.json
+++ b/fixtures/websites/35-hyper-minimal-blog/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "blog",
     "minimal",

--- a/fixtures/websites/36-church-community/fixture.json
+++ b/fixtures/websites/36-church-community/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "church",
     "community",

--- a/fixtures/websites/37-art-gallery-exhibition/fixture.json
+++ b/fixtures/websites/37-art-gallery-exhibition/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "art-gallery",
     "exhibition",

--- a/fixtures/websites/38-medical-clinic/fixture.json
+++ b/fixtures/websites/38-medical-clinic/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "medical",
     "clinic",

--- a/fixtures/websites/39-old-internet-cms/fixture.json
+++ b/fixtures/websites/39-old-internet-cms/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "local-business",
     "rental",

--- a/fixtures/websites/4-course-education/fixture.json
+++ b/fixtures/websites/4-course-education/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "education",
     "course",

--- a/fixtures/websites/40-job-board/fixture.json
+++ b/fixtures/websites/40-job-board/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "job-board",
     "listings",

--- a/fixtures/websites/41-generative-art-studio/fixture.json
+++ b/fixtures/websites/41-generative-art-studio/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "generative-art",
     "creative-tech",

--- a/fixtures/websites/42-immersive-product-launch/fixture.json
+++ b/fixtures/websites/42-immersive-product-launch/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "product-launch",
     "automotive",

--- a/fixtures/websites/43-interactive-space-explorer/fixture.json
+++ b/fixtures/websites/43-interactive-space-explorer/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "interactive",
     "space",

--- a/fixtures/websites/44-experimental-zine/fixture.json
+++ b/fixtures/websites/44-experimental-zine/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "zine",
     "experimental",

--- a/fixtures/websites/45-markdown-ssg-blog/fixture.json
+++ b/fixtures/websites/45-markdown-ssg-blog/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "blog",
     "markdown",

--- a/fixtures/websites/46-mdx-design-system/fixture.json
+++ b/fixtures/websites/46-mdx-design-system/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "docs",
     "design-system",

--- a/fixtures/websites/47-digital-garden/fixture.json
+++ b/fixtures/websites/47-digital-garden/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "digital-garden",
     "notes",

--- a/fixtures/websites/48-desktop-os-sim/fixture.json
+++ b/fixtures/websites/48-desktop-os-sim/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "os-sim",
     "desktop",

--- a/fixtures/websites/49-terminal-text-adventure/fixture.json
+++ b/fixtures/websites/49-terminal-text-adventure/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "game",
     "text-adventure",

--- a/fixtures/websites/5-documentation-knowledge-base/fixture.json
+++ b/fixtures/websites/5-documentation-knowledge-base/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "docs",
     "knowledge-base",

--- a/fixtures/websites/50-web-audio-synth/fixture.json
+++ b/fixtures/websites/50-web-audio-synth/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "synth",
     "web-audio",

--- a/fixtures/websites/51-cursed-arg-site/fixture.json
+++ b/fixtures/websites/51-cursed-arg-site/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "arg",
     "experimental",

--- a/fixtures/websites/52-css-3d-world/fixture.json
+++ b/fixtures/websites/52-css-3d-world/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "3d",
     "webgl",

--- a/fixtures/websites/53-live-ops-dashboard/fixture.json
+++ b/fixtures/websites/53-live-ops-dashboard/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "dashboard",
     "ops",

--- a/fixtures/websites/54-physics-sandbox/fixture.json
+++ b/fixtures/websites/54-physics-sandbox/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "physics",
     "sandbox",

--- a/fixtures/websites/55-algorithm-visualizer/fixture.json
+++ b/fixtures/websites/55-algorithm-visualizer/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "algorithm",
     "visualizer",

--- a/fixtures/websites/56-code-playground/fixture.json
+++ b/fixtures/websites/56-code-playground/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "code-editor",
     "playground",

--- a/fixtures/websites/57-webgl-shader-gallery/fixture.json
+++ b/fixtures/websites/57-webgl-shader-gallery/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "webgl",
     "shader",

--- a/fixtures/websites/58-infinite-whiteboard/fixture.json
+++ b/fixtures/websites/58-infinite-whiteboard/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "whiteboard",
     "diagramming",

--- a/fixtures/websites/59-spreadsheet/fixture.json
+++ b/fixtures/websites/59-spreadsheet/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "spreadsheet",
     "app",

--- a/fixtures/websites/6-editorial-magazine/fixture.json
+++ b/fixtures/websites/6-editorial-magazine/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "docs/blog",
+  "fixture_class": "docs/blog",
   "tags": [
     "magazine",
     "editorial",

--- a/fixtures/websites/60-node-editor/fixture.json
+++ b/fixtures/websites/60-node-editor/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "node-editor",
     "procedural",

--- a/fixtures/websites/61-photo-editor/fixture.json
+++ b/fixtures/websites/61-photo-editor/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "photo-editor",
     "image-editor",

--- a/fixtures/websites/62-platformer-game/fixture.json
+++ b/fixtures/websites/62-platformer-game/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "game",
     "platformer",

--- a/fixtures/websites/63-map-explorer/fixture.json
+++ b/fixtures/websites/63-map-explorer/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "map",
     "explorer",

--- a/fixtures/websites/64-kanban-board/fixture.json
+++ b/fixtures/websites/64-kanban-board/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "kanban",
     "board",

--- a/fixtures/websites/65-terminal-emulator/fixture.json
+++ b/fixtures/websites/65-terminal-emulator/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "terminal",
     "emulator",

--- a/fixtures/websites/66-regex-tester/fixture.json
+++ b/fixtures/websites/66-regex-tester/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "regex",
     "tester",

--- a/fixtures/websites/67-dataviz-studio/fixture.json
+++ b/fixtures/websites/67-dataviz-studio/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "data-viz",
     "charts",

--- a/fixtures/websites/68-drum-machine/fixture.json
+++ b/fixtures/websites/68-drum-machine/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "drum-machine",
     "web-audio",

--- a/fixtures/websites/69-markdown-editor/fixture.json
+++ b/fixtures/websites/69-markdown-editor/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "markdown-editor",
     "writing",

--- a/fixtures/websites/7-event-conference/fixture.json
+++ b/fixtures/websites/7-event-conference/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "event",
     "conference",

--- a/fixtures/websites/70-typing-test/fixture.json
+++ b/fixtures/websites/70-typing-test/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "app/dashboard",
+  "fixture_class": "app/dashboard",
   "tags": [
     "typing-test",
     "utility",

--- a/fixtures/websites/71-beyond-the-block/fixture.json
+++ b/fixtures/websites/71-beyond-the-block/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "canvas/webgl/audio/runtime-heavy",
+  "fixture_class": "canvas/webgl/audio/runtime-heavy",
   "tags": [
     "demo",
     "interactive",

--- a/fixtures/websites/72-why-wordpress/fixture.json
+++ b/fixtures/websites/72-why-wordpress/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "marketing",
     "editorial",

--- a/fixtures/websites/73-h44-lacrosse/fixture.json
+++ b/fixtures/websites/73-h44-lacrosse/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "sports",
     "lacrosse",

--- a/fixtures/websites/74-lumen-coffee/fixture.json
+++ b/fixtures/websites/74-lumen-coffee/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "ecommerce/catalog",
+  "fixture_class": "ecommerce/catalog",
   "tags": [
     "ecommerce",
     "coffee",
@@ -11,6 +11,11 @@
     "mini-cart",
     "multipage",
     "localstorage"
+  ],
+  "capabilities": [
+    "commerce-products",
+    "checkout",
+    "forms"
   ],
   "complexity": 3
 }

--- a/fixtures/websites/75-inkwell-books/fixture.json
+++ b/fixtures/websites/75-inkwell-books/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "ecommerce/catalog",
+  "fixture_class": "ecommerce/catalog",
   "tags": [
     "ecommerce",
     "bookstore",
@@ -11,6 +11,11 @@
     "mini-cart",
     "multipage",
     "localstorage"
+  ],
+  "capabilities": [
+    "commerce-products",
+    "checkout",
+    "forms"
   ],
   "complexity": 3
 }

--- a/fixtures/websites/76-sole-society/fixture.json
+++ b/fixtures/websites/76-sole-society/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "ecommerce/catalog",
+  "fixture_class": "ecommerce/catalog",
   "tags": [
     "ecommerce",
     "sneakers",
@@ -12,6 +12,11 @@
     "multipage",
     "localstorage",
     "marquee"
+  ],
+  "capabilities": [
+    "commerce-products",
+    "checkout",
+    "forms"
   ],
   "complexity": 3
 }

--- a/fixtures/websites/77-fernwood-plants/fixture.json
+++ b/fixtures/websites/77-fernwood-plants/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "ecommerce/catalog",
+  "fixture_class": "ecommerce/catalog",
   "tags": [
     "ecommerce",
     "plants",
@@ -11,6 +11,11 @@
     "mini-cart",
     "multipage",
     "localstorage"
+  ],
+  "capabilities": [
+    "commerce-products",
+    "checkout",
+    "forms"
   ],
   "complexity": 3
 }

--- a/fixtures/websites/78-terra-ceramics/fixture.json
+++ b/fixtures/websites/78-terra-ceramics/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "ecommerce/catalog",
+  "fixture_class": "ecommerce/catalog",
   "tags": [
     "ecommerce",
     "ceramics",
@@ -11,6 +11,11 @@
     "mini-cart",
     "multipage",
     "localstorage"
+  ],
+  "capabilities": [
+    "commerce-products",
+    "checkout",
+    "forms"
   ],
   "complexity": 3
 }

--- a/fixtures/websites/8-local-service-business/fixture.json
+++ b/fixtures/websites/8-local-service-business/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "local-business",
     "services",

--- a/fixtures/websites/9-membership-community/fixture.json
+++ b/fixtures/websites/9-membership-community/fixture.json
@@ -1,5 +1,5 @@
 {
-  "class": "marketing/static",
+  "fixture_class": "marketing/static",
   "tags": [
     "membership",
     "community",


### PR DESCRIPTION
## What

- Normalizes the legacy `class` manifest key to `fixture_class` across all 76 manifests still using the alias (values preserved byte-for-byte; 30-cursed-pangolin-fanwiki already used the new key).
- Reclassifies the five store-style fixtures 74-78 (lumen-coffee, inkwell-books, sole-society, fernwood-plants, terra-ceramics) as `ecommerce/catalog` with reviewed capabilities `[commerce-products, checkout, forms]` — each verified by reading the fixture HTML/JS: product grids with prices, add-to-cart flows, cart drawers/pages with checkout buttons, newsletter/signup forms.
- Deliberately NOT reclassified after review: 13-realistic-small-business (price display, no purchase path), 2-onepager-coffee (menu, not catalog), 39-old-internet-cms (call-to-confirm rental list), 42-immersive-product-launch (single-product reservation funnel).
- Builds on #494 (19/20 capabilities).

## Why

Manifests are the sole source of truth for SSI matrix lanes and capability-driven dependency provisioning (static-site-importer#547). The `ecommerce/catalog` lane now selects exactly 7 fixtures and each will get real WooCommerce provisioning + product seeding in the sandbox.

## Verification

All manifests parse; matrix discovery: 77 fixtures, 77 known classes, 0 unknown; `--class ecommerce/catalog` lane selects exactly the 7 judged fixtures.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 (claude-fable-5) via opencode, orchestrated agent workflow
- **Used for:** Manifest inventory, per-fixture HTML review and classification judgments, normalization, lane verification. Reviewed by Chris Huber.