### PR TITLE
Clamp mobile Figma image fallbacks

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -148,7 +148,8 @@ final class BreakpointMediaDiffBuilder
         $baseStyles = array();
         $this->collectVariantNodeStyles($baseNode, 0, null, null, 'r', $baseStyles);
 
-        $rules = array();
+        $desktopRules = array();
+        $mobileRules = array();
         foreach ( $baseStyles as $base ) {
             $class = isset($base['class']) && is_scalar($base['class']) ? (string) $base['class'] : '';
             $node = is_array($base['node'] ?? null) ? $base['node'] : array();
@@ -158,38 +159,30 @@ final class BreakpointMediaDiffBuilder
             }
 
             $depth = isset($base['depth']) && is_numeric($base['depth']) ? (int) $base['depth'] : 0;
-            $declarations = $this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null);
-            $changed = array();
-            foreach ( $declarations as $declaration ) {
-                $parts = explode(':', $declaration, 2);
-                if ( 2 !== count($parts) ) {
-                    continue;
-                }
-                $property = trim($parts[0]);
-                $value = trim($parts[1]);
-                if ( ! array_key_exists($property, $baseMap) || $baseMap[$property] !== $value ) {
-                    $changed[] = $property . ':' . $value;
-                }
+            $desktopChanged = $this->changedDeclarations($this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null), $baseMap);
+            if ( ! empty($desktopChanged) ) {
+                $desktopRules[] = '.' . $class . '{' . implode(';', array_values(array_unique($desktopChanged))) . '}';
             }
 
-            if ( ! empty($changed) ) {
-                $rules[] = '.' . $class . '{' . implode(';', array_values(array_unique($changed))) . '}';
+            $mobileChanged = $this->changedDeclarations($this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null, true), $baseMap);
+            if ( ! empty($mobileChanged) ) {
+                $mobileRules[] = '.' . $class . '{' . implode(';', array_values(array_unique($mobileChanged))) . '}';
             }
         }
 
-        if ( empty($rules) ) {
+        if ( empty($desktopRules) && empty($mobileRules) ) {
             return array();
         }
 
-        $rules = array_values(array_unique($rules));
-        $breakpoints = array(767);
-        if ( $rootWidth > 1200.0 ) {
-            $breakpoints[] = (int) floor($rootWidth - 1.0);
+        $desktopRules = array_values(array_unique($desktopRules));
+        $mobileRules = array_values(array_unique($mobileRules));
+        $blocks = array();
+        if ( $rootWidth > 1200.0 && ! empty($desktopRules) ) {
+            $blocks[] = $this->mediaBlock((int) floor($rootWidth - 1.0), $desktopRules);
         }
-        $breakpoints = array_values(array_unique(array_filter($breakpoints, static fn (int $breakpoint): bool => $breakpoint > 0)));
-        rsort($breakpoints, SORT_NUMERIC);
+        $blocks[] = $this->mediaBlock(767, ! empty($mobileRules) ? $mobileRules : $desktopRules);
 
-        return array_map(fn (int $breakpoint): string => $this->mediaBlock($breakpoint, $rules), $breakpoints);
+        return $blocks;
     }
 
     /**
@@ -197,7 +190,7 @@ final class BreakpointMediaDiffBuilder
      * @param array<string, string> $baseMap
      * @return array<int, string>
      */
-    private function desktopOnlyResponsiveFallbackDeclarations(array $node, array $baseMap, int $depth, ?float $fallbackWidth = null): array
+    private function desktopOnlyResponsiveFallbackDeclarations(array $node, array $baseMap, int $depth, ?float $fallbackWidth = null, bool $mobile = false): array
     {
         $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
         $width = $this->responsiveCssWidth($baseMap) ?? $this->nodeBoxDimension($node, 'width') ?? $fallbackWidth;
@@ -251,7 +244,42 @@ final class BreakpointMediaDiffBuilder
             }
         }
 
+        if ( $mobile && null !== $width && $width > 340.0 && isset($baseMap['background-image']) && str_contains((string) $baseMap['background-image'], 'url(') ) {
+            $declarations[] = 'width:100%';
+            $declarations[] = 'max-width:100%';
+            if ( null !== $height && $height > 0.0 ) {
+                $declarations[] = 'height:auto';
+                $declarations[] = 'aspect-ratio:' . ($this->number)($width) . ' / ' . ($this->number)($height);
+            }
+            if ( isset($baseMap['background-size']) && ! in_array($baseMap['background-size'], array('cover', 'contain'), true) ) {
+                $declarations[] = 'background-size:cover';
+            }
+        }
+
         return array_values(array_unique($declarations));
