### PR TITLE
Add Figma fixture matrix bench harness

### DIFF
--- a/figma-transformer/README.md
+++ b/figma-transformer/README.md
@@ -104,6 +104,28 @@ add_filter(
 
 No pure-PHP Zstandard decoder is bundled today. Unsupported runtimes report `figma_transformer_zstd_extension_missing` or adapter failure diagnostics and continue parsing the rest of the archive metadata.
 
+### Fixture Matrix Bench
+
+The Homeboy fixture matrix bench shells out to `scripts/figma-fixture-matrix.php`, reads its `summary.json`, and reports duration, fixture-count, failure-count, per-fixture timing, and available quality counters as Homeboy metrics. Fixture files are intentionally supplied out of tree.
+
+Run a single local fixture:
+
+```sh
+homeboy bench --rig figma-transformer-fixture-matrix --profile fixture-matrix --setting bench_env.FIGMA_FIXTURE_MATRIX_FIXTURE=/path/to/fixture.fig --path /path/to/blocks-engine
+```
+
+Run a fixture corpus manually:
+
+```sh
+homeboy bench --rig figma-transformer-fixture-matrix --profile fixture-matrix --setting-json bench_env='{"FIGMA_FIXTURE_MATRIX_FIXTURES":["/path/to/fixture-a.fig","/path/to/fixture-b.fig","/path/to/fixture-c.fig"]}' --path /path/to/blocks-engine
+```
+
+The bench script is also directly runnable for local debugging:
+
+```sh
+node figma-transformer/bench/figma-fixture-matrix.bench.mjs --fixture=/path/to/fixture.fig
+```
+
 ### Large `.fig` Memory Profiles
 
 Large production `.fig` exports should default to bounded inspection before full scenegraph materialization. Keep the library defaults conservative: the eager Kiwi message decode limit is 16 MB, the selective decode preflight limit is 32 MB, and the zstd inflated chunk limit is 64 MB. With those defaults, oversized modern Kiwi messages are reported with `figma_transformer_kiwi_message_decode_skipped_preflight` instead of risking a PHP fatal.

--- a/figma-transformer/bench/figma-fixture-matrix.bench.mjs
+++ b/figma-transformer/bench/figma-fixture-matrix.bench.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const figmaRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const repoRoot = path.dirname(figmaRoot);
+const matrixScript = path.join(figmaRoot, 'scripts', 'figma-fixture-matrix.php');
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const result = runFigmaFixtureMatrixBench({ args: process.argv.slice(2) });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if ((result.metrics.failed_fixture_count || 0) > 0 || result.metadata.matrix_exit_code !== 0) {
+    process.exitCode = result.metadata.matrix_exit_code || 1;
+  }
+}
+
+export default function runFigmaFixtureMatrixBench(context = {}) {
+  const args = Array.isArray(context.args) ? context.args : [];
+  const options = parseOptions(args);
+  const outputDir = path.resolve(options.outputDir || process.env.FIGMA_FIXTURE_MATRIX_OUTPUT_DIR || path.join(process.env.HOMEBOY_ARTIFACT_ROOT || os.tmpdir(), `figma-transformer-fixture-matrix-bench-${Date.now()}`));
+  const matrixArgs = buildMatrixArgs(options, outputDir);
+  const startedAt = process.hrtime.bigint();
+  const runtime = spawnSync('php', [matrixScript, ...matrixArgs], {
+    cwd: repoRoot,
+    env: process.env,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 100,
+  });
+  const wallDurationMs = Number((process.hrtime.bigint() - startedAt) / 1000000n);
+  const summaryPath = path.join(outputDir, 'summary.json');
+  const summary = readJson(summaryPath) || parseLastJsonObject(runtime.stdout) || {};
+
+  if (!summary || !Array.isArray(summary.fixtures)) {
+    throw new Error(`Figma fixture matrix did not produce a readable summary at ${summaryPath}. stderr: ${runtime.stderr || '<empty>'}`);
+  }
+
+  return summarizeBench(summary, {
+    outputDir,
+    summaryPath,
+    matrixArgs,
+    wallDurationMs,
+    exitCode: runtime.status ?? 1,
+    signal: runtime.signal,
+    stderr: runtime.stderr,
+  });
+}
+
+function buildMatrixArgs(options, outputDir) {
+  const matrixArgs = [];
+  for (const fixture of fixturePaths(options)) {
+    matrixArgs.push(`--fixture=${fixture}`);
+  }
+  if (options.fixtureDir) {
+    matrixArgs.push(`--fixture-dir=${options.fixtureDir}`);
+  }
+  if (options.includeFixtureDir) {
+    matrixArgs.push('--include-fixture-dir');
+  }
+  matrixArgs.push(`--output-dir=${outputDir}`);
+  matrixArgs.push(...envPassthroughArgs());
+  matrixArgs.push(...options.passthrough);
+  return matrixArgs;
+}
+
+function fixturePaths(options) {
+  const values = [...options.fixtures];
+  values.push(...envList('FIGMA_FIXTURE_MATRIX_FIXTURES'));
+  if (process.env.FIGMA_FIXTURE_MATRIX_FIXTURE) {
+    values.push(process.env.FIGMA_FIXTURE_MATRIX_FIXTURE);
+  }
+  return unique(values.map((item) => item.trim()).filter(Boolean));
+}
+
+function envPassthroughArgs() {
+  return envList('FIGMA_FIXTURE_MATRIX_ARGS');
+}
+
+function envList(name) {
+  const value = process.env[name];
+  if (!value) {
+    return [];
+  }
+  const trimmed = value.trim();
+  if (trimmed.startsWith('[')) {
+    const decoded = JSON.parse(trimmed);
+    if (!Array.isArray(decoded)) {
+      throw new Error(`${name} must be a JSON array when it starts with '['.`);
+    }
+    return decoded.map(String);
+  }
+  return trimmed.split(path.delimiter).map((item) => item.trim()).filter(Boolean);
+}
+
+function summarizeBench(summary, runtime) {
+  const fixtures = summary.fixtures;
+  const metrics = {
+    total_duration_ms: numberOr(runtime.wallDurationMs),
+    matrix_duration_ms: sumMetric(fixtures, 'duration_ms'),
+    inspect_duration_ms: sumMetric(fixtures, 'inspect_duration_ms'),
+    fixture_count: fixtures.length,
+    passed_fixture_count: fixtures.filter((fixture) => fixture.status === 'completed' || fixture.status === 'inspected').length,
+    failed_fixture_count: fixtures.filter((fixture) => !['completed', 'inspected', 'planned'].includes(String(fixture.status || ''))).length,
+    vector_placeholder_count: sumQuality(fixtures, vectorPlaceholderCount),
+    missing_asset_count: sumQuality(fixtures, missingAssetCount),
+  };
+
+  for (const fixture of fixtures) {
+    const id = metricId(fixture.id || path.basename(String(fixture.path || 'fixture')));
+    if (Number.isFinite(Number(fixture.duration_ms))) {
+      metrics[`fixture_${id}_duration_ms`] = Number(fixture.duration_ms);
+    }
+    if (Number.isFinite(Number(fixture.inspect_duration_ms))) {
+      metrics[`fixture_${id}_inspect_duration_ms`] = Number(fixture.inspect_duration_ms);
+    }
+    if (Number.isFinite(Number(fixture.vector_placeholders))) {
+      metrics[`fixture_${id}_vector_placeholder_count`] = Number(fixture.vector_placeholders);
+    }
+    const fixtureMissingAssets = missingAssetCount(fixture);
+    if (fixtureMissingAssets > 0) {
+      metrics[`fixture_${id}_missing_asset_count`] = fixtureMissingAssets;
+    }
+  }
+
+  return {
+    metrics,
+    artifacts: artifactMap(summary, runtime.summaryPath),
+    metadata: {
+      schema: 'blocks-engine/figma-transformer/fixture-matrix-bench/v1',
+      output_dir: runtime.outputDir,
+      matrix_summary: runtime.summaryPath,
+      matrix_args: runtime.matrixArgs,
+      matrix_exit_code: runtime.exitCode,
+      matrix_signal: runtime.signal || null,
+      stderr: runtime.stderr || '',
+      fixture_statuses: Object.fromEntries(fixtures.map((fixture) => [String(fixture.id || fixture.path), fixture.status || null])),
+    },
+  };
+}
+
+function artifactMap(summary, summaryPath) {
+  const artifacts = {
+    summary: { path: summaryPath },
+    output_dir: { path: String(summary.output_dir || path.dirname(summaryPath)) },
+  };
+  for (const fixture of summary.fixtures || []) {
+    const id = metricId(fixture.id || path.basename(String(fixture.path || 'fixture')));
+    for (const [key, value] of Object.entries({
+      [`fixture_${id}_inspect`]: fixture.inspect_path,
+      [`fixture_${id}_result`]: fixture.result_path,
+      [`fixture_${id}_artifact_dir`]: fixture.artifact_dir,
+    })) {
+      if (typeof value === 'string' && value) {
+        artifacts[key] = { path: value };
+      }
+    }
+  }
+  return artifacts;
+}
+
+function vectorPlaceholderCount(fixture) {
+  return numberOr(fixture.vector_placeholders || fixture.artifact_quality?.vectors?.placeholders || fixture.quality_summary?.vector_placeholders);
+}
+
+function missingAssetCount(fixture) {
+  const direct = firstNumber([
+    fixture.missing_asset_count,
+    fixture.missing_assets_count,
+    fixture.quality_summary?.missing_asset_count,
+    fixture.quality_summary?.missing_assets,
+    fixture.artifact_quality?.missing_asset_count,
+    fixture.artifact_quality?.missing_assets_count,
+    fixture.artifact_quality?.summary?.missing_asset_count,
+    fixture.artifact_quality?.summary?.missing_assets,
+  ]);
+  if (direct !== null) {
+    return direct;
+  }
+  const codes = Array.isArray(fixture.diagnostic_codes) ? fixture.diagnostic_codes : [];
+  return codes.filter((code) => String(code).includes('missing_asset')).length;
+}
+
+function sumMetric(fixtures, key) {
+  return fixtures.reduce((total, fixture) => total + numberOr(fixture[key]), 0);
+}
+
+function sumQuality(fixtures, getter) {
+  return fixtures.reduce((total, fixture) => total + getter(fixture), 0);
+}
+
+function firstNumber(values) {
+  for (const value of values) {
+    const number = Number(value);
+    if (Number.isFinite(number)) {
+      return number;
+    }
+  }
+  return null;
+}
+
+function numberOr(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function metricId(value) {
+  return String(value).toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'fixture';
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function parseLastJsonObject(text) {
+  if (!text) {
+    return null;
+  }
+  const start = text.lastIndexOf('\n{');
+  const jsonText = start === -1 ? text.trim() : text.slice(start + 1).trim();
+  try {
+    return JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+}
+
+function parseOptions(args) {
+  const options = {
+    fixtures: [],
+    passthrough: [],
+    includeFixtureDir: false,
+    help: false,
+  };
+  for (const arg of args) {
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg === '--include-fixture-dir') {
+      options.includeFixtureDir = true;
+      continue;
+    }
+    if (arg.startsWith('--fixture=')) {
+      options.fixtures.push(arg.slice('--fixture='.length));
+      continue;
+    }
+    if (arg.startsWith('--fixture-dir=')) {
+      options.fixtureDir = arg.slice('--fixture-dir='.length);
+      continue;
+    }
+    if (arg.startsWith('--output-dir=')) {
+      options.outputDir = arg.slice('--output-dir='.length);
+      continue;
+    }
+    options.passthrough.push(arg);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:\n  node figma-transformer/bench/figma-fixture-matrix.bench.mjs [matrix options]\n\nInputs:\n  --fixture=/path/file.fig               Repeatable explicit fixture path.\n  --fixture-dir=/path/to/fixtures        Discover fixtures through the matrix script.\n  --output-dir=/path                     Artifact directory.\n  FIGMA_FIXTURE_MATRIX_FIXTURES          JSON array, or ${path.delimiter}-delimited fixture paths.\n  FIGMA_FIXTURE_MATRIX_FIXTURE           Single fixture path.\n  FIGMA_FIXTURE_MATRIX_ARGS              JSON array, or ${path.delimiter}-delimited extra matrix args.\n\nAll other CLI args are passed through to figma-fixture-matrix.php.\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/figma-transformer/rigs/fixture-matrix/rig.json
+++ b/figma-transformer/rigs/fixture-matrix/rig.json
@@ -5,13 +5,40 @@
     "blocks-engine": {
       "path": "${package.root}/../../..",
       "branch": "trunk",
-      "extensions": {}
+      "extensions": {
+        "nodejs": {}
+      }
     }
   },
   "resources": {
     "paths": [
       "${components.blocks-engine.path}"
     ]
+  },
+  "bench": {
+    "default_component": "blocks-engine",
+    "iterations": 1,
+    "warmup_iterations": 0,
+    "path_inputs": [
+      "--path",
+      "bench_env.FIGMA_FIXTURE_MATRIX_FIXTURE",
+      "bench_env.FIGMA_FIXTURE_MATRIX_FIXTURES",
+      "bench_env.FIGMA_FIXTURE_MATRIX_OUTPUT_DIR"
+    ],
+    "result_gates": {
+      "failed_fixture_count": { "lte": 0 }
+    }
+  },
+  "bench_workloads": {
+    "nodejs": [
+      {
+        "path": "${components.blocks-engine.path}/figma-transformer/bench/figma-fixture-matrix.bench.mjs"
+      }
+    ]
+  },
+  "bench_profiles": {
+    "smoke": ["figma-fixture-matrix"],
+    "fixture-matrix": ["figma-fixture-matrix"]
   },
   "pipeline": {
     "check": [


### PR DESCRIPTION
## Summary
- Add a Node bench harness for the Figma fixture matrix script.
- Register the fixture matrix Homeboy bench workload/profile and failed-fixture gate.
- Document portable bench usage examples for local fixture corpora.

## Verification
- `node --check figma-transformer/bench/figma-fixture-matrix.bench.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('figma-transformer/rigs/fixture-matrix/rig.json','utf8'));"`
- `homeboy rig lint figma-transformer/rigs/fixture-matrix --id figma-transformer-fixture-matrix`
- `node figma-transformer/bench/figma-fixture-matrix.bench.mjs --fixture=/Users/chubes/Downloads/Fisiostetic.fig`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Prepared the PR, verified the bench harness, adjusted reviewer-facing docs to use portable examples, and drafted this description.