### PR TITLE
Measure Figma source loss across visual domains

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiParser.php
+++ b/figma-transformer/src/FigFile/FigKiwiParser.php
@@ -238,6 +238,7 @@ final class FigKiwiParser
                         );
                         $metadata['classification'] = 'kiwi_message';
                         $metadata['kiwi_message'] = $messageResult['message'];
+                        $this->attachSkippedFieldInventory($metadata, $payload, $kiwiSchema, $fieldPolicy, $diagnostics);
                         if ( null !== $nodeGate ) {
                             $metadata['kiwi_node_gate'] = $nodeGate;
                         }
@@ -263,6 +264,8 @@ final class FigKiwiParser
                 if ( null !== $messageResult['message'] ) {
                     $metadata['classification'] = 'kiwi_message';
                     $metadata['kiwi_message'] = $messageResult['message'];
+                    $fieldPolicy = true === ($options['render_text_glyph_paths'] ?? false) ? $this->kiwiDecoder->scenegraphFieldPolicyWithTextGlyphs() : array();
+                    $this->attachSkippedFieldInventory($metadata, $payload, $kiwiSchema, $fieldPolicy, $diagnostics);
                     if ( null !== $nodeGate ) {
                         $metadata['kiwi_node_gate'] = $nodeGate;
                     }
@@ -290,6 +293,24 @@ final class FigKiwiParser
         }
 
         return $metadata;
