### PR TITLE
Preserve wrapped definition list content

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1261,11 +1261,41 @@ final class HtmlTransformer
 
         if ( 'dl' === $tagName ) {
             $items = $this->definitionListItems($element);
-            if ( array() === $items ) {
+            if ( array() !== $items ) {
+                return $this->createBlock('core/list', $this->presentationAttributes($element), $items, $element);
+            }
+
+            $children = $this->convertChildren($element, $fallbacks, true);
+            if ( array() === $children ) {
                 return null;
             }
 
-            return $this->createBlock('core/list', $this->presentationAttributes($element), $items, $element);
+            return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+        }
+
+        if ( 'dt' === $tagName ) {
+            $content = $this->richTextContentWithMaterializedInlineStyles($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        }
+
+        if ( 'dd' === $tagName ) {
+            if ( $this->hasBlockContentChildren($element) ) {
+                $children = $this->convertChildren($element, $fallbacks, true);
+                if ( array() !== $children ) {
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+                }
+            }
+
+            $content = $this->richTextContentWithMaterializedInlineStyles($element);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
         }
 
         if ( 'blockquote' === $tagName ) {

--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -371,8 +371,9 @@ final class FontMaterializationPlanBuilder
     /**
      * Extract integer weights from a Google Fonts axis suffix.
      *
-     * Supports `css2` axis tuples (`wght@400;700`, `ital,wght@0,400;1,700`)
-     * and the legacy `css` weight list (`400,700`). Defaults to `[400]`.
+     * Supports `css2` axis tuples (`wght@400;700`, `ital,wght@0,400;1,700`),
+     * Google Fonts ranges (`wght@300..900`), and the legacy `css` weight list
+     * (`400,700`). Defaults to `[400]`.
      *
      * @return array<int,int>
      */
@@ -391,19 +392,39 @@ final class FontMaterializationPlanBuilder
             foreach ( explode(';', $tuples) as $tuple ) {
                 $values = explode(',', $tuple);
                 $value = false === $wghtIndex ? end($values) : ($values[$wghtIndex] ?? null);
-                if ( is_numeric($value) ) {
-                    $weights[] = (int) $value;
-                }
+                array_push($weights, ...$this->expandFontWeightToken((string) $value));
             }
         } else {
             foreach ( explode(',', $axes) as $token ) {
-                if ( preg_match('/(\d{2,4})/', $token, $match) ) {
-                    $weights[] = (int) $match[1];
-                }
+                array_push($weights, ...$this->expandFontWeightToken($token));
             }
         }
 
         return array() === $weights ? array(400) : $weights;
+    }
+
+    /**
+     * @return array<int,int>
+     */
+    private function expandFontWeightToken(string $token): array
+    {
+        $token = trim($token);
+        if ( preg_match('/^(\d{2,4})\.\.(\d{2,4})$/', $token, $range) ) {
+            $start = max(1, min(1000, (int) $range[1]));
+            $end = max(1, min(1000, (int) $range[2]));
+            if ( $start > $end ) {
+                [$start, $end] = array($end, $start);
+            }
+
+            $weights = array();
+            for ( $weight = (int) (ceil($start / 100) * 100); $weight <= $end; $weight += 100 ) {
+                $weights[] = $weight;
+            }
+
+            return array() === $weights ? array($start, $end) : $weights;
+        }
+
+        return is_numeric($token) ? array((int) $token) : array();
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2126,6 +2126,13 @@ $assert('Oswald' === ($webFontPlan['roles']['heading'] ?? null), 'web-font detec
 $assert('Inter' === ($webFontPlan['roles']['body'] ?? null), 'web-font detection maps body typeface from font-family declaration');
 $assert('@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Oswald:wght@400;500;600;700&display=swap");' === ($webFontPlan['css'] ?? null), 'web-font detection materializes deterministic google fonts css');
 
+$rangeFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
+    '<head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300..900;1,300..900&amp;family=JetBrains+Mono:wght@400&amp;display=swap"></head>',
+    'body { font-family: "Crimson Pro", Georgia, serif; } .mono { font-family: "JetBrains Mono", monospace; }'
+);
+$assert(array(300, 400, 500, 600, 700, 800, 900) === ($rangeFontPlan['fonts'][0]['weights'] ?? null), 'web-font detection expands css2 font-weight ranges');
+$assert('@import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400&display=swap");' === ($rangeFontPlan['css'] ?? null), 'web-font detection preserves ranged google font weights deterministically');
+
 // Legacy css (v1) link syntax with `|`-separated families and comma weight lists.
 $legacyFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
     '<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700|Lora">',

--- a/php-transformer/tests/fixtures/parity/html-wrapped-definition-list-native.json
+++ b/php-transformer/tests/fixtures/parity/html-wrapped-definition-list-native.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-wrapped-definition-list-native",
+  "description": "Preserves valid wrapped dt/dd definition-list entries as editable native blocks instead of dropping entry bodies.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-wrapped-definition-list-native.json",
+    "notes": "Generic CV/resume and directory row coverage for dl structures whose term/description pairs are wrapped in divs."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "New generic wrapped definition-list behavior has no legacy equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"section\"><h2>Education</h2><dl class=\"entries\"><div class=\"entry\"><dt class=\"entry__date mono\">2017-2022</dt><dd class=\"entry__body\"><p class=\"entry__title\">Ph.D., Neuroscience</p><p class=\"entry__org\"><em>Stanford University</em></p><p class=\"entry__detail\">Dissertation on attention failure.</p></dd></div></dl></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "section" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "entries" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "entry" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "entry__date mono" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "entry__body" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"entries\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"entry__date mono\">2017-2022</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"entry__title\">Ph.D., Neuroscience</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"entry__org\"><em>Stanford University</em></p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"entry__detail\">Dissertation on attention failure.</p>" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:html" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve wrapped definition-list content when `<dl>` entries are wrapped in container elements such as `<dl><div><dt>...`.
- Convert wrapped `dt`/`dd` content into native editable blocks instead of dropping the entry bodies.
- Expand Google Fonts `wght@300..900` ranges deterministically instead of collapsing ranged weights to `400`.

## Evidence
- Deterministic harness measured CV fixture native blocks improving from 109 to 219.
- Missing CV sections were restored while `core/html` stayed at 0.
- Local verification on this clean `origin/trunk` branch: `php tests/parity/run.php` passed 225 fixtures.
- Local verification on this clean `origin/trunk` branch: `php tests/contract/run.php` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-causing definition-list and font-range handling gaps via the fixture-matrix, fix + parity coverage