### PR TITLE
Preserve min-height block dimensions

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
@@ -93,6 +93,11 @@ final class StyleAttributeMapper
             $style['spacing'] = $spacing;
         }
 
+        $dimensions = $this->dimensions($normalized, $consumed);
+        if ( array() !== $dimensions ) {
+            $style['dimensions'] = $dimensions;
+        }
+
         $blockGap = $this->blockGap($normalized, $consumed);
         if ( '' !== $blockGap ) {
             $style['spacing']['blockGap'] = $blockGap;
@@ -177,6 +182,11 @@ final class StyleAttributeMapper
         $blockGap = trim((string) ($spacing['blockGap'] ?? ''));
         if ( '' !== $blockGap ) {
             $declarations[] = 'gap:' . $blockGap;
+        }
+
+        $dimensions = is_array($style['dimensions'] ?? null) ? $style['dimensions'] : array();
+        if ( '' !== trim((string) ($dimensions['minHeight'] ?? '')) ) {
+            $declarations[] = 'min-height:' . trim((string) $dimensions['minHeight']);
         }
 
         $typography    = is_array($style['typography'] ?? null) ? $style['typography'] : array();
@@ -302,6 +312,41 @@ final class StyleAttributeMapper
         }
 
         return '';
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, bool> $consumed
+     * @return array<string, string>
+     */
+    private function dimensions(array $declarations, array &$consumed): array
+    {
+        $minHeight = trim((string) ($declarations['min-height'] ?? ''));
+        if ( '' === $minHeight || ! $this->isCssLengthLike($minHeight) ) {
+            return array();
+        }
+
+        $consumed['min-height'] = true;
+
+        return array( 'minHeight' => $minHeight );
+    }
+
+    private function isCssLengthLike(string $value): bool
+    {
+        $value = trim($value);
+        if ( '' === $value ) {
+            return false;
+        }
+
+        if ( preg_match('/^(?:calc|min|max|clamp)\s*\(/i', $value) ) {
+            return CssValueSplitter::hasBalancedParens($value);
+        }
+
+        if ( preg_match('/^var\s*\(\s*--[a-z0-9_-]+/i', $value) ) {
+            return str_ends_with($value, ')') && CssValueSplitter::hasBalancedParens($value);
+        }
+
+        return (bool) preg_match('/^(?:0|[0-9]*\.?[0-9]+(?:px|em|rem|%|vh|vw|svh|svw|lvh|lvw|dvh|dvw|vmin|vmax|ch|ex|lh|rlh))$/i', $value);
     }
 
     /**

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -41,7 +41,7 @@ $assert('space-between' === ($attrs['layout']['justifyContent'] ?? ''), '6: just
 $assert(! isset($attrs['style']['box-shadow']), '7: unsupported box-shadow is not stored as block style', json_encode($attrs['style'] ?? array()));
 $assert(! is_string($attrs['style'] ?? null), '8: block style attr is structured, never a raw style string');
 
-$groupHtml = '<div class="hero-row" style="display:flex;justify-content:center;gap:1rem;padding:2rem;background:var(--wp--preset--color--base)"><p>Hello</p><p>World</p></div>';
+$groupHtml = '<div class="hero-row" style="display:flex;justify-content:center;gap:1rem;min-height:100svh;padding:2rem;background:var(--wp--preset--color--base)"><p>Hello</p><p>World</p></div>';
 $groupResult = ( new HtmlTransformer() )->transform($groupHtml, array())->toArray();
 $group = $groupResult['blocks'][0] ?? array();
 $groupAttrs = is_array($group['attrs'] ?? null) ? $group['attrs'] : array();
@@ -53,13 +53,15 @@ $assert(str_contains($groupInnerHtml, 'has-base-background-color has-background'
 $assert(str_contains($groupInnerHtml, 'is-layout-flex wp-block-columns-is-layout-flex'), '12: rendered wrapper uses layout support classes', $groupInnerHtml);
 $assert(! str_contains($groupInnerHtml, 'gap:1rem'), '13: rendered wrapper omits blockGap when the core save shape does not reproduce it', $groupInnerHtml);
 $assert(! str_contains($groupInnerHtml, 'display:flex') && ! str_contains($groupInnerHtml, 'justify-content:center'), '14: rendered wrapper does not carry raw flex declarations', $groupInnerHtml);
+$assert('100svh' === ($groupAttrs['style']['dimensions']['minHeight'] ?? ''), '15: min-height maps to Gutenberg dimensions support', json_encode($groupAttrs['style']['dimensions'] ?? array()));
+$assert(str_contains($groupInnerHtml, 'min-height:100svh'), '16: rendered wrapper preserves section min-height geometry', $groupInnerHtml);
 
 $stackHtml = '<div class="hero-content"><p>Eyebrow</p><h1>Low Tide Table</h1><div></div><p>Local shrimp.</p><div><p>Next Run</p></div><div><a href="#reserve">Reserve</a></div></div>';
 $stackResult = ( new HtmlTransformer() )->transform($stackHtml, array())->toArray();
 $stack = $stackResult['blocks'][0] ?? array();
 
-$assert('core/group' === ($stack['blockName'] ?? ''), '15: multi-child hero content stack stays a group, not columns', (string) ($stack['blockName'] ?? '(none)'));
-$assert('hero-content' === (($stack['attrs']['className'] ?? '')), '16: multi-child hero content stack keeps source class for stylesheet materialization', json_encode($stack['attrs'] ?? array()));
+$assert('core/group' === ($stack['blockName'] ?? ''), '17: multi-child hero content stack stays a group, not columns', (string) ($stack['blockName'] ?? '(none)'));
+$assert('hero-content' === (($stack['attrs']['className'] ?? '')), '18: multi-child hero content stack keeps source class for stylesheet materialization', json_encode($stack['attrs'] ?? array()));
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Block style support conversion tests: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
## Summary
- Maps valid CSS `min-height` values into Gutenberg `style.dimensions.minHeight`.
- Serializes `style.dimensions.minHeight` back to `min-height` through the existing block-support style path.
- Adds unit coverage that section/card wrapper min-height survives without raw flex style leakage or vertical-stack columnization.

## Evidence
- `php tests/unit/block-style-support-conversion.php`
- `composer test`
- Static parity summaries remained unchanged for `15-saas`, `2-onepager-coffee`, `31-personal-cv-academic`, and `3-artist-music`; this is expected because the static harness does not track geometry properties.
- Browser geometry probe on affected fixtures showed target hero height matching source after preserving `min-height`:
  - `2-onepager-coffee`: source `900px`; synthetic pre-change target `873px`; current target `900px`.
  - `3-artist-music`: source `832px`; synthetic pre-change target `731px`; current target `832px`.

## Risk
- Low: only maps `min-height`, not width/max-width/gap/position, and does not affect columns recognition.
- Values are limited to length-like CSS values, balanced `calc()`/`min()`/`max()`/`clamp()`, and balanced CSS variables.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified the PHP transformer change with Chris directing the parity target and constraints.
