### PR TITLE
Extract linked SVG logo classifier

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2421,11 +2421,16 @@ final class HtmlTransformer
      */
     private function linkedSvgLogoBlockFromAnchor(DOMElement $anchor, array &$fallbacks): ?array
     {
-        if ( ! $this->hasLogoBrandSignal($anchor) || 0 === $anchor->getElementsByTagName('svg')->length ) {
+        if ( ! $this->isLinkedSvgLogoAnchor($anchor) ) {
             return null;
         }
 
         return $this->convertLinkWrapperGroup($anchor, $fallbacks);
+    }
+
+    private function isLinkedSvgLogoAnchor(DOMElement $anchor): bool
+    {
+        return $this->hasLogoBrandSignal($anchor) && 0 < $anchor->getElementsByTagName('svg')->length;
     }
 
     private function hasLogoBrandSignal(DOMElement $element): bool


### PR DESCRIPTION
## Summary
- Extract the linked SVG logo anchor predicate into a named helper.
- Keep the existing link-wrapper conversion path unchanged for logo anchors containing inline SVGs.

## Testing
- `composer test`
- `composer test:parity`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected the PHP transformer SVG/logo handling, made the behavior-preserving refactor, ran tests, and drafted this PR description.