### PR TITLE
Extract navigation underline color resolver

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -57,6 +57,7 @@
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/custom-block-generator.php",
       "php tests/unit/css-value-splitter.php",
+      "php tests/unit/navigation-underline-color-resolver.php",
       "php tests/unit/block-style-support-conversion.php",
       "php tests/unit/content-round-trip-reporter.php",
       "php tests/unit/content-round-trip-form-echo.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -19,13 +19,13 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\GalleryPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationUnderlineColorResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ParameterTablePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\SvgMaterializationTrait;
@@ -154,6 +154,8 @@ final class HtmlTransformer
     private readonly SpacerPattern $spacerPattern;
 
     private readonly PatternRecognizerRegistry $patternRecognizers;
+
+    private readonly NavigationUnderlineColorResolver $navigationUnderlineColorResolver;
 
     private readonly DiagnosticsCollector $diagnosticsCollector;
 
@@ -341,6 +343,7 @@ final class HtmlTransformer
             new AccordionPattern(),
             new NavigationPattern(),
         ));
+        $this->navigationUnderlineColorResolver = new NavigationUnderlineColorResolver();
         $this->diagnosticsCollector = new DiagnosticsCollector();
         $this->semanticParityReporter = new SemanticParityReporter($this->runtime);
         $this->contentRoundTripReporter = new ContentRoundTripReporter();
