### PR TITLE
Improve Figma responsive row stacking

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -213,14 +213,26 @@ final class BreakpointMediaDiffBuilder
             $declarations[] = 'max-width:100%';
             if ( null !== $height && $height > 240.0 && 'absolute' !== $position ) {
                 $declarations[] = 'height:auto';
-                if ( ! $wrapsRow ) {
+                if ( ! $wrapsRow && ! $this->hasContainerChild($node) ) {
                     $declarations[] = 'min-height:' . ($this->number)(min($height, 720.0)) . 'px';
                 }
             }
             if ( $wrapsRow ) {
-                $declarations[] = 'flex-wrap:wrap';
-                $declarations[] = 'align-content:flex-start';
+                if ( $this->hasContainerChild($node) ) {
+                    $declarations[] = 'flex-direction:column';
+                    $declarations[] = 'align-items:stretch';
+                    $declarations[] = 'flex-wrap:nowrap';
+                } else {
+                    $declarations[] = 'flex-wrap:wrap';
+                    $declarations[] = 'align-content:flex-start';
+                }
             }
+
+            if ( in_array($display, array('grid', 'inline-grid'), true) && $this->hasContainerChild($node) ) {
+                $declarations[] = 'grid-template-columns:1fr';
+            }
+
+            array_push($declarations, ...$this->responsivePaddingClampDeclarations($baseMap));
         }
 
         if ( 'TEXT' === $type && null !== $width && $width > 320.0 ) {
@@ -240,6 +252,43 @@ final class BreakpointMediaDiffBuilder
         }
 
         return array_values(array_unique($declarations));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function hasContainerChild(array $node): bool
