### PR TITLE
Preserve source CSS row layout fidelity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -114,8 +114,7 @@ final class ColumnsPattern
             || ( $this->looksLikeSplitLayout($element) && 2 === $this->directElementChildCount($element) )
             || ( $this->looksLikeDocumentationLayout($element) && $this->hasSidebarAndContentChildren($element) )
             || $this->hasSidebarAndContentChildren($element)
-            || preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?flex/', $inlineStyle)
-            || ( 2 < $this->directElementChildCount($element) && preg_match('/(?:^|;)\s*grid-template-columns\s*:/', $style) );
+            || preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?flex/', $inlineStyle);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -221,6 +221,10 @@ trait StyleResolutionTrait
             return true;
         }
 
+        if ( 'li' === $tagName && $this->hasMultipleStyledInlineChildren($element) ) {
+            return true;
+        }
+
         $tokens = strtolower(trim(implode(' ', array(
             $this->attr($element, 'class'),
             $this->attr($element, 'id'),
@@ -241,6 +245,27 @@ trait StyleResolutionTrait
         }
 
         return false;
+    }
+
+    private function hasMultipleStyledInlineChildren(DOMElement $element): bool
+    {
+        $styledInlineChildren = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( 'br' !== $tagName && ! $this->isInlineContentElement($tagName) ) {
+                continue;
+            }
+
+            if ( '' !== trim($this->attr($child, 'class')) || '' !== trim($this->attr($child, 'style')) ) {
+                ++$styledInlineChildren;
+            }
+        }
+
+        return $styledInlineChildren >= 2;
     }
 
     /**
@@ -374,7 +399,7 @@ trait StyleResolutionTrait
         }
 
         foreach ( preg_split('/\s+/', $selector) ?: array() as $part ) {
-            if ( ! preg_match('/^(?:[a-z][a-z0-9_-]*)?(?:\.[A-Za-z0-9_-]+)+$|^\.[A-Za-z0-9_-]+$/i', $part) ) {
+            if ( ! preg_match('/^(?:[a-z][a-z0-9_-]*)?(?:\.[A-Za-z0-9_-]+)+$|^\.[A-Za-z0-9_-]+$|^[a-z][a-z0-9_-]*$/i', $part) ) {
                 return false;
             }
         }
@@ -435,7 +460,11 @@ trait StyleResolutionTrait
 
     private function matchesCssSelectorPart(DOMElement $element, string $selector): bool
     {
-        if ( ! preg_match('/^(?:(?<tag>[a-z][a-z0-9_-]*))?(?<classes>(?:\.[A-Za-z0-9_-]+)+)$/i', $selector, $match) ) {
+        if ( ! preg_match('/^(?:(?<tag>[a-z][a-z0-9_-]*))?(?<classes>(?:\.[A-Za-z0-9_-]+)*)$/i', $selector, $match) ) {
+            return false;
+        }
+
+        if ( empty($match['tag']) && empty($match['classes']) ) {
             return false;
         }
 
@@ -443,7 +472,7 @@ trait StyleResolutionTrait
             return false;
         }
 
-        $classes = preg_split('/\./', ltrim((string) $match['classes'], '.')) ?: array();
+        $classes = preg_split('/\./', ltrim((string) ($match['classes'] ?? ''), '.')) ?: array();
         $elementClasses = preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array();
         foreach ( $classes as $class ) {
             if ( ! in_array($class, $elementClasses, true) ) {
@@ -518,7 +547,7 @@ trait StyleResolutionTrait
         if ( preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $style)
             && ! preg_match('/(?:^|;)\s*flex-direction\s*:\s*column(?:-reverse)?\b/', $style)
         ) {
-            if ( ! preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $inlineStyle) ) {
+            if ( ! preg_match('/(?:^|;)\s*display\s*:\s*(inline-)?flex\b/', $inlineStyle) && $this->hasOwnStyleHook($element) ) {
                 return array();
             }
 
@@ -547,6 +576,11 @@ trait StyleResolutionTrait
         }
 
         return array();
+    }
+
+    private function hasOwnStyleHook(DOMElement $element): bool
+    {
+        return '' !== trim($this->attr($element, 'class')) || '' !== trim($this->attr($element, 'id'));
     }
 
     private function layoutJustifyContent(string $value): string

--- a/php-transformer/tests/fixtures/parity/html-css-grid-row-stays-transparent-group.json
+++ b/php-transformer/tests/fixtures/parity/html-css-grid-row-stays-transparent-group.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-css-grid-row-stays-transparent-group",
+  "description": "Keeps arbitrary source CSS-grid rows as transparent groups instead of inserting core/column wrappers that break direct-child layout selectors.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-css-grid-row-stays-transparent-group.json",
+    "notes": "Product-neutral fixture for schedule/list rows that use grid-template-columns for direct children but are not semantic column sections."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div class=\"event-row\" style=\"display:grid;grid-template-columns:90px 1fr auto;align-items:center;gap:2rem;padding:1.5rem 0\"><div class=\"date\">Mar 8</div><div class=\"venue\">The Moth House</div><a class=\"btn\" href=\"/tickets\">Tickets</a></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "event-row" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "date" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "venue" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/buttons" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"event-row\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:columns" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-structured-list-descendant-css-row-styles.json
+++ b/php-transformer/tests/fixtures/parity/html-structured-list-descendant-css-row-styles.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-structured-list-descendant-css-row-styles",
+  "description": "Resolves class-scoped tag descendant CSS such as .tracklist li onto decomposed structured list rows so source row spacing/layout survives native block conversion.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-structured-list-descendant-css-row-styles.json",
+    "notes": "Product-neutral fixture for track lists, schedules, and metadata rows whose source CSS targets list items through a parent class."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<ul class=\"tracklist\"><li><span class=\"track-num\">01</span><span class=\"track-title\">Kindling</span><span class=\"track-dur\">3:42</span></li></ul>",
+    "options": {
+      "static_css": ".tracklist{list-style:none}.tracklist li{display:flex;align-items:baseline;gap:1.25rem;padding:0.9rem 0}.track-title{flex:1}"
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "tracklist" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "layout": { "type": "flex" } } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "track-num", "content": "01" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "className": "track-title", "content": "Kindling" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "className": "track-dur", "content": "3:42" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"layout\":{\"type\":\"flex\"}" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "padding-top:0.9rem" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"track-title\">Kindling</p>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## What
Preserves source CSS row layouts by guarding grid/columns conversion, keeping scoped tag descendant selectors, and retaining `li` row layout styling. Adds parity fixtures `html-css-grid-row-stays-transparent-group.json` and `html-structured-list-descendant-css-row-styles.json`.

## Root cause
The transformer over-converted some source row/grid/list structures into columns and dropped scoped descendant selectors such as list-row CSS. That stripped the emitted markup of the structure and scoped styles needed for album/menu/track/tour rows to match the source.

## Visual evidence
Fixture-matrix full-page runs on `2-onepager-coffee` and `3-artist-music` show the affected regions improving: segmented ticker/menu cards keep their styled row/card treatment, tracklist rows retain row styling, and tour rows are no longer incorrectly column-wrapped.

## Extension/backward compatibility
This changes emitted markup/style decisions for source row layouts: some structures that were previously converted into Columns blocks now remain transparent groups/list rows with scoped descendant CSS. Consumers depending on the old auto-column wrapping or dropped descendant selectors should verify their assumptions.

## Stacking / merge order
PR #500 is merged into `trunk` (`b3f541a`), so this branch is independent and targets `trunk` directly. Suggested review/merge order for this batch: 1. structured inline chrome classes (#501), 2. SVG layout context (#502), 3. rich text line segments (#503), 4. this PR.

## Tests
From `php-transformer/`:
- `php tests/parity/run.php` — passed, 215 fixtures
- `php tests/contract/run.php` — passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause via fixture-matrix visual-parity evidence, fix design, parity fixtures