### PR TITLE
Fix Figma page selection diagnostics

### DIFF
--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -205,8 +205,10 @@ function matrix_candidate_rank(array $candidate): int
     } elseif ( in_array($type, array('COMPONENT', 'INSTANCE'), true) ) {
         $score -= 400;
     }
-    if ( in_array($parentType, array('CANVAS', 'SECTION'), true) ) {
-        $score += 100;
+    if ( 'CANVAS' === $parentType ) {
+        $score += 500;
+    } elseif ( 'SECTION' === $parentType ) {
+        $score += 80;
     }
     if ( 1 === preg_match('/\b(home|homepage|desktop|page|website|landing|lp|archive|single|blog|theme|build|hosts?|agenc(?:y|ies)|pricing|features?|about|contact)\b/', $name . ' ' . $pageName) ) {
         $score += 200;
@@ -336,7 +338,7 @@ function matrix_is_page_like_candidate(array $candidate): bool
         }
     }
 
-    return $width >= 900.0 && $width <= 2048.0 && $height >= 700.0 && $textCount > 0 && in_array($parentType, array('CANVAS', 'SECTION'), true);
+    return $width >= 900.0 && $width <= 2560.0 && $height >= 700.0 && $textCount > 0 && in_array($parentType, array('CANVAS', 'SECTION'), true);
 }
 
 function matrix_is_reference_page_name(string $pageName): bool

--- a/figma-transformer/src/Html/CssPositioningResolver.php
+++ b/figma-transformer/src/Html/CssPositioningResolver.php
@@ -31,17 +31,10 @@ final class CssPositioningResolver
         $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
         $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
         $parentIsFreeform = true === ($parentLayout['freeform'] ?? false);
-        $left = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'x', $parentNode);
-        $top = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'y', $parentNode);
+        $offsets = $this->effectiveOffsets($box, $parentNode, $node);
+        $left = $offsets['x'];
+        $top = $offsets['y'];
         $centerInsetVisualChild = null !== $node && null !== $parentNode && $this->isInsetSingleVisualChild($node, $parentNode);
-        if ( null !== $node ) {
-            $left = $this->componentSourceCloneScalarOffset($node, $box, $parentBox, 'x', $left);
-            $top = $this->componentSourceCloneScalarOffset($node, $box, $parentBox, 'y', $top);
-        }
-        if ( null !== $node && $this->hasComponentCloneGeometry($node) ) {
-            $left = $this->componentCloneSourceOffset($node, $box, $parentBox, 'x', $left);
-            $top = $this->componentCloneSourceOffset($node, $box, $parentBox, 'y', $top);
-        }
         $constraints = is_array($layout['constraints'] ?? null) ? $layout['constraints'] : array();
         if ( $centerInsetVisualChild ) {
             $left = $this->centeredInsetOffset($box, $parentBox, 'width');
@@ -61,6 +54,34 @@ final class CssPositioningResolver
         }
 
         return $styles;
+    }
+
+    /**
+     * Resolve the near-edge offsets CSS will use before constraint-specific
+     * anchoring. Diagnostics consume this so component clone/source geometry is
+     * judged against emitted placement, not stale source coordinates.
+     *
+     * @param array<string, mixed> $box
+     * @param array<string, mixed>|null $parentNode
+     * @param array<string, mixed>|null $node
+     * @return array{x: float|null, y: float|null}
+     */
+    public function effectiveOffsets(array $box, ?array $parentNode, ?array $node = null): array
+    {
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        $left = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'x', $parentNode);
+        $top = $this->layoutIntentClassifier->positionOffset($box, $parentBox, 'y', $parentNode);
+
+        if ( null !== $node ) {
+            $left = $this->componentSourceCloneScalarOffset($node, $box, $parentBox, 'x', $left);
+            $top = $this->componentSourceCloneScalarOffset($node, $box, $parentBox, 'y', $top);
+        }
+        if ( null !== $node && $this->hasComponentCloneGeometry($node) ) {
+            $left = $this->componentCloneSourceOffset($node, $box, $parentBox, 'x', $left);
+            $top = $this->componentCloneSourceOffset($node, $box, $parentBox, 'y', $top);
+        }
+
+        return array('x' => $left, 'y' => $top);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -4637,8 +4637,9 @@ final class StaticHtmlEmitter
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
-        $left = $this->positionOffset($box, $parentBox, 'x', $parentNode);
-        $top = $this->positionOffset($box, $parentBox, 'y', $parentNode);
+        $offsets = $this->cssPositioningResolver()->effectiveOffsets($box, $parentNode, $node);
+        $left = $offsets['x'];
+        $top = $offsets['y'];
         $width = isset($box['width']) && is_numeric($box['width']) ? (float) $box['width'] : 0.0;
         $height = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : 0.0;
         $parentWidth = isset($parentBox['width']) && is_numeric($parentBox['width']) ? (float) $parentBox['width'] : null;

--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -43,7 +43,7 @@ final class ScenegraphPagePlanner
     /**
      * Page-candidacy dimension band. A real page artboard is a tall, scrolling
      * frame whose width sits in the realistic device range (small mobile through
-     * wide desktop). Frames outside this band are top-level on the canvas but are
+     * extra-wide desktop). Frames outside this band are top-level on the canvas but are
      * not pages: layout-grid guides / chips (narrower than {@see PAGE_MIN_WIDTH_PX}),
      * oversized presentation / overview / style-guide boards (wider than
      * {@see PAGE_MAX_WIDTH_PX}), and decorative dividers / cover thumbnails /
@@ -51,7 +51,7 @@ final class ScenegraphPagePlanner
      * `frame_ids` bypass this band so any requested frame stays selectable.
      */
     private const PAGE_MIN_WIDTH_PX  = 320.0;
