### PR TITLE
Prefer deep desktop responsive primaries

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -76,7 +76,7 @@ final class ScenegraphPagePlanner
      * downstream `@media`-aware emitter consumes):
      *
      *     array(
-     *         // Primary (widest/desktop) variant drives these page-level fields.
+     *         // Primary (desktop/page-depth) variant drives these page-level fields.
      *         'frame_id'              => string,   // primary variant frame id
      *         'name'                  => string,
      *         'slug'                  => string,   // deduped, derived from primary
@@ -113,13 +113,13 @@ final class ScenegraphPagePlanner
      *             device_hint: string,    // desktop|tablet|mobile|unknown
      *             viewport_width: float|null,
      *             viewport_height: float|null,
-     *             primary: bool,          // true for the widest/desktop variant
-     *             order: int,             // 0-based, widest first
+     *             primary: bool,          // true for the selected desktop/page-depth variant
+     *             order: int,             // 0-based, primary first
      *         }>,
      *         'diagnostics'           => array<int, array<string, mixed>>,
      *     )
      *
-     * Variants are ordered widest-first (desktop, tablet, mobile, unknown), so
+     * Variants are ordered primary-first (desktop/page-depth, then breakpoint width), so
      * `variants[0]` is always the primary that drives the page slug/identity.
      *
      * @param array<string, mixed> $source Decoded Figma scenegraph source array.
