### PR TITLE
Keep conditional CSS out of static block styles

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -258,6 +258,7 @@ trait StyleResolutionTrait
         }
 
         $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
+        $css = $this->stripConditionalCssAtRules($css);
         $rules = array();
         if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
             return array();
@@ -280,6 +281,51 @@ trait StyleResolutionTrait
         }
 
         return array_slice($rules, 0, 200);
+    }
+
+    /**
+     * Remove conditional at-rules before applying the lightweight top-level CSS
+     * rule parser. The transformer has no viewport/container context, so folding
+     * responsive rules into static block attributes makes mobile declarations
+     * unconditional on desktop imports.
+     */
+    private function stripConditionalCssAtRules(string $css): string
+    {
+        $length = strlen($css);
+        $output = '';
+        for ( $index = 0; $index < $length; ) {
+            if ( '@' !== $css[$index] ) {
+                $output .= $css[$index];
+                ++$index;
+                continue;
+            }
+
+            if ( ! preg_match('/\G@(media|supports|container)\b/i', $css, $match, 0, $index) ) {
+                $output .= $css[$index];
+                ++$index;
+                continue;
+            }
+
+            $brace = strpos($css, '{', $index);
+            if ( false === $brace ) {
+                break;
+            }
+
+            $depth = 1;
+            $cursor = $brace + 1;
+            while ( $cursor < $length && $depth > 0 ) {
+                if ( '{' === $css[$cursor] ) {
+                    ++$depth;
+                } elseif ( '}' === $css[$cursor] ) {
+                    --$depth;
+                }
+                ++$cursor;
+            }
+
+            $index = $cursor;
+        }
+
+        return $output;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -258,7 +258,7 @@ trait StyleResolutionTrait
         }
 
         $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
-        $css = $this->stripConditionalCssAtRules($css);
+        $css = $this->topLevelCssRules($css);
         $rules = array();
         if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
             return array();
@@ -283,49 +283,110 @@ trait StyleResolutionTrait
         return array_slice($rules, 0, 200);
     }
 
