### PR TITLE
Improve button visual diagnostics

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -60,6 +60,7 @@
       "php tests/unit/fallback-finding-normalizer.php",
       "php tests/unit/navigation-underline-color-resolver.php",
       "php tests/unit/button-signal-classifier.php",
+      "php tests/unit/button-visual-probe-diagnostics.php",
       "php tests/unit/block-style-support-conversion.php",
       "php tests/unit/content-round-trip-reporter.php",
       "php tests/unit/content-round-trip-form-echo.php",

--- a/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
+++ b/php-transformer/src/VisualParity/ButtonMenuVisualProbe.php
@@ -141,6 +141,7 @@ final class ButtonMenuVisualProbe
                     'classes' => $this->tokens($node->hasAttribute('class') ? $node->getAttribute('class') : ''),
                     'signals' => $this->signals($node),
                     'hierarchy' => $this->hierarchy($node),
+                    'wrapper_chrome' => $this->wrapperChrome($node, $rules),
                     'style' => $this->computedStyle($node, $rules),
                     'geometry' => $this->geometry($node, $rules),
                 ), static fn ($value): bool => null !== $value && array() !== $value && '' !== $value);
@@ -516,6 +517,59 @@ final class ButtonMenuVisualProbe
         }
 
         return $geometry;
+    }
+
+    /**
+     * @param array<int, array{selector: string, declarations: array<string, string>}> $rules
+     * @return array<string, mixed>|null
+     */
+    private function wrapperChrome(DOMElement $element, array $rules): ?array
+    {
+        for ( $node = $element->parentNode; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( 'body' === strtolower($node->tagName) ) {
+                break;
+            }
+
+            $style = $this->visualChromeStyle($this->computedStyle($node, $rules));
+            if ( array() === $style ) {
+                continue;
+            }
+
+            return array_filter(array(
+                'tag' => strtolower($node->tagName),
+                'selector' => $this->selector($node),
+                'classes' => $this->tokens($node->hasAttribute('class') ? $node->getAttribute('class') : ''),
+                'style' => $style,
+            ), static fn ($value): bool => array() !== $value && '' !== $value);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string> $style
+     * @return array<string, string>
+     */
+    private function visualChromeStyle(array $style): array
+    {
+        $fields = array(
+            'background',
+            'background-color',
+            'border',
+            'border-color',
+            'border-radius',
+            'box-shadow',
+            'padding',
+            'padding-bottom',
+            'padding-left',
+            'padding-right',
+            'padding-top',
+        );
+
+        $chrome = array_intersect_key($style, array_flip($fields));
+        ksort($chrome);
+
+        return array_filter($chrome, static fn (string $value): bool => '' !== trim($value));
     }
 
     private function childElementCount(DOMElement $element): int

--- a/php-transformer/src/VisualParity/ButtonMenuVisualProbeComparator.php
+++ b/php-transformer/src/VisualParity/ButtonMenuVisualProbeComparator.php
@@ -8,7 +8,7 @@ final class ButtonMenuVisualProbeComparator
     public const SCHEMA = 'blocks-engine/php-transformer/visual-parity-probe-comparison/v1';
 
     private const STYLE_GROUPS = array(
-        'background' => array('background-color'),
+        'fill' => array('background', 'background-color'),
         'border' => array(
             'border',
             'border-bottom-color',
@@ -35,6 +35,8 @@ final class ButtonMenuVisualProbeComparator
             'border-top-right-radius',
         ),
         'padding' => array('padding', 'padding-bottom', 'padding-left', 'padding-right', 'padding-top'),
+        'text_color' => array('color'),
+        'width' => array('width', 'min-width'),
     );
 
     /**
@@ -59,11 +61,14 @@ final class ButtonMenuVisualProbeComparator
 
             unset($unmatchedTargetIndexes[$targetIndex]);
             $targetProbe = $targetProbes[$targetIndex];
+            $styleDeltas = $this->styleDeltas($sourceProbe, $targetProbe);
+            $missingStyleRisks = $this->missingStyleRisks($sourceProbe, $targetProbe);
             $matches[] = array_filter(array(
                 'source' => $this->candidateSummary($sourceProbe, $sourceIndex),
                 'target' => $this->candidateSummary($targetProbe, $targetIndex),
-                'style_deltas' => $this->styleDeltas($sourceProbe, $targetProbe),
-                'missing_style_risks' => $this->missingStyleRisks($sourceProbe, $targetProbe),
+                'style_deltas' => $styleDeltas,
+                'missing_style_risks' => $missingStyleRisks,
+                'mismatch_causes' => $this->mismatchCauses($sourceProbe, $targetProbe, $styleDeltas, $missingStyleRisks),
             ), static fn ($value): bool => array() !== $value);
         }
 
@@ -74,10 +79,19 @@ final class ButtonMenuVisualProbeComparator
 
         $styleDeltaCount = 0;
         $missingStyleRiskCount = 0;
+        $causeCounts = array();
         foreach ( $matches as $match ) {
             $styleDeltaCount += count($match['style_deltas'] ?? array());
             $missingStyleRiskCount += count($match['missing_style_risks'] ?? array());
+            foreach ( $match['mismatch_causes'] ?? array() as $cause ) {
+                if ( ! is_array($cause) ) {
+                    continue;
+                }
+                $code = (string) ($cause['code'] ?? 'unknown');
+                $causeCounts[$code] = ($causeCounts[$code] ?? 0) + 1;
+            }
         }
+        ksort($causeCounts);
 
         return array(
             'schema' => self::SCHEMA,
@@ -90,6 +104,7 @@ final class ButtonMenuVisualProbeComparator
                 'unmatched_target_total' => count($unmatchedTarget),
                 'style_delta_total' => $styleDeltaCount,
                 'missing_style_risk_total' => $missingStyleRiskCount,
+                'mismatch_cause_counts' => $causeCounts,
             ),
             'matches' => $matches,
             'unmatched_source' => $unmatchedSource,
@@ -222,6 +237,152 @@ final class ButtonMenuVisualProbeComparator
         }
 
         return $risks;
+    }
+
+    /**
+     * @param array<string, mixed> $sourceProbe
+     * @param array<string, mixed> $targetProbe
+     * @param array<int, array<string, mixed>> $styleDeltas
+     * @param array<int, array<string, mixed>> $missingStyleRisks
+     * @return array<int, array<string, mixed>>
+     */
+    private function mismatchCauses(array $sourceProbe, array $targetProbe, array $styleDeltas, array $missingStyleRisks): array
+    {
+        $causes = array();
+        $missingGroups = $this->missingRiskGroups($missingStyleRisks);
+
+        foreach ( $styleDeltas as $delta ) {
+            $group = (string) ($delta['group'] ?? 'style');
+            if ( isset($missingGroups[$group]) && array() === ($delta['target'] ?? array()) ) {
+                continue;
+            }
+            $causes[] = array_filter(array(
+                'code' => 'button_' . $group . '_mismatch',
+                'category' => $group,
+                'source' => $delta['source'] ?? array(),
+                'target' => $delta['target'] ?? array(),
+                'guidance' => $this->guidanceForGroup($group),
+            ), static fn ($value): bool => array() !== $value && '' !== $value);
+        }
+
+        foreach ( $missingStyleRisks as $risk ) {
+            $code = (string) ($risk['code'] ?? 'missing_style');
+            $group = (string) ($risk['group'] ?? 'default_style_leakage');
+            $causes[] = array_filter(array(
+                'code' => 'target_default_button_style' === $code ? 'button_default_style_leakage' : 'button_' . $group . '_missing',
+                'category' => $group,
+                'source' => $risk['source'] ?? array(),
+                'signal' => $risk['signal'] ?? null,
+                'guidance' => 'target_default_button_style' === $code ? 'Target looks like browser/core default button chrome; preserve explicit source button styles or remove unintended button promotion.' : $this->guidanceForGroup($group),
+            ), static fn ($value): bool => null !== $value && array() !== $value && '' !== $value);
+        }
+
+        $sourceDepth = (int) ($sourceProbe['hierarchy']['menu_depth'] ?? 0);
+        $targetDepth = (int) ($targetProbe['hierarchy']['menu_depth'] ?? 0);
+        if ( $sourceDepth !== $targetDepth ) {
+            $causes[] = array(
+                'code' => 'button_nesting_mismatch',
+                'category' => 'nesting',
+                'source' => array('menu_depth' => $sourceDepth),
+                'target' => array('menu_depth' => $targetDepth),
+                'guidance' => 'Button/menu item moved across list or navigation depth; inspect wrapper conversion before tuning styles.',
+            );
+        }
+
+        $wrapperDelta = $this->wrapperChromeDelta($sourceProbe, $targetProbe);
+        if ( array() !== $wrapperDelta ) {
+            $causes[] = array_filter(array(
+                'code' => 'button_wrapper_chrome_mismatch',
+                'category' => 'wrapper_chrome',
+                'source' => $wrapperDelta['source'] ?? array(),
+                'target' => $wrapperDelta['target'] ?? array(),
+                'guidance' => 'Visual chrome lives on a parent wrapper in one side; preserve wrapper block style/supports before changing button attributes.',
+            ), static fn ($value): bool => array() !== $value && '' !== $value);
+        }
+
+        return $this->uniqueCauses($causes);
+    }
+
+    private function guidanceForGroup(string $group): string
+    {
+        return match ($group) {
+            'width' => 'Compare source width/min-width against core/button width support or wrapper layout constraints.',
+            'padding' => 'Preserve source padding on the button/link element or its wrapper block spacing support.',
+            'radius' => 'Preserve source border radius on the core/button border support.',
+            'fill' => 'Preserve source fill/background color and avoid theme default fill leakage.',
+            'border' => 'Preserve border width/style/color together; partial border emission usually changes button shape.',
+            'text_color' => 'Preserve link text color separately from fill/background color.',
+            default => '',
+        };
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $missingStyleRisks
+     * @return array<string, bool>
+     */
+    private function missingRiskGroups(array $missingStyleRisks): array
+    {
+        $groups = array();
+        foreach ( $missingStyleRisks as $risk ) {
+            $group = (string) ($risk['group'] ?? '');
+            if ( '' !== $group ) {
+                $groups[$group] = true;
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @param array<string, mixed> $sourceProbe
+     * @param array<string, mixed> $targetProbe
+     * @return array<string, mixed>
+     */
+    private function wrapperChromeDelta(array $sourceProbe, array $targetProbe): array
+    {
+        $sourceStyle = $this->wrapperChromeStyle($sourceProbe);
+        $targetStyle = $this->wrapperChromeStyle($targetProbe);
+        if ( array() === $sourceStyle || $sourceStyle === $targetStyle ) {
+            return array();
+        }
+
+        return array_filter(array(
+            'source' => array_filter(array(
+                'selector' => $sourceProbe['wrapper_chrome']['selector'] ?? null,
+                'style' => $sourceStyle,
+            ), static fn ($value): bool => null !== $value && array() !== $value && '' !== $value),
+            'target' => array_filter(array(
+                'selector' => $targetProbe['wrapper_chrome']['selector'] ?? null,
+                'style' => $targetStyle,
+            ), static fn ($value): bool => null !== $value && array() !== $value && '' !== $value),
+        ), static fn ($value): bool => array() !== $value);
+    }
+
+    /** @param array<string, mixed> $probe */
+    private function wrapperChromeStyle(array $probe): array
+    {
+        $style = $probe['wrapper_chrome']['style'] ?? array();
+        return is_array($style) ? array_filter($style, 'is_string') : array();
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $causes
+     * @return array<int, array<string, mixed>>
+     */
+    private function uniqueCauses(array $causes): array
+    {
+        $unique = array();
+        $seen = array();
+        foreach ( $causes as $cause ) {
+            $key = (string) ($cause['code'] ?? '') . '|' . (string) ($cause['category'] ?? '');
+            if ( isset($seen[$key]) ) {
+                continue;
+            }
+            $seen[$key] = true;
+            $unique[] = $cause;
+        }
+
+        return $unique;
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/visual-parity-compare-default-grey-regression.json
+++ b/php-transformer/tests/fixtures/parity/visual-parity-compare-default-grey-regression.json
@@ -20,11 +20,14 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "schema", "assert": "equals", "value": "blocks-engine/php-transformer/visual-parity-probe-comparison/v1" },
     { "path": "summary.matched_total", "assert": "equals", "value": 1 },
-    { "path": "summary.style_delta_total", "assert": "equals", "value": 4 },
-    { "path": "summary.missing_style_risk_total", "assert": "equals", "value": 1 },
+    { "path": "summary.style_delta_total", "assert": "equals", "value": 5 },
+    { "path": "summary.missing_style_risk_total", "assert": "equals", "value": 2 },
+    { "path": "summary.mismatch_cause_counts.button_fill_mismatch", "assert": "equals", "value": 1 },
+    { "path": "summary.mismatch_cause_counts.button_text_color_missing", "assert": "equals", "value": 1 },
     { "path": "matches.0.source.text", "assert": "equals", "value": "Book now" },
     { "path": "matches.0.target.signals.2", "assert": "equals", "value": "default-button-style-watch" },
-    { "path": "matches.0.style_deltas.0.group", "assert": "equals", "value": "background" },
+    { "path": "matches.0.style_deltas.0.group", "assert": "equals", "value": "fill" },
+    { "path": "matches.0.mismatch_causes.0.code", "assert": "equals", "value": "button_fill_mismatch" },
     { "path": "matches.0.missing_style_risks.0.code", "assert": "equals", "value": "target_default_button_style" }
   ]
 }

--- a/php-transformer/tests/unit/button-visual-probe-diagnostics.php
+++ b/php-transformer/tests/unit/button-visual-probe-diagnostics.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit coverage for button/menu visual probe mismatch classification.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\ButtonMenuVisualProbe;
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\ButtonMenuVisualProbeComparator;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$compare = static function (string $source, string $target): array {
+    $probe = new ButtonMenuVisualProbe();
+    return ( new ButtonMenuVisualProbeComparator() )->compare(
+        $probe->extract($source),
+        $probe->extract($target)
+    );
+};
+
+$causeCodes = static function (array $report): array {
+    $causes = $report['matches'][0]['mismatch_causes'] ?? array();
+    $codes = array();
+    foreach ( is_array($causes) ? $causes : array() as $cause ) {
+        if ( is_array($cause) && isset($cause['code']) ) {
+            $codes[] = (string) $cause['code'];
+        }
+    }
+    sort($codes);
+    return $codes;
+};
+
+$source = <<<'HTML'
+<style>
+.hero .cta { width: 220px; min-width: 180px; padding: 14px 24px; border-radius: 999px; background-color: #135e96; border: 2px solid #0b3d5c; color: #ffffff; }
+</style>
+<div class="hero" style="padding:20px;background:#eef6ff;border-radius:24px"><a class="cta" href="/demo">Get started</a></div>
+HTML;
+
+$target = <<<'HTML'
+<style>
+.wp-block-button__link { background-color: #eeeeee; border: 1px solid #cccccc; color: #111111; padding: 8px 12px; }
+</style>
+<div><a class="wp-block-button__link" href="/demo">Get started</a></div>
+HTML;
+
+$report = $compare($source, $target);
+$codes = $causeCodes($report);
+
+foreach ( array(
+    'button_border_mismatch',
+    'button_default_style_leakage',
+    'button_fill_mismatch',
+    'button_padding_mismatch',
+    'button_radius_missing',
+    'button_text_color_mismatch',
+    'button_width_missing',
+    'button_wrapper_chrome_mismatch',
+) as $expectedCode ) {
+    $assert(in_array($expectedCode, $codes, true), "reports {$expectedCode}", json_encode($codes));
+}
+
+$counts = $report['summary']['mismatch_cause_counts'] ?? array();
+$assert(1 === ($counts['button_padding_mismatch'] ?? 0), 'summary counts classified padding causes', json_encode($counts));
+$assert(1 === ($counts['button_wrapper_chrome_mismatch'] ?? 0), 'summary counts wrapper chrome causes', json_encode($counts));
+
+$nestedSource = '<nav><ul><li><a href="/demo">Get started</a></li></ul></nav>';
+$nestedTarget = '<nav><ul><li><ul><li><a href="/demo">Get started</a></li></ul></li></ul></nav>';
+$nestedReport = $compare($nestedSource, $nestedTarget);
+$assert(in_array('button_nesting_mismatch', $causeCodes($nestedReport), true), 'reports nesting depth mismatch', json_encode($nestedReport['matches'][0] ?? array()));
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Button visual probe diagnostic tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "Button visual probe diagnostic tests: {$passes} passed\n");


### PR DESCRIPTION
## Summary
- capture nearest styled wrapper chrome in button/menu visual probes
- classify button visual mismatches into deterministic causes: width, padding, radius, fill, border, text color, wrapper chrome, nesting, and default style leakage
- add focused unit coverage and update the default-grey visual parity fixture for the new taxonomy

## Testing
- php tests/unit/button-visual-probe-diagnostics.php
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the diagnostic taxonomy, tests, verification, and PR preparation with Chris reviewing/owning the change.