### PR TITLE
Reduce nested Figma input islands

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -945,6 +945,10 @@ final class StaticHtmlEmitter
                         }
                         continue;
                     }
+                    if ( $formControlAccessoryControl && ( $this->isInputLike($child, $node) || $this->isTextareaLike($child, $node) ) ) {
+                        $this->recordDecisionTrace('source_loss_accounting', 'nested_form_control_chrome_converted_to_parent_control', $child, 'skip_child', $node, array('depth' => $depth + 1));
+                        continue;
+                    }
                     if ( 'li' === $tag && $this->isListMarkerTextChild($child) ) {
                         $this->recordDecisionTrace('source_loss_accounting', 'list_marker_text_suppressed', $child, 'skip_child', $node, array('depth' => $depth + 1));
                         continue;

--- a/figma-transformer/tests/contract/FormControlContract.php
+++ b/figma-transformer/tests/contract/FormControlContract.php
@@ -189,6 +189,52 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     $assert(str_contains($css, '.figma-node-form-input-input{width:280px;height:46px;'), 'form-control-input-preserves-visual-css');
     $assert(str_contains($css, '.figma-node-form-comment-comment-textarea{width:420px;height:128px;'), 'form-control-textarea-preserves-visual-css');
 
+    $nestedInputShellResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Nested Input Shell Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'nested-input:root',
+                'type'     => 'FRAME',
+                'name'     => 'Newsletter Signup',
+                'width'    => 480,
+                'height'   => 120,
+                'children' => array(
+                    array(
+                        'id'           => 'nested-input:field',
+                        'type'         => 'FRAME',
+                        'name'         => 'Input',
+                        'width'        => 280,
+                        'height'       => 46,
+                        'layoutMode'   => 'HORIZONTAL',
+                        'cornerRadius' => 4,
+                        'fills'        => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                        'children'     => array(
+                            array(
+                                'id'           => 'nested-input:inner-field',
+                                'type'         => 'FRAME',
+                                'name'         => 'Input',
+                                'width'        => 278,
+                                'height'       => 44,
+                                'layoutMode'   => 'HORIZONTAL',
+                                'cornerRadius' => 4,
+                                'fills'        => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                                'children'     => array(
+                                    array('id' => 'nested-input:inner-placeholder', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Your email address', 'fontSize' => 16),
+                                ),
+                            ),
+                        ),
+                    ),
+                    array('id' => 'nested-input:button', 'type' => 'FRAME', 'name' => 'Submit button', 'width' => 120, 'height' => 46, 'children' => array(
+                        array('id' => 'nested-input:button-text', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Subscribe'),
+                    )),
+                ),
+            ),
+        ),
+    ));
+    $nestedInputShellHtml = $fileContent($nestedInputShellResult, 'index.html');
+    $assert(1 === substr_count($nestedInputShellHtml, 'data-figma-synthetic-control="input"'), 'form-control-nested-input-shell-emits-single-control');
+    $assert(! str_contains($nestedInputShellHtml, 'data-figma-node-id="nested-input:inner-field"'), 'form-control-nested-input-shell-suppresses-child-control-shell');
+
     $nestedFormResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Nested Form Guard Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- Suppress nested input-like control shells when the parent input wrapper has already emitted a synthetic form control.
- Adds a form-control contract fixture proving nested input shells emit one control instead of duplicate inputs.

## FSE Pilot diagnostics
Generated from latest `origin/trunk` with the FSE Pilot `.fig -> HTML` matrix using `--max-pages=6 --max-nodes=7000`.

Before:
- Readiness: `48 / critical`
- Responsive coverage: `0.735`
- Route coverage: `1.000`
- Giant fixed sections: `2`
- Form islands: `7`
- SVG islands: `156`
- Input islands: `26`
- Form-validity risk: `48`

After:
- Readiness: `48 / critical`
- Responsive coverage: `0.735`
- Route coverage: `1.000`
- Giant fixed sections: `2`
- Form islands: `7`
- SVG islands: `149`
- Input islands: `16`
- Form-validity risk: `38`

## Verification
- `composer test` from `figma-transformer/`
- FSE Pilot fixture matrix: completed, `success_with_warnings`
- Fisiostetic sanity fixture matrix: completed, readiness `75 / medium`, form/input islands remain `0`

## Remaining blockers
- FSE remains `critical` because responsive fixed-width coverage (`50`) and two giant fixed sections still dominate the readiness score.
- This PR intentionally does not attempt layout/responsive fixes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Generated diagnostics, implemented the focused `.fig -> HTML` emitter/test change, and drafted this PR description.