+    }
+
+    /**
+     * Record the selective decoder's bounded skipped-field evidence alongside
+     * the real Kiwi message so downstream artifact diagnostics can use it.
+     *
+     * @param array<string, mixed> $metadata
+     * @param array<string, mixed> $schema
+     * @param array<string, mixed> $fieldPolicy
+     * @param array<int, array<string, mixed>> $diagnostics
+     */
+    private function attachSkippedFieldInventory(array &$metadata, string $payload, array $schema, array $fieldPolicy, array &$diagnostics): void
+    {
+        $inventoryResult = $this->kiwiDecoder->inventorySkippedFieldsSelective($payload, $schema, 'Message', $fieldPolicy);
+        $diagnostics = array_merge($diagnostics, $inventoryResult['diagnostics']);
+        if ( is_array($inventoryResult['inventory'] ?? null) ) {
+            $metadata['kiwi_skipped_field_inventory'] = $inventoryResult['inventory'];
+        }
     }
 
     /**

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -163,6 +163,10 @@ final class FigmaTransformer
 
         $scenegraphCandidate = $this->decodedScenegraphCandidate($archive);
         if ( null !== $scenegraphCandidate ) {
+            $sourceLossEvidence = $this->sourceLossEvidenceForChunk($archive, (int) $scenegraphCandidate['report']['chunk_index']);
+            if ( ! empty($sourceLossEvidence) ) {
+                $options['source_loss_evidence'] = $sourceLossEvidence;
+            }
             $options['archive_asset_content_resolver'] = fn (array $asset): ?array => $this->archiveReader->hydrateAssetContent($path, $asset, $options);
             $scenegraph = $this->withArchiveAssets($scenegraphCandidate['payload'], $archive['assets']);
             $scenegraphResult = $this->transformScenegraph($scenegraph, $options)->toArray();
@@ -302,6 +306,20 @@ final class FigmaTransformer
         $selected = $candidates[0];
         $selected['candidate_count'] = count($candidates);
         return $selected;
+    }
+
+    /**
+     * @param array<string, mixed> $archive
+     * @return array<string, mixed>
+     */
+    private function sourceLossEvidenceForChunk(array $archive, int $chunkIndex): array
+    {
+        $chunk = $archive['archive']['canvas']['chunks'][$chunkIndex] ?? null;
+        $inventory = is_array($chunk) && is_array($chunk['payload']['kiwi_skipped_field_inventory'] ?? null)
+            ? $chunk['payload']['kiwi_skipped_field_inventory']
+            : null;
+
+        return null === $inventory ? array() : array('skipped_field_inventory' => $inventory);
     }
 
     /**
@@ -1943,12 +1961,13 @@ final class FigmaTransformer
             );
         }
         $sourceLossCoverage = $this->sourceLossCoverage($images, $vectors);
-        if ( ! empty($sourceLossCoverage['not_emitted_source_nodes']) ) {
+        $uncoveredSourceNodes = (int) ($sourceLossCoverage['node_coverage']['uncovered_source_nodes'] ?? 0);
+        if ( $uncoveredSourceNodes > 0 ) {
             $signals[] = array(
                 'severity' => 'warning',
                 'code' => 'source_loss_coverage_gap',
-                'count' => (int) $sourceLossCoverage['not_emitted_source_nodes'],
-                'coverage_ratio' => (float) $sourceLossCoverage['coverage_ratio'],
+                'uncovered_source_nodes' => $uncoveredSourceNodes,
+                'node_coverage_ratio' => (float) ($sourceLossCoverage['node_coverage']['coverage_ratio'] ?? 1.0),
                 'domains' => $sourceLossCoverage['domains'],
             );
         }

--- a/figma-transformer/src/Html/SourceLossCoverageBuilder.php
+++ b/figma-transformer/src/Html/SourceLossCoverageBuilder.php
@@ -18,18 +18,36 @@ final class SourceLossCoverageBuilder
         $decoded = 0;
         $emitted = 0;
         $notEmitted = 0;
+        $unsupportedFields = 0;
         foreach ( $domains as $domain ) {
             $decoded += (int) ($domain['decoded_source_nodes'] ?? 0);
             $emitted += (int) ($domain['emitted_source_nodes'] ?? 0);
             $notEmitted += (int) ($domain['not_emitted_source_nodes'] ?? 0);
+            $unsupportedFields += (int) ($domain['field_support']['unsupported_field_occurrences'] ?? 0);
         }
 
+        $nodeCoverageRatio = $decoded > 0 ? round($emitted / $decoded, 3) : 1.0;
+        $uncovered = max(0, $notEmitted, $decoded - $emitted);
+
         return array(
-            'schema' => 'blocks-engine/figma-transformer/source-loss-coverage/v1',
+            'schema' => 'blocks-engine/figma-transformer/source-loss-coverage/v2',
             'decoded_source_nodes' => $decoded,
             'emitted_source_nodes' => $emitted,
             'not_emitted_source_nodes' => $notEmitted,
-            'coverage_ratio' => $decoded > 0 ? round($emitted / $decoded, 3) : 1.0,
+            'node_coverage' => array(
+                'unit' => 'source_nodes',
+                'decoded_source_nodes' => $decoded,
+                'emitted_source_nodes' => $emitted,
+                'not_emitted_source_nodes' => $notEmitted,
+                'uncovered_source_nodes' => $uncovered,
+                'coverage_ratio' => $nodeCoverageRatio,
+            ),
+            'field_support' => array(
+                'unit' => 'field_occurrences',
+                'unsupported_visual_field_occurrences' => $unsupportedFields,
+                'support_status' => $unsupportedFields > 0 ? 'unsupported_fields_present' : 'not_measured',
+            ),
+            'full_coverage' => 0 === $uncovered && 0 === $unsupportedFields,
             'domains' => $domains,
         );
     }
@@ -37,18 +55,85 @@ final class SourceLossCoverageBuilder
     /**
      * @return array<string, mixed>
      */
