### PR TITLE
Improve Figma HTML form control semantics

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -351,6 +351,14 @@ final class StaticHtmlEmitter
     private array $listItemIdCache = array();
 
     /**
+     * Per-page emitted form control name counts, used to keep generated names
+     * unique without losing the first canonical name such as `s` or `email`.
+     *
+     * @var array<string, int>
+     */
+    private array $formControlNameCounts = array();
+
+    /**
      * Tree depth at which a frame can read as a top-level <section> for the page
      * being emitted. When the page is a single wrapping frame, its bands sit one
      * level down (depth 1); when bands are emitted as sibling root nodes, they
@@ -407,6 +415,7 @@ final class StaticHtmlEmitter
         $this->currentTemplateSlug = is_scalar($options['static_site_template_slug'] ?? null) ? (string) $options['static_site_template_slug'] : $this->templateSlugFromPath($pagePath);
         $this->stickyLayoutCoordinator()->detectStickyGhostCandidates($nodes);
         $this->listItemIdCache = array();
+        $this->formControlNameCounts = array();
         $this->prepareHeadingRanking($nodes);
         $this->prepareHeadingAnchors($nodes, $pagePath);
         $diagnostics = array();
@@ -642,6 +651,7 @@ final class StaticHtmlEmitter
             $seenPaths[$path] = true;
 
             $this->listItemIdCache = array();
+            $this->formControlNameCounts = array();
             $this->currentTemplateType = is_scalar($page['page_type'] ?? null) ? (string) $page['page_type'] : '';
             $this->currentTemplateSlug = is_scalar($page['slug'] ?? null) ? (string) $page['slug'] : $this->templateSlugFromPath($path);
             $this->prepareHeadingRanking(array($frameNode));
@@ -693,6 +703,7 @@ final class StaticHtmlEmitter
             $this->currentPagePath = 'index.html';
             $this->currentTemplateType = '';
             $this->currentTemplateSlug = 'index';
+            $this->formControlNameCounts = array();
             $fallbackNodes = $this->nodeList($scenegraph);
             $this->prepareHeadingRanking($fallbackNodes);
             $this->prepareHeadingAnchors($fallbackNodes, 'index.html');
@@ -1041,7 +1052,7 @@ final class StaticHtmlEmitter
         } elseif ( 'ol' === $tag && null !== $sourceTextList && isset($sourceTextList['start']) ) {
             $attributes .= ' start="' . $this->sanitizeAttribute((string) $sourceTextList['start']) . '"';
         } elseif ( 'button' === $tag ) {
-            $attributes .= $this->buttonControlAttributes($node);
+            $attributes .= $this->buttonControlAttributes($node, $insideForm);
         } elseif ( 'form' === $tag ) {
             $attributes .= $this->formAttributes($node);
         }
@@ -2294,7 +2305,24 @@ final class StaticHtmlEmitter
      */
     private function formControlAttributes(array $node, string $tag, ?array $parentNode = null): string
     {
-        return $this->staticHtmlSemanticClassifier()->formControlAttributes($node, $tag, $parentNode);
+        $attributes = $this->staticHtmlSemanticClassifier()->formControlAttributes($node, $tag, $parentNode);
+        if ( 1 !== preg_match('/\bname="([^"]+)"/', $attributes, $matches) ) {
+            return $attributes;
+        }
+
+        $name = $matches[1];
+        $count = $this->formControlNameCounts[$name] ?? 0;
+        $this->formControlNameCounts[$name] = $count + 1;
+        if ( 0 === $count ) {
+            return $attributes;
+        }
+
+        $suffix = trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower((string) ($node['id'] ?? ''))), '-');
+        if ( '' === $suffix ) {
+            $suffix = (string) ($count + 1);
+        }
+
+        return preg_replace('/\bname="[^"]+"/', 'name="' . $this->sanitizeAttribute($name . '-' . $suffix) . '"', $attributes, 1) ?? $attributes;
     }
 
     /**
@@ -2330,14 +2358,18 @@ final class StaticHtmlEmitter
     /**
      * @param array<string, mixed> $node
      */
