### PR TITLE
Preserve inline color and navigation button fidelity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1493,7 +1493,7 @@ final class HtmlTransformer
             $logo = $this->logoPattern->match(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
                 fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
             );
@@ -2009,7 +2009,7 @@ final class HtmlTransformer
         }
 
         $content = (string) ($attrs['content'] ?? '');
-        if ( '' === $content || ! preg_match('/<(?:span|a)\b/i', $content) ) {
+        if ( '' === $content || ! preg_match('/<(?:span|a|em|i|strong|b|mark|small|sub|sup)\b/i', $content) ) {
             return $attrs;
         }
 
@@ -2051,18 +2051,20 @@ final class HtmlTransformer
             }
         }
 
+        // Unwrap any remaining styling hooks (sibling / partial content) unless
+        // their visual style can be carried by RichText's mark format.
+        foreach ( $this->richTextStylingHookElements($body) as $inline ) {
+            if ( $this->replaceRichTextStylingHookWithMark($inline) ) {
+                continue;
+            }
+            if ( 'span' === strtolower($inline->tagName) ) {
+                $this->unwrapElement($inline);
+            }
+        }
+
         foreach ( $this->richTextAnchors($body) as $anchor ) {
             $anchor->removeAttribute('class');
             $anchor->removeAttribute('style');
-        }
-
-        // Unwrap any remaining styling-hook spans (sibling / partial content)
-        // unless their visual style can be carried by RichText's mark format.
-        foreach ( $this->stylingHookSpans($body) as $span ) {
-            if ( $this->replaceSpanWithRichTextMark($span) ) {
-                continue;
-            }
-            $this->unwrapElement($span);
         }
 
         $newContent = $this->innerHtml($body);
@@ -2152,6 +2154,27 @@ final class HtmlTransformer
         return $hasStyling;
     }
 