-    /**
-     * Remove conditional at-rules before applying the lightweight top-level CSS
-     * rule parser. The transformer has no viewport/container context, so folding
-     * responsive rules into static block attributes makes mobile declarations
-     * unconditional on desktop imports.
-     */
-    private function stripConditionalCssAtRules(string $css): string
+    private function topLevelCssRules(string $css): string
     {
-        $length = strlen($css);
         $output = '';
-        for ( $index = 0; $index < $length; ) {
-            if ( '@' !== $css[$index] ) {
-                $output .= $css[$index];
-                ++$index;
+        $length = strlen($css);
+        $depth = 0;
+
+        for ( $offset = 0; $offset < $length; ++$offset ) {
+            $char = $css[$offset];
+
+            if ( '"' === $char || "'" === $char ) {
+                $output .= $char;
+                for ( ++$offset; $offset < $length; ++$offset ) {
+                    $output .= $css[$offset];
+                    if ( '\\' === $css[$offset] ) {
+                        if ( $offset + 1 < $length ) {
+                            ++$offset;
+                            $output .= $css[$offset];
+                        }
+                        continue;
+                    }
+                    if ( $char === $css[$offset] ) {
+                        break;
+                    }
+                }
                 continue;
             }
 
-            if ( ! preg_match('/\G@(media|supports|container)\b/i', $css, $match, 0, $index) ) {
-                $output .= $css[$index];
-                ++$index;
-                continue;
-            }
-
-            $brace = strpos($css, '{', $index);
-            if ( false === $brace ) {
-                break;
-            }
-
-            $depth = 1;
-            $cursor = $brace + 1;
-            while ( $cursor < $length && $depth > 0 ) {
-                if ( '{' === $css[$cursor] ) {
+            if ( 0 !== $depth || '@' !== $char ) {
+                if ( '{' === $char ) {
                     ++$depth;
-                } elseif ( '}' === $css[$cursor] ) {
+                } elseif ( '}' === $char && $depth > 0 ) {
                     --$depth;
                 }
-                ++$cursor;
+                $output .= $char;
+                continue;
             }
 
-            $index = $cursor;
+            $blockStart = $this->findCssToken($css, '{', $offset);
+            $statementEnd = $this->findCssToken($css, ';', $offset);
+            if ( null === $blockStart || ( null !== $statementEnd && $statementEnd < $blockStart ) ) {
+                if ( null === $statementEnd ) {
+                    break;
+                }
+                $offset = $statementEnd;
+                continue;
+            }
+
+            $atRuleDepth = 1;
+            for ( $innerOffset = $blockStart + 1; $innerOffset < $length; ++$innerOffset ) {
+                if ( '"' === $css[$innerOffset] || "'" === $css[$innerOffset] ) {
+                    $quote = $css[$innerOffset];
+                    for ( ++$innerOffset; $innerOffset < $length; ++$innerOffset ) {
+                        if ( '\\' === $css[$innerOffset] ) {
+                            ++$innerOffset;
+                            continue;
+                        }
+                        if ( $quote === $css[$innerOffset] ) {
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                if ( '{' === $css[$innerOffset] ) {
+                    ++$atRuleDepth;
+                    continue;
+                }
+                if ( '}' === $css[$innerOffset] ) {
+                    --$atRuleDepth;
+                    if ( 0 === $atRuleDepth ) {
+                        $offset = $innerOffset;
+                        continue 2;
+                    }
+                }
+            }
+
+            break;
         }
 
         return $output;
+    }
+
+    private function findCssToken(string $css, string $token, int $offset): ?int
+    {
+        $length = strlen($css);
+        for ( ; $offset < $length; ++$offset ) {
+            if ( '"' === $css[$offset] || "'" === $css[$offset] ) {
+                $quote = $css[$offset];
+                for ( ++$offset; $offset < $length; ++$offset ) {
+                    if ( '\\' === $css[$offset] ) {
+                        ++$offset;
+                        continue;
+                    }
+                    if ( $quote === $css[$offset] ) {
+                        break;
+                    }
+                }
+                continue;
+            }
+            if ( $token === $css[$offset] ) {
+                return $offset;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-class-layout-media-rule-contained.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-class-layout-media-rule-contained.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-class-layout-media-rule-contained",
+  "description": "Class-owned desktop layout around a preserved inline SVG does not inherit mobile @media declarations as unconditional block styles.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-class-layout-media-rule-contained.json",
+    "notes": "Regression guard for class-owned SVG layout context: conditional CSS rules are viewport-bound and must not be folded into static desktop block attributes without a matching viewport."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<style>.release-grid{display:grid;grid-template-columns:260px 1fr;gap:5rem}.cover-wrap{position:relative}.ep-cover{width:100%;aspect-ratio:1;display:block}@media (max-width: 768px){.release-grid{grid-template-columns:1fr;gap:2rem}.cover-wrap{max-width:220px;margin:0 auto}.ep-cover{max-width:220px}}</style><main><section class=\"release-grid\"><div class=\"cover-wrap\"><svg class=\"ep-cover\" viewBox=\"0 0 500 500\" role=\"img\" aria-label=\"EP cover\"><defs><linearGradient id=\"paint\"><stop offset=\"0%\" stop-color=\"currentColor\"></stop><stop offset=\"100%\" stop-color=\"#b8552a\"></stop></linearGradient></defs><rect width=\"500\" height=\"500\" fill=\"url(#paint)\"></rect></svg></div><div><h2>Between the Fog</h2><p>New EP.</p></div></section></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "release-grid" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "cover-wrap" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/html" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-group release-grid\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-group cover-wrap\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<svg class=\"ep-cover\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "margin-right:auto" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "max-width:220px" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-media-query-rules-not-inlined-desktop.json
+++ b/php-transformer/tests/fixtures/parity/html-media-query-rules-not-inlined-desktop.json
@@ -1,0 +1,25 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-media-query-rules-not-inlined-desktop",
+  "description": "Keeps responsive-only CSS rules out of unconditional block inline styles so desktop source spacing is not overwritten by mobile declarations.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-media-query-rules-not-inlined-desktop.json",
+    "notes": "Regression coverage for static style extraction applying nested @media rules unconditionally."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers upstream static CSS extraction behavior with no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<!doctype html><html><head><style>.hero-title{font-size:clamp(5rem, 13vw, 13rem);line-height:0.92}@media (max-width: 768px){.hero-title{font-size:clamp(4rem, 18vw, 7rem)}}@supports (display: grid){.hero-title{letter-spacing:-0.04em}}</style></head><body><section class=\"hero\"><h1 class=\"hero-title\">Mara<br>Vale</h1></section></body></html>"
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "font-size:clamp(5rem, 13vw, 13rem)" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "line-height:0.92" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "font-size:clamp(4rem, 18vw, 7rem)" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "letter-spacing:-0.04em" }
+  ]
+}


### PR DESCRIPTION
## What
Keeps top-level CSS at-rules out of static block style materialization so responsive/conditional CSS is not folded into unconditional inline block styles. This uses the quote-aware `topLevelCssRules()` / `findCssToken()` scanner, which strips block at-rules such as `@media`, `@supports`, `@container`, `@keyframes`, plus statement at-rules such as `@import`, before the lightweight static-rule extractor runs.

This now carries both regression fixtures:
- `html-inline-svg-class-layout-media-rule-contained.json` for the inline-SVG/layout media-rule containment case.
- `html-media-query-rules-not-inlined-desktop.json` for the hero vertical-offset regression where mobile font-size and `@supports` declarations leaked into desktop static styles.

## Root cause
Style resolution was treating declarations inside top-level at-rules as if they were unconditional static declarations. That let responsive/mobile declarations escape their conditional context, including layout declarations around preserved inline SVG regions and mobile hero typography that shifted desktop vertical positioning.

## Visual evidence
Fixture-matrix full-page runs on `2-onepager-coffee` and `3-artist-music` show corrected layout context: conditional class styles no longer leak into static block styles, preventing the page-height drift/regional layout shifts seen before this fix.

The added hero fixture covers the same primitive from the desktop typography side: the desktop `font-size:clamp(5rem, 13vw, 13rem)` remains materialized while the mobile `@media` font-size and `@supports` letter-spacing are not emitted as unconditional block styles.

## Extension/backward compatibility
This changes emitted style materialization by excluding top-level at-rule declarations from static block styles. Consumers that previously read leaked conditional declarations from emitted inline/static styles should instead rely on the original conditional CSS context.

## Stacking / merge order
PR #500 is merged into `trunk` (`b3f541a`), so this branch is independent and targets `trunk` directly. This PR now also owns the hero vertical-offset fix from `fix/hero-vertical-offset`; do not open or merge that branch separately.

Suggested review/merge order for this batch: 1. structured inline chrome classes (#501), 2. this PR, 3. rich text line segments, 4. row layout fidelity.

## Tests
From `php-transformer/`:
- `php tests/parity/run.php` — passed, 215 fixtures
- `php tests/contract/run.php` — passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause via fixture-matrix visual-parity evidence, fix design, parity fixtures