-    private function buttonControlAttributes(array $node): string
+    private function buttonControlAttributes(array $node, bool $insideForm): string
     {
         $label = trim($this->subtreePlainText($node));
         $name = (string) ($node['name'] ?? '');
         $haystack = strtolower($name . ' ' . $label);
-        $type = preg_match('/(^|[^a-z])(submit|send|post|search|sign up|subscribe)([^a-z]|$)/', $haystack) ? 'submit' : 'button';
+        $submitIntent = 1 === preg_match('/(^|[^a-z])(submit|send|post|search|sign up|subscribe)([^a-z]|$)/', $haystack);
+        $type = $insideForm && $submitIntent ? 'submit' : 'button';
 
         $attributes = ' type="' . $type . '"';
+        if ( ! $insideForm && $submitIntent ) {
+            $attributes .= ' data-figma-action-intent="submit"';
+        }
         if ( '' === $label && '' !== $name ) {
             $attributes .= ' aria-label="' . $this->sanitizeAttribute($name) . '"';
         }

--- a/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
+++ b/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
@@ -443,7 +443,7 @@ final class StaticHtmlSemanticClassifier
         } elseif ( 'email' === $type ) {
             $attributes .= ' name="email"';
         } elseif ( 'textarea' === $tag ) {
-            $attributes .= ' name="message"';
+            $attributes .= ' name="' . ($this->sanitizeAttribute)($this->textareaControlName($node, $haystack)) . '"';
         }
         if ( '' !== $placeholder ) {
             $attributes .= ' placeholder="' . ($this->sanitizeAttribute)($placeholder) . '"';
@@ -458,6 +458,16 @@ final class StaticHtmlSemanticClassifier
         }
 
         return $attributes;
