### PR TITLE
Fix max-width block save shape

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
@@ -188,9 +188,9 @@ final class StyleAttributeMapper
         if ( '' !== trim((string) ($dimensions['minHeight'] ?? '')) ) {
             $declarations[] = 'min-height:' . trim((string) $dimensions['minHeight']);
         }
-        if ( '' !== trim((string) ($dimensions['maxWidth'] ?? '')) ) {
-            $declarations[] = 'max-width:' . trim((string) $dimensions['maxWidth']);
-        }
+        // Core stores dimensions.maxWidth in block attrs but does not reproduce
+        // it as an inline wrapper declaration in save(), so emitting it here
+        // makes otherwise native blocks fail editor validation.
 
         $typography    = is_array($style['typography'] ?? null) ? $style['typography'] : array();
         $typographyMap = array(

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -66,8 +66,8 @@ $cardMarkup = (string) ($cardResult['serialized_blocks'] ?? '');
 
 $assert('1120px' === ($cardShellAttrs['style']['dimensions']['maxWidth'] ?? ''), '17: section max-width maps to dimensions support', json_encode($cardShellAttrs['style']['dimensions'] ?? array()));
 $assert('360px' === ($cardAttrs['style']['dimensions']['maxWidth'] ?? ''), '18: card max-width maps to dimensions support', json_encode($cardAttrs['style']['dimensions'] ?? array()));
-$assert(str_contains($cardMarkup, 'max-width:1120px'), '19: rendered section preserves max-width geometry', $cardMarkup);
-$assert(str_contains($cardMarkup, 'max-width:360px'), '20: rendered card preserves max-width geometry', $cardMarkup);
+$assert(! str_contains($cardMarkup, 'max-width:1120px'), '19: rendered section omits max-width that core save() does not reproduce', $cardMarkup);
+$assert(! str_contains($cardMarkup, 'max-width:360px'), '20: rendered card omits max-width that core save() does not reproduce', $cardMarkup);
 $assert(! str_contains($cardMarkup, 'style="max-width:1120px;margin:0 auto;padding:5rem 2rem"'), '21: rendered section does not keep unsupported raw style wholesale', $cardMarkup);
 
 $labelHtml = '<section class="pricing"><div class="section-head"><div class="tag">Pricing</div><h2>Simple plans</h2></div><article class="pricing-card"><div class="tier-name">Team</div><div class="tier-price"><span class="amount">$29</span>/mo</div><div class="use-case-result">Launch faster</div></article></section>';


### PR DESCRIPTION
## Summary
- Stop serializing dimensions.maxWidth as an inline wrapper declaration in php-transformer block save markup.
- Keep dimensions.maxWidth in block attrs, but align rendered markup with what WordPress core save() reproduces.
- Update block style support coverage for canonical save-shape parity.

## Verification
- `php php-transformer/tests/unit/block-style-support-conversion.php` passes with 36 assertions.
- CV fixture verification with this transformer override reports 219/219 editor-valid blocks, 0 invalid blocks, editor_valid_block_rate 1.0.
- Coffee guard reports 214/214 editor-valid blocks, 0 invalid blocks, editor_valid_block_rate 1.0.
- Artist guard reports 126/126 editor-valid blocks, 0 invalid blocks, editor_valid_block_rate 1.0.

## Notes
- This fixes editor-invalid evidence for the CV max-width save-shape regression.
- CV remains a browser-review candidate rather than solved because visual parity is still 2.80% against a 0.00% threshold.
- Coffee and Artist still show existing static-site-importer editor-open runtime failures from `getCurrentPost` being undefined; this PR does not address that separate recipe/runtime path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Compared scorecard artifacts, identified the generic save-shape mismatch, implemented the patch, and ran focused verification.