@@ -1153,61 +1156,13 @@ final class HtmlTransformer
 
     private function navigationUnderlineColor(DOMElement $item, DOMElement $anchor): string
     {
-        foreach ( array( $anchor, $item ) as $element ) {
-            $declarations = $this->presentationDeclarations($element);
-            foreach ( array( 'text-decoration-color', 'border-bottom-color', 'border-color' ) as $property ) {
-                $color = $this->usableCssColor((string) ($declarations[ $property ] ?? ''));
-                if ( '' !== $color ) {
-                    return $color;
-                }
-            }
-        }
-
-        foreach ( $this->staticPseudoElementStyleRules as $rule ) {
-            if ( ! $this->matchesCssSelector($anchor, $rule['selector']) && ! $this->matchesCssSelector($item, $rule['selector']) ) {
-                continue;
-            }
-
-            $declarations = $rule['declarations'];
-            foreach ( array( 'background-color', 'background', 'border-bottom-color', 'border-color', 'color' ) as $property ) {
-                $color = $this->usableCssColor((string) ($declarations[ $property ] ?? ''));
-                if ( '' !== $color ) {
-                    return $color;
-                }
-            }
-        }
-
-        foreach ( array( $anchor, $item ) as $element ) {
-            $color = $this->usableCssColor((string) ($this->presentationDeclarations($element)['color'] ?? ''));
-            if ( '' !== $color ) {
-                return $color;
-            }
-        }
-
-        return '';
-    }
-
-    private function usableCssColor(string $value): string
-    {
-        $value = trim($value);
-        if ( '' === $value ) {
-            return '';
-        }
-
-        $lower = strtolower($value);
-        if ( in_array($lower, array( 'transparent', 'none', 'inherit', 'initial', 'unset', 'revert', 'auto' ), true) ) {
-            return '';
-        }
-
-        if ( str_contains($value, '(') && ( ! str_ends_with($value, ')') || ! CssValueSplitter::hasBalancedParens($value) ) ) {
-            return '';
-        }
-
-        if ( preg_match('/^#[0-9a-f]{3,8}$/i', $value) || preg_match('/^(?:rgb|rgba|hsl|hsla|var)\s*\(/i', $value) || 'currentcolor' === $lower || preg_match('/^[a-z]+$/', $lower) ) {
-            return 'currentcolor' === $lower ? 'currentColor' : $value;
-        }
-
-        return '';
+        return $this->navigationUnderlineColorResolver->resolve(
+            $item,
+            $anchor,
+            fn (DOMElement $element): array => $this->presentationDeclarations($element),
+            $this->staticPseudoElementStyleRules,
+            fn (DOMElement $element, string $selector): bool => $this->matchesCssSelector($element, $selector)
+        );
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationUnderlineColorResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationUnderlineColorResolver.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
+use DOMElement;
+
+final class NavigationUnderlineColorResolver
+{
+    /**
+     * @param callable(DOMElement): array<string, string> $presentationDeclarations
+     * @param array<int, array{selector: string, pseudo: string, declarations: array<string, string>}> $staticPseudoElementStyleRules
+     * @param callable(DOMElement, string): bool $matchesCssSelector
+     */
+    public function resolve(DOMElement $item, DOMElement $anchor, callable $presentationDeclarations, array $staticPseudoElementStyleRules, callable $matchesCssSelector): string
+    {
+        foreach ( array( $anchor, $item ) as $element ) {
+            $declarations = $presentationDeclarations($element);
+            foreach ( array( 'text-decoration-color', 'border-bottom-color', 'border-color' ) as $property ) {
+                $color = $this->usableCssColor((string) ($declarations[ $property ] ?? ''));
+                if ( '' !== $color ) {
+                    return $color;
+                }
+            }
+        }
+
+        foreach ( $staticPseudoElementStyleRules as $rule ) {
+            if ( ! $matchesCssSelector($anchor, $rule['selector']) && ! $matchesCssSelector($item, $rule['selector']) ) {
+                continue;
+            }
+
+            $declarations = $rule['declarations'];
+            foreach ( array( 'background-color', 'background', 'border-bottom-color', 'border-color', 'color' ) as $property ) {
+                $color = $this->usableCssColor((string) ($declarations[ $property ] ?? ''));
+                if ( '' !== $color ) {
+                    return $color;
+                }
+            }
+        }
+
+        foreach ( array( $anchor, $item ) as $element ) {
+            $color = $this->usableCssColor((string) ($presentationDeclarations($element)['color'] ?? ''));
+            if ( '' !== $color ) {
+                return $color;
+            }
+        }
+
+        return '';
+    }
+
+    private function usableCssColor(string $value): string
+    {
+        $value = trim($value);
+        if ( '' === $value ) {
+            return '';
+        }
+
+        $lower = strtolower($value);
+        if ( in_array($lower, array( 'transparent', 'none', 'inherit', 'initial', 'unset', 'revert', 'auto' ), true) ) {
+            return '';
+        }
+
+        if ( str_contains($value, '(') && ( ! str_ends_with($value, ')') || ! CssValueSplitter::hasBalancedParens($value) ) ) {
+            return '';
+        }
+
+        if ( preg_match('/^#[0-9a-f]{3,8}$/i', $value) || preg_match('/^(?:rgb|rgba|hsl|hsla|var)\s*\(/i', $value) || 'currentcolor' === $lower || preg_match('/^[a-z]+$/', $lower) ) {
+            return 'currentcolor' === $lower ? 'currentColor' : $value;
+        }
+
+        return '';
+    }
+}

--- a/php-transformer/tests/unit/navigation-underline-color-resolver.php
+++ b/php-transformer/tests/unit/navigation-underline-color-resolver.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit tests for active navigation underline color resolution precedence.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationUnderlineColorResolver;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$document = new DOMDocument();
+$previousLibxmlState = libxml_use_internal_errors(true);
+$document->loadHTML('<!doctype html><html><body><nav><ul><li class="current"><a class="active" href="/">Home</a></li></ul></nav></body></html>');
+libxml_clear_errors();
+libxml_use_internal_errors($previousLibxmlState);
+$item = $document->getElementsByTagName('li')->item(0);
+$anchor = $document->getElementsByTagName('a')->item(0);
+
+if ( ! $item instanceof DOMElement || ! $anchor instanceof DOMElement ) {
+    fwrite(STDERR, 'FAIL: test DOM did not initialize' . PHP_EOL);
+    exit(1);
+}
+
+$resolver = new NavigationUnderlineColorResolver();
+
+$assert(
+    '#123456' === $resolver->resolve(
+        $item,
+        $anchor,
+        static fn (DOMElement $element): array => $element->tagName === 'a' ? array( 'text-decoration-color' => '#123456', 'color' => '#abcdef' ) : array( 'border-color' => '#654321' ),
+        array(),
+        static fn (): bool => false
+    ),
+    '1: explicit anchor text-decoration-color wins before item border color'
+);
+
+$assert(
+    'rgba(1, 2, 3, .4)' === $resolver->resolve(
+        $item,
+        $anchor,
+        static fn (): array => array(),
+        array(
+            array(
+                'selector'     => '.active::after',
+                'pseudo'       => 'after',
+                'declarations' => array( 'background-color' => 'rgba(1, 2, 3, .4)' ),
+            ),
+        ),
+        static fn (DOMElement $element, string $selector): bool => $element->tagName === 'a' && '.active::after' === $selector
+    ),
+    '2: matching pseudo-element background-color is used when direct decoration colors are absent'
+);
+
+$assert(
+    'currentColor' === $resolver->resolve(
+        $item,
+        $anchor,
+        static fn (DOMElement $element): array => $element->tagName === 'a' ? array( 'color' => 'currentcolor' ) : array(),
+        array(
+            array(
+                'selector'     => '.active::after',
+                'pseudo'       => 'after',
+                'declarations' => array( 'background-color' => 'transparent' ),
+            ),
+        ),
+        static fn (): bool => true
+    ),
+    '3: transparent pseudo color is ignored and text color fallback normalizes currentcolor'
+);
+
+$assert(
+    '' === $resolver->resolve(
+        $item,
+        $anchor,
+        static fn (): array => array( 'color' => 'rgba(1,' ),
+        array(),
+        static fn (): bool => false
+    ),
+    '4: truncated functional color values are rejected'
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Navigation underline color resolver tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "Navigation underline color resolver tests: {$passes} passed\n");


### PR DESCRIPTION
## Summary
- Extract active navigation underline color lookup from `HtmlTransformer` into `NavigationUnderlineColorResolver`.
- Keep the existing resolution order: direct decoration/border colors, matching pseudo-element colors, then text-color fallback.
- Add focused unit coverage for resolver precedence and invalid color rejection.

## Testing
- `php tests/unit/navigation-underline-color-resolver.php`
- `composer test`

## Behavior change
- Intended behavior-preserving refactor only. No fixture output changes expected.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Inspected PR/trunk state, extracted PHP transformer resolver code, added targeted unit coverage, and ran verification.