### PR TITLE
Preserve SaaS logo and styled marker primitives

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1259,6 +1259,12 @@ final class HtmlTransformer
             if ( $this->richTextRequiresHtmlFallback($content) ) {
                 return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($this->outerHtml($element)) ), array(), $element);
             }
+            if ( $this->hasEmptyVisualInlineChild($element) ) {
+                $children = $this->convertChildren($element, $fallbacks, true);
+                if ( array() !== $children ) {
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+                }
+            }
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
                 if ( $this->isRuntimeDomTarget($element) ) {
                     return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
@@ -1310,6 +1316,10 @@ final class HtmlTransformer
                 }
                 if ( array() !== $children ) {
                     return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+                }
+
+                if ( $this->shouldPreserveEmptyVisualElement($element) ) {
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
                 }
 
                 return null;
@@ -2735,7 +2745,38 @@ final class HtmlTransformer
             return false;
         }
 
-        return in_array(strtolower($this->attr($element, 'role')), array( 'presentation', 'none' ), true) || 'true' === strtolower($this->attr($element, 'aria-hidden'));
+        if ( in_array(strtolower($this->attr($element, 'role')), array( 'presentation', 'none' ), true) || 'true' === strtolower($this->attr($element, 'aria-hidden')) ) {
+            return true;
+        }
+
+        if ( ! $this->isInlineContentElement(strtolower($element->tagName)) ) {
+            return false;
+        }
+
+        $tokens = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id') . ' ' . $this->attr($element, 'role')));
+        if ( ! preg_match('/(?:^|[^a-z0-9])(?:badge|chip|pill|status|indicator|marker|dot|orb|icon)(?:[^a-z0-9]|$)/', $tokens) ) {
+            return false;
+        }
+
+        $declarations = $this->presentationDeclarations($element);
+        foreach ( array( 'background', 'background-color', 'border', 'border-color', 'border-width', 'border-radius', 'box-shadow', 'width', 'height', 'min-width', 'min-height' ) as $property ) {
+            if ( isset($declarations[$property]) && '' !== trim($declarations[$property]) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasEmptyVisualInlineChild(DOMElement $element): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && $this->isInlineContentElement(strtolower($child->tagName)) && $this->shouldPreserveEmptyVisualElement($child) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isInlineContentElement(string $tagName): bool

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -217,7 +217,7 @@ trait StyleResolutionTrait
     private function isHighValueStyledElement(DOMElement $element): bool
     {
         $tagName = strtolower($element->tagName);
-        if ( in_array($tagName, array( 'button', 'nav', 'article', 'svg' ), true) ) {
+        if ( in_array($tagName, array( 'button', 'header', 'footer', 'main', 'nav', 'article', 'aside', 'section', 'svg' ), true) ) {
             return true;
         }
 
@@ -231,7 +231,7 @@ trait StyleResolutionTrait
             $this->attr($element, 'role'),
         ))));
 
-        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|logo|brand|branding|cards?|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap|hero|masthead|banner|media|image|photo|gallery|cover|thumb|thumbnail|art|artwork|illustration)(?:[^a-z0-9]|$)/', $tokens) ) {
+        if ( preg_match('/(?:^|[^a-z0-9])(?:btn|button|cta|action|nav|menu|logo|brand|branding|cards?|tile|panel|pricing|price|product|grid|columns|layout|stack|cluster|row|wrap|hero|masthead|banner|badge|chip|pill|status|indicator|marker|dot|orb|media|image|photo|gallery|cover|thumb|thumbnail|art|artwork|illustration)(?:[^a-z0-9]|$)/', $tokens) ) {
             return true;
         }
 