-    private const PAGE_MAX_WIDTH_PX  = 2048.0;
+    private const PAGE_MAX_WIDTH_PX  = 2560.0;
     private const PAGE_MIN_HEIGHT_PX = 700.0;
 
     public function __construct(
@@ -620,9 +620,8 @@ final class ScenegraphPagePlanner
      * candidacy — it drops top-level frames that are structurally on the canvas
      * but are plainly not pages: layout-grid guides and chips (too narrow),
      * decorative "Title Card" dividers / cover thumbnails / device mockups (too
-     * short), and oversized presentation/overview artboards (too wide, e.g. a
-     * 2238px "Home Page – Desktop" overview board colliding with the real 1440px
-     * page). Explicit `frame_ids` bypass this gate entirely.
+     * short), and oversized presentation/overview artboards (too wide). Explicit
+     * `frame_ids` bypass this gate entirely.
      */
     private function isPageSizedCandidate(float $width, float $height): bool
     {

--- a/figma-transformer/tests/contract/ComponentCloneEmissionContract.php
+++ b/figma-transformer/tests/contract/ComponentCloneEmissionContract.php
@@ -58,6 +58,12 @@ function blocks_engine_figma_transformer_run_component_clone_emission_contract(c
     );
     $assert(in_array('left:1180px', $scalarStyles, true), 'component-clone-page-local-css-uses-clone-scalar-x');
     $assert(in_array('top:72px', $scalarStyles, true), 'component-clone-page-local-css-uses-clone-scalar-y');
+    $scalarEffectiveOffsets = $scalarPositioning->effectiveOffsets(
+        array('x' => 1774, 'y' => 2387, 'width' => 225, 'height' => 48, 'coordinate_space' => 'local', 'local_origin' => 'page'),
+        array('box' => array('x' => 0, 'y' => 0, 'width' => 1440, 'height' => 145), 'layout' => array('freeform' => true)),
+        array('figma_component_source_id' => 'component-source:page-local-css', 'x' => 1180, 'y' => 72)
+    );
+    $assert(array('x' => 1180.0, 'y' => 72.0) === $scalarEffectiveOffsets, 'component-clone-effective-offsets-use-clone-scalar');
 
     $headerChromePositioning = new Automattic\BlocksEngine\FigmaTransformer\Html\CssPositioningResolver(
         new Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier(),

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -57,6 +57,37 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
         ),
     ), 5);
 
+    $wideRootSelection = matrix_select_frame_ids(array(
+        'candidates' => array(
+            array(
+                'id'         => 'frame:fisiostetic-home',
+                'name'       => 'Fisiostetic home page',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 500,
+                'width'      => 2095,
+                'height'     => 6200,
+                'text_count' => 120,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Fisiostetic'),
+            ),
+            array(
+                'id'         => 'frame:pricing-section',
+                'name'       => 'Pricing',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'page',
+                'score'      => 900,
+                'width'      => 1440,
+                'height'     => 1200,
+                'text_count' => 20,
+                'parent'     => array('type' => 'SECTION'),
+                'page'       => array('name' => 'Fisiostetic'),
+            ),
+        ),
+    ), 1);
+
     $matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
     file_put_contents($matrixSelectionLockPath, json_encode(array(
         'schema'   => 'blocks-engine/figma-transformer/fixture-matrix/v1',
@@ -130,6 +161,7 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
 
     $assert(! in_array('frame:title-card', $matrixSelection, true), 'fixture-matrix-selection-skips-dev-marked-title-card');
     $assert(array('frame:home-desktop', 'frame:single-desktop') === $matrixSelection, 'fixture-matrix-selection-falls-back-to-page-like-frames');
+    $assert(array('frame:fisiostetic-home') === $wideRootSelection, 'fixture-matrix-selection-prefers-wide-root-page-over-section-frame');
     $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
     $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
     $assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');


### PR DESCRIPTION
## Summary
- Widen Figma page candidate selection to include extra-wide desktop pages up to 2560px and prefer canvas-root pages over section frames.
- Share CSS effective-offset resolution between emitted positioning and diagnostics so component clone/source geometry diagnostics use the same offsets as emitted CSS.
- Add contract coverage for wide root page selection and component clone effective offsets.

## Verification
- `composer test` from `figma-transformer` passed.
- `git diff --check` passed.
- Bounded Fisiostetic inspect-only matrix passed, selecting the 2095px canvas-root page frame `19:185`.
- Bounded Twenty Twenty-Five Community inspect-only matrix passed, selecting `6338:2979`, `3137:2792`, and `4720:1953`.
- Existing full matrix transform evidence for Fisiostetic and Twenty Twenty-Five Community completed with warnings; Fisiostetic showed `large_css_offset_count: 0` and `large_absolute_offset_count: 0`.

## Caveats
- Visual parity was not run; matrix parity statuses remain `not_run`.
- Twenty Twenty-Five Community full transform evidence still reports pre-existing quality warnings for missing render assets and one large CSS offset; this PR targets page selection and clone/source effective-offset diagnostics, not full fixture parity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Prepared the branch for review, ran verification, summarized evidence, and drafted this PR description.