### PR TITLE
Clamp desktop-only absolute fallback offsets

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -204,6 +204,10 @@ final class BreakpointMediaDiffBuilder
         if ( $isContainer && null !== $width && $width > 767.0 ) {
             $declarations[] = 'width:100%';
             $declarations[] = 'max-width:100%';
+            if ( 'absolute' === $position ) {
+                $declarations[] = 'left:0';
+                $declarations[] = 'right:auto';
+            }
             if ( null !== $height && $height > 240.0 && 'absolute' !== $position ) {
                 $declarations[] = 'height:auto';
                 if ( ! $wrapsRow && ! $this->hasContainerChild($node) ) {
@@ -231,6 +235,10 @@ final class BreakpointMediaDiffBuilder
         if ( 'TEXT' === $type && null !== $width && $width > 320.0 ) {
             $declarations[] = 'width:100%';
             $declarations[] = 'max-width:100%';
+            if ( 'absolute' === $position ) {
+                $declarations[] = 'left:0';
+                $declarations[] = 'right:auto';
+            }
             if ( null !== $height && $height > 0.0 ) {
                 $declarations[] = 'height:auto';
             }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -8151,6 +8151,37 @@ if ( preg_match('/@media \(max-width:1439px\)\{(?<block>[\s\S]*?)\n\}/', $deskto
 $assert(! str_contains($desktopOnlyWideFallbackBlock, '.figma-node-desktop-only-image-service-image{'), 'desktop-only-image-fallback-not-clamped-at-desktop');
 $assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-desktop-only-image-service-image\{[^}]*width:100%[^}]*max-width:100%[^}]*height:auto[^}]*aspect-ratio:538 \/ 381/s', $desktopOnlyImageFallbackCss) === 1, 'desktop-only-image-fallback-clamped-at-mobile');
 
+$desktopOnlyAbsoluteFallbackResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
+    array(
+        'name'   => 'Desktop-only absolute fallback fixture',
+        'assets' => array(),
+        'nodes'  => array(
+            array(
+                'id' => 'desktop-absolute:root', 'type' => 'FRAME', 'name' => 'Desktop Page', 'box' => array('width' => 1440, 'height' => 800),
+                'children' => array(
+                    array(
+                        'id' => 'desktop-absolute:panel', 'type' => 'FRAME', 'name' => 'Offset Panel', 'box' => array('x' => 360, 'y' => 96, 'width' => 900, 'height' => 120),
+                        'layout' => array('positioning' => 'absolute'),
+                        'children' => array(
+                            array('id' => 'desktop-absolute:text', 'type' => 'TEXT', 'name' => 'Offset Text', 'characters' => 'Fluid text should not retain a desktop left offset.', 'box' => array('x' => 24, 'y' => 24, 'width' => 520, 'height' => 32), 'layout' => array('positioning' => 'absolute')),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+    array('pages' => array(array('frame_id' => 'desktop-absolute:root', 'name' => 'Home', 'path' => 'index.html', 'entrypoint' => true)))
+);
+$desktopOnlyAbsoluteFallbackCss = '';
+foreach ( $desktopOnlyAbsoluteFallbackResult['files'] ?? array() as $desktopOnlyAbsoluteFallbackFile ) {
+    if ( is_array($desktopOnlyAbsoluteFallbackFile) && 'style.css' === ($desktopOnlyAbsoluteFallbackFile['path'] ?? null) ) {
+        $desktopOnlyAbsoluteFallbackCss = (string) ($desktopOnlyAbsoluteFallbackFile['content'] ?? '');
+    }
+}
+$assert('success' === ($desktopOnlyAbsoluteFallbackResult['status'] ?? null), 'desktop-only-absolute-fallback-transform-success');
+$assert(preg_match('/@media \(max-width:1439px\)\{[\s\S]*\.figma-node-desktop-absolute-panel-offset-panel\{[^}]*width:100%[^}]*max-width:100%[^}]*left:0[^}]*right:auto/s', $desktopOnlyAbsoluteFallbackCss) === 1, 'desktop-only-absolute-fallback-fluid-container-resets-left');
+$assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-desktop-absolute-text-offset-text\{[^}]*width:100%[^}]*max-width:100%[^}]*left:0[^}]*right:auto/s', $desktopOnlyAbsoluteFallbackCss) === 1, 'desktop-only-absolute-fallback-fluid-text-resets-left');
+
 if ( ! empty($failures) ) {
     fwrite(STDERR, "Figma Transformer contract failures:\n- " . implode("\n- ", $failures) . "\n");
     exit(1);


### PR DESCRIPTION
## Summary
- Reset horizontal offsets when desktop-only responsive fallback fluidizes absolutely positioned oversized nodes.
- Add contract coverage for absolute container/text fallback behavior.

## Validation
- Figma transformer contract suite passed.
- Fisiostetic fixture matrix completed with valid DOM capture.
- Three-fixture matrix completed with valid DOM capture for all selected pages.

## Fisiostetic metrics
- Readiness: 44 -> 48, still critical
- Layout mismatch count: 298 -> 297
- Rendered DOM risk: 6 -> 2
- DOM horizontal overflow: 2 -> 0
- DOM viewport width leak: 2 -> 0
- Route coverage: 1.000 -> 1.000
- Missing assets: 0 -> 0
- Missing semantic roles: 0 -> 0

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** improved generic Figma-to-HTML transformer parity and validated fixture evidence.