### PR TITLE
Preserve explicit Figma instance paint overrides

### DIFF
--- a/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
+++ b/figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
@@ -344,7 +344,7 @@ final class FigKiwiDecodePolicy
     {
         // Stroke geometry (#328): weight/align/dash fields feed border emission.
         return array(
-            'fillPaints', 'strokePaints', 'backgroundPaints',
+            'fillPaints', 'fills', 'strokePaints', 'strokes', 'backgroundPaints',
             'styleIdForFill', 'styleIdForStrokeFill', 'styleIdForStroke',
             'strokeWeight', 'strokeAlign', 'strokeCap', 'strokeJoin', 'dashPattern',
             'borderStrokeWeightsIndependent', 'borderTopWeight', 'borderBottomWeight',

--- a/figma-transformer/src/Scenegraph/PaintNormalizer.php
+++ b/figma-transformer/src/Scenegraph/PaintNormalizer.php
@@ -79,18 +79,50 @@ final class PaintNormalizer
     private function normalizeLocalPaintCollections(array $node, string $nodeId, array &$diagnostics): array
     {
         $collections = array();
-        foreach ( self::PAINT_COLLECTION_SOURCES as $sourceKey => $targetKey ) {
-            if ( ! is_array($node[$sourceKey] ?? null) ) {
+        $sources = self::PAINT_COLLECTION_SOURCES;
+        foreach ( array('fills', 'strokes') as $collection ) {
+            foreach ( $this->explicitInstancePaintOverrideFields($node, $collection) as $sourceKey ) {
+                if ( isset($sources[$sourceKey]) ) {
+                    // Apply explicit aliases after retained component paint fields.
+                    $sources[$sourceKey] = null;
+                }
+            }
+        }
+
+        foreach ( $sources as $sourceKey => $targetKey ) {
+            if ( null === $targetKey ) {
                 continue;
+            }
+
+            $this->normalizeLocalPaintCollection($collections, $node, $nodeId, $sourceKey, $targetKey, $diagnostics);
+        }
+        foreach ( array('fills', 'strokes') as $collection ) {
+            foreach ( $this->explicitInstancePaintOverrideFields($node, $collection) as $sourceKey ) {
+                $targetKey = self::PAINT_COLLECTION_SOURCES[$sourceKey] ?? null;
+                if ( null !== $targetKey ) {
+                    $this->normalizeLocalPaintCollection($collections, $node, $nodeId, $sourceKey, $targetKey, $diagnostics);
+                }
+            }
+        }
+
+        return $collections;
+    }
+
+    /**
+     * @param array<string, array<int, array<string, mixed>>> $collections
+     * @param array<string, mixed>                            $node
+     * @param array<int, array<string, mixed>>                $diagnostics
+     */
+    private function normalizeLocalPaintCollection(array &$collections, array $node, string $nodeId, string $sourceKey, string $targetKey, array &$diagnostics): void
+    {
+            if ( ! is_array($node[$sourceKey] ?? null) ) {
+                return;
             }
 
             $paints = $this->normalizePaintList($node[$sourceKey], $nodeId, $sourceKey, $diagnostics);
             if ( ! empty($paints) ) {
                 $collections[$targetKey] = $paints;
             }
-        }
-
-        return $collections;
     }
 
     /**
@@ -151,17 +183,47 @@ final class PaintNormalizer
 
     /**
      * @param array<string, mixed> $node
-     * @return array{winner: string, local_vector_source: bool, reason: string}
+     * @return array{winner: string, local_vector_source: bool, local_provenance: string, local_source_fields: array<int, string>, reason: string}
      */
     private function resolveLocalStylePaintPrecedence(array $node, string $collection, bool $hasLocalPaints): array
     {
+        $instanceOverrideFields = $this->explicitInstancePaintOverrideFields($node, $collection);
+        $hasExplicitInstanceOverride = $hasLocalPaints && ! empty($instanceOverrideFields);
         $hasLocalVectorSource = $hasLocalPaints && $this->hasLocalVectorPaintSource($node, $collection);
+
+        if ( $hasExplicitInstanceOverride ) {
+            return array(
+                'winner'              => 'local',
+                'local_vector_source' => $hasLocalVectorSource,
+                'local_provenance'    => 'instance_override',
+                'local_source_fields' => $instanceOverrideFields,
+                'reason'              => 'explicit_instance_paint_override',
+            );
+        }
 
         return array(
             'winner'              => $hasLocalVectorSource ? 'local' : 'style',
             'local_vector_source' => $hasLocalVectorSource,
-            'reason'              => $hasLocalVectorSource ? 'local_vector_geometry' : 'style_reference',
+            'local_provenance'    => $hasLocalVectorSource ? 'vector_geometry' : 'unproven_node_field',
+            'local_source_fields' => array(),
+            'reason'              => $hasLocalVectorSource ? 'local_vector_geometry' : 'referenced_style_without_explicit_local_override',
         );
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function explicitInstancePaintOverrideFields(array $node, string $collection): array
+    {
+        $fields = $node['_figma_instance_paint_override_fields'][$collection] ?? null;
+        if ( ! is_array($fields) ) {
+            return array();
+        }
+
+        $fields = array_values(array_filter($fields, static fn (mixed $field): bool => is_string($field) && '' !== $field));
+        sort($fields, SORT_STRING);
+        return array_values(array_unique($fields));
     }
 
     /**
@@ -323,7 +385,7 @@ final class PaintNormalizer
      * @param array<int, array<string, mixed>> $diagnostics
      * @param array<int, array<string, mixed>> $localPaints
      * @param array<int, array<string, mixed>> $stylePaints
-     * @param array{winner: string, local_vector_source: bool, reason: string} $precedence
+     * @param array{winner: string, local_vector_source: bool, local_provenance: string, local_source_fields: array<int, string>, reason: string} $precedence
      */
     private function appendLocalStylePaintConflictDiagnostic(array &$diagnostics, string $nodeId, string $collection, string $styleId, array $localPaints, array $stylePaints, array $precedence): void
     {
@@ -350,6 +412,10 @@ final class PaintNormalizer
                 'geometry_backed' => $precedence['local_vector_source'],
                 'precedence'      => $precedence['winner'],
                 'precedence_rule' => $precedence['reason'],
+                'local_paint_provenance' => $precedence['local_provenance'],
+                'local_paint_source_fields' => $precedence['local_source_fields'],
+                'style_paint_provenance' => 'referenced_style',
+                'resolution_reason' => $precedence['reason'],
                 'local_paints'    => $localPaints,
                 'style_paints'    => $stylePaints,
             ),

--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -2667,6 +2667,10 @@ final class ScenegraphNormalizer
 			$hasFieldOverride = false;
             $sourcePaths = $this->instanceChildOverrideSourcePaths($child, $parentSourcePaths);
             $overrideFields = $this->instanceOverrideFieldsForChild($child, $overrides, $sourcePaths);
+            $paintOverrideFields = $this->instancePaintOverrideFields($overrideFields);
+            if ( ! empty($paintOverrideFields) ) {
+                $child['_figma_instance_paint_override_fields'] = $paintOverrideFields;
+            }
             $swapComponentId = isset($overrideFields['_figma_instance_swap_component_id']) && is_scalar($overrideFields['_figma_instance_swap_component_id']) ? (string) $overrideFields['_figma_instance_swap_component_id'] : null;
             unset($overrideFields['_figma_instance_swap_component_id']);
             $nestedComponentPropertyOverrides = $this->nestedComponentPropertyOverridesForChild($child, $overrideFields, $components);
@@ -2684,11 +2688,6 @@ final class ScenegraphNormalizer
                     $value = $this->normalizeInstanceOverridePaintField($child, $field, $value);
                 }
                 $child[$field] = $value;
-                if ( in_array($field, array('fills', 'fillPaints'), true) ) {
-                    unset($child['styleIdForFill']);
-                } elseif ( in_array($field, array('strokes', 'strokePaints'), true) ) {
-                    unset($child['styleIdForStrokeFill'], $child['styleIdForStroke']);
-                }
 				if ( in_array($field, array('characters', 'text'), true) && is_array($child['figma_text'] ?? null) ) {
 					$child['figma_text']['characters'] = (string) $value;
 				} elseif ( 'textData' === $field && is_array($value) && isset($value['characters']) && is_scalar($value['characters']) && is_array($child['figma_text'] ?? null) ) {
@@ -2708,6 +2707,30 @@ final class ScenegraphNormalizer
         }
 
         return $children;
+    }
+
+    /**
+     * @param array<string, mixed> $overrideFields
+     * @return array<string, array<int, string>>
+     */
+    private function instancePaintOverrideFields(array $overrideFields): array
+    {
+        $collections = array();
+        foreach ( array(
+            'fills'   => array('fillPaints', 'fills'),
+            'strokes' => array('strokePaints', 'strokes'),
+        ) as $collection => $fields ) {
+            foreach ( $fields as $field ) {
+                if ( array_key_exists($field, $overrideFields) ) {
+                    $collections[$collection][] = $field;
+                }
+            }
+            if ( isset($collections[$collection]) ) {
+                sort($collections[$collection], SORT_STRING);
+            }
+        }
+
+        return $collections;
     }
 
     /**

--- a/figma-transformer/tests/contract/KiwiParserContract.php
+++ b/figma-transformer/tests/contract/KiwiParserContract.php
@@ -323,7 +323,8 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
         $kiwiImagePaintSchema['schema'] ?? array()
     );
     $kiwiDirectImagePaint = $kiwiImagePaintMessage['message']['nodeChanges'][0]['fillPaints'][0] ?? array();
-    $kiwiOverrideImagePaint = $kiwiImagePaintMessage['message']['nodeChanges'][0]['symbolData']['symbolOverrides'][0]['fillPaints'][0] ?? array();
+    $kiwiOverrideImagePaint = $kiwiImagePaintMessage['message']['nodeChanges'][0]['symbolData']['symbolOverrides'][0]['fills'][0] ?? array();
+    $kiwiOverrideStrokePaint = $kiwiImagePaintMessage['message']['nodeChanges'][0]['symbolData']['symbolOverrides'][0]['strokes'][0] ?? array();
     $kiwiImagePaintNode = $kiwiImagePaintMessage['message']['nodeChanges'][0] ?? array();
     $kiwiDirectFillStyle = $kiwiImagePaintMessage['message']['nodeChanges'][0]['styleIdForFill']['guid'] ?? array();
     $kiwiDirectStrokeStyle = $kiwiImagePaintMessage['message']['nodeChanges'][0]['styleIdForStrokeFill']['guid'] ?? array();
@@ -350,10 +351,50 @@ function blocks_engine_figma_transformer_run_kiwi_parser_contract(callable $asse
     $assert('library-asset-node' === ($kiwiImagePaintNode['sourceLibraryKey'] ?? null), 'kiwi-selective-decodes-node-source-library-key');
     $assert(false === ($kiwiOverrideImagePaint['imageShouldColorManage'] ?? null), 'kiwi-selective-decodes-override-image-color-management');
     $assert(9 === ($kiwiOverrideImagePaint['animationFrame'] ?? null), 'kiwi-selective-decodes-override-image-animation-frame');
+    $assert('override-stroke-hash' === ($kiwiOverrideStrokePaint['image']['hash'] ?? null), 'kiwi-selective-decodes-override-stroke-alias');
     $assert(9001 === ($kiwiDirectFillStyle['sessionID'] ?? null) && 101 === ($kiwiDirectFillStyle['localID'] ?? null), 'kiwi-selective-decodes-style-id-for-fill');
     $assert(9001 === ($kiwiDirectStrokeStyle['sessionID'] ?? null) && 102 === ($kiwiDirectStrokeStyle['localID'] ?? null), 'kiwi-selective-decodes-style-id-for-stroke-fill');
     $assert(9002 === ($kiwiOverrideFillStyle['sessionID'] ?? null) && 201 === ($kiwiOverrideFillStyle['localID'] ?? null), 'kiwi-selective-decodes-override-style-id-for-fill');
     $assert(9002 === ($kiwiOverrideStrokeStyle['sessionID'] ?? null) && 202 === ($kiwiOverrideStrokeStyle['localID'] ?? null), 'kiwi-selective-decodes-override-style-id-for-stroke-fill');
+    $kiwiPaintOverrideDiagnostics = array();
+    $kiwiPaintOverrideFields = ( new \Automattic\BlocksEngine\FigmaTransformer\Scenegraph\InstanceResolver() )->normalizeInstanceOverrides($kiwiImagePaintNode, 'kiwi:paint-override', $kiwiPaintOverrideDiagnostics);
+    $assert('override-hash' === ($kiwiPaintOverrideFields['9002:200']['fills'][0]['image']['hash'] ?? null), 'kiwi-paint-override-resolver-preserves-fill-alias');
+    $assert('override-stroke-hash' === ($kiwiPaintOverrideFields['9002:200']['strokes'][0]['image']['hash'] ?? null), 'kiwi-paint-override-resolver-preserves-stroke-alias');
+    $assert(9002 === ($kiwiPaintOverrideFields['9002:200']['styleIdForFill']['guid']['sessionID'] ?? null), 'kiwi-paint-override-resolver-preserves-referenced-style-with-local-paint');
+    $kiwiDecodedOverrideScenegraph = array(
+        'name'  => 'Kiwi Decoded Paint Override Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'kiwi:paint-component',
+                'type'     => 'COMPONENT',
+                'name'     => 'Kiwi paint component',
+                'children' => array(
+                    array(
+                        'id'           => '9002:200',
+                        'type'         => 'FRAME',
+                        'name'         => 'Kiwi paint target',
+                        'width'        => 40,
+                        'height'       => 20,
+                        'fillPaints'   => $kiwiImagePaintNode['fillPaints'],
+                        'strokePaints' => $kiwiImagePaintNode['fillPaints'],
+                    ),
+                ),
+            ),
+            array(
+                'id'         => 'kiwi:paint-instance',
+                'type'       => 'INSTANCE',
+                'name'       => 'Kiwi paint instance',
+                'symbolData' => array('symbolID' => 'kiwi:paint-component', 'symbolOverrides' => $kiwiPaintOverrideFields),
+            ),
+        ),
+    );
+    $kiwiDecodedOverrideNormalized = ( new ScenegraphNormalizer() )->normalize($kiwiDecodedOverrideScenegraph);
+    $kiwiDecodedOverrideNode = $kiwiDecodedOverrideNormalized['nodes'][1]['children'][0] ?? array();
+    $kiwiDecodedOverrideResult = blocks_engine_figma_transformer_transform_scenegraph($kiwiDecodedOverrideScenegraph);
+    $kiwiDecodedOverrideHtml = $fileContent($kiwiDecodedOverrideResult, 'index.html');
+    $assert('override-hash' === ($kiwiDecodedOverrideNode['figma_paints']['fills'][0]['ref'] ?? null), 'kiwi-decoded-fill-alias-normalizes-over-retained-fill-paint');
+    $assert('6f766572726964652d7374726f6b652d68617368' === ($kiwiDecodedOverrideNode['figma_paints']['strokes'][0]['ref'] ?? null), 'kiwi-decoded-stroke-alias-normalizes-over-retained-stroke-paint');
+    $assert(str_contains($kiwiDecodedOverrideHtml, 'data-figma-node-id="9002:200"'), 'kiwi-decoded-paint-overrides-emit-resolved-instance-child');
     $kiwiImageNormalizer = new ScenegraphNormalizer();
     $kiwiImagePaintNode['id'] = 'kiwi:asset-node';
     $kiwiImageNormalized = $kiwiImageNormalizer->normalize(array('name' => 'Kiwi Asset Metadata Fixture', 'nodes' => array($kiwiImagePaintNode)));
@@ -1235,10 +1276,10 @@ function blocks_engine_figma_transformer_kiwi_image_paint_schema_fixture(): stri
         . chr(1)
         . blocks_engine_figma_transformer_wire_varint(1)
         . blocks_engine_figma_transformer_kiwi_schema_field('symbolOverrides', 11, true, 1)
-        // def11: MESSAGE NodeChange { type, fillPaints[], symbolData, styleIdForFill, styleIdForStrokeFill, exportSettings, publishID, sourceLibraryKey }
+        // def11: MESSAGE NodeChange { type, fillPaints[], symbolData, styleIdForFill, styleIdForStrokeFill, exportSettings, publishID, sourceLibraryKey, guid, fills[], strokes[] }
         . blocks_engine_figma_transformer_kiwi_string('NodeChange')
         . chr(2)
-        . blocks_engine_figma_transformer_wire_varint(8)
+        . blocks_engine_figma_transformer_wire_varint(11)
         . blocks_engine_figma_transformer_kiwi_schema_field('type', -6, false, 1)
         . blocks_engine_figma_transformer_kiwi_schema_field('fillPaints', 8, true, 2)
         . blocks_engine_figma_transformer_kiwi_schema_field('symbolData', 10, false, 3)
@@ -1247,6 +1288,9 @@ function blocks_engine_figma_transformer_kiwi_image_paint_schema_fixture(): stri
         . blocks_engine_figma_transformer_kiwi_schema_field('exportSettings', 7, true, 6)
         . blocks_engine_figma_transformer_kiwi_schema_field('publishID', -6, false, 7)
         . blocks_engine_figma_transformer_kiwi_schema_field('sourceLibraryKey', -6, false, 8)
+        . blocks_engine_figma_transformer_kiwi_schema_field('guid', 2, false, 9)
+        . blocks_engine_figma_transformer_kiwi_schema_field('fills', 8, true, 10)
+        . blocks_engine_figma_transformer_kiwi_schema_field('strokes', 8, true, 11)
         // def12: MESSAGE Message { type, nodeChanges[] }
         . blocks_engine_figma_transformer_kiwi_string('Message')
         . chr(2)
@@ -1281,13 +1325,18 @@ function blocks_engine_figma_transformer_kiwi_image_paint_message_fixture(): str
         . blocks_engine_figma_transformer_wire_varint(1)
         . blocks_engine_figma_transformer_wire_varint(1)
         . blocks_engine_figma_transformer_kiwi_string('RECTANGLE')
-        . blocks_engine_figma_transformer_wire_varint(2)
+        . blocks_engine_figma_transformer_wire_varint(10)
         . blocks_engine_figma_transformer_wire_varint(1)
         . blocks_engine_figma_transformer_kiwi_image_paint_bytes('override-hash', false, 30.0, 1.25, 9, 'xyz', 0.25)
+        . blocks_engine_figma_transformer_wire_varint(11)
+        . blocks_engine_figma_transformer_wire_varint(1)
+        . blocks_engine_figma_transformer_kiwi_image_paint_bytes('override-stroke-hash', false, 30.0, 1.25, 9, 'xyz', 0.25)
         . blocks_engine_figma_transformer_wire_varint(4)
         . blocks_engine_figma_transformer_kiwi_style_id_bytes(9002, 201)
         . blocks_engine_figma_transformer_wire_varint(5)
         . blocks_engine_figma_transformer_kiwi_style_id_bytes(9002, 202)
+        . blocks_engine_figma_transformer_wire_varint(9)
+        . blocks_engine_figma_transformer_kiwi_style_id_bytes(9002, 200)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0)
         . blocks_engine_figma_transformer_wire_varint(0);

--- a/figma-transformer/tests/contract/VectorRenderingContract.php
+++ b/figma-transformer/tests/contract/VectorRenderingContract.php
@@ -394,6 +394,95 @@ function blocks_engine_figma_transformer_run_vector_rendering_contract(Closure $
     $assert(str_contains($containerPaintWithStyleCss, '.figma-node-frame-stale-local-with-style-stale-local-with-style{width:28px;height:3px;background:#ffcf00'), 'style-fill-wins-over-container-stale-local-fill');
     $assert('style' === ($containerPaintWithStyleDiagnostics[0]['context']['precedence'] ?? null), 'container-style-fill-conflict-diagnostic-precedence');
     $assert('warning' === ($containerPaintWithStyleDiagnostics[0]['severity'] ?? null), 'container-style-fill-conflict-diagnostic-warning');
+    $assert('unproven_node_field' === ($containerPaintWithStyleDiagnostics[0]['context']['local_paint_provenance'] ?? null), 'container-style-fill-conflict-diagnostic-local-provenance');
+    $assert('referenced_style_without_explicit_local_override' === ($containerPaintWithStyleDiagnostics[0]['context']['resolution_reason'] ?? null), 'container-style-fill-conflict-diagnostic-resolution-reason');
+
+    $instancePaintPrecedenceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Instance Paint Precedence Fixture',
+        'nodes' => array(
+            array(
+                'guid'       => array('sessionID' => 810, 'localID' => 1),
+                'type'       => 'RECTANGLE',
+                'name'       => 'Accent paint style',
+                'styleType'  => 'FILL',
+                'fillPaints' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 0.8, 'b' => 0, 'a' => 1))),
+            ),
+            array(
+                'guid'     => array('sessionID' => 810, 'localID' => 2),
+                'type'     => 'COMPONENT',
+                'name'     => 'Styled panel component',
+                'children' => array(
+                    array(
+                        'guid'           => array('sessionID' => 810, 'localID' => 3),
+                        'type'           => 'FRAME',
+                        'name'           => 'Panel',
+                        'width'          => 80,
+                        'height'         => 40,
+                        'styleIdForFill' => array('guid' => array('sessionID' => 810, 'localID' => 1)),
+                        'styleIdForStrokeFill' => array('guid' => array('sessionID' => 810, 'localID' => 1)),
+                        'fillPaints'     => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                        'strokePaints'   => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                        'strokeWeight'   => 2,
+                    ),
+                ),
+            ),
+            array(
+                'id'         => 'instance:inherited-paint',
+                'type'       => 'INSTANCE',
+                'name'       => 'Inherited paint instance',
+                'symbolData' => array('symbolID' => array('sessionID' => 810, 'localID' => 2)),
+            ),
+            array(
+                'id'         => 'instance:explicit-paint',
+                'type'       => 'INSTANCE',
+                'name'       => 'Explicit paint instance',
+                'symbolData' => array(
+                    'symbolID' => array('sessionID' => 810, 'localID' => 2),
+                    'symbolOverrides' => array(
+                        array(
+                            'guidPath'       => array('guids' => array(array('sessionID' => 810, 'localID' => 3))),
+                            'fills'          => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))),
+                            'strokes'        => array(array('type' => 'SOLID', 'color' => array('r' => 0.2, 'g' => 0.4, 'b' => 0.6, 'a' => 1))),
+                            'styleIdForFill' => array('guid' => array('sessionID' => 810, 'localID' => 1)),
+                            'styleIdForStrokeFill' => array('guid' => array('sessionID' => 810, 'localID' => 1)),
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                'id'               => 'detached:local-paint',
+                'type'             => 'FRAME',
+                'name'             => 'Detached local panel',
+                'width'            => 80,
+                'height'           => 40,
+                'detachedSymbolId' => array('sessionID' => 810, 'localID' => 2),
+                'fillPaints'       => array(array('type' => 'SOLID', 'color' => array('r' => 0.2, 'g' => 0.4, 'b' => 0.6, 'a' => 1))),
+            ),
+        ),
+    ));
+    $instancePaintPrecedenceCss = $fileContent($instancePaintPrecedenceResult, 'style.css');
+    $inheritedPaintRule = blocks_engine_figma_transformer_contract_css_rule($instancePaintPrecedenceCss, '.figma-node-instance-inherited-paint-810-3-panel');
+    $explicitPaintRule = blocks_engine_figma_transformer_contract_css_rule($instancePaintPrecedenceCss, '.figma-node-instance-explicit-paint-810-3-panel');
+    $instancePaintPrecedenceDiagnostics = array_values(array_filter(
+        $instancePaintPrecedenceResult['diagnostics'] ?? array(),
+        static fn (array $diagnostic): bool => 'figma_local_style_paint_conflict' === ($diagnostic['code'] ?? null)
+            && str_contains((string) ($diagnostic['context']['node_id'] ?? ''), '810:3')
+    ));
+    $explicitPaintDiagnostic = null;
+    foreach ( $instancePaintPrecedenceDiagnostics as $diagnostic ) {
+        if ( 'local' === ($diagnostic['context']['precedence'] ?? null) ) {
+            $explicitPaintDiagnostic = $diagnostic;
+            break;
+        }
+    }
+    $assert(str_contains($inheritedPaintRule, 'background:#ffcc00'), 'instance-inherited-style-paint-wins-over-default-local-paint');
+    $assert(str_contains($explicitPaintRule, 'background:#ffffff'), 'instance-explicit-local-paint-wins-over-referenced-style');
+    $assert(str_contains($explicitPaintRule, 'border:2px solid #336699'), 'instance-explicit-stroke-alias-wins-over-retained-stroke-paint');
+    $assert(str_contains($instancePaintPrecedenceCss, '.figma-node-detached-local-paint-detached-local-panel{width:80px;height:40px;background:#336699'), 'detached-node-retains-local-paint');
+    $assert('instance_override' === ($explicitPaintDiagnostic['context']['local_paint_provenance'] ?? null), 'instance-explicit-paint-diagnostic-local-provenance');
+    $assert(array('fills') === ($explicitPaintDiagnostic['context']['local_paint_source_fields'] ?? null), 'instance-explicit-paint-diagnostic-source-fields');
+    $assert('referenced_style' === ($explicitPaintDiagnostic['context']['style_paint_provenance'] ?? null), 'instance-explicit-paint-diagnostic-style-provenance');
+    $assert('explicit_instance_paint_override' === ($explicitPaintDiagnostic['context']['resolution_reason'] ?? null), 'instance-explicit-paint-diagnostic-resolution-reason');
 
     $shapeCommandBlobPaintWithStyleResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'        => 'Shape Command Blob Paint Style Fixture',


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `agent-task-214309dc-b463-4777-b596-af37d12fb0cc` into review-ready branch `fix/figma-paint-precedence`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:agent-task-214309dc-b463-4777-b596-af37d12fb0cc`
- **Homeboy run ID:** `agent-task-214309dc-b463-4777-b596-af37d12fb0cc`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-paint-precedence`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/328

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Local paint wins only when decoded instance override provenance explicitly names the affected collection.
- **Evidence discriminators preserved:** explicit instance fill/stroke override fields
- **Nearby contracts preserved:** referenced styles remain authoritative for inherited or unproven local paint fields

## Attempt summary
GPT-5.6 Sol candidate corrected after independent review; decoded fill/stroke alias coverage and full contracts green.

## Gate results
- contract-tests: passed (targeted)
- decoded-override-provenance: passed (targeted)
- independent-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer --working-dir=figma-transformer test`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/src/FigFile/FigKiwiDecodePolicy.php
- figma-transformer/src/Scenegraph/PaintNormalizer.php
- figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
- figma-transformer/tests/contract/KiwiParserContract.php
- figma-transformer/tests/contract/VectorRenderingContract.php

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-paint-precedence`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented and reviewed paint precedence and provenance fixes from raw .fig evidence.
