### PR TITLE
Clarify omitted fixture route diagnostics

### DIFF
--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -184,6 +184,7 @@ function matrix_canonical_template_candidate_rank(array $candidate, string $page
 function matrix_omitted_page_candidate_records(array $inspection, array $selectedFrameIds): array
 {
     $selected = array_fill_keys($selectedFrameIds, true);
+    $selectedBucketFrameIds = matrix_selected_bucket_frame_ids($inspection, $selectedFrameIds);
     $omitted = array();
     foreach ( is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array() as $candidate ) {
         if ( ! is_array($candidate) || ! isset($candidate['id']) || ! is_scalar($candidate['id']) ) {
@@ -193,19 +194,52 @@ function matrix_omitted_page_candidate_records(array $inspection, array $selecte
         if ( isset($selected[$id]) || ! matrix_is_page_like_candidate($candidate) ) {
             continue;
         }
-        $omitted[] = array(
+        $bucket = matrix_candidate_bucket($candidate);
+        $selectedBucketFrameId = $selectedBucketFrameIds[$bucket] ?? null;
+        $record = array(
             'id' => $id,
             'name' => (string) ($candidate['name'] ?? ''),
             'page_type' => (string) ($candidate['page_type'] ?? ''),
-            'bucket' => matrix_candidate_bucket($candidate),
+            'bucket' => $bucket,
             'rank' => matrix_candidate_rank($candidate),
-            'reason' => 'max_pages_or_route_selection',
+            'reason' => null !== $selectedBucketFrameId ? 'covered_by_selected_route_bucket' : 'outside_page_cap',
         );
+        if ( null !== $selectedBucketFrameId ) {
+            $record['selected_bucket_frame_id'] = $selectedBucketFrameId;
+        }
+        $omitted[] = $record;
     }
 
     usort($omitted, static fn (array $a, array $b): int => ((int) ($b['rank'] ?? 0)) <=> ((int) ($a['rank'] ?? 0)));
 
     return $omitted;
+}
+
+/**
+ * @param array<string, mixed> $inspection
+ * @param array<int, string>   $selectedFrameIds
+ * @return array<string, string>
+ */
+function matrix_selected_bucket_frame_ids(array $inspection, array $selectedFrameIds): array
+{
+    $selected = array_fill_keys($selectedFrameIds, true);
+    $bucketFrameIds = array();
+    foreach ( is_array($inspection['candidates'] ?? null) ? $inspection['candidates'] : array() as $candidate ) {
+        if ( ! is_array($candidate) || ! isset($candidate['id']) || ! is_scalar($candidate['id']) ) {
+            continue;
+        }
+        $id = (string) $candidate['id'];
+        if ( ! isset($selected[$id]) || ! matrix_is_page_like_candidate($candidate) ) {
+            continue;
+        }
+
+        $bucket = matrix_candidate_bucket($candidate);
+        if ( ! isset($bucketFrameIds[$bucket]) ) {
+            $bucketFrameIds[$bucket] = $id;
+        }
+    }
+
+    return $bucketFrameIds;
 }
 
 /**

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -231,6 +231,66 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     );
     $canonicalTemplateSelection = matrix_select_frame_ids($canonicalTemplateSelectionInspection, 5);
     $canonicalTemplateOmissions = matrix_omitted_page_candidate_records($canonicalTemplateSelectionInspection, $canonicalTemplateSelection);
+    $coveredBucketOmissions = matrix_omitted_page_candidate_records(array(
+        'candidates' => array(
+            array(
+                'id'         => 'frame:home-desktop',
+                'name'       => 'Home Page - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 500,
+                'width'      => 1440,
+                'height'     => 4400,
+                'text_count' => 20,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups'),
+            ),
+            array(
+                'id'         => 'frame:home-alt',
+                'name'       => 'Home Page - Alternate Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 450,
+                'width'      => 1200,
+                'height'     => 5200,
+                'text_count' => 20,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups'),
+            ),
+        ),
+    ), array('frame:home-desktop'));
+    $pageCapOnlyOmissions = matrix_omitted_page_candidate_records(array(
+        'candidates' => array(
+            array(
+                'id'         => 'frame:home-desktop',
+                'name'       => 'Home Page - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 500,
+                'width'      => 1440,
+                'height'     => 4400,
+                'text_count' => 20,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups'),
+            ),
+            array(
+                'id'         => 'frame:single-desktop',
+                'name'       => 'Blog Post - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'single',
+                'score'      => 650,
+                'width'      => 1440,
+                'height'     => 8400,
+                'text_count' => 80,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups'),
+            ),
+        ),
+    ), array('frame:home-desktop'));
     $matrixVisualReadiness = matrix_fixture_visual_readiness(array(
         'id'                 => 'risk-fixture',
         'selected_frame_ids' => array('frame:home'),
@@ -459,6 +519,10 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(! in_array('frame:screenshot', $componentComposedFrontPageSelection, true), 'fixture-matrix-selection-skips-screenshot-utility-frame');
     $assert(array('frame:home-desktop', 'frame:single-desktop', 'frame:archive-desktop', 'frame:404-desktop', 'frame:page-desktop') === $canonicalTemplateSelection, 'fixture-matrix-selection-preserves-canonical-template-coverage-under-page-cap');
     $assert('frame:contact-desktop' === ($canonicalTemplateOmissions[0]['id'] ?? null), 'fixture-matrix-selection-reports-omitted-page-candidates');
+    $assert('covered_by_selected_route_bucket' === ($coveredBucketOmissions[0]['reason'] ?? null), 'fixture-matrix-selection-explains-selected-bucket-omission');
+    $assert('frame:home-desktop' === ($coveredBucketOmissions[0]['selected_bucket_frame_id'] ?? null), 'fixture-matrix-selection-reports-selected-bucket-frame');
+    $assert('outside_page_cap' === ($pageCapOnlyOmissions[0]['reason'] ?? null), 'fixture-matrix-selection-explains-page-cap-omission');
+    $assert(! array_key_exists('selected_bucket_frame_id', $pageCapOnlyOmissions[0] ?? array()), 'fixture-matrix-selection-omits-selected-bucket-frame-when-not-covered');
     $assert('medium' === ($matrixVisualReadiness['visual_risk_bucket'] ?? null), 'fixture-matrix-visual-readiness-buckets-risk');
     $assert(0.5 === ($matrixVisualReadiness['route_coverage_ratio'] ?? null), 'fixture-matrix-visual-readiness-route-coverage');
     $assert(4 === ($matrixVisualReadiness['risk_categories']['responsive_coverage']['count'] ?? null), 'fixture-matrix-visual-readiness-responsive-risk-count');


### PR DESCRIPTION
## Summary
- Split fixture matrix omitted page candidate diagnostics into concrete reasons: `covered_by_selected_route_bucket` and `outside_page_cap`.
- Include `selected_bucket_frame_id` when an omitted candidate is covered by an already-selected route bucket.
- Add contract coverage for both omitted-candidate reason paths.

## Relation to PR 578
- PR #578 adjusts fixture matrix route coverage counting and responsive diagnostics.
- This PR does not touch route coverage denominator/numerator logic or responsive diagnostics. It only clarifies omitted candidate reason metadata used to understand why route candidates were not selected.
- Landing order is flexible. If #578 lands first, this should rebase cleanly because the changed files do not overlap with #578 except the fixture matrix contract file.

## Validation
- `composer test:contract` from `figma-transformer`
- `php -l figma-transformer/scripts/figma-fixture-selection.php`
- `php -l figma-transformer/tests/contract/FixtureMatrixContract.php`

TT5 fixture run was not performed because no local TT5 `.fig` fixture was available in this checkout; fixture files are intentionally gitignored.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Inspected PR #578, implemented the diagnostics refactor and contract tests, ran validation, and drafted this PR description.
