### PR TITLE
Add desktop Figma responsive fallback CSS

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -78,7 +78,7 @@ final class BreakpointMediaDiffBuilder
     {
         $variants = is_array($page['variants'] ?? null) ? array_values($page['variants']) : array();
         if ( count($variants) < 2 ) {
-            return array();
+            return $this->desktopOnlyResponsiveFallbackMediaBlocks($page, $baseNode);
         }
 
         $baseStyles = array();
@@ -127,6 +127,150 @@ final class BreakpointMediaDiffBuilder
         }
 
         return $blocks;
+    }
+
+    /**
+     * Desktop-only Figma files often export one oversized fixed canvas. Keep the
+     * source desktop rules intact and add a narrow-screen safety layer only when
+     * the page root itself clearly exceeds common mobile/tablet widths.
+     *
+     * @param array<string, mixed> $page
+     * @param array<string, mixed> $baseNode
+     * @return array<int, string>
+     */
+    private function desktopOnlyResponsiveFallbackMediaBlocks(array $page, array $baseNode): array
+    {
+        $rootWidth = $this->nodeBoxDimension($baseNode, 'width') ?? $this->primaryVariantViewportWidth($page);
+        if ( null === $rootWidth || $rootWidth < 960.0 ) {
+            return array();
+        }
+
+        $baseStyles = array();
+        $this->collectVariantNodeStyles($baseNode, 0, null, null, 'r', $baseStyles);
+
+        $rules = array();
+        foreach ( $baseStyles as $base ) {
+            $class = isset($base['class']) && is_scalar($base['class']) ? (string) $base['class'] : '';
+            $node = is_array($base['node'] ?? null) ? $base['node'] : array();
+            $baseMap = $this->styleDeclarationMap(is_array($base['styles'] ?? null) ? $base['styles'] : array());
+            if ( '' === $class || empty($node) || empty($baseMap) || $this->usesFullBleedViewportBreakout($baseMap) ) {
+                continue;
+            }
+
+            $depth = isset($base['depth']) && is_numeric($base['depth']) ? (int) $base['depth'] : 0;
+            $declarations = $this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null);
+            $changed = array();
+            foreach ( $declarations as $declaration ) {
+                $parts = explode(':', $declaration, 2);
+                if ( 2 !== count($parts) ) {
+                    continue;
+                }
+                $property = trim($parts[0]);
+                $value = trim($parts[1]);
+                if ( ! array_key_exists($property, $baseMap) || $baseMap[$property] !== $value ) {
+                    $changed[] = $property . ':' . $value;
+                }
+            }
+
+            if ( ! empty($changed) ) {
+                $rules[] = '.' . $class . '{' . implode(';', array_values(array_unique($changed))) . '}';
+            }
+        }
+
+        if ( empty($rules) ) {
+            return array();
+        }
+
+        return array($this->mediaBlock(767, array_values(array_unique($rules))));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, string> $baseMap
+     * @return array<int, string>
+     */
+    private function desktopOnlyResponsiveFallbackDeclarations(array $node, array $baseMap, int $depth, ?float $fallbackWidth = null): array
+    {
+        $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
+        $width = $this->responsiveCssWidth($baseMap) ?? $this->nodeBoxDimension($node, 'width') ?? $fallbackWidth;
+        $height = $this->cssPixelValue($baseMap['height'] ?? '');
+        $display = (string) ($baseMap['display'] ?? '');
+        $position = (string) ($baseMap['position'] ?? '');
+        $isContainer = in_array($type, array('FRAME', 'GROUP', 'INSTANCE', 'COMPONENT', 'SYMBOL', 'SECTION'), true);
+        $declarations = array();
+
+        if ( $isContainer && null !== $width && $width > 767.0 ) {
+            $declarations[] = 'width:100%';
+            $declarations[] = 'max-width:100%';
+            if ( null !== $height && $height > 240.0 && 'absolute' !== $position ) {
+                $declarations[] = 'height:auto';
+                $declarations[] = 'min-height:' . ($this->number)(min($height, 720.0)) . 'px';
+            }
+            if ( in_array($display, array('flex', 'inline-flex'), true) && 'row' === ($baseMap['flex-direction'] ?? null) ) {
+                $declarations[] = 'flex-wrap:wrap';
+                $declarations[] = 'align-content:flex-start';
+            }
+        }
+
+        if ( 'TEXT' === $type && null !== $width && $width > 320.0 ) {
+            $declarations[] = 'width:100%';
+            $declarations[] = 'max-width:100%';
+            if ( null !== $height && $height > 0.0 ) {
+                $declarations[] = 'height:auto';
+            }
+            if ( in_array($baseMap['white-space'] ?? '', array('pre', 'pre-line', 'nowrap'), true) ) {
+                $declarations[] = 'white-space:normal';
+                $declarations[] = 'overflow-wrap:anywhere';
+            }
+            if ( $depth <= 2 && 'absolute' === $position ) {
+                $declarations[] = 'left:24px';
+                $declarations[] = 'right:24px';
+            }
+        }
+
+        return array_values(array_unique($declarations));
+    }
+
+    /**
+     * @param array<string, string> $baseMap
+     */
+    private function responsiveCssWidth(array $baseMap): ?float
+    {
+        $width = $this->cssPixelValue($baseMap['width'] ?? '');
+        if ( null === $width && '100%' === ($baseMap['width'] ?? null) ) {
+            $width = $this->cssPixelValue($baseMap['max-width'] ?? '');
+        }
+
+        return $width;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function nodeBoxDimension(array $node, string $dimension): ?float
+    {
+        foreach ( array('box', 'figma_box') as $boxKey ) {
+            $box = is_array($node[$boxKey] ?? null) ? $node[$boxKey] : array();
+            if ( isset($box[$dimension]) && is_numeric($box[$dimension]) ) {
+                return (float) $box[$dimension];
+            }
+        }
+
+        return isset($node[$dimension]) && is_numeric($node[$dimension]) ? (float) $node[$dimension] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $page
+     */
+    private function primaryVariantViewportWidth(array $page): ?float
+    {
+        foreach ( is_array($page['variants'] ?? null) ? $page['variants'] : array() as $variant ) {
+            if ( is_array($variant) && true === ($variant['primary'] ?? false) && is_numeric($variant['viewport_width'] ?? null) ) {
+                return (float) $variant['viewport_width'];
+            }
+        }
+
+        return is_numeric($page['viewport_width'] ?? null) ? (float) $page['viewport_width'] : null;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -382,6 +382,7 @@ final class StaticHtmlEmitter
         $this->emittedNodeMetadata = array();
         $this->suppressedVisualNodeIds = array();
         $this->decisionTraces = array();
+        $this->breakpointMediaDiffBuilder()->resetDecisionTraces();
         $this->stickyLayoutCoordinator()->reset();
         $this->linkState->resetForSinglePage($this->normalizeLinkTargetPaths($options));
         $title = $this->sanitizeText((string) ($scenegraph['name'] ?? 'Figma Site'));
@@ -418,7 +419,8 @@ final class StaticHtmlEmitter
         $cssRules = $shared['rules'];
         $body     = $this->staticHtmlCssRuleSet()->applySharedClassMapToHtml($body, $shared['class_map']);
 
-        $cssWithoutFontCss = $this->htmlArtifactAssembler()->stylesheet('', (string) $designSystem['css'], $cssRules);
+        $mediaBlocks = $this->desktopOnlyFallbackMediaBlocks($scenegraph, $nodes);
+        $cssWithoutFontCss = $this->htmlArtifactAssembler()->stylesheet('', (string) $designSystem['css'], $cssRules, $mediaBlocks);
         $fontUsage = $this->fontUsage($nodeStyleDiagnostics, $cssWithoutFontCss, $body);
         $fontFamilies = array_column($fontUsage, 'family');
         $fontResolution = $this->fontResolver()->resolve($fontUsage, $operatorFontCss, $familyOverrides);
@@ -428,7 +430,7 @@ final class StaticHtmlEmitter
             $diagnostics[] = $diagnostic;
         }
 
-        $css = $this->htmlArtifactAssembler()->stylesheet($fontCss, (string) $designSystem['css'], $cssRules);
+        $css = $this->htmlArtifactAssembler()->stylesheet($fontCss, (string) $designSystem['css'], $cssRules, $mediaBlocks);
         $files = array(
             array(
                 'path'      => 'index.html',
@@ -489,6 +491,35 @@ final class StaticHtmlEmitter
                 'asset_count' => count($assetFiles),
             ),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $scenegraph
+     * @param array<int, mixed> $nodes
+     * @return array<int, string>
+     */
+    private function desktopOnlyFallbackMediaBlocks(array $scenegraph, array $nodes): array
+    {
+        $blocks = array();
+        $nodeMap = $this->nodeMap($scenegraph);
+        foreach ( $nodes as $node ) {
+            if ( ! is_array($node) ) {
+                continue;
+            }
+
+            $viewportWidth = $this->boxValue($node, 'width');
+            $blocks = array_merge($blocks, $this->breakpointMediaDiffBuilder()->buildMediaBlocks(array(
+                'variants' => array(
+                    array(
+                        'frame_id'       => is_scalar($node['id'] ?? null) ? (string) $node['id'] : '',
+                        'viewport_width' => $viewportWidth,
+                        'primary'        => true,
+                    ),
+                ),
+            ), $node, $nodeMap));
+        }
+
+        return array_values(array_unique($blocks));
     }
 
     /**

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -1657,12 +1657,13 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     }
     $assert('success' === ($responsiveEmitResult['status'] ?? null), 'responsive-emit-status-success');
     $assert('' !== $responsiveEmitCss, 'responsive-emit-stylesheet-present');
-    // Two narrower breakpoints => exactly two media blocks, keyed at the MIDPOINT
-    // between adjacent variant widths (not the narrow variant's own width).
+    // Two narrower breakpoints plus one wide desktop-only page fallback => three
+    // media blocks. Variant breakpoints are keyed at the MIDPOINT between
+    // adjacent variant widths (not the narrow variant's own width).
     // desktop=1440, tablet=834, mobile=390:
     //   tablet breakpoint = round((1440+834)/2) = 1137
     //   mobile breakpoint = round((834+390)/2)  = 612
-    $assert(2 === substr_count($responsiveEmitCss, '@media'), 'responsive-emit-two-media-blocks');
+    $assert(3 === substr_count($responsiveEmitCss, '@media'), 'responsive-emit-two-variant-media-blocks-plus-desktop-fallback');
     $assert(str_contains($responsiveEmitCss, '@media (max-width:1137px){'), 'responsive-emit-tablet-media-query');
     $assert(str_contains($responsiveEmitCss, '@media (max-width:612px){'), 'responsive-emit-mobile-media-query');
     // Base layout uses the primary (desktop) variant styles, emitted before media.
@@ -1685,8 +1686,9 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(! preg_match('/\.figma-node-cards-desktop-card-a-image-card-image\{[^}]*height:auto/', $responsiveEmitMobileBlock), 'responsive-emit-mobile-leaf-image-keeps-fixed-height');
     $assert(! preg_match('/\.figma-node-cards-desktop-decor-absolute-decorative-rail\{[^}]*height:auto/', $responsiveEmitMobileBlock), 'responsive-emit-mobile-absolute-decoration-keeps-fixed-height');
     $assert(! str_contains($responsiveEmitMobileBlock, '.figma-node-frame-home-desktop-home-desktop{width:390px'), 'responsive-emit-mobile-root-does-not-pin-variant-width');
-    // The single-variant About page contributes NO media override for its nodes.
-    $assert(0 === preg_match('/@media[^@]*figma-node-card-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-no-media');
+    // The single-variant About page contributes only a conservative desktop-only
+    // fallback media block.
+    $assert(1 === preg_match('/@media \(max-width:767px\)\{[\s\S]*figma-node-frame-about-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-desktop-fallback-media');
 
     $responsiveMismatchScenegraph = array(
         'name'  => 'Responsive Mismatched Mobile Site',
@@ -2076,8 +2078,9 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(preg_match('/\.figma-node-centered-grid-shell-desktop-cards-grid\{[^}]*margin-left:auto[^}]*margin-right:auto/s', $responsiveCenteredGridCss) === 1, 'responsive-emit-mobile-centered-grid-shell-base-centered');
     $assert(preg_match('/@media \(max-width:915px\)\{[\s\S]*\.figma-node-centered-grid-shell-desktop-cards-grid\{[^}]*width:calc\(100% - 48px\)[^}]*grid-template-columns:1fr/s', $responsiveCenteredGridCss) === 1, 'responsive-emit-mobile-centered-grid-shell-keeps-centered-fluid-role');
 
-    // SINGLE-VARIANT PAGE PARITY: a page plan with only primary variants emits the
-    // SAME CSS as today — zero `@media` queries.
+    // SINGLE-VARIANT PAGE RESPONSIVENESS: a page plan with only a primary wide
+    // desktop frame gets a conservative mobile fallback media query rather than
+    // shipping a fixed-width canvas with no responsive layer.
     $singleVariantPagePlan = array(
         'pages' => array(
             array(
@@ -2101,7 +2104,8 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
         }
     }
     $assert('' !== $singleVariantCss, 'responsive-emit-single-variant-stylesheet-present');
-    $assert(! str_contains($singleVariantCss, '@media'), 'responsive-emit-single-variant-no-media-query');
+    $assert(str_contains($singleVariantCss, '@media (max-width:767px)'), 'responsive-emit-single-variant-mobile-fallback-media-query');
+    $assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-frame-about-about\{[^}]*max-width:100%/s', $singleVariantCss) === 1, 'responsive-emit-single-variant-root-fallback-width');
     
     $planDiagnosticByCode = static function (array $plan, string $code): ?array {
         foreach ( $plan['diagnostics'] ?? array() as $diagnostic ) {
@@ -2814,9 +2818,9 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(true === ($responsiveLivePagePlan['pages'][0]['responsive'] ?? null), 'responsive-live-plan-flagged-responsive');
     $assert(2 === ($responsiveLivePagePlan['pages'][0]['breakpoint_count'] ?? null), 'responsive-live-plan-two-breakpoints');
     
-    // SINGLE-FRAME PARITY: a source with one frame still produces ONE
-    // non-responsive page with NO `@media` block (the live wiring only fires for
-    // detected responsive variant-groups).
+    // SINGLE-FRAME RESPONSIVENESS: a source with one wide desktop frame still
+    // produces one non-responsive page, plus a conservative mobile fallback
+    // media block for the fixed-width canvas.
     $singleFrameLiveResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Single Frame Live Fixture',
         'nodes' => array(
@@ -2847,6 +2851,6 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(in_array($singleFrameLiveResult['status'] ?? null, array('success', 'success_with_warnings'), true), 'single-frame-live-transform-success');
     $assert(1 === ($singleFrameLiveResult['metrics']['page_count'] ?? null), 'single-frame-live-single-page');
     $assert('' !== $singleFrameLiveStyle, 'single-frame-live-stylesheet-emitted');
-    $assert(! str_contains($singleFrameLiveStyle, '@media'), 'single-frame-live-no-media-block');
+    $assert(str_contains($singleFrameLiveStyle, '@media (max-width:767px)'), 'single-frame-live-desktop-fallback-media-block');
     $assert(false === ($singleFrameLiveResult['source_reports']['figma']['pages']['pages'][0]['responsive'] ?? true), 'single-frame-live-plan-not-responsive');
 }


### PR DESCRIPTION
## Summary
- Add conservative mobile fallback media CSS for desktop-only Figma exports with oversized fixed canvases.
- Wire fallback media blocks into static HTML stylesheet assembly.
- Update contract coverage for single-variant and single-frame responsive fallback behavior.

## Before/after diagnostics
- Before: single-variant and single-frame Figma pages emitted fixed desktop CSS with no responsive media block, leaving wide desktop canvases pinned on narrow screens.
- After: desktop-only pages wider than common mobile/tablet widths emit a conservative `@media (max-width:767px)` fallback that constrains oversized containers/text to `width:100%` / `max-width:100%`, relaxes tall container height, and wraps row flex containers.
- Existing multi-variant responsive behavior remains covered by midpoint breakpoint contract assertions.

## Verification
- `php -l figma-transformer/src/Html/BreakpointMediaDiffBuilder.php`
- `php -l figma-transformer/src/Html/StaticHtmlEmitter.php`
- `php -l figma-transformer/tests/contract/SiteGenerationContract.php`
- `php figma-transformer/tests/contract/run.php`
- Targeted Fisiostetic parser transform attempted against local exported Figma artifacts; the parser decoded 0 raw/normalized nodes, so it was not usable as parity evidence for this PR.

## Artifact evidence
- Contract suite now asserts the fallback `@media (max-width:767px)` block for single-variant page plans and single-frame live transforms.
- Fisiostetic transform attempts produced parser reports with `raw_node_count: 0`, `normalized_node_count: 0`, and `emitted_visual_node_count: 0`; caveat recorded above.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing and preparing this responsive fallback PR, running verification, and drafting the PR summary.