-    public function domain(int $decoded, int $emitted, int $notEmitted, int $intentionallySuppressed = 0): array
+    public function domain(int $decoded, int $emitted, int $notEmitted, int $intentionallySuppressed = 0, int $unsupported = 0, array $evidence = array()): array
     {
         $decoded = max(0, $decoded);
         $emitted = max(0, $emitted);
         $notEmitted = max(0, $notEmitted);
         $intentionallySuppressed = max(0, $intentionallySuppressed);
+        $unsupported = max(0, $unsupported);
+        $covered = min($decoded, $emitted + $intentionallySuppressed);
+        $uncovered = max($notEmitted, $decoded - $covered);
 
         return array(
             'decoded_source_nodes' => $decoded,
-            'emitted_source_nodes' => min($decoded, $emitted + $intentionallySuppressed),
+            'emitted_source_nodes' => $covered,
             'intentionally_suppressed_source_nodes' => min($decoded, $intentionallySuppressed),
             'not_emitted_source_nodes' => $notEmitted,
+            'node_coverage' => array(
+                'unit' => 'source_nodes',
+                'coverage_ratio' => $decoded > 0 ? round($covered / $decoded, 3) : 1.0,
+                'uncovered_source_nodes' => $uncovered,
+            ),
+            'field_support' => array(
+                'unit' => 'field_occurrences',
+                'unsupported_field_occurrences' => $unsupported,
+            ),
+            'evidence' => $evidence,
+        );
+    }
+
+    /**
+     * Convert bounded Kiwi skipped-field evidence into visual-domain counts.
+     * Metadata roles remain visible in the evidence summary but do not affect
+     * visual coverage.
+     *
+     * @param array<string, mixed> $inventory
+     * @return array{domains: array<string, int>, summary: array<string, mixed>}
+     */
+    public function skippedFieldEvidence(array $inventory): array
+    {
+        $summary = is_array($inventory['summary'] ?? null) ? $inventory['summary'] : $inventory;
+        $byRole = is_array($summary['by_role'] ?? null) ? $summary['by_role'] : array();
+        $domainByRole = array(
+            'text_style' => 'text',
+            'fills_images' => 'paint_style',
+            'geometry_layout' => 'geometry_layout',
+            'component_overrides' => 'component_overrides',
+            'masks_effects' => 'paint_style',
+            'vectors' => 'vectors',
+        );
+        $excludedRoles = array('document_metadata', 'dev_status', 'export_metadata');
+        $domains = array();
+        $excluded = 0;
+        $unclassified = 0;
+        $unclassifiedByRole = array();
+
+        foreach ( $byRole as $role => $count ) {
+            $count = max(0, (int) $count);
+            if ( isset($domainByRole[$role]) ) {
+                $domain = $domainByRole[$role];
+                $domains[$domain] = ($domains[$domain] ?? 0) + $count;
+            } elseif ( in_array($role, $excludedRoles, true) ) {
+                $excluded += $count;
+            } else {
+                $unclassified += $count;
+                $unclassifiedByRole[$role] = $count;
+            }
+        }
+        ksort($domains);
+
+        return array(
+            'domains' => $domains,
+            'summary' => array(
+                'schema' => (string) ($inventory['schema'] ?? 'blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1'),
+                'total_occurrences' => (int) ($summary['occurrences'] ?? array_sum($byRole)),
+                'visually_meaningful_unsupported_occurrences' => array_sum($domains),
+                'excluded_metadata_occurrences' => $excluded,
+                'unclassified_occurrences' => $unclassified,
+                'unclassified_by_role' => $unclassifiedByRole,
+                'by_role' => $byRole,
+            ),
         );
     }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -481,7 +481,18 @@ final class StaticHtmlEmitter
         }
 
         $visualNodeMap = $this->visualNodeMap($nodes);
-        $transformDiagnostics = $this->transformDiagnostics($nodes, $visualNodeMap, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics, $body);
+        $transformDiagnostics = $this->transformDiagnostics(
+            $nodes,
+            $visualNodeMap,
+            $assetFiles,
+            $fontFamilies,
+            $fontUsage,
+            $fontResolution,
+            $css,
+            array_merge(is_array($scenegraph['diagnostics'] ?? null) ? $scenegraph['diagnostics'] : array(), $diagnostics),
+            $body,
+            is_array($options['source_loss_evidence'] ?? null) ? $options['source_loss_evidence'] : array()
+        );
         foreach ( $this->unresolvedSourceFontDiagnostics($fontResolution) as $diagnostic ) {
             $diagnostics[] = $diagnostic;
         }
@@ -762,7 +773,18 @@ final class StaticHtmlEmitter
         }
 
         $visualNodeMap = $this->visualNodeMap($renderedNodes);
-        $transformDiagnostics = $this->transformDiagnostics($renderedNodes, $visualNodeMap, $assetFiles, $fontFamilies, $fontUsage, $fontResolution, $css, $diagnostics, $this->htmlArtifactAssembler()->htmlFilesContent($files));
+        $transformDiagnostics = $this->transformDiagnostics(
+            $renderedNodes,
+            $visualNodeMap,
+            $assetFiles,
+            $fontFamilies,
+            $fontUsage,
+            $fontResolution,
+            $css,
+            array_merge(is_array($scenegraph['diagnostics'] ?? null) ? $scenegraph['diagnostics'] : array(), $diagnostics),
+            $this->htmlArtifactAssembler()->htmlFilesContent($files),
+            is_array($options['source_loss_evidence'] ?? null) ? $options['source_loss_evidence'] : array()
+        );
         foreach ( $this->unresolvedSourceFontDiagnostics($fontResolution) as $diagnostic ) {
             $diagnostics[] = $diagnostic;
         }
