### PR TITLE
Improve sidebar form column detection

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -57,6 +57,10 @@ final class ColumnsPattern
                 continue;
             }
 
+            if ( XML_COMMENT_NODE === $child->nodeType ) {
+                continue;
+            }
+
             if ( ! $child instanceof DOMElement ) {
                 return null;
             }
@@ -170,8 +174,8 @@ final class ColumnsPattern
 
             $name = strtolower(trim($child->tagName . ' ' . $this->attr($child, 'class') . ' ' . $this->attr($child, 'id') . ' ' . $this->attr($child, 'role')));
             $hasSidebar = $hasSidebar || (bool) preg_match('/(?:^|[\s_-])(?:aside|sidebar|toc|table[\s_-]+of[\s_-]+contents)(?:$|[\s_-])/', $name);
-            $hasContent = $hasContent || in_array(strtolower($child->tagName), array( 'article', 'main' ), true)
-                || (bool) preg_match('/(?:^|[\s_-])(?:main|content|article|docs?[\s_-]+content|documentation[\s_-]+content)(?:$|[\s_-])/', $name);
+            $hasContent = $hasContent || in_array(strtolower($child->tagName), array( 'article', 'form', 'main' ), true)
+                || (bool) preg_match('/(?:^|[\s_-])(?:main|content|article|form|docs?[\s_-]+content|documentation[\s_-]+content)(?:$|[\s_-])/', $name);
         }
 
         return $hasSidebar && $hasContent;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -963,6 +963,18 @@ $assert(array() === ($asideContainer['fallbacks'] ?? array()), 'semantic aside c
 $assert(str_contains($asideSerialized, 'sidebar'), 'semantic aside container preserves CSS-addressable sidebar class');
 $assert(str_contains($asideSerialized, '<!-- wp:navigation'), 'semantic aside container preserves nested navigation patterns');
 
+$sidebarFormLayout = ( new HtmlTransformer() )->transform(
+    '<main><div class="contact-content"><!-- left rail --><aside class="contact-sidebar"><h2>Booking</h2><p>Email us.</p></aside><!-- form pane --><div class="contact-form-wrap"><h2>Contact</h2><form><label>Name<input name="name"></label><button type="submit">Send</button></form></div></div></main>',
+    array(
+        'strict'          => true,
+        'allow_fallbacks' => true,
+    )
+)->toArray();
+$sidebarFormSerialized = (string) ($sidebarFormLayout['serialized_blocks'] ?? '');
+$assert(str_contains($sidebarFormSerialized, '<!-- wp:columns'), 'sidebar plus form layouts convert to native columns instead of one raw HTML island');
+$assert(str_contains($sidebarFormSerialized, 'contact-sidebar'), 'sidebar plus form layout preserves sidebar class on the column wrapper');
+$assert(str_contains($sidebarFormSerialized, 'contact-form-wrap'), 'sidebar plus form layout preserves form-side class on the column wrapper');
+
 $nonprofitNavigation = ( new HtmlTransformer() )->transform(
     '<header><nav aria-label="Main navigation"><ul><li><a href="/">Home</a></li><li><a href="/the-measure/">The Measure</a></li><li><a href="/supporters/">Supporters</a></li><li><a href="/volunteer/">Volunteer</a></li><li><a href="/donate/">Donate</a></li><li><a href="/faq/">FAQ</a></li><li><a href="/vote-yes/">Vote YES</a></li></ul></nav></header><main><h1>Campaign</h1></main><footer>Paid for by neighbors.</footer>',
     array(


### PR DESCRIPTION
## Summary
- Ignore HTML comments when evaluating candidate column containers.
- Treat a form-tagged sibling as the content pane when paired with a sidebar child.
- Add contract coverage for a commented sidebar-plus-form layout converting to native columns.

## Verification
- php tests/contract/run.php
- php tests/unit/button-signal-classifier.php
- Direct Artist contact transform emits one core/columns block.
- SSI Artist focused surface matrix rerun: run id 9091e2c3-efeb-42d6-a48e-76245048b8f5, still failing on remaining visual/editor/runtime blockers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigation, implementation, focused verification, and PR drafting.