### PR TITLE
Preserve styled rich text line segments

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1159,7 +1159,7 @@ final class HtmlTransformer
         }
 
         if ( preg_match('/^h([1-6])$/', $tagName, $matches) ) {
-            $content = $this->innerHtml($element);
+            $content = $this->richTextContentWithMaterializedInlineStyles($element);
             if ( $this->richTextRequiresHtmlFallback($content) ) {
                 return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($this->outerHtml($element)) ), array(), $element);
             }
@@ -1174,7 +1174,7 @@ final class HtmlTransformer
         }
 
         if ( 'p' === $tagName ) {
-            $content = $this->innerHtml($element);
+            $content = $this->richTextContentWithMaterializedInlineStyles($element);
             if ( $this->richTextRequiresHtmlFallback($content) ) {
                 return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($this->outerHtml($element)) ), array(), $element);
             }
@@ -1190,7 +1190,7 @@ final class HtmlTransformer
         }
 
         if ( 'address' === $tagName ) {
-            $content = $this->innerHtml($element);
+            $content = $this->richTextContentWithMaterializedInlineStyles($element);
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
                 return null;
             }
@@ -2056,9 +2056,12 @@ final class HtmlTransformer
             $anchor->removeAttribute('style');
         }
 
-        // Unwrap any remaining styling-hook spans (sibling / partial content):
-        // best-effort, the class styling is not representable as valid RichText.
+        // Unwrap any remaining styling-hook spans (sibling / partial content)
+        // unless their visual style can be carried by RichText's mark format.
         foreach ( $this->stylingHookSpans($body) as $span ) {
+            if ( $this->replaceSpanWithRichTextMark($span) ) {
+                continue;
+            }
             $this->unwrapElement($span);
         }
 