+    }
+
+    /** @param array<string, mixed> $node */
+    private function textareaControlName(array $node, string $haystack): string
+    {
+        $base = str_contains($haystack, 'comment') || str_contains($haystack, 'reply') ? 'comment' : 'message';
+        $id = strtolower((string) ($node['id'] ?? ''));
+        $suffix = trim((string) preg_replace('/[^a-z0-9]+/', '-', $id), '-');
+
+        return '' === $suffix ? $base : $base . '-' . $suffix;
     }
 
     /**

--- a/figma-transformer/tests/contract/FormControlContract.php
+++ b/figma-transformer/tests/contract/FormControlContract.php
@@ -178,7 +178,7 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     $assert(str_contains($html, 'placeholder="Search this site"'), 'form-control-search-uses-placeholder');
     $assert(str_contains($html, '<div class="figma-node-form-search-icon-search-field-with-icon"'), 'form-control-search-icon-keeps-visual-wrapper');
     $assert(str_contains($html, 'data-figma-node-id="form:search-icon:icon"'), 'form-control-search-icon-preserves-icon-child');
-    $assert(str_contains($html, '<input class="figma-node-form-search-icon-search-field-with-icon__control" data-figma-synthetic-control="input" type="search" name="s" placeholder="Search for..."'), 'form-control-search-icon-emits-nested-input');
+    $assert(str_contains($html, '<input class="figma-node-form-search-icon-search-field-with-icon__control" data-figma-synthetic-control="input" type="search" name="s-form-search-icon" placeholder="Search for..."'), 'form-control-search-icon-emits-nested-input');
     $assert(! str_contains($html, 'data-figma-node-id="form:search-icon:text"'), 'form-control-search-icon-suppresses-presentational-placeholder');
     $assert(str_contains($css, '.figma-node-form-search-icon-search-field-with-icon__control{border:0;background:transparent;padding:0;margin:0;min-width:0;flex:1;font:inherit;color:inherit;outline:none}'), 'form-control-search-icon-input-reset-css');
     $assert(str_contains($html, '<textarea class="figma-node-form-comment-comment-textarea"'), 'form-control-comment-emits-textarea-tag');
@@ -342,7 +342,7 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     $assert(str_contains($layeredButtonHtml, 'data-figma-node-id="layered:button:icon"'), 'layered-button-preserves-meaningful-icon-layer');
     $assert(! str_contains($layeredButtonHtml, 'data-figma-node-id="layered:button:bg"'), 'layered-button-suppresses-decorative-background-child');
     blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $layeredButtonCss, '.figma-node-layered-button-book-now-button', array('background:#0d527a', 'border-radius:12px', 'border:2px solid #ffffff', 'box-sizing:border-box'), 'layered-button-composes-background-child-styles');
-    $assert(str_contains($layeredButtonHtml, '<button class="figma-node-layered-submit-subscribe-button"') && str_contains($layeredButtonHtml, 'type="submit"'), 'layered-button-preserves-submit-behavior');
+    $assert(str_contains($layeredButtonHtml, '<button class="figma-node-layered-submit-subscribe-button"') && str_contains($layeredButtonHtml, 'type="button" data-figma-action-intent="submit"'), 'layered-button-outside-form-emits-safe-action-metadata');
     $assert(! str_contains($layeredButtonHtml, 'data-figma-node-id="layered:submit:bg"'), 'layered-submit-suppresses-decorative-background-child');
     blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $layeredButtonCss, '.figma-node-layered-submit-subscribe-button', array('background:#ffffff', 'border-radius:999px'), 'layered-submit-composes-background-child-styles');
 
@@ -406,5 +406,50 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     $assert(str_contains($fieldShellHtml, 'data-figma-synthetic-control="input"') && str_contains($fieldShellHtml, 'type="email" name="email" placeholder="Your email"'), 'form-control-field-shell-emits-synthetic-email-input');
     $assert(str_contains($fieldShellHtml, 'data-figma-node-id="field-shell:email-bg"'), 'form-control-field-shell-keeps-email-chrome');
     $assert(! str_contains($fieldShellHtml, 'data-figma-node-id="field-shell:email-placeholder"'), 'form-control-field-shell-suppresses-email-placeholder');
-    $assert(str_contains($fieldShellHtml, 'data-figma-synthetic-control="textarea"') && str_contains($fieldShellHtml, 'name="message" placeholder="Message"'), 'form-control-field-shell-emits-synthetic-message-textarea');
+    $assert(str_contains($fieldShellHtml, 'data-figma-synthetic-control="textarea"') && str_contains($fieldShellHtml, 'name="message-field-shell-message" placeholder="Message"'), 'form-control-field-shell-emits-synthetic-message-textarea');
+
+    $duplicateTextareaResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Duplicate Textarea Names Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'duplicate-textarea:root',
+                'type'     => 'FRAME',
+                'name'     => 'Comment Form',
+                'width'    => 640,
+                'height'   => 360,
+                'children' => array(
+                    array('id' => 'duplicate-textarea:first', 'type' => 'FRAME', 'name' => 'Comment textarea', 'width' => 420, 'height' => 128, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'duplicate-textarea:first-placeholder', 'type' => 'TEXT', 'name' => 'Placeholder', 'characters' => 'Leave a comment'),
+                    )),
+                    array('id' => 'duplicate-textarea:second', 'type' => 'FRAME', 'name' => 'Comment textarea', 'width' => 420, 'height' => 128, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'duplicate-textarea:second-placeholder', 'type' => 'TEXT', 'name' => 'Placeholder', 'characters' => 'Leave a comment'),
+                    )),
+                    array('id' => 'duplicate-textarea:submit', 'type' => 'FRAME', 'name' => 'Submit button', 'width' => 120, 'height' => 44, 'cornerRadius' => 8, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))), 'children' => array(
+                        array('id' => 'duplicate-textarea:submit-text', 'type' => 'TEXT', 'name' => 'Button', 'characters' => 'Post Comment'),
+                    )),
+                ),
+            ),
+        ),
+    ));
+    $duplicateTextareaHtml = $fileContent($duplicateTextareaResult, 'index.html');
+    $assert(str_contains($duplicateTextareaHtml, 'name="comment-duplicate-textarea-first"') && str_contains($duplicateTextareaHtml, 'name="comment-duplicate-textarea-second"'), 'form-control-textarea-names-derive-from-node-id');
+    $assert(0 === preg_match('/name="comment"/', $duplicateTextareaHtml), 'form-control-textarea-does-not-emit-duplicate-generic-name');
+
+    $outsideSubmitResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Action Button Outside Form Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'outside-submit:root',
+                'type'     => 'FRAME',
+                'name'     => 'Hero actions',
+                'children' => array(
+                    array('id' => 'outside-submit:button', 'type' => 'FRAME', 'name' => 'Subscribe button', 'width' => 140, 'height' => 44, 'cornerRadius' => 999, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))), 'children' => array(
+                        array('id' => 'outside-submit:button-text', 'type' => 'TEXT', 'name' => 'Button', 'characters' => 'Subscribe'),
+                    )),
+                ),
+            ),
+        ),
+    ));
+    $outsideSubmitHtml = $fileContent($outsideSubmitResult, 'index.html');
+    $assert(str_contains($outsideSubmitHtml, '<button class="figma-node-outside-submit-button-subscribe-button"') && str_contains($outsideSubmitHtml, 'type="button" data-figma-action-intent="submit"'), 'form-control-outside-submit-button-emits-safe-action-metadata');
 }


### PR DESCRIPTION
## Summary
- keep submit-like buttons outside real forms as safe `type="button"` controls with `data-figma-action-intent="submit"` metadata
- make emitted form control names page-unique while preserving the first canonical name such as `s` or `email`
- derive textarea names from intent plus node id so comment/message controls avoid duplicate synthetic names
- extend the existing Figma form-control contract coverage for duplicate textarea names and out-of-form submit actions

## Before/after diagnostics
FSE fixture: `/Users/chubes/Developer/blocks-engine/figma-transformer/fixtures/🛠️ FSE Pilot Build Theme.fig`

- Before artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/blocks-engine-form-semantics-before/fse-pilot-build-theme`
- After artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/blocks-engine-form-semantics-after/fse-pilot-build-theme`
- Forms: `6 -> 6`
- Inputs: `24 -> 24`
- Textareas: `0 -> 0`
- Buttons: `23 -> 23`
- Submit buttons outside forms: `9 -> 0`
- Explicit action metadata outside forms: `0 -> 9`
- Duplicate form control names: `9 -> 0`

TT5 sanity fixture: `/Users/chubes/Downloads/Twenty Twenty-Five (Community).fig`

- Before artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/blocks-engine-form-semantics-tt5-before/twenty-twenty-five-community`
- After artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/blocks-engine-form-semantics-tt5-after/twenty-twenty-five-community`
- Forms: `0 -> 0`
- Inputs: `0 -> 0`
- Textareas: `0 -> 0`
- Buttons: `15 -> 15`
- Submit buttons outside forms: `11 -> 0`
- Explicit action metadata outside forms: `0 -> 11`
- Duplicate form control names: `0 -> 0`

## Verification
- `composer test` from `figma-transformer/`
- FSE fixture matrix transform with `--max-pages=6 --max-nodes=20000`
- TT5 fixture matrix transform with `--max-pages=6 --max-nodes=20000`
- targeted HTML form/control scanner over before/after artifacts

## Notes
- Strictly `.fig -> HTML`; this does not create or modify WordPress blocks.
- The generated fixture matrix still reports existing non-form quality warnings such as giant fixed section risk and missing semantic roles; those are unchanged by this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Drafted and verified the form-control semantics patch, contract tests, fixture generation, and PR evidence.