### PR TITLE
Centralize DOM box validity diagnostics

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix-quality.php
+++ b/figma-transformer/scripts/figma-fixture-matrix-quality.php
@@ -250,8 +250,11 @@ function matrix_analyze_dom_box_report(array $report, string $sourcePath = ''): 
     }
 
     $summary['page_count'] = count($pageReports);
-    $summary['dom_capture_valid'] = $summary['page_count'] > 0 && 0 === $summary['dom_capture_invalid_count'];
-    $summary['dom_css_loaded'] = $summary['page_count'] > 0 && 0 === $summary['dom_css_not_loaded_count'];
+    $summary = array_merge($summary, matrix_dom_box_validity_summary(
+        (int) $summary['page_count'],
+        (int) $summary['dom_capture_invalid_count'],
+        (int) $summary['dom_css_not_loaded_count']
+    ));
     $summary['risk_bucket'] = matrix_dom_box_risk_bucket((int) $summary['risk_score']);
 
     return array_filter(array(
@@ -289,11 +292,14 @@ function matrix_analyze_dom_box_entrypoint(array $entrypoint): array
     } else {
         $summary['dom_css_not_loaded_count'] = 1;
     }
+    $summary = array_merge($summary, matrix_dom_box_validity_summary(
+        1,
+        (int) $summary['dom_capture_invalid_count'],
+        (int) $summary['dom_css_not_loaded_count']
+    ));
 
     if ( ! $domCaptureValid ) {
         $summary['risk_bucket'] = 'low';
-        $summary['dom_capture_valid'] = false;
-        $summary['dom_css_loaded'] = $domCssLoaded;
         return array_filter(array(
             'page_path' => isset($entrypoint['page_path']) && is_scalar($entrypoint['page_path']) ? (string) $entrypoint['page_path'] : '',
             'viewport' => $viewport,
@@ -375,8 +381,6 @@ function matrix_analyze_dom_box_entrypoint(array $entrypoint): array
         + $summary['dom_offscreen_box_count']
         + $summary['dom_missing_node_id_box_count'];
     $summary['risk_bucket'] = matrix_dom_box_risk_bucket((int) $summary['risk_score']);
-    $summary['dom_capture_valid'] = true;
-    $summary['dom_css_loaded'] = true;
 
     return array(
         'page_path' => isset($entrypoint['page_path']) && is_scalar($entrypoint['page_path']) ? (string) $entrypoint['page_path'] : '',
@@ -407,6 +411,17 @@ function matrix_dom_box_empty_summary(): array
         'dom_css_not_loaded_count' => 0,
         'risk_score' => 0,
         'risk_bucket' => 'low',
+    );
+}
+
+/**
+ * @return array{dom_capture_valid: bool, dom_css_loaded: bool}
+ */
+function matrix_dom_box_validity_summary(int $pageCount, int $captureInvalidCount, int $cssNotLoadedCount): array
+{
+    return array(
+        'dom_capture_valid' => $pageCount > 0 && 0 === $captureInvalidCount,
+        'dom_css_loaded' => $pageCount > 0 && 0 === $cssNotLoadedCount,
     );
 }
 

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -467,6 +467,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(2 === ($domBoxQuality['summary']['dom_horizontal_overflow_count'] ?? null), 'fixture-matrix-dom-box-quality-horizontal-overflow');
     $assert(true === ($domBoxQuality['summary']['dom_css_loaded'] ?? null), 'fixture-matrix-dom-box-quality-css-loaded');
     $assert(true === ($domBoxQuality['summary']['dom_capture_valid'] ?? null), 'fixture-matrix-dom-box-quality-capture-valid');
+    $assert(array_key_exists('dom_css_loaded', $domBoxQuality['pages'][0]['summary'] ?? array()), 'fixture-matrix-dom-box-page-summary-has-css-loaded');
+    $assert(array_key_exists('dom_capture_valid', $domBoxQuality['pages'][0]['summary'] ?? array()), 'fixture-matrix-dom-box-page-summary-has-capture-valid');
     $assert(1 === ($domBoxQuality['summary']['dom_viewport_width_leak_count'] ?? null), 'fixture-matrix-dom-box-quality-viewport-width-leak');
     $assert(1 === ($domBoxQuality['summary']['dom_huge_vertical_spacing_count'] ?? null), 'fixture-matrix-dom-box-quality-huge-vertical-spacing');
     $assert(1 === ($domBoxQuality['summary']['dom_collapsed_box_count'] ?? null), 'fixture-matrix-dom-box-quality-collapsed-box');
@@ -474,6 +476,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(2 === ($domBoxQuality['summary']['dom_missing_node_id_box_count'] ?? null), 'fixture-matrix-dom-box-quality-missing-node-id-boxes');
     $assert(false === ($invalidDomBoxQuality['summary']['dom_css_loaded'] ?? null), 'fixture-matrix-invalid-dom-box-css-not-loaded');
     $assert(false === ($invalidDomBoxQuality['summary']['dom_capture_valid'] ?? null), 'fixture-matrix-invalid-dom-box-capture-invalid');
+    $assert(false === ($invalidDomBoxQuality['pages'][0]['summary']['dom_css_loaded'] ?? null), 'fixture-matrix-invalid-dom-box-page-css-not-loaded');
+    $assert(false === ($invalidDomBoxQuality['pages'][0]['summary']['dom_capture_valid'] ?? null), 'fixture-matrix-invalid-dom-box-page-capture-invalid');
     $assert(1 === ($invalidDomBoxQuality['summary']['dom_capture_invalid_count'] ?? null), 'fixture-matrix-invalid-dom-box-invalid-count');
     $assert(0 === ($invalidDomBoxQuality['summary']['dom_horizontal_overflow_count'] ?? null), 'fixture-matrix-invalid-dom-box-does-not-score-horizontal-overflow');
     $assert('dom_capture_invalid' === ($invalidDomBoxQuality['pages'][0]['findings'][0]['code'] ?? null), 'fixture-matrix-invalid-dom-box-finding');


### PR DESCRIPTION
## Summary
- Centralizes DOM box validity summary ownership in `matrix_dom_box_validity_summary()`.
- Reuses the helper for aggregate DOM box quality summaries and per-page summaries.
- Adds contract assertions that page summaries keep the required `dom_css_loaded` and `dom_capture_valid` keys for valid and invalid captures.

## Behavior compatibility
- Intended behavior-preserving refactor: emitted `dom_capture_valid` and `dom_css_loaded` values remain derived from page count, invalid capture count, and CSS-not-loaded count exactly as before.
- No schema version changes and no metric key renames.

## Tests
- `composer test` from `figma-transformer`
- `php tests/contract/run.php` from `figma-transformer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Inspected diagnostics contracts, drafted the small refactor and contract assertions, and ran local verification.