### PR TITLE
Preserve inline SVG image namespaces

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4511,7 +4511,7 @@ final class HtmlTransformer
             return null;
         }
 
-        $html = $this->minifyInlineSvgForImage($html);
+        $html = $this->ensureSvgImageNamespace($this->minifyInlineSvgForImage($html));
         $dataUri = 'data:image/svg+xml,' . rawurlencode($html);
         if ( strlen($dataUri) > self::MAX_INLINE_SVG_IMAGE_DATA_URI_BYTES ) {
             return null;
@@ -4544,6 +4544,15 @@ final class HtmlTransformer
         $html = preg_replace('/<!--.*?-->/s', '', $html) ?? $html;
         $html = preg_replace('/>\s+</', '><', $html) ?? $html;
         return trim($html);
+    }
+
+    private function ensureSvgImageNamespace(string $html): string
+    {
+        if ( preg_match('/<svg\b[^>]*\sxmlns\s*=/i', $html) ) {
+            return $html;
+        }
+
+        return preg_replace('/<svg\b/i', '<svg xmlns="http://www.w3.org/2000/svg"', $html, 1) ?? $html;
     }
 
     private function isNativeImageCompatibleSvg(DOMElement $element, string $html): bool

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-image-namespace-parity.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-image-namespace-parity.json
@@ -1,0 +1,30 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-image-namespace-parity",
+  "description": "Safe inline SVGs converted to native core/image data URIs include an SVG namespace so browser image documents render instead of failing while remaining editable as image blocks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-image-namespace-parity.json",
+    "notes": "Generic inline-SVG-as-image serialization parity. Not fixture-specific."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\"><circle cx=\"7\" cy=\"7\" r=\"6\" stroke=\"#2DD4C8\" stroke-width=\"1.5\"></circle></svg>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/image" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.blockName", "assert": "equals", "value": "core/image" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "data:image/svg+xml" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add an SVG XML namespace when safe inline SVGs serialize through the current `core/image` data-URI path.
- Keeps safe inline SVG image blocks browser-loadable without changing the current materialization strategy.

## Evidence
- Deterministic harness measured the SaaS fixture improving from 15 failed SVG image loads to 0 failed loads.
- Local verification on this clean `origin/trunk` branch: `php tests/parity/run.php` passed 225 fixtures.
- Local verification on this clean `origin/trunk` branch: `php tests/contract/run.php` passed.

## SVG materialization assessment
- This patch only corrects the existing data-URI serialization path by ensuring encoded SVG documents include `xmlns="http://www.w3.org/2000/svg"`.
- The local `feat/svg-materialize-to-image` branch is not a divergent materialization implementation in the current checkout state; it resolves to the already-merged inline SVG box fidelity work.
- Because the namespace fix is local to the current path and does not externalize or otherwise change asset materialization policy, it is safe to land standalone.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-causing inline SVG data-URI browser image-load failures via the fixture-matrix, fix + parity coverage