@@ -2182,6 +2185,117 @@ final class HtmlTransformer
     private function richTextRequiresHtmlFallback(string $content): bool
     {
         return (bool) preg_match('/<(?:svg|canvas|img|picture|video|audio|iframe|object|embed|input|button|select|textarea|form)\b/i', $content);
+    }
+
+    private function richTextContentWithMaterializedInlineStyles(DOMElement $element): string
+    {
+        $content = $this->innerHtml($element);
+        if ( '' === $content || ! preg_match('/<span\b/i', $content) ) {
+            return $content;
+        }
+
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $content . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
+        if ( ! $body instanceof DOMElement ) {
+            return $content;
+        }
+
+        $sourceSpans = array();
+        foreach ( $element->getElementsByTagName('span') as $sourceSpan ) {
+            if ( $sourceSpan instanceof DOMElement ) {
+                $sourceSpans[] = $sourceSpan;
+            }
+        }
+
+        $targetSpans = array();
+        foreach ( $body->getElementsByTagName('span') as $targetSpan ) {
+            if ( $targetSpan instanceof DOMElement ) {
+                $targetSpans[] = $targetSpan;
+            }
+        }
+
+        foreach ( $targetSpans as $index => $targetSpan ) {
+            $sourceSpan = $sourceSpans[$index] ?? null;
+            if ( ! $sourceSpan instanceof DOMElement || ! $this->isStylingHookSpan($sourceSpan) ) {
+                continue;
+            }
+
+            $inline = $this->richTextInlineVisualDeclarations($sourceSpan);
+            if ( array() === $inline ) {
+                continue;
+            }
+
+            $existing = $this->cssDeclarations($this->attr($targetSpan, 'style'));
+            $targetSpan->setAttribute('style', $this->cssDeclarationString(array_merge($inline, $existing)));
+        }
+
+        return $this->innerHtml($body);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function richTextInlineVisualDeclarations(DOMElement $element): array
+    {
+        $allowed = array_flip(array(
+            'background-color',
+            'color',
+            'display',
+            'font-size',
+            'font-style',
+            'font-weight',
+            'letter-spacing',
+            'line-height',
+            'text-decoration',
+            'text-transform',
+        ));
+
+        $declarations = array();
+        foreach ( $this->staticStyleRules as $rule ) {
+            if ( $this->matchesCssSelector($element, $rule['selector']) ) {
+                $declarations = array_merge($declarations, $rule['declarations']);
+            }
+        }
+        $declarations = array_merge($declarations, $this->cssDeclarations($this->attr($element, 'style')));
+
+        return array_intersect_key($declarations, $allowed);
+    }
+
+    private function replaceSpanWithRichTextMark(DOMElement $span): bool
+    {
+        $declarations = $this->richTextInlineVisualDeclarations($span);
+        $hasUsefulInlineStyle = isset($declarations['color']) || isset($declarations['background-color']) || 'block' === strtolower(trim((string) ($declarations['display'] ?? '')));
+        if ( ! $hasUsefulInlineStyle ) {
+            return false;
+        }
+
+        if ( isset($declarations['color']) && ! isset($declarations['background-color']) ) {
+            $declarations['background-color'] = 'transparent';
+        }
+
+        $document = $span->ownerDocument;
+        if ( ! $document instanceof DOMDocument ) {
+            return false;
+        }
+
+        $mark = $document->createElement('mark');
+        $mark->setAttribute('style', $this->cssDeclarationString($declarations));
+        while ( null !== $span->firstChild ) {
+            $mark->appendChild($span->firstChild);
+        }
+
+        $parent = $span->parentNode;
+        if ( ! $parent instanceof DOMNode ) {
+            return false;
+        }
+
+        $parent->replaceChild($mark, $span);
+        return true;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-richtext-partial-span-visual-mark.json
+++ b/php-transformer/tests/fixtures/parity/html-richtext-partial-span-visual-mark.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-richtext-partial-span-visual-mark",
+  "description": "Carries visual styles from a partial classed RichText span by materializing supported CSS into a mark format instead of dropping the styling hook entirely.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-richtext-partial-span-visual-mark.json",
+    "notes": "Generic RichText fidelity coverage for headings with styled line segments where class hooks are not safe to keep in RichText content."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers WordPress block-validity normalization beyond the legacy converter behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<!doctype html><html><head><style>.hero-title{font-size:clamp(3rem,10vw,8rem);line-height:.9;color:#fff}.hero-title .accent{display:block;color:#b8893a}</style></head><body><h1 class=\"hero-title\">Driftwood <span class=\"accent\">Roasters</span></h1></body></html>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/heading", "attrs": { "level": 1, "className": "hero-title", "style": { "typography": { "fontSize": "clamp(3rem,10vw,8rem)", "lineHeight": ".9" }, "color": { "text": "#fff" } } } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<mark style=\"display:block;color:#b8893a;background-color:transparent\">Roasters</mark>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "class=\"accent\"" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## What
Preserves partially styled inline rich text segments by emitting visual `mark` spans where source spans carry segment-specific styling. Adds the parity fixture `html-richtext-partial-span-visual-mark.json`.

## Root cause
RichText emission collapsed partially styled child spans into a single text run, losing segment-level visual styling such as the gold headline line/phrase treatment. The emitted markup no longer had a target for the source CSS, so hero typography metrics drifted.

## Visual evidence
Fixture-matrix full-page runs on `2-onepager-coffee` and `3-artist-music` show the styled headline segment restored, including the gold line/segment treatment and page-height drift correction from roughly `+36px` to `-5px` in the measured full-page comparison.

## Extension/backward compatibility
This changes emitted rich text markup by preserving styled partial spans as `mark` elements. Consumers that assumed those spans were flattened into plain text may need to account for preserved inline visual markup.

## Stacking / merge order
PR #500 is merged into `trunk` (`b3f541a`), so this branch is independent and targets `trunk` directly. Suggested review/merge order for this batch: 1. structured inline chrome classes (#501), 2. SVG layout context (#502), 3. this PR, 4. row layout fidelity.

## Tests
From `php-transformer/`:
- `php tests/parity/run.php` — passed, 214 fixtures
- `php tests/contract/run.php` — passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause via fixture-matrix visual-parity evidence, fix design, parity fixtures