### PR TITLE
Preserve outline button and active navigation fidelity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -25,6 +25,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecogniz
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
@@ -290,6 +291,11 @@ final class HtmlTransformer
     private array $staticStyleRules = array();
 
     /**
+     * @var array<int, array{selector: string, pseudo: string, declarations: array<string, string>}>
+     */
+    private array $staticPseudoElementStyleRules = array();
+
+    /**
      * @var array<string, bool>
      */
     private array $runtimeDomSelectors = array();
@@ -370,6 +376,7 @@ final class HtmlTransformer
         $this->gutenbergIncompatibilities = array();
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $this->staticStyleRules = $this->staticStyleRules($html, (string) ($options['static_css'] ?? ''));
+        $this->staticPseudoElementStyleRules = $this->staticPseudoElementStyleRules($html, (string) ($options['static_css'] ?? ''));
         $this->cssCustomProperties = $this->cssCustomProperties($html, (string) ($options['static_css'] ?? ''));
         $this->resetPresentationResolutionCache();
         $this->runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
@@ -760,7 +767,8 @@ final class HtmlTransformer
             fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement),
             $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
             fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
-            fn (DOMElement $sourceElement, array $excludedTags): array => $this->convertPatternChildrenWithoutTags($sourceElement, $excludedTags)
+            fn (DOMElement $sourceElement, array $excludedTags): array => $this->convertPatternChildrenWithoutTags($sourceElement, $excludedTags),
+            fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor)
         );
     }
 
@@ -1138,8 +1146,68 @@ final class HtmlTransformer
             ),
             null,
             null,
-            null
+            null,
+            fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor)
         );
+    }
+
+    private function navigationUnderlineColor(DOMElement $item, DOMElement $anchor): string
+    {
+        foreach ( array( $anchor, $item ) as $element ) {
+            $declarations = $this->presentationDeclarations($element);
+            foreach ( array( 'text-decoration-color', 'border-bottom-color', 'border-color' ) as $property ) {
+                $color = $this->usableCssColor((string) ($declarations[ $property ] ?? ''));
+                if ( '' !== $color ) {
+                    return $color;
+                }
+            }
+        }
+
+        foreach ( $this->staticPseudoElementStyleRules as $rule ) {
+            if ( ! $this->matchesCssSelector($anchor, $rule['selector']) && ! $this->matchesCssSelector($item, $rule['selector']) ) {
+                continue;
+            }
+
+            $declarations = $rule['declarations'];
+            foreach ( array( 'background-color', 'background', 'border-bottom-color', 'border-color', 'color' ) as $property ) {
+                $color = $this->usableCssColor((string) ($declarations[ $property ] ?? ''));
+                if ( '' !== $color ) {
+                    return $color;
+                }
+            }
+        }
+
+        foreach ( array( $anchor, $item ) as $element ) {
+            $color = $this->usableCssColor((string) ($this->presentationDeclarations($element)['color'] ?? ''));
+            if ( '' !== $color ) {
+                return $color;
+            }
+        }
+
+        return '';
+    }
+
+    private function usableCssColor(string $value): string
+    {
+        $value = trim($value);
+        if ( '' === $value ) {
+            return '';
+        }
+
+        $lower = strtolower($value);
+        if ( in_array($lower, array( 'transparent', 'none', 'inherit', 'initial', 'unset', 'revert', 'auto' ), true) ) {
+            return '';
+        }
+
+        if ( str_contains($value, '(') && ( ! str_ends_with($value, ')') || ! CssValueSplitter::hasBalancedParens($value) ) ) {
+            return '';
+        }
+
+        if ( preg_match('/^#[0-9a-f]{3,8}$/i', $value) || preg_match('/^(?:rgb|rgba|hsl|hsla|var)\s*\(/i', $value) || 'currentcolor' === $lower || preg_match('/^[a-z]+$/', $lower) ) {
+            return 'currentcolor' === $lower ? 'currentColor' : $value;
+        }
+
+        return '';
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -219,10 +219,24 @@ final class ButtonsPattern
         }
 
         if ( $isOutline ) {
+            if ( array() !== $native ) {
+                $attrs['className'] = 'is-style-outline';
+            }
             $attrs['style']['color']['background'] = 'transparent';
+            if ( ! $this->hasBorderRadius($attrs) ) {
+                $attrs['style']['border']['radius'] = '0';
+            }
         }
 
         return $attrs;
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function hasBorderRadius(array $attrs): bool
+    {
+        return '' !== trim((string) ($attrs['style']['border']['radius'] ?? ''));
     }
 
     private function mergeClassNames(string ...$classNames): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -301,6 +301,10 @@ final class NavigationPattern implements PatternRecognizerInterface
             $itemAttrs['className'] = $anchorAttrs['className'];
         }
 
