### PR TITLE
Improve Figma text wrapping artifacts

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -6144,7 +6144,7 @@ final class StaticHtmlEmitter
             if ( 'TEXT' === $type && $this->textShouldUseFluidFlowBox($node, $parentNode) ) {
                 if ( 'width' === $dimension && isset($box['width']) && is_numeric($box['width']) ) {
                     $styles[] = 'width:100%';
-                    $styles[] = 'max-width:' . $this->number((float) $box['width']) . 'px';
+                    $styles[] = 'max-width:' . $this->textFlowMaxWidth($node, (float) $box['width']);
                 }
                 continue;
             }
@@ -6275,6 +6275,11 @@ final class StaticHtmlEmitter
                     continue;
                 }
                 $styles[] = $style;
+            }
+            if ( $this->textShouldUseFluidFlowBox($node, $parentNode) ) {
+                foreach ( $this->textWrappingStyles($node, $parentNode, $grandParentNode) as $style ) {
+                    $styles[] = $style;
+                }
             }
             if ( $this->textShouldUseMeasuredFlexHeight($node, $parentNode) ) {
                 $styles[] = 'overflow:visible';
@@ -7138,22 +7143,85 @@ final class StaticHtmlEmitter
      */
     private function textShouldUseFluidFlowBox(array $node, ?array $parentNode): bool
     {
-        if ( 'TEXT' !== strtoupper((string) ($node['type'] ?? '')) || null === $parentNode ) {
+        if ( 'TEXT' !== strtoupper((string) ($node['type'] ?? '')) ) {
             return false;
         }
 
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        if ( 'absolute' === ($layout['positioning'] ?? null) || ($this->isFreeformContainer($parentNode) && ! $this->freeformContainerShouldUseFlow($parentNode)) ) {
-            return false;
-        }
-
-        $name = strtolower((string) ($node['name'] ?? ''));
-        if ( ! str_contains($name, 'paragraph') && ! str_contains($name, 'body') && ! str_contains($name, 'copy') && ! str_contains($name, 'lede') && ! str_contains($name, 'supporting text') ) {
+        if ( 'absolute' === ($layout['positioning'] ?? null) || (null !== $parentNode && $this->isFreeformContainer($parentNode) && ! $this->freeformContainerShouldUseFlow($parentNode)) ) {
             return false;
         }
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
-        return isset($box['width']) && is_numeric($box['width']) && (float) $box['width'] >= 280.0;
+        $hasResponsiveWidth = isset($box['width']) && is_numeric($box['width']) && (float) $box['width'] >= 280.0;
+        if ( null === $parentNode ) {
+            $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+            $textAutoResize = strtoupper((string) ($text['auto_resize'] ?? $node['text_auto_resize'] ?? ''));
+            $fontSize = $this->textFontSize($node);
+            return $hasResponsiveWidth
+                && $this->textHasDerivedLineBreaks($node)
+                && ! $this->textHasLineBreaks($node)
+                && ! in_array($textAutoResize, array('HEIGHT', 'WIDTH_AND_HEIGHT'), true)
+                && (null === $fontSize || $fontSize <= 96.0);
+        }
+
+        $name = strtolower((string) ($node['name'] ?? ''));
+        $textIntent = str_contains($name, 'paragraph')
+            || str_contains($name, 'body')
+            || str_contains($name, 'copy')
+            || str_contains($name, 'lede')
+            || str_contains($name, 'supporting text');
+        if ( ! $textIntent ) {
+            return false;
+        }
+
+        return $hasResponsiveWidth;
+    }
+
+    /** @param array<string, mixed> $node */
+    private function textFlowMaxWidth(array $node, float $pixelWidth): string
+    {
+        $px = $this->number($pixelWidth) . 'px';
+        $characters = trim(strip_tags($this->textContent($node)));
+        if ( '' === $characters ) {
+            return $px;
+        }
+
+        $name = strtolower((string) ($node['name'] ?? ''));
+        $wordCount = $this->textWordCount($node);
+        if ( $wordCount >= 12 || $this->hasBodyTextNameIntent($name) ) {
+            return 'min(' . $px . ',72ch)';
+        }
+        if ( str_contains($name, 'title') || str_contains($name, 'heading') || str_contains($name, 'headline') ) {
+            return 'min(' . $px . ',18ch)';
+        }
+
+        return $px;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed>|null $parentNode
+     * @param array<string, mixed>|null $grandParentNode
+     * @return array<int, string>
+     */
+    private function textWrappingStyles(array $node, ?array $parentNode, ?array $grandParentNode): array
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        if ( $this->textIsAtomicSingleLineLabel($node, $text) || $this->textShouldPreserveChromeSpacing($node, $parentNode, $grandParentNode) ) {
+            return array();
+        }
+
+        $styles = array('overflow-wrap:break-word');
+        $tag = $this->semanticTag($node, strtoupper((string) ($node['type'] ?? '')), strtolower((string) ($node['name'] ?? '')), 1, $parentNode, $grandParentNode);
+        if ( in_array($tag, array('h1', 'h2', 'h3', 'h4', 'h5', 'h6'), true) ) {
+            $styles[] = 'text-wrap:balance';
+        } elseif ( 'p' === $tag || $this->hasBodyTextNameIntent(strtolower((string) ($node['name'] ?? ''))) ) {
+            $styles[] = 'hyphens:auto';
+            $styles[] = 'text-wrap:pretty';
+        }
+
+        return $styles;
     }
 
     /**
@@ -7276,7 +7344,7 @@ final class StaticHtmlEmitter
                 return '';
             }
 
-            return $this->sanitizeText($this->trimTextContent($this->textShouldUseFluidFlowBox($node, $parentNode) ? $characters : $this->derivedLineBreakText($characters, $text)));
+            return $this->sanitizeText($this->normalizeTextContentWhitespace($characters));
         }
 
         $characters = (string) ($node['characters'] ?? $node['text'] ?? '');
@@ -7284,12 +7352,14 @@ final class StaticHtmlEmitter
             return '';
         }
 
-        return $this->sanitizeText($this->trimTextContent($characters));
+        return $this->sanitizeText($this->normalizeTextContentWhitespace($characters));
     }
 
-    private function trimTextContent(string $characters): string
+    private function normalizeTextContentWhitespace(string $characters): string
     {
-        return trim($characters);
+        $characters = str_replace(array("\r\n", "\r"), "\n", trim($characters));
+
+        return preg_replace('/[^\S\n]+/u', ' ', $characters) ?? $characters;
     }
 
     /**
@@ -8074,8 +8144,8 @@ final class StaticHtmlEmitter
         }
         if ( $this->textShouldPreserveChromeSpacing($node, $parentNode, $grandParentNode) ) {
             $styles[] = 'white-space:pre-wrap';
-        } elseif ( ( $this->textHasLineBreaks($node) || $this->textHasDerivedLineBreaks($node) ) && ! $this->shouldSplitParagraphs($node) ) {
-            $styles[] = $this->textHasDerivedLineBreaks($node) && ! $this->textHasLineBreaks($node) ? 'white-space:pre' : 'white-space:pre-line';
+        } elseif ( $this->textHasLineBreaks($node) && ! $this->shouldSplitParagraphs($node) ) {
+            $styles[] = 'white-space:pre-line';
         } elseif ( $this->textIsAtomicSingleLineLabel($node, $text) ) {
             $styles[] = 'white-space:nowrap';
         }
@@ -8169,7 +8239,7 @@ final class StaticHtmlEmitter
      */
     private function textShouldPreserveChromeSpacing(array $node, ?array $parentNode, ?array $grandParentNode): bool
     {
-        $characters = strip_tags($this->textContent($node));
+        $characters = $this->rawDecodedText($node);
         if ( ! preg_match('/ {2,}/', $characters) ) {
             return false;
         }

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -428,8 +428,8 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     ));
     $derivedSoftWrapCss = $fileContent($derivedSoftWrapResult, 'style.css');
     $derivedSoftWrapHtml = $fileContent($derivedSoftWrapResult, 'index.html');
-    $assert(str_contains($derivedSoftWrapCss, '.figma-node-text-derived-soft-wrap-measured-soft-wrap-heading{width:342px;height:100px;font-size:56px;line-height:50px;white-space:pre}'), 'derived-soft-wrap-preserves-line-boxes-without-browser-rewrap');
-    $assert(str_contains($derivedSoftWrapHtml, "We\u{2019}re all\nabout Lego"), 'derived-soft-wrap-html-keeps-measured-line-break');
+    $assert(str_contains($derivedSoftWrapCss, '.figma-node-text-derived-soft-wrap-measured-soft-wrap-heading{width:100%;max-width:min(342px,18ch);font-size:56px;line-height:50px;overflow-wrap:break-word;text-wrap:balance'), 'derived-soft-wrap-uses-responsive-css-wrap');
+    $assert(str_contains($derivedSoftWrapHtml, "We\u{2019}re all about Lego") && ! str_contains($derivedSoftWrapHtml, "We\u{2019}re all\nabout Lego"), 'derived-soft-wrap-html-keeps-source-text');
 
     $unsupportedGlyphScenegraph = array(
         'name'  => 'Unsupported Glyph Diagnostic Fixture',
@@ -776,8 +776,8 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     ));
     $derivedLineBreakHtml = $fileContent($derivedLineBreakResult, 'index.html');
     $derivedLineBreakCss = $fileContent($derivedLineBreakResult, 'style.css');
-    $assert(str_contains($derivedLineBreakHtml, "First line\nSecond line"), 'derived-baselines-insert-line-breaks');
-    $assert(str_contains($derivedLineBreakCss, '.figma-node-text-derived-lines-measured-lines{width:120px;height:44px;line-height:22px;white-space:pre}'), 'derived-baselines-enable-pre');
+    $assert(str_contains($derivedLineBreakHtml, 'First line Second line') && ! str_contains($derivedLineBreakHtml, "First line\nSecond line"), 'derived-baselines-preserve-source-text');
+    $assert(str_contains($derivedLineBreakCss, '.figma-node-text-derived-lines-measured-lines{width:120px;height:44px;line-height:22px}') && ! str_contains($derivedLineBreakCss, 'white-space:pre'), 'derived-baselines-avoid-soft-wrap-pre');
     $assert(! str_contains($derivedLineBreakCss, 'line-height:40px;line-height:22px'), 'derived-baselines-replace-source-line-height');
     
     $derivedHugTextHeightResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -856,7 +856,7 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
             $derivedMeasuredLineHeightDiagnostic = $styleDiagnostic;
         }
     }
