### PR TITLE
Improve button border diagnostics

### DIFF
--- a/php-transformer/src/VisualParity/ButtonMenuVisualProbeComparator.php
+++ b/php-transformer/src/VisualParity/ButtonMenuVisualProbeComparator.php
@@ -185,8 +185,8 @@ final class ButtonMenuVisualProbeComparator
         $targetStyle = $this->style($targetProbe);
 
         foreach ( self::STYLE_GROUPS as $group => $fields ) {
-            $sourceValues = $this->groupValues($sourceStyle, $fields);
-            $targetValues = $this->groupValues($targetStyle, $fields);
+            $sourceValues = $this->styleGroupValues($sourceStyle, $group, $fields);
+            $targetValues = $this->styleGroupValues($targetStyle, $group, $fields);
             if ( array() === $sourceValues || $sourceValues === $targetValues ) {
                 continue;
             }
@@ -216,14 +216,14 @@ final class ButtonMenuVisualProbeComparator
         $sourceStyle = $this->style($sourceProbe);
         $targetStyle = $this->style($targetProbe);
         foreach ( self::STYLE_GROUPS as $group => $fields ) {
-            if ( array() === $this->groupValues($sourceStyle, $fields) ) {
+            if ( array() === $this->styleGroupValues($sourceStyle, $group, $fields) ) {
                 continue;
             }
-            if ( array() === $this->groupValues($targetStyle, $fields) ) {
+            if ( array() === $this->styleGroupValues($targetStyle, $group, $fields) ) {
                 $risks[] = array(
                     'code' => 'missing_' . $group . '_style',
                     'group' => $group,
-                    'source' => $this->groupValues($sourceStyle, $fields),
+                    'source' => $this->styleGroupValues($sourceStyle, $group, $fields),
                 );
             }
         }
@@ -409,13 +409,47 @@ final class ButtonMenuVisualProbeComparator
 
     /**
      * @param array<string, string> $style
+     * @param array<int, string> $fields
+     * @return array<string, string>
+     */
+    private function styleGroupValues(array $style, string $group, array $fields): array
+    {
+        $values = $this->groupValues($style, $fields);
+        if ( 'border' !== $group ) {
+            return $values;
+        }
+
+        return array_filter($values, static function (string $value, string $property): bool {
+            $normalized = strtolower(trim($value));
+            if ( '' === $normalized ) {
+                return false;
+            }
+
+            if ( in_array($property, array('border', 'border-top', 'border-right', 'border-bottom', 'border-left'), true) ) {
+                return ! preg_match('/^(?:none|0(?:\.0+)?(?:px|rem|em)?)(?:\s+none)?$/', $normalized);
+            }
+
+            if ( str_ends_with($property, '-width') ) {
+                return ! preg_match('/^0(?:\.0+)?(?:px|rem|em)?$/', $normalized);
+            }
+
+            if ( str_ends_with($property, '-style') ) {
+                return 'none' !== $normalized;
+            }
+
+            return true;
+        }, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * @param array<string, string> $style
      * @return array<int, string>
      */
     private function sourceVisualStyleGroups(array $style): array
     {
         $groups = array();
         foreach ( self::STYLE_GROUPS as $group => $fields ) {
-            if ( array() !== $this->groupValues($style, $fields) ) {
+            if ( array() !== $this->styleGroupValues($style, $group, $fields) ) {
                 $groups[] = $group;
             }
         }

--- a/php-transformer/tests/unit/button-visual-probe-diagnostics.php
+++ b/php-transformer/tests/unit/button-visual-probe-diagnostics.php
@@ -82,6 +82,18 @@ $nestedTarget = '<nav><ul><li><ul><li><a href="/demo">Get started</a></li></ul><
 $nestedReport = $compare($nestedSource, $nestedTarget);
 $assert(in_array('button_nesting_mismatch', $causeCodes($nestedReport), true), 'reports nesting depth mismatch', json_encode($nestedReport['matches'][0] ?? array()));
 
+$borderlessReport = $compare(
+    '<style>.cta{border:none;padding:12px 20px;background:#111;color:#fff}</style><a class="cta" href="/demo">Start</a>',
+    '<style>.wp-block-button__link{padding:12px 20px;background:#111;color:#fff}</style><a class="wp-block-button__link" href="/demo">Start</a>'
+);
+$assert(! in_array('button_border_missing', $causeCodes($borderlessReport), true), 'ignores non-visual border:none declarations', json_encode($borderlessReport['matches'][0] ?? array()));
+
+$zeroBorderReport = $compare(
+    '<style>.cta{border:0;padding:12px 20px;background:#111;color:#fff}</style><a class="cta" href="/demo">Start</a>',
+    '<style>.wp-block-button__link{padding:12px 20px;background:#111;color:#fff}</style><a class="wp-block-button__link" href="/demo">Start</a>'
+);
+$assert(! in_array('button_border_missing', $causeCodes($zeroBorderReport), true), 'ignores non-visual border:0 declarations', json_encode($zeroBorderReport['matches'][0] ?? array()));
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Button visual probe diagnostic tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary
- Normalize non-visual button border declarations (`border:none`, `border:0`, zero border widths, `*-style:none`) out of the visual border diagnostic group.
- Keeps real visual border losses reported, while removing false `button_border_missing` noise from source buttons that intentionally have no border.
- Adds unit coverage for `border:none` and `border:0` so button diagnostics do not treat absent chrome as lost chrome.

## Button mismatch taxonomy update
Before this diagnostic pass across `15-saas`, `3-artist-music`, and `86-fitness-studio`, exact-code leader was `button_border_missing` at 17. Inspection showed recurring false positives from non-visual declarations:
- SaaS: 4 instances from `border:none`.
- Fitness: 2 instances from `border:0`.

After normalization across the same fixtures:
- `button_text_color_mismatch`: 16
- `button_wrapper_chrome_mismatch`: 16
- `button_default_style_leakage`: 13
- `button_border_missing`: 11
- `button_fill_mismatch`: 10
- `button_padding_mismatch`: 9

Interpretation: border is still real for Artist/Fitness icon controls, but the top recurring actionable causes are now text color and wrapper chrome instead of false border noise.

## Verification
- `composer test:unit`
- `composer test`
- `composer static-parity -- --fixture 15-saas --top 5` -> existing report-only fail: score 0.7968, prop-par 0.9863, coverage 0.8079, matched 196/484, findings 107
- `composer static-parity -- --fixture 3-artist-music --top 5` -> existing report-only fail: score 0.7995, prop-par 0.9932, coverage 0.8050, matched 58/241, findings 49
- `composer static-parity -- --fixture 86-fitness-studio --top 5` -> warning: score 0.8844, prop-par 1.0000, coverage 0.8844, matched 148/199, findings 23

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Diagnosed recurring button mismatch buckets, implemented the PHP diagnostic normalization, added tests, and ran verification.
