### PR TITLE
Make Figma fixture rig health checks fixture-independent

### DIFF
--- a/figma-transformer/rigs/fixture-matrix/rig.json
+++ b/figma-transformer/rigs/fixture-matrix/rig.json
@@ -49,9 +49,9 @@
       },
       {
         "kind": "command",
-        "label": "Figma fixture matrix dry run",
+        "label": "Figma fixture matrix CLI loads",
         "cwd": "${components.blocks-engine.path}",
-        "command": "php figma-transformer/scripts/figma-fixture-matrix.php --dry-run"
+        "command": "php figma-transformer/scripts/figma-fixture-matrix.php --help"
       }
     ],
     "up": [


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `c8317226-1787-41ac-8f3d-0b092ea766fa` into review-ready branch `fix/figma-rig-check-fixtures`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:c8317226-1787-41ac-8f3d-0b092ea766fa`
- **Homeboy run ID:** `c8317226-1787-41ac-8f3d-0b092ea766fa`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-rig-check-fixtures`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/328

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Only the fixture-matrix rig health probe changes; actual bench fixture validation remains in the matrix runner.
- **Evidence discriminators preserved:** health check executes without fixture inputs
- **Nearby contracts preserved:** real matrix runs still fail when no fixture is selected

## Attempt summary
Rig check now validates CLI loading without requiring runtime fixture selection.

## Gate results
- rig-check: passed (targeted)
- contract-tests: passed (targeted)

## Verification capability
- `targeted_checks_run`: `homeboy rig check <fixture-matrix-rig> --path <checkout>`, `composer --working-dir=figma-transformer test`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/rigs/fixture-matrix/rig.json

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-rig-check-fixtures`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-caused the rig preflight failure and implemented the fixture-independent health probe.
