### PR TITLE
Preserve structured inline chrome classes

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1494,7 +1494,7 @@ final class HtmlTransformer
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->outerHtml($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
                 fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
             );
             if ( null !== $logo ) {
@@ -1719,7 +1719,7 @@ final class HtmlTransformer
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->outerHtml($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
                 fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
             );
             if ( null !== $logo ) {
@@ -2607,6 +2607,11 @@ final class HtmlTransformer
             return null;
         }
 
+        $structuredInlineItems = $this->structuredInlineItemBlocks($element);
+        if ( null !== $structuredInlineItems ) {
+            return $this->createBlock('core/group', $this->presentationAttributes($element), $structuredInlineItems, $element);
+        }
+
         $content = $this->innerHtml($element);
         if ( '' === trim($this->runtime->stripAllTags($content)) ) {
             return null;
@@ -2645,6 +2650,54 @@ final class HtmlTransformer
         }
 
         return $nonAnchorText;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function structuredInlineItemBlocks(DOMElement $element): ?array
+    {
+        $blocks = array();
+
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType ) {
+                if ( '' !== trim($child->textContent ?? '') ) {
+                    return null;
+                }
+                continue;
+            }
+
+            if ( XML_COMMENT_NODE === $child->nodeType ) {
+                continue;
+            }
+
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( ! $this->isClassedPhrasingItem($child) ) {
+                return null;
+            }
+
+            $content = $this->innerHtml($child);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            $blocks[] = $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($child), array( 'content' => $content )), array(), $child);
+        }
+
+        return 1 < count($blocks) ? $blocks : null;
+    }
+
+    private function isClassedPhrasingItem(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( 'br' === $tagName || ( 'a' !== $tagName && ! $this->isInlineContentElement($tagName) ) ) {
+            return false;
+        }
+
+        return '' !== trim($this->attr($element, 'class')) || '' !== trim($this->attr($element, 'style'));
     }
 
     private function dynamicTextContent(DOMElement $element): ?string

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -25,6 +25,10 @@ final class LogoPattern
             return null;
         }
 
+        if ( 'a' === $tagName && $this->hasStructuredAnchorChrome($element) ) {
+            return $createBlock('core/html', array( 'content' => $outerHtml($element) ), array(), $element);
+        }
+
         $content = 'a' === $tagName ? $this->anchorLogoContent($element, $innerHtml($element)) : $this->logoLabelHtml($innerHtml($element));
         if ( '' === trim($content) ) {
             return null;
@@ -176,6 +180,44 @@ final class LogoPattern
             }
 
             if ( $this->containsBlockContent($child) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasStructuredAnchorChrome(DOMElement $anchor): bool
+    {
+        if ( '' === trim($anchor->getAttribute('class')) ) {
+            return false;
+        }
+
+        foreach ( $anchor->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( '' !== trim($child->getAttribute('class')) || $this->descendantHasClassedInlineChrome($child) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function descendantHasClassedInlineChrome(DOMElement $element): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            if ( '' !== trim($child->getAttribute('class')) ) {
+                return true;
+            }
+
+            if ( $this->descendantHasClassedInlineChrome($child) ) {
                 return true;
             }
         }

--- a/php-transformer/tests/fixtures/parity/html-structured-inline-chrome-class-preservation.json
+++ b/php-transformer/tests/fixtures/parity/html-structured-inline-chrome-class-preservation.json
@@ -1,0 +1,44 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-structured-inline-chrome-class-preservation",
+  "description": "Preserves class-targeted logo anchors and segmented inline chrome instead of flattening them into unstyled paragraph text.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-structured-inline-chrome-class-preservation.json",
+    "notes": "Covers generic source-CSS selectors that require classes on anchor/span-like chrome rather than only the parent block."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<nav class=\"nav\"><a href=\"#home\" class=\"brand-logo\" aria-label=\"Home\"><span class=\"brand-mark\" aria-hidden=\"true\"><svg viewBox=\"0 0 10 10\"><circle cx=\"5\" cy=\"5\" r=\"4\"></circle></svg></span><span><span class=\"brand-name\">Roasters</span><span class=\"brand-sub\">Est. 2018</span></span></a><ul class=\"nav-links\"><li><a href=\"#menu\">Menu</a></li><li><a href=\"#contact\">Contact</a></li></ul><button class=\"nav-toggle\" aria-label=\"Open navigation\"><span></span><span></span></button></nav><div class=\"ticker-band\"><div class=\"ticker-track\"><span class=\"ticker-item\">Small Batch</span><span class=\"ticker-item ticker-dot\">•</span><span class=\"ticker-item\">Direct Trade</span></div></div><article class=\"menu-card\"><div class=\"card-footer\"><span class=\"card-tag\">Espresso</span><span class=\"card-price\">$4.50</span></div></article>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "nav" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/html" },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "nav-links" } },
+    { "path": "blocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "ticker-track" } },
+    { "path": "blocks.1.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "ticker-item" } },
+    { "path": "blocks.2.innerBlocks.0", "name": "core/group", "attrs": { "className": "card-footer" } },
+    { "path": "blocks.2.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "card-tag" } },
+    { "path": "blocks.2.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "card-price" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"brand-logo\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"brand-name\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "viewBox=\"0 0 10 10\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-group ticker-track" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"ticker-item\">Small Batch</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"ticker-item ticker-dot\">•</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-group card-footer" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"card-tag\">Espresso</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"card-price\">$4.50</p>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "Small Batch•Direct Trade" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## What
Preserves source classes on structured inline chrome, including logo/navigation-style phrasing wrappers, instead of flattening styled chrome down to generic underlined text. Adds the parity fixture `html-structured-inline-chrome-class-preservation.json`.

## Root cause
The PHP transformer was discarding class-bearing inline chrome while decomposing phrasing content and logo-like text. Source markup that carried styling hooks for logo/nav regions was emitted without the wrapper/class structure needed for downstream CSS to match.

## Visual evidence
Fixture-matrix full-page runs on `2-onepager-coffee` and `3-artist-music` show the header/logo/nav region improving from plain underlined text to the styled logo/navigation chrome confirmed in the source visual reference.

## Extension/backward compatibility
This changes emitted markup by preserving additional inline wrapper classes in chrome regions. Consumers that depended on the previous flattened, class-stripped header/logo markup may see extra class-bearing inline elements and should treat them as fidelity-preserving source structure.

## Stacking / merge order
PR #500 is merged into `trunk` (`b3f541a`), so this branch is independent and targets `trunk` directly. Suggested review/merge order for this batch: 1. this PR, 2. SVG layout context, 3. rich text line segments, 4. row layout fidelity.

## Tests
From `php-transformer/`:
- `php tests/parity/run.php` — passed, 214 fixtures
- `php tests/contract/run.php` — passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause via fixture-matrix visual-parity evidence, fix design, parity fixtures