+    {
+        foreach ( ($this->nodeList)($node) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $childType = strtoupper((string) ($child['type'] ?? 'FRAME'));
+            if ( in_array($childType, array('FRAME', 'GROUP', 'INSTANCE', 'COMPONENT', 'SYMBOL', 'SECTION'), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, string> $baseMap
+     * @return array<int, string>
+     */
+    private function responsivePaddingClampDeclarations(array $baseMap): array
+    {
+        $declarations = array();
+        foreach ( array('top', 'right', 'bottom', 'left') as $edge ) {
+            $property = 'padding-' . $edge;
+            $padding = $this->cssPixelValue($baseMap[$property] ?? '');
+            if ( null !== $padding && $padding > 24.0 ) {
+                $declarations[] = $property . ':24px';
+            }
+        }
+
+        return $declarations;
     }
 
     /**

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -548,6 +548,61 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     $assert(str_contains($responsiveShellCss, '.figma-node-responsive-shell-padded-padded-content-shell{width:100%;max-width:1170px;height:48px;'), 'quality-diagnostics-padded-centered-flow-shell-renders-responsive-width');
     $assert(str_contains($responsiveShellCss, '.figma-node-responsive-shell-off-center-off-center-card{width:420px;height:48px;'), 'quality-diagnostics-off-center-flow-child-keeps-intrinsic-width');
 
+    $desktopOnlyResponsiveRowsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Desktop Only Responsive Rows Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'responsive-rows:root',
+                'type'     => 'FRAME',
+                'name'     => 'Desktop page',
+                'width'    => 1440,
+                'height'   => 1200,
+                'layoutMode' => 'VERTICAL',
+                'children' => array(
+                    array(
+                        'id'       => 'responsive-rows:hero',
+                        'type'     => 'FRAME',
+                        'name'     => 'Hero row',
+                        'width'    => 1216,
+                        'height'   => 420,
+                        'layoutMode' => 'HORIZONTAL',
+                        'paddingLeft' => 64,
+                        'paddingRight' => 64,
+                        'itemSpacing' => 48,
+                        'children' => array(
+                            array('id' => 'responsive-rows:hero-copy', 'type' => 'FRAME', 'name' => 'Hero copy', 'width' => 560, 'height' => 320, 'children' => array(
+                                array('id' => 'responsive-rows:hero-title', 'type' => 'TEXT', 'name' => 'Hero title', 'characters' => 'Fisiostetic', 'width' => 420, 'height' => 64, 'fontSize' => 48),
+                            )),
+                            array('id' => 'responsive-rows:hero-media', 'type' => 'FRAME', 'name' => 'Hero media', 'width' => 520, 'height' => 320),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'responsive-rows:pricing',
+                        'type'     => 'FRAME',
+                        'name'     => 'Pricing cards',
+                        'width'    => 1216,
+                        'height'   => 360,
+                        'layoutMode' => 'HORIZONTAL',
+                        'itemSpacing' => 24,
+                        'children' => array(
+                            array('id' => 'responsive-rows:price-a', 'type' => 'FRAME', 'name' => 'Price card', 'width' => 380, 'height' => 280),
+                            array('id' => 'responsive-rows:price-b', 'type' => 'FRAME', 'name' => 'Price card', 'width' => 380, 'height' => 280),
+                            array('id' => 'responsive-rows:price-c', 'type' => 'FRAME', 'name' => 'Price card', 'width' => 380, 'height' => 280),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $desktopOnlyResponsiveRowsCss = $fileContent($desktopOnlyResponsiveRowsResult, 'style.css');
+    $desktopOnlyResponsiveRowsTabletBlockPosition = strpos($desktopOnlyResponsiveRowsCss, '@media (max-width:1439px)');
+    $assert(false !== $desktopOnlyResponsiveRowsTabletBlockPosition, 'desktop-only-responsive-rows-emits-tablet-safety-block');
+    $desktopOnlyResponsiveRowsTabletBlock = false === $desktopOnlyResponsiveRowsTabletBlockPosition ? '' : substr($desktopOnlyResponsiveRowsCss, $desktopOnlyResponsiveRowsTabletBlockPosition);
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-hero-hero-row', array('width:100%', 'max-width:100%', 'height:auto', 'flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap', 'padding-right:24px', 'padding-left:24px'), 'desktop-only-responsive-hero-row-stacks-at-tablet');
+    blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-hero-hero-row', array('min-height:420px', 'flex-wrap:wrap'), 'desktop-only-responsive-hero-row-has-no-fixed-min-height-floor-or-wrap-only-layout');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap'), 'desktop-only-responsive-pricing-cards-stack-at-tablet');
+    blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('min-height:360px', 'flex-wrap:wrap'), 'desktop-only-responsive-pricing-cards-have-no-fixed-min-height-floor-or-wrap-only-layout');
+
     $fluidManagedStackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Fluid Managed Stack Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- Changes desktop-only Figma responsive fallback rows with container children from wrap-only behavior to deliberate column stacking with stretched children.
- Clamps oversized responsive padding and avoids adding fixed min-height floors for stacked row/card containers.
- Adds contract coverage for hero/card rows proving column stacking and no fixed min-height floor.

## Evidence
- Fresh Fisiostetic artifact generated with `php bin/figma-transformer "$FIGMA_FIXTURE" --zstd-command=/opt/homebrew/bin/zstd --output-dir=.artifacts/fisiostetic-after`.
- Before/after CSS shows Fisiostetic hero/services/process/about/pricing/map/final CTA responsive rules move from `flex-wrap:wrap;align-content:flex-start` plus min-height floors to `flex-direction:column;align-items:stretch;flex-wrap:nowrap`, with padding clamped to `24px` where applicable.
- Fisiostetic diagnostics after generation: `media_query_count: 2`, `effective_responsive_coverage_ratio: 0.444`, `fixed_width_over_desktop_count: 1`, `fixed_width_over_desktop_uncovered_count: 0`, `quality_status: warn`.
- Fixture matrix run: `php scripts/figma-fixture-matrix.php --fixture="$FISIOSTETIC_FIXTURE" --fixture="$FSE_FIXTURE" --zstd-command=/opt/homebrew/bin/zstd --output-dir=.artifacts/fixture-matrix`.
- Matrix result: Fisiostetic completed, readiness `74/high`; FSE sanity completed, readiness `42/critical` with existing giant-section/form-semantic warnings outside this PR scope.

## Tests
- `composer test` in `figma-transformer/`
- Fisiostetic + FSE fixture matrix command above

## Residual risks
- This PR stays within `.fig -> HTML/CSS/assets/artifact`; it does not validate downstream SSI or WordPress block conversion.
- Visual pixel parity was not run; matrix parity status remains `not_run`.
- Aggregate Fisiostetic responsive coverage ratio is unchanged because the change improves rule behavior for already-covered classes rather than changing covered-class counts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Implementing the responsive CSS policy, adding contract tests, generating local artifacts, and preparing verification evidence.
