### PR TITLE
Add Figma HTML visual risk matrix metrics

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix-quality.php
+++ b/figma-transformer/scripts/figma-fixture-matrix-quality.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param array<int, array<string, mixed>> $fixtures
+ * @return array<string, mixed>
+ */
+function matrix_quality_matrix(array $fixtures): array
+{
+    $keys = array(
+        'missing_asset_nodes',
+        'vector_placeholders',
+        'image_block_count',
+        'vector_image_fallbacks',
+        'media_query_count',
+        'fixed_width_over_desktop_count',
+        'fixed_width_declaration_count',
+        'fixed_width_without_responsive_override_count',
+        'giant_fixed_section_count',
+        'large_overflow_risk_count',
+        'fallback_prone_form_island_count',
+        'fallback_prone_svg_island_count',
+        'fallback_prone_input_island_count',
+        'invalid_list_child_count',
+        'missing_semantic_role_count',
+        'missing_emitted_text_nodes',
+        'layout_mismatch_count',
+        'render_style_mismatch_count',
+        'link_targets_unresolved',
+        'invalid_css_numeric_tokens',
+        'breakpoint_override_leak_count',
+        'large_absolute_offset_count',
+        'large_css_offset_count',
+        'large_negative_left_count',
+        'off_canvas_visual_node_count',
+        'clipped_visual_node_count',
+        'fixed_width_over_desktop_uncovered_count',
+        'uncomposed_vector_child_nodes',
+    );
+    $totals = array_fill_keys($keys, 0);
+    $qualityStatuses = array();
+    $signalCounts = array();
+    $riskBucketCounts = array_fill_keys(array('low', 'medium', 'high', 'critical', 'unknown'), 0);
+    $riskCategoryTotals = array_fill_keys(array('responsive_coverage', 'absolute_scaffolding', 'text_wrapping_leaks', 'image_geometry_fidelity', 'form_validity', 'route_coverage', 'unsupported_vectors'), 0);
+    $perFixtureReadiness = array();
+    $coverageNumerator = 0;
+    $coverageDenominator = 0;
+    $routeCoverageNumerator = 0;
+    $routeCoverageDenominator = 0;
+
+    foreach ( $fixtures as $fixture ) {
+        if ( ! is_array($fixture) ) {
+            continue;
+        }
+        $summary = is_array($fixture['quality_summary'] ?? null) ? $fixture['quality_summary'] : array();
+        foreach ( $keys as $key ) {
+            $totals[$key] += matrix_quality_summary_int($summary, $key);
+        }
+        $coverageNumerator += (int) ($summary['fixed_width_with_responsive_override_count'] ?? 0);
+        $coverageDenominator += (int) ($summary['fixed_width_declaration_count'] ?? 0);
+        $selectedRouteCount = count(is_array($fixture['selected_frame_ids'] ?? null) ? $fixture['selected_frame_ids'] : array());
+        $omittedRouteCount = count(is_array($fixture['omitted_page_candidates'] ?? null) ? $fixture['omitted_page_candidates'] : array());
+        $routeCoverageNumerator += $selectedRouteCount;
+        $routeCoverageDenominator += $selectedRouteCount + $omittedRouteCount;
+        $status = isset($fixture['quality_status']) && is_scalar($fixture['quality_status']) ? (string) $fixture['quality_status'] : 'unknown';
+        $qualityStatuses[$status] = ($qualityStatuses[$status] ?? 0) + 1;
+        foreach ( is_array($fixture['artifact_quality']['signals'] ?? null) ? $fixture['artifact_quality']['signals'] : array() as $signal ) {
+            if ( ! is_array($signal) || ! isset($signal['code']) || ! is_scalar($signal['code']) ) {
+                continue;
+            }
+            $code = (string) $signal['code'];
+            $signalCounts[$code] = ($signalCounts[$code] ?? 0) + 1;
+        }
+
+        $readiness = is_array($fixture['visual_readiness'] ?? null) ? $fixture['visual_readiness'] : matrix_fixture_visual_readiness($fixture);
+        $bucket = isset($readiness['visual_risk_bucket']) && is_scalar($readiness['visual_risk_bucket']) ? (string) $readiness['visual_risk_bucket'] : 'unknown';
+        $riskBucketCounts[$bucket] = ($riskBucketCounts[$bucket] ?? 0) + 1;
+        foreach ( $riskCategoryTotals as $category => $_count ) {
+            $riskCategoryTotals[$category] += (int) ($readiness['risk_categories'][$category]['count'] ?? 0);
+        }
+        $perFixtureReadiness[] = array(
+            'id' => isset($fixture['id']) && is_scalar($fixture['id']) ? (string) $fixture['id'] : '',
+            'status' => $fixture['status'] ?? null,
+            'readiness_score' => $readiness['readiness_score'] ?? null,
+            'visual_risk_bucket' => $readiness['visual_risk_bucket'] ?? 'unknown',
+            'route_coverage_ratio' => $readiness['route_coverage_ratio'] ?? null,
+            'risk_categories' => $readiness['risk_categories'] ?? array(),
+        );
+    }
+
+    ksort($qualityStatuses);
+    ksort($signalCounts);
+    ksort($riskBucketCounts);
+
+    return array(
+        'schema' => 'blocks-engine/figma-transformer/fixture-matrix-quality/v1',
+        'fixture_count' => count($fixtures),
+        'quality_status_counts' => $qualityStatuses,
+        'signal_counts' => $signalCounts,
+        'visual_risk_bucket_counts' => $riskBucketCounts,
+        'risk_category_totals' => $riskCategoryTotals,
+        'per_fixture_readiness' => $perFixtureReadiness,
+        'effective_responsive_coverage_ratio' => $coverageDenominator > 0 ? round($coverageNumerator / $coverageDenominator, 3) : 1.0,
+        'route_coverage_ratio' => $routeCoverageDenominator > 0 ? round($routeCoverageNumerator / $routeCoverageDenominator, 3) : 1.0,
+        'totals' => $totals,
+    );
+}
+
+/**
+ * @param array<string, mixed> $fixture
+ * @return array<string, mixed>
+ */
+function matrix_fixture_visual_readiness(array $fixture): array
+{
+    $summary = is_array($fixture['quality_summary'] ?? null) ? $fixture['quality_summary'] : array();
+    $selectedRouteCount = count(is_array($fixture['selected_frame_ids'] ?? null) ? $fixture['selected_frame_ids'] : array());
+    $omittedRouteCount = count(is_array($fixture['omitted_page_candidates'] ?? null) ? $fixture['omitted_page_candidates'] : array());
+    $routeCoverageRatio = ($selectedRouteCount + $omittedRouteCount) > 0 ? round($selectedRouteCount / ($selectedRouteCount + $omittedRouteCount), 3) : 1.0;
+
+    $categories = array(
+        'responsive_coverage' => matrix_risk_category(
+            matrix_quality_summary_int($summary, 'fixed_width_without_responsive_override_count')
+                + matrix_quality_summary_int($summary, 'fixed_width_over_desktop_uncovered_count')
+                + (true === ($summary['desktop_canvas_without_responsive_breakpoints'] ?? null) ? 1 : 0),
+            array('fixed_width_without_responsive_override_count', 'fixed_width_over_desktop_uncovered_count', 'desktop_canvas_without_responsive_breakpoints')
+        ),
+        'absolute_scaffolding' => matrix_risk_category(
+            matrix_quality_summary_int($summary, 'large_absolute_offset_count')
+                + matrix_quality_summary_int($summary, 'large_css_offset_count')
+                + matrix_quality_summary_int($summary, 'large_negative_left_count')
+                + matrix_quality_summary_int($summary, 'off_canvas_visual_node_count')
+                + matrix_quality_summary_int($summary, 'clipped_visual_node_count')
+                + matrix_quality_summary_int($summary, 'giant_fixed_section_count')
+                + matrix_quality_summary_int($summary, 'large_overflow_risk_count'),
+            array('large_absolute_offset_count', 'large_css_offset_count', 'large_negative_left_count', 'off_canvas_visual_node_count', 'clipped_visual_node_count', 'giant_fixed_section_count', 'large_overflow_risk_count')
+        ),
+        'text_wrapping_leaks' => matrix_risk_category(
+            matrix_quality_summary_int($summary, 'missing_emitted_text_nodes')
+                + matrix_quality_summary_int($summary, 'breakpoint_override_leak_count')
+                + matrix_quality_summary_int($summary, 'layout_mismatch_count')
+                + matrix_quality_summary_int($summary, 'render_style_mismatch_count'),
+            array('missing_emitted_text_nodes', 'breakpoint_override_leak_count', 'layout_mismatch_count', 'render_style_mismatch_count')
+        ),
+        'image_geometry_fidelity' => matrix_risk_category(
+            matrix_quality_summary_int($summary, 'missing_asset_nodes')
+                + matrix_quality_summary_int($summary, 'vector_image_fallbacks')
+                + matrix_quality_summary_int($summary, 'image_heavy_landmark_candidates'),
+            array('missing_asset_nodes', 'vector_image_fallbacks', 'image_heavy_landmark_candidates')
+        ),
+        'form_validity' => matrix_risk_category(
+            matrix_quality_summary_int($summary, 'fallback_prone_form_island_count')
+                + matrix_quality_summary_int($summary, 'fallback_prone_input_island_count')
+                + matrix_quality_summary_int($summary, 'invalid_list_child_count')
+                + matrix_quality_summary_int($summary, 'missing_semantic_role_count'),
+            array('fallback_prone_form_island_count', 'fallback_prone_input_island_count', 'invalid_list_child_count', 'missing_semantic_role_count')
+        ),
+        'route_coverage' => matrix_risk_category(
+            matrix_quality_summary_int($summary, 'link_targets_unresolved') + $omittedRouteCount,
+            array('link_targets_unresolved', 'omitted_page_candidates')
+        ),
+        'unsupported_vectors' => matrix_risk_category(
+            matrix_quality_summary_int($summary, 'vector_placeholders')
+                + matrix_quality_summary_int($summary, 'uncomposed_vector_child_nodes')
+                + ((float) ($summary['vector_decode_coverage_ratio'] ?? 1.0) < 1.0 ? 1 : 0),
+            array('vector_placeholders', 'uncomposed_vector_child_nodes', 'vector_decode_coverage_ratio')
+        ),
+    );
+
+    $riskPoints = 0;
+    foreach ( $categories as $category ) {
+        $riskPoints += min(25, (int) ($category['count'] ?? 0));
+    }
+    $readinessScore = max(0, 100 - $riskPoints);
+
+    return array(
+        'schema' => 'blocks-engine/figma-transformer/fixture-visual-readiness/v1',
+        'readiness_score' => $readinessScore,
+        'visual_risk_bucket' => matrix_visual_risk_bucket($readinessScore),
+        'route_coverage_ratio' => $routeCoverageRatio,
+        'risk_categories' => $categories,
+    );
+}
+
+function matrix_visual_risk_bucket(int $readinessScore): string
+{
+    if ( $readinessScore >= 90 ) {
+        return 'low';
+    }
+    if ( $readinessScore >= 75 ) {
+        return 'medium';
+    }
+    if ( $readinessScore >= 50 ) {
+        return 'high';
+    }
+
+    return 'critical';
+}
+
+/**
+ * @param array<int, string> $signals
+ * @return array{count: int, signals: array<int, string>}
+ */
+function matrix_risk_category(int $count, array $signals): array
+{
+    return array(
+        'count' => $count,
+        'signals' => $signals,
+    );
+}
+
+/**
+ * @param array<string, mixed> $summary
+ */
+function matrix_quality_summary_int(array $summary, string $key): int
+{
+    if ( isset($summary[$key]) && is_numeric($summary[$key]) ) {
+        return (int) $summary[$key];
+    }
+
+    if ( isset($summary['html_artifact']) && is_array($summary['html_artifact']) && isset($summary['html_artifact'][$key]) && is_numeric($summary['html_artifact'][$key]) ) {
+        return (int) $summary['html_artifact'][$key];
+    }
+
+    return 0;
+}

