### PR TITLE
Reduce Figma HTML flow scaffolding

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1022,7 +1022,7 @@ final class StaticHtmlEmitter
         if ( null !== $semanticRole ) {
             $attributes .= ' data-figma-semantic-role="' . $this->sanitizeAttribute($semanticRole) . '"';
         }
-        if ( $this->layoutIntentShouldEmitClass($layoutIntent) ) {
+        if ( is_array($layoutIntent) && ($this->layoutIntentShouldEmitClass($layoutIntent) || ($this->freeformContainerShouldUseFlow($node) && ! $this->nodeWillPositionAbsolute($node, $parentNode))) ) {
             $attributes .= $this->layoutIntentAttributes($layoutIntent);
         }
         $anchorId = $this->headingAnchorId($node, $tag);
@@ -2173,13 +2173,7 @@ final class StaticHtmlEmitter
     {
         $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node);
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        if ( empty($layout['display'] ?? null) && is_array($layoutIntent) && in_array($layoutIntent['intent'] ?? '', array(
-            LayoutIntentClassifier::LAYOUT_INTENT_CARD_ROW,
-            LayoutIntentClassifier::LAYOUT_INTENT_CARD_GRID,
-            LayoutIntentClassifier::LAYOUT_INTENT_PRICING_GRID,
-            LayoutIntentClassifier::LAYOUT_INTENT_SERVICE_GRID,
-            LayoutIntentClassifier::LAYOUT_INTENT_ARTICLE_GRID,
-        ), true) ) {
+        if ( empty($layout['display'] ?? null) && $this->layoutIntentCanUseFlow($layoutIntent) && $this->isContentOnlyFlowScaffold($node) ) {
             return true;
         }
 
@@ -6331,7 +6325,7 @@ final class StaticHtmlEmitter
         }
 
         $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node, $parentNode);
