### PR TITLE
Improve Figma HTML artifact responsiveness

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -181,7 +181,15 @@ final class BreakpointMediaDiffBuilder
             return array();
         }
 
-        return array($this->mediaBlock(767, array_values(array_unique($rules))));
+        $rules = array_values(array_unique($rules));
+        $breakpoints = array(767);
+        if ( $rootWidth > 1200.0 ) {
+            $breakpoints[] = (int) floor($rootWidth - 1.0);
+        }
+        $breakpoints = array_values(array_unique(array_filter($breakpoints, static fn (int $breakpoint): bool => $breakpoint > 0)));
+        rsort($breakpoints, SORT_NUMERIC);
+
+        return array_map(fn (int $breakpoint): string => $this->mediaBlock($breakpoint, $rules), $breakpoints);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -985,6 +985,10 @@ final class StaticHtmlEmitter
         }
 
         $attributes = sprintf(' class="%1$s" data-figma-node-id="%2$s" data-figma-node-name="%3$s"', $className, $id, $attributeName);
+        $semanticRole = $this->semanticRoleMetadata($node, $tag, $type, $name);
+        if ( null !== $semanticRole ) {
+            $attributes .= ' data-figma-semantic-role="' . $this->sanitizeAttribute($semanticRole) . '"';
+        }
         $anchorId = $this->headingAnchorId($node, $tag);
         if ( null !== $anchorId ) {
             $attributes .= ' id="' . $this->sanitizeAttribute($anchorId) . '"';
@@ -1229,6 +1233,87 @@ final class StaticHtmlEmitter
     private function semanticTag(array $node, string $type, string $name, int $depth, ?array $parentNode, ?array $grandParentNode = null): string
     {
         return $this->staticHtmlSemanticClassifier()->semanticTag($node, $type, $name, $depth, $this->sectionDepth, $parentNode, $grandParentNode);
+    }
+
+    /** @param array<string, mixed> $node */
+    private function semanticRoleMetadata(array $node, string $tag, string $type, string $name): ?string
+    {
+        if ( 'TEXT' === $type ) {
+            return null;
+        }
+
+        if ( in_array($tag, array('header', 'nav', 'footer'), true) ) {
+            return $tag;
+        }
+
+        $nameHaystack = strtolower(trim($name));
+        if ( '' === $nameHaystack ) {
+            return null;
+        }
+
+        if ( $this->containsSemanticRoleToken($nameHaystack, array('nav', 'navigation', 'menu')) ) {
+            return 'nav';
+        }
+        if ( $this->containsSemanticRoleToken($nameHaystack, array('service', 'services', 'treatment', 'treatments', 'tratamiento', 'tratamientos')) ) {
+            return 'services';
+        }
+        if ( $this->containsSemanticRoleToken($nameHaystack, array('pricing', 'price', 'prices', 'plans', 'precios', 'precio')) ) {
+            return 'pricing';
+        }
+        if ( $this->containsSemanticRoleToken($nameHaystack, array('map', 'location', 'visit us', 'visitanos')) ) {
+            return 'map';
+        }
+        if ( $this->containsSemanticRoleToken($nameHaystack, array('contact', 'contacto', 'phone', 'telephone', 'address', 'whatsapp')) ) {
+            return 'contact';
+        }
+        if ( $this->containsSemanticRoleToken($nameHaystack, array('cta', 'call to action', 'book now', 'reserve', 'reservar', 'appointment', 'cita')) ) {
+            return 'cta';
+        }
+
+        $subtreeHaystack = strtolower(trim(strip_tags($this->subtreePlainText($node))));
+        if ( '' === $subtreeHaystack ) {
+            return null;
+        }
+
+        if ( in_array($tag, array('button', 'a'), true) ) {
+            if ( $this->containsSemanticRoleToken($subtreeHaystack, array('contact', 'contacto', 'phone', 'telephone', 'address', 'whatsapp')) ) {
+                return 'contact';
+            }
+            if ( $this->containsSemanticRoleToken($subtreeHaystack, array('cta', 'call to action', 'book now', 'reserve', 'reservar', 'appointment', 'cita')) ) {
+                return 'cta';
+            }
+        }
+
+        if ( 'section' === $tag ) {
+            if ( $this->containsSemanticRoleToken($subtreeHaystack, array('service', 'services', 'treatment', 'treatments', 'tratamiento', 'tratamientos')) ) {
+                return 'services';
+            }
+            if ( $this->containsSemanticRoleToken($subtreeHaystack, array('pricing', 'price', 'prices', 'plans', 'precios', 'precio')) ) {
+                return 'pricing';
+            }
+            if ( $this->containsSemanticRoleToken($subtreeHaystack, array('map', 'location', 'visit us', 'visitanos')) ) {
+                return 'map';
+            }
+            if ( $this->containsSemanticRoleToken($subtreeHaystack, array('contact', 'contacto', 'phone', 'telephone', 'address', 'whatsapp')) ) {
+                return 'contact';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, string> $tokens
+     */
+    private function containsSemanticRoleToken(string $haystack, array $tokens): bool
+    {
+        foreach ( $tokens as $token ) {
+            if ( str_contains($haystack, $token) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isFooterTextContext(?array $parentNode, ?array $grandParentNode): bool

--- a/figma-transformer/tests/contract/HtmlValidityContract.php
+++ b/figma-transformer/tests/contract/HtmlValidityContract.php
@@ -94,6 +94,50 @@ function blocks_engine_figma_transformer_run_html_validity_contract(callable $as
                             array('id' => 'validity:footer-privacy', 'type' => 'TEXT', 'name' => 'Footer text', 'characters' => 'Privacy Policy', 'fontSize' => 16, 'height' => 20),
                         ),
                     ),
+                    array(
+                        'id'       => 'validity:services',
+                        'type'     => 'FRAME',
+                        'name'     => 'Services Section',
+                        'width'    => 1200,
+                        'height'   => 320,
+                        'children' => array(
+                            array('id' => 'validity:services-heading', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Services', 'fontSize' => 48),
+                            array('id' => 'validity:services-copy', 'type' => 'TEXT', 'name' => 'Description', 'characters' => 'Treatment options', 'fontSize' => 18),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'validity:pricing',
+                        'type'     => 'FRAME',
+                        'name'     => 'Pricing',
+                        'width'    => 1200,
+                        'height'   => 320,
+                        'children' => array(
+                            array('id' => 'validity:pricing-heading', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Prices', 'fontSize' => 48),
+                            array('id' => 'validity:pricing-copy', 'type' => 'TEXT', 'name' => 'Description', 'characters' => 'Plans and prices', 'fontSize' => 18),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'validity:contact-map',
+                        'type'     => 'FRAME',
+                        'name'     => 'Contact Map',
+                        'width'    => 1200,
+                        'height'   => 320,
+                        'children' => array(
+                            array('id' => 'validity:contact-heading', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Contact', 'fontSize' => 48),
+                            array('id' => 'validity:contact-copy', 'type' => 'TEXT', 'name' => 'Description', 'characters' => 'Visit our map location', 'fontSize' => 18),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'validity:final-cta',
+                        'type'     => 'FRAME',
+                        'name'     => 'Final CTA',
+                        'width'    => 1200,
+                        'height'   => 320,
+                        'children' => array(
+                            array('id' => 'validity:cta-heading', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Book an appointment', 'fontSize' => 48),
+                            array('id' => 'validity:cta-copy', 'type' => 'TEXT', 'name' => 'Description', 'characters' => 'Reserve now', 'fontSize' => 18),
+                        ),
+                    ),
                 ),
             ),
             array(
@@ -141,6 +185,11 @@ function blocks_engine_figma_transformer_run_html_validity_contract(callable $as
     $html = $fileContent($result, 'index.html');
     $links = $result['source_report']['transform_diagnostics']['links'] ?? array();
     $assert(str_contains($html, '<main class="figma-root" data-figma-root="true" data-page-title="Home Page" aria-label="Home Page" data-page-path="index.html">'), 'html-validity-document-root-carries-page-legibility-metadata');
+    $assert(str_contains($html, 'data-figma-node-id="validity:nav" data-figma-node-name="Navigation" data-figma-semantic-role="nav"'), 'html-validity-nav-carries-semantic-role-metadata');
+    $assert(str_contains($html, 'data-figma-node-id="validity:services" data-figma-node-name="Services Section" data-figma-semantic-role="services"'), 'html-validity-services-section-carries-semantic-role-metadata');
+    $assert(str_contains($html, 'data-figma-node-id="validity:pricing" data-figma-node-name="Pricing" data-figma-semantic-role="pricing"'), 'html-validity-pricing-section-carries-semantic-role-metadata');
+    $assert(str_contains($html, 'data-figma-node-id="validity:contact-map" data-figma-node-name="Contact Map" data-figma-semantic-role="map"'), 'html-validity-map-section-carries-semantic-role-metadata');
+    $assert(str_contains($html, 'data-figma-node-id="validity:final-cta" data-figma-node-name="Final CTA" data-figma-semantic-role="cta"'), 'html-validity-cta-section-carries-semantic-role-metadata');
     $assert(str_contains($html, '<a class="figma-link" href="archive.html" data-figma-link-type="implicit-route"><div class="figma-node-validity-news-item-menu-item"'), 'html-validity-menu-item-container-linked');
     $assert(str_contains($html, 'class="figma-node-validity-packed-nav-main-nav-links" data-figma-node-id="validity:packed-nav" data-figma-node-name="Main Nav Links"><a class="figma-link" href="archive.html" data-figma-link-type="implicit-route">News</a>      <a class="figma-link" href="page.html" data-figma-link-type="implicit-route">About</a>      <a class="figma-link" href="contact.html" data-figma-link-type="implicit-route">Contact</a>'), 'html-validity-packed-route-text-preserves-spacing-with-inline-links');
     $assert(! str_contains($html, '<a class="figma-link" href="archive.html" data-figma-link-type="implicit-route"><span class="figma-node-validity-news-text-text"'), 'html-validity-linked-menu-item-suppresses-descendant-anchor');

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -1657,13 +1657,13 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     }
     $assert('success' === ($responsiveEmitResult['status'] ?? null), 'responsive-emit-status-success');
     $assert('' !== $responsiveEmitCss, 'responsive-emit-stylesheet-present');
-    // Two narrower breakpoints plus one wide desktop-only page fallback => three
+    // Two narrower breakpoints plus two wide desktop-only page fallbacks => four
     // media blocks. Variant breakpoints are keyed at the MIDPOINT between
     // adjacent variant widths (not the narrow variant's own width).
     // desktop=1440, tablet=834, mobile=390:
     //   tablet breakpoint = round((1440+834)/2) = 1137
     //   mobile breakpoint = round((834+390)/2)  = 612
-    $assert(3 === substr_count($responsiveEmitCss, '@media'), 'responsive-emit-two-variant-media-blocks-plus-desktop-fallback');
+    $assert(4 === substr_count($responsiveEmitCss, '@media'), 'responsive-emit-two-variant-media-blocks-plus-desktop-fallback');
     $assert(str_contains($responsiveEmitCss, '@media (max-width:1137px){'), 'responsive-emit-tablet-media-query');
     $assert(str_contains($responsiveEmitCss, '@media (max-width:612px){'), 'responsive-emit-mobile-media-query');
     // Base layout uses the primary (desktop) variant styles, emitted before media.
@@ -1686,8 +1686,9 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(! preg_match('/\.figma-node-cards-desktop-card-a-image-card-image\{[^}]*height:auto/', $responsiveEmitMobileBlock), 'responsive-emit-mobile-leaf-image-keeps-fixed-height');
     $assert(! preg_match('/\.figma-node-cards-desktop-decor-absolute-decorative-rail\{[^}]*height:auto/', $responsiveEmitMobileBlock), 'responsive-emit-mobile-absolute-decoration-keeps-fixed-height');
     $assert(! str_contains($responsiveEmitMobileBlock, '.figma-node-frame-home-desktop-home-desktop{width:390px'), 'responsive-emit-mobile-root-does-not-pin-variant-width');
-    // The single-variant About page contributes only a conservative desktop-only
-    // fallback media block.
+    // The single-variant About page contributes source-width and mobile
+    // desktop-only fallback media blocks.
+    $assert(1 === preg_match('/@media \(max-width:1439px\)\{[\s\S]*figma-node-frame-about-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-source-width-fallback-media');
     $assert(1 === preg_match('/@media \(max-width:767px\)\{[\s\S]*figma-node-frame-about-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-desktop-fallback-media');
 
     $responsiveMismatchScenegraph = array(


### PR DESCRIPTION
## Summary
- Add a source-width responsive safety breakpoint for oversized single-variant Figma HTML artifacts, while keeping the existing mobile safety breakpoint.
- Emit generic data-figma-semantic-role metadata for recognizable HTML artifact sections/actions such as nav, services, pricing, map, contact, and CTA.
- Add contract coverage for semantic metadata and source-width desktop-only fallback CSS.

## Evidence
- Before Fisiostetic matrix/artifact: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fisiostetic-before
- After Fisiostetic matrix/artifact: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fisiostetic-after2
- After sanity rerun: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fisiostetic-after2-sanity

## Verification
- composer test:contract
- php figma-transformer/scripts/figma-fixture-matrix.php --fixture=/Users/chubes/Downloads/Fisiostetic.fig --output-dir=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/fisiostetic-after2 --no-dry-run

## Notes
- This stays strictly in the .fig -> HTML/CSS/assets artifact path. It does not generate WordPress blocks from .fig.
- DOM-box capture was not available locally because HOMEBOY_DOM_BOX_CAPTURE_COMMAND is not configured.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Drafted and implemented the generic Blocks Engine fix, regenerated Fisiostetic artifacts, and ran contract verification under Chris's direction.