--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 $root = dirname(__DIR__, 2);
 $figmaRoot = $root . '/figma-transformer';
 require_once __DIR__ . '/figma-fixture-selection.php';
+require_once __DIR__ . '/figma-fixture-matrix-quality.php';
 
 $options = matrix_options($argv);
 if ( true === ($options['help'] ?? false) ) {
@@ -270,6 +271,7 @@ foreach ( $fixtures as $fixture ) {
                     $record['parity']['layout_mismatch_count'] = $record['quality_summary']['layout_mismatch_count'] ?? $record['parity']['layout_mismatch_count'];
                     $record['parity']['layout_mismatch_status'] = $record['quality_summary']['layout_mismatch_status'] ?? null;
                 }
+                $record['visual_readiness'] = matrix_fixture_visual_readiness($record);
             }
         }
     }
@@ -283,74 +285,6 @@ if ( ! $dryRun ) {
 }
 
 echo json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
-
-/**
- * @param array<int, array<string, mixed>> $fixtures
- * @return array<string, mixed>
- */
-function matrix_quality_matrix(array $fixtures): array
-{
-    $keys = array(
-        'missing_asset_nodes',
-        'vector_placeholders',
-        'image_block_count',
-        'vector_image_fallbacks',
-        'media_query_count',
-        'fixed_width_over_desktop_count',
-        'fixed_width_declaration_count',
-        'fixed_width_without_responsive_override_count',
-        'giant_fixed_section_count',
-        'large_overflow_risk_count',
-        'fallback_prone_form_island_count',
-        'fallback_prone_svg_island_count',
-        'fallback_prone_input_island_count',
-        'invalid_list_child_count',
-        'missing_semantic_role_count',
-        'missing_emitted_text_nodes',
-        'layout_mismatch_count',
-        'render_style_mismatch_count',
-        'link_targets_unresolved',
-        'invalid_css_numeric_tokens',
-    );
-    $totals = array_fill_keys($keys, 0);
-    $qualityStatuses = array();
-    $signalCounts = array();
-    $coverageNumerator = 0;
-    $coverageDenominator = 0;
-
-    foreach ( $fixtures as $fixture ) {
-        if ( ! is_array($fixture) ) {
-            continue;
-        }
-        $summary = is_array($fixture['quality_summary'] ?? null) ? $fixture['quality_summary'] : array();
-        foreach ( $keys as $key ) {
-            $totals[$key] += (int) ($summary[$key] ?? 0);
-        }
-        $coverageNumerator += (int) ($summary['fixed_width_with_responsive_override_count'] ?? 0);
-        $coverageDenominator += (int) ($summary['fixed_width_declaration_count'] ?? 0);
-        $status = isset($fixture['quality_status']) && is_scalar($fixture['quality_status']) ? (string) $fixture['quality_status'] : 'unknown';
-        $qualityStatuses[$status] = ($qualityStatuses[$status] ?? 0) + 1;
-        foreach ( is_array($fixture['artifact_quality']['signals'] ?? null) ? $fixture['artifact_quality']['signals'] : array() as $signal ) {
-            if ( ! is_array($signal) || ! isset($signal['code']) || ! is_scalar($signal['code']) ) {
-                continue;
-            }
-            $code = (string) $signal['code'];
-            $signalCounts[$code] = ($signalCounts[$code] ?? 0) + 1;
-        }
-    }
-
-    ksort($qualityStatuses);
-    ksort($signalCounts);
-
-    return array(
-        'schema' => 'blocks-engine/figma-transformer/fixture-matrix-quality/v1',
-        'fixture_count' => count($fixtures),
-        'quality_status_counts' => $qualityStatuses,
-        'signal_counts' => $signalCounts,
-        'effective_responsive_coverage_ratio' => $coverageDenominator > 0 ? round($coverageNumerator / $coverageDenominator, 3) : 1.0,
-        'totals' => $totals,
-    );
-}
 
 function matrix_options(array $argv): array
 {

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../../scripts/figma-fixture-matrix-quality.php';
+
 /**
  * @param callable(bool, string): void $assert
  */
@@ -216,6 +218,66 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     );
     $canonicalTemplateSelection = matrix_select_frame_ids($canonicalTemplateSelectionInspection, 3);
     $canonicalTemplateOmissions = matrix_omitted_page_candidate_records($canonicalTemplateSelectionInspection, $canonicalTemplateSelection);
