### PR TITLE
Fix outline button style fidelity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -554,6 +554,7 @@ final class BlockFactory
         $typographyMap = array(
             'fontSize'      => 'font-size',
             'fontWeight'    => 'font-weight',
+            'letterSpacing' => 'letter-spacing',
             'lineHeight'    => 'line-height',
             'textTransform' => 'text-transform',
         );

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonStyleResolver.php
@@ -34,7 +34,7 @@ final class ButtonStyleResolver
     /**
      * Typography supports projected onto buttons, in canonical emission order.
      */
-    private const BUTTON_TYPOGRAPHY = array( 'fontSize', 'fontWeight', 'lineHeight', 'textTransform' );
+    private const BUTTON_TYPOGRAPHY = array( 'fontSize', 'fontWeight', 'letterSpacing', 'lineHeight', 'textTransform' );
 
     private readonly StyleAttributeMapper $mapper;
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -203,8 +203,9 @@ final class ButtonsPattern
         // produces an unsupported attribute and invalid block markup, so drop it.
         unset($attrs['layout']);
         $resolvedStyle = (string) $resolvedStyle($element);
-        if ( $this->hasOutlineSignal($element, $resolvedStyle) ) {
-            $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' is-style-outline');
+        $isOutline     = $this->hasOutlineSignal($element, $resolvedStyle);
+        if ( $isOutline ) {
+            $attrs['className'] = 'is-style-outline';
         }
 
         // Translate the resolved source CSS (inline style merged with the matched
@@ -217,7 +218,7 @@ final class ButtonsPattern
             $attrs = array_merge($attrs, $native);
         }
 
-        if ( $this->hasOutlineSignal($element, $resolvedStyle) ) {
+        if ( $isOutline ) {
             $attrs['style']['color']['background'] = 'transparent';
         }
 
@@ -247,7 +248,11 @@ final class ButtonsPattern
             return false;
         }
 
-        return preg_match('/(?:^|;)\s*background(?:-color)?\s*:\s*(?:transparent|none|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))/i', $normalized) === 1;
+        if ( ! preg_match('/(?:^|;)\s*background(?:-color)?\s*:\s*([^;]+)/i', $normalized, $matches) ) {
+            return true;
+        }
+
+        return preg_match('/^(?:transparent|none|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))\s*$/i', trim((string) ($matches[1] ?? ''))) === 1;
     }
 
     private function hasButtonSignal(DOMElement $anchor): bool

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -306,6 +306,7 @@ trait StyleResolutionTrait
             'flex-wrap',
             'font-size',
             'font-weight',
+            'letter-spacing',
             'gap',
             'grid-template-columns',
             'grid-template-rows',

--- a/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "cta ghost-link is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button cta ghost-link is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:currentColor;border-style:solid;border-width:2px;border-radius:8px;color:#135e96;background-color:transparent;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px;font-weight:600;text-transform:none" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "btn btn-ghost is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-ghost is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-color:#135e96;border-style:solid;border-width:2px;border-radius:8px;color:#135e96;background-color:transparent;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json
@@ -1,0 +1,30 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-style-fidelity-outline-split-css",
+  "description": "Outlined CTA buttons with border shorthand on a base class and color on variant classes resolve to native transparent core/button styles without preserving source chrome classes on the wrapper.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json",
+    "notes": "Covers generic bordered/no-fill CTA CSS split across base and variant classes, matching the Mara Vale hero button shape."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New native outline button style-fidelity behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<!doctype html><html><head><style>:root{--ember:#b8552a;--bone:#e6d8c5}.cta-row{display:flex;gap:1rem}.btn{display:inline-flex;padding:.8rem 1.8rem;font-size:.7rem;letter-spacing:.16em;text-transform:uppercase;border:1px solid}.btn-primary{border-color:var(--ember);color:var(--bone)}</style></head><body><main><div class=\"cta-row\"><a href=\"/music\" class=\"btn btn-primary\"><span>Listen Now</span></a><a href=\"/tour\" class=\"btn btn-primary\"><span>Tour Dates</span></a></div></main></body></html>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Listen Now", "url": "/music", "className": "is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Tour Dates", "url": "/tour", "className": "is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button\" style=\"border-color:var(--ember);border-style:solid;border-width:1px;color:var(--bone);background-color:transparent;padding-top:.8rem;padding-right:1.8rem;padding-bottom:.8rem;padding-left:1.8rem;font-size:.7rem;letter-spacing:.16em;text-transform:uppercase\" href=\"/music\">Listen Now</a></div>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp-block-button btn btn-primary" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button btn btn-primary" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Book now", "url": "/book", "className": "primary", "style": { "color": { "background": "#2563eb", "text": "#fff" }, "border": { "width": "2px", "style": "solid", "color": "#2563eb", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "secondary is-style-outline", "style": { "color": { "text": "#2563eb", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#2563eb", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
@@ -26,7 +26,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button primary\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:#2563eb;border-style:solid;border-width:2px;border-radius:999px;color:#fff;background-color:#2563eb;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button secondary is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:currentColor;border-style:solid;border-width:2px;border-radius:999px;color:#2563eb;background-color:transparent;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700" }
   ]
 }


### PR DESCRIPTION
## Summary
- Treat bordered buttons with no paintable background as outline buttons in the PHP transformer.
- Emit `background:transparent` on the `core/button` link for outline buttons.
- Keep `is-style-outline` on the wrapper while suppressing source CSS classes from outline button wrappers, so linked source CSS cannot paint a second outer button.
- Preserve letter-spacing through style resolution.

## Before / after emitted markup story
Before this change, the outer `.wp-block-button` wrapper could carry source classes like `.btn` while the inner `core/button` link received theme/button chrome. When the linked source CSS also targeted those `.btn` classes, it painted the wrapper as a second button around the already-themed inner link, producing double-chrome.

After this change, outline buttons keep the semantic Gutenberg wrapper style (`is-style-outline`) but do not carry the source CSS classes on that wrapper. The inner link receives the intended transparent outline styling, so the source stylesheet cannot paint an additional outer button shell.

## Why this is generic
The behavior keys off resolved CSS declarations: border presence, paintable background state, and resolved text styling. It does not special-case the new fixture or any source-site class names.

## Evidence
- `php tests/parity/run.php` passes: 213 fixtures.
- `php tests/contract/run.php` passes: canonical block style attributes, HTML-to-blocks, and format bridge scaffold contracts.
- In a controlled SSI fixture-matrix run, `3-artist-music` visual mismatch improved from `0.9939` to `0.1471` when combined with the SSI-side fix; button double-chrome was visually eliminated in candidate screenshots.

## Compatibility
Existing consumers or extension paths that relied on source CSS classes appearing on outline button wrappers will see those classes suppressed for outline buttons. The wrapper still carries `is-style-outline`, and the source class suppression is intentional to prevent linked source CSS from painting the wrapper as a second button.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause trace of button double-chrome, fix design, parity fixtures