-    $assert(str_contains($derivedMeasuredLineHeightCss, '.figma-node-text-derived-measured-line-height-measured-line-height{width:120px;height:40px;line-height:23px;white-space:pre}'), 'derived-baselines-prefer-position-delta-line-height');
+    $assert(str_contains($derivedMeasuredLineHeightCss, '.figma-node-text-derived-measured-line-height-measured-line-height{width:120px;height:40px;line-height:23px}'), 'derived-baselines-prefer-position-delta-line-height');
     $assert('23px' === ($derivedMeasuredLineHeightDiagnostic['expected']['line_height'] ?? null), 'derived-baselines-measured-line-height-expected-diagnostic');
     $assert('23px' === ($derivedMeasuredLineHeightDiagnostic['emitted']['line_height'] ?? null), 'derived-baselines-measured-line-height-emitted-diagnostic');
     $assert(array() === ($derivedMeasuredLineHeightDiagnostic['mismatches'] ?? null), 'derived-baselines-measured-line-height-no-diagnostic-mismatch');

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6255,7 +6255,7 @@ $fluidParagraphResult = blocks_engine_figma_transformer_transform_scenegraph(arr
 $fluidParagraphHtml = $fileContent($fluidParagraphResult, 'index.html');
 $fluidParagraphCss = $fileContent($fluidParagraphResult, 'style.css');
 $fluidParagraphRule = blocks_engine_figma_transformer_contract_css_rule($fluidParagraphCss, '.figma-node-fluid-copy-paragraph-paragraph');
-$assert(str_contains($fluidParagraphRule, 'width:100%') && str_contains($fluidParagraphRule, 'max-width:640px') && ! str_contains($fluidParagraphRule, 'height:116px') && ! str_contains($fluidParagraphRule, 'white-space:'), 'fluid-paragraph-uses-intrinsic-max-width');
+$assert(str_contains($fluidParagraphRule, 'width:100%') && str_contains($fluidParagraphRule, 'max-width:min(640px,72ch)') && str_contains($fluidParagraphRule, 'overflow-wrap:break-word') && str_contains($fluidParagraphRule, 'hyphens:auto') && ! str_contains($fluidParagraphRule, 'height:116px') && ! str_contains($fluidParagraphRule, 'white-space:'), 'fluid-paragraph-uses-intrinsic-max-width');
 $assert(str_contains($fluidParagraphRule, 'flex-shrink:1') && str_contains($fluidParagraphRule, 'min-width:0'), 'fluid-paragraph-can-shrink-in-flex-flow');
 $assert(str_contains($fluidParagraphHtml, 'source words intact') && ! str_contains($fluidParagraphHtml, "source\nwords"), 'fluid-paragraph-avoids-derived-soft-wrap-content');
 


### PR DESCRIPTION
## Summary
- Treat derived Figma soft-wrap baselines as layout evidence instead of authoring synthetic text newlines.
- Normalize emitted DOM text whitespace while preserving authored line breaks and chrome spacing cases.
- Add responsive text box wrapping for flow prose/headings with ch-based max-width caps and browser wrapping hints.

## Before / after examples
- Soft-wrap heading before: CSS emitted `width:342px;height:100px;font-size:56px;line-height:50px;white-space:pre` and HTML contained `We’re all\nabout Lego`.
- Soft-wrap heading after: CSS emits `width:100%;max-width:min(342px,18ch);font-size:56px;line-height:50px;overflow-wrap:break-word;text-wrap:balance` and HTML keeps `We’re all about Lego`.
- Flow paragraph after: CSS emits `width:100%;max-width:min(640px,72ch);font-size:18px;overflow-wrap:break-word;hyphens:auto;text-wrap:pretty`; HTML keeps `source words intact` with no baked `source\nwords` break.

## Diagnostics / verification
- `php figma-transformer/tests/contract/run.php`
- `composer test` from `figma-transformer/`
- `php figma-transformer/scripts/figma-fixture-matrix.php --dry-run --only=fisiostetic,tt5,fse` reports no fixtures selected because no `.fig` fixture files are present in this worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Drafted and verified the Figma HTML text wrapping refactor and contract coverage with Chris's direction.