+    $matrixVisualReadiness = matrix_fixture_visual_readiness(array(
+        'id'                 => 'risk-fixture',
+        'selected_frame_ids' => array('frame:home'),
+        'omitted_page_candidates' => array(array('id' => 'frame:contact')),
+        'quality_summary'    => array(
+            'fixed_width_without_responsive_override_count' => 2,
+            'fixed_width_over_desktop_uncovered_count' => 1,
+            'desktop_canvas_without_responsive_breakpoints' => true,
+            'large_absolute_offset_count' => 3,
+            'large_css_offset_count' => 1,
+            'missing_emitted_text_nodes' => 4,
+            'layout_mismatch_count' => 2,
+            'missing_asset_nodes' => 1,
+            'fallback_prone_form_island_count' => 1,
+            'fallback_prone_input_island_count' => 2,
+            'link_targets_unresolved' => 1,
+            'vector_placeholders' => 2,
+            'vector_decode_coverage_ratio' => 0.8,
+            'html_artifact' => array(
+                'breakpoint_override_leak_count' => 1,
+            ),
+        ),
+    ));
+    $matrixQualitySummary = matrix_quality_matrix(array(
+        array(
+            'id' => 'ready-fixture',
+            'status' => 'completed',
+            'quality_status' => 'pass',
+            'selected_frame_ids' => array('frame:home', 'frame:about'),
+            'omitted_page_candidates' => array(),
+            'quality_summary' => array(
+                'fixed_width_declaration_count' => 4,
+                'fixed_width_with_responsive_override_count' => 4,
+                'vector_decode_coverage_ratio' => 1.0,
+            ),
+            'artifact_quality' => array('signals' => array()),
+        ),
+        array(
+            'id' => 'risk-fixture',
+            'status' => 'completed',
+            'quality_status' => 'warn',
+            'selected_frame_ids' => array('frame:home'),
+            'omitted_page_candidates' => array(array('id' => 'frame:contact')),
+            'quality_summary' => array(
+                'fixed_width_declaration_count' => 4,
+                'fixed_width_with_responsive_override_count' => 1,
+                'fixed_width_without_responsive_override_count' => 3,
+                'fallback_prone_input_island_count' => 2,
+                'link_targets_unresolved' => 1,
+                'vector_placeholders' => 1,
+                'html_artifact' => array(
+                    'breakpoint_override_leak_count' => 2,
+                ),
+            ),
+            'artifact_quality' => array('signals' => array(
+                array('code' => 'responsive_fixed_width_without_override'),
+                array('code' => 'fallback_prone_html_islands'),
+            )),
+        ),
+    ));
 
     $matrixSelectionLockPath = $matrixFixtureDir . '/selection-lock.json';
     file_put_contents($matrixSelectionLockPath, json_encode(array(
@@ -295,6 +357,16 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(! in_array('frame:comments-utility', $componentComposedFrontPageSelection, true), 'fixture-matrix-selection-skips-utility-template-frame');
     $assert(array('frame:home-desktop', 'frame:single-desktop', 'frame:archive-desktop', 'frame:404-desktop', 'frame:page-desktop') === $canonicalTemplateSelection, 'fixture-matrix-selection-preserves-canonical-template-coverage-under-page-cap');
     $assert('frame:contact-desktop' === ($canonicalTemplateOmissions[0]['id'] ?? null), 'fixture-matrix-selection-reports-omitted-page-candidates');
+    $assert('medium' === ($matrixVisualReadiness['visual_risk_bucket'] ?? null), 'fixture-matrix-visual-readiness-buckets-risk');
+    $assert(0.5 === ($matrixVisualReadiness['route_coverage_ratio'] ?? null), 'fixture-matrix-visual-readiness-route-coverage');
+    $assert(4 === ($matrixVisualReadiness['risk_categories']['responsive_coverage']['count'] ?? null), 'fixture-matrix-visual-readiness-responsive-risk-count');
+    $assert(7 === ($matrixVisualReadiness['risk_categories']['text_wrapping_leaks']['count'] ?? null), 'fixture-matrix-visual-readiness-text-risk-count');
+    $assert('blocks-engine/figma-transformer/fixture-matrix-quality/v1' === ($matrixQualitySummary['schema'] ?? null), 'fixture-matrix-quality-schema');
+    $assert(0.625 === ($matrixQualitySummary['effective_responsive_coverage_ratio'] ?? null), 'fixture-matrix-quality-responsive-coverage-ratio');
+    $assert(0.75 === ($matrixQualitySummary['route_coverage_ratio'] ?? null), 'fixture-matrix-quality-route-coverage-ratio');
+    $assert(2 === ($matrixQualitySummary['totals']['breakpoint_override_leak_count'] ?? null), 'fixture-matrix-quality-nested-html-artifact-total');
+    $assert(3 === ($matrixQualitySummary['risk_category_totals']['responsive_coverage'] ?? null), 'fixture-matrix-quality-risk-category-total');
+    $assert(2 === count($matrixQualitySummary['per_fixture_readiness'] ?? array()), 'fixture-matrix-quality-per-fixture-readiness');
     $assert(is_array($matrixAliasSummary), 'fixture-matrix-alias-json-summary');
     $assert('/opt/homeboy-alias' === ($matrixAliasSummary['homeboy_command'] ?? null), 'fixture-matrix-homeboy-bin-alias');
     $assert(true === ($matrixAliasSummary['dom_box_provider_command_configured'] ?? null), 'fixture-matrix-dom-box-command-alias-configured');


### PR DESCRIPTION
## Summary
- Adds derived Figma HTML visual-readiness diagnostics to the fixture matrix output.
- Adds per-fixture `visual_readiness` with score, risk bucket, route coverage, and risk categories.
- Expands aggregate `quality_matrix` metrics with visual-risk bucket counts, risk category totals, per-fixture readiness, route coverage, and additional visual-risk totals.
- Keeps scope to Blocks Engine Figma artifact diagnostics; no SSI or WordPress block import changes.

## New matrix metrics
- `fixtures[].visual_readiness.readiness_score`
- `fixtures[].visual_readiness.visual_risk_bucket`
- `fixtures[].visual_readiness.route_coverage_ratio`
- `fixtures[].visual_readiness.risk_categories`
- `quality_matrix.visual_risk_bucket_counts`
- `quality_matrix.risk_category_totals`
- `quality_matrix.per_fixture_readiness`
- `quality_matrix.route_coverage_ratio`
- additional totals for breakpoint leaks, absolute/off-canvas/clipped geometry, uncovered desktop fixed widths, and uncomposed vector children

## Validation
- `composer test:contract` in `figma-transformer`
- `php -l figma-transformer/scripts/figma-fixture-matrix.php`
- `php -l figma-transformer/scripts/figma-fixture-matrix-quality.php`
- `php -l figma-transformer/tests/contract/FixtureMatrixContract.php`
- Generated a latest matrix locally for the three known Figma fixtures: FSE Pilot Build Theme, Dr Aarti Nasta, and Design Early Medical / Peter Attia. All completed.

## Matrix snapshot
- Aggregate responsive coverage: `0.575`
- Aggregate route coverage: `0.145`
- Risk buckets: `critical: 3`
- Per-fixture readiness: FSE Pilot Build Theme `43 / critical`; Dr Aarti Nasta `41 / critical`; Design Early Medical / Peter Attia `0 / critical`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Drafted and verified the matrix diagnostics helper, contract coverage, local fixture matrix run, and PR text.