+    private function isRichTextInlineStylingHookElement(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( 'span' === $tagName ) {
+            return $this->isStylingHookSpan($element);
+        }
+
+        if ( ! in_array($tagName, array( 'em', 'i', 'strong', 'b', 'mark', 'small', 'sub', 'sup' ), true) ) {
+            return false;
+        }
+
+        foreach ( $element->attributes ?? array() as $attribute ) {
+            $attributeName = strtolower($attribute->nodeName);
+            if ( 'class' !== $attributeName && 'style' !== $attributeName ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /**
      * @return array<int, DOMElement>
      */
@@ -2165,6 +2188,21 @@ final class HtmlTransformer
         }
 
         return $spans;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function richTextStylingHookElements(DOMElement $container): array
+    {
+        $elements = array();
+        foreach ( $container->getElementsByTagName('*') as $element ) {
+            if ( $element instanceof DOMElement && $this->isRichTextInlineStylingHookElement($element) ) {
+                $elements[] = $element;
+            }
+        }
+
+        return $elements;
     }
 
     /**
@@ -2190,7 +2228,7 @@ final class HtmlTransformer
     private function richTextContentWithMaterializedInlineStyles(DOMElement $element): string
     {
         $content = $this->innerHtml($element);
-        if ( '' === $content || ! preg_match('/<span\b/i', $content) ) {
+        if ( '' === $content || ! preg_match('/<(?:span|em|i|strong|b|mark|small|sub|sup)\b/i', $content) ) {
             return $content;
         }
 
@@ -2205,33 +2243,33 @@ final class HtmlTransformer
             return $content;
         }
 
-        $sourceSpans = array();
-        foreach ( $element->getElementsByTagName('span') as $sourceSpan ) {
-            if ( $sourceSpan instanceof DOMElement ) {
-                $sourceSpans[] = $sourceSpan;
+        $sourceInlines = array();
+        foreach ( $element->getElementsByTagName('*') as $sourceInline ) {
+            if ( $sourceInline instanceof DOMElement && $this->isRichTextInlineStylingHookElement($sourceInline) ) {
+                $sourceInlines[] = $sourceInline;
             }
         }
 
-        $targetSpans = array();
-        foreach ( $body->getElementsByTagName('span') as $targetSpan ) {
-            if ( $targetSpan instanceof DOMElement ) {
-                $targetSpans[] = $targetSpan;
+        $targetInlines = array();
+        foreach ( $body->getElementsByTagName('*') as $targetInline ) {
+            if ( $targetInline instanceof DOMElement && $this->isRichTextInlineStylingHookElement($targetInline) ) {
+                $targetInlines[] = $targetInline;
             }
         }
 
-        foreach ( $targetSpans as $index => $targetSpan ) {
-            $sourceSpan = $sourceSpans[$index] ?? null;
-            if ( ! $sourceSpan instanceof DOMElement || ! $this->isStylingHookSpan($sourceSpan) ) {
+        foreach ( $targetInlines as $index => $targetInline ) {
+            $sourceInline = $sourceInlines[$index] ?? null;
+            if ( ! $sourceInline instanceof DOMElement ) {
                 continue;
             }
 
-            $inline = $this->richTextInlineVisualDeclarations($sourceSpan);
+            $inline = $this->richTextInlineVisualDeclarations($sourceInline);
             if ( array() === $inline ) {
                 continue;
             }
 
-            $existing = $this->cssDeclarations($this->attr($targetSpan, 'style'));
-            $targetSpan->setAttribute('style', $this->cssDeclarationString(array_merge($inline, $existing)));
+            $existing = $this->cssDeclarations($this->attr($targetInline, 'style'));
+            $targetInline->setAttribute('style', $this->cssDeclarationString(array_merge($inline, $existing)));
         }
 
         return $this->innerHtml($body);
@@ -2266,9 +2304,9 @@ final class HtmlTransformer
         return array_intersect_key($declarations, $allowed);
     }
 
-    private function replaceSpanWithRichTextMark(DOMElement $span): bool
+    private function replaceRichTextStylingHookWithMark(DOMElement $element): bool
     {
-        $declarations = $this->richTextInlineVisualDeclarations($span);
+        $declarations = $this->richTextInlineVisualDeclarations($element);
         $hasUsefulInlineStyle = isset($declarations['color']) || isset($declarations['background-color']) || 'block' === strtolower(trim((string) ($declarations['display'] ?? '')));
         if ( ! $hasUsefulInlineStyle ) {
             return false;
@@ -2278,23 +2316,30 @@ final class HtmlTransformer
             $declarations['background-color'] = 'transparent';
         }
 
-        $document = $span->ownerDocument;
+        $document = $element->ownerDocument;
         if ( ! $document instanceof DOMDocument ) {
             return false;
         }
 
         $mark = $document->createElement('mark');
         $mark->setAttribute('style', $this->cssDeclarationString($declarations));
-        while ( null !== $span->firstChild ) {
-            $mark->appendChild($span->firstChild);
+        while ( null !== $element->firstChild ) {
+            $mark->appendChild($element->firstChild);
         }
 
-        $parent = $span->parentNode;
+        $parent = $element->parentNode;
         if ( ! $parent instanceof DOMNode ) {
             return false;
         }
 
-        $parent->replaceChild($mark, $span);
+        if ( in_array(strtolower($element->tagName), array( 'span', 'mark' ), true) ) {
+            $parent->replaceChild($mark, $element);
+            return true;
+        }
+
+        $element->removeAttribute('class');
+        $element->removeAttribute('style');
+        $element->appendChild($mark);
         return true;
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -205,7 +205,7 @@ final class ButtonsPattern
         $resolvedStyle = (string) $resolvedStyle($element);
         $isOutline     = $this->hasOutlineSignal($element, $resolvedStyle);
         if ( $isOutline ) {
-            $attrs['className'] = 'is-style-outline';
+            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), 'is-style-outline');
         }
 
         // Translate the resolved source CSS (inline style merged with the matched
@@ -223,6 +223,20 @@ final class ButtonsPattern
         }
 
         return $attrs;
+    }
+
+    private function mergeClassNames(string ...$classNames): string
+    {
+        $classes = array();
+        foreach ( $classNames as $className ) {
+            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $class ) {
+                if ( '' !== $class && ! in_array($class, $classes, true) ) {
+                    $classes[] = $class;
+                }
+            }
+        }
+
+        return implode(' ', $classes);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -69,9 +69,18 @@ final class LogoPattern
         $html = preg_replace('/<img\b[^>]*\balt\s*=\s*(["\'])(.*?)\1[^>]*>/is', '$2', $html) ?? $html;
         $html = preg_replace('/<img\b[^>]*>/is', '', $html) ?? $html;
         $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>\s*<\/\1>/i', '', $html) ?? $html;
-        $text = $this->plainText(preg_replace('/<\/?[a-z][a-z0-9]*\b[^>]*>/i', ' ', $html) ?? $html);
+        $html = trim($html);
+        $text = $this->plainText($html);
+        if ( '' === $text ) {
+            return '';
+        }
 
-        return '' === $text ? '' : htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        if ( preg_match('/<\/?(?!em\b|i\b|strong\b|b\b|mark\b|small\b|sub\b|sup\b|br\b)[a-z][a-z0-9]*\b[^>]*>/i', $html) ) {
+            $flattened = $this->plainText(preg_replace('/<\/?[a-z][a-z0-9]*\b[^>]*>/i', ' ', $html) ?? $html);
+            return htmlspecialchars('' !== $flattened ? $flattened : $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        return $html;
     }
 
     private function unwrapPresentationalSpan(string $html): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -27,6 +27,10 @@ final class NavigationPattern implements PatternRecognizerInterface
             return null;
         }
 
+        if ( $this->hasDirectBrandingAnchorBesideListNavigation($element, $innerHtml) ) {
+            return null;
+        }
+
         $links = $this->navigationBlocks($element, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget);
 
         if ( array() === $links ) {
@@ -52,6 +56,43 @@ final class NavigationPattern implements PatternRecognizerInterface
         }
 
         return $url;
+    }
+
+    private function hasDirectBrandingAnchorBesideListNavigation(DOMElement $element, callable $innerHtml): bool
+    {
+        if ( 'nav' !== strtolower($element->tagName) && ! $this->hasNavigationSignal($element) ) {
+            return false;
+        }
+
+        $hasDirectAnchor = false;
+        $hasListNavigation = false;
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+
+            $tagName = strtolower($child->tagName);
+            if ( 'a' === $tagName && $this->hasBrandAnchorSignal($child) && '' !== $this->anchorLabel($child, $innerHtml) && ! preg_match('/<(?:' . self::BLOCK_LEVEL_LABEL_TAGS . ')\b/i', $innerHtml($child)) ) {
+                $hasDirectAnchor = true;
+                continue;
+            }
+
+            if ( in_array($tagName, array( 'ul', 'ol' ), true) && array() !== $this->navigationBlocksFromList($child, static fn (): array => array(), $innerHtml, static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+                'blockName'   => $name,
+                'attrs'       => $attrs,
+                'innerBlocks' => $innerBlocks,
+            )) ) {
+                $hasListNavigation = true;
+            }
+        }
+
+        return $hasDirectAnchor && $hasListNavigation;
+    }
+
+    private function hasBrandAnchorSignal(DOMElement $anchor): bool
+    {
+        $haystack = strtolower(trim($this->attr($anchor, 'class') . ' ' . $this->attr($anchor, 'id') . ' ' . $this->attr($anchor, 'aria-label') . ' ' . $this->attr($anchor, 'title')));
+        return (bool) preg_match('/(?:^|[^a-z0-9])(?:brand|branding|logo|site-title|site-name|home-link|home-logo)(?:[^a-z0-9]|$)/', $haystack);
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-brand-anchor-beside-active-nav-list.json
+++ b/php-transformer/tests/fixtures/parity/html-brand-anchor-beside-active-nav-list.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-brand-anchor-beside-active-nav-list",
+  "description": "Keeps a direct brand/home anchor beside a list menu out of dynamic core/navigation so RichText logo color and active-list selector hooks survive.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-brand-anchor-beside-active-nav-list.json",
+    "notes": "Generic header shape: nav landmark with direct brand anchor plus ul/li menu; preserves .nav-links a.active CSS scope."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This fixture covers native block decomposition fidelity beyond the legacy converter."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<nav class=\"site-nav\"><a href=\"index.html\" class=\"nav-logo\">Mara <em>Vale</em></a><ul class=\"nav-links\"><li><a href=\"index.html\" class=\"active\">Home</a></li><li><a href=\"music.html\">Music</a></li></ul></nav>",
+    "options": { "static_css": ".nav-logo em{font-style:normal;color:#b8552a}.nav-links a.active::after{width:100%}" }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-nav", "tagName": "nav" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "nav-logo" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "nav-links" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "className": "active", "label": "Home", "url": "index.html", "kind": "custom", "anchorClassName": "active" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"nav-logo\"><a href=\"index.html\">Mara <em><mark style=\"color:#b8552a;background-color:transparent\">Vale</mark></em></a></p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"className\":\"nav-links\",\"overlayMenu\":\"mobile\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"className\":\"active\",\"label\":\"Home\",\"url\":\"index.html\",\"kind\":\"custom\",\"anchorClassName\":\"active\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"label\":\"Mara \\u003cem" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "cta ghost-link is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button cta ghost-link is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:currentColor;border-style:solid;border-width:2px;border-radius:8px;color:#135e96;background-color:transparent;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px;font-weight:600;text-transform:none" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-outline-preserves-source-classes-and-metrics.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-preserves-source-classes-and-metrics.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-button-outline-preserves-source-classes-and-metrics",
+  "description": "Preserves source classes on outline core/buttons while carrying border radius and padding through native button style attributes.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-button-outline-preserves-source-classes-and-metrics.json",
+    "notes": "Generic button geometry fixture: sharp rectangle radius, exact padding, and source class hook survive with is-style-outline."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Native button geometry/style fidelity is a PHP transformer behavior."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"btn btn-outline\" href=\"/tour\">Tour Dates</a>",
+    "options": { "static_css": ".btn{padding:14px 28px;border-radius:0;border:1px solid #e6d8c5}.btn-outline{background:transparent;color:#e6d8c5}" }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn btn-outline is-style-outline", "text": "Tour Dates", "url": "/tour", "style": { "color": { "text": "#e6d8c5", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "#e6d8c5", "radius": "0" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } } } } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-outline is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\" style=\"border-color:#e6d8c5;border-style:solid;border-width:1px;border-radius:0;color:#e6d8c5;background-color:transparent;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px\" href=\"/tour\">Tour Dates</a></div>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "btn btn-ghost is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-ghost is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-color:#135e96;border-style:solid;border-width:2px;border-radius:8px;color:#135e96;background-color:transparent;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-button-style-fidelity-outline-split-css",
-  "description": "Outlined CTA buttons with border shorthand on a base class and color on variant classes resolve to native transparent core/button styles without preserving source chrome classes on the wrapper.",
+  "description": "Outlined CTA buttons with border shorthand on a base class and color on variant classes resolve to native transparent core/button styles while preserving source chrome classes on the wrapper.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json",
@@ -17,14 +17,13 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Listen Now", "url": "/music", "className": "is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Tour Dates", "url": "/tour", "className": "is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Listen Now", "url": "/music", "className": "btn btn-primary is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Tour Dates", "url": "/tour", "className": "btn btn-primary is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button\" style=\"border-color:var(--ember);border-style:solid;border-width:1px;color:var(--bone);background-color:transparent;padding-top:.8rem;padding-right:1.8rem;padding-bottom:.8rem;padding-left:1.8rem;font-size:.7rem;letter-spacing:.16em;text-transform:uppercase\" href=\"/music\">Listen Now</a></div>" },
-    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp-block-button btn btn-primary" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-primary is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button\" style=\"border-color:var(--ember);border-style:solid;border-width:1px;color:var(--bone);background-color:transparent;padding-top:.8rem;padding-right:1.8rem;padding-bottom:.8rem;padding-left:1.8rem;font-size:.7rem;letter-spacing:.16em;text-transform:uppercase\" href=\"/music\">Listen Now</a></div>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button btn btn-primary" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Book now", "url": "/book", "className": "primary", "style": { "color": { "background": "#2563eb", "text": "#fff" }, "border": { "width": "2px", "style": "solid", "color": "#2563eb", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#2563eb", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "secondary is-style-outline", "style": { "color": { "text": "#2563eb", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
@@ -26,7 +26,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button primary\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:#2563eb;border-style:solid;border-width:2px;border-radius:999px;color:#fff;background-color:#2563eb;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button secondary is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:currentColor;border-style:solid;border-width:2px;border-radius:999px;color:#2563eb;background-color:transparent;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-inline-color-format-in-heading.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-color-format-in-heading.json
@@ -1,0 +1,29 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-color-format-in-heading",
+  "description": "Materializes class-owned color on nested RichText inline format elements as native mark formatting inside headings.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-color-format-in-heading.json",
+    "notes": "Generic inline color fixture for a mostly-one-color heading with a nested colored <em>."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "RichText inline color materialization is a native WordPress fidelity improvement."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<h1 class=\"brand\">Mara <em>Vale</em></h1>",
+    "options": { "static_css": ".brand em{font-style:normal;color:#b8552a}" }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/heading", "attrs": { "className": "brand", "content": "Mara <em><mark style=\"color:#b8552a;background-color:transparent\">Vale</mark></em>", "level": 1 } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<h1 class=\"wp-block-heading brand\">Mara <em><mark style=\"color:#b8552a;background-color:transparent\">Vale</mark></em></h1>" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve inline heading/link color spans through RichText mark color conversion instead of losing branded inline emphasis.
- Preserve current-page navigation active hooks when an active link is beside brand anchors in list-based navigation.
- Carry outline button source classes, border radius, and spacing metrics so imported buttons keep source visual intent.

## Root cause
The HTML transformer was flattening inline color markup and dropping source styling signals during conversion to native blocks. Navigation and button patterns also lost source-specific classes/metrics that matter to visual parity.

## Evidence
- Added parity fixtures for inline color in headings, brand anchors beside active nav list items, and outline button class/metric preservation.
- Visual-parity journey context: this lands fixes from the coffee 34% -> 7% mismatch reduction and artist hero inline-color/nav/button fidelity work.
- Local verification: `php tests/parity/run.php` passed 222 fixtures; `php tests/contract/run.php` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause via fixture-matrix visual evidence, fix design, parity fixtures + diagnostics