@@ -1814,7 +1814,7 @@ final class ScenegraphPagePlanner
     }
 
     /**
-     * Order group members widest-first so the primary variant sorts first.
+     * Order group members primary-first so the emitted page identity sorts first.
      *
      * @param array<int, string>                  $ids
      * @param array<string, array<string, mixed>> $candidates
@@ -1826,36 +1826,67 @@ final class ScenegraphPagePlanner
         usort(
             $ids,
             function (string $left, string $right) use ($candidates, $detectionById): int {
+                $leftPrimaryScore = $this->variantPrimaryScore($left, $candidates, $detectionById);
+                $rightPrimaryScore = $this->variantPrimaryScore($right, $candidates, $detectionById);
+                if ( $leftPrimaryScore !== $rightPrimaryScore ) {
+                    return $rightPrimaryScore <=> $leftPrimaryScore;
+                }
+
                 $leftWidth = (float) ($candidates[$left]['dimensions']['width'] ?? 0);
                 $rightWidth = (float) ($candidates[$right]['dimensions']['width'] ?? 0);
                 if ( $leftWidth !== $rightWidth ) {
                     return $rightWidth <=> $leftWidth;
                 }
 
-                $leftRank = $this->deviceRank((string) ($detectionById[$left]['device_hint'] ?? 'unknown'));
-                $rightRank = $this->deviceRank((string) ($detectionById[$right]['device_hint'] ?? 'unknown'));
-
-                return $leftRank <=> $rightRank ?: strcmp($left, $right);
+                return strcmp($left, $right);
             }
         );
 
         return array_values($ids);
     }
 
-    private function deviceRank(string $deviceHint): int
+    /**
+     * Score responsive siblings for primary selection. Device class is the first
+     * signal, then route/page content depth. This lets a real long desktop page
+     * beat a shallow ultra-wide exploration/mockup board without dropping that
+     * wide board or mobile frame from the responsive variants.
+     *
+     * @param array<string, array<string, mixed>> $candidates
+     * @param array<string, array<string, mixed>> $detectionById
+     */
+    private function variantPrimaryScore(string $id, array $candidates, array $detectionById): int
     {
-        return match ( $deviceHint ) {
-            'desktop' => 0,
-            'tablet'  => 1,
-            'mobile'  => 2,
-            default   => 3,
+        $deviceScore = match ( (string) ($detectionById[$id]['device_hint'] ?? 'unknown') ) {
+            'desktop' => 6000,
+            'tablet'  => 4000,
+            'unknown' => 3000,
+            'mobile'  => 1000,
+            default   => 0,
         };
+
+        $candidate = $candidates[$id] ?? array();
+        $dimensions = is_array($candidate['dimensions'] ?? null) ? $candidate['dimensions'] : array();
+        $stats = is_array($candidate['stats'] ?? null) ? $candidate['stats'] : array();
+        $width = (float) ($dimensions['width'] ?? 0);
+        $height = (float) ($dimensions['height'] ?? 0);
+        $textCount = (int) ($stats['texts'] ?? 0);
+        $nodeCount = (int) ($stats['nodes'] ?? 0);
+
+        $depthScore = min(900, (int) round($height / 8.0))
+            + min(400, $textCount * 8)
+            + min(240, intdiv($nodeCount, 4));
+        $shallowWidePenalty = $width >= 1600.0 && $height > 0.0 && $height < max(1200.0, $width * 0.65) ? 500 : 0;
+
+        return $deviceScore
+            + (int) ($candidate['score'] ?? 0)
+            + $depthScore
+            - $shallowWidePenalty;
     }
 
     /**
      * Build the ordered breakpoint-variant list for one page plan.
      *
-     * @param array<int, string>                  $members Ordered frame ids (widest first).
+     * @param array<int, string>                  $members Ordered frame ids (primary first).
      * @param array<string, array<string, mixed>> $candidates
      * @param array<string, array<string, mixed>> $detectionById
      * @return array<int, array<string, mixed>>

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -105,6 +105,60 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     }
     $assert('single' === ($reportedTemplatePaths['single.html'] ?? null) && 'archive' === ($reportedTemplatePaths['archive.html'] ?? null) && '404' === ($reportedTemplatePaths['404.html'] ?? null), 'template-source-report-preserves-page-types');
 
+    $responsivePrimaryResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Responsive Primary Selection Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'responsive-primary:wide-short',
+                'type'     => 'FRAME',
+                'name'     => 'Home Page Desktop',
+                'width'    => 2238,
+                'height'   => 869,
+                'children' => array(
+                    array('id' => 'responsive-primary:wide-title', 'type' => 'TEXT', 'name' => 'Heading', 'text' => 'Wide exploration', 'fontSize' => 48),
+                    array('id' => 'responsive-primary:wide-card', 'type' => 'TEXT', 'name' => 'Preview card', 'text' => 'Short preview', 'fontSize' => 18),
+                ),
+            ),
+            array(
+                'id'       => 'responsive-primary:desktop-long',
+                'type'     => 'FRAME',
+                'name'     => 'Home Page Desktop',
+                'width'    => 1440,
+                'height'   => 4421,
+                'children' => array(
+                    array('id' => 'responsive-primary:desktop-hero', 'type' => 'TEXT', 'name' => 'Heading', 'text' => 'Full homepage', 'fontSize' => 56),
+                    array('id' => 'responsive-primary:desktop-intro', 'type' => 'TEXT', 'name' => 'Intro', 'text' => 'Intro copy', 'fontSize' => 20),
+                    array('id' => 'responsive-primary:desktop-service-1', 'type' => 'TEXT', 'name' => 'Service', 'text' => 'Service one', 'fontSize' => 18),
+                    array('id' => 'responsive-primary:desktop-service-2', 'type' => 'TEXT', 'name' => 'Service', 'text' => 'Service two', 'fontSize' => 18),
+                    array('id' => 'responsive-primary:desktop-service-3', 'type' => 'TEXT', 'name' => 'Service', 'text' => 'Service three', 'fontSize' => 18),
+                    array('id' => 'responsive-primary:desktop-feature-1', 'type' => 'TEXT', 'name' => 'Feature', 'text' => 'Feature one', 'fontSize' => 18),
+                    array('id' => 'responsive-primary:desktop-feature-2', 'type' => 'TEXT', 'name' => 'Feature', 'text' => 'Feature two', 'fontSize' => 18),
+                    array('id' => 'responsive-primary:desktop-feature-3', 'type' => 'TEXT', 'name' => 'Feature', 'text' => 'Feature three', 'fontSize' => 18),
+                    array('id' => 'responsive-primary:desktop-quote', 'type' => 'TEXT', 'name' => 'Quote', 'text' => 'Testimonial', 'fontSize' => 22),
+                    array('id' => 'responsive-primary:desktop-footer', 'type' => 'TEXT', 'name' => 'Footer', 'text' => 'Footer copy', 'fontSize' => 16),
+                ),
+            ),
+            array(
+                'id'       => 'responsive-primary:mobile',
+                'type'     => 'FRAME',
+                'name'     => 'Home Page Mobile',
+                'width'    => 390,
+                'height'   => 8142,
+                'children' => array(
+                    array('id' => 'responsive-primary:mobile-hero', 'type' => 'TEXT', 'name' => 'Heading', 'text' => 'Full homepage', 'fontSize' => 36),
+                    array('id' => 'responsive-primary:mobile-copy', 'type' => 'TEXT', 'name' => 'Intro', 'text' => 'Mobile copy', 'fontSize' => 18),
+                ),
+            ),
+        ),
+    ), array('multi_page' => true));
+    $responsivePrimaryPage = $responsivePrimaryResult['source_reports']['figma']['pages']['pages'][0] ?? array();
+    $responsivePrimaryVariantIds = array_values(array_map(
+        static fn (array $variant): string => (string) ($variant['frame_id'] ?? ''),
+        is_array($responsivePrimaryPage['variants'] ?? null) ? $responsivePrimaryPage['variants'] : array()
+    ));
+    $assert('responsive-primary:desktop-long' === ($responsivePrimaryPage['frame_id'] ?? null), 'responsive-primary-selection-prefers-long-desktop-page');
+    $assert(in_array('responsive-primary:mobile', $responsivePrimaryVariantIds, true), 'responsive-primary-selection-preserves-mobile-variant');
+
     $singlePageArtifactResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Single Page Artifact Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- Prefer responsive group primaries by device class plus page content depth instead of raw width alone.
- Penalize shallow ultra-wide variants so exploration/mockup boards remain responsive variants instead of owning the emitted page identity.
- Add a contract fixture covering a short ultra-wide homepage, long desktop homepage, and mobile homepage variant.

## Verification
- `php figma-transformer/tests/contract/run.php`
- `php -l figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php`
- `php -l figma-transformer/tests/contract/SiteGenerationContract.php`
- Regenerated the FSE Pilot Build Theme artifact locally: `index.html` primary changed from `11320:3027` to `3468:1038`, while `4197:4735` remains a responsive variant.
- Ran local Fisiostetic and Twenty Twenty-Five fixture matrix sanity transforms; both completed with existing warning-level artifact quality diagnostics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed the responsive primary selection issue, implemented the planner/test changes, and ran local verification.