### PR TITLE
Preserve Figma line stroke semantics in vector fallbacks

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -6160,6 +6160,10 @@ final class StaticHtmlEmitter
             return false;
         }
 
+        if ( 'LINE' === $type && $rendersInlineVectorSvg ) {
+            return false;
+        }
+
         if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE'), true) ) {
             return true;
         }

--- a/figma-transformer/src/Html/VectorSvgRenderer.php
+++ b/figma-transformer/src/Html/VectorSvgRenderer.php
@@ -755,7 +755,12 @@ final class VectorSvgRenderer
     {
         $paint = $this->svgPaintAttributes($node);
         if ( 'LINE' === $type ) {
-            if ( ! $this->hasSvgStroke($paint) ) {
+            $paint = $this->lineStrokePaintAttributes($node);
+            if ( empty($paint) && $this->hasExplicitVectorSource($node) ) {
+                return array();
+            }
+            if ( empty($paint) ) {
+                $paint[] = 'fill="none"';
                 $paint[] = 'stroke="currentColor"';
                 $paint[] = 'stroke-width="1"';
             }
@@ -817,10 +822,14 @@ final class VectorSvgRenderer
      */
     private function zeroHeightVectorElements(array $node, string $type, float $width, float $height): array
     {
-        $paint = $this->svgPaintAttributes($node);
+        $paint = 'LINE' === $type ? $this->lineStrokePaintAttributes($node) : $this->svgPaintAttributes($node);
         if ( $this->hasSvgStroke($paint) ) {
             $paint = array_values(array_filter($paint, static fn (string $attribute): bool => ! str_starts_with($attribute, 'fill=')));
             return array('<line x1="0" y1="' . $this->number($height / 2) . '" x2="' . $this->number($width) . '" y2="' . $this->number($height / 2) . '" ' . implode(' ', $paint) . '/>');
+        }
+
+        if ( 'LINE' === $type && $this->hasExplicitVectorSource($node) ) {
+            return array();
         }
 
         if ( 'LINE' === $type || $this->hasVisibleCssVectorPaint($node, 'strokes') ) {
@@ -1251,6 +1260,49 @@ final class VectorSvgRenderer
         }
 
         return $attributes;
+    }
+
+    /**
+     * LINE primitives are stroke-only. Raw paints remain useful when a caller
+     * supplies a partially normalized node after command-blob decoding fails.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function lineStrokePaintAttributes(array $node): array
+    {
+        $paints = is_array($node['figma_paints']['strokes'] ?? null) ? $node['figma_paints']['strokes'] : array();
+        if ( empty($paints) ) {
+            $paints = is_array($node['strokePaints'] ?? null) ? $node['strokePaints'] : (is_array($node['strokes'] ?? null) ? $node['strokes'] : array());
+        }
+
+        $stroke = $this->firstSolidPaint($this->visiblePaints($paints));
+        if ( null === $stroke ) {
+            return array();
+        }
+
+        $attributes = array(
+            'fill="none"',
+            'stroke="' . $this->sanitizeAttribute($stroke) . '"',
+            'stroke-width="' . $this->number($this->strokeWeight($node)) . '"',
+        );
+        array_push($attributes, ...$this->strokeGeometryAttributes($node));
+
+        return $attributes;
+    }
+
+    /**
+     * @param array<int, mixed> $paints
+     * @return array<int, mixed>
+     */
+    private function visiblePaints(array $paints): array
+    {
+        return array_values(array_filter(
+            $paints,
+            static fn (mixed $paint): bool => is_array($paint)
+                && false !== ($paint['visible'] ?? true)
+                && (! isset($paint['opacity']) || ! is_numeric($paint['opacity']) || (float) $paint['opacity'] > 0.0)
+        ));
     }
 
     /**

--- a/figma-transformer/tests/contract/VectorCommandBlobContract.php
+++ b/figma-transformer/tests/contract/VectorCommandBlobContract.php
@@ -71,4 +71,124 @@ function blocks_engine_figma_transformer_run_vector_command_blob_contract(callab
     $assert(! in_array('unsupported_vector_command_blob', $longStrokeCommandDiagnosticCodes, true), 'long-stroke-command-blob-decodes-without-diagnostic');
     $assert(str_contains($longStrokeCommandHtml, 'data-figma-node-id="long-stroke:vector"') && str_contains($longStrokeCommandHtml, 'data-figma-vector="true"'), 'long-stroke-command-blob-renders');
     $assert(0 === ($longStrokeCommandTransformDiagnostics['vectors']['placeholders'] ?? null), 'long-stroke-command-blob-no-placeholder');
+
+    $lineFallbackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Twenty Twenty-Five LINE Fallback Fixture',
+        'blobs' => array(array('bytes' => "\xff")),
+        'nodes' => array(
+            array(
+                'id'             => '3137:3138',
+                'type'           => 'LINE',
+                'name'           => 'Separator',
+                'width'          => 1340,
+                'height'         => 0,
+                'strokeWeight'   => 1,
+                'strokeCap'      => 'ROUND',
+                'strokeJoin'     => 'BEVEL',
+                'dashPattern'    => array(4, 2),
+                'strokePaints'   => array(array(
+                    'type'    => 'SOLID',
+                    'color'   => array('r' => 0.1176470588, 'g' => 0.1176470588, 'b' => 0.1176470588, 'a' => 1),
+                    'opacity' => 0.2,
+                )),
+                'fillPaints'     => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0, 'b' => 0))),
+                'strokeGeometry' => array(array('commandsBlob' => 0)),
+            ),
+        ),
+    ));
+    $lineFallbackHtml = blocks_engine_figma_transformer_contract_file_content($lineFallbackResult, 'index.html');
+    $lineFallbackCss = blocks_engine_figma_transformer_contract_file_content($lineFallbackResult, 'style.css');
+    $lineFallbackCodes = array_map(
+        static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+        $lineFallbackResult['diagnostics'] ?? array()
+    );
+    $assert(str_contains($lineFallbackHtml, 'data-figma-node-id="3137:3138"') && str_contains($lineFallbackHtml, 'viewBox="0 0 1340 1"'), 'unsupported-line-command-blob-preserves-width-and-stroke-height');
+    $assert(str_contains($lineFallbackHtml, '<line x1="0" y1="0.5" x2="1340" y2="0.5" stroke="rgba(30,30,30,0.2)" stroke-width="1" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2"/>'), 'unsupported-line-command-blob-preserves-exact-stroke-semantics');
+    $assert(! str_contains($lineFallbackHtml, 'fill="#ff0000"') && ! str_contains($lineFallbackCss, 'background:#ff0000'), 'unsupported-line-command-blob-does-not-invent-fill-semantics');
+    $assert(in_array('unsupported_vector_command_blob', $lineFallbackCodes, true), 'unsupported-line-command-blob-keeps-conservative-diagnostic');
+    $assert(0 === ($lineFallbackResult['source_reports']['figma']['html']['transform_diagnostics']['vectors']['placeholders'] ?? null), 'unsupported-line-command-blob-needs-no-placeholder');
+
+    $malformedLineResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Malformed LINE Fallback Fixture',
+        'nodes' => array(
+            array(
+                'id'             => 'line:malformed',
+                'type'           => 'LINE',
+                'name'           => 'Malformed separator',
+                'width'          => 1340,
+                'height'         => 0,
+                'strokeWeight'   => 1,
+                'strokePaints'   => array(array('type' => 'SOLID', 'color' => array('r' => 'invalid'))),
+                'strokeGeometry' => array(array('commandsBlob' => 99)),
+            ),
+        ),
+    ));
+    $malformedLineHtml = blocks_engine_figma_transformer_contract_file_content($malformedLineResult, 'index.html');
+    $malformedLineCodes = array_map(
+        static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+        $malformedLineResult['diagnostics'] ?? array()
+    );
+    $assert(str_contains($malformedLineHtml, 'data-figma-node-id="line:malformed"') && str_contains($malformedLineHtml, 'data-figma-unsupported-vector="true"'), 'malformed-line-without-stroke-uses-safe-placeholder');
+    $assert(! str_contains($malformedLineHtml, 'stroke="currentColor"') && ! str_contains($malformedLineHtml, '<line '), 'malformed-line-does-not-invent-stroke-or-fill');
+    $assert(in_array('figma_vector_command_blob_missing', $malformedLineCodes, true), 'malformed-line-keeps-missing-blob-diagnostic');
+
+    $invisibleLineFallbackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Invisible LINE Fallback Fixture',
+        'blobs' => array(array('bytes' => "\xff")),
+        'nodes' => array(
+            array(
+                'id'             => 'line:invisible',
+                'type'           => 'LINE',
+                'name'           => 'Invisible separator',
+                'width'          => 100,
+                'height'         => 0,
+                'strokePaints'   => array(array('type' => 'SOLID', 'visible' => false, 'color' => array('r' => 0, 'g' => 0, 'b' => 0))),
+                'strokeGeometry' => array(array('commandsBlob' => 0)),
+            ),
+        ),
+    ));
+    $invisibleLineFallbackHtml = blocks_engine_figma_transformer_contract_file_content($invisibleLineFallbackResult, 'index.html');
+    $assert(str_contains($invisibleLineFallbackHtml, 'data-figma-unsupported-vector="true"'), 'hidden-line-stroke-keeps-placeholder');
+    $assert(! str_contains($invisibleLineFallbackHtml, '<line ') && ! str_contains($invisibleLineFallbackHtml, 'stroke="currentColor"'), 'hidden-line-stroke-does-not-become-visible');
+
+    $transparentLineFallbackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Transparent LINE Fallback Fixture',
+        'blobs' => array(array('bytes' => "\xff")),
+        'nodes' => array(
+            array(
+                'id'             => 'line:transparent',
+                'type'           => 'LINE',
+                'name'           => 'Transparent separator',
+                'width'          => 100,
+                'height'         => 0,
+                'strokePaints'   => array(array('type' => 'SOLID', 'opacity' => 0, 'color' => array('r' => 0, 'g' => 0, 'b' => 0))),
+                'strokeGeometry' => array(array('commandsBlob' => 0)),
+            ),
+        ),
+    ));
+    $transparentLineFallbackHtml = blocks_engine_figma_transformer_contract_file_content($transparentLineFallbackResult, 'index.html');
+    $assert(str_contains($transparentLineFallbackHtml, 'data-figma-unsupported-vector="true"'), 'zero-opacity-line-stroke-keeps-placeholder');
+    $assert(! str_contains($transparentLineFallbackHtml, '<line ') && ! str_contains($transparentLineFallbackHtml, 'stroke="currentColor"'), 'zero-opacity-line-stroke-does-not-become-visible');
+
+    $nonZeroLineFallbackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Non-Zero LINE Fallback Fixture',
+        'blobs' => array(array('bytes' => "\xff")),
+        'nodes' => array(
+            array(
+                'id'             => 'line:non-zero',
+                'type'           => 'LINE',
+                'name'           => 'Diagonal separator',
+                'width'          => 100,
+                'height'         => 20,
+                'strokeWeight'   => 3,
+                'strokeCap'      => 'SQUARE',
+                'strokeJoin'     => 'MITER',
+                'dashPattern'    => array(8, 4),
+                'strokePaints'   => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0, 'b' => 0))),
+                'strokeGeometry' => array(array('commandsBlob' => 0)),
+            ),
+        ),
+    ));
+    $nonZeroLineFallbackHtml = blocks_engine_figma_transformer_contract_file_content($nonZeroLineFallbackResult, 'index.html');
+    $assert(str_contains($nonZeroLineFallbackHtml, '<line x1="0" y1="0" x2="100" y2="20" fill="none" stroke="#ff0000" stroke-width="3" stroke-linecap="square" stroke-linejoin="miter" stroke-dasharray="8 4"/>'), 'non-zero-line-fallback-preserves-stroke-geometry');
 }


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `agent-task-e4aff578-61ac-4e48-81ec-95887e6e4fd2` into review-ready branch `fix/figma-vector-fallbacks`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:agent-task-e4aff578-61ac-4e48-81ec-95887e6e4fd2`
- **Homeboy run ID:** `agent-task-e4aff578-61ac-4e48-81ec-95887e6e4fd2`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-vector-fallbacks`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/328

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** The fallback is restricted to LINE primitives and preserves conservative behavior for unsupported general vector networks.
- **Evidence discriminators preserved:** LINE primitive with unsupported command blob and explicit visible source stroke
- **Nearby contracts preserved:** hidden and zero-opacity paints do not emit visible strokes

## Attempt summary
GPT-5.6 Sol candidate corrected after independent review; hidden/transparent and non-zero LINE contracts green.

## Gate results
- contract-tests: passed (targeted)
- hidden-stroke-safety: passed (targeted)
- line-semantics: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer --working-dir=figma-transformer test`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/src/Html/StaticHtmlEmitter.php
- figma-transformer/src/Html/VectorSvgRenderer.php
- figma-transformer/tests/contract/VectorCommandBlobContract.php

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-vector-fallbacks`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented and reviewed safe line-vector fallbacks from raw .fig evidence.
