### PR TITLE
Deduplicate generated block class attrs

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -62,6 +62,8 @@ final class BlockFactory
      */
     private function normalizeAttrsForBlock(string $name, array $attrs): array
     {
+        $attrs = $this->normalizeClassNameAttr($attrs);
+
         if ( in_array($name, array( 'core/group', 'core/columns' ), true) ) {
             unset($attrs['style']['dimensions']['maxWidth']);
             if ( empty($attrs['style']['dimensions']) ) {
@@ -82,6 +84,33 @@ final class BlockFactory
             }
         }
 
+        return $attrs;
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     * @return array<string, mixed>
+     */
+    private function normalizeClassNameAttr(array $attrs): array
+    {
+        if ( ! is_string($attrs['className'] ?? null) ) {
+            return $attrs;
+        }
+
+        $classes = array();
+        foreach ( preg_split('/\s+/', trim($attrs['className'])) ?: array() as $class ) {
+            if ( '' === $class || GeneratedGutenbergClassPolicy::isGeneratedClassName($class) || in_array($class, $classes, true) ) {
+                continue;
+            }
+            $classes[] = $class;
+        }
+
+        if ( array() === $classes ) {
+            unset($attrs['className']);
+            return $attrs;
+        }
+
+        $attrs['className'] = implode(' ', $classes);
         return $attrs;
     }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -804,6 +804,24 @@ $assert(! str_contains($canonicalWrapperAttrsSerialized, 'style="display:grid'),
 $assert(str_contains($canonicalWrapperAttrsSerialized, '<h2 class="wp-block-heading has-text-color section-title" style="color:red">Menu</h2>'), 'heading wrappers include canonical and support classes with supported color style');
 $assert(str_contains($canonicalWrapperAttrsSerialized, '<p class="card-desc" style="margin-bottom:1rem">Fresh daily.</p>'), 'paragraph wrappers preserve runtime-addressable classes and supported margin style');
 
+$paragraphGeneratedClassLeakResult = ( new HtmlTransformer() )->transform(
+    '<main><p class="has-text-color has-text-color hero-tagline" style="color:red">Slow roasted daily.</p></main>'
+)->toArray();
+$paragraphGeneratedClassLeakBlock = $paragraphGeneratedClassLeakResult['blocks'][0] ?? array();
+$paragraphGeneratedClassLeakSerialized = (string) ($paragraphGeneratedClassLeakResult['serialized_blocks'] ?? '');
+$assert('hero-tagline' === ($paragraphGeneratedClassLeakBlock['attrs']['className'] ?? ''), 'paragraph className strips duplicate generated color classes while preserving custom classes');
+$assert(str_contains($paragraphGeneratedClassLeakSerialized, '<p class="has-text-color hero-tagline" style="color:red">Slow roasted daily.</p>'), 'paragraph serialization emits generated has-text-color once before custom classes');
+$assert(1 === substr_count($paragraphGeneratedClassLeakSerialized, 'has-text-color'), 'paragraph serialization emits has-text-color exactly once');
+$assert('pass' === ($paragraphGeneratedClassLeakResult['source_reports']['wp_block_validity']['status'] ?? ''), 'paragraph with stripped generated className passes generated block validity checks');
+
+$paragraphFactoryGeneratedClassLeakBlock = ( new BlockFactory() )->create('core/paragraph', array(
+    'content'   => 'Slow roasted daily.',
+    'className' => 'has-text-color has-text-color hero-tagline',
+    'style'     => array('color' => array('text' => 'red')),
+));
+$assert('hero-tagline' === ($paragraphFactoryGeneratedClassLeakBlock['attrs']['className'] ?? ''), 'BlockFactory strips generated classes from direct paragraph className attrs');
+$assert(str_contains((string) ($paragraphFactoryGeneratedClassLeakBlock['innerHTML'] ?? ''), '<p class="has-text-color hero-tagline" style="color:red">Slow roasted daily.</p>'), 'BlockFactory paragraph innerHTML emits a single generated color class');
+
 $paragraphSvgResult = ( new HtmlTransformer() )->transform(
     '<main><p class="social-link"><a class="social-link" href="#" aria-label="Follow"><svg viewBox="0 0 10 10" aria-hidden="true"><path d="M0 0h10v10H0z"></path></svg></a></p></main>'
 )->toArray();


### PR DESCRIPTION
## Summary
- Normalize block `className` attrs at the serializer boundary to strip generated Gutenberg classes and duplicate class tokens before comment attrs and saved HTML are produced.
- Preserve custom source classes such as `hero-tagline` while letting block support emit generated classes like `has-text-color` exactly once.
- Add contract coverage for the Coffee-style duplicate `has-text-color` paragraph mismatch through both full HTML transform and direct `BlockFactory` usage.

## Evidence
- Lab blocker evidence run: `55267331-ad9c-4a71-9a41-be7cb9254c95`.
- Before: 4 editor invalids; affected fixtures were `2-onepager-coffee`, `3-artist-music` (2 blocks), and `31-personal-cv-academic`; snippets showed `core/paragraph` class mismatches like `has-text-color has-text-color hero-tagline`.
- After focused local fixture validation: `2-onepager-coffee`, `3-artist-music`, `31-personal-cv-academic`, and `15-saas` all report `wp_block_validity=pass`, 0 findings, 0 duplicate `has-text-color`, and 0 `core/html` fallback blocks.
- `composer test:canonical`
- `composer test` (includes 229 PHP transformer parity fixtures)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated Lab artifacts, mapped the invalid paragraph mismatch to generated class leakage, implemented the serializer fix and regression coverage, and ran verification.