### PR TITLE
feat(fixtures): introduce solved fixture corpus and candidate lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 **/docs/superpowers/
 node_modules/
 figma-transformer/tmp/
+
+# Generated-site candidates (raw generation output; promote to fixtures/websites/ deliberately)
+fixtures/candidates/

--- a/fixtures/solved/README.md
+++ b/fixtures/solved/README.md
@@ -1,0 +1,38 @@
+# Solved Fixture Corpus
+
+This directory contains **permanent regression fixtures** for the Static Site Importer (SSI) fixture matrix.
+
+## Promotion convention
+
+A fixture moves from `fixtures/websites/` to `fixtures/solved/` only when:
+
+1. An SSI fixture-matrix run grades it `solved_candidate`.
+2. A human reviews the evidence and agrees the fixture is genuinely solved.
+3. The move is performed as a deliberate `git mv` (do not copy + delete).
+
+See the SSI fixture-matrix docs for the exact `solved_candidate` definition:
+
+- [docs/fixture-matrix.md](../../../../static-site-importer/blob/main/docs/fixture-matrix.md)
+- [docs/gutenberg-incompatibility-registry.md](../../../../static-site-importer/blob/main/docs/gutenberg-incompatibility-registry.md)
+
+## Lifecycle
+
+```
+fixtures/candidates/   (untracked raw generation output)
+        |
+        v
+fixtures/websites/     (active corpus under evaluation)
+        |
+        v
+fixtures/solved/       (permanent regression fixtures)
+```
+
+- `fixtures/candidates/` is listed in `.gitignore`; raw generation output never commits directly.
+- `fixtures/websites/` is the active corpus. The SSI fixture matrix runs against this corpus plus `fixtures/solved/`.
+- `fixtures/solved/` is the regression corpus. Once a fixture is promoted here it must stay solved.
+
+## Regression contract
+
+A solved fixture that regresses in the fixture matrix is a **hard failure**. The SSI registry surfaces this as `solved_regression`, distinct from ordinary blockers, and the matrix run fails until the regression is fixed or the fixture is demoted back to `fixtures/websites/` after review.
+
+Do not add fixtures here manually. Use the SSI promotion tool (`tools/promote-solved-fixture.mjs`) or an equivalent reviewed `git mv` workflow.

--- a/fixtures/websites/README.md
+++ b/fixtures/websites/README.md
@@ -15,6 +15,21 @@ One flat directory per fixture: `fixtures/websites/<id>/`. The directory basenam
 is the fixture ID. There is no nesting — class is metadata (in `fixture.json`), not
 directory structure.
 
+Fixture lifecycle
+-----------------
+
+The corpus is organized into three stages:
+
+- `fixtures/candidates/` — untracked raw generation output. This directory is
+  `.gitignore`d; candidates are reviewed before entering the tracked corpus.
+- `fixtures/websites/` — the active corpus under evaluation. The Static Site
+  Importer fixture matrix discovers and runs fixtures from this directory.
+- `fixtures/solved/` — permanent regression fixtures. A fixture moves here only
+  after an SSI fixture-matrix run grades it `solved_candidate` and the move is
+  reviewed and performed as `git mv`.
+
+See `../solved/README.md` for the promotion and regression contract.
+
 Each fixture directory contains:
 
 - An `index.html` entry point plus any supporting assets/content files (the source


### PR DESCRIPTION
This PR establishes the "solved fixture" regression corpus in blocks-engine.

## What changed
- Added `fixtures/solved/README.md` documenting the promotion convention and hard regression contract.
- Added `fixtures/candidates/` to `.gitignore` as untracked raw generation output.
- Updated `fixtures/websites/README.md` with the candidate → websites → solved lifecycle.

## Promotion convention
A fixture moves from `fixtures/websites/` to `fixtures/solved/` only when an SSI fixture-matrix run grades it `solved_candidate` and the move is reviewed and performed as a deliberate `git mv`. A solved fixture that regresses is a hard failure surfaced in the registry as `solved_regression`.

## Related PR
- SSI companion: https://github.com/Automattic/static-site-importer/pull/621

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 via OpenCode (orchestrator), Kimi K2.7 Code via OpenCode (implementation)
- **Used for:** Designed and implemented the solved-fixture promotion mechanic

Refs Automattic/static-site-importer#489