### PR TITLE
Refactor PHP button link dispatch

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -28,6 +28,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\ButtonLinkDispatchTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\FormDispatchTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\NavigationToggleSuppressionTrait;
@@ -39,6 +40,7 @@ use DOMNode;
 
 final class HtmlTransformer
 {
+    use ButtonLinkDispatchTrait;
     use DomHelpersTrait;
     use FormDispatchTrait;
     use NavigationToggleSuppressionTrait;
@@ -1202,66 +1204,11 @@ final class HtmlTransformer
         }
 
         if ( 'a' === $tagName ) {
-            $linkedLogo = $this->linkedSvgLogoBlockFromAnchor($element, $fallbacks);
-            if ( null !== $linkedLogo ) {
-                return $linkedLogo;
-            }
-
-            $logo = $this->logoPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
-            if ( null !== $logo ) {
-                return $logo;
-            }
-
-            $button = $this->buttonsPattern->matchAnchor(
-                $element,
-                fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
-            if ( null !== $button ) {
-                return $button;
-            }
-
-            if ( '' === trim($element->textContent ?? '') && '' !== $this->safeLinkUrl($this->attr($element, 'href')) && '' !== trim($this->attr($element, 'aria-label')) ) {
-                return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $this->outerHtml($element) )), array(), $element);
-            }
-
-            if ( '' === trim($element->textContent ?? '') ) {
-                return null;
-            }
-
-            if ( $this->hasBlockContentChildren($element) ) {
-                $linkWrapper = $this->convertLinkWrapperGroup($element, $fallbacks);
-                if ( null !== $linkWrapper ) {
-                    return $linkWrapper;
-                }
-            }
-
-            return $this->createBlock('core/paragraph', array( 'content' => $this->outerHtml($element) ), array(), $element);
+            return $this->convertAnchorDispatchElement($element, $fallbacks);
         }
 
         if ( 'button' === $tagName ) {
-            if ( $this->isRuntimeDomTarget($element) ) {
-                $this->recordRuntimeControlIsland($element);
-                return $this->htmlPreservationBlock($element);
-            }
-
-            return $this->buttonsPattern->matchButton(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            return $this->convertButtonDispatchElement($element);
         }
 
         if ( 'svg' === $tagName ) {

--- a/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
+
+use DOMElement;
+
+trait ButtonLinkDispatchTrait
+{
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    private function convertAnchorDispatchElement(DOMElement $element, array &$fallbacks): ?array
+    {
+        $linkedLogo = $this->linkedSvgLogoBlockFromAnchor($element, $fallbacks);
+        if ( null !== $linkedLogo ) {
+            return $linkedLogo;
+        }
+
+        $logo = $this->logoPattern->match(
+            $element,
+            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
+            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
+        );
+        if ( null !== $logo ) {
+            return $logo;
+        }
+
+        $button = $this->buttonsPattern->matchAnchor(
+            $element,
+            fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
+            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+            fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
+            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
+        );
+        if ( null !== $button ) {
+            return $button;
+        }
+
+        if ( '' === trim($element->textContent ?? '') && '' !== $this->safeLinkUrl($this->attr($element, 'href')) && '' !== trim($this->attr($element, 'aria-label')) ) {
+            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $this->outerHtml($element) )), array(), $element);
+        }
+
+        if ( '' === trim($element->textContent ?? '') ) {
+            return null;
+        }
+
+        if ( $this->hasBlockContentChildren($element) ) {
+            $linkWrapper = $this->convertLinkWrapperGroup($element, $fallbacks);
+            if ( null !== $linkWrapper ) {
+                return $linkWrapper;
+            }
+        }
+
+        return $this->createBlock('core/paragraph', array( 'content' => $this->outerHtml($element) ), array(), $element);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function convertButtonDispatchElement(DOMElement $element): ?array
+    {
+        if ( $this->isRuntimeDomTarget($element) ) {
+            $this->recordRuntimeControlIsland($element);
+            return $this->htmlPreservationBlock($element);
+        }
+
+        return $this->buttonsPattern->matchButton(
+            $element,
+            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
+        );
+    }
+}

--- a/php-transformer/tests/unit/button-signal-classifier.php
+++ b/php-transformer/tests/unit/button-signal-classifier.php
@@ -58,6 +58,17 @@ $assert('core/buttons' === ($result['blocks'][0]['blockName'] ?? ''), '11: style
 $assert('core/button' === ($button['blockName'] ?? ''), '12: styled anchor inner block is core/button', json_encode($button));
 $assert('/buy' === ($button['attrs']['url'] ?? ''), '13: styled anchor promotion preserves URL', json_encode($button['attrs'] ?? array()));
 
+$buttonResult = ( new HtmlTransformer() )->transform('<button style="padding:12px 18px;background:#135e96;color:#fff">Buy tickets</button>', array())->toArray();
+$nativeButton = $buttonResult['blocks'][0]['innerBlocks'][0] ?? array();
+$assert('core/buttons' === ($buttonResult['blocks'][0]['blockName'] ?? ''), '14: native button is dispatched to core/buttons', json_encode($buttonResult['blocks'] ?? array()));
+$assert('core/button' === ($nativeButton['blockName'] ?? ''), '15: native button inner block is core/button', json_encode($nativeButton));
+$assert('button' === ($nativeButton['attrs']['tagName'] ?? ''), '16: native button keeps button tagName', json_encode($nativeButton['attrs'] ?? array()));
+
+$plainLinkResult = ( new HtmlTransformer() )->transform('<a href="/about">About us</a>', array())->toArray();
+$plainLink = $plainLinkResult['blocks'][0] ?? array();
+$assert('core/paragraph' === ($plainLink['blockName'] ?? ''), '17: plain anchor stays paragraph rich text', json_encode($plainLinkResult['blocks'] ?? array()));
+$assert(str_contains((string) ($plainLink['innerHTML'] ?? ''), 'href="/about"'), '18: plain anchor preserves href in content', json_encode($plainLink ?? array()));
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "ButtonSignalClassifier unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary
- Extract anchor/button conversion dispatch from HtmlTransformer into ButtonLinkDispatchTrait.
- Preserve existing dispatch order for linked logos, logo pattern matching, button promotion, plain links, link wrappers, and runtime-preserved buttons.
- Add direct unit assertions for native button dispatch and plain link preservation.

## Tests
- php tests/unit/button-signal-classifier.php
- composer test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Implemented the behavior-preserving extraction, added focused assertions, and ran verification.