### PR TITLE
Improve Figma TT5 page selection and parity diagnostics

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -50,7 +50,9 @@ if ( isset($options['frame_ids']) ) {
     foreach ( $fixtures as $index => $fixture ) {
         $fixtures[$index]['mode'] = 'transform';
         $fixtures[$index]['frame_ids'] = $globalFrameIds;
-        $fixtures[$index]['entry_frame_id'] = (string) ($options['entry_frame_id'] ?? ($globalFrameIds[0] ?? ''));
+        if ( isset($options['entry_frame_id']) ) {
+            $fixtures[$index]['entry_frame_id'] = (string) $options['entry_frame_id'];
+        }
         $fixtures[$index]['selection_source'] = 'manual_frame_ids';
     }
 } elseif ( ! empty($selectionLock['records']) ) {
@@ -63,7 +65,9 @@ if ( isset($options['frame_ids']) ) {
         $lockRecord = $selectionLock['records'][$fixtureId];
         $fixtures[$index]['mode'] = 'transform';
         $fixtures[$index]['frame_ids'] = $lockRecord['frame_ids'];
-        $fixtures[$index]['entry_frame_id'] = $lockRecord['entry_frame_id'] ?? ($lockRecord['frame_ids'][0] ?? '');
+        if ( isset($lockRecord['entry_frame_id']) ) {
+            $fixtures[$index]['entry_frame_id'] = $lockRecord['entry_frame_id'];
+        }
         $fixtures[$index]['selection_source'] = 'selection_lock';
     }
 }