+        if ( $this->hasCurrentNavigationSignal($item) || $this->hasCurrentNavigationSignal($anchor) ) {
+            $baseAttrs['style']['typography']['textDecoration'] = 'underline';
+        }
+
         // The anchor/submenu CSS rides on the preserved classNames + companion CSS;
         // a raw inline `style` string on the navigation-link/submenu inner markup
         // would diverge from the block save() output, so it is not emitted (#261).
@@ -346,6 +350,21 @@ final class NavigationPattern implements PatternRecognizerInterface
 
         $attrs['className'] = implode(' ', $classNames);
         return $attrs;
+    }
+
+    private function hasCurrentNavigationSignal(DOMElement $element): bool
+    {
+        if ( '' !== trim($this->attr($element, 'aria-current')) ) {
+            return true;
+        }
+
+        foreach ( preg_split('/[^a-z0-9]+/', strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'id'))) ?: array() as $token ) {
+            if ( in_array($token, array( 'active', 'current', 'current-menu-item', 'current-page-item', 'current_page_item', 'is-active', 'selected' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function primaryNavigationAnchor(DOMElement $element): ?DOMElement

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -20,6 +20,7 @@ final class NavigationPattern implements PatternRecognizerInterface
         $innerHtml = $context->innerHtmlCallback();
         $createBlock = $context->createBlockCallback();
         $isRuntimeDomTarget = $context->isRuntimeDomTargetCallback();
+        $navigationUnderlineColor = $context->navigationUnderlineColorCallback();
 
         if ( 'nav' !== strtolower($element->tagName) && ! $this->hasNavigationSignal($element) && ! $this->hasDirectListNavigationSignal($element) ) {
             return null;
@@ -33,7 +34,7 @@ final class NavigationPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $links = $this->navigationBlocks($element, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget);
+        $links = $this->navigationBlocks($element, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget, false, $navigationUnderlineColor);
 
         if ( array() === $links ) {
             return null;
@@ -100,13 +101,13 @@ final class NavigationPattern implements PatternRecognizerInterface
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function navigationBlocks(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null, bool $allowsDescriptiveChrome = false): array
+    private function navigationBlocks(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null, bool $allowsDescriptiveChrome = false, ?callable $navigationUnderlineColor = null): array
     {
         $blocks = array();
         $allowsDescriptiveChrome = $allowsDescriptiveChrome || $this->hasSubmenuSignal($element);
         $allowsDirectItems = $allowsDescriptiveChrome || 'nav' === strtolower($element->tagName) || $this->hasNavigationSignal($element) || $this->hasSubmenuSignal($element) || in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true);
         if ( in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true) ) {
-            return $this->navigationBlocksFromList($element, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget);
+            return $this->navigationBlocksFromList($element, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget, $navigationUnderlineColor);
         }
 
         foreach ( $element->childNodes as $child ) {
@@ -133,12 +134,12 @@ final class NavigationPattern implements PatternRecognizerInterface
                 if ( ! $allowsDirectItems ) {
                     return array();
                 }
-                $blocks[] = $this->navigationLinkBlock($child, $presentationAttributes, $innerHtml, $createBlock, $child);
+                $blocks[] = $this->navigationLinkBlock($child, $presentationAttributes, $innerHtml, $createBlock, $child, $navigationUnderlineColor);
                 continue;
             }
 
             if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'ul', 'ol' ), true) ) {
-                $listBlocks = $this->navigationBlocksFromList($child, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget);
+                $listBlocks = $this->navigationBlocksFromList($child, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget, $navigationUnderlineColor);
                 if ( array() === $listBlocks ) {
                     return array();
                 }
@@ -151,14 +152,14 @@ final class NavigationPattern implements PatternRecognizerInterface
                     return array();
                 }
 
-                $block = $this->navigationBlockFromItem($child, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget);
+                $block = $this->navigationBlockFromItem($child, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget, $navigationUnderlineColor);
                 if ( null !== $block ) {
                     $blocks[] = $block;
                     continue;
                 }
 
                 if ( $this->isNavigationWrapperElement($child) ) {
-                    $wrappedBlocks = $this->navigationBlocks($child, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget, $allowsDescriptiveChrome);
+                    $wrappedBlocks = $this->navigationBlocks($child, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget, $allowsDescriptiveChrome, $navigationUnderlineColor);
                     if ( array() !== $wrappedBlocks ) {
                         $blocks = array_merge($blocks, $wrappedBlocks);
                         continue;
@@ -179,7 +180,7 @@ final class NavigationPattern implements PatternRecognizerInterface
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function navigationBlocksFromList(DOMElement $list, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null): array
+    private function navigationBlocksFromList(DOMElement $list, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null, ?callable $navigationUnderlineColor = null): array
     {
         $blocks = array();
         foreach ( $list->childNodes as $item ) {
@@ -199,7 +200,7 @@ final class NavigationPattern implements PatternRecognizerInterface
                 return array();
             }
 
-            $block = $this->navigationBlockFromItem($item, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget);
+            $block = $this->navigationBlockFromItem($item, $presentationAttributes, $innerHtml, $createBlock, $isRuntimeDomTarget, $navigationUnderlineColor);
             if ( null === $block ) {
                 return array();
             }
@@ -210,7 +211,7 @@ final class NavigationPattern implements PatternRecognizerInterface
         return $blocks;
     }
 
-    private function navigationBlockFromItem(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null): ?array
+    private function navigationBlockFromItem(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null, ?callable $navigationUnderlineColor = null): ?array
     {
         $anchor = $this->primaryNavigationAnchor($element);
         if ( ! $anchor instanceof DOMElement || '' === $this->anchorLabel($anchor, $innerHtml) ) {
@@ -235,23 +236,23 @@ final class NavigationPattern implements PatternRecognizerInterface
                 'kind'  => 'custom',
             );
             $submenuContainer = $this->submenuContainers($element, $anchor)[0] ?? null;
-            return $createBlock('core/navigation-submenu', $this->navigationItemAttributes($element, $anchor, $submenuContainer, $submenuAttrs, $presentationAttributes), $submenuBlocks, $element);
+            return $createBlock('core/navigation-submenu', $this->navigationItemAttributes($element, $anchor, $submenuContainer, $submenuAttrs, $presentationAttributes, $navigationUnderlineColor), $submenuBlocks, $element);
         }
 
         if ( 1 !== count($this->anchorsExcludingSubmenus($element, $anchor)) ) {
             return null;
         }
 
-        return $this->navigationLinkBlock($anchor, $presentationAttributes, $innerHtml, $createBlock, $element);
+        return $this->navigationLinkBlock($anchor, $presentationAttributes, $innerHtml, $createBlock, $element, $navigationUnderlineColor);
     }
 
-    private function navigationLinkBlock(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?DOMElement $item = null): array
+    private function navigationLinkBlock(DOMElement $anchor, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?DOMElement $item = null, ?callable $navigationUnderlineColor = null): array
     {
         return $createBlock('core/navigation-link', $this->navigationItemAttributes($item ?? $anchor, $anchor, null, array(
             'label' => $this->anchorLabel($anchor, $innerHtml),
             'url'   => $this->safeNavigationUrl($anchor->hasAttribute('href') ? $anchor->getAttribute('href') : ''),
             'kind'  => 'custom',
-        ), $presentationAttributes), array(), $anchor);
+        ), $presentationAttributes, $navigationUnderlineColor), array(), $anchor);
     }
 
     private function anchorLabel(DOMElement $anchor, callable $innerHtml): string
