### PR TITLE
Improve Figma layout intent artifacts

### DIFF
--- a/figma-transformer/src/Html/LayoutIntentClassifier.php
+++ b/figma-transformer/src/Html/LayoutIntentClassifier.php
@@ -9,6 +9,16 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
  */
 final class LayoutIntentClassifier
 {
+    public const LAYOUT_INTENT_FLOW_SECTION = 'flow-section';
+    public const LAYOUT_INTENT_STACK = 'stack';
+    public const LAYOUT_INTENT_NAV_ROW = 'nav-row';
+    public const LAYOUT_INTENT_CARD_ROW = 'card-row';
+    public const LAYOUT_INTENT_CARD_GRID = 'card-grid';
+    public const LAYOUT_INTENT_PRICING_GRID = 'pricing-grid';
+    public const LAYOUT_INTENT_SERVICE_GRID = 'service-grid';
+    public const LAYOUT_INTENT_ARTICLE_GRID = 'article-grid';
+    public const LAYOUT_INTENT_CTA = 'cta';
+
     public const STACK_REASON_ABSOLUTE_CHILD = StackingContextPolicy::STACK_REASON_ABSOLUTE_CHILD;
     public const STACK_REASON_DECORATIVE_UNDERLAY = StackingContextPolicy::STACK_REASON_DECORATIVE_UNDERLAY;
     public const STACK_REASON_FREEFORM_CONTAINER = StackingContextPolicy::STACK_REASON_FREEFORM_CONTAINER;
@@ -288,11 +298,254 @@ final class LayoutIntentClassifier
     }
 
     /**
+     * Classifies broad layout intent for static HTML artifacts. This stays at
+     * the HTML/CSS seam so downstream importers can consume intent without this
+     * transformer knowing about any block system.
+     *
+     * @param array<string, mixed>      $node
+     * @param array<string, mixed>|null $parentNode
+     * @return array{intent: string, display: string, direction: string, collection: string|null, item_count: int, column_count: int|null, gap: float|null, confidence: string}|null
+     */
+    public function layoutIntent(array $node, ?array $parentNode = null): ?array
+    {
+        $children = $this->layoutContentChildren($node);
+        if ( count($children) < 2 ) {
+            return null;
+        }
+
+        $role = $this->chromeGroupRole($node, $parentNode, null === $parentNode ? 0 : 1);
+        if ( self::CHROME_GROUP_ROLE_NAVIGATION === $role || $this->isNavigationContainer($children) ) {
+            return $this->layoutIntentResult(self::LAYOUT_INTENT_NAV_ROW, 'flex', 'row', null, $children, 1, $this->averageMainAxisGap($children, 'row'), 'high');
+        }
+        if ( in_array($role, array(self::CHROME_GROUP_ROLE_HEADER, self::CHROME_GROUP_ROLE_FOOTER, self::CHROME_GROUP_ROLE_SOCIAL), true) ) {
+            return null;
+        }
+        if ( self::CHROME_GROUP_ROLE_CTA === $role ) {
+            return $this->layoutIntentResult(self::LAYOUT_INTENT_CTA, 'flex', 'column', null, $children, 1, $this->averageMainAxisGap($children, 'column'), 'medium');
+        }
+
+        $shape = $this->childFlowShape($children);
+        $name = strtolower((string) ($node['name'] ?? ''));
+        $text = strtolower($this->subtreePlainText($node));
+        $haystack = $name . ' ' . $text;
+        $hasRepeatedContent = $this->hasRichRepeatedContent($children) || $this->repeatedChildShape($children);
+        $collection = null;
+        $intent = null;
+
+        if ( $hasRepeatedContent && $this->matchesAny($haystack, array('pricing', 'prices', 'plans', 'plan ', '$', '/mo', '/month', 'per month')) ) {
+            $intent = self::LAYOUT_INTENT_PRICING_GRID;
+            $collection = 'pricing';
+        } elseif ( $hasRepeatedContent && $this->matchesAny($name, array('services', 'service', 'treatments', 'treatment', 'features', 'feature')) ) {
+            $intent = self::LAYOUT_INTENT_SERVICE_GRID;
+            $collection = 'services';
+        } elseif ( $hasRepeatedContent && $this->matchesAny($name, array('articles', 'article', 'blog', 'posts', 'post ', 'news', 'journal', 'stories')) ) {
+            $intent = self::LAYOUT_INTENT_ARTICLE_GRID;
+            $collection = 'articles';
+        } elseif ( $hasRepeatedContent && $this->matchesAny($name, array('cards', 'card', 'grid', 'columns')) ) {
+            $intent = 'grid' === $shape['display'] ? self::LAYOUT_INTENT_CARD_GRID : self::LAYOUT_INTENT_CARD_ROW;
+            $collection = 'cards';
+        } elseif ( 'column' === $shape['direction'] && $this->looksLikeSectionName($name) ) {
+            $intent = self::LAYOUT_INTENT_FLOW_SECTION;
+        } elseif ( 'column' === $shape['direction'] ) {
+            $intent = self::LAYOUT_INTENT_STACK;
+        }
+
+        if ( null === $intent ) {
+            return null;
+        }
+
+        $display = in_array($intent, array(self::LAYOUT_INTENT_CARD_GRID, self::LAYOUT_INTENT_PRICING_GRID, self::LAYOUT_INTENT_SERVICE_GRID, self::LAYOUT_INTENT_ARTICLE_GRID), true) ? 'grid' : 'flex';
+        $direction = 'grid' === $display ? 'grid' : $shape['direction'];
+        return $this->layoutIntentResult($intent, $display, $direction, $collection, $children, 'grid' === $display ? $shape['column_count'] : 1, $shape['gap'], null !== $collection ? 'high' : 'medium');
+    }
+
+    /**
      * @param array<string, mixed> $node
      */
     private function hasNoDeclaredDisplay(array $node): bool
     {
         return empty($node['layout']['display'] ?? null);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $children
+     * @return array{display: string, direction: string, column_count: int, gap: float|null}
+     */
+    private function childFlowShape(array $children): array
+    {
+        $rows = array();
+        $columns = array();
+        foreach ( $children as $child ) {
+            $x = $this->boxValue($child, 'x');
+            $y = $this->boxValue($child, 'y');
+            if ( null === $x || null === $y ) {
+                continue;
+            }
+            $this->appendClusterValue($rows, $y);
+            $this->appendClusterValue($columns, $x);
+        }
+
+        $rowCount = count($rows);
+        $columnCount = max(1, count($columns));
+        if ( $rowCount >= 2 && $columnCount >= 2 ) {
+            return array('display' => 'grid', 'direction' => 'grid', 'column_count' => $columnCount, 'gap' => $this->averageGridGap($children));
+        }
+
+        $direction = $columnCount >= 2 && $rowCount <= 1 ? 'row' : 'column';
+        return array('display' => 'flex', 'direction' => $direction, 'column_count' => $columnCount, 'gap' => $this->averageMainAxisGap($children, $direction));
+    }
+
+    /** @param array<int, float> $clusters */
+    private function appendClusterValue(array &$clusters, float $value): void
+    {
+        foreach ( $clusters as $cluster ) {
+            if ( abs($cluster - $value) <= 8.0 ) {
+                return;
+            }
+        }
+        $clusters[] = $value;
+        sort($clusters, SORT_NUMERIC);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $children
+     */
+    private function averageGridGap(array $children): ?float
+    {
+        return $this->averageMainAxisGap($children, 'row') ?? $this->averageMainAxisGap($children, 'column');
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $children
+     */
+    private function averageMainAxisGap(array $children, string $direction): ?float
+    {
+        $axis = 'row' === $direction ? 'x' : 'y';
+        $size = 'row' === $direction ? 'width' : 'height';
+        $items = array();
+        foreach ( $children as $child ) {
+            $start = $this->boxValue($child, $axis);
+            $length = $this->boxValue($child, $size);
+            if ( null !== $start && null !== $length ) {
+                $items[] = array('start' => $start, 'end' => $start + $length);
+            }
+        }
+        if ( count($items) < 2 ) {
+            return null;
+        }
+        usort($items, static fn (array $a, array $b): int => $a['start'] <=> $b['start']);
+        $gaps = array();
+        for ( $i = 1; $i < count($items); $i++ ) {
+            $gap = $items[$i]['start'] - $items[$i - 1]['end'];
+            if ( $gap >= 0.0 && $gap <= 160.0 ) {
+                $gaps[] = $gap;
+            }
+        }
+        if ( empty($gaps) ) {
+            return null;
+        }
+
+        return array_sum($gaps) / count($gaps);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $children
+     */
+    private function repeatedChildShape(array $children): bool
+    {
+        if ( count($children) < 2 ) {
+            return false;
+        }
+        $widths = array();
+        $heights = array();
+        foreach ( $children as $child ) {
+            $width = $this->boxValue($child, 'width');
+            $height = $this->boxValue($child, 'height');
+            if ( null === $width || null === $height || ! $this->subtreeHasText($child) ) {
+                return false;
+            }
+            $widths[] = $width;
+            $heights[] = $height;
+        }
+
+        return $this->valuesAreNearUniform($widths, 0.35) && $this->valuesAreNearUniform($heights, 0.45);
+    }
+
+    /** @param array<int, float> $values */
+    private function valuesAreNearUniform(array $values, float $tolerance): bool
+    {
+        $min = min($values);
+        $max = max($values);
+        if ( $min <= 0.0 ) {
+            return false;
+        }
+
+        return (($max - $min) / $min) <= $tolerance;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, array<string, mixed>>
+     */
+    private function layoutContentChildren(array $node): array
+    {
+        $children = array();
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) || false === ($child['visible'] ?? null) ) {
+                continue;
+            }
+            if ( $this->isPrimitiveVisualOnly($child) && ! $this->subtreeHasLink($child) ) {
+                continue;
+            }
+            if ( ! $this->subtreeHasText($child) && ! $this->subtreeHasLink($child) ) {
+                continue;
+            }
+            $children[] = $child;
+        }
+
+        return $children;
+    }
+
+    /** @param array<string, mixed> $node */
+    private function isPrimitiveVisualOnly(array $node): bool
+    {
+        $type = strtoupper((string) ($node['type'] ?? ''));
+        return in_array($type, self::PRIMITIVE_VECTOR_SHAPE_TYPES, true) && ! $this->subtreeHasText($node);
+    }
+
+    /** @param array<int, string> $needles */
+    private function matchesAny(string $haystack, array $needles): bool
+    {
+        foreach ( $needles as $needle ) {
+            if ( str_contains($haystack, $needle) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function looksLikeSectionName(string $name): bool
+    {
+        return $this->matchesAny($name, array('section', 'hero', 'content', 'intro', 'main', 'cta', 'call to action'));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $children
+     * @return array{intent: string, display: string, direction: string, collection: string|null, item_count: int, column_count: int|null, gap: float|null, confidence: string}
+     */
+    private function layoutIntentResult(string $intent, string $display, string $direction, ?string $collection, array $children, ?int $columnCount, ?float $gap, string $confidence): array
+    {
+        return array(
+            'intent'       => $intent,
+            'display'      => $display,
+            'direction'    => $direction,
+            'collection'   => $collection,
+            'item_count'   => count($children),
+            'column_count' => $columnCount,
+            'gap'          => null === $gap ? null : round($gap, 3),
+            'confidence'   => $confidence,
+        );
     }
 
     /**

--- a/figma-transformer/src/Html/PositioningStyleResolver.php
+++ b/figma-transformer/src/Html/PositioningStyleResolver.php
@@ -38,7 +38,7 @@ final class PositioningStyleResolver
         $styles = array();
         $isDecorativeFlexUnderlay = null !== $parentNode && $this->isDecorativeFlexUnderlay($node, $parentNode);
         $parentFreeformUsesFlow = null !== $parentNode && $this->freeformContainerShouldUseFlow($parentNode);
-        $willPositionAbsolute = (null !== $parentNode && $this->isFreeformContainer($parentNode) && ! $parentFreeformUsesFlow) || 'absolute' === ($layout['positioning'] ?? null) || $isDecorativeFlexUnderlay;
+        $willPositionAbsolute = (null !== $parentNode && $this->isFreeformContainer($parentNode) && ! $parentFreeformUsesFlow) || ('absolute' === ($layout['positioning'] ?? null) && ! $parentFreeformUsesFlow) || $isDecorativeFlexUnderlay;
         $stackingContextPlan = $this->layoutIntentClassifier->stackingContextPlan($node, $parentNode);
         $effectiveZIndex = isset($stackingContextPlan['z_index']) && is_int($stackingContextPlan['z_index']) ? $stackingContextPlan['z_index'] : null;
         $zIndexReason = isset($stackingContextPlan['z_index_reason']) && is_string($stackingContextPlan['z_index_reason']) ? $stackingContextPlan['z_index_reason'] : null;
@@ -98,7 +98,7 @@ final class PositioningStyleResolver
             $reasonCode = 'decorative_flex_underlay_absolute';
         } elseif ( null !== $parentNode && $this->isFreeformContainer($parentNode) && ! $parentFreeformUsesFlow ) {
             $reasonCode = 'freeform_parent_absolute_child';
-        } elseif ( 'absolute' === ($layout['positioning'] ?? null) ) {
+        } elseif ( 'absolute' === ($layout['positioning'] ?? null) && ! $parentFreeformUsesFlow ) {
             $reasonCode = 'explicit_absolute_positioning';
         }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1015,11 +1015,15 @@ final class StaticHtmlEmitter
             }
         }
 
+        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node, $parentNode);
         $elementClassName = null === $imageElement ? $className : $className . ' figma-image-asset';
         $attributes = sprintf(' class="%1$s" data-figma-node-id="%2$s" data-figma-node-name="%3$s"', $elementClassName, $id, $attributeName);
         $semanticRole = $this->semanticRoleMetadata($node, $tag, $type, $name);
         if ( null !== $semanticRole ) {
             $attributes .= ' data-figma-semantic-role="' . $this->sanitizeAttribute($semanticRole) . '"';
+        }
+        if ( $this->layoutIntentShouldEmitClass($layoutIntent) ) {
+            $attributes .= $this->layoutIntentAttributes($layoutIntent);
         }
         $anchorId = $this->headingAnchorId($node, $tag);
         if ( null !== $anchorId ) {
@@ -2144,10 +2148,23 @@ final class StaticHtmlEmitter
      */
     private function freeformContainerShouldUseFlow(array $node): bool
     {
-        if ( ! $this->isFreeformContainer($node) ) {
+        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node);
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        if ( empty($layout['display'] ?? null) && is_array($layoutIntent) && in_array($layoutIntent['intent'] ?? '', array(
+            LayoutIntentClassifier::LAYOUT_INTENT_CARD_ROW,
+            LayoutIntentClassifier::LAYOUT_INTENT_CARD_GRID,
+            LayoutIntentClassifier::LAYOUT_INTENT_PRICING_GRID,
+            LayoutIntentClassifier::LAYOUT_INTENT_SERVICE_GRID,
+            LayoutIntentClassifier::LAYOUT_INTENT_ARTICLE_GRID,
+        ), true) ) {
+            return true;
+        }
+
+        if ( ! empty($this->listItemIds($node)) ) {
             return false;
         }
-        if ( ! empty($this->listItemIds($node)) ) {
+
+        if ( ! $this->isFreeformContainer($node) ) {
             return false;
         }
 
@@ -6133,7 +6150,7 @@ final class StaticHtmlEmitter
         foreach ( array('width', 'height') as $dimension ) {
             $sizingKey = 'width' === $dimension ? 'sizing_horizontal' : 'sizing_vertical';
             $sizing = strtoupper((string) ($layout[$sizingKey] ?? ''));
-            if ( 'height' === $dimension && isset($box['height']) && is_numeric($box['height']) && $this->canvasShellResolver()->nodeShouldUseFlowHeight($type, $layout, $canvasShell) ) {
+            if ( 'height' === $dimension && isset($box['height']) && is_numeric($box['height']) && ($this->canvasShellResolver()->nodeShouldUseFlowHeight($type, $layout, $canvasShell) || $this->freeformContainerShouldUseFlow($node) || (empty($layout['display'] ?? null) && $this->layoutIntentShouldEmitClass($this->layoutIntentClassifier()->layoutIntent($node, $parentNode)))) ) {
                 $styles[] = 'min-height:' . $this->number((float) $box['height']) . 'px';
                 continue;
             }
@@ -6285,6 +6302,13 @@ final class StaticHtmlEmitter
             $styles[] = $style;
         }
 
+        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node, $parentNode);
+        if ( empty($layout['display'] ?? null) && $this->layoutIntentShouldEmitClass($layoutIntent) ) {
+            foreach ( $this->layoutIntentStyles($layoutIntent) as $style ) {
+                $styles[] = $style;
+            }
+        }
+
         foreach ( array(
             'display'         => 'display',
             'flex_direction'  => 'flex-direction',
@@ -6368,6 +6392,56 @@ final class StaticHtmlEmitter
         }
 
         return $scaled;
+    }
+
+    /**
+     * @param array{intent: string, display: string, direction: string, collection: string|null, item_count: int, column_count: int|null, gap: float|null, confidence: string} $layoutIntent
+     * @return array<int, string>
+     */
+    private function layoutIntentStyles(array $layoutIntent): array
+    {
+        $styles = array();
+        if ( 'grid' === ($layoutIntent['display'] ?? null) ) {
+            $columns = isset($layoutIntent['column_count']) && is_int($layoutIntent['column_count']) && $layoutIntent['column_count'] > 1 ? $layoutIntent['column_count'] : 2;
+            $styles[] = 'display:grid';
+            $styles[] = 'grid-template-columns:repeat(' . (string) $columns . ',minmax(0,1fr))';
+        } else {
+            $styles[] = 'display:flex';
+            $styles[] = 'flex-direction:' . ('row' === ($layoutIntent['direction'] ?? null) ? 'row' : 'column');
+            if ( in_array($layoutIntent['intent'] ?? '', array(LayoutIntentClassifier::LAYOUT_INTENT_CARD_ROW, LayoutIntentClassifier::LAYOUT_INTENT_NAV_ROW), true) ) {
+                $styles[] = 'align-items:center';
+            }
+        }
+
+        if ( isset($layoutIntent['gap']) && is_numeric($layoutIntent['gap']) && (float) $layoutIntent['gap'] > 0.0 ) {
+            $styles[] = 'gap:' . $this->number((float) $layoutIntent['gap']) . 'px';
+        }
+
+        return $styles;
+    }
+
+    /** @param array<string, mixed>|null $layoutIntent */
+    private function layoutIntentShouldEmitClass(?array $layoutIntent): bool
+    {
+        return is_array($layoutIntent) && null !== ($layoutIntent['collection'] ?? null);
+    }
+
+    /**
+     * @param array{intent: string, display: string, direction: string, collection: string|null, item_count: int, column_count: int|null, gap: float|null, confidence: string} $layoutIntent
+     */
+    private function layoutIntentAttributes(array $layoutIntent): string
+    {
+        $attributes = ' data-figma-layout-intent="' . $this->sanitizeAttribute((string) ($layoutIntent['intent'] ?? '')) . '"';
+        $attributes .= ' data-figma-layout-display="' . $this->sanitizeAttribute((string) ($layoutIntent['display'] ?? '')) . '"';
+        $attributes .= ' data-figma-layout-direction="' . $this->sanitizeAttribute((string) ($layoutIntent['direction'] ?? '')) . '"';
+        if ( null !== ($layoutIntent['collection'] ?? null) ) {
+            $attributes .= ' data-figma-collection="' . $this->sanitizeAttribute((string) $layoutIntent['collection']) . '"';
+        }
+        if ( isset($layoutIntent['column_count']) && is_int($layoutIntent['column_count']) && $layoutIntent['column_count'] > 1 ) {
+            $attributes .= ' data-figma-layout-columns="' . $this->sanitizeAttribute((string) $layoutIntent['column_count']) . '"';
+        }
+
+        return $attributes;
     }
 
     private function scaleFullBleedImageCropDeclaration(string $style, float $sourceWidth, string $kind): string

--- a/figma-transformer/tests/contract/LayoutFrameRoleContract.php
+++ b/figma-transformer/tests/contract/LayoutFrameRoleContract.php
@@ -271,4 +271,52 @@ function blocks_engine_figma_transformer_run_layout_frame_role_contract(callable
         'children' => array(array('id' => 'chrome:cta-label', 'type' => 'TEXT', 'characters' => 'Book now')),
     );
     $assert(LayoutIntentClassifier::CHROME_GROUP_ROLE_CTA === $intent->chromeGroupRole($cta, null, 1), 'layout-intent-cta-group-classifies-cta');
+
+    $pricingGrid = array(
+        'id'       => 'layout:pricing',
+        'type'     => 'FRAME',
+        'name'     => 'Pricing plans grid',
+        'box'      => array('x' => 0, 'y' => 0, 'width' => 960, 'height' => 420),
+        'children' => array(
+            array('id' => 'layout:basic', 'type' => 'FRAME', 'name' => 'Basic plan card', 'box' => array('x' => 0, 'y' => 0, 'width' => 300, 'height' => 180), 'children' => array(array('id' => 'layout:basic-title', 'type' => 'TEXT', 'characters' => 'Basic'), array('id' => 'layout:basic-price', 'type' => 'TEXT', 'characters' => '$19/mo'))),
+            array('id' => 'layout:pro', 'type' => 'FRAME', 'name' => 'Pro plan card', 'box' => array('x' => 330, 'y' => 0, 'width' => 300, 'height' => 180), 'children' => array(array('id' => 'layout:pro-title', 'type' => 'TEXT', 'characters' => 'Pro'), array('id' => 'layout:pro-price', 'type' => 'TEXT', 'characters' => '$49/mo'))),
+            array('id' => 'layout:team', 'type' => 'FRAME', 'name' => 'Team plan card', 'box' => array('x' => 0, 'y' => 220, 'width' => 300, 'height' => 180), 'children' => array(array('id' => 'layout:team-title', 'type' => 'TEXT', 'characters' => 'Team'), array('id' => 'layout:team-price', 'type' => 'TEXT', 'characters' => '$99/mo'))),
+            array('id' => 'layout:enterprise', 'type' => 'FRAME', 'name' => 'Enterprise plan card', 'box' => array('x' => 330, 'y' => 220, 'width' => 300, 'height' => 180), 'children' => array(array('id' => 'layout:enterprise-title', 'type' => 'TEXT', 'characters' => 'Enterprise'), array('id' => 'layout:enterprise-price', 'type' => 'TEXT', 'characters' => 'Contact us'))),
+        ),
+    );
+    $pricingIntent = $intent->layoutIntent($pricingGrid);
+    $assert(LayoutIntentClassifier::LAYOUT_INTENT_PRICING_GRID === ($pricingIntent['intent'] ?? null), 'layout-intent-pricing-grid-classifies');
+    $assert('grid' === ($pricingIntent['display'] ?? null), 'layout-intent-pricing-grid-display');
+    $assert(2 === ($pricingIntent['column_count'] ?? null), 'layout-intent-pricing-grid-columns');
+
+    $navIntent = $intent->layoutIntent($nav);
+    $assert(LayoutIntentClassifier::LAYOUT_INTENT_NAV_ROW === ($navIntent['intent'] ?? null), 'layout-intent-nav-row-classifies');
+
+    $artifactResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Layout Intent Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'intent:root',
+                'type'     => 'FRAME',
+                'name'     => 'Pricing section',
+                'width'    => 960,
+                'height'   => 420,
+                'children' => array(
+                    array('id' => 'intent:basic', 'type' => 'FRAME', 'name' => 'Basic pricing card', 'x' => 0, 'y' => 0, 'width' => 300, 'height' => 180, 'layoutPositioning' => 'ABSOLUTE', 'children' => array(array('id' => 'intent:basic-title', 'type' => 'TEXT', 'text' => 'Basic'), array('id' => 'intent:basic-price', 'type' => 'TEXT', 'text' => '$19/mo'))),
+                    array('id' => 'intent:pro', 'type' => 'FRAME', 'name' => 'Pro pricing card', 'x' => 330, 'y' => 0, 'width' => 300, 'height' => 180, 'layoutPositioning' => 'ABSOLUTE', 'children' => array(array('id' => 'intent:pro-title', 'type' => 'TEXT', 'text' => 'Pro'), array('id' => 'intent:pro-price', 'type' => 'TEXT', 'text' => '$49/mo'))),
+                    array('id' => 'intent:team', 'type' => 'FRAME', 'name' => 'Team pricing card', 'x' => 0, 'y' => 220, 'width' => 300, 'height' => 180, 'layoutPositioning' => 'ABSOLUTE', 'children' => array(array('id' => 'intent:team-title', 'type' => 'TEXT', 'text' => 'Team'), array('id' => 'intent:team-price', 'type' => 'TEXT', 'text' => '$99/mo'))),
+                    array('id' => 'intent:enterprise', 'type' => 'FRAME', 'name' => 'Enterprise pricing card', 'x' => 330, 'y' => 220, 'width' => 300, 'height' => 180, 'layoutPositioning' => 'ABSOLUTE', 'children' => array(array('id' => 'intent:enterprise-title', 'type' => 'TEXT', 'text' => 'Enterprise'), array('id' => 'intent:enterprise-price', 'type' => 'TEXT', 'text' => 'Contact us'))),
+                ),
+            ),
+        ),
+    ));
+    $artifactHtml = blocks_engine_figma_transformer_contract_file_content($artifactResult, 'index.html');
+    $artifactCss = blocks_engine_figma_transformer_contract_file_content($artifactResult, 'style.css');
+    $pricingRule = blocks_engine_figma_transformer_contract_css_rule($artifactCss, '.figma-node-intent-root-pricing-section');
+    $basicRule = blocks_engine_figma_transformer_contract_css_rule($artifactCss, '.figma-node-intent-basic-basic-pricing-card');
+    $assert(str_contains($artifactHtml, 'data-figma-layout-intent="pricing-grid"'), 'layout-intent-artifact-emits-intent-attribute');
+    $assert(str_contains($artifactHtml, 'data-figma-layout-display="grid"'), 'layout-intent-artifact-emits-layout-display');
+    $assert(str_contains($artifactHtml, 'data-figma-collection="pricing"'), 'layout-intent-artifact-emits-collection');
+    $assert(str_contains($pricingRule, 'display:grid') && str_contains($pricingRule, 'grid-template-columns:repeat(2,minmax(0,1fr))') && str_contains($pricingRule, 'min-height:420px') && ! str_contains($pricingRule, ';height:420px'), 'layout-intent-artifact-grid-flow-css');
+    $assert(! str_contains($basicRule, 'position:absolute'), 'layout-intent-artifact-grid-child-uses-flow-positioning');
 }


### PR DESCRIPTION
## Summary
- add generic layout intent classification for HTML/CSS artifacts, including nav rows, card rows/grids, pricing grids, service grids, article grids, stacks, and flow sections
- emit collection layout metadata as `data-figma-layout-*` attributes in static HTML artifacts without emitting WordPress blocks
- infer grid/flex flow CSS for collection-like Figma frames without declared Auto Layout, and keep children in document flow instead of preserving absolute offsets
- keep existing explicit Auto Layout, chrome, responsive variant, and semantic class contracts intact

## Before / after artifact shape
Before:
```html
<ul class="figma-node-intent-root-pricing-section" data-figma-node-id="intent:root" data-figma-node-name="Pricing section">
  <li class="figma-node-intent-basic-basic-pricing-card">...</li>
</ul>
```
```css
.figma-node-intent-root-pricing-section{width:960px;height:420px;position:relative}
.figma-node-intent-basic-basic-pricing-card{width:300px;height:180px;position:absolute;left:0px;top:0px}
```

After:
```html
<ul class="figma-node-intent-root-pricing-section" data-figma-node-id="intent:root" data-figma-node-name="Pricing section" data-figma-semantic-role="pricing" data-figma-layout-intent="pricing-grid" data-figma-layout-display="grid" data-figma-layout-direction="grid" data-figma-collection="pricing" data-figma-layout-columns="2">
  <li class="figma-node-intent-basic-basic-pricing-card">...</li>
</ul>
```
```css
.figma-node-intent-root-pricing-section{width:960px;min-height:420px;position:relative;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:30px}
/* child cards stay in normal grid flow; no position:absolute offsets */
```

## Tests
- `composer test` from `figma-transformer/`

## Fixture verification
- Contract coverage includes pricing-grid classifier and emitted artifact behavior, including absolute child suppression in the generated HTML/CSS artifact path.
- I could not run the named Fisiostetic or FSE/TT5 `.fig` fixtures because this checkout does not contain committed `.fig` files or Fisiostetic fixture artifacts; `figma-transformer/fixtures` only contains README/.gitignore and the CLI requires an input `.fig` or scenegraph JSON.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigating the Figma HTML artifact pipeline, implementing classifier/emitter changes, adding contract coverage, and running verification.