### PR TITLE
Add Figma HTML readiness diagnostics

### DIFF
--- a/figma-transformer/bench/figma-fixture-matrix.bench.mjs
+++ b/figma-transformer/bench/figma-fixture-matrix.bench.mjs
@@ -112,6 +112,13 @@ function summarizeBench(summary, runtime) {
     failed_fixture_count: fixtures.filter((fixture) => !['completed', 'inspected', 'planned'].includes(String(fixture.status || ''))).length,
     vector_placeholder_count: sumQuality(fixtures, vectorPlaceholderCount),
     missing_asset_count: sumQuality(fixtures, missingAssetCount),
+    fixed_width_without_responsive_override_count: sumSummary(fixtures, 'fixed_width_without_responsive_override_count'),
+    giant_fixed_section_count: sumSummary(fixtures, 'giant_fixed_section_count'),
+    large_overflow_risk_count: sumSummary(fixtures, 'large_overflow_risk_count'),
+    fallback_prone_html_island_count: sumSummary(fixtures, 'fallback_prone_form_island_count') + sumSummary(fixtures, 'fallback_prone_svg_island_count') + sumSummary(fixtures, 'fallback_prone_input_island_count'),
+    invalid_list_child_count: sumSummary(fixtures, 'invalid_list_child_count'),
+    missing_semantic_role_count: sumSummary(fixtures, 'missing_semantic_role_count'),
+    effective_responsive_coverage_ratio: numberOr(summary.quality_matrix?.effective_responsive_coverage_ratio, aggregateResponsiveCoverage(fixtures)),
   };
 
   for (const fixture of fixtures) {
@@ -128,6 +135,12 @@ function summarizeBench(summary, runtime) {
     const fixtureMissingAssets = missingAssetCount(fixture);
     if (fixtureMissingAssets > 0) {
       metrics[`fixture_${id}_missing_asset_count`] = fixtureMissingAssets;
+    }
+    for (const key of ['fixed_width_without_responsive_override_count', 'giant_fixed_section_count', 'large_overflow_risk_count', 'invalid_list_child_count', 'missing_semantic_role_count']) {
+      const value = summaryValue(fixture, key);
+      if (value > 0) {
+        metrics[`fixture_${id}_${key}`] = value;
+      }
     }
   }
 
@@ -195,6 +208,24 @@ function sumMetric(fixtures, key) {
 
 function sumQuality(fixtures, getter) {
   return fixtures.reduce((total, fixture) => total + getter(fixture), 0);
+}
+
+function sumSummary(fixtures, key) {
+  return fixtures.reduce((total, fixture) => total + summaryValue(fixture, key), 0);
+}
+
+function summaryValue(fixture, key) {
+  return numberOr(fixture.quality_summary?.[key] ?? fixture.artifact_quality?.summary?.[key]);
+}
+
+function aggregateResponsiveCoverage(fixtures) {
+  let covered = 0;
+  let total = 0;
+  for (const fixture of fixtures) {
+    covered += summaryValue(fixture, 'fixed_width_with_responsive_override_count');
+    total += summaryValue(fixture, 'fixed_width_declaration_count');
+  }
+  return total > 0 ? Number((covered / total).toFixed(3)) : 1;
 }
 
 function firstNumber(values) {

--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -278,10 +278,79 @@ foreach ( $fixtures as $fixture ) {
 }
 
 if ( ! $dryRun ) {
+    $summary['quality_matrix'] = matrix_quality_matrix($summary['fixtures']);
     file_put_contents($outputDir . '/summary.json', json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
 }
 
 echo json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+
+/**
+ * @param array<int, array<string, mixed>> $fixtures
+ * @return array<string, mixed>
+ */
+function matrix_quality_matrix(array $fixtures): array
+{
+    $keys = array(
+        'missing_asset_nodes',
+        'vector_placeholders',
+        'image_block_count',
+        'vector_image_fallbacks',
+        'media_query_count',
+        'fixed_width_over_desktop_count',
+        'fixed_width_declaration_count',
+        'fixed_width_without_responsive_override_count',
+        'giant_fixed_section_count',
+        'large_overflow_risk_count',
+        'fallback_prone_form_island_count',
+        'fallback_prone_svg_island_count',
+        'fallback_prone_input_island_count',
+        'invalid_list_child_count',
+        'missing_semantic_role_count',
+        'missing_emitted_text_nodes',
+        'layout_mismatch_count',
+        'render_style_mismatch_count',
+        'link_targets_unresolved',
+        'invalid_css_numeric_tokens',
+    );
+    $totals = array_fill_keys($keys, 0);
+    $qualityStatuses = array();
+    $signalCounts = array();
+    $coverageNumerator = 0;
+    $coverageDenominator = 0;
+
+    foreach ( $fixtures as $fixture ) {
+        if ( ! is_array($fixture) ) {
+            continue;
+        }
+        $summary = is_array($fixture['quality_summary'] ?? null) ? $fixture['quality_summary'] : array();
+        foreach ( $keys as $key ) {
+            $totals[$key] += (int) ($summary[$key] ?? 0);
+        }
+        $coverageNumerator += (int) ($summary['fixed_width_with_responsive_override_count'] ?? 0);
+        $coverageDenominator += (int) ($summary['fixed_width_declaration_count'] ?? 0);
+        $status = isset($fixture['quality_status']) && is_scalar($fixture['quality_status']) ? (string) $fixture['quality_status'] : 'unknown';
+        $qualityStatuses[$status] = ($qualityStatuses[$status] ?? 0) + 1;
+        foreach ( is_array($fixture['artifact_quality']['signals'] ?? null) ? $fixture['artifact_quality']['signals'] : array() as $signal ) {
+            if ( ! is_array($signal) || ! isset($signal['code']) || ! is_scalar($signal['code']) ) {
+                continue;
+            }
+            $code = (string) $signal['code'];
+            $signalCounts[$code] = ($signalCounts[$code] ?? 0) + 1;
+        }
+    }
+
+    ksort($qualityStatuses);
+    ksort($signalCounts);
+
+    return array(
+        'schema' => 'blocks-engine/figma-transformer/fixture-matrix-quality/v1',
+        'fixture_count' => count($fixtures),
+        'quality_status_counts' => $qualityStatuses,
+        'signal_counts' => $signalCounts,
+        'effective_responsive_coverage_ratio' => $coverageDenominator > 0 ? round($coverageNumerator / $coverageDenominator, 3) : 1.0,
+        'totals' => $totals,
+    );
+}
 
 function matrix_options(array $argv): array
 {

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -1521,8 +1521,23 @@ final class FigmaTransformer
             'schema' => 'blocks-engine/figma-transformer/html-artifact-diagnostics/v1',
             'media_query_count' => 0,
             'fixed_width_over_desktop_count' => 0,
+            'fixed_width_declaration_count' => 0,
+            'fixed_width_with_responsive_override_count' => 0,
+            'fixed_width_without_responsive_override_count' => 0,
+            'effective_responsive_coverage_ratio' => 1.0,
+            'fixed_width_samples' => array(),
             'large_fixed_canvas_height' => false,
             'desktop_canvas_without_responsive_breakpoints' => false,
+            'giant_fixed_section_count' => 0,
+            'giant_fixed_sections' => array(),
+            'large_overflow_risk_count' => 0,
+            'large_overflow_risks' => array(),
+            'fallback_prone_form_island_count' => 0,
+            'fallback_prone_svg_island_count' => 0,
+            'fallback_prone_input_island_count' => 0,
+            'invalid_list_child_count' => 0,
+            'missing_semantic_role_count' => 0,
+            'semantic_role_samples' => array(),
         );
         $decisionTraces = array(
             'schema' => 'blocks-engine/figma-transformer/decision-traces/v1',
@@ -1581,7 +1596,11 @@ final class FigmaTransformer
             DiagnosticAggregation::addIntegerCounts($css, $pageCss, array('invalid_numeric_token_count'));
             DiagnosticAggregation::appendContextSamples($css, 'invalid_numeric_tokens', $pageCss, 'invalid_numeric_tokens', $pageContext);
             $pageHtmlArtifact = is_array($diagnostics['html_artifact'] ?? null) ? $diagnostics['html_artifact'] : array();
-            DiagnosticAggregation::addIntegerCounts($htmlArtifact, $pageHtmlArtifact, array('media_query_count', 'fixed_width_over_desktop_count'));
+            DiagnosticAggregation::addIntegerCounts($htmlArtifact, $pageHtmlArtifact, array('media_query_count', 'fixed_width_over_desktop_count', 'fixed_width_declaration_count', 'fixed_width_with_responsive_override_count', 'fixed_width_without_responsive_override_count', 'giant_fixed_section_count', 'large_overflow_risk_count', 'fallback_prone_form_island_count', 'fallback_prone_svg_island_count', 'fallback_prone_input_island_count', 'invalid_list_child_count', 'missing_semantic_role_count'));
+            DiagnosticAggregation::appendContextSamples($htmlArtifact, 'fixed_width_samples', $pageHtmlArtifact, 'fixed_width_samples', $pageContext);
+            DiagnosticAggregation::appendContextSamples($htmlArtifact, 'giant_fixed_sections', $pageHtmlArtifact, 'giant_fixed_sections', $pageContext);
+            DiagnosticAggregation::appendContextSamples($htmlArtifact, 'large_overflow_risks', $pageHtmlArtifact, 'large_overflow_risks', $pageContext);
+            DiagnosticAggregation::appendContextSamples($htmlArtifact, 'semantic_role_samples', $pageHtmlArtifact, 'semantic_role_samples', $pageContext);
             $htmlArtifact['large_fixed_canvas_height'] = ! empty($htmlArtifact['large_fixed_canvas_height']) || ! empty($pageHtmlArtifact['large_fixed_canvas_height']);
             $htmlArtifact['desktop_canvas_without_responsive_breakpoints'] = ! empty($htmlArtifact['desktop_canvas_without_responsive_breakpoints']) || ! empty($pageHtmlArtifact['desktop_canvas_without_responsive_breakpoints']);
             $this->mergeDecisionTraceDiagnostics($decisionTraces, is_array($diagnostics['decision_traces'] ?? null) ? $diagnostics['decision_traces'] : array(), $pageContext);
@@ -1689,6 +1708,14 @@ final class FigmaTransformer
         }
         ksort($decisionTraces['reason_counts']);
         ksort($decisionTraces['domain_counts']);
+        $htmlArtifact['fixed_width_samples'] = array_slice(array_values($htmlArtifact['fixed_width_samples']), 0, 25);
+        $htmlArtifact['giant_fixed_sections'] = array_slice(array_values($htmlArtifact['giant_fixed_sections']), 0, 25);
+        $htmlArtifact['large_overflow_risks'] = array_slice(array_values($htmlArtifact['large_overflow_risks']), 0, 25);
+        $htmlArtifact['semantic_role_samples'] = array_slice(array_values($htmlArtifact['semantic_role_samples']), 0, 25);
+        $fixedWidthDeclarationCount = (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0);
+        $htmlArtifact['effective_responsive_coverage_ratio'] = $fixedWidthDeclarationCount > 0
+            ? round((int) ($htmlArtifact['fixed_width_with_responsive_override_count'] ?? 0) / $fixedWidthDeclarationCount, 3)
+            : 1.0;
         ksort($positionalParity['root_stacking_reason_counts']);
         $positionalParity['fixed_over_root_width_underlays'] = array_slice(array_values($positionalParity['fixed_over_root_width_underlays']), 0, 25);
         $positionalParity['chrome_overflow_nodes'] = array_slice(array_values($positionalParity['chrome_overflow_nodes']), 0, 25);
@@ -1858,6 +1885,53 @@ final class FigmaTransformer
                 'large_fixed_canvas_height' => (bool) ($htmlArtifact['large_fixed_canvas_height'] ?? false),
             );
         }
+        if ( (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0) >= 8 && (float) ($htmlArtifact['effective_responsive_coverage_ratio'] ?? 1.0) < 0.35 ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'low_effective_responsive_coverage',
+                'coverage_ratio' => (float) ($htmlArtifact['effective_responsive_coverage_ratio'] ?? 0.0),
+                'fixed_width_declaration_count' => (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0),
+                'fixed_width_without_responsive_override_count' => (int) ($htmlArtifact['fixed_width_without_responsive_override_count'] ?? 0),
+                'sample_rules' => array_slice(is_array($htmlArtifact['fixed_width_samples'] ?? null) ? $htmlArtifact['fixed_width_samples'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($htmlArtifact['giant_fixed_section_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'giant_fixed_section_risk',
+                'count' => (int) $htmlArtifact['giant_fixed_section_count'],
+                'sample_rules' => array_slice(is_array($htmlArtifact['giant_fixed_sections'] ?? null) ? $htmlArtifact['giant_fixed_sections'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($htmlArtifact['large_overflow_risk_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'large_overflow_risk',
+                'count' => (int) $htmlArtifact['large_overflow_risk_count'],
+                'sample_rules' => array_slice(is_array($htmlArtifact['large_overflow_risks'] ?? null) ? $htmlArtifact['large_overflow_risks'] : array(), 0, 10),
+            );
+        }
+        $fallbackProneIslandCount = (int) ($htmlArtifact['fallback_prone_form_island_count'] ?? 0) + (int) ($htmlArtifact['fallback_prone_svg_island_count'] ?? 0) + (int) ($htmlArtifact['fallback_prone_input_island_count'] ?? 0);
+        if ( $fallbackProneIslandCount >= 3 ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'fallback_prone_html_islands',
+                'form_islands' => (int) ($htmlArtifact['fallback_prone_form_island_count'] ?? 0),
+                'svg_islands' => (int) ($htmlArtifact['fallback_prone_svg_island_count'] ?? 0),
+                'input_islands' => (int) ($htmlArtifact['fallback_prone_input_island_count'] ?? 0),
+            );
+        }
+        if ( ! empty($htmlArtifact['invalid_list_child_count']) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'invalid_list_children', 'count' => (int) $htmlArtifact['invalid_list_child_count']);
+        }
+        if ( (int) ($htmlArtifact['missing_semantic_role_count'] ?? 0) >= 2 ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'missing_semantic_roles',
+                'count' => (int) $htmlArtifact['missing_semantic_role_count'],
+                'sample_nodes' => array_slice(is_array($htmlArtifact['semantic_role_samples'] ?? null) ? $htmlArtifact['semantic_role_samples'] : array(), 0, 10),
+            );
+        }
         $sourceLossCoverage = $this->sourceLossCoverage($images, $vectors);
         if ( ! empty($sourceLossCoverage['not_emitted_source_nodes']) ) {
             $signals[] = array(
@@ -1931,7 +2005,18 @@ final class FigmaTransformer
                 'invalid_css_numeric_tokens' => (int) ($css['invalid_numeric_token_count'] ?? 0),
                 'media_query_count' => (int) ($htmlArtifact['media_query_count'] ?? 0),
                 'fixed_width_over_desktop_count' => (int) ($htmlArtifact['fixed_width_over_desktop_count'] ?? 0),
+                'effective_responsive_coverage_ratio' => (float) ($htmlArtifact['effective_responsive_coverage_ratio'] ?? 1.0),
+                'fixed_width_declaration_count' => (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0),
+                'fixed_width_with_responsive_override_count' => (int) ($htmlArtifact['fixed_width_with_responsive_override_count'] ?? 0),
+                'fixed_width_without_responsive_override_count' => (int) ($htmlArtifact['fixed_width_without_responsive_override_count'] ?? 0),
                 'desktop_canvas_without_responsive_breakpoints' => (bool) ($htmlArtifact['desktop_canvas_without_responsive_breakpoints'] ?? false),
+                'giant_fixed_section_count' => (int) ($htmlArtifact['giant_fixed_section_count'] ?? 0),
+                'large_overflow_risk_count' => (int) ($htmlArtifact['large_overflow_risk_count'] ?? 0),
+                'fallback_prone_form_island_count' => (int) ($htmlArtifact['fallback_prone_form_island_count'] ?? 0),
+                'fallback_prone_svg_island_count' => (int) ($htmlArtifact['fallback_prone_svg_island_count'] ?? 0),
+                'fallback_prone_input_island_count' => (int) ($htmlArtifact['fallback_prone_input_island_count'] ?? 0),
+                'invalid_list_child_count' => (int) ($htmlArtifact['invalid_list_child_count'] ?? 0),
+                'missing_semantic_role_count' => (int) ($htmlArtifact['missing_semantic_role_count'] ?? 0),
                 'large_absolute_offset_count' => (int) ($layout['large_absolute_offset_count'] ?? 0),
                 'empty_visible_container_count' => (int) ($layout['empty_visible_container_count'] ?? 0),
                 'empty_visible_container_blocker_count' => (int) ($layout['empty_visible_container_blocker_count'] ?? 0),

--- a/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
@@ -179,23 +179,12 @@ final class StaticHtmlEmissionDiagnostics
         $breakpointLeaks = $this->breakpointOverrideLeaks($css);
         $absoluteToFlowConversions = $this->absoluteToFlowConversions($css);
         $mediaQueryCount = preg_match_all('/@media\s*\(max-width:[^)]+\)/i', $css) ?: 0;
-        $fixedWidthOverDesktopCount = 0;
-        if ( preg_match_all('/\bwidth:([0-9.]+)px\b/i', $css, $widthMatches) ) {
-            foreach ( is_array($widthMatches[1] ?? null) ? $widthMatches[1] : array() as $width ) {
-                if ( (float) $width > 1440.0 ) {
-                    ++$fixedWidthOverDesktopCount;
-                }
-            }
-        }
-        $largeFixedCanvasHeight = false;
-        if ( preg_match_all('/\b(?:height|min-height):([0-9.]+)px\b/i', $css, $heightMatches) ) {
-            foreach ( is_array($heightMatches[1] ?? null) ? $heightMatches[1] : array() as $height ) {
-                if ( (float) $height >= 3000.0 ) {
-                    $largeFixedCanvasHeight = true;
-                    break;
-                }
-            }
-        }
+        $fixedWidthCoverage = $this->fixedWidthCoverage($css);
+        $fixedWidthOverDesktopCount = (int) $fixedWidthCoverage['fixed_width_over_desktop_count'];
+        $largeFixedSections = $this->largeFixedSections($css);
+        $largeOverflowRules = $this->largeOverflowRules($css);
+        $htmlSemantics = $this->htmlSemanticRiskDiagnostics($html);
+        $largeFixedCanvasHeight = ! empty($largeFixedSections['giant_fixed_section_count']);
 
         return array(
             'schema' => 'blocks-engine/figma-transformer/html-artifact-diagnostics/v1',
@@ -214,12 +203,230 @@ final class StaticHtmlEmissionDiagnostics
             'overlarge_inline_svg_ratio' => $htmlBytes >= 2048 && $inlineSvgBytes >= 32768 && $inlineSvgRatio >= 0.35,
             'media_query_count' => $mediaQueryCount,
             'fixed_width_over_desktop_count' => $fixedWidthOverDesktopCount,
+            'effective_responsive_coverage_ratio' => (float) $fixedWidthCoverage['effective_responsive_coverage_ratio'],
+            'fixed_width_declaration_count' => (int) $fixedWidthCoverage['fixed_width_declaration_count'],
+            'fixed_width_with_responsive_override_count' => (int) $fixedWidthCoverage['fixed_width_with_responsive_override_count'],
+            'fixed_width_without_responsive_override_count' => (int) $fixedWidthCoverage['fixed_width_without_responsive_override_count'],
+            'fixed_width_samples' => $fixedWidthCoverage['fixed_width_samples'],
             'large_fixed_canvas_height' => $largeFixedCanvasHeight,
             'desktop_canvas_without_responsive_breakpoints' => 0 === $mediaQueryCount && $largeFixedCanvasHeight && $structuralElementCount >= 80,
+            'giant_fixed_section_count' => (int) $largeFixedSections['giant_fixed_section_count'],
+            'giant_fixed_sections' => $largeFixedSections['giant_fixed_sections'],
+            'large_overflow_risk_count' => count($largeOverflowRules),
+            'large_overflow_risks' => array_slice($largeOverflowRules, 0, 25),
+            'fallback_prone_form_island_count' => (int) $htmlSemantics['fallback_prone_form_island_count'],
+            'fallback_prone_svg_island_count' => (int) $htmlSemantics['fallback_prone_svg_island_count'],
+            'fallback_prone_input_island_count' => (int) $htmlSemantics['fallback_prone_input_island_count'],
+            'invalid_list_child_count' => (int) $htmlSemantics['invalid_list_child_count'],
+            'missing_semantic_role_count' => (int) $htmlSemantics['missing_semantic_role_count'],
+            'semantic_role_samples' => $htmlSemantics['semantic_role_samples'],
             'breakpoint_override_leak_count' => count($breakpointLeaks),
             'breakpoint_override_leaks' => array_slice($breakpointLeaks, 0, 25),
             'absolute_to_flow_conversion_count' => count($absoluteToFlowConversions),
             'absolute_to_flow_conversions' => array_slice($absoluteToFlowConversions, 0, 25),
+        );
+    }
+
+    /**
+     * @return array{fixed_width_declaration_count: int, fixed_width_over_desktop_count: int, fixed_width_with_responsive_override_count: int, fixed_width_without_responsive_override_count: int, effective_responsive_coverage_ratio: float, fixed_width_samples: array<int, array<string, mixed>>}
+     */
+    private function fixedWidthCoverage(string $css): array
+    {
+        $rules = $this->cssRuleDeclarations($css);
+        $base = array();
+        $responsive = array();
+        $samples = array();
+        $fixedWidthOverDesktopCount = 0;
+
+        foreach ( $rules as $rule ) {
+            $selector = (string) ($rule['selector'] ?? '');
+            $declarations = (string) ($rule['declarations'] ?? '');
+            $classes = $this->selectorClassNames($selector);
+            if ( ! empty($rule['media']) && preg_match('/(?:^|;)\s*width\s*:/i', $declarations) ) {
+                foreach ( $classes as $class ) {
+                    $responsive[$class] = true;
+                }
+                continue;
+            }
+
+            $width = $this->cssNumericDeclaration($declarations, 'width');
+            if ( null === $width || $width < 320.0 ) {
+                continue;
+            }
+
+            foreach ( $classes as $class ) {
+                $base[$class] = true;
+                if ( $width > 1440.0 ) {
+                    ++$fixedWidthOverDesktopCount;
+                }
+                if ( count($samples) < 25 ) {
+                    $samples[] = array(
+                        'class' => $class,
+                        'width' => $width,
+                        'selector' => $selector,
+                    );
+                }
+            }
+        }
+
+        $baseClasses = array_keys($base);
+        $coveredCount = count(array_filter($baseClasses, static fn (string $class): bool => isset($responsive[$class])));
+        $totalCount = count($baseClasses);
+
+        return array(
+            'fixed_width_declaration_count' => $totalCount,
+            'fixed_width_over_desktop_count' => $fixedWidthOverDesktopCount,
+            'fixed_width_with_responsive_override_count' => $coveredCount,
+            'fixed_width_without_responsive_override_count' => max(0, $totalCount - $coveredCount),
+            'effective_responsive_coverage_ratio' => $totalCount > 0 ? round($coveredCount / $totalCount, 3) : 1.0,
+            'fixed_width_samples' => $samples,
+        );
+    }
+
+    /**
+     * @return array<int, array{selector: string, declarations: string, media: string}>
+     */
+    private function cssRuleDeclarations(string $css): array
+    {
+        $rules = array();
+        $mediaRanges = array();
+        if ( preg_match_all('/@media\s*([^{}]+)\s*\{((?:[^{}]+\{[^{}]*\}\s*)+)\}/is', $css, $mediaMatches, PREG_OFFSET_CAPTURE) ) {
+            foreach ( $mediaMatches[0] as $index => $match ) {
+                $mediaRanges[] = array(
+                    'start' => (int) $match[1],
+                    'end' => (int) $match[1] + strlen((string) $match[0]),
+                    'media' => trim((string) ($mediaMatches[1][$index][0] ?? '')),
+                );
+            }
+        }
+
+        if ( preg_match_all('/([^{}@]+)\{([^{}]*)\}/s', $css, $matches, PREG_OFFSET_CAPTURE) ) {
+            foreach ( $matches[0] as $index => $match ) {
+                $offset = (int) $match[1];
+                $media = '';
+                foreach ( $mediaRanges as $range ) {
+                    if ( $offset >= $range['start'] && $offset <= $range['end'] ) {
+                        $media = $range['media'];
+                        break;
+                    }
+                }
+                $rules[] = array(
+                    'selector' => trim((string) ($matches[1][$index][0] ?? '')),
+                    'declarations' => (string) ($matches[2][$index][0] ?? ''),
+                    'media' => $media,
+                );
+            }
+        }
+
+        return $rules;
+    }
+
+    private function cssNumericDeclaration(string $declarations, string $property): ?float
+    {
+        if ( 1 !== preg_match('/(?:^|;)\s*' . preg_quote($property, '/') . '\s*:\s*([0-9.]+)px\b/i', $declarations, $match) ) {
+            return null;
+        }
+
+        return (float) $match[1];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function selectorClassNames(string $selector): array
+    {
+        if ( ! preg_match_all('/\.([a-zA-Z0-9_-]+)/', $selector, $matches) ) {
+            return array();
+        }
+
+        return array_values(array_unique(array_map('strval', $matches[1])));
+    }
+
+    /**
+     * @return array{giant_fixed_section_count: int, giant_fixed_sections: array<int, array<string, mixed>>}
+     */
+    private function largeFixedSections(string $css): array
+    {
+        $sections = array();
+        foreach ( $this->cssRuleDeclarations($css) as $rule ) {
+            $height = $this->cssNumericDeclaration((string) $rule['declarations'], 'height') ?? $this->cssNumericDeclaration((string) $rule['declarations'], 'min-height');
+            $width = $this->cssNumericDeclaration((string) $rule['declarations'], 'width');
+            if ( null === $height || $height < 1800.0 || (null !== $width && $width < 960.0) || '' !== (string) $rule['media'] ) {
+                continue;
+            }
+            $sections[] = array(
+                'selector' => (string) $rule['selector'],
+                'width' => $width,
+                'height' => $height,
+            );
+        }
+
+        return array(
+            'giant_fixed_section_count' => count($sections),
+            'giant_fixed_sections' => array_slice($sections, 0, 25),
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function largeOverflowRules(string $css): array
+    {
+        $risks = array();
+        foreach ( $this->cssRuleDeclarations($css) as $rule ) {
+            $declarations = (string) $rule['declarations'];
+            $width = $this->cssNumericDeclaration($declarations, 'width') ?? 0.0;
+            if ( $width < 960.0 || ! preg_match('/(?:^|;)\s*overflow(?:-x)?\s*:\s*(hidden|clip|scroll)\b/i', $declarations, $match) ) {
+                continue;
+            }
+            $risks[] = array(
+                'selector' => (string) $rule['selector'],
+                'width' => $width,
+                'overflow' => strtolower((string) $match[1]),
+            );
+        }
+
+        return $risks;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function htmlSemanticRiskDiagnostics(string $html): array
+    {
+        $invalidListChildren = 0;
+        if ( preg_match_all('/<(ul|ol)\b[^>]*>(.*?)<\/\1>/is', $html, $listMatches) ) {
+            foreach ( is_array($listMatches[2] ?? null) ? $listMatches[2] : array() as $innerHtml ) {
+                $withoutValidItems = preg_replace('/<li\b[^>]*>.*?<\/li>/is', '', (string) $innerHtml) ?? (string) $innerHtml;
+                $invalidListChildren += preg_match_all('/<([a-z][a-z0-9:-]*)\b/i', $withoutValidItems) ?: 0;
+            }
+        }
+
+        $semanticRoleSamples = array();
+        $missingSemanticRoleCount = 0;
+        if ( preg_match_all('/<(section|article|aside|nav|header|footer|main)\b([^>]*)>/i', $html, $roleMatches, PREG_SET_ORDER) ) {
+            foreach ( $roleMatches as $match ) {
+                $attributes = (string) ($match[2] ?? '');
+                if ( str_contains($attributes, 'data-figma-semantic-role=') || str_contains($attributes, 'aria-label=') ) {
+                    continue;
+                }
+                ++$missingSemanticRoleCount;
+                if ( count($semanticRoleSamples) < 25 ) {
+                    $semanticRoleSamples[] = array(
+                        'tag' => strtolower((string) ($match[1] ?? '')),
+                        'attributes' => trim($attributes),
+                    );
+                }
+            }
+        }
+
+        return array(
+            'fallback_prone_form_island_count' => preg_match_all('/<form\b[^>]*>.*?<\/(?:form)>/is', $html) ?: 0,
+            'fallback_prone_svg_island_count' => preg_match_all('/<svg\b[^>]*>.*?<\/svg>/is', $html) ?: 0,
+            'fallback_prone_input_island_count' => preg_match_all('/<(?:input|textarea|select)\b/i', $html) ?: 0,
+            'invalid_list_child_count' => $invalidListChildren,
+            'missing_semantic_role_count' => $missingSemanticRoleCount,
+            'semantic_role_samples' => $semanticRoleSamples,
         );
     }
 

--- a/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
+++ b/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
@@ -222,6 +222,57 @@ final class TransformDiagnosticsBuilder
                 'large_fixed_canvas_height' => (bool) ($htmlArtifact['large_fixed_canvas_height'] ?? false),
             );
         }
+        if ( (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0) >= 8 && (float) ($htmlArtifact['effective_responsive_coverage_ratio'] ?? 1.0) < 0.35 ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'low_effective_responsive_coverage',
+                'coverage_ratio' => (float) ($htmlArtifact['effective_responsive_coverage_ratio'] ?? 0.0),
+                'fixed_width_declaration_count' => (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0),
+                'fixed_width_without_responsive_override_count' => (int) ($htmlArtifact['fixed_width_without_responsive_override_count'] ?? 0),
+                'sample_rules' => array_slice(is_array($htmlArtifact['fixed_width_samples'] ?? null) ? $htmlArtifact['fixed_width_samples'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($htmlArtifact['giant_fixed_section_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'giant_fixed_section_risk',
+                'count' => (int) $htmlArtifact['giant_fixed_section_count'],
+                'sample_rules' => array_slice(is_array($htmlArtifact['giant_fixed_sections'] ?? null) ? $htmlArtifact['giant_fixed_sections'] : array(), 0, 10),
+            );
+        }
+        if ( ! empty($htmlArtifact['large_overflow_risk_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'large_overflow_risk',
+                'count' => (int) $htmlArtifact['large_overflow_risk_count'],
+                'sample_rules' => array_slice(is_array($htmlArtifact['large_overflow_risks'] ?? null) ? $htmlArtifact['large_overflow_risks'] : array(), 0, 10),
+            );
+        }
+        $fallbackProneIslandCount = (int) ($htmlArtifact['fallback_prone_form_island_count'] ?? 0) + (int) ($htmlArtifact['fallback_prone_svg_island_count'] ?? 0) + (int) ($htmlArtifact['fallback_prone_input_island_count'] ?? 0);
+        if ( $fallbackProneIslandCount >= 3 ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'fallback_prone_html_islands',
+                'form_islands' => (int) ($htmlArtifact['fallback_prone_form_island_count'] ?? 0),
+                'svg_islands' => (int) ($htmlArtifact['fallback_prone_svg_island_count'] ?? 0),
+                'input_islands' => (int) ($htmlArtifact['fallback_prone_input_island_count'] ?? 0),
+            );
+        }
+        if ( ! empty($htmlArtifact['invalid_list_child_count']) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'invalid_list_children',
+                'count' => (int) $htmlArtifact['invalid_list_child_count'],
+            );
+        }
+        if ( (int) ($htmlArtifact['missing_semantic_role_count'] ?? 0) >= 2 ) {
+            $signals[] = array(
+                'severity' => 'info',
+                'code' => 'missing_semantic_roles',
+                'count' => (int) $htmlArtifact['missing_semantic_role_count'],
+                'sample_nodes' => array_slice(is_array($htmlArtifact['semantic_role_samples'] ?? null) ? $htmlArtifact['semantic_role_samples'] : array(), 0, 10),
+            );
+        }
         if ( ! empty($htmlArtifact['overlarge_inline_svg_ratio']) ) {
             $signals[] = array(
                 'severity' => 'warning',
@@ -317,7 +368,18 @@ final class TransformDiagnosticsBuilder
                 'empty_visible_container_blocker_count' => (int) ($layout['empty_visible_container_blocker_count'] ?? 0),
                 'media_query_count' => (int) ($htmlArtifact['media_query_count'] ?? 0),
                 'fixed_width_over_desktop_count' => (int) ($htmlArtifact['fixed_width_over_desktop_count'] ?? 0),
+                'effective_responsive_coverage_ratio' => (float) ($htmlArtifact['effective_responsive_coverage_ratio'] ?? 1.0),
+                'fixed_width_declaration_count' => (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0),
+                'fixed_width_with_responsive_override_count' => (int) ($htmlArtifact['fixed_width_with_responsive_override_count'] ?? 0),
+                'fixed_width_without_responsive_override_count' => (int) ($htmlArtifact['fixed_width_without_responsive_override_count'] ?? 0),
                 'desktop_canvas_without_responsive_breakpoints' => (bool) ($htmlArtifact['desktop_canvas_without_responsive_breakpoints'] ?? false),
+                'giant_fixed_section_count' => (int) ($htmlArtifact['giant_fixed_section_count'] ?? 0),
+                'large_overflow_risk_count' => (int) ($htmlArtifact['large_overflow_risk_count'] ?? 0),
+                'fallback_prone_form_island_count' => (int) ($htmlArtifact['fallback_prone_form_island_count'] ?? 0),
+                'fallback_prone_svg_island_count' => (int) ($htmlArtifact['fallback_prone_svg_island_count'] ?? 0),
+                'fallback_prone_input_island_count' => (int) ($htmlArtifact['fallback_prone_input_island_count'] ?? 0),
+                'invalid_list_child_count' => (int) ($htmlArtifact['invalid_list_child_count'] ?? 0),
+                'missing_semantic_role_count' => (int) ($htmlArtifact['missing_semantic_role_count'] ?? 0),
                 'decoded_text_nodes' => (int) ($text['decoded_text_node_count'] ?? 0),
                 'emitted_text_nodes' => (int) ($text['emitted_text_node_count'] ?? 0),
                 'intentionally_suppressed_text_nodes' => (int) ($text['intentionally_suppressed_text_node_count'] ?? 0),

--- a/figma-transformer/tests/contract/HtmlValidityContract.php
+++ b/figma-transformer/tests/contract/HtmlValidityContract.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter;
+use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics;
+use Automattic\BlocksEngine\FigmaTransformer\Html\TransformDiagnosticsBuilder;
 
 /**
  * @param callable(bool, string): void $assert
@@ -212,6 +214,42 @@ function blocks_engine_figma_transformer_run_html_validity_contract(callable $as
     $assert(0 === $xpath->query('//a[.//a]')->length, 'html-validity-no-nested-anchors');
     $assert(0 === $xpath->query('//a[.//button]')->length, 'html-validity-no-anchor-wrapped-buttons');
     $assert(0 === $xpath->query('//ul/*[not(self::li)]')->length, 'html-validity-ul-direct-children-are-li');
+
+    $artifactDiagnostics = (new StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        '<main><section class="hero"><div>Hero</div></section><ul><a href="#">Bad direct link</a><li>Good</li></ul><form><input type="email"><svg><path d="M0 0H10V10Z"></path></svg></form></main>',
+        '.hero{width:1600px;height:2400px;overflow:hidden}.card{width:640px}.media{width:480px}.tile-a{width:360px}.tile-b{width:360px}.tile-c{width:360px}.tile-d{width:360px}.tile-e{width:360px}@media (max-width: 767px){.media{width:100%}}'
+    );
+    $assert(8 === ($artifactDiagnostics['fixed_width_declaration_count'] ?? null), 'html-validity-artifact-diagnostics-counts-fixed-width-declarations');
+    $assert(1 === ($artifactDiagnostics['fixed_width_with_responsive_override_count'] ?? null), 'html-validity-artifact-diagnostics-counts-responsive-covered-widths');
+    $assert(7 === ($artifactDiagnostics['fixed_width_without_responsive_override_count'] ?? null), 'html-validity-artifact-diagnostics-counts-uncovered-fixed-widths');
+    $assert(0.125 === ($artifactDiagnostics['effective_responsive_coverage_ratio'] ?? null), 'html-validity-artifact-diagnostics-reports-effective-responsive-coverage');
+    $assert(1 === ($artifactDiagnostics['giant_fixed_section_count'] ?? null), 'html-validity-artifact-diagnostics-flags-giant-fixed-section');
+    $assert(1 === ($artifactDiagnostics['large_overflow_risk_count'] ?? null), 'html-validity-artifact-diagnostics-flags-large-overflow-risk');
+    $assert(1 === ($artifactDiagnostics['fallback_prone_form_island_count'] ?? null), 'html-validity-artifact-diagnostics-counts-form-islands');
+    $assert(1 === ($artifactDiagnostics['fallback_prone_svg_island_count'] ?? null), 'html-validity-artifact-diagnostics-counts-svg-islands');
+    $assert(1 === ($artifactDiagnostics['fallback_prone_input_island_count'] ?? null), 'html-validity-artifact-diagnostics-counts-input-islands');
+    $assert(1 === ($artifactDiagnostics['invalid_list_child_count'] ?? null), 'html-validity-artifact-diagnostics-detects-invalid-list-children');
+    $assert(2 === ($artifactDiagnostics['missing_semantic_role_count'] ?? null), 'html-validity-artifact-diagnostics-detects-missing-semantic-role');
+
+    $artifactQuality = (new TransformDiagnosticsBuilder())->artifactQualityDiagnostics(
+        array('missing_assets' => array(), 'image_block_count' => 0, 'total_node_count' => 0),
+        array('placeholders' => 0, 'rendered_asset_fallbacks' => 0),
+        array('missing_css' => array(), 'usage' => array()),
+        array('emitted_files' => 0),
+        array('count' => 0, 'bytes' => 0),
+        array(),
+        array(),
+        array(),
+        array(),
+        array(),
+        array(),
+        array(),
+        $artifactDiagnostics
+    );
+    $artifactSignalCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), $artifactQuality['signals'] ?? array());
+    foreach ( array('low_effective_responsive_coverage', 'giant_fixed_section_risk', 'large_overflow_risk', 'fallback_prone_html_islands', 'invalid_list_children', 'missing_semantic_roles') as $code ) {
+        $assert(in_array($code, $artifactSignalCodes, true), 'html-validity-artifact-quality-signal-' . $code);
+    }
 
     $entrypointFallbackResult = (new StaticHtmlEmitter())->emitSite(array(
         'name'  => 'Implicit Entrypoint Fallback Fixture',


### PR DESCRIPTION
## Summary
- Adds deterministic HTML artifact readiness diagnostics for Figma output before any WordPress import/block generation.
- Surfaces effective responsive coverage, uncovered fixed widths, giant fixed sections, large overflow risks, fallback-prone form/svg/input islands, invalid list children, and missing semantic role metadata.
- Aggregates the new readiness counters into fixture matrix summaries and Homeboy bench metrics.

## Before/after fixture matrix
Ran against three local operator-owned fixtures: Fisiostetic, Twenty Twenty-Five (Community), FSE Pilot Build Theme.

Before (`origin/trunk`):
- quality statuses: `pass: 3`
- existing totals: `media_query_count=24`, `fixed_width_over_desktop_count=12`, `image_block_count=61`, `vector_placeholders=0`, `missing_asset_nodes=0`, `layout_mismatch_count=0`
- readiness categories added here were not present: effective responsive coverage, uncovered fixed widths, giant sections, fallback-prone islands, invalid list children, missing semantic roles

After (this branch):
- quality statuses: `warn: 3`
- quality matrix effective responsive coverage: `0.487`
- totals: `fixed_width_declaration_count=357`, `fixed_width_without_responsive_override_count=183`, `giant_fixed_section_count=13`, `large_overflow_risk_count=0`, `fallback_prone_form_island_count=6`, `fallback_prone_svg_island_count=168`, `fallback_prone_input_island_count=24`, `invalid_list_child_count=0`, `missing_semantic_role_count=33`
- unchanged cleanliness signals: `missing_asset_nodes=0`, `vector_placeholders=0`, `missing_emitted_text_nodes=0`, `layout_mismatch_count=0`, `invalid_css_numeric_tokens=0`

Per fixture after:
- Fisiostetic: coverage `0.444`, fixed uncovered `50`, giant fixed sections `1`, fallback-prone islands `15`, missing semantic roles `0`
- Twenty Twenty-Five (Community): coverage `0.333`, fixed uncovered `74`, giant fixed sections `5`, fallback-prone islands `11`, missing semantic roles `19`
- FSE Pilot Build Theme: coverage `0.622`, fixed uncovered `59`, giant fixed sections `7`, fallback-prone islands `172`, missing semantic roles `14`

## Verification
- `composer test` in `figma-transformer` passed.
- `git diff --check` passed.
- Fixture matrix after: `php scripts/figma-fixture-matrix.php --fixture=/Users/chubes/Downloads/Fisiostetic.fig --fixture=/Users/chubes/Downloads/Twenty\ Twenty-Five\ \(Community\).fig --fixture=/Users/chubes/Downloads/🛠️\ FSE\ Pilot\ Build\ Theme.fig --max-pages=3 --output-dir=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/figma-html-readiness-after`
- Fixture matrix before used the same command in an `origin/trunk` worktree with output dir `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/figma-html-readiness-before`.

## Notes
- This PR stays strictly in `.fig -> HTML artifact` diagnostics and fixture-matrix aggregation. It does not add or invoke WordPress block generation.
- Real `.fig` files are operator-owned local inputs and are not committed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Implemented the diagnostic/matrix changes, contract tests, fixture verification runs, and PR preparation under Chris's direction.