@@ -292,7 +293,7 @@ final class NavigationPattern implements PatternRecognizerInterface
      * @param array<string, mixed> $baseAttrs
      * @return array<string, mixed>
      */
-    private function navigationItemAttributes(DOMElement $item, DOMElement $anchor, ?DOMElement $submenuContainer, array $baseAttrs, callable $presentationAttributes): array
+    private function navigationItemAttributes(DOMElement $item, DOMElement $anchor, ?DOMElement $submenuContainer, array $baseAttrs, callable $presentationAttributes, ?callable $navigationUnderlineColor = null): array
     {
         $itemAttrs = $item->isSameNode($anchor) ? array() : $this->withoutCoreNavigationClasses($presentationAttributes($item));
         $anchorAttrs = $this->withoutCoreNavigationClasses($presentationAttributes($anchor));
@@ -303,6 +304,13 @@ final class NavigationPattern implements PatternRecognizerInterface
 
         if ( $this->hasCurrentNavigationSignal($item) || $this->hasCurrentNavigationSignal($anchor) ) {
             $baseAttrs['style']['typography']['textDecoration'] = 'underline';
+            $decorationColor = null !== $navigationUnderlineColor ? trim((string) $navigationUnderlineColor($item, $anchor)) : '';
+            if ( '' === $decorationColor ) {
+                $decorationColor = $this->activeNavigationUnderlineColor($anchorAttrs, $itemAttrs);
+            }
+            if ( '' !== $decorationColor ) {
+                $baseAttrs['style']['typography']['textDecorationColor'] = $decorationColor;
+            }
         }
 
         // The anchor/submenu CSS rides on the preserved classNames + companion CSS;
@@ -312,6 +320,47 @@ final class NavigationPattern implements PatternRecognizerInterface
             'anchorClassName'  => $anchorAttrs['className'] ?? '',
             'submenuClassName' => $submenuAttrs['className'] ?? '',
         )), static fn ($value): bool => '' !== $value);
