### PR TITLE
Classify responsive route omissions

### DIFF
--- a/figma-transformer/scripts/figma-fixture-selection.php
+++ b/figma-transformer/scripts/figma-fixture-selection.php
@@ -196,14 +196,20 @@ function matrix_omitted_page_candidate_records(array $inspection, array $selecte
         }
         $bucket = matrix_candidate_bucket($candidate);
         $selectedBucketFrameId = $selectedBucketFrameIds[$bucket] ?? null;
+        $selectedResponsiveSiblingFrameId = matrix_selected_responsive_sibling_frame_id($candidate, $selected);
         $record = array(
             'id' => $id,
             'name' => (string) ($candidate['name'] ?? ''),
             'page_type' => (string) ($candidate['page_type'] ?? ''),
             'bucket' => $bucket,
             'rank' => matrix_candidate_rank($candidate),
-            'reason' => null !== $selectedBucketFrameId ? 'covered_by_selected_route_bucket' : 'outside_page_cap',
+            'reason' => null !== $selectedResponsiveSiblingFrameId
+                ? 'covered_by_selected_responsive_variant'
+                : (null !== $selectedBucketFrameId ? 'covered_by_selected_route_bucket' : 'outside_page_cap'),
         );
+        if ( null !== $selectedResponsiveSiblingFrameId ) {
+            $record['selected_responsive_sibling_frame_id'] = $selectedResponsiveSiblingFrameId;
+        }
         if ( null !== $selectedBucketFrameId ) {
             $record['selected_bucket_frame_id'] = $selectedBucketFrameId;
         }
@@ -213,6 +219,25 @@ function matrix_omitted_page_candidate_records(array $inspection, array $selecte
     usort($omitted, static fn (array $a, array $b): int => ((int) ($b['rank'] ?? 0)) <=> ((int) ($a['rank'] ?? 0)));
 
     return $omitted;
+}
+
+/**
+ * @param array<string, mixed> $candidate
+ * @param array<string, bool>  $selected
+ */
+function matrix_selected_responsive_sibling_frame_id(array $candidate, array $selected): ?string
+{
+    foreach ( is_array($candidate['responsive_siblings'] ?? null) ? $candidate['responsive_siblings'] : array() as $sibling ) {
+        if ( ! is_array($sibling) || ! isset($sibling['id']) || ! is_scalar($sibling['id']) ) {
+            continue;
+        }
+        $id = (string) $sibling['id'];
+        if ( isset($selected[$id]) ) {
+            return $id;
+        }
+    }
+
+    return null;
 }
 
 /**

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -261,6 +261,39 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
             ),
         ),
     ), array('frame:home-desktop'));
+    $coveredResponsiveVariantOmissions = matrix_omitted_page_candidate_records(array(
+        'candidates' => array(
+            array(
+                'id'         => 'frame:home-desktop',
+                'name'       => 'Home Page - Desktop',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 500,
+                'width'      => 1440,
+                'height'     => 4400,
+                'text_count' => 20,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups'),
+            ),
+            array(
+                'id'         => 'frame:home-tablet',
+                'name'       => 'Home Page - Tablet',
+                'type'       => 'FRAME',
+                'role'       => 'page',
+                'page_type'  => 'front_page',
+                'score'      => 450,
+                'width'      => 1024,
+                'height'     => 5200,
+                'text_count' => 20,
+                'parent'     => array('type' => 'CANVAS'),
+                'page'       => array('name' => 'Mockups'),
+                'responsive_siblings' => array(
+                    array('id' => 'frame:home-desktop', 'device_hint' => 'desktop'),
+                ),
+            ),
+        ),
+    ), array('frame:home-desktop'));
     $pageCapOnlyOmissions = matrix_omitted_page_candidate_records(array(
         'candidates' => array(
             array(
@@ -528,6 +561,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert('frame:contact-desktop' === ($canonicalTemplateOmissions[0]['id'] ?? null), 'fixture-matrix-selection-reports-omitted-page-candidates');
     $assert('covered_by_selected_route_bucket' === ($coveredBucketOmissions[0]['reason'] ?? null), 'fixture-matrix-selection-explains-selected-bucket-omission');
     $assert('frame:home-desktop' === ($coveredBucketOmissions[0]['selected_bucket_frame_id'] ?? null), 'fixture-matrix-selection-reports-selected-bucket-frame');
+    $assert('covered_by_selected_responsive_variant' === ($coveredResponsiveVariantOmissions[0]['reason'] ?? null), 'fixture-matrix-selection-explains-selected-responsive-variant-omission');
+    $assert('frame:home-desktop' === ($coveredResponsiveVariantOmissions[0]['selected_responsive_sibling_frame_id'] ?? null), 'fixture-matrix-selection-reports-selected-responsive-sibling-frame');
     $assert('outside_page_cap' === ($pageCapOnlyOmissions[0]['reason'] ?? null), 'fixture-matrix-selection-explains-page-cap-omission');
     $assert(! array_key_exists('selected_bucket_frame_id', $pageCapOnlyOmissions[0] ?? array()), 'fixture-matrix-selection-omits-selected-bucket-frame-when-not-covered');
     $assert('medium' === ($matrixVisualReadiness['visual_risk_bucket'] ?? null), 'fixture-matrix-visual-readiness-buckets-risk');


### PR DESCRIPTION
## Summary
- Classify omitted responsive sibling frames separately from generic selected route bucket coverage.
- Record the selected responsive sibling frame id for reviewer-facing fixture matrix diagnostics.

## Validation
- php figma-transformer/tests/contract/run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT 5.5 via OpenCode, plus Lab OpenCode subagent
- **Used for:** Drafted the focused patch, rebased it manually onto current trunk, and ran validation.