### PR TITLE
Use proportional anchors for Figma media overlays

### DIFF
--- a/figma-transformer/src/Html/CssPositioningResolver.php
+++ b/figma-transformer/src/Html/CssPositioningResolver.php
@@ -46,10 +46,10 @@ final class CssPositioningResolver
             unset($constraints['horizontal'], $constraints['vertical']);
         }
 
-        foreach ( $this->axisConstraintStyles('horizontal', is_scalar($constraints['horizontal'] ?? null) ? (string) $constraints['horizontal'] : null, $left, $parentBox, $box, $layout, $parentNode, $centerWithinFluidCanvas, $parentIsFreeform) as $style ) {
+        foreach ( $this->axisConstraintStyles('horizontal', is_scalar($constraints['horizontal'] ?? null) ? (string) $constraints['horizontal'] : null, $left, $parentBox, $box, $layout, $parentNode, $node, $centerWithinFluidCanvas, $parentIsFreeform) as $style ) {
             $styles[] = $style;
         }
-        foreach ( $this->axisConstraintStyles('vertical', is_scalar($constraints['vertical'] ?? null) ? (string) $constraints['vertical'] : null, $top, $parentBox, $box, $layout, $parentNode) as $style ) {
+        foreach ( $this->axisConstraintStyles('vertical', is_scalar($constraints['vertical'] ?? null) ? (string) $constraints['vertical'] : null, $top, $parentBox, $box, $layout, $parentNode, $node, false, $parentIsFreeform) as $style ) {
             $styles[] = $style;
         }
 
@@ -246,7 +246,7 @@ final class CssPositioningResolver
      * @param array<string, mixed> $layout
      * @return array<int, string>
      */
-    private function axisConstraintStyles(string $axis, ?string $constraint, ?float $offset, array $parentBox, array $box, array $layout, ?array $parentNode, bool $centerWithinFluidCanvas = false, bool $parentIsFreeform = false): array
+    private function axisConstraintStyles(string $axis, ?string $constraint, ?float $offset, array $parentBox, array $box, array $layout, ?array $parentNode, ?array $node, bool $centerWithinFluidCanvas = false, bool $parentIsFreeform = false): array
     {
         $isHorizontal = 'horizontal' === $axis;
         $startProp = $isHorizontal ? 'left' : 'top';
@@ -259,6 +259,23 @@ final class CssPositioningResolver
         $constraint = null === $constraint ? null : strtoupper($constraint);
 
         $styles = array();
+
+        if ( null !== $offset && null !== $parentSize && null !== $boxSize && $this->shouldUseProportionalOverlayOffset($axis, $constraint, $parentBox, $box, $parentNode, $node, $parentIsFreeform) ) {
+            $percent = $this->number(( $offset / $parentSize ) * 100.0) . '%';
+            $trailing = $parentSize - $offset - $boxSize;
+            $trailingPercent = $this->number(( max(0.0, $trailing) / $parentSize ) * 100.0) . '%';
+
+            if ( $farPin === $constraint ) {
+                $styles[] = $endProp . ':' . $trailingPercent;
+                return $styles;
+            }
+
+            $styles[] = $startProp . ':' . $percent;
+            if ( $bothPin === $constraint && $trailing >= -0.5 ) {
+                $styles[] = $endProp . ':' . $trailingPercent;
+            }
+            return $styles;
+        }
 
         // Far-edge-only pin (REST RIGHT/BOTTOM, Kiwi MAX): anchor to the trailing
         // edge and drop the leading offset so the node stays glued on resize.
@@ -329,6 +346,119 @@ final class CssPositioningResolver
 
         $trailing = $parentSize - $offset - $boxSize;
         return abs($offset - $trailing) <= 1.0;
+    }
+
+    /**
+     * @param array<string, mixed> $parentBox
+     * @param array<string, mixed> $box
+     * @param array<string, mixed>|null $parentNode
+     * @param array<string, mixed>|null $node
+     */
+    private function shouldUseProportionalOverlayOffset(string $axis, ?string $constraint, array $parentBox, array $box, ?array $parentNode, ?array $node, bool $parentIsFreeform): bool
+    {
+        if ( null === $parentNode || null === $node || ! $parentIsFreeform || ! $this->isFluidMediaContainer($parentNode) || ! $this->isOverlayLikeChild($node, $box, $parentBox) ) {
+            return false;
+        }
+
+        $constraint = null === $constraint ? null : strtoupper($constraint);
+        $allowed = 'horizontal' === $axis ? array(null, 'LEFT', 'RIGHT', 'LEFT_RIGHT', 'SCALE') : array(null, 'TOP', 'BOTTOM', 'TOP_BOTTOM', 'SCALE');
+        return in_array($constraint, $allowed, true);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isFluidMediaContainer(array $node): bool
+    {
+        $name = strtolower((string) ($node['name'] ?? ''));
+        if ( 1 === preg_match('/\b(map|image|photo|picture|media)\b/', $name) ) {
+            return true;
+        }
+
+        $parentBox = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $parentArea = $this->area($parentBox);
+        if ( $parentArea <= 0.0 ) {
+            return false;
+        }
+
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) || ! $this->isMediaSurfaceNode($child) ) {
+                continue;
+            }
+
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : $child;
+            if ( $this->area($childBox) >= $parentArea * 0.5 ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $box
+     * @param array<string, mixed> $parentBox
+     */
+    private function isOverlayLikeChild(array $node, array $box, array $parentBox): bool
+    {
+        if ( $this->isImageBackedNode($node) ) {
+            return false;
+        }
+
+        $parentArea = $this->area($parentBox);
+        $childArea = $this->area($box);
+        if ( $parentArea <= 0.0 || $childArea <= 0.0 ) {
+            return false;
+        }
+
+        return $childArea <= $parentArea * 0.35;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isMediaSurfaceNode(array $node): bool
+    {
+        if ( $this->isImageBackedNode($node) ) {
+            return true;
+        }
+
+        $name = strtolower((string) ($node['name'] ?? ''));
+        return 1 === preg_match('/\b(map|image|photo|picture|media)\b/', $name);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function isImageBackedNode(array $node): bool
+    {
+        if ( isset($node['asset_id']) || isset($node['image_hash']) || isset($node['imageHash']) ) {
+            return true;
+        }
+
+        foreach ( array('fillPaints', 'fills') as $paintKey ) {
+            $paints = is_array($node[$paintKey] ?? null) ? $node[$paintKey] : array();
+            foreach ( $paints as $paint ) {
+                if ( is_array($paint) && 'IMAGE' === strtoupper((string) ($paint['type'] ?? '')) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $box
+     */
+    private function area(array $box): float
+    {
+        if ( ! isset($box['width'], $box['height']) || ! is_numeric($box['width']) || ! is_numeric($box['height']) ) {
+            return 0.0;
+        }
+
+        return max(0.0, (float) $box['width']) * max(0.0, (float) $box['height']);
     }
 
     /**

--- a/figma-transformer/tests/contract/ResponsiveOverlayAnchoringContract.php
+++ b/figma-transformer/tests/contract/ResponsiveOverlayAnchoringContract.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_responsive_overlay_anchoring_contract(callable $assert): void
+{
+    $imageHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    $scenegraph = array(
+        'name'   => 'Responsive overlay fixture',
+        'assets' => array(
+            $imageHash => array(
+                'name'      => 'Map Image',
+                'mime_type' => 'image/png',
+                'content'   => 'map image bytes',
+            ),
+        ),
+        'nodes'  => array(
+            array(
+                'id'         => 'overlay:root',
+                'type'       => 'FRAME',
+                'name'       => 'Overlay page',
+                'width'      => 1200,
+                'height'     => 800,
+                'layoutMode' => 'VERTICAL',
+                'children'   => array(
+                    array(
+                        'id'       => 'overlay:map',
+                        'type'     => 'FRAME',
+                        'name'     => 'Clinic map',
+                        'width'    => 800,
+                        'height'   => 400,
+                        'children' => array(
+                            array(
+                                'id'                => 'overlay:map-image',
+                                'type'              => 'RECTANGLE',
+                                'name'              => 'Map image',
+                                'width'             => 800,
+                                'height'            => 400,
+                                'layoutPositioning' => 'ABSOLUTE',
+                                'fillPaints'        => array(
+                                    array(
+                                        'type'  => 'IMAGE',
+                                        'image' => array('hash' => hex2bin($imageHash)),
+                                    ),
+                                ),
+                            ),
+                            array(
+                                'id'                => 'overlay:label',
+                                'type'              => 'FRAME',
+                                'name'              => 'Location label',
+                                'x'                 => 200,
+                                'y'                 => 100,
+                                'width'             => 160,
+                                'height'            => 40,
+                                'layoutPositioning' => 'ABSOLUTE',
+                                'fill'              => array('r' => 0.2, 'g' => 0.2, 'b' => 0.2),
+                            ),
+                            array(
+                                'id'                => 'overlay:pin',
+                                'type'              => 'ELLIPSE',
+                                'name'              => 'Location pin',
+                                'x'                 => 400,
+                                'y'                 => 120,
+                                'width'             => 24,
+                                'height'            => 24,
+                                'layoutPositioning' => 'ABSOLUTE',
+                                'fill'              => array('r' => 1, 'g' => 0, 'b' => 0),
+                            ),
+                            array(
+                                'id'                => 'overlay:photo',
+                                'type'              => 'RECTANGLE',
+                                'name'              => 'Large photo replacement',
+                                'x'                 => 40,
+                                'y'                 => 20,
+                                'width'             => 700,
+                                'height'            => 340,
+                                'layoutPositioning' => 'ABSOLUTE',
+                                'fillPaints'        => array(
+                                    array(
+                                        'type'  => 'IMAGE',
+                                        'image' => array('hash' => hex2bin($imageHash)),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    );
+
+    $result = blocks_engine_figma_transformer_contract_transform($scenegraph);
+    $css = blocks_engine_figma_transformer_contract_file_content($result, 'style.css');
+
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $css, '.figma-node-overlay-label-location-label', array('position:absolute', 'left:25%', 'top:25%'), 'responsive-overlay-label-uses-percent-offsets');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $css, '.figma-node-overlay-pin-location-pin', array('position:absolute', 'left:50%', 'top:30%'), 'responsive-overlay-pin-uses-percent-offsets');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $css, '.figma-node-overlay-photo-large-photo-replacement', array('position:absolute', 'left:40px', 'top:20px'), 'large-image-child-keeps-pixel-offsets');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/NodeTraceContract.php';
 require_once __DIR__ . '/OriginInferenceContract.php';
 require_once __DIR__ . '/ParserParityContract.php';
 require_once __DIR__ . '/RenderStyleMismatchContract.php';
+require_once __DIR__ . '/ResponsiveOverlayAnchoringContract.php';
 require_once __DIR__ . '/SemanticAccessibilityContract.php';
 require_once __DIR__ . '/SiteGenerationContract.php';
 require_once __DIR__ . '/StackingContextPolicyContract.php';
@@ -1380,6 +1381,7 @@ $assert(in_array('generated-vs-source-clipping', $genericCauses, true), 'layout-
 $assert(in_array('vector-shell-wrapper-offset', $genericCauses, true), 'layout-mismatch-vector-shell-wrapper-offset-suspected-cause');
 blocks_engine_figma_transformer_run_layout_mismatch_contract($assert);
 blocks_engine_figma_transformer_run_render_style_mismatch_contract($assert);
+blocks_engine_figma_transformer_run_responsive_overlay_anchoring_contract($assert);
 blocks_engine_figma_transformer_run_geometry_box_contract($assert);
 
 $layoutMismatchTransformResult = blocks_engine_figma_transformer_transform_scenegraph(array(


### PR DESCRIPTION
## Summary
- Emit percentage-based edge offsets for small absolute overlays inside freeform image/map media containers in `.fig -> HTML` output.
- Detect media containers generically from the parent name or a dominant media/image child, while preserving pixel offsets for dominant image-backed children.
- Add a focused Figma transformer contract covering proportional label/pin placement and large image child exclusion.

## Before / after CSS examples
Fisiostetic hero bubble:
```css
/* before */
.figma-node-20-64-bubble{...position:absolute;left:0px;top:129.483px;...}

/* after */
.figma-node-20-64-bubble{...position:absolute;left:0%;top:21.814%;...}
```

Fisiostetic map overlays:
```css
/* before */
.figma-node-21-455-location-icon{...position:absolute;left:416.407px;top:132.691px;...}
.figma-node-24-100-fisioestetic{...position:absolute;left:360.832px;top:74.198px;...}

/* after */
.figma-node-21-455-location-icon{...position:absolute;left:47.7%;top:18.139%;...}
.figma-node-24-100-fisioestetic{...position:absolute;left:41.334%;top:10.143%;...}
```

## Verification
- `php figma-transformer/tests/contract/run.php`
- Generated fresh Fisiostetic `.fig -> HTML` before/after artifacts and confirmed hero bubble, map pin, and map label use proportional offsets after the change.
- Generated FSE/TT5 sanity artifact for `🛠️ FSE Pilot Build Theme.fig` frame `3468:1118`; transform completed with `success_with_warnings` diagnostics.

## Risks
- The detector intentionally targets small non-image absolute children inside freeform media containers. It may convert offsets for decorative overlays in similarly named media groups, but dominant image-backed children are excluded to avoid scaling primary media placement.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated Fisiostetic artifacts, implemented the Figma HTML positioning policy, added contract coverage, and ran verification.