+    }
+
+    /**
+     * @param array<string, mixed> $anchorAttrs
+     * @param array<string, mixed> $itemAttrs
+     */
+    private function activeNavigationUnderlineColor(array $anchorAttrs, array $itemAttrs): string
+    {
+        foreach ( array( $anchorAttrs, $itemAttrs ) as $attrs ) {
+            $textColor = $attrs['style']['color']['text'] ?? null;
+            if ( is_string($textColor) && '' !== trim($textColor) ) {
+                return trim($textColor);
+            }
+        }
+
+        foreach ( array( $anchorAttrs, $itemAttrs ) as $attrs ) {
+            $style = $attrs['style'] ?? null;
+            if ( ! is_array($style) ) {
+                continue;
+            }
+            $serialized = $this->serializedStyleColor($style);
+            if ( '' !== $serialized ) {
+                return $serialized;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $style
+     */
+    private function serializedStyleColor(array $style): string
+    {
+        $serialized = (string) json_encode($style);
+        if ( preg_match('/"(?:textDecorationColor|borderColor|color)"\s*:\s*"((?:\\\\.|[^"\\\\])+)"/', $serialized, $match) ) {
+            $decoded = json_decode('"' . $match[1] . '"');
+            return is_string($decoded) ? trim($decoded) : '';
+        }
+
+        return '';
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -14,6 +14,7 @@ final class PatternContext
      * @param callable(DOMElement): bool|null $isRuntimeDomTarget
      * @param callable(DOMElement): array<int, array<string, mixed>>|null $convertChildren
      * @param callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null $convertChildrenWithoutTags
+     * @param callable(DOMElement, DOMElement): string|null $navigationUnderlineColor
      */
     public function __construct(
         private readonly mixed $presentationAttributes,
@@ -21,7 +22,8 @@ final class PatternContext
         private readonly mixed $createBlock,
         private readonly mixed $isRuntimeDomTarget = null,
         private readonly mixed $convertChildren = null,
-        private readonly mixed $convertChildrenWithoutTags = null
+        private readonly mixed $convertChildrenWithoutTags = null,
+        private readonly mixed $navigationUnderlineColor = null
     ) {
     }
 
@@ -71,5 +73,13 @@ final class PatternContext
     public function convertChildrenWithoutTagsCallback(): ?callable
     {
         return is_callable($this->convertChildrenWithoutTags) ? $this->convertChildrenWithoutTags : null;
+    }
+
+    /**
+     * @return callable(DOMElement, DOMElement): string|null
+     */
+    public function navigationUnderlineColorCallback(): ?callable
+    {
+        return is_callable($this->navigationUnderlineColor) ? $this->navigationUnderlineColor : null;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -308,6 +308,53 @@ trait StyleResolutionTrait
         return array_slice($rules, 0, 200);
     }
 
+    /**
+     * @return array<int, array{selector: string, pseudo: string, declarations: array<string, string>}>
+     */
+    private function staticPseudoElementStyleRules(string $html, string $linkedCss): array
+    {
+        $css = trim($linkedCss);
+        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
+            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map('trim', $matches[1]));
+        }
+
+        if ( '' === trim($css) ) {
+            return array();
+        }
+
+        $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
+        $css = $this->topLevelCssRules($css);
+        $rules = array();
+        if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        foreach ( $matches as $match ) {
+            $declarations = $this->safeVisualDeclarations($this->cssDeclarations((string) $match[2]));
+            if ( array() === $declarations ) {
+                continue;
+            }
+
+            foreach ( explode(',', (string) $match[1]) as $selector ) {
+                $selector = trim($selector);
+                if ( ! preg_match('/::?(before|after)\b/i', $selector, $pseudoMatch) ) {
+                    continue;
+                }
+
+                $baseSelector = trim((string) preg_replace('/::?(?:before|after)\b/i', '', $selector));
+                if ( '' !== $baseSelector && ! $this->selectorCarriesPseudoState($baseSelector) && $this->isSupportedCssSelector($baseSelector) ) {
+                    $rules[] = array(
+                        'selector'     => $baseSelector,
+                        'pseudo'       => strtolower($pseudoMatch[1]),
+                        'declarations' => $declarations,
+                    );
+                }
+            }
+        }
+
+        return array_slice($rules, 0, 200);
+    }
+
     private function topLevelCssRules(string $css): string
     {
         $output = '';
@@ -586,7 +633,7 @@ trait StyleResolutionTrait
             return false;
         }
 
-        $classes = preg_split('/\./', ltrim((string) ($match['classes'] ?? ''), '.')) ?: array();
+        $classes = array_values(array_filter(preg_split('/\./', ltrim((string) ($match['classes'] ?? ''), '.')) ?: array(), static fn (string $class): bool => '' !== $class));
         $elementClasses = preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array();
         foreach ( $classes as $class ) {
             if ( ! in_array($class, $elementClasses, true) ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1127,6 +1127,17 @@ $assert('underline' === ($activeNavigationLinks[0]['attrs']['style']['typography
 $assert(! isset($activeNavigationLinks[1]['attrs']['style']['typography']['textDecoration']), 'inactive navigation link does not get active underline styling');
 $assert(str_contains((string) ($activeNavigation['serialized_blocks'] ?? ''), '"textDecoration":"underline"'), 'active navigation underline intent is serialized into the dynamic navigation-link block attrs');
 
+$activeNavigationColor = ( new HtmlTransformer() )->transform(
+    '<style>.nav-links a{color:var(--bone)}.nav-links a.active{color:var(--bone);text-decoration:underline}.nav-links a.active::after{content:"";display:block;background:var(--ember);height:2px;width:100%}</style><nav aria-label="Primary"><ul class="nav-links"><li><a href="/" class="active">Home</a></li><li><a href="/music">Music</a></li></ul></nav>'
+)->toArray();
+$activeNavigationColorLinks = $activeNavigationColor['blocks'][0]['innerBlocks'] ?? array();
+$activeNavigationColorSerialized = (string) ($activeNavigationColor['serialized_blocks'] ?? '');
+$assert('var(--ember)' === ($activeNavigationColorLinks[0]['attrs']['style']['typography']['textDecorationColor'] ?? ''), 'active navigation underline color carries source pseudo underline paint');
+$assert(! isset($activeNavigationColorLinks[1]['attrs']['style']['typography']['textDecorationColor']), 'inactive navigation link does not get underline color styling');
+$assert(str_contains($activeNavigationColorSerialized, '<!-- wp:navigation-link'), 'active navigation color case keeps canonical navigation-link serialization');
+$assert(str_contains($activeNavigationColorSerialized, '"textDecorationColor":"var(--ember)"'), 'active navigation underline color is serialized into the dynamic navigation-link block attrs');
+$assert(! str_contains($activeNavigationColorSerialized, '<li class="wp-block-navigation-item'), 'active navigation color serialization emits no invalid static navigation item markup');
+
 $headerCluster = ( new HtmlTransformer() )->transform(
     '<header class="site-header"><a class="site-logo" href="/">Acme Lab</a><nav class="primary-nav" aria-label="Primary"><a class="nav-link" href="/work">Work</a><a class="nav-link" href="/docs"><span>Docs</span></a></nav><form class="site-search" role="search" action="/search"><label for="q">Search</label><input id="q" type="search" name="q" placeholder="Search docs"><button type="submit">Search</button></form><div class="header-actions"><a class="cta" href="/start">Get started</a></div></header>'
 )->toArray();

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -546,7 +546,16 @@ $outlineButton = ( new HtmlTransformer() )->transform(
 $outlineButtonMarkup = (string) ($outlineButton['serialized_blocks'] ?? '');
 $assert(str_contains($outlineButtonMarkup, '<!-- wp:button'), 'styled anchor with presentational span materializes as core/button');
 $assert(str_contains($outlineButtonMarkup, 'background-color:transparent'), 'outline button emits transparent background to suppress default theme fill');
+$assert(str_contains($outlineButtonMarkup, 'border-radius:0'), 'outline button with no source radius emits square radius to suppress default rounded inner button chrome');
+$assert(! str_contains($outlineButtonMarkup, '<div class="wp-block-button btn btn-secondary'), 'outline button with native styles avoids duplicating source button chrome on the outer wrapper');
 $assert(! str_contains($outlineButtonMarkup, '<span>Tickets</span>'), 'button label unwraps presentational span to avoid nested default styling');
+
+$roundedOutlineButton = ( new HtmlTransformer() )->transform(
+    '<main><a class="btn btn-secondary" style="display:inline-block;padding:1rem 2rem;border:1px solid #c4a070;border-radius:12px;background:transparent;color:#eee" href="/tickets">Tickets</a></main>'
+)->toArray();
+$roundedOutlineButtonMarkup = (string) ($roundedOutlineButton['serialized_blocks'] ?? '');
+$assert(str_contains($roundedOutlineButtonMarkup, 'border-radius:12px'), 'outline button preserves an explicit source border radius');
+$assert(! str_contains($roundedOutlineButtonMarkup, 'border-radius:0'), 'outline button does not override an explicit source border radius');
 
 $separatorResult = ( new HtmlTransformer() )->transform('<main><hr class="wp-block-separator has-alpha-channel-opacity has-css-opacity divider"></main>')->toArray();
 $separatorMarkup = (string) ($separatorResult['serialized_blocks'] ?? '');
@@ -1109,6 +1118,14 @@ $assert('nav-link' === ($runtimeTargetNavigationItemAttrs['className'] ?? ''), '
 // wp.blocks.validateBlock flag the block invalid in the editor.
 $assert(str_contains($runtimeTargetNavigationSerialized, '"className":"nav-link"'), 'runtime-target navigation link classes are preserved in the canonical navigation-link block comment');
 $assert(! str_contains($runtimeTargetNavigationSerialized, '<li class="wp-block-navigation-item'), 'canonical navigation-link emits no static <li> markup that the editor would reject');
+
+$activeNavigation = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary"><ul class="nav-links"><li><a href="/" class="active">Home</a></li><li><a href="/music">Music</a></li></ul></nav>'
+)->toArray();
+$activeNavigationLinks = $activeNavigation['blocks'][0]['innerBlocks'] ?? array();
+$assert('underline' === ($activeNavigationLinks[0]['attrs']['style']['typography']['textDecoration'] ?? ''), 'active navigation link carries native underline style intent');
+$assert(! isset($activeNavigationLinks[1]['attrs']['style']['typography']['textDecoration']), 'inactive navigation link does not get active underline styling');
+$assert(str_contains((string) ($activeNavigation['serialized_blocks'] ?? ''), '"textDecoration":"underline"'), 'active navigation underline intent is serialized into the dynamic navigation-link block attrs');
 
 $headerCluster = ( new HtmlTransformer() )->transform(
     '<header class="site-header"><a class="site-logo" href="/">Acme Lab</a><nav class="primary-nav" aria-label="Primary"><a class="nav-link" href="/work">Work</a><a class="nav-link" href="/docs"><span>Docs</span></a></nav><form class="site-search" role="search" action="/search"><label for="q">Search</label><input id="q" type="search" name="q" placeholder="Search docs"><button type="submit">Search</button></form><div class="header-actions"><a class="cta" href="/start">Get started</a></div></header>'

--- a/php-transformer/tests/fixtures/parity/html-brand-anchor-beside-active-nav-list.json
+++ b/php-transformer/tests/fixtures/parity/html-brand-anchor-beside-active-nav-list.json
@@ -27,7 +27,7 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<p class=\"nav-logo\"><a href=\"index.html\">Mara <em><mark style=\"color:#b8552a;background-color:transparent\">Vale</mark></em></a></p>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation {\"className\":\"nav-links\",\"overlayMenu\":\"mobile\"} -->" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"className\":\"active\",\"label\":\"Home\",\"url\":\"index.html\",\"kind\":\"custom\",\"anchorClassName\":\"active\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"className\":\"active\",\"label\":\"Home\",\"url\":\"index.html\",\"kind\":\"custom\",\"style\":{\"typography\":{\"textDecoration\":\"underline\"}},\"anchorClassName\":\"active\"} -->" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "\"label\":\"Mara \\u003cem" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "cta ghost-link is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button cta ghost-link is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:currentColor;border-style:solid;border-width:2px;border-radius:8px;color:#135e96;background-color:transparent;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px;font-weight:600;text-transform:none" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-outline-preserves-source-classes-and-metrics.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-preserves-source-classes-and-metrics.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-button-outline-preserves-source-classes-and-metrics",
-  "description": "Preserves source classes on outline core/buttons while carrying border radius and padding through native button style attributes.",
+  "description": "Preserves outline core/button chrome while carrying border radius and padding through native button style attributes.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-button-outline-preserves-source-classes-and-metrics.json",
-    "notes": "Generic button geometry fixture: sharp rectangle radius, exact padding, and source class hook survive with is-style-outline."
+    "notes": "Generic button geometry fixture: sharp rectangle radius, exact padding, and outline style intent survive with is-style-outline."
   },
   "legacy_comparison": {
     "skip": true,
@@ -18,12 +18,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn btn-outline is-style-outline", "text": "Tour Dates", "url": "/tour", "style": { "color": { "text": "#e6d8c5", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "#e6d8c5", "radius": "0" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "is-style-outline", "text": "Tour Dates", "url": "/tour", "style": { "color": { "text": "#e6d8c5", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "#e6d8c5", "radius": "0" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-outline is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\" style=\"border-color:#e6d8c5;border-style:solid;border-width:1px;border-radius:0;color:#e6d8c5;background-color:transparent;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px\" href=\"/tour\">Tour Dates</a></div>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\" style=\"border-color:#e6d8c5;border-style:solid;border-width:1px;border-radius:0;color:#e6d8c5;background-color:transparent;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px\" href=\"/tour\">Tour Dates</a></div>" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-from-css.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "btn btn-ghost is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-ghost is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-color:#135e96;border-style:solid;border-width:2px;border-radius:8px;color:#135e96;background-color:transparent;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json
+++ b/php-transformer/tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-button-style-fidelity-outline-split-css",
-  "description": "Outlined CTA buttons with border shorthand on a base class and color on variant classes resolve to native transparent core/button styles while preserving source chrome classes on the wrapper.",
+  "description": "Outlined CTA buttons with border shorthand on a base class and color on variant classes resolve to native transparent core/button styles.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-button-style-fidelity-outline-split-css.json",
@@ -17,13 +17,13 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Listen Now", "url": "/music", "className": "btn btn-primary is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Tour Dates", "url": "/tour", "className": "btn btn-primary is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Listen Now", "url": "/music", "className": "is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)", "radius": "0" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Tour Dates", "url": "/tour", "className": "is-style-outline", "style": { "color": { "text": "var(--bone)", "background": "transparent" }, "border": { "width": "1px", "style": "solid", "color": "var(--ember)", "radius": "0" }, "spacing": { "padding": { "top": ".8rem", "right": "1.8rem", "bottom": ".8rem", "left": "1.8rem" } }, "typography": { "fontSize": ".7rem", "letterSpacing": ".16em", "textTransform": "uppercase" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btn btn-primary is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button\" style=\"border-color:var(--ember);border-style:solid;border-width:1px;color:var(--bone);background-color:transparent;padding-top:.8rem;padding-right:1.8rem;padding-bottom:.8rem;padding-left:1.8rem;font-size:.7rem;letter-spacing:.16em;text-transform:uppercase\" href=\"/music\">Listen Now</a></div>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button\" style=\"border-color:var(--ember);border-style:solid;border-width:1px;border-radius:0;color:var(--bone);background-color:transparent;padding-top:.8rem;padding-right:1.8rem;padding-bottom:.8rem;padding-left:1.8rem;font-size:.7rem;letter-spacing:.16em;text-transform:uppercase\" href=\"/music\">Listen Now</a></div>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "wp-block-button__link has-text-color has-background has-border-color has-custom-font-size wp-element-button btn btn-primary" }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/html-cta-container-static-css-button-style-signals.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Book now", "url": "/book", "className": "primary", "style": { "color": { "background": "#2563eb", "text": "#fff" }, "border": { "width": "2px", "style": "solid", "color": "#2563eb", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "secondary is-style-outline", "style": { "color": { "text": "#2563eb", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#2563eb", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
@@ -26,7 +26,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button primary\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:#2563eb;border-style:solid;border-width:2px;border-radius:999px;color:#fff;background-color:#2563eb;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button secondary is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:currentColor;border-style:solid;border-width:2px;border-radius:999px;color:#2563eb;background-color:transparent;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700" }
   ]
 }


### PR DESCRIPTION
## Summary
- Preserve outline button styling as native core/button attrs without duplicating source button chrome on the outer wrapper.
- Emit square radius for outline buttons when the source has no explicit radius, while preserving explicit source radii.
- Materialize active/current navigation link underline intent as native typography text decoration.

## Verification
- `php php-transformer/tests/contract/run.php`
- Fixture matrix local-hot regression: `3-artist-music` improved from 5.86% to 0.58% aligned mismatch, editor validation stayed 120/120, invalid blocks stayed 0, core/html stayed 0.
- Four-fixture regression set improved or held: `15-saas` 44.31% -> 34.55%, `2-onepager-coffee` 6.94% -> 6.59%, `31-personal-cv-academic` 5.04% -> 2.70%.
- Scoped Lab run for `3-artist-music` after final fix: aligned mismatch 0.61%; gate still fails because visual threshold is zero.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via opencode
- **Used for:** Chris and the coding agent collaborated on root-cause analysis, implementation, focused tests, fixture verification, and PR preparation.