### PR TITLE
Dedupe global footer shell in compiled site pages

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -395,6 +395,7 @@ final class ArtifactCompiler
     private function safeHtmlDocumentHtml(string $html, string $entryPath, array $files): string
     {
         $html = $this->withoutMaterializedScriptTags($html, $entryPath, $files);
+        $html = $this->withoutGlobalTemplatePartShell($html, $files);
         $html = preg_replace_callback('/<img\s+[^>]*src\s*=\s*(["\'])([^"\']+)\1[^>]*>/i', function (array $matches) use ($entryPath, $files): string {
             $asset = $this->findAssetByHtmlReference((string) $matches[2], $entryPath, $files);
             if ( is_array($asset) && 'image/svg+xml' === ($asset['mime_type'] ?? '') && ! $this->isSafeImageAsset($asset) ) {
@@ -405,6 +406,93 @@ final class ArtifactCompiler
         }, $html) ?? $html;
 
         return preg_replace('/<figure\b[^>]*>\s*<\/figure>/i', '', $html) ?? $html;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     */
+    private function withoutGlobalTemplatePartShell(string $html, array $files): string
+    {
+        $areas = $this->templatePartAreas($files);
+        if ( ! in_array('footer', $areas, true) ) {
+            return $html;
+        }
+
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        if ( ! $loaded ) {
+            return $html;
+        }
+
+        $body = $document->getElementsByTagName('body')->item(0);
+        if ( ! $body instanceof DOMElement ) {
+            return $html;
+        }
+
+        $removed = false;
+        $candidates = array();
+        foreach ( $body->getElementsByTagName('*') as $element ) {
+            if ( $element instanceof DOMElement && $this->isGlobalFooterShellElement($element) ) {
+                $candidates[] = $element;
+            }
+        }
+
+        foreach ( $candidates as $element ) {
+            if ( null !== $element->parentNode ) {
+                $element->parentNode->removeChild($element);
+                $removed = true;
+            }
+        }
+
+        if ( ! $removed ) {
+            return $html;
+        }
+
+        $result = '';
+        foreach ( $body->childNodes as $child ) {
+            $result .= $document->saveHTML($child) ?: '';
+        }
+
+        return $result;
+    }
+
+    private function isGlobalFooterShellElement(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( 'footer' !== $tagName && 'contentinfo' !== strtolower((string) $element->getAttribute('role')) ) {
+            return false;
+        }
+
+        for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+            $ancestorTag = strtolower($ancestor->tagName);
+            if ( in_array($ancestorTag, array( 'main', 'article', 'blockquote', 'figure' ), true) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array<int, string>
+     */
+    private function templatePartAreas(array $files): array
+    {
+        $areas = array();
+        foreach ( $files as $file ) {
+            if ( ! is_array($file) || ! $this->isTemplatePartFile($file) ) {
+                continue;
+            }
+
+            $areas[] = $this->templatePartArea((string) ($file['path'] ?? ''), (string) ($file['role'] ?? ''));
+        }
+
+        return array_values(array_unique($areas));
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1805,6 +1805,26 @@ $assert(($staticPlan['totals']['routes'] ?? null) === ($staticSummary['route_cou
 $assert(($staticPlan['totals']['navigation_links'] ?? null) === ($staticSummary['navigation_link_count'] ?? null), 'conversion report navigation link count matches materialization plan totals');
 $assert(($staticPlan['totals']['menus'] ?? null) === ($staticSummary['menu_count'] ?? null), 'conversion report menu count matches materialization plan totals');
 
+$footerShellSite = $compiler->compile(
+    array(
+        'entry' => 'index.html',
+        'files' => array(
+            'index.html' => '<!doctype html><html><body><main><h1>Home</h1><p>Body copy</p></main><footer class="site-footer"><nav><a href="/privacy">Privacy</a></nav><p>Global footer copy</p></footer></body></html>',
+            'about.html' => '<!doctype html><html><body><main><article><h1>About</h1><footer class="article-footer"><p>Article byline footer</p></footer></article></main><footer class="site-footer"><p>Global footer copy</p></footer></body></html>',
+            'parts/footer.html' => '<footer class="site-footer"><nav><a href="/privacy">Privacy</a></nav><p>Global footer copy</p></footer>',
+        ),
+    )
+)->toArray();
+$footerShellPages = $footerShellSite['source_reports']['compiled_site']['pages'] ?? array();
+$footerShellTemplateParts = $footerShellSite['source_reports']['compiled_site']['template_parts'] ?? array();
+$footerShellIndexPage = array_values(array_filter($footerShellPages, static fn (array $page): bool => 'index.html' === ($page['source_path'] ?? '')))[0] ?? array();
+$footerShellAboutPage = array_values(array_filter($footerShellPages, static fn (array $page): bool => 'about.html' === ($page['source_path'] ?? '')))[0] ?? array();
+$footerShellPart = $footerShellTemplateParts[0] ?? array();
+$assert(! str_contains((string) ($footerShellIndexPage['block_markup'] ?? ''), 'Global footer copy'), 'compiled site removes global footer shell from page body when a footer template part exists');
+$assert(str_contains((string) ($footerShellPart['block_markup'] ?? ''), 'Global footer copy'), 'compiled site preserves global footer copy in the footer template part');
+$assert(str_contains((string) ($footerShellAboutPage['block_markup'] ?? ''), 'Article byline footer'), 'compiled site preserves page-local article footer content while pruning global footer shell');
+$assert(! str_contains((string) ($footerShellAboutPage['block_markup'] ?? ''), 'Global footer copy'), 'compiled site does not duplicate global footer shell on secondary page bodies');
+
 $runtimeDependencySite = $compiler->compile(
     array(
         'entrypoint' => 'index.html',


### PR DESCRIPTION
## Summary
- Prunes global source footer landmarks from compiled page body markup when the artifact already contains a footer template part.
- Preserves page-local/article footers under main/article/blockquote/figure.
- Keeps the global footer content materialized through the footer template part instead of duplicating it on every page body.

## Source signals
- Footer template part exists via parts/footer.html, template-parts/footer.html, or role=template-part with footer area detection.
- Source footer shell is a footer element or role=contentinfo outside page-local containers: main, article, blockquote, figure.

## Verification
- php php-transformer/tests/contract/run.php
- composer test
- Targeted artifact evidence: index.html page_has_global=no, about.html page_has_global=no, about.html page_has_article=yes, footer_part_has_global=yes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the artifact compilation path, implemented the footer shell dedupe, added contract coverage, and ran verification.