-        if ( empty($layout['display'] ?? null) && $this->layoutIntentShouldEmitClass($layoutIntent) ) {
+        if ( empty($layout['display'] ?? null) && is_array($layoutIntent) && ($this->layoutIntentShouldEmitClass($layoutIntent) || ($this->freeformContainerShouldUseFlow($node) && ! $positioningStyleDecision->willPositionAbsolute)) ) {
             foreach ( $this->layoutIntentStyles($layoutIntent) as $style ) {
                 $styles[] = $style;
             }
@@ -6452,6 +6446,96 @@ final class StaticHtmlEmitter
     private function layoutIntentShouldEmitClass(?array $layoutIntent): bool
     {
         return is_array($layoutIntent) && null !== ($layoutIntent['collection'] ?? null);
+    }
+
+    /** @param array<string, mixed>|null $layoutIntent */
+    private function layoutIntentCanUseFlow(?array $layoutIntent): bool
+    {
+        return is_array($layoutIntent) && in_array($layoutIntent['intent'] ?? '', array(
+            LayoutIntentClassifier::LAYOUT_INTENT_FLOW_SECTION,
+            LayoutIntentClassifier::LAYOUT_INTENT_STACK,
+            LayoutIntentClassifier::LAYOUT_INTENT_NAV_ROW,
+            LayoutIntentClassifier::LAYOUT_INTENT_CARD_ROW,
+            LayoutIntentClassifier::LAYOUT_INTENT_CARD_GRID,
+            LayoutIntentClassifier::LAYOUT_INTENT_PRICING_GRID,
+            LayoutIntentClassifier::LAYOUT_INTENT_SERVICE_GRID,
+            LayoutIntentClassifier::LAYOUT_INTENT_ARTICLE_GRID,
+            LayoutIntentClassifier::LAYOUT_INTENT_CTA,
+        ), true);
+    }
+
+    /** @param array<string, mixed> $node */
+    private function isContentOnlyFlowScaffold(array $node): bool
+    {
+        if ( in_array(strtoupper((string) ($node['type'] ?? '')), array('COMPONENT', 'INSTANCE'), true) ) {
+            return false;
+        }
+
+        if ( $this->subtreeHasComponentCloneGeometry($node) || $this->hasDecorativeFlexUnderlayChild($node) || null !== $this->layoutIntentClassifier()->chromeGroupRole($node, null, 1) ) {
+            return false;
+        }
+
+        $name = strtolower((string) ($node['name'] ?? ''));
+        if ( ! preg_match('/\b(section|content|main|hero|intro|cards?|grid|columns?|services?|features?|articles?|posts?|pricing|plans?|cta|call to action)\b/', $name) ) {
+            return false;
+        }
+
+        $contentChildren = 0;
+        foreach ( array_values(array_filter($this->nodeList($node), 'is_array')) as $child ) {
+            if ( $this->subtreeIsDecorativeSeparator($child) || $this->isFullyClippedDecorativeChild($child, $node) || $this->isDecorativeFlexUnderlay($child, $node) ) {
+                continue;
+            }
+            if ( $this->subtreeHasComponentCloneGeometry($child) ) {
+                return false;
+            }
+            if ( ! $this->subtreeHasText($child) && ! $this->subtreeHasLink($child) ) {
+                return false;
+            }
+            $layout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( 'absolute' !== ($layout['positioning'] ?? null) ) {
+                return false;
+            }
+            ++$contentChildren;
+        }
+
+        return $contentChildren >= 2;
+    }
+
+    /**
+     * @param array<string, mixed>      $node
+     * @param array<string, mixed>|null $parentNode
+     */
+    private function nodeWillPositionAbsolute(array $node, ?array $parentNode): bool
+    {
+        if ( null === $parentNode ) {
+            return false;
+        }
+
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        return ($this->isFreeformContainer($parentNode) && ! $this->freeformContainerShouldUseFlow($parentNode))
+            || ('absolute' === ($layout['positioning'] ?? null) && ! $this->freeformContainerShouldUseFlow($parentNode))
+            || $this->isDecorativeFlexUnderlay($node, $parentNode);
+    }
+
+    /** @param array<string, mixed> $node */
+    private function subtreeHasComponentCloneGeometry(array $node): bool
+    {
+        if ( true === ($node['_component_source_clone_geometry'] ?? false) || isset($node['figma_component_source_id']) ) {
+            return true;
+        }
+        foreach ( array('box', 'figma_box') as $boxKey ) {
+            $box = is_array($node[$boxKey] ?? null) ? $node[$boxKey] : array();
+            if ( 'component_source_clone' === ($box['geometry_semantics'] ?? null) ) {
+                return true;
+            }
+        }
+        foreach ( array_values(array_filter($this->nodeList($node), 'is_array')) as $child ) {
+            if ( $this->subtreeHasComponentCloneGeometry($child) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -140,6 +140,63 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     $qualityRootRule = blocks_engine_figma_transformer_contract_css_rule($qualityCss, '.figma-node-quality-root-desktop-fixed-root');
     $assert(str_contains($qualityRootRule, 'width:100%') && ! str_contains($qualityRootRule, 'max-width:1440px'), 'quality-diagnostics-root-fills-viewport-without-implicit-canvas-cap');
 
+    $flowScaffoldResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Flow Scaffold Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'flow-scaffold:root',
+                'type'     => 'FRAME',
+                'name'     => 'Content Section',
+                'width'    => 720,
+                'height'   => 420,
+                'children' => array(
+                    array(
+                        'id'                => 'flow-scaffold:intro',
+                        'type'              => 'TEXT',
+                        'name'              => 'Intro heading',
+                        'text'              => 'Flow content heading',
+                        'x'                 => 48,
+                        'y'                 => 64,
+                        'width'             => 360,
+                        'height'            => 48,
+                        'layoutPositioning' => 'ABSOLUTE',
+                    ),
+                    array(
+                        'id'                => 'flow-scaffold:body',
+                        'type'              => 'TEXT',
+                        'name'              => 'Body copy',
+                        'text'              => 'Body copy that follows the heading in source order.',
+                        'x'                 => 48,
+                        'y'                 => 136,
+                        'width'             => 420,
+                        'height'            => 64,
+                        'layoutPositioning' => 'ABSOLUTE',
+                    ),
+                    array(
+                        'id'                => 'flow-scaffold:cta',
+                        'type'              => 'TEXT',
+                        'name'              => 'Call to action',
+                        'text'              => 'Read more',
+                        'x'                 => 48,
+                        'y'                 => 232,
+                        'width'             => 120,
+                        'height'            => 32,
+                        'layoutPositioning' => 'ABSOLUTE',
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $flowScaffoldHtml = $fileContent($flowScaffoldResult, 'index.html');
+    $flowScaffoldCss = $fileContent($flowScaffoldResult, 'style.css');
+    $flowScaffoldRootRule = blocks_engine_figma_transformer_contract_css_rule($flowScaffoldCss, '.figma-node-flow-scaffold-root-content-section');
+    $flowScaffoldIntroRule = blocks_engine_figma_transformer_contract_css_rule($flowScaffoldCss, '.figma-node-flow-scaffold-intro-intro-heading');
+    $flowScaffoldBodyRule = blocks_engine_figma_transformer_contract_css_rule($flowScaffoldCss, '.figma-node-flow-scaffold-body-body-copy');
+    $assert(str_contains($flowScaffoldHtml, 'data-figma-layout-intent="nav-row"'), 'flow-scaffold-section-emits-layout-intent');
+    $assert(str_contains($flowScaffoldRootRule, 'display:flex') && str_contains($flowScaffoldRootRule, 'flex-direction:row'), 'flow-scaffold-section-emits-flow-css');
+    $assert(! str_contains($flowScaffoldIntroRule, 'position:absolute') && ! str_contains($flowScaffoldIntroRule, 'left:') && ! str_contains($flowScaffoldIntroRule, 'top:'), 'flow-scaffold-absolute-heading-enters-normal-flow');
+    $assert(! str_contains($flowScaffoldBodyRule, 'position:absolute') && ! str_contains($flowScaffoldBodyRule, 'left:') && ! str_contains($flowScaffoldBodyRule, 'top:'), 'flow-scaffold-absolute-body-enters-normal-flow');
+
     $socialIconResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'   => 'Social Icon Fixture',
         'assets' => array(


### PR DESCRIPTION
## Summary
- Adds a safe content-only flow scaffold path for Figma HTML containers whose children are explicitly absolute but classified as layout-intent flow.
- Emits layout-intent attributes/styles for those safe normal-flow containers while avoiding nodes that still position absolutely.
- Adds a contract fixture proving absolute text rows in a content section enter normal flow without left/top offsets.

## Verification
- php figma-transformer/tests/contract/run.php
- FSE fixture regenerated before/after from latest origin/trunk using figma-transformer/scripts/figma-fixture-matrix.php with the local FSE .fig fixture.

## FSE Artifact Counts
- Before raw generated HTML/CSS count: position:absolute=119, pixel/calc offset declarations=580.
- After raw generated HTML/CSS count: position:absolute=121, pixel/calc offset declarations=584.
- Readiness summary remained: large_css_offset_count=0, large_absolute_offset_count=0.

## Blockers / Notes
- This PR proves the safe synthetic content-scaffold path, but the current FSE fixture did not improve. It regressed by two nested absolute rules, so this should be reviewed as an incremental guarded primitive rather than the final FSE reduction.
- I could not locate local Fisiostetic or TT5 .fig fixtures in /Users/chubes/Developer or this Studio workspace, so those sanity runs were not performed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and verified the scoped Figma HTML transformer change, generated FSE artifacts, measured counts, and prepared this PR.