### PR TITLE
Prefer visible labels for form controls

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -939,7 +939,7 @@ final class StaticHtmlEmitter
                     if ( $formControlAccessoryControl && $this->isFormControlPlaceholderChild($child) ) {
                         $this->recordDecisionTrace('source_loss_accounting', 'placeholder_child_converted_to_form_control', $child, 'skip_child', $node, array('depth' => $depth + 1));
                         if ( ! $insertedAccessoryInput ) {
-                            $content .= $this->syntheticFormControlMarkup($node, $className, $textareaAccessoryControl ? 'textarea' : 'input');
+                            $content .= $this->syntheticFormControlMarkup($node, $className, $textareaAccessoryControl ? 'textarea' : 'input', $parentNode);
                             $cssRules[] = $this->syntheticFormControlResetCss($className, $textareaAccessoryControl ? 'textarea' : 'input');
                             $insertedAccessoryInput = true;
                         }

--- a/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
+++ b/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
@@ -447,7 +447,7 @@ final class StaticHtmlSemanticClassifier
         }
         if ( '' !== $placeholder ) {
             $attributes .= ' placeholder="' . ($this->sanitizeAttribute)($placeholder) . '"';
-            $attributes .= ' aria-label="' . ($this->sanitizeAttribute)($placeholder) . '"';
+            $attributes .= ' aria-label="' . ($this->sanitizeAttribute)('' !== $label ? $label : $placeholder) . '"';
         } elseif ( '' !== $label && $this->isSpatiallyLabeledInputRectangle($node, $parentNode) ) {
             $attributes .= ' placeholder="' . ($this->sanitizeAttribute)($label) . '"';
             $attributes .= ' aria-label="' . ($this->sanitizeAttribute)($label) . '"';

--- a/figma-transformer/tests/contract/FormControlContract.php
+++ b/figma-transformer/tests/contract/FormControlContract.php
@@ -300,6 +300,18 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
                             )),
                         ),
                     ),
+                    array(
+                        'id'       => 'labeled:search-field',
+                        'type'     => 'FRAME',
+                        'name'     => 'Search Field',
+                        'children' => array(
+                            array('id' => 'labeled:search-label', 'type' => 'TEXT', 'name' => 'Label', 'characters' => 'Search', 'fontSize' => 14),
+                            array('id' => 'labeled:search-input', 'type' => 'FRAME', 'name' => 'Search field', 'width' => 320, 'height' => 44, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                                array('id' => 'labeled:search-icon', 'type' => 'ELLIPSE', 'name' => 'Search icon', 'width' => 16, 'height' => 16, 'strokePaints' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1)))),
+                                array('id' => 'labeled:search-placeholder', 'type' => 'TEXT', 'name' => 'Placeholder', 'characters' => 'Keywords', 'fontSize' => 16),
+                            )),
+                        ),
+                    ),
                     array('id' => 'labeled:submit', 'type' => 'FRAME', 'name' => 'Submit button', 'width' => 140, 'height' => 46, 'cornerRadius' => 999, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))), 'children' => array(
                         array('id' => 'labeled:submit-text', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Post Comment', 'fontSize' => 16),
                     )),
@@ -311,6 +323,7 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     $assert(str_contains($labeledHtml, 'data-figma-node-id="labeled:name-input"') && str_contains($labeledHtml, 'aria-label="Name *"'), 'form-control-nearby-label-names-text-input');
     $assert(str_contains($labeledHtml, 'data-figma-node-id="labeled:email-input"') && str_contains($labeledHtml, 'type="email" name="email"') && str_contains($labeledHtml, 'aria-label="Email *"'), 'form-control-nearby-label-infers-email-input');
     $assert(str_contains($labeledHtml, '<textarea class="figma-node-labeled-comment-input-input"') && str_contains($labeledHtml, 'aria-label="Comment"'), 'form-control-nearby-label-infers-comment-textarea');
+    $assert(str_contains($labeledHtml, '<input class="figma-node-labeled-search-input-search-field__control"') && str_contains($labeledHtml, 'placeholder="Keywords"') && str_contains($labeledHtml, 'aria-label="Search"'), 'form-control-nearby-label-names-accessory-input-with-placeholder');
 
     $layeredButtonResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Layered Button Fixture',


### PR DESCRIPTION
## Summary
- Prefer visible form labels when synthesizing fallback form controls.
- Keep placeholder text from becoming the accessible label when a real label is present.

## Validation
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT 5.5 via OpenCode, plus Lab OpenCode subagent
- **Used for:** Drafted the focused patch, rebased it locally, and ran validation.