@@ -3850,9 +3872,10 @@ final class StaticHtmlEmitter
      * @param array<int, array<string, mixed>> $fontUsage
      * @param array<string, mixed> $fontResolution
      * @param array<int, array<string, mixed>> $diagnostics
+     * @param array<string, mixed> $sourceLossEvidence
      * @return array<string, mixed>
      */
-    private function transformDiagnostics(array $nodes, array $visualNodeMap, array $assetFiles, array $fontFamilies, array $fontUsage, array $fontResolution, string $css, array $diagnostics, string $html = ''): array
+    private function transformDiagnostics(array $nodes, array $visualNodeMap, array $assetFiles, array $fontFamilies, array $fontUsage, array $fontResolution, string $css, array $diagnostics, string $html = '', array $sourceLossEvidence = array()): array
     {
         $image = array(
             'paint_refs'      => 0,
@@ -4064,7 +4087,7 @@ final class StaticHtmlEmitter
             'links' => $links,
             'css' => $cssDiagnostics,
             'html_artifact' => $htmlArtifactDiagnostics,
-            'artifact_quality' => $this->transformDiagnosticsBuilder()->artifactQualityDiagnostics($image, $vectors, $fonts, $assets, $generatedSvgAssets, $layout, $links, $text, $components, $effects, $maskEffectClipping, $cssDiagnostics, $htmlArtifactDiagnostics, $responsiveDecisionTraces),
+            'artifact_quality' => $this->transformDiagnosticsBuilder()->artifactQualityDiagnostics($image, $vectors, $fonts, $assets, $generatedSvgAssets, $layout, $links, $text, $components, $effects, $maskEffectClipping, $cssDiagnostics, $htmlArtifactDiagnostics, $responsiveDecisionTraces, $diagnostics, $sourceLossEvidence),
             'diagnostic_codes' => $this->diagnosticCodeCounts($diagnostics),
         );
     }

--- a/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
+++ b/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
@@ -24,9 +24,11 @@ final class TransformDiagnosticsBuilder
      * @param array<string, mixed> $css
      * @param array<string, mixed> $htmlArtifact
      * @param array<string, mixed> $decisionTraces
+     * @param array<int, array<string, mixed>> $sourceDiagnostics
+     * @param array<string, mixed> $sourceLossEvidence
      * @return array<string, mixed>
      */
-    public function artifactQualityDiagnostics(array $image, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout, array $links = array(), array $text = array(), array $components = array(), array $effects = array(), array $maskEffectClipping = array(), array $css = array(), array $htmlArtifact = array(), array $decisionTraces = array()): array
+    public function artifactQualityDiagnostics(array $image, array $vectors, array $fonts, array $assets, array $generatedSvgAssets, array $layout, array $links = array(), array $text = array(), array $components = array(), array $effects = array(), array $maskEffectClipping = array(), array $css = array(), array $htmlArtifact = array(), array $decisionTraces = array(), array $sourceDiagnostics = array(), array $sourceLossEvidence = array()): array
     {
         $signals = array();
 
@@ -314,13 +316,16 @@ final class TransformDiagnosticsBuilder
             ) + $absoluteToFlowEvidence['summary'];
         }
 
