### PR TITLE
Add semantic image fit metadata

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1090,7 +1090,7 @@ final class StaticHtmlEmitter
     /**
      * @param array<string, mixed> $node
      * @param array<int, mixed>    $children
-     * @return array{src: string, alt: string, scale_mode: string, background_size: string|null, background_position: string|null, crop_rect: array<string, mixed>|null}|null
+     * @return array{src: string, alt: string, scale_mode: string, background_size: string|null, background_position: string|null, object_fit: string, object_position: string, crop_rect: array<string, mixed>|null}|null
      */
     private function imageElementMetadata(array $node, string $type, array $children): ?array
     {
@@ -1123,17 +1123,21 @@ final class StaticHtmlEmitter
             'scale_mode'          => $scaleMode,
             'background_size'     => isset($backgroundStyles['size']) ? (string) $backgroundStyles['size'] : null,
             'background_position' => isset($backgroundStyles['position']) ? (string) $backgroundStyles['position'] : null,
+            'object_fit'          => $this->imageObjectFit($scaleMode),
+            'object_position'     => $this->imageObjectPosition(isset($backgroundStyles['position']) ? (string) $backgroundStyles['position'] : null),
             'crop_rect'           => empty($paint) ? null : $this->imagePaintCropRect($paint),
         );
     }
 
-    /** @param array{src: string, alt: string, scale_mode: string, background_size: string|null, background_position: string|null, crop_rect: array<string, mixed>|null} $metadata */
+    /** @param array{src: string, alt: string, scale_mode: string, background_size: string|null, background_position: string|null, object_fit: string, object_position: string, crop_rect: array<string, mixed>|null} $metadata */
     private function imageElementAttributes(array $metadata): string
     {
         $attributes = ' src="' . $this->sanitizeAttribute($metadata['src']) . '"';
         $attributes .= ' alt="' . $this->sanitizeAttribute($metadata['alt']) . '"';
         $attributes .= ' loading="lazy" decoding="async"';
-        $attributes .= ' data-figma-image-fill="true" data-figma-image-scale-mode="' . $this->sanitizeAttribute($metadata['scale_mode']) . '"';
+        $attributes .= ' style="object-fit:' . $this->sanitizeAttribute($metadata['object_fit']) . ';object-position:' . $this->sanitizeAttribute($metadata['object_position']) . '"';
+        $attributes .= ' data-figma-image-fill="true" data-figma-image-rendering="semantic-img" data-figma-image-scale-mode="' . $this->sanitizeAttribute($metadata['scale_mode']) . '"';
+        $attributes .= ' data-figma-image-object-fit="' . $this->sanitizeAttribute($metadata['object_fit']) . '" data-figma-image-object-position="' . $this->sanitizeAttribute($metadata['object_position']) . '"';
         if ( null !== $metadata['background_size'] ) {
             $attributes .= ' data-figma-image-background-size="' . $this->sanitizeAttribute($metadata['background_size']) . '"';
         }
@@ -1145,6 +1149,25 @@ final class StaticHtmlEmitter
         }
 
         return $attributes;