--- a/php-transformer/tests/fixtures/parity/html-saas-style-boundaries.json
+++ b/php-transformer/tests/fixtures/parity/html-saas-style-boundaries.json
@@ -1,0 +1,48 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-saas-style-boundaries",
+  "description": "Preserves generic styled SaaS-like logo, navigation, badge, and trusted-section boundaries without raw HTML fallbacks.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-saas-style-boundaries.json",
+    "notes": "Generic fixture for styled marketing landing-page primitives."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"site-header\"><a class=\"brand-logo\" href=\"/\"><svg viewBox=\"0 0 12 12\" aria-hidden=\"true\"><circle cx=\"6\" cy=\"6\" r=\"5\"></circle></svg><span>Relay Atlas</span></a><nav class=\"primary-nav\"><a href=\"#features\">Features</a><a href=\"#pricing\">Pricing</a></nav></header><main><section class=\"hero\"><p class=\"beta-badge\"><span class=\"status-orb\"></span><span>Now in open beta</span></p><h1>Every launch mapped.</h1></section><section class=\"trusted-by\" aria-label=\"Trusted by\"><article class=\"trusted-card\"><h3>Launch teams</h3><p>Keep work aligned.</p></article><article class=\"trusted-card\"><h3>Ops teams</h3><p>Surface risks early.</p></article><article class=\"trusted-card\"><h3>Founders</h3><p>Ship with context.</p></article></section></main>",
+    "options": {
+      "static_css": ".site-header{display:flex;align-items:center;gap:24px}.brand-logo{display:flex;align-items:center;gap:10px;font-weight:700}.primary-nav{display:flex;align-items:center;gap:16px}.beta-badge{display:inline-flex;align-items:center;gap:6px;border:1px solid #a36e12;border-radius:999px;padding:4px 12px}.beta-badge .status-orb{width:6px;height:6px;border-radius:999px;background:#3eca7a}.trusted-by{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}.trusted-card{background:#112240;border:1px solid rgba(255,255,255,.12);border-radius:8px;padding:18px}"
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header", "tagName": "header" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "brand-logo" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph" },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
+    { "path": "blocks.1", "name": "core/group", "attrs": { "tagName": "main" } },
+    { "path": "blocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "hero", "tagName": "section" } },
+    { "path": "blocks.1.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "beta-badge" } },
+    { "path": "blocks.1.innerBlocks.0.innerBlocks.1", "name": "core/heading" },
+    { "path": "blocks.1.innerBlocks.1", "name": "core/group", "attrs": { "className": "trusted-by", "tagName": "section" } },
+    { "path": "blocks.1.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "trusted-card", "tagName": "article" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 2 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "assets/materialized-svg/" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/\"><span>Relay Atlas</span></a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "beta-badge" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "status-orb" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "trusted-by" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "trusted-card" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<svg" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve logo anchors that combine safe inline SVG artwork with text by emitting a native image plus linked text in a flex group.
- Resolve source CSS for semantic landmark containers and marker/badge-like classes so SaaS-style sections retain more visual structure.
- Preserve empty styled inline visual markers, such as status dots/orbs, when CSS proves they have visible box styling.
- Add parity coverage for logo/nav classification and generic SaaS-like badge/trusted-section style boundaries.

## Verification
- composer test in php-transformer passed.
- Local SSI matrix for 15-saas via direct bench passed execution but still fails visual parity:
  - aligned mismatch: 42.44%
  - raw mismatch: 44.63%
  - editor validity: 263/263 valid
  - core/html blocks: 0
  - script fallback: 1
  - artifacts: /tmp/static-site-importer-fixture-matrix-saas-direct-20260706b/visual-compare/15-saas/source.png, candidate.png, diff.png

## Limitations
- This PR improves the baseline 15-saas aligned mismatch from the reported 44.31% to 42.44%, but it does not make the fixture visually acceptable.
- Remaining SaaS visual mismatch is dominated by broad restyle/position drift, especially CTA button row layout, vertical rhythm/spacing, and section/card offsets. The local matrix reports restyle_geometry 75,548 px and position_offset 35,770 px.
- The fixture beta orb is currently represented by CSS pseudo-element styling, so the new empty inline marker primitive is covered generically but does not move the current 15-saas metric.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Inspecting the existing worktree, implementing generic PHP transformer fixes, adding parity fixtures, running local verification, and drafting this PR description.
