### PR TITLE
Improve Figma HTML semantics and text trimming

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -6982,7 +6982,7 @@ final class StaticHtmlEmitter
                 return '';
             }
 
-            return $this->sanitizeText($this->textShouldUseFluidFlowBox($node, $parentNode) ? $characters : $this->derivedLineBreakText($characters, $text));
+            return $this->sanitizeText($this->trimTextContent($this->textShouldUseFluidFlowBox($node, $parentNode) ? $characters : $this->derivedLineBreakText($characters, $text)));
         }
 
         $characters = (string) ($node['characters'] ?? $node['text'] ?? '');
@@ -6990,7 +6990,12 @@ final class StaticHtmlEmitter
             return '';
         }
 
-        return $this->sanitizeText($characters);
+        return $this->sanitizeText($this->trimTextContent($characters));
+    }
+
+    private function trimTextContent(string $characters): string
+    {
+        return trim($characters);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
+++ b/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
@@ -134,9 +134,11 @@ final class StaticHtmlSemanticClassifier
 
         $children = array_values(array_filter(($this->nodeList)($node), 'is_array'));
 
-        if ( null !== $parentNode && $this->isListItemOf($node, $parentNode) ) {
+        if ( null !== $parentNode && $this->isListItemOf($node, $parentNode) && ! $this->isTopLevelSection($parentNode, $depth - 1, $sectionDepth, $grandParentNode, $this->children($parentNode)) ) {
             return 'li';
         }
+
+        $isTopLevelSection = 'FRAME' === $type && $this->isTopLevelSection($node, $depth, $sectionDepth, $parentNode, $children);
 
         if ( $this->isTextareaLike($node, $parentNode) ) {
             return $this->hasFormControlAccessoryChildren($node) ? 'div' : 'textarea';
@@ -162,7 +164,7 @@ final class StaticHtmlSemanticClassifier
             return 'button';
         }
 
-        if ( ! empty($this->listItemIds($node)) ) {
+        if ( ! $isTopLevelSection && ! empty($this->listItemIds($node)) ) {
             return $this->listLooksOrdered($node) ? 'ol' : 'ul';
         }
 
@@ -175,7 +177,7 @@ final class StaticHtmlSemanticClassifier
             return 'article';
         }
 
-        if ( 'FRAME' === $type && $this->isTopLevelSection($node, $depth, $sectionDepth, $parentNode, $children) ) {
+        if ( $isTopLevelSection ) {
             return 'section';
         }
 
@@ -766,6 +768,15 @@ final class StaticHtmlSemanticClassifier
     private function listLooksOrdered(array $container): bool
     {
         return ($this->listLooksOrdered)($container);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, array<string, mixed>>
+     */
+    private function children(array $node): array
+    {
+        return array_values(array_filter(($this->nodeList)($node), 'is_array'));
     }
 
     /**

--- a/figma-transformer/tests/contract/SemanticAccessibilityContract.php
+++ b/figma-transformer/tests/contract/SemanticAccessibilityContract.php
@@ -97,6 +97,45 @@ function blocks_engine_figma_transformer_run_semantic_accessibility_contract(cal
     $assert(str_contains($largeBodyTextHtml, '<p class="figma-node-semantic-large-body-supporting-supporting-text"'), 'semantic-accessibility-large-supporting-text-paragraph');
     $assert(! str_contains($largeBodyTextHtml, '<h2 class="figma-node-semantic-large-body-body-body"'), 'semantic-accessibility-large-body-text-not-heading');
 
+    $topLevelListLikeSectionResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Top Level List Like Section Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'semantic:list-section-root',
+                'type'     => 'FRAME',
+                'name'     => 'Home',
+                'width'    => 1200,
+                'height'   => 1000,
+                'children' => array(
+                    array(
+                        'id'       => 'semantic:list-section-hero',
+                        'type'     => 'FRAME',
+                        'name'     => 'Hero',
+                        'width'    => 1200,
+                        'height'   => 300,
+                        'children' => array(array('id' => 'semantic:list-section-hero-title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Hero', 'fontSize' => 48)),
+                    ),
+                    array(
+                        'id'       => 'semantic:pricing-section',
+                        'type'     => 'FRAME',
+                        'name'     => 'Pricing',
+                        'width'    => 1200,
+                        'height'   => 500,
+                        'children' => array(
+                            array('id' => 'semantic:pricing-card-a', 'type' => 'FRAME', 'name' => 'Basic Card', 'children' => array(array('id' => 'semantic:pricing-card-a-title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Basic', 'fontSize' => 24))),
+                            array('id' => 'semantic:pricing-card-b', 'type' => 'FRAME', 'name' => 'Pro Card', 'children' => array(array('id' => 'semantic:pricing-card-b-title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Pro', 'fontSize' => 24))),
+                            array('id' => 'semantic:pricing-card-c', 'type' => 'FRAME', 'name' => 'Team Card', 'children' => array(array('id' => 'semantic:pricing-card-c-title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Team', 'fontSize' => 24))),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $topLevelListLikeSectionHtml = $fileContent($topLevelListLikeSectionResult, 'index.html');
+    $assert(str_contains($topLevelListLikeSectionHtml, '<section class="figma-node-semantic-pricing-section-pricing"'), 'semantic-accessibility-top-level-list-like-frame-keeps-section-landmark');
+    $assert(! str_contains($topLevelListLikeSectionHtml, '<ul class="figma-node-semantic-pricing-section-pricing"'), 'semantic-accessibility-top-level-list-like-frame-not-ul');
+    $assert(! str_contains($topLevelListLikeSectionHtml, '<li class="figma-node-semantic-pricing-card-a-basic-card"'), 'semantic-accessibility-top-level-list-like-frame-children-not-li');
+
     $booleanLabelResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Decorative Boolean Label Fixture',
         'nodes' => array(

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -19,6 +19,23 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     $multilineTextCss = $fileContent($multilineTextResult, 'style.css');
     $assert(str_contains($multilineTextCss, '.figma-node-text-multiline-checklist-text{font-size:16px;white-space:pre-line}'), 'multiline-text-preserves-line-breaks');
 
+    $edgeWhitespaceTextResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Edge Whitespace Text Fixture',
+        'nodes' => array(
+            array(
+                'id'         => 'text:edge-whitespace',
+                'type'       => 'TEXT',
+                'name'       => 'Padded Text',
+                'characters' => "  One\nTwo   ",
+                'fontSize'   => 16,
+            ),
+        ),
+    ));
+    $edgeWhitespaceTextHtml = $fileContent($edgeWhitespaceTextResult, 'index.html');
+    $assert(str_contains($edgeWhitespaceTextHtml, '>One' . "\n" . 'Two<'), 'text-content-trims-edge-whitespace');
+    $assert(! str_contains($edgeWhitespaceTextHtml, '>  One'), 'text-content-trims-leading-whitespace');
+    $assert(! str_contains($edgeWhitespaceTextHtml, 'Two   <'), 'text-content-trims-trailing-whitespace');
+
     $styleTokenFontResolution = ( new \Automattic\BlocksEngine\FigmaTransformer\Html\FontResolver() )->resolve(array(
         array(
             'family' => 'Skolar Latin',


### PR DESCRIPTION
## Summary
- keep page-level list-like Figma frames as section landmarks instead of emitting a bare list container
- prevent those section frames from forcing direct card children into `li` tags
- trim leading/trailing source whitespace from emitted plain text while preserving internal line breaks

## Verification
- `composer test` from `figma-transformer/`
- Fisiostetic fixture matrix transform passed locally: 1 fixture, 0 failures, 0 vector placeholders, 0 missing assets

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated Fisiostetic transform artifacts, implemented generic Blocks Engine fixes, added contract coverage, and ran local verification.