@@ -136,7 +140,7 @@ foreach ( $fixtures as $fixture ) {
         $record['selection'] = $fixture['selection_source'] ?? (isset($fixture['frame_ids']) ? 'manual_frame_ids' : 'auto_from_inspection');
         $hasDryRunFrameIds = isset($fixture['frame_ids']) && is_array($fixture['frame_ids']);
         $dryRunFrameIds = $hasDryRunFrameIds ? $fixture['frame_ids'] : array('<selected-frame-ids>');
-        $dryRunEntryFrameId = (string) ($fixture['entry_frame_id'] ?? ($hasDryRunFrameIds ? ($dryRunFrameIds[0] ?? '') : '<entry-frame-id>'));
+        $dryRunEntryFrameId = isset($fixture['entry_frame_id']) ? (string) $fixture['entry_frame_id'] : null;
         $record['evidence'] = matrix_fixture_evidence($evidenceOptions, $fixture, matrix_dry_run_pages($dryRunFrameIds));
         if ( $captureDomBoxes ) {
             $record['dom_box_capture'] = array(
@@ -174,7 +178,9 @@ foreach ( $fixtures as $fixture ) {
     $record['selection'] = $fixture['selection_source'] ?? (isset($fixture['frame_ids']) ? 'manual_frame_ids' : 'auto_from_inspection');
     $record['selected_frame_ids'] = $frameIds;
     $record['selected_frames'] = matrix_selected_frame_records(is_array($inspection) ? $inspection : array(), $frameIds);
-    $record['entry_frame_id'] = (string) ($fixture['entry_frame_id'] ?? ($frameIds[0] ?? ''));
+    if ( isset($fixture['entry_frame_id']) ) {
+        $record['entry_frame_id'] = (string) $fixture['entry_frame_id'];
+    }
     $record['evidence'] = matrix_fixture_evidence($evidenceOptions, $fixture, $record['selected_frames']);
 
     if ( $inspectOnly ) {
@@ -189,7 +195,7 @@ foreach ( $fixtures as $fixture ) {
         continue;
     }
 
-    $command = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $captureDomBoxes ? array() : ($record['evidence']['transform_arguments'] ?? array()));
+    $command = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'] ?? null, $fixtureOutputDir, $resultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $captureDomBoxes ? array() : ($record['evidence']['transform_arguments'] ?? array()));
     $record['command'] = $command;
     passthru($command, $exitCode);
     $record['exit_code'] = $exitCode;
@@ -220,7 +226,7 @@ foreach ( $fixtures as $fixture ) {
                 ));
                 $capturedEvidence = matrix_fixture_evidence($capturedEvidenceOptions, $fixture, $record['selected_frames']);
                 $rerunResultPath = $outputDir . '/' . $fixture['id'] . '-result-with-dom-boxes.json';
-                $rerunCommand = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'], $fixtureOutputDir, $rerunResultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $capturedEvidence['transform_arguments'] ?? array());
+                $rerunCommand = matrix_transform_command($figmaRoot, $fixturePath, $frameIds, $record['entry_frame_id'] ?? null, $fixtureOutputDir, $rerunResultPath, $zstdCommand, $maxNodes, $fontCssPassthrough['arguments'], $capturedEvidence['transform_arguments'] ?? array());
                 $record['dom_box_rerun_command'] = $rerunCommand;
                 passthru($rerunCommand, $rerunExitCode);
                 $record['dom_box_rerun_exit_code'] = $rerunExitCode;
@@ -687,7 +693,7 @@ function matrix_inspect_command(string $figmaRoot, string $fixturePath, string $
  * @param array<int, string> $fontCssArguments
  * @param array<int, string> $evidenceArguments
  */
-function matrix_transform_command(string $figmaRoot, string $fixturePath, array $frameIds, string $entryFrameId, string $fixtureOutputDir, string $resultPath, string $zstdCommand, int $maxNodes, array $fontCssArguments = array(), array $evidenceArguments = array()): string
+function matrix_transform_command(string $figmaRoot, string $fixturePath, array $frameIds, ?string $entryFrameId, string $fixtureOutputDir, string $resultPath, string $zstdCommand, int $maxNodes, array $fontCssArguments = array(), array $evidenceArguments = array()): string
 {
     $parts = array(
         escapeshellarg(PHP_BINARY),
@@ -698,10 +704,13 @@ function matrix_transform_command(string $figmaRoot, string $fixturePath, array 
         '--zstd-command=' . escapeshellarg($zstdCommand),
         '--multi-page',
         '--frame-ids=' . escapeshellarg(implode(',', $frameIds)),
-        '--entry-frame-id=' . escapeshellarg($entryFrameId),
         '--max-nodes=' . $maxNodes,
         '--output-dir=' . escapeshellarg($fixtureOutputDir),
     );
+
+    if ( null !== $entryFrameId && '' !== $entryFrameId ) {
+        $parts[] = '--entry-frame-id=' . escapeshellarg($entryFrameId);
+    }
 
     array_push($parts, ...$fontCssArguments);
     array_push($parts, ...$evidenceArguments);

--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -328,6 +328,12 @@ function matrix_is_page_like_candidate(array $candidate): bool
     if ( 'design_system' === matrix_candidate_role($candidate) ) {
         return false;
     }
+    if ( matrix_is_utility_template_candidate($candidate) ) {
+        return false;
+    }
+    if ( in_array((string) ($candidate['page_type'] ?? ''), array('front_page', 'single', 'archive', 'page'), true) ) {
+        return $width >= 900.0 && $width <= 2560.0 && $height >= 700.0 && in_array($parentType, array('CANVAS', 'SECTION'), true);
+    }
     // Fallback name-based exclusion for frames without role classification.
     if ( null === matrix_candidate_role($candidate) ) {
         if ( 1 === preg_match('/\b(style guide|style tile|template|preview|core blocks|component|footer|header|menu)\b/', $name) ) {
@@ -339,6 +345,16 @@ function matrix_is_page_like_candidate(array $candidate): bool
     }
 
     return $width >= 900.0 && $width <= 2560.0 && $height >= 700.0 && $textCount > 0 && in_array($parentType, array('CANVAS', 'SECTION'), true);
+}
+
+/**
+ * @param array<string, mixed> $candidate
+ */
+function matrix_is_utility_template_candidate(array $candidate): bool
+{
+    $name = strtolower(trim((string) ($candidate['name'] ?? '')));
+
+    return in_array($name, array('comments', 'post content', 'query loop'), true);
 }
 
 function matrix_is_reference_page_name(string $pageName): bool

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -4898,6 +4898,9 @@ final class StaticHtmlEmitter
             if ( $this->isContainedCssOffset($className, $visualNodeMapByClass, $visualNodeMapById) ) {
                 continue;
             }
+            if ( $this->isPlausibleInCanvasCssOffset($left, $top, $body) ) {
+                continue;
+            }
             $sample = array_filter(array(
                 'node_id' => (string) ($node['node_id'] ?? ''),
                 'name' => (string) ($node['name'] ?? ''),
@@ -4915,6 +4918,26 @@ final class StaticHtmlEmitter
         }
 
         return array_values($samples);
+    }
+
+    private function isPlausibleInCanvasCssOffset(?float $left, ?float $top, string $body): bool
+    {
+        if ( null !== $left && $left < 0.0 ) {
+            return false;
+        }
+        if ( null !== $top && $top < 0.0 ) {
+            return false;
+        }
+
+        $width = $this->cssPixelDeclarationValue($body, 'width');
+        if ( null !== $left && $left > 1440.0 ) {
+            return false;
+        }
+        if ( null !== $left && null !== $width && ($left + $width) > 2560.0 ) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -5577,6 +5600,14 @@ final class StaticHtmlEmitter
             return 'decorative_zero_height_separator';
         }
 
+        if ( $height <= 80.0 && 1 === preg_match('/\b(spacer|gap)\b/i', $name) ) {
+            return 'layout_spacer';
+        }
+
+        if ( $height <= 12.0 && $width >= 600.0 ) {
+            return 'layout_spacer';
+        }
+
         if ( $this->isFormControlChrome($node, $parentNode, $width, $height) ) {
             return 'form_control_chrome';
         }
@@ -5590,7 +5621,7 @@ final class StaticHtmlEmitter
 
     private function isNonBlockingEmptyVisibleContainerCategory(string $category): bool
     {
-        return in_array($category, array('decorative_zero_height_separator', 'form_control_chrome'), true);
+        return in_array($category, array('decorative_zero_height_separator', 'form_control_chrome', 'layout_spacer'), true);
     }
 
     /**

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -353,6 +353,45 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     $assert(0 === ($containedVerticalOffsetDiagnostics['layout']['large_css_offset_count'] ?? null), 'diagnostics-evidence-contained-vertical-offset-no-large-css-offset');
     blocks_engine_figma_transformer_contract_assert_no_quality_signal($assert, $containedVerticalOffsetResult, 'large_css_offsets', 'diagnostics-evidence-contained-vertical-offset-no-quality-signal');
 
+    $desktopRightAlignedResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Diagnostics Desktop Right Aligned Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'diag:desktop-right-page',
+                'type'     => 'FRAME',
+                'name'     => 'Desktop Right Page',
+                'width'    => 1440,
+                'height'   => 900,
+                'children' => array(
+                    array('id' => 'diag:desktop-right-copy', 'type' => 'TEXT', 'name' => 'Right aligned copy', 'text' => 'Designed with WordPress', 'x' => 1227, 'y' => 632, 'width' => 162, 'height' => 18),
+                ),
+            ),
+        ),
+    ));
+    $desktopRightAlignedDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($desktopRightAlignedResult);
+    $assert(0 === ($desktopRightAlignedDiagnostics['layout']['large_css_offset_count'] ?? null), 'diagnostics-evidence-desktop-right-aligned-no-large-css-offset');
+    blocks_engine_figma_transformer_contract_assert_no_quality_signal($assert, $desktopRightAlignedResult, 'large_css_offsets', 'diagnostics-evidence-desktop-right-aligned-no-quality-signal');
+
+    $layoutSpacerResult = blocks_engine_figma_transformer_contract_transform(array(
+        'name'  => 'Diagnostics Layout Spacer Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'diag:layout-spacer-page',
+                'type'     => 'FRAME',
+                'name'     => 'Layout Spacer Page',
+                'width'    => 1440,
+                'height'   => 900,
+                'children' => array(
+                    array('id' => 'diag:layout-spacer', 'type' => 'FRAME', 'name' => 'Spacer', 'x' => 0, 'y' => 120, 'width' => 1440, 'height' => 70),
+                    array('id' => 'diag:layout-hairline-spacer', 'type' => 'FRAME', 'name' => 'Frame 1000005928', 'x' => 0, 'y' => 240, 'width' => 1331, 'height' => 10),
+                ),
+            ),
+        ),
+    ));
+    $layoutSpacerDiagnostics = blocks_engine_figma_transformer_contract_transform_diagnostics($layoutSpacerResult);
+    $assert(2 === ($layoutSpacerDiagnostics['layout']['empty_visible_container_count'] ?? null), 'diagnostics-evidence-layout-spacer-empty-container-count');
+    $assert(0 === ($layoutSpacerDiagnostics['layout']['empty_visible_container_blocker_count'] ?? null), 'diagnostics-evidence-layout-spacer-non-blocking');
+
     $decorativeHairlineResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Diagnostics Decorative Hairline Offset Fixture',
         'nodes' => array(

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -88,6 +88,50 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
         ),
     ), 1);
 
+    $componentComposedFrontPageSelection = matrix_select_frame_ids(array(
+        'candidates' => array(
+            array(
+                'id'         => 'frame:archive-template',
+                'name'       => 'News blog with various grids',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'archive',
+                'score'      => 722,
+                'width'      => 1440,
+                'height'     => 3328,
+                'text_count' => 28,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Templates'),
+            ),
+            array(
+                'id'         => 'frame:component-front-page',
+                'name'       => 'Business Homepage',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 480,
+                'width'      => 1440,
+                'height'     => 3875,
+                'text_count' => 0,
+                'parent'     => array('type' => 'SECTION'),
+                'page'       => array('name' => 'Patterns'),
+            ),
+            array(
+                'id'         => 'frame:comments-utility',
+                'name'       => 'Comments',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'page',
+                'score'      => 900,
+                'width'      => 1440,
+                'height'     => 1800,
+                'text_count' => 3,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Templates'),
+            ),
+        ),
+    ), 2);
+
     $matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
     file_put_contents($matrixSelectionLockPath, json_encode(array(
         'schema'   => 'blocks-engine/figma-transformer/fixture-matrix/v1',
@@ -162,6 +206,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(! in_array('frame:title-card', $matrixSelection, true), 'fixture-matrix-selection-skips-dev-marked-title-card');
     $assert(array('frame:home-desktop', 'frame:single-desktop') === $matrixSelection, 'fixture-matrix-selection-falls-back-to-page-like-frames');
     $assert(array('frame:fisiostetic-home') === $wideRootSelection, 'fixture-matrix-selection-prefers-wide-root-page-over-section-frame');
+    $assert('frame:component-front-page' === ($componentComposedFrontPageSelection[0] ?? null), 'fixture-matrix-selection-keeps-component-composed-front-page');
+    $assert(! in_array('frame:comments-utility', $componentComposedFrontPageSelection, true), 'fixture-matrix-selection-skips-utility-template-frame');
     $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
     $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
     $assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');


### PR DESCRIPTION
## Summary
- Let fixture matrix transforms preserve transformer-owned front-page entrypoint selection instead of forcing the first selected frame as `index.html`.
- Treat classifier-known page types as page candidates even when direct text is nested through component/instance composition, so component-composed homepages can be selected.
- Skip utility template frames such as Comments/Post Content/Query Loop during automatic fixture-matrix page selection.
- Avoid false quality blockers for right-aligned desktop CSS offsets and layout spacer frames.

## TT5 verification
Fixture: `/Users/chubes/Downloads/Twenty Twenty-Five (Community).fig`

Before artifact root: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-matrix-before`
- Selected entrypoint: `Post with sidebar` -> `index.html`
- Missing asset nodes: `0`
- Emitted asset files: `14`
- Image blocks: `40`
- Vector placeholders: `0`
- Large CSS offsets: `1`
- Empty visible container blockers: `1`
- Quality status: `pass`

After artifact root: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-matrix-final`
- Selected entrypoint: `Business Homepage` -> `index.html`
- Selected frames: `Business Homepage`, `Post with sidebar`, `News blog with various grids`, `News blog with featured posts grid`, `Landing Page: Product/Event`, `Blog: Magazine`
- Missing asset nodes: `0`
- Emitted asset files: `23`
- Image blocks: `43`
- Vector placeholders: `0`
- Large CSS offsets: `0`
- Empty visible container blockers: `0`
- Quality status: `pass`

## Tests
- `php -d memory_limit=1536M figma-transformer/tests/contract/run.php`
- `php figma-transformer/scripts/figma-fixture-matrix.php --fixture="/Users/chubes/Downloads/Twenty Twenty-Five (Community).fig" --output-dir="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-matrix-final" --zstd-command="/opt/homebrew/bin/zstd" --max-nodes=12000 --max-pages=6 --inspect-limit=160`

## Remaining TT5 blockers
- Pixel/browser visual parity was not run in this PR; matrix parity status remains `not_run`.
- Transform still reports upstream decode/style diagnostics (`figma_local_style_paint_conflict`, `figma_missing_paint_style_reference`, `figma_node_zero_dimension`, `unsupported_vector_command_blob`) but they do not create missing assets, placeholders, or quality blockers for the selected pages.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Implemented and verified the generic transformer/matrix fixes, contract tests, and TT5 fixture evidence.