+    }
+
+    /**
+     * @param array<int, string> $declarations
+     * @param array<string, string> $baseMap
+     * @return array<int, string>
+     */
+    private function changedDeclarations(array $declarations, array $baseMap): array
+    {
+        $changed = array();
+        foreach ( $declarations as $declaration ) {
+            $parts = explode(':', $declaration, 2);
+            if ( 2 !== count($parts) ) {
+                continue;
+            }
+            $property = trim($parts[0]);
+            $value = trim($parts[1]);
+            if ( ! array_key_exists($property, $baseMap) || $baseMap[$property] !== $value ) {
+                $changed[] = $property . ':' . $value;
+            }
+        }
+
+        return $changed;
     }
 
     /**

--- a/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
+++ b/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
@@ -87,8 +87,9 @@ final class ResponsiveBreakpointSafetyPolicy
         }
 
         $contentWidth = max(1.0, $viewportWidth - 48.0);
+        $mobileContentWidth = min($contentWidth, 340.0);
         $height = $this->cssPixelValue($baseMap['height'] ?? '') ?? $this->nodeBoxHeight($node);
-        $isOverwide = $width > $contentWidth || $width > 767.0;
+        $isOverwide = $width > $contentWidth || $width > 767.0 || ($viewportWidth <= 767.0 && $width > $mobileContentWidth);
         $hasBackgroundImage = isset($baseMap['background-image']) && str_contains((string) $baseMap['background-image'], 'url(');
 
         if ( 'TEXT' === $type ) {

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -8054,6 +8054,13 @@ $assert(! preg_match('/@media \(max-width:915px\)\{[\s\S]*\.figma-node-abstext-c
 $responsiveSafetyResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
     array(
         'name' => 'Responsive Safety Fixture',
+        'assets' => array(
+            'safety-photo' => array(
+                'name' => 'Safety Photo',
+                'mime_type' => 'image/jpeg',
+                'content' => 'safety image bytes',
+            ),
+        ),
         'nodes' => array(
             array(
                 'id' => 'safety:desktop', 'type' => 'FRAME', 'name' => 'Desktop', 'box' => array('width' => 1440, 'height' => 900),
@@ -8078,6 +8085,7 @@ $responsiveSafetyResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\St
                             array('id' => 'safety:footer-row', 'type' => 'FRAME', 'name' => 'Frame 19', 'box' => array('x' => 0, 'y' => 352, 'width' => 1440, 'height' => 131), 'layout' => array('positioning' => 'absolute', 'display' => 'flex', 'flex_direction' => 'row', 'justify_content' => 'space-between', 'align_items' => 'center')),
                         ),
                     ),
+                    array('id' => 'safety:service-image', 'type' => 'RECTANGLE', 'name' => 'Service Image', 'box' => array('width' => 538, 'height' => 381), 'asset_id' => 'safety-photo'),
                 ),
             ),
             array(
@@ -8104,7 +8112,44 @@ $assert(preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-safety-head
 $assert(preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-safety-nav-navigation\{[^}]*width:100%[^}]*max-width:100%[^}]*flex-wrap:wrap/s', $responsiveSafetyCss) === 1, 'responsive-safety-navigation-wraps');
 $assert(preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-safety-newsletter-newsletter-signup\{[^}]*width:calc\(100% - 48px\)[^}]*max-width:342px[^}]*left:24px/s', $responsiveSafetyCss) === 1, 'responsive-safety-newsletter-defixed');
 $assert(preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-safety-footer-row-frame-19\{[^}]*position:relative[^}]*left:auto[^}]*top:auto[^}]*flex-wrap:wrap/s', $responsiveSafetyCss) === 1, 'responsive-safety-footer-row-defixed');
+$assert(preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-safety-service-image-service-image\{[^}]*width:100%[^}]*max-width:100%[^}]*height:auto[^}]*aspect-ratio:538 \/ 381/s', $responsiveSafetyCss) === 1, 'responsive-safety-clamps-mobile-image-leaf');
 $assert(! preg_match('/@media \(max-width:915px\)\{[\s\S]*\.figma-node-safety-newsletter-newsletter-signup\{[^}]*width:calc\(100% - 48px\)/s', $responsiveSafetyCss), 'responsive-safety-fallbacks-do-not-leak-to-midpoint');
+
+$desktopOnlyImageFallbackResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
+    array(
+        'name' => 'Desktop-only image fallback fixture',
+        'assets' => array(
+            'desktop-only-photo' => array(
+                'name' => 'Desktop Only Photo',
+                'mime_type' => 'image/jpeg',
+                'content' => 'desktop-only image bytes',
+            ),
+        ),
+        'nodes' => array(
+            array(
+                'id' => 'desktop-only:root', 'type' => 'FRAME', 'name' => 'Desktop page', 'box' => array('width' => 1440, 'height' => 800),
+                'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                'children' => array(
+                    array('id' => 'desktop-only:image', 'type' => 'RECTANGLE', 'name' => 'Service Image', 'box' => array('width' => 538, 'height' => 381), 'asset_id' => 'desktop-only-photo'),
+                ),
+            ),
+        ),
+    ),
+    array('pages' => array(array('frame_id' => 'desktop-only:root', 'name' => 'Home', 'path' => 'index.html', 'entrypoint' => true)))
+);
+$desktopOnlyImageFallbackCss = '';
+foreach ( $desktopOnlyImageFallbackResult['files'] ?? array() as $desktopOnlyImageFallbackFile ) {
+    if ( is_array($desktopOnlyImageFallbackFile) && 'style.css' === ($desktopOnlyImageFallbackFile['path'] ?? null) ) {
+        $desktopOnlyImageFallbackCss = (string) ($desktopOnlyImageFallbackFile['content'] ?? '');
+    }
+}
+$assert('success' === ($desktopOnlyImageFallbackResult['status'] ?? null), 'desktop-only-image-fallback-transform-success');
+$desktopOnlyWideFallbackBlock = '';
+if ( preg_match('/@media \(max-width:1439px\)\{(?<block>[\s\S]*?)\n\}/', $desktopOnlyImageFallbackCss, $desktopOnlyWideFallbackMatch) ) {
+    $desktopOnlyWideFallbackBlock = (string) ($desktopOnlyWideFallbackMatch['block'] ?? '');
+}
+$assert(! str_contains($desktopOnlyWideFallbackBlock, '.figma-node-desktop-only-image-service-image{'), 'desktop-only-image-fallback-not-clamped-at-desktop');
+$assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-desktop-only-image-service-image\{[^}]*width:100%[^}]*max-width:100%[^}]*height:auto[^}]*aspect-ratio:538 \/ 381/s', $desktopOnlyImageFallbackCss) === 1, 'desktop-only-image-fallback-clamped-at-mobile');
 
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");


### PR DESCRIPTION
## Summary
- Clamp desktop-only Figma background/image leaf boxes in the mobile fallback media block when their fixed width exceeds common mobile content width.
- Keep the existing wide desktop fallback block free of the new image leaf clamp.
- Add contract coverage for both responsive-variant and desktop-only fallback paths.

## Fisiostetic evidence
Generated the Fisiostetic Figma-to-HTML fixture locally before and after this patch using the figma transformer with an external zstd decoder. The generated artifact showed no missing assets.

Before:
- effective responsive coverage: `0.444`
- fixed width declarations: `90`
- fixed widths with responsive override: `40`
- fixed widths without responsive override: `50`
- fixed-width-over-desktop count: `1` (covered)

After:
- effective responsive coverage: `0.544`
- fixed width declarations: `90`
- fixed widths with responsive override: `49`
- fixed widths without responsive override: `41`
- fixed-width-over-desktop count: `1` (covered)

CSS examples added at max-width 767px:
```css
.figma-node-19-442-image{width:100%;max-width:100%;height:auto;aspect-ratio:538.299 / 381.174}
.figma-node-20-389-image{width:100%;max-width:100%;height:auto;aspect-ratio:538.299 / 381.174}
.figma-node-21-450-map-image{width:100%;max-width:100%;height:auto;aspect-ratio:872.97 / 731.531;background-size:cover}
```

## Verification
- `composer test:contract` in `figma-transformer`: passed
- Fisiostetic regeneration with external zstd decoder: passed, no missing assets
- `composer test` in `php-transformer`: passed, including canonical contracts, parity fixtures, and package install proof
- `pnpm test` in `packages/blocks-engine`: not run, `pnpm` is not installed in this shell

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Investigated Fisiostetic artifact CSS leaks, implemented the scoped figma-transformer fix and tests, regenerated evidence, and drafted this PR description
