### PR TITLE
Refactor form control semantics

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Classification/FormControlClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/FormControlClassifier.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification;
+
+use DOMElement;
+
+final class FormControlClassifier
+{
+    /**
+     * Native elements that participate in form control semantics.
+     *
+     * @var array<int, string>
+     */
+    public const CONTROL_TAGS = array( 'button', 'input', 'select', 'textarea' );
+
+    /**
+     * Controls that collect user-entered values rather than only submitting or
+     * carrying hidden/runtime state.
+     *
+     * @var array<int, string>
+     */
+    public const DATA_ENTRY_TAGS = array( 'input', 'select', 'textarea' );
+
+    public static function isControlElement(DOMElement $element): bool
+    {
+        return in_array(strtolower($element->tagName), self::CONTROL_TAGS, true);
+    }
+
+    public static function controlType(DOMElement $control): string
+    {
+        $tagName = strtolower($control->tagName);
+        if ( 'input' === $tagName ) {
+            $type = strtolower(trim($control->hasAttribute('type') ? $control->getAttribute('type') : ''));
+            return '' !== $type ? $type : 'text';
+        }
+        if ( 'button' === $tagName ) {
+            $type = strtolower(trim($control->hasAttribute('type') ? $control->getAttribute('type') : ''));
+            return '' !== $type ? $type : 'submit';
+        }
+        if ( 'select' === $tagName && $control->hasAttribute('multiple') ) {
+            return 'select-multiple';
+        }
+
+        return $tagName;
+    }
+
+    public static function isDataEntryControl(DOMElement $control): bool
+    {
+        $tagName = strtolower($control->tagName);
+        if ( in_array($tagName, array( 'select', 'textarea' ), true) ) {
+            return true;
+        }
+
+        if ( 'input' !== $tagName ) {
+            return false;
+        }
+
+        return ! in_array(
+            self::controlType($control),
+            array( 'submit', 'reset', 'button', 'image', 'hidden', 'file' ),
+            true
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Classification/SubtreeClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Classification/SubtreeClassifier.php
@@ -61,8 +61,6 @@ final class SubtreeClassifier
         'accordion',
     );
 
-    private const FORM_CONTROL_TAGS = array( 'input', 'select', 'textarea' );
-
     public function classify(DOMElement $element, ?ClassificationContext $context = null): ClassificationResult
     {
         $context = $context ?? new ClassificationContext();
@@ -262,7 +260,7 @@ final class SubtreeClassifier
 
         return array(
             // DOM-derived structural signals.
-            'form_controls'         => $this->countDescendants($elements, self::FORM_CONTROL_TAGS),
+            'form_controls'         => $this->countDescendants($elements, FormControlClassifier::DATA_ENTRY_TAGS),
             'submit_or_form'        => $this->hasTag($elements, array( 'form' )) || $this->hasSubmit($elements),
             'canvas'               => $this->hasTag($elements, array( 'canvas' )),
             'contenteditable'      => $this->hasAttributeNamed($elements, 'contenteditable'),

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformationOptions;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\FormControlClassifier;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\ContentRoundTripReporter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsCollector;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
@@ -5523,20 +5524,7 @@ final class HtmlTransformer
      */
     private function isDataEntryControl(DOMElement $control): bool
     {
-        $tagName = strtolower($control->tagName);
-        if ( in_array($tagName, array( 'select', 'textarea' ), true) ) {
-            return true;
-        }
-
-        if ( 'input' !== $tagName ) {
-            return false;
-        }
-
-        return ! in_array(
-            $this->formControlType($control),
-            array( 'submit', 'reset', 'button', 'image', 'hidden', 'file' ),
-            true
-        );
+        return FormControlClassifier::isDataEntryControl($control);
     }
 
     private function isReadableFormControl(DOMElement $control): bool
@@ -5800,25 +5788,12 @@ final class HtmlTransformer
 
     private function isFormControlElement(DOMElement $element): bool
     {
-        return in_array(strtolower($element->tagName), array( 'button', 'input', 'select', 'textarea' ), true);
+        return FormControlClassifier::isControlElement($element);
     }
 
     private function formControlType(DOMElement $control): string
     {
-        $tagName = strtolower($control->tagName);
-        if ( 'input' === $tagName ) {
-            $type = strtolower(trim($this->attr($control, 'type')));
-            return '' !== $type ? $type : 'text';
-        }
-        if ( 'button' === $tagName ) {
-            $type = strtolower(trim($this->attr($control, 'type')));
-            return '' !== $type ? $type : 'submit';
-        }
-        if ( 'select' === $tagName && $control->hasAttribute('multiple') ) {
-            return 'select-multiple';
-        }
-
-        return $tagName;
+        return FormControlClassifier::controlType($control);
     }
 
     private function formControlLabel(DOMElement $control): string

--- a/php-transformer/tests/fixtures/parity/html-runtime-label-control-island.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-label-control-island.json
@@ -1,0 +1,38 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-runtime-label-control-island",
+  "description": "Preserves a label shell around a runtime-targeted control instead of flattening it to readable static text.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-runtime-label-control-island.json",
+    "notes": "Generic nested control-shell coverage for runtime DOM target handling."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime control shell preservation is an upstream primitive with no legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<main><label class=\"field-shell\">Quantity <input class=\"js-qty\" type=\"number\" name=\"quantity\" value=\"2\"></label></main>",
+    "options": {
+      "runtime_dom_selectors": [".js-qty"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/html" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "source_reports.html.runtime_islands", "assert": "count", "count": 1 },
+    { "path": "source_reports.html.runtime_islands.0.kind", "assert": "equals", "value": "control" },
+    { "path": "source_reports.html.runtime_islands.0.selector", "assert": "equals", "value": ".js-qty" },
+    { "path": "source_reports.html.runtime_islands.0.control.name", "assert": "equals", "value": "quantity" },
+    { "path": "source_reports.html.runtime_islands.0.control.type", "assert": "equals", "value": "number" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<label class=\"field-shell\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<input class=\"js-qty\" type=\"number\" name=\"quantity\" value=\"2\">" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "Quantity: 2" },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a shared PHP form control classifier for control tags, input type inference, and data-entry detection.
- Routes HtmlTransformer form-control helpers and SubtreeClassifier form-control signals through the shared primitive.
- Adds a fixture proving runtime-targeted controls nested in label shells are preserved as runtime islands instead of flattened to static readable text.

## Validation
- `composer test` from `php-transformer/` passed, including canonical contracts, unit tests, 230 parity fixtures, and packaging install proof.
- Direct FSE fixture matrix with valid Homeboy DOM capture completed using `figma-transformer/scripts/figma-fixture-matrix.php --capture-dom-boxes` and `php-transformer/tools/visual-parity/bin/dom-box-provider.mjs`.

## FSE Residual Risk
- This is a maintainability/coverage change, not a fixture-specific risk reduction.
- FSE residuals remain visible: form validity risk 19, SVG/Form/Input islands 98/4/11, missing semantic roles 4.
- DOM capture was valid and CSS loaded; broader visual readiness remains critical due existing layout/responsive risks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Inspected semantic/form/input handling, implemented the shared classifier and fixture coverage, ran validation, and drafted this PR description.