-        $sourceLossCoverage = $this->sourceLossCoverage($image, $vectors, $text, $components, $effects, $maskEffectClipping);
-        if ( ! empty($sourceLossCoverage['not_emitted_source_nodes']) ) {
+        $sourceLossCoverage = $this->sourceLossCoverage($image, $vectors, $text, $components, $effects, $maskEffectClipping, $htmlArtifact, $sourceDiagnostics, $sourceLossEvidence);
+        $uncoveredNodes = (int) ($sourceLossCoverage['node_coverage']['uncovered_source_nodes'] ?? 0);
+        $unsupportedFields = (int) ($sourceLossCoverage['field_support']['unsupported_visual_field_occurrences'] ?? 0);
+        if ( $uncoveredNodes > 0 || $unsupportedFields > 0 ) {
             $signals[] = array(
                 'severity' => 'warning',
                 'code' => 'source_loss_coverage_gap',
-                'count' => (int) $sourceLossCoverage['not_emitted_source_nodes'],
-                'coverage_ratio' => (float) $sourceLossCoverage['coverage_ratio'],
+                'uncovered_source_nodes' => $uncoveredNodes,
+                'unsupported_visual_field_occurrences' => $unsupportedFields,
+                'node_coverage_ratio' => (float) ($sourceLossCoverage['node_coverage']['coverage_ratio'] ?? 1.0),
                 'domains' => $sourceLossCoverage['domains'],
             );
         }
@@ -509,19 +514,69 @@ final class TransformDiagnosticsBuilder
      * @param array<string, mixed> $components
      * @param array<string, mixed> $effects
      * @param array<string, mixed> $maskEffectClipping
+     * @param array<string, mixed> $htmlArtifact
+     * @param array<int, array<string, mixed>> $sourceDiagnostics
+     * @param array<string, mixed> $sourceLossEvidence
      * @return array<string, mixed>
      */
-    private function sourceLossCoverage(array $image, array $vectors, array $text, array $components, array $effects, array $maskEffectClipping): array
+    private function sourceLossCoverage(array $image, array $vectors, array $text, array $components, array $effects, array $maskEffectClipping, array $htmlArtifact, array $sourceDiagnostics, array $sourceLossEvidence): array
     {
         $sourceLossCoverageBuilder = new SourceLossCoverageBuilder();
+        $diagnosticCounts = array_count_values(array_values(array_filter(array_map(
+            static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+            $sourceDiagnostics
+        ))));
+        $skippedFields = $sourceLossCoverageBuilder->skippedFieldEvidence(
+            is_array($sourceLossEvidence['skipped_field_inventory'] ?? null) ? $sourceLossEvidence['skipped_field_inventory'] : array()
+        );
+        $skippedByDomain = $skippedFields['domains'];
+        $paintStyleDiagnosticCounts = (int) ($diagnosticCounts['figma_local_style_paint_conflict'] ?? 0)
+            + (int) ($diagnosticCounts['figma_missing_paint_style_reference'] ?? 0)
+            + (int) ($diagnosticCounts['figma_missing_effect_style_reference'] ?? 0);
+        $textStyleDiagnosticCount = (int) ($diagnosticCounts['figma_missing_text_style_reference'] ?? 0);
+        $overrideCandidates = (int) ($components['override_candidate_node_count'] ?? 0);
+        $overridesApplied = (int) ($components['override_applied_node_count'] ?? 0);
+        $unsupportedOverrides = (int) ($diagnosticCounts['figma_instance_override_unsupported'] ?? 0);
         $domains = array(
-            'images' => $sourceLossCoverageBuilder->imageDomain($image),
-            'vectors' => $sourceLossCoverageBuilder->vectorDomain($vectors),
             'text' => $sourceLossCoverageBuilder->domain(
                 (int) ($text['decoded_text_node_count'] ?? 0),
                 (int) ($text['emitted_text_node_count'] ?? 0),
                 (int) ($text['missing_emitted_text_node_count'] ?? 0),
-                (int) ($text['intentionally_suppressed_text_node_count'] ?? 0)
+                (int) ($text['intentionally_suppressed_text_node_count'] ?? 0),
+                (int) ($skippedByDomain['text'] ?? 0),
+                array('informational_style_diagnostic_count' => $textStyleDiagnosticCount)
+            ),
+            'paint_style' => $sourceLossCoverageBuilder->domain(
+                0,
+                0,
+                0,
+                0,
+                (int) ($skippedByDomain['paint_style'] ?? 0),
+                array('informational_style_diagnostic_count' => $paintStyleDiagnosticCounts)
+            ),
+            'geometry_layout' => $sourceLossCoverageBuilder->domain(
+                0,
+                0,
+                0,
+                0,
+                (int) ($skippedByDomain['geometry_layout'] ?? 0),
+                array('absolute_to_flow_conversion_count' => (int) ($htmlArtifact['absolute_to_flow_conversion_count'] ?? 0))
+            ),
+            'component_overrides' => $sourceLossCoverageBuilder->domain(
+                $overrideCandidates,
+                $overridesApplied,
+                max(0, $overrideCandidates - $overridesApplied),
+                0,
+                $unsupportedOverrides + (int) ($skippedByDomain['component_overrides'] ?? 0),
+                array('unsupported_override_diagnostic_count' => $unsupportedOverrides)
+            ),
+            'images' => $sourceLossCoverageBuilder->imageDomain($image),
+            'vectors' => $sourceLossCoverageBuilder->domain(
+                (int) ($vectors['nodes'] ?? 0),
+                (int) ($vectors['rendered_paths'] ?? 0) + (int) ($vectors['rendered_asset_fallbacks'] ?? 0),
+                (int) ($vectors['placeholders'] ?? 0),
+                0,
+                (int) ($skippedByDomain['vectors'] ?? 0)
             ),
             'components' => $sourceLossCoverageBuilder->domain(
                 (int) ($components['clone_source_node_count'] ?? 0),
@@ -542,7 +597,9 @@ final class TransformDiagnosticsBuilder
             ),
         );
 
-        return $sourceLossCoverageBuilder->aggregate($domains);
+        $coverage = $sourceLossCoverageBuilder->aggregate($domains);
+        $coverage['skipped_field_evidence'] = $skippedFields['summary'];
+        return $coverage;
     }
 
     /**

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -37,12 +37,63 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('visual_node_map_summary', 'nodes_with_emitted_metadata'), 2, 'diagnostics-evidence-normal-visual-map-summary-emitted-count');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('visual_node_map_summary', 'page_path_counts', 'index.html'), 2, 'diagnostics-evidence-normal-visual-map-summary-page-count');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('visual_node_map_summary', 'emitted_class_samples', 0, 'node_id'), 'diag:normal-page', 'diagnostics-evidence-normal-visual-map-summary-sample-node');
-    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('artifact_quality', 'summary', 'source_loss_coverage', 'schema'), 'blocks-engine/figma-transformer/source-loss-coverage/v1', 'diagnostics-evidence-normal-source-loss-schema');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('artifact_quality', 'summary', 'source_loss_coverage', 'schema'), 'blocks-engine/figma-transformer/source-loss-coverage/v2', 'diagnostics-evidence-normal-source-loss-schema');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('decision_traces', 'schema'), 'blocks-engine/figma-transformer/decision-traces/v1', 'diagnostics-evidence-normal-decision-traces-schema');
-    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('artifact_quality', 'summary', 'source_loss_coverage', 'coverage_ratio'), 1.0, 'diagnostics-evidence-normal-source-loss-clean-ratio');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $normalDiagnostics, array('artifact_quality', 'summary', 'source_loss_coverage', 'node_coverage', 'coverage_ratio'), 1.0, 'diagnostics-evidence-normal-source-loss-clean-node-ratio');
     blocks_engine_figma_transformer_contract_assert_no_quality_signal($assert, $normalResult, 'decoded_text_not_emitted', 'diagnostics-evidence-normal-no-missing-text-signal');
     blocks_engine_figma_transformer_contract_assert_no_quality_signal($assert, $normalResult, 'clipped_visual_area', 'diagnostics-evidence-normal-no-clipped-area-signal');
     blocks_engine_figma_transformer_contract_assert_no_quality_signal($assert, $normalResult, 'source_loss_coverage_gap', 'diagnostics-evidence-normal-no-source-loss-signal');
+
+    $sourceEvidenceQuality = (new \Automattic\BlocksEngine\FigmaTransformer\Html\TransformDiagnosticsBuilder())->artifactQualityDiagnostics(
+        array('node_refs' => 1, 'asset_nodes' => array(array('emitted' => true))),
+        array('nodes' => 1, 'rendered_paths' => 1),
+        array(),
+        array(),
+        array(),
+        array(),
+        array(),
+        array('decoded_text_node_count' => 2, 'emitted_text_node_count' => 2),
+        array('override_candidate_node_count' => 2, 'override_applied_node_count' => 1),
+        array(),
+        array(),
+        array(),
+        array('absolute_to_flow_conversion_count' => 1),
+        array(),
+        array(
+            array('code' => 'figma_local_style_paint_conflict'),
+            array('code' => 'figma_missing_text_style_reference'),
+            array('code' => 'figma_instance_override_unsupported'),
+        ),
+        array('skipped_field_inventory' => array(
+            'schema' => 'blocks-engine/figma-transformer/kiwi-skipped-field-inventory/v1',
+            'summary' => array(
+                'occurrences' => 9,
+                'by_role' => array(
+                    'geometry_layout' => 2,
+                    'document_metadata' => 3,
+                    'text_style' => 1,
+                    'fills_images' => 1,
+                    'export_metadata' => 1,
+                    'unknown_visual_role' => 1,
+                ),
+            ),
+        ))
+    );
+    $sourceEvidenceCoverage = $sourceEvidenceQuality['summary']['source_loss_coverage'] ?? array();
+    $assert(array('text', 'paint_style', 'geometry_layout', 'component_overrides', 'images', 'vectors', 'components', 'effects', 'masks') === array_keys($sourceEvidenceCoverage['domains'] ?? array()), 'diagnostics-evidence-source-loss-explicit-domain-order');
+    $assert('source_nodes' === ($sourceEvidenceCoverage['node_coverage']['unit'] ?? null), 'diagnostics-evidence-source-loss-node-unit');
+    $assert('field_occurrences' === ($sourceEvidenceCoverage['field_support']['unit'] ?? null), 'diagnostics-evidence-source-loss-field-unit');
+    $assert(1 === ($sourceEvidenceCoverage['node_coverage']['uncovered_source_nodes'] ?? null), 'diagnostics-evidence-source-loss-uncovered-nodes');
+    $assert(0.833 === ($sourceEvidenceCoverage['node_coverage']['coverage_ratio'] ?? null), 'diagnostics-evidence-source-loss-node-ratio');
+    $assert(5 === ($sourceEvidenceCoverage['field_support']['unsupported_visual_field_occurrences'] ?? null), 'diagnostics-evidence-source-loss-unsupported-fields');
+    $assert(0.5 === ($sourceEvidenceCoverage['domains']['component_overrides']['node_coverage']['coverage_ratio'] ?? null), 'diagnostics-evidence-source-loss-component-override-node-ratio');
+    $assert(1 === ($sourceEvidenceCoverage['domains']['text']['evidence']['informational_style_diagnostic_count'] ?? null), 'diagnostics-evidence-source-loss-missing-text-style-informational');
+    $assert(4 === ($sourceEvidenceCoverage['skipped_field_evidence']['visually_meaningful_unsupported_occurrences'] ?? null), 'diagnostics-evidence-source-loss-visual-skipped-count');
+    $assert(4 === ($sourceEvidenceCoverage['skipped_field_evidence']['excluded_metadata_occurrences'] ?? null), 'diagnostics-evidence-source-loss-metadata-skipped-count');
+    $assert(1 === ($sourceEvidenceCoverage['skipped_field_evidence']['unclassified_occurrences'] ?? null), 'diagnostics-evidence-source-loss-unclassified-skipped-count');
+    $assert(1 === ($sourceEvidenceCoverage['skipped_field_evidence']['unclassified_by_role']['unknown_visual_role'] ?? null), 'diagnostics-evidence-source-loss-unclassified-skipped-role');
+    $assert(false === ($sourceEvidenceCoverage['full_coverage'] ?? null), 'diagnostics-evidence-source-loss-unsupported-not-full');
+    $assert(0 === ($sourceEvidenceCoverage['domains']['geometry_layout']['node_coverage']['uncovered_source_nodes'] ?? null), 'diagnostics-evidence-source-loss-absolute-to-flow-not-loss');
 
     $positioningTraceResult = blocks_engine_figma_transformer_contract_transform(array(
         'name'  => 'Diagnostics Positioning Trace Fixture',
@@ -900,11 +951,11 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     $assert('index.html' === ($multiPageDiagnostics['layout']['positional_parity']['decision_trace_samples'][0]['page_path'] ?? null), 'diagnostics-evidence-multi-page-positional-sample-context');
     $sourceLossCoverage = $multiPageDiagnostics['artifact_quality']['summary']['source_loss_coverage'] ?? array();
     $sourceLossSignal = blocks_engine_figma_transformer_contract_artifact_quality_signal($multiPageResult, 'source_loss_coverage_gap');
-    $assert(2 === ($sourceLossCoverage['not_emitted_source_nodes'] ?? null), 'diagnostics-evidence-multi-page-source-loss-total-count');
+    $assert(2 === ($sourceLossCoverage['node_coverage']['not_emitted_source_nodes'] ?? null), 'diagnostics-evidence-multi-page-source-loss-total-count');
     $assert(0 === ($sourceLossCoverage['domains']['images']['not_emitted_source_nodes'] ?? null), 'diagnostics-evidence-multi-page-source-loss-image-domain-count');
     $assert(2 === ($sourceLossCoverage['domains']['vectors']['not_emitted_source_nodes'] ?? null), 'diagnostics-evidence-multi-page-source-loss-vector-domain-count');
-    $assert(0.5 === ($sourceLossCoverage['coverage_ratio'] ?? null), 'diagnostics-evidence-multi-page-source-loss-ratio');
-    $assert(2 === ($sourceLossSignal['count'] ?? null), 'diagnostics-evidence-multi-page-source-loss-signal-count');
+    $assert(0.5 === ($sourceLossCoverage['node_coverage']['coverage_ratio'] ?? null), 'diagnostics-evidence-multi-page-source-loss-ratio');
+    $assert(2 === ($sourceLossSignal['uncovered_source_nodes'] ?? null), 'diagnostics-evidence-multi-page-source-loss-signal-count');
     $assert('fail' === ($multiPageDiagnostics['artifact_quality']['quality_status'] ?? null), 'diagnostics-evidence-multi-page-source-loss-quality-fail');
     blocks_engine_figma_transformer_contract_assert_quality_signal($assert, $multiPageResult, 'missing_render_assets', 'diagnostics-evidence-multi-page-source-loss-missing-assets-signal');
     blocks_engine_figma_transformer_contract_assert_quality_signal($assert, $multiPageResult, 'vector_placeholders', 'diagnostics-evidence-multi-page-source-loss-vector-signal');

--- a/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
+++ b/figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
+use Automattic\BlocksEngine\FigmaTransformer\FigmaTransformer;
 
 /**
  * @param callable(bool, string): void $assert
@@ -105,6 +106,14 @@ function blocks_engine_figma_transformer_run_kiwi_skipped_field_inventory_contra
     $assert(is_array($written), 'kiwi-skipped-inventory-output-file-json');
     $assert('blocks-engine/figma-transformer/kiwi-skipped-field-inventory-file/v1' === ($written['schema'] ?? null), 'kiwi-skipped-inventory-output-file-schema');
     $assert(11 === ($written['summary']['field_count'] ?? null), 'kiwi-skipped-inventory-output-file-field-count');
+
+    $fixture = blocks_engine_figma_transformer_kiwi_inventory_fixture();
+    $fileResult = (new FigmaTransformer())->transformFile($fixture)->toArray();
+    @unlink($fixture);
+    $coverage = $fileResult['source_reports']['figma']['html']['transform_diagnostics']['artifact_quality']['summary']['source_loss_coverage'] ?? array();
+    $assert(6 === ($coverage['field_support']['unsupported_visual_field_occurrences'] ?? null), 'kiwi-skipped-inventory-transform-file-visual-fields-reach-diagnostics');
+    $assert(false === ($coverage['full_coverage'] ?? null), 'kiwi-skipped-inventory-transform-file-unsupported-fields-prevent-full-coverage');
+    $assert(2 === ($coverage['skipped_field_evidence']['unclassified_occurrences'] ?? null), 'kiwi-skipped-inventory-transform-file-unclassified-fields-visible');
 }
 
 function blocks_engine_figma_transformer_kiwi_inventory_fixture(): string


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `agent-task-8b9a6a9c-1a3f-4c4d-9b32-569b741f844c` into review-ready branch `fix/figma-source-loss-coverage`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:agent-task-8b9a6a9c-1a3f-4c4d-9b32-569b741f844c`
- **Homeboy run ID:** `agent-task-8b9a6a9c-1a3f-4c4d-9b32-569b741f844c`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-source-loss-coverage`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/328

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Node emission coverage and skipped-field support use separate denominators and explicit units.
- **Evidence discriminators preserved:** visually meaningful skipped Kiwi field inventory reaches real file-transform diagnostics
- **Nearby contracts preserved:** image and vector source-node counters remain available

## Attempt summary
GPT-5.6 Sol candidate redesigned after independent review; production .fig evidence path and unit-safe metrics verified.

## Gate results
- contract-tests: passed (targeted)
- production-evidence-path: passed (targeted)
- unit-safe-coverage: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer --working-dir=figma-transformer test`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/src/FigFile/FigKiwiParser.php
- figma-transformer/src/FigmaTransformer.php
- figma-transformer/src/Html/SourceLossCoverageBuilder.php
- figma-transformer/src/Html/StaticHtmlEmitter.php
- figma-transformer/src/Html/TransformDiagnosticsBuilder.php
- figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
- figma-transformer/tests/contract/KiwiSkippedFieldInventoryContract.php

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-source-loss-coverage`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented and reviewed source-loss diagnostics from raw .fig evidence.