+    }
+
+    private function imageObjectFit(string $scaleMode): string
+    {
+        return match ( strtoupper($scaleMode) ) {
+            'FIT' => 'contain',
+            'STRETCH' => 'fill',
+            'TILE' => 'none',
+            default => 'cover',
+        };
+    }
+
+    private function imageObjectPosition(?string $backgroundPosition): string
+    {
+        if ( null === $backgroundPosition || '' === trim($backgroundPosition) ) {
+            return 'center';
+        }
+
+        return $backgroundPosition;
     }
 
     /**

--- a/figma-transformer/tests/contract/ImagePaintContract.php
+++ b/figma-transformer/tests/contract/ImagePaintContract.php
@@ -12,8 +12,8 @@ function blocks_engine_figma_transformer_run_image_paint_contract(callable $asse
     $html = $fileContent($result, 'index.html');
     blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $css, '.figma-node-1-4-hero-image-rectangle', array('width:320px', 'height:180px', 'position:absolute', 'left:10px', 'top:20px', 'background:#ff0000', 'background-image:url("assets/hero-image.svg")'), 'css-rectangle-asset-style');
     blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $css, '.figma-node-1-5-nested-image-paint', array('background-image:url("assets/fixture-photo.jpg")'), 'css-nested-image-hash-asset-style');
-    $assert(str_contains($html, '<img class="figma-node-1-4-hero-image-rectangle figma-image-asset"') && str_contains($html, 'src="assets/hero-image.svg"') && str_contains($html, 'data-figma-image-fill="true"'), 'asset-backed-rectangle-emits-img-element');
-    $assert(str_contains($html, '<img class="figma-node-1-5-nested-image-paint figma-image-asset"') && str_contains($html, 'src="assets/fixture-photo.jpg"') && str_contains($html, 'data-figma-image-scale-mode="FILL"') && str_contains($html, 'data-figma-image-background-size='), 'image-paint-emits-img-with-crop-metadata');
+    $assert(str_contains($html, '<img class="figma-node-1-4-hero-image-rectangle figma-image-asset"') && str_contains($html, 'src="assets/hero-image.svg"') && str_contains($html, 'data-figma-image-fill="true"') && str_contains($html, 'data-figma-image-rendering="semantic-img"'), 'asset-backed-rectangle-emits-img-element');
+    $assert(str_contains($html, '<img class="figma-node-1-5-nested-image-paint figma-image-asset"') && str_contains($html, 'src="assets/fixture-photo.jpg"') && str_contains($html, 'data-figma-image-scale-mode="FILL"') && str_contains($html, 'data-figma-image-background-size=') && str_contains($html, 'data-figma-image-object-fit="cover"'), 'image-paint-emits-img-with-crop-metadata');
     $assert('fixture image bytes' === $fileContent($result, 'assets/fixture-photo.jpg'), 'asset-content-preserved');
 
     $imageUnderlayGuardResult = blocks_engine_figma_transformer_transform_scenegraph(array(
@@ -50,6 +50,7 @@ function blocks_engine_figma_transformer_run_image_paint_contract(callable $asse
     $imageUnderlayGuardCss = $fileContent($imageUnderlayGuardResult, 'style.css');
     $imageUnderlayGuardUnderlays = $imageUnderlayGuardResult['source_reports']['figma']['html']['transform_diagnostics']['layout']['decorative_underlays'] ?? array();
     blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $imageUnderlayGuardCss, '.figma-node-imageguard-photo-large-photo', array('width:900px', 'height:520px', 'background-image:url("assets/guard-image.svg")', 'background-size:cover', 'background-position:center', 'flex-shrink:0'), 'image-backed-child-remains-flex-child');
+    $assert(str_contains($fileContent($imageUnderlayGuardResult, 'index.html'), '<img class="figma-node-imageguard-photo-large-photo figma-image-asset"') && str_contains($fileContent($imageUnderlayGuardResult, 'index.html'), 'data-figma-image-object-fit="cover"'), 'image-backed-child-emits-semantic-img-with-fit-metadata');
     $assert(0 === ($imageUnderlayGuardUnderlays['count'] ?? null), 'image-backed-child-not-decorative-underlay-diagnostic');
 
     $imageBackedVectorResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary
- Add explicit semantic image rendering metadata to Figma HTML artifacts.
- Map Figma image scale modes to `object-fit`/`object-position` on emitted `<img>` elements while preserving existing CSS background crop metadata for visual fidelity.
- Extend image paint contract coverage for the new metadata.

## Fixture evidence
Ran the Figma fixture matrix for:
- Twenty Twenty-Five (Community)
- Fisiostetic
- FSE Pilot Build Theme

Before/after summary:

| Fixture | Quality | Images | Semantic `<img>` | Rendering metadata | Object-fit metadata | Crop metadata | CSS backgrounds | Empty visible containers |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| TT5 before | pass | 24 | 41 | 0 | 0 | 41 | 22 | 0 |
| TT5 after | pass | 24 | 41 | 41 | 41 | 41 | 22 | 0 |
| Fisiostetic before | pass | 11 | 22 | 0 | 0 | 22 | 11 | 0 |
| Fisiostetic after | pass | 11 | 22 | 22 | 22 | 22 | 11 | 0 |
| FSE before | pass | 26 | 0 | 0 | 0 | 0 | 26 | 27 |
| FSE after | pass | 26 | 0 | 0 | 0 | 0 | 26 | 27 |

FSE selected image layers remain CSS-background based in this fixture selection; the existing 27 empty visible containers are non-blocking quality signals and unchanged by this metadata-only image artifact change.

## Tests
- `composer test` in `figma-transformer/`
- `php figma-transformer/scripts/figma-fixture-matrix.php --fixture=<TT5> --fixture=<Fisiostetic> --fixture=<FSE> --output-dir=<local artifact dir> --max-pages=3 --max-nodes=5000`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the metadata refactor, updated contract coverage, and ran local fixture verification.