### PR TITLE
Improve PHP button CTA fidelity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -306,7 +306,7 @@ final class BlockFactory
 
         $wrapperAttrs = array(
             'id'    => (string) ($attrs['anchor'] ?? ''),
-            'class' => $this->mergeClassNames('wp-block-button', (string) ($attrs['className'] ?? '')),
+            'class' => $this->mergeClassNames('wp-block-button', $this->buttonWidthClasses($attrs), (string) ($attrs['className'] ?? '')),
         );
 
         $controlAttrs = array(
@@ -322,6 +322,19 @@ final class BlockFactory
 
         $href = '' !== ($attrs['url'] ?? '') ? ' href="' . htmlspecialchars((string) $attrs['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"' : '';
         return '<div' . $this->htmlAttrs($wrapperAttrs) . '><a' . $this->htmlAttrs($controlAttrs) . $href . '>' . ($attrs['text'] ?? '') . '</a></div>';
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function buttonWidthClasses(array $attrs): string
+    {
+        $width = (int) ($attrs['width'] ?? 0);
+        if ( ! in_array($width, array( 25, 50, 75, 100 ), true) ) {
+            return '';
+        }
+
+        return 'has-custom-width wp-block-button__width-' . $width;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -70,10 +70,10 @@ final class ButtonsPattern
      */
     public function matchContainer(DOMElement $element, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $attr, callable $createBlock): ?array
     {
-		$wrappedAnchor = $this->singleSimpleAnchorChild($element);
-		if ( null !== $wrappedAnchor && $this->hasButtonSignal($element) ) {
-			return $createBlock('core/buttons', array(), array( $this->buttonBlockFromAnchor($wrappedAnchor, $presentationAttributes, $resolvedStyle, $innerHtml, $attr, $createBlock, $element) ), $element);
-		}
+        $wrappedAnchor = $this->singleSimpleAnchorChild($element);
+        if ( null !== $wrappedAnchor && $this->hasWrapperButtonSignal($element) ) {
+            return $createBlock('core/buttons', array(), array( $this->buttonBlockFromAnchor($wrappedAnchor, $presentationAttributes, $resolvedStyle, $innerHtml, $attr, $createBlock, $element) ), $element);
+        }
 
 		$containerHasButtonSignal = $this->hasContainerButtonSignal($element) || $this->isDirectAnchorRow($element);
         $buttons = array();
@@ -359,10 +359,22 @@ final class ButtonsPattern
 			&& preg_match('/(?:^|;)\s*background(?:-color)?\s*:\s*(?:transparent|none|inherit|initial|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))\s*(?:;|$)/', $style) !== 1;
 	}
 
-	private function hasContainerButtonSignal(DOMElement $element): bool
-	{
-		return $this->hasAnyToken($element, array( 'buttons', 'button', 'btns', 'cta', 'actions' )) || $this->hasPhrase($element, array( 'button-group', 'button-row', 'cta-group', 'call-to-action' ));
-	}
+    private function hasContainerButtonSignal(DOMElement $element): bool
+    {
+        return $this->hasAnyToken($element, array( 'buttons', 'button', 'btns', 'cta', 'actions' )) || $this->hasPhrase($element, array( 'button-group', 'button-row', 'cta-group', 'call-to-action' ));
+    }
+
+    private function hasWrapperButtonSignal(DOMElement $element): bool
+    {
+        if ( 'button' === strtolower($element->hasAttribute('role') ? $element->getAttribute('role') : '') ) {
+            return true;
+        }
+
+        return $this->hasButtonClassSignal($element)
+            || $this->hasAnyToken($element, array( 'cta', 'action' ))
+            || $this->hasPhrase($element, array( 'call-to-action', 'primary-action', 'secondary-action' ))
+            || $this->hasButtonStyleSignal($element);
+    }
 
 	private function isDirectAnchorRow(DOMElement $element): bool
 	{

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -70,6 +70,11 @@ final class ButtonsPattern
      */
     public function matchContainer(DOMElement $element, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $attr, callable $createBlock): ?array
     {
+		$wrappedAnchor = $this->singleSimpleAnchorChild($element);
+		if ( null !== $wrappedAnchor && $this->hasButtonSignal($element) ) {
+			return $createBlock('core/buttons', array(), array( $this->buttonBlockFromAnchor($wrappedAnchor, $presentationAttributes, $resolvedStyle, $innerHtml, $attr, $createBlock, $element) ), $element);
+		}
+
 		$containerHasButtonSignal = $this->hasContainerButtonSignal($element) || $this->isDirectAnchorRow($element);
         $buttons = array();
         foreach ( $element->childNodes as $child ) {
@@ -93,12 +98,14 @@ final class ButtonsPattern
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>
      */
-    private function buttonBlockFromAnchor(DOMElement $anchor, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $attr, callable $createBlock): array
+    private function buttonBlockFromAnchor(DOMElement $anchor, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $attr, callable $createBlock, ?DOMElement $presentationElement = null): array
     {
-        return $createBlock('core/button', array_filter(array_merge($this->buttonPresentationAttributes($anchor, $presentationAttributes, $resolvedStyle), array(
+        $presentationElement ??= $anchor;
+
+        return $createBlock('core/button', array_filter(array_merge($this->buttonPresentationAttributes($presentationElement, $presentationAttributes, $resolvedStyle), array(
             'text' => $this->buttonText($anchor, $innerHtml($anchor)),
             'url'  => $attr($anchor, 'href'),
-        )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $anchor);
+        )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $presentationElement);
     }
 
     private function buttonText(DOMElement $element, string $html): string
@@ -218,6 +225,11 @@ final class ButtonsPattern
             $attrs = array_merge($attrs, $native);
         }
 
+		$width = $this->buttonWidth($resolvedStyle);
+		if ( null !== $width ) {
+			$attrs['width'] = $width;
+		}
+
         if ( $isOutline ) {
             if ( array() !== $native ) {
                 $attrs['className'] = 'is-style-outline';
@@ -252,6 +264,15 @@ final class ButtonsPattern
 
         return implode(' ', $classes);
     }
+
+	private function buttonWidth(string $style): ?int
+	{
+		if ( ! preg_match('/(?:^|;)\s*width\s*:\s*(25|50|75|100)%\s*(?:;|$)/i', $style, $matches) ) {
+			return null;
+		}
+
+		return (int) $matches[1];
+	}
 
     /**
      * @return array<string, string>
@@ -368,6 +389,26 @@ final class ButtonsPattern
 		}
 
 		return $anchors > 1 && 0 === $buttonSignals;
+	}
+
+	private function singleSimpleAnchorChild(DOMElement $element): ?DOMElement
+	{
+		$anchor = null;
+		foreach ( $element->childNodes as $child ) {
+			if ( $child instanceof DOMElement ) {
+				if ( null !== $anchor || 'a' !== strtolower($child->tagName) || '' === trim($child->textContent ?? '') || ! $this->isSimpleAnchor($child) ) {
+					return null;
+				}
+				$anchor = $child;
+				continue;
+			}
+
+			if ( '' !== trim($child->textContent ?? '') ) {
+				return null;
+			}
+		}
+
+		return $anchor;
 	}
 
 	private function isSimpleAnchor(DOMElement $anchor): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -600,6 +600,30 @@ $roundedOutlineButtonMarkup = (string) ($roundedOutlineButton['serialized_blocks
 $assert(str_contains($roundedOutlineButtonMarkup, 'border-radius:12px'), 'outline button preserves an explicit source border radius');
 $assert(! str_contains($roundedOutlineButtonMarkup, 'border-radius:0'), 'outline button does not override an explicit source border radius');
 
+$wrapperOwnedButton = ( new HtmlTransformer() )->transform(
+    '<main><div class="hero-cta" role="button" style="display:inline-flex;align-items:center;padding:14px 24px;border-radius:999px;background:#2563eb;color:#ffffff;font-weight:700"><a href="/start"><span>Start free</span></a></div></main>'
+)->toArray();
+$wrapperOwnedButtonMarkup = (string) ($wrapperOwnedButton['serialized_blocks'] ?? '');
+$assert(str_contains($wrapperOwnedButtonMarkup, '<!-- wp:button'), 'button-like wrapper with a single simple anchor materializes as core/button');
+$assert(str_contains($wrapperOwnedButtonMarkup, 'href="/start"'), 'button-like wrapper preserves the nested anchor URL on the native button');
+$assert(str_contains($wrapperOwnedButtonMarkup, 'Start free'), 'button-like wrapper preserves the nested anchor label');
+$assert(str_contains($wrapperOwnedButtonMarkup, 'background-color:#2563eb'), 'button-like wrapper applies wrapper-owned fill color to the native button chrome');
+$assert(str_contains($wrapperOwnedButtonMarkup, 'color:#ffffff'), 'button-like wrapper applies wrapper-owned text color to the native button chrome');
+$assert(str_contains($wrapperOwnedButtonMarkup, 'border-radius:999px'), 'button-like wrapper applies wrapper-owned radius to the native button chrome');
+$assert(str_contains($wrapperOwnedButtonMarkup, 'padding-top:14px'), 'button-like wrapper applies wrapper-owned padding to the native button chrome');
+$assert('pass' === ($wrapperOwnedButton['source_reports']['wp_block_validity']['status'] ?? ''), 'button-like wrapper conversion emits valid native button markup');
+
+$fullWidthButton = ( new HtmlTransformer() )->transform(
+    '<main><a class="btn tier-cta" style="display:inline-flex;width:100%;justify-content:center;padding:10px 18px;background:#111827;color:#ffffff" href="/pricing">Start free</a></main>'
+)->toArray();
+$fullWidthButtonMarkup = (string) ($fullWidthButton['serialized_blocks'] ?? '');
+$assert(100 === ($fullWidthButton['blocks'][0]['innerBlocks'][0]['attrs']['width'] ?? null), '100% source button width maps to the native core/button width attribute');
+$assert(str_contains($fullWidthButtonMarkup, '<div class="wp-block-button has-custom-width wp-block-button__width-100 btn tier-cta">'), '100% source button width emits canonical core/button width wrapper classes');
+$assert('pass' === ($fullWidthButton['source_reports']['wp_block_validity']['status'] ?? ''), 'full-width button serialization passes generated WordPress block validity checks');
+
+$plainWrappedLink = ( new HtmlTransformer() )->transform('<main><div class="card-link"><a href="/docs">Read docs</a></div></main>')->toArray();
+$assert(! str_contains((string) ($plainWrappedLink['serialized_blocks'] ?? ''), '<!-- wp:button'), 'plain single-anchor wrappers without button signals do not become buttons');
+
 $separatorResult = ( new HtmlTransformer() )->transform('<main><hr class="wp-block-separator has-alpha-channel-opacity has-css-opacity divider"></main>')->toArray();
 $separatorMarkup = (string) ($separatorResult['serialized_blocks'] ?? '');
 $separatorAttrs = $separatorResult['blocks'][0]['attrs'] ?? array();


### PR DESCRIPTION
## Summary
- Map source button widths of 25/50/75/100% to native core/button width attributes and canonical wrapper classes.
- Promote button-like single-anchor wrappers using wrapper-owned chrome while preserving nested anchor URL and label.
- Keep direct anchor CTAs styled from their own source class/CSS instead of misclassifying neutral ancestors as wrapper-owned buttons.
- Add PHP contract coverage for full-width CTAs, nested wrapper chrome, and plain wrapped links staying non-buttons.

## Verification
- `composer validate --strict && composer test` in `php-transformer` passed locally.
- GitHub check `Composer validate and test` passed on PR #531.
- Static parity spot checks matched baseline exactly: `15-saas` score 0.7446, `3-artist-music` score 0.7583, `37-art-gallery-exhibition` score 0.7976.
- Targeted validity check: `15-saas/index.html`, `3-artist-music/index.html`, `37-art-gallery-exhibition/index.html`, and `37-art-gallery-exhibition/artists.html` all reported `wp_block_validity=pass` with zero findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Diagnosed the PHP transformer regression, implemented the wrapper promotion fix, and ran verification.