### PR TITLE
Preserve canonical Figma template coverage

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -174,6 +174,7 @@ foreach ( $fixtures as $fixture ) {
     $record['selection'] = $fixture['selection_source'] ?? (isset($fixture['frame_ids']) ? 'manual_frame_ids' : 'auto_from_inspection');
     $record['selected_frame_ids'] = $frameIds;
     $record['selected_frames'] = matrix_selected_frame_records(is_array($inspection) ? $inspection : array(), $frameIds);
+    $record['omitted_page_candidates'] = matrix_omitted_page_candidate_records(is_array($inspection) ? $inspection : array(), $frameIds);
     $record['entry_frame_id'] = (string) ($fixture['entry_frame_id'] ?? ($frameIds[0] ?? ''));
     $record['evidence'] = matrix_fixture_evidence($evidenceOptions, $fixture, $record['selected_frames']);
 

--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -40,7 +40,7 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
     $selectedBuckets = array();
     $deferred = array();
     foreach ( $candidates as $candidate ) {
-        if ( count($selected) >= $maxPages || ! is_array($candidate) ) {
+        if ( ! is_array($candidate) ) {
             break;
         }
 
@@ -60,7 +60,7 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
     }
 
     foreach ( $deferred as $candidate ) {
-        if ( count($selected) >= $maxPages || ! is_array($candidate) ) {
+        if ( ! is_array($candidate) ) {
             break;
         }
 
@@ -69,6 +69,8 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
             $selected[] = $id;
         }
     }
+
+    $selected = matrix_preserve_canonical_template_frame_ids($selected, $candidates, $maxPages);
 
     if ( empty($selected) ) {
         $fallbackCandidates = ! empty($pageLikeCandidates) ? $pageLikeCandidates : $candidates;
@@ -85,6 +87,96 @@ function matrix_select_frame_ids(array $inspection, int $maxPages): array
     }
 
     return matrix_order_selected_frame_ids($selected, $candidates);
+}
+
+/**
+ * Preserve canonical WordPress template families under a matrix page cap.
+ *
+ * @param array<int, string> $selected
+ * @param array<int, mixed>  $candidates
+ * @return array<int, string>
+ */
+function matrix_preserve_canonical_template_frame_ids(array $selected, array $candidates, int $maxPages): array
+{
+    if ( $maxPages < 1 || count($selected) <= $maxPages ) {
+        return array_slice(array_values($selected), 0, max(1, $maxPages));
+    }
+
+    $selectedSet = array_fill_keys($selected, true);
+    $candidateById = array();
+    foreach ( $candidates as $candidate ) {
+        if ( ! is_array($candidate) || ! isset($candidate['id']) || ! is_scalar($candidate['id']) ) {
+            continue;
+        }
+        $candidateById[(string) $candidate['id']] = $candidate;
+    }
+
+    $canonicalTypes = array('front_page', 'single', 'archive', '404', 'page');
+    $required = array();
+    foreach ( $canonicalTypes as $pageType ) {
+        foreach ( $candidates as $candidate ) {
+            if ( ! is_array($candidate) || ! isset($candidate['id']) || ! is_scalar($candidate['id']) ) {
+                continue;
+            }
+            $id = (string) $candidate['id'];
+            if ( ! isset($selectedSet[$id]) || $pageType !== (string) ($candidate['page_type'] ?? '') ) {
+                continue;
+            }
+            $required[] = $id;
+            break;
+        }
+    }
+
+    if ( count($required) >= $maxPages ) {
+        if ( $maxPages < 3 ) {
+            return array_slice($required, 0, $maxPages);
+        }
+
+        return $required;
+    }
+
+    foreach ( $selected as $id ) {
+        if ( count($required) >= $maxPages ) {
+            break;
+        }
+        if ( isset($candidateById[$id]) && ! in_array($id, $required, true) ) {
+            $required[] = $id;
+        }
+    }
+
+    return $required;
+}
+
+/**
+ * @param array<string, mixed> $inspection
+ * @param array<int, string>   $selectedFrameIds
+ * @return array<int, array<string, mixed>>
+ */
+function matrix_omitted_page_candidate_records(array $inspection, array $selectedFrameIds): array
+{
+    $selected = array_fill_keys($selectedFrameIds, true);
+    $omitted = array();
+    foreach ( is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array() as $candidate ) {
+        if ( ! is_array($candidate) || ! isset($candidate['id']) || ! is_scalar($candidate['id']) ) {
+            continue;
+        }
+        $id = (string) $candidate['id'];
+        if ( isset($selected[$id]) || ! matrix_is_page_like_candidate($candidate) ) {
+            continue;
+        }
+        $omitted[] = array(
+            'id' => $id,
+            'name' => (string) ($candidate['name'] ?? ''),
+            'page_type' => (string) ($candidate['page_type'] ?? ''),
+            'bucket' => matrix_candidate_bucket($candidate),
+            'rank' => matrix_candidate_rank($candidate),
+            'reason' => 'max_pages_or_route_selection',
+        );
+    }
+
+    usort($omitted, static fn (array $a, array $b): int => ((int) ($b['rank'] ?? 0)) <=> ((int) ($a['rank'] ?? 0)));
+
+    return $omitted;
 }
 
 /**
@@ -191,7 +283,7 @@ function matrix_candidate_rank(array $candidate): int
     $pageType = (string) ($candidate['page_type'] ?? '');
     if ( 'front_page' === $pageType ) {
         $score += 300;
-    } elseif ( in_array($pageType, array('single', 'archive', 'page'), true) ) {
+    } elseif ( in_array($pageType, array('single', 'archive', '404', 'page'), true) ) {
         $score += 120;
     }
 
@@ -263,6 +355,7 @@ function matrix_candidate_bucket(array $candidate): string
         'about' => '/\babout\b/',
         'contact' => '/\bcontact\b/',
         'archive' => '/\barchive\b/',
+        'not_found' => '/\b(404|not\s+found)\b/',
         'single' => '/\b(single|post page)\b/',
         'theme' => '/\b(theme|build)\b/',
         'landing' => '/\b(landing|lp)\b/',
@@ -295,7 +388,7 @@ function matrix_candidate_selection_reasons(array $candidate): array
     if ( in_array($parentType, array('CANVAS', 'SECTION'), true) ) {
         $reasons[] = 'top_level_candidate';
     }
-    if ( 1 === preg_match('/\b(home|homepage|website|landing|lp|archive|single|blog|theme|build|hosts?|agenc(?:y|ies)|pricing|features?|about|contact)\b/', $name . ' ' . $pageName) ) {
+    if ( 1 === preg_match('/\b(home|homepage|website|landing|lp|archive|single|blog|theme|build|404|not\s+found|hosts?|agenc(?:y|ies)|pricing|features?|about|contact)\b/', $name . ' ' . $pageName) ) {
         $reasons[] = 'page_like_name';
     }
     if ( ! matrix_is_reference_page_name($pageName) && 1 === preg_match('/\b(website comps?|pages?|screens?|final|production|dev handoff)\b/', $pageName) ) {

--- a/figma-transformer/src/Scenegraph/ScenegraphFrameClassifier.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphFrameClassifier.php
@@ -39,6 +39,7 @@ final class ScenegraphFrameClassifier
     public const PAGE_TYPE_FRONT_PAGE = 'front_page';
     public const PAGE_TYPE_SINGLE     = 'single';
     public const PAGE_TYPE_ARCHIVE    = 'archive';
+    public const PAGE_TYPE_404        = '404';
     public const PAGE_TYPE_PAGE       = 'page';
     public const PAGE_TYPE_UNKNOWN    = 'unknown';
 
@@ -246,6 +247,10 @@ final class ScenegraphFrameClassifier
 
         if ( 1 === preg_match('/\b(archive|blog|index|news|articles|posts|category|categories|tag|search\s*results|listing)\b/i', $name) ) {
             return self::PAGE_TYPE_ARCHIVE;
+        }
+
+        if ( 1 === preg_match('/\b(404|not\s+found|error\s+page)\b/i', $name) ) {
+            return self::PAGE_TYPE_404;
         }
 
         if ( 1 === preg_match('/\b(about|contact|pricing|services?|team|faq|privacy|terms|page|portfolio|gallery|product|shop)\b/i', $name) ) {

--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -794,6 +794,7 @@ final class ScenegraphPagePlanner
             ScenegraphFrameClassifier::PAGE_TYPE_FRONT_PAGE => 0,
             ScenegraphFrameClassifier::PAGE_TYPE_SINGLE     => 0,
             ScenegraphFrameClassifier::PAGE_TYPE_ARCHIVE    => 0,
+            ScenegraphFrameClassifier::PAGE_TYPE_404        => 0,
             ScenegraphFrameClassifier::PAGE_TYPE_PAGE       => 0,
             ScenegraphFrameClassifier::PAGE_TYPE_UNKNOWN    => 0,
         );

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -88,6 +88,91 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
         ),
     ), 1);
 
+    $canonicalTemplateSelectionInspection = array(
+        'candidates' => array(
+            array(
+                'id'         => 'frame:home-desktop',
+                'name'       => 'Home Page - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 500,
+                'width'      => 1440,
+                'height'     => 4400,
+                'text_count' => 20,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+            array(
+                'id'         => 'frame:single-desktop',
+                'name'       => 'Blog Post - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'single',
+                'score'      => 650,
+                'width'      => 1440,
+                'height'     => 8400,
+                'text_count' => 80,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+            array(
+                'id'         => 'frame:page-desktop',
+                'name'       => 'Page - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'page',
+                'score'      => 620,
+                'width'      => 1440,
+                'height'     => 3200,
+                'text_count' => 30,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+            array(
+                'id'         => 'frame:archive-desktop',
+                'name'       => 'Archive - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'archive',
+                'score'      => 440,
+                'width'      => 1440,
+                'height'     => 3600,
+                'text_count' => 36,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+            array(
+                'id'         => 'frame:404-desktop',
+                'name'       => '404 Page - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => '404',
+                'score'      => 350,
+                'width'      => 1440,
+                'height'     => 1800,
+                'text_count' => 12,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+            array(
+                'id'         => 'frame:contact-desktop',
+                'name'       => 'Contact - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'page',
+                'score'      => 300,
+                'width'      => 1440,
+                'height'     => 1800,
+                'text_count' => 12,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups (dev handoff)'),
+            ),
+        ),
+    );
+    $canonicalTemplateSelection = matrix_select_frame_ids($canonicalTemplateSelectionInspection, 3);
+    $canonicalTemplateOmissions = matrix_omitted_page_candidate_records($canonicalTemplateSelectionInspection, $canonicalTemplateSelection);
+
     $matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
     file_put_contents($matrixSelectionLockPath, json_encode(array(
         'schema'   => 'blocks-engine/figma-transformer/fixture-matrix/v1',
@@ -162,6 +247,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(! in_array('frame:title-card', $matrixSelection, true), 'fixture-matrix-selection-skips-dev-marked-title-card');
     $assert(array('frame:home-desktop', 'frame:single-desktop') === $matrixSelection, 'fixture-matrix-selection-falls-back-to-page-like-frames');
     $assert(array('frame:fisiostetic-home') === $wideRootSelection, 'fixture-matrix-selection-prefers-wide-root-page-over-section-frame');
+    $assert(array('frame:home-desktop', 'frame:single-desktop', 'frame:archive-desktop', 'frame:404-desktop', 'frame:page-desktop') === $canonicalTemplateSelection, 'fixture-matrix-selection-preserves-canonical-template-coverage-under-page-cap');
+    $assert('frame:contact-desktop' === ($canonicalTemplateOmissions[0]['id'] ?? null), 'fixture-matrix-selection-reports-omitted-page-candidates');
     $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
     $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
     $assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');


### PR DESCRIPTION
## Summary
- Preserve one representative per canonical WordPress template family during Figma fixture matrix auto-selection, even when the exploratory max-pages cap would otherwise drop archive, 404, or page templates.
- Classify 404/not found frames as a first-class Figma page type for downstream coverage and diagnostics.
- Report page-like candidates omitted by matrix selection so fixture evidence explains what was left out.

## FSE Pilot evidence
Fixture: `/Users/chubes/Downloads/🛠️ FSE Pilot Build Theme.fig`

Before artifact root: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-pilot-baseline`
- Emitted pages: `index.html`, `blog-post.html`, `page.html`
- Coverage: 3 pages; Archive and 404 were present in inspection but omitted by `max-pages=3` selection.

After artifact root: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-pilot-after-2`
- Emitted pages: `index.html`, `blog-post.html`, `archive.html`, `404-page.html`, `page.html`
- Coverage: 5 pages; `omitted_page_candidates` is empty; artifact quality is `pass`.
- HTML includes semantic header/nav/footer, newsletter forms, blog comments, linked generated assets, and responsive media queries.

## Verification
- `composer test:contract` from `figma-transformer`
- `php figma-transformer/scripts/figma-fixture-matrix.php --fixture="/Users/chubes/Downloads/🛠️ FSE Pilot Build Theme.fig" --output-dir="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fse-pilot-after-2"`

## Remaining FSE blockers
- Transform still reports source/style diagnostics from the decoded Figma payload: missing effect/paint/text style references and zero-dimension nodes.
- Visual pixel parity was not run in this pass; matrix parity status is `not_run`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated FSE Pilot matrix coverage, implemented the generic fixture selection/classification changes, added contract coverage, ran verification, and drafted this PR description.
