### PR TITLE
Preserve SaaS card text wrapper geometry

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1562,6 +1562,11 @@ final class HtmlTransformer
                 return $inlineTokenGroup;
             }
 
+            $visualTextWrapper = $this->visualTextWrapperBlockFromElement($element);
+            if ( null !== $visualTextWrapper ) {
+                return $visualTextWrapper;
+            }
+
             $inlineContent = $this->paragraphBlockFromInlineContentWrapper($element);
             if ( null !== $inlineContent ) {
                 return $inlineContent;
@@ -2586,6 +2591,50 @@ final class HtmlTransformer
         ))));
 
         return 1 === preg_match('/(?:^|[^a-z0-9])(?:chips?|pills?|badges?|tags?|filters?|facets?)(?:[^a-z0-9]|$)/', $tokens);
+    }
+
+    private function visualTextWrapperBlockFromElement(DOMElement $element): ?array
+    {
+        if ( ! in_array(strtolower($element->tagName), array( 'div', 'span' ), true) || $this->hasBlockContentChildren($element) ) {
+            return null;
+        }
+
+        $content = $this->richTextContentWithMaterializedInlineStyles($element);
+        if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextRequiresHtmlFallback($content) ) {
+            return null;
+        }
+
+        if ( ! $this->hasVisualTextWrapperSignal($element) ) {
+            return null;
+        }
+
+        return $this->createBlock(
+            'core/group',
+            $this->presentationAttributes($element),
+            array( $this->createBlock('core/paragraph', array( 'content' => $content )) ),
+            $element
+        );
+    }
+
+    private function hasVisualTextWrapperSignal(DOMElement $element): bool
+    {
+        $className = strtolower($this->attr($element, 'class'));
+        if ( preg_match('/(?:^|[\s_-])(?:badge|tag|label|eyebrow|kicker|meta|pill|chip|stat|num|price|amount|result|caption|title|name)(?:$|[\s_-])/', $className) ) {
+            return true;
+        }
+
+        if ( 0 < $this->childElementCount($element) ) {
+            return false;
+        }
+
+        $declarations = $this->presentationDeclarations($element);
+        foreach ( array( 'display', 'gap', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'border', 'border-color', 'border-radius', 'width', 'height', 'min-width', 'max-width', 'min-height' ) as $property ) {
+            if ( isset($declarations[$property]) && '' !== trim((string) $declarations[$property]) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function paragraphBlockFromInlineContentWrapper(DOMElement $element): ?array

--- a/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
@@ -188,6 +188,9 @@ final class StyleAttributeMapper
         if ( '' !== trim((string) ($dimensions['minHeight'] ?? '')) ) {
             $declarations[] = 'min-height:' . trim((string) $dimensions['minHeight']);
         }
+        if ( '' !== trim((string) ($dimensions['maxWidth'] ?? '')) ) {
+            $declarations[] = 'max-width:' . trim((string) $dimensions['maxWidth']);
+        }
 
         $typography    = is_array($style['typography'] ?? null) ? $style['typography'] : array();
         $typographyMap = array(
@@ -321,14 +324,21 @@ final class StyleAttributeMapper
      */
     private function dimensions(array $declarations, array &$consumed): array
     {
+        $dimensions = array();
+
         $minHeight = trim((string) ($declarations['min-height'] ?? ''));
-        if ( '' === $minHeight || ! $this->isCssLengthLike($minHeight) ) {
-            return array();
+        if ( '' !== $minHeight && $this->isCssLengthLike($minHeight) ) {
+            $dimensions['minHeight'] = $minHeight;
+            $consumed['min-height']  = true;
         }
 
-        $consumed['min-height'] = true;
+        $maxWidth = trim((string) ($declarations['max-width'] ?? ''));
+        if ( '' !== $maxWidth && $this->isCssLengthLike($maxWidth) ) {
+            $dimensions['maxWidth'] = $maxWidth;
+            $consumed['max-width']  = true;
+        }
 
-        return array( 'minHeight' => $minHeight );
+        return $dimensions;
     }
 
     private function isCssLengthLike(string $value): bool

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -56,12 +56,37 @@ $assert(! str_contains($groupInnerHtml, 'display:flex') && ! str_contains($group
 $assert('100svh' === ($groupAttrs['style']['dimensions']['minHeight'] ?? ''), '15: min-height maps to Gutenberg dimensions support', json_encode($groupAttrs['style']['dimensions'] ?? array()));
 $assert(str_contains($groupInnerHtml, 'min-height:100svh'), '16: rendered wrapper preserves section min-height geometry', $groupInnerHtml);
 
+$cardHtml = '<section class="pricing-shell" style="max-width:1120px;margin:0 auto;padding:5rem 2rem"><article class="pricing-card" style="max-width:360px;padding:2rem;background:#fff"><h2>Team</h2><p>Scale every launch.</p></article></section>';
+$cardResult = ( new HtmlTransformer() )->transform($cardHtml, array())->toArray();
+$cardShell = $cardResult['blocks'][0] ?? array();
+$card = $cardShell['innerBlocks'][0] ?? array();
+$cardShellAttrs = is_array($cardShell['attrs'] ?? null) ? $cardShell['attrs'] : array();
+$cardAttrs = is_array($card['attrs'] ?? null) ? $card['attrs'] : array();
+$cardMarkup = (string) ($cardResult['serialized_blocks'] ?? '');
+
+$assert('1120px' === ($cardShellAttrs['style']['dimensions']['maxWidth'] ?? ''), '17: section max-width maps to dimensions support', json_encode($cardShellAttrs['style']['dimensions'] ?? array()));
+$assert('360px' === ($cardAttrs['style']['dimensions']['maxWidth'] ?? ''), '18: card max-width maps to dimensions support', json_encode($cardAttrs['style']['dimensions'] ?? array()));
+$assert(str_contains($cardMarkup, 'max-width:1120px'), '19: rendered section preserves max-width geometry', $cardMarkup);
+$assert(str_contains($cardMarkup, 'max-width:360px'), '20: rendered card preserves max-width geometry', $cardMarkup);
+$assert(! str_contains($cardMarkup, 'style="max-width:1120px;margin:0 auto;padding:5rem 2rem"'), '21: rendered section does not keep unsupported raw style wholesale', $cardMarkup);
+
+$labelHtml = '<section class="pricing"><div class="section-head"><div class="tag">Pricing</div><h2>Simple plans</h2></div><article class="pricing-card"><div class="tier-name">Team</div><div class="tier-price"><span class="amount">$29</span>/mo</div><div class="use-case-result">Launch faster</div></article></section>';
+$labelCss = '.tag{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:100px}.pricing-card{padding:2rem}.tier-name{font-family:monospace;font-size:11px;letter-spacing:.12em;text-transform:uppercase}.tier-price{display:flex;align-items:flex-end;gap:6px}.use-case-result{display:flex;align-items:center;gap:8px;padding:10px 14px;border-radius:6px}';
+$labelResult = ( new HtmlTransformer() )->transform($labelHtml, array('static_css' => $labelCss))->toArray();
+$labelMarkup = (string) ($labelResult['serialized_blocks'] ?? '');
+
+$assert(str_contains($labelMarkup, '<div class="wp-block-group tag'), '22: class-owned section badge stays a group wrapper', $labelMarkup);
+$assert(str_contains($labelMarkup, '<div class="wp-block-group tier-name'), '23: class-owned card tier label stays a group wrapper', $labelMarkup);
+$assert(str_contains($labelMarkup, '<div class="wp-block-group tier-price'), '24: class-owned card price row stays a group wrapper', $labelMarkup);
+$assert(str_contains($labelMarkup, '<div class="wp-block-group use-case-result'), '25: class-owned card result row stays a group wrapper', $labelMarkup);
+$assert(! str_contains($labelMarkup, '<p class="tier-name"'), '26: card label is not flattened into a paragraph that breaks wrapper CSS', $labelMarkup);
+
 $stackHtml = '<div class="hero-content"><p>Eyebrow</p><h1>Low Tide Table</h1><div></div><p>Local shrimp.</p><div><p>Next Run</p></div><div><a href="#reserve">Reserve</a></div></div>';
 $stackResult = ( new HtmlTransformer() )->transform($stackHtml, array())->toArray();
 $stack = $stackResult['blocks'][0] ?? array();
 
-$assert('core/group' === ($stack['blockName'] ?? ''), '17: multi-child hero content stack stays a group, not columns', (string) ($stack['blockName'] ?? '(none)'));
-$assert('hero-content' === (($stack['attrs']['className'] ?? '')), '18: multi-child hero content stack keeps source class for stylesheet materialization', json_encode($stack['attrs'] ?? array()));
+$assert('core/group' === ($stack['blockName'] ?? ''), '27: multi-child hero content stack stays a group, not columns', (string) ($stack['blockName'] ?? '(none)'));
+$assert('hero-content' === (($stack['attrs']['className'] ?? '')), '28: multi-child hero content stack keeps source class for stylesheet materialization', json_encode($stack['attrs'] ?? array()));
 
 $paintCss = '.pricing-card{background:radial-gradient(circle at 20% 10%,rgba(255,255,255,.9),rgba(255,255,255,0) 38%),linear-gradient(180deg,#fff,#f5efe4);background-position:center top;background-size:120% 80%,100% 100%;background-repeat:no-repeat;box-shadow:0 28px 80px rgba(20,12,4,.18);padding:2rem;border-radius:24px}';
 $paintHtml = '<main><section class="pricing-card"><h2>Roast Club</h2><p>Fresh coffee every week.</p></section></main>';
@@ -69,19 +94,19 @@ $paintResult = ( new HtmlTransformer() )->transform($paintHtml, array('static_cs
 $paintBlock = $paintResult['blocks'][0] ?? array();
 $paintAttrs = is_array($paintBlock['attrs'] ?? null) ? $paintBlock['attrs'] : array();
 
-$assert('pricing-card' === ($paintAttrs['className'] ?? ''), '17: high-value card wrapper keeps source class for class-owned paint CSS', json_encode($paintAttrs));
-$assert(! isset($paintAttrs['style']['box-shadow']), '18: class-owned box-shadow is not stored as an unsupported block style attr', json_encode($paintAttrs['style'] ?? array()));
-$assert(! isset($paintAttrs['style']['background-position']) && ! isset($paintAttrs['style']['background-size']), '19: background layer controls stay out of block style attrs', json_encode($paintAttrs['style'] ?? array()));
+$assert('pricing-card' === ($paintAttrs['className'] ?? ''), '29: high-value card wrapper keeps source class for class-owned paint CSS', json_encode($paintAttrs));
+$assert(! isset($paintAttrs['style']['box-shadow']), '30: class-owned box-shadow is not stored as an unsupported block style attr', json_encode($paintAttrs['style'] ?? array()));
+$assert(! isset($paintAttrs['style']['background-position']) && ! isset($paintAttrs['style']['background-size']), '31: background layer controls stay out of block style attrs', json_encode($paintAttrs['style'] ?? array()));
 
 $rulesMethod = new ReflectionMethod(HtmlTransformer::class, 'staticStyleRules');
 $paintRules = $rulesMethod->invoke(new HtmlTransformer(), '', $paintCss);
 $paintDeclarations = $paintRules[0]['declarations'] ?? array();
 
-$assert(($paintDeclarations['background'] ?? '') === 'radial-gradient(circle at 20% 10%,rgba(255,255,255,.9),rgba(255,255,255,0) 38%),linear-gradient(180deg,#fff,#f5efe4)', '20: radial and layered backgrounds survive safe CSS resolution', json_encode($paintDeclarations));
-$assert(($paintDeclarations['background-position'] ?? '') === 'center top', '21: background-position survives safe CSS resolution', json_encode($paintDeclarations));
-$assert(($paintDeclarations['background-size'] ?? '') === '120% 80%,100% 100%', '22: background-size survives safe CSS resolution', json_encode($paintDeclarations));
-$assert(($paintDeclarations['background-repeat'] ?? '') === 'no-repeat', '23: background-repeat survives safe CSS resolution', json_encode($paintDeclarations));
-$assert(($paintDeclarations['box-shadow'] ?? '') === '0 28px 80px rgba(20,12,4,.18)', '24: box-shadow survives safe CSS resolution', json_encode($paintDeclarations));
+$assert(($paintDeclarations['background'] ?? '') === 'radial-gradient(circle at 20% 10%,rgba(255,255,255,.9),rgba(255,255,255,0) 38%),linear-gradient(180deg,#fff,#f5efe4)', '32: radial and layered backgrounds survive safe CSS resolution', json_encode($paintDeclarations));
+$assert(($paintDeclarations['background-position'] ?? '') === 'center top', '33: background-position survives safe CSS resolution', json_encode($paintDeclarations));
+$assert(($paintDeclarations['background-size'] ?? '') === '120% 80%,100% 100%', '34: background-size survives safe CSS resolution', json_encode($paintDeclarations));
+$assert(($paintDeclarations['background-repeat'] ?? '') === 'no-repeat', '35: background-repeat survives safe CSS resolution', json_encode($paintDeclarations));
+$assert(($paintDeclarations['box-shadow'] ?? '') === '0 28px 80px rgba(20,12,4,.18)', '36: box-shadow survives safe CSS resolution', json_encode($paintDeclarations));
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Block style support conversion tests: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
## Summary
- Preserve class-owned SaaS/card text micro-wrappers as `core/group` wrappers instead of flattening them into paragraphs when their classes carry visual geometry semantics like badges, tags, prices, results, labels, names, and captions.
- Preserve `max-width` through the existing dimensions support mapper/serializer alongside `min-height`.
- Add PHP regression coverage for section/card max-width geometry and SaaS-style section/card label wrappers.

## Root cause
SaaS sections and cards kept their outer grid/card classes, but text-only inner wrappers such as `.tag`, `.tier-name`, `.tier-price`, `.use-case-result`, and `.featured-badge` were flattened into paragraph/text shapes. The source CSS targets those wrapper classes for display, gap, padding, border radius, and card label geometry, so the transformed DOM lost selector addressability and produced high `restyle_geometry` / `position_offset` symptoms. Inline `max-width` was also not mapped through dimensions support, so section/card width constraints could be dropped when not class-owned.

## Metrics
Static parity from `php tools/static-parity/run.php --fixture <fixture> --top 1`:

| Fixture | Baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| `15-saas` score | 0.7446 | 0.7968 | +0.0522 |
| `15-saas` prop-par | 0.9435 | 0.9863 | +0.0428 |
| `15-saas` coverage | 0.7893 | 0.8079 | +0.0186 |
| `15-saas` findings | 150 | 107 | -43 |
| `2-onepager-coffee` score | 0.7229 | 0.7229 | 0 |
| `3-artist-music` score | 0.7583 | 0.7995 | +0.0412 |
| `31-personal-cv-academic` score | 0.9611 | 0.9611 | 0 |

## Tests
- `php tests/unit/block-style-support-conversion.php`
- `php tests/contract/run.php`
- `php tests/parity/run.php`
- `php tools/static-parity/run.php --fixture 15-saas --top 1`
- `php tools/static-parity/run.php --fixture 2-onepager-coffee --top 1`
- `php tools/static-parity/run.php --fixture 3-artist-music --top 1`
- `php tools/static-parity/run.php --fixture 31-personal-cv-academic --top 1`

## Remaining SaaS Geometry Map
- Still high: SVG/map mockup elements are materialized differently, leaving many unmatched source SVG/text/g nodes.
- Still high: navigation/button anchors are intentionally out of scope for this pass.
- Remaining section/card issues: hover-state border-color/style deltas on integration/use-case/pricing cards; some inline text wrappers inside SVG-adjacent/product-sidebar areas still unmatched.
- Improved: section/card micro-wrapper geometry for badges/tags/labels/prices/results and max-width constraints.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated SaaS static parity findings, implemented the PHP-only geometry preservation change, added regression tests, and ran verification/metric comparisons.
