### PR TITLE
Improve TT5 Figma HTML semantic readiness

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1467,6 +1467,24 @@ final class StaticHtmlEmitter
             return null;
         }
 
+        if ( 'article' === $tag ) {
+            if ( $this->containsSemanticRoleToken($nameHaystack, array('comment', 'reply')) ) {
+                return 'comment';
+            }
+            if ( $this->containsSemanticRoleToken($nameHaystack, array('card', 'preview')) ) {
+                return 'post-card';
+            }
+            if ( $this->containsSemanticRoleToken($nameHaystack, array('query', 'loop')) ) {
+                return 'query-item';
+            }
+
+            return 'article';
+        }
+
+        if ( 'section' === $tag && $this->hasQueryContainerName($nameHaystack) ) {
+            return 'query';
+        }
+
         if ( $this->containsSemanticRoleToken($nameHaystack, array('nav', 'navigation', 'menu')) ) {
             return 'nav';
         }

--- a/figma-transformer/tests/contract/SemanticAccessibilityContract.php
+++ b/figma-transformer/tests/contract/SemanticAccessibilityContract.php
@@ -71,6 +71,7 @@ function blocks_engine_figma_transformer_run_semantic_accessibility_contract(cal
 
     $html = $fileContent($result, 'index.html');
     $assert(str_contains($html, '<article class="figma-node-semantic-comment-comment'), 'semantic-accessibility-comment-emits-article');
+    $assert(str_contains($html, 'data-figma-node-id="semantic:comment"') && str_contains($html, 'data-figma-semantic-role="comment"'), 'semantic-accessibility-comment-article-has-role-metadata');
     $assert(str_contains($html, '<blockquote class="figma-node-semantic-quote-blockquote'), 'semantic-accessibility-blockquote-emits-blockquote');
     $assert(str_contains($html, 'data-figma-node-id="semantic:icon"') && str_contains($html, 'aria-hidden="true" focusable="false"'), 'semantic-accessibility-generic-icon-decorative');
     $assert(str_contains($html, 'data-figma-node-id="semantic:logo-icon"') && str_contains($html, 'role="img" aria-label="Logo"'), 'semantic-accessibility-logo-icon-keeps-accessible-name');
@@ -135,6 +136,40 @@ function blocks_engine_figma_transformer_run_semantic_accessibility_contract(cal
     $assert(str_contains($topLevelListLikeSectionHtml, '<section class="figma-node-semantic-pricing-section-pricing"'), 'semantic-accessibility-top-level-list-like-frame-keeps-section-landmark');
     $assert(! str_contains($topLevelListLikeSectionHtml, '<ul class="figma-node-semantic-pricing-section-pricing"'), 'semantic-accessibility-top-level-list-like-frame-not-ul');
     $assert(! str_contains($topLevelListLikeSectionHtml, '<li class="figma-node-semantic-pricing-card-a-basic-card"'), 'semantic-accessibility-top-level-list-like-frame-children-not-li');
+
+    $articleCardRoleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Article Card Role Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'semantic:article-card-root',
+                'type'     => 'FRAME',
+                'name'     => 'Archive',
+                'children' => array(
+                    array(
+                        'id'       => 'semantic:query-loop',
+                        'type'     => 'FRAME',
+                        'name'     => 'Query Loop',
+                        'children' => array(
+                            array(
+                                'id'       => 'semantic:article-card',
+                                'type'     => 'FRAME',
+                                'name'     => 'Post Card',
+                                'children' => array(
+                                    array('id' => 'semantic:article-card-title', 'type' => 'TEXT', 'name' => 'Title', 'characters' => 'Post title', 'fontSize' => 24),
+                                    array('id' => 'semantic:article-card-excerpt', 'type' => 'TEXT', 'name' => 'Excerpt', 'characters' => 'Post excerpt copy.', 'fontSize' => 16),
+                                    array('id' => 'semantic:article-card-date', 'type' => 'TEXT', 'name' => 'Date', 'characters' => 'July 6, 2026', 'fontSize' => 14),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $articleCardRoleHtml = $fileContent($articleCardRoleResult, 'index.html');
+    $assert(str_contains($articleCardRoleHtml, 'data-figma-node-id="semantic:query-loop"') && str_contains($articleCardRoleHtml, 'data-figma-semantic-role="query"'), 'semantic-accessibility-query-section-has-role-metadata');
+    $assert(str_contains($articleCardRoleHtml, '<article class="figma-node-semantic-article-card-post-card'), 'semantic-accessibility-post-card-emits-article');
+    $assert(str_contains($articleCardRoleHtml, 'data-figma-node-id="semantic:article-card"') && str_contains($articleCardRoleHtml, 'data-figma-semantic-role="post-card"'), 'semantic-accessibility-post-card-article-has-role-metadata');
 
     $booleanLabelResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Decorative Boolean Label Fixture',


### PR DESCRIPTION
## Summary
- Add generic semantic role metadata for emitted article containers, including article, comment, query-item, and post-card structures.
- Add semantic role metadata for query/archive sections.
- Extend semantic accessibility contract coverage for comment articles, query sections, and post-card articles.

## TT5 evidence
Fixture: `Twenty Twenty-Five (Community).fig`
Command shape: `php figma-transformer/scripts/figma-fixture-matrix.php --fixture=... --zstd-command=/opt/homebrew/bin/zstd --max-nodes=5000 --max-pages=3 --inspect-limit=100`

Before, latest `origin/trunk`:
- Readiness: `31 / critical`
- Responsive coverage: `0.330`
- Route coverage: `0.097`
- Selected pages: `3` (`Business Homepage`, `Post with sidebar`, `News blog with various grids`)
- Omitted route candidates: `28`
- Fixed widths without responsive overrides: `69`
- Missing semantic roles: `19`

After this branch:
- Readiness: `49 / critical`
- Responsive coverage: `0.330`
- Route coverage: `0.097`
- Selected pages: `3` (`Business Homepage`, `Post with sidebar`, `News blog with various grids`)
- Omitted route candidates: `28`
- Fixed widths without responsive overrides: `69`
- Missing semantic roles: `1`

This PR intentionally improves semantic role coverage only; route selection and responsive metrics are unchanged.

## Verification
- `composer test:contract` from `figma-transformer`
- TT5 fixture matrix before/after with zstd and bounded limits
- `composer test:canonical` from `php-transformer` as downstream FSE/materialization sanity

## Blockers
- None. Remaining TT5 critical readiness is driven by responsive coverage and route cap coverage, outside this narrow semantic fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Implemented the semantic metadata change, added contract coverage, ran local TT5 and contract verification, and drafted the PR evidence.