### PR TITLE
Make Figma responsive variants source-directional

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -95,37 +95,30 @@ final class BreakpointMediaDiffBuilder
         }
 
         $blocks = array();
-        $prevViewportWidth = $primaryViewportWidth;
-        foreach ( $variants as $variant ) {
-            if ( ! is_array($variant) || true === ($variant['primary'] ?? false) ) {
-                continue;
-            }
-
-            $variantId = isset($variant['frame_id']) && is_scalar($variant['frame_id']) ? (string) $variant['frame_id'] : '';
-            $viewportWidth = $variant['viewport_width'] ?? null;
-            if ( '' === $variantId || ! isset($nodeMap[$variantId]) || ! is_numeric($viewportWidth) ) {
+        foreach ( $this->responsiveVariantsInCascadeOrder($variants, $primaryViewportWidth) as $responsiveVariant ) {
+            $variant = $responsiveVariant['variant'];
+            $mediaQuery = $responsiveVariant['media_query'];
+            $variantId = (string) $variant['frame_id'];
+            $viewportWidth = (float) $variant['viewport_width'];
+            if ( ! isset($nodeMap[$variantId]) ) {
                 continue;
             }
 
             $variantStyles = array();
             $this->collectVariantNodeStyles($nodeMap[$variantId], 0, null, null, 'r', $variantStyles);
 
-            $breakpointPx = null !== $prevViewportWidth && $prevViewportWidth > (float) $viewportWidth
-                ? (int) round(($prevViewportWidth + (float) $viewportWidth) / 2)
-                : (int) round((float) $viewportWidth);
-
             $diffRules = $this->diffRules($baseStyles, $variantStyles);
             if ( ! empty($diffRules) ) {
-                $blocks[] = $this->mediaBlock($breakpointPx, $diffRules);
+                $blocks[] = $this->mediaBlock($mediaQuery['feature'], $mediaQuery['breakpoint'], $diffRules);
             }
 
-            $safetyRules = $this->responsiveSafetyRules($baseStyles, $variantStyles, (float) $viewportWidth, $this->matchedBreakpointGeometryClasses($baseStyles, $variantStyles));
+            $safetyRules = $this->responsiveSafetyRules($baseStyles, $variantStyles, $viewportWidth, $this->matchedBreakpointGeometryClasses($baseStyles, $variantStyles));
             if ( ! empty($safetyRules) ) {
-                $safetyBreakpointPx = (float) $viewportWidth <= 480.0 ? (int) round((float) $viewportWidth) : $breakpointPx;
-                $blocks[] = $this->mediaBlock($safetyBreakpointPx, $safetyRules);
+                $safetyBreakpointPx = 'max-width' === $mediaQuery['feature'] && $viewportWidth <= 480.0
+                    ? (int) round($viewportWidth)
+                    : $mediaQuery['breakpoint'];
+                $blocks[] = $this->mediaBlock($mediaQuery['feature'], $safetyBreakpointPx, $safetyRules);
             }
-
-            $prevViewportWidth = (float) $viewportWidth;
         }
 
         return $blocks;
@@ -180,9 +173,9 @@ final class BreakpointMediaDiffBuilder
         $mobileRules = array_values(array_unique($mobileRules));
         $blocks = array();
         if ( $rootWidth > 1200.0 && ! empty($desktopRules) ) {
-            $blocks[] = $this->mediaBlock((int) floor($rootWidth - 1.0), $desktopRules);
+            $blocks[] = $this->mediaBlock('max-width', (int) floor($rootWidth - 1.0), $desktopRules);
         }
-        $blocks[] = $this->mediaBlock(767, ! empty($mobileRules) ? $mobileRules : $desktopRules);
+        $blocks[] = $this->mediaBlock('max-width', 767, ! empty($mobileRules) ? $mobileRules : $desktopRules);
 
         return $blocks;
     }
@@ -380,11 +373,89 @@ final class BreakpointMediaDiffBuilder
     }
 
     /**
+     * @return array{feature: string, breakpoint: int}|null
+     */
+    private function variantMediaQuery(float $primaryViewportWidth, float $variantViewportWidth): ?array
+    {
+        if ( $variantViewportWidth === $primaryViewportWidth ) {
+            return null;
+        }
+
+        $midpoint = (int) round(($primaryViewportWidth + $variantViewportWidth) / 2);
+        if ( $variantViewportWidth < $primaryViewportWidth ) {
+            return array(
+                'feature'    => 'max-width',
+                'breakpoint' => min($midpoint, (int) ceil($primaryViewportWidth) - 1),
+            );
+        }
+
+        return array(
+            'feature'    => 'min-width',
+            'breakpoint' => max($midpoint, (int) floor($primaryViewportWidth) + 1),
+        );
+    }
+
+    /**
+     * Sort same-direction ranges by cascade specificity, independently of the
+     * planner's input order. Keep the diff and safety blocks adjacent per variant.
+     *
+     * @param array<int, mixed> $variants
+     * @return array<int, array{variant: array<string, mixed>, media_query: array{feature: string, breakpoint: int}, input_index: int}>
+     */
+    private function responsiveVariantsInCascadeOrder(array $variants, ?float $primaryViewportWidth): array
+    {
+        if ( null === $primaryViewportWidth ) {
+            return array();
+        }
+
+        $responsiveVariants = array();
+        foreach ( $variants as $inputIndex => $variant ) {
+            if ( ! is_array($variant) || true === ($variant['primary'] ?? false) ) {
+                continue;
+            }
+
+            $variantId = isset($variant['frame_id']) && is_scalar($variant['frame_id']) ? (string) $variant['frame_id'] : '';
+            $viewportWidth = $variant['viewport_width'] ?? null;
+            if ( '' === $variantId || ! is_numeric($viewportWidth) ) {
+                continue;
+            }
+
+            $mediaQuery = $this->variantMediaQuery($primaryViewportWidth, (float) $viewportWidth);
+            if ( null === $mediaQuery ) {
+                continue;
+            }
+
+            $responsiveVariants[] = array(
+                'variant'     => $variant,
+                'media_query' => $mediaQuery,
+                'input_index' => (int) $inputIndex,
+            );
+        }
+
+        usort($responsiveVariants, static function (array $left, array $right): int {
+            $leftQuery = $left['media_query'];
+            $rightQuery = $right['media_query'];
+            if ( $leftQuery['feature'] !== $rightQuery['feature'] ) {
+                return 'max-width' === $leftQuery['feature'] ? -1 : 1;
+            }
+
+            $comparison = $leftQuery['breakpoint'] <=> $rightQuery['breakpoint'];
+            if ( 'max-width' === $leftQuery['feature'] ) {
+                $comparison *= -1;
+            }
+
+            return 0 !== $comparison ? $comparison : $left['input_index'] <=> $right['input_index'];
+        });
+
+        return $responsiveVariants;
+    }
+
+    /**
      * @param array<int, string> $rules
      */
-    private function mediaBlock(int $breakpointPx, array $rules): string
+    private function mediaBlock(string $feature, int $breakpointPx, array $rules): string
     {
-        return '@media (max-width:' . ($this->number)((float) $breakpointPx) . 'px){'
+        return '@media (' . $feature . ':' . ($this->number)((float) $breakpointPx) . 'px){'
             . "\n" . implode("\n", $rules) . "\n}";
     }
 
@@ -460,6 +531,7 @@ final class BreakpointMediaDiffBuilder
             $changed = array();
             $baseContainsSticky = true === ($base['contains_sticky'] ?? false);
             $preserveFullBleedBreakout = $this->usesFullBleedViewportBreakout($baseMap);
+            $releasesFullBleedToFlow = $preserveFullBleedBreakout && $this->responsiveDeclarationsConvertAbsoluteToFlow($baseMap, $variantDeclarations);
             $baseNode = is_array($base['node'] ?? null) ? $base['node'] : array();
             $variantNode = is_array($variantStyles[$pathKey]['node'] ?? null) ? $variantStyles[$pathKey]['node'] : array();
             $baseParentNode = is_array($base['parent_node'] ?? null) ? $base['parent_node'] : null;
@@ -480,7 +552,7 @@ final class BreakpointMediaDiffBuilder
                 if ( $preservePaginationRow && in_array($property, array('height', 'flex-wrap', 'align-content'), true) ) {
                     continue;
                 }
-                if ( $preserveFullBleedBreakout && in_array($property, array('width', 'left', 'right', 'margin-left'), true) ) {
+                if ( $preserveFullBleedBreakout && ! $releasesFullBleedToFlow && in_array($property, array('width', 'left', 'right', 'margin-left', 'margin-right'), true) ) {
                     continue;
                 }
                 if ( 'height' === $property && $this->shouldUseResponsiveAutoHeight($value, $baseMap, $baseNode, $variantNode, $variantParentNode) ) {
@@ -512,6 +584,15 @@ final class BreakpointMediaDiffBuilder
                 }
                 if ( ! array_key_exists($property, $baseMap) || $baseMap[$property] !== $value ) {
                     $changed[] = $property . ':' . $value;
+                }
+            }
+
+            if ( $releasesFullBleedToFlow ) {
+                foreach ( array('left:auto', 'right:auto', 'top:auto', 'bottom:auto', 'margin-left:0', 'margin-right:0') as $declaration ) {
+                    [$property, $value] = explode(':', $declaration, 2);
+                    if ( ! array_key_exists($property, $baseMap) || $baseMap[$property] !== $value ) {
+                        $changed[] = $declaration;
+                    }
                 }
             }
 

--- a/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
+++ b/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
@@ -187,7 +187,7 @@ final class ResponsiveBreakpointSafetyPolicy
                 return array('reason_code' => '', 'declarations' => array());
             }
 
-            $footerChildDeclarations = array('position:relative', 'left:auto', 'right:auto', 'top:auto', 'max-width:100%', 'margin-left:0');
+            $footerChildDeclarations = array('position:relative', 'left:auto', 'right:auto', 'top:auto', 'bottom:auto', 'max-width:100%', 'margin-left:0', 'margin-right:0');
             if ( $isContainer ) {
                 array_unshift($footerChildDeclarations, 'width:100%', 'max-width:100%', 'height:auto');
                 array_push($footerChildDeclarations, 'justify-content:flex-start', 'align-items:center', 'flex-wrap:wrap', 'gap:16px');

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -2047,25 +2047,25 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert('' !== $responsiveEmitCss, 'responsive-emit-stylesheet-present');
     // Two narrower breakpoints plus wide desktop-only/generic safety fallbacks
     // produce at least four media blocks. Variant breakpoints are keyed at the MIDPOINT between
-    // adjacent variant widths (not the narrow variant's own width).
+    // each variant and the primary source width (not the narrow variant's own width).
     // desktop=1440, tablet=834, mobile=390:
     //   tablet breakpoint = round((1440+834)/2) = 1137
-    //   mobile breakpoint = round((834+390)/2)  = 612
+    //   mobile breakpoint = round((1440+390)/2) = 915
     $assert(substr_count($responsiveEmitCss, '@media') >= 4, 'responsive-emit-two-variant-media-blocks-plus-desktop-fallback');
     $assert(str_contains($responsiveEmitCss, '@media (max-width:1137px){'), 'responsive-emit-tablet-media-query');
-    $assert(str_contains($responsiveEmitCss, '@media (max-width:612px){'), 'responsive-emit-mobile-media-query');
+    $assert(str_contains($responsiveEmitCss, '@media (max-width:915px){'), 'responsive-emit-mobile-media-query');
     // Base layout uses the primary (desktop) variant styles, emitted before media.
     $responsiveEmitBasePos = strpos($responsiveEmitCss, '.figma-node-card-desktop-hero-card{width:1200px;height:400px;background:#ff0000}');
     $assert(false !== $responsiveEmitBasePos, 'responsive-emit-base-uses-primary-variant');
     $responsiveEmitFirstMediaPos = strpos($responsiveEmitCss, '@media');
     $assert(false !== $responsiveEmitFirstMediaPos && $responsiveEmitBasePos < $responsiveEmitFirstMediaPos, 'responsive-emit-base-precedes-media');
     // Narrower-wins cascade: tablet block precedes mobile block.
-    $assert(strpos($responsiveEmitCss, '@media (max-width:1137px)') < strpos($responsiveEmitCss, '@media (max-width:612px)'), 'responsive-emit-cascade-widest-first');
+    $assert(strpos($responsiveEmitCss, '@media (max-width:1137px)') < strpos($responsiveEmitCss, '@media (max-width:915px)'), 'responsive-emit-cascade-widest-first');
     // Media blocks override on the BASE class names, carrying only changed props.
-    $responsiveEmitTabletBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:1137px)'), strpos($responsiveEmitCss, '@media (max-width:612px)') - strpos($responsiveEmitCss, '@media (max-width:1137px)'));
+    $responsiveEmitTabletBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:1137px)'), strpos($responsiveEmitCss, '@media (max-width:915px)') - strpos($responsiveEmitCss, '@media (max-width:1137px)'));
     $assert(str_contains($responsiveEmitTabletBlock, '.figma-node-card-desktop-hero-card{width:calc(100% - 134px);max-width:1200px}'), 'responsive-emit-tablet-card-width-diff-only');
     $assert(! str_contains($responsiveEmitTabletBlock, 'background:'), 'responsive-emit-tablet-omits-unchanged-background');
-    $responsiveEmitMobileBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:612px)'));
+    $responsiveEmitMobileBlock = substr($responsiveEmitCss, strpos($responsiveEmitCss, '@media (max-width:915px)'));
     $assert(str_contains($responsiveEmitMobileBlock, '.figma-node-frame-home-desktop-home-desktop{height:3200px}'), 'responsive-emit-mobile-root-keeps-fluid-width');
     $assert(str_contains($responsiveEmitMobileBlock, '.figma-node-card-desktop-hero-card{width:calc(100% - 40px);max-width:1200px;height:500px;background:#00ff00}'), 'responsive-emit-mobile-card-diffs-width-height-background');
     $assert(str_contains($responsiveEmitMobileBlock, '.figma-node-cards-desktop-article-cards{width:calc(100% - 40px);max-width:760px;margin-left:auto;margin-right:auto;height:auto;flex-direction:column}'), 'responsive-emit-mobile-row-container-fluid-auto-height-centered');

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -7488,7 +7488,7 @@ $assert(
     'responsive-breakpoint-safety-policy-footer-chrome-decision-seam'
 );
 $assert(
-    array('reason_code' => 'responsive_footer_child_chrome_safety', 'declarations' => array('position:relative', 'left:auto', 'right:auto', 'top:auto', 'max-width:100%', 'margin-left:0')) === $responsiveBreakpointSafetyPolicy->responsiveChromeFlowDecision(
+    array('reason_code' => 'responsive_footer_child_chrome_safety', 'declarations' => array('position:relative', 'left:auto', 'right:auto', 'top:auto', 'bottom:auto', 'max-width:100%', 'margin-left:0', 'margin-right:0')) === $responsiveBreakpointSafetyPolicy->responsiveChromeFlowDecision(
         array('id' => 'policy:footer-link', 'type' => 'TEXT', 'name' => 'Footer Link'),
         array('id' => 'policy:footer', 'type' => 'FRAME', 'name' => 'Footer'),
         array('position' => 'absolute', 'left' => '435px', 'top' => '91px'),
@@ -7623,6 +7623,104 @@ $assert(str_contains($midpointBreakpointCss, '@media (max-width:915px){'), 'midp
 $assert(! str_contains($midpointBreakpointCss, '@media (max-width:390px){'), 'midpoint-breakpoint-not-variant-own-width');
 $assert(str_contains($midpointBreakpointCss, '.figma-node-bp-band-band{width:100vw;height:120px;position:absolute;top:0px;left:50%;margin-left:-50vw'), 'responsive-full-bleed-base-uses-viewport-breakout');
 $assert(! preg_match('/@media \(max-width:915px\)\{[\s\S]*\.figma-node-bp-band-band\{[^}]*\b(?:width:100%|left:0px|margin-left:0px)/', $midpointBreakpointCss), 'responsive-full-bleed-media-preserves-viewport-breakout');
+
+$sourceRelativeBreakpointResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
+    array(
+        'name'   => 'Source-relative Breakpoint Fixture',
+        'assets' => array(),
+        'nodes'  => array(
+            array(
+                'id' => 'direction:primary', 'type' => 'FRAME', 'name' => 'Home Primary', 'box' => array('width' => 1440, 'height' => 900),
+                'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                'children' => array(
+                    array('id' => 'direction:marker', 'type' => 'RECTANGLE', 'name' => 'Range Marker', 'box' => array('width' => 240, 'height' => 80), 'background' => '#111111'),
+                    array(
+                        'id' => 'direction:footer', 'type' => 'FRAME', 'name' => 'Footer', 'box' => array('width' => 1440, 'height' => 180),
+                        'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                        'children' => array(
+                            array('id' => 'direction:footer-band', 'type' => 'FRAME', 'name' => 'Footer Content', 'box' => array('x' => -2, 'y' => 20, 'width' => 1444, 'height' => 120), 'layout' => array('positioning' => 'absolute', 'z_index' => 1), 'background' => '#444444'),
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                'id' => 'direction:wide-large', 'type' => 'FRAME', 'name' => 'Home Wide Large', 'box' => array('width' => 2238, 'height' => 900),
+                'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                'children' => array(
+                    array('id' => 'direction:marker-wide-large', 'type' => 'RECTANGLE', 'name' => 'Range Marker', 'box' => array('width' => 320, 'height' => 80), 'background' => '#333333'),
+                    array(
+                        'id' => 'direction:footer-wide-large', 'type' => 'FRAME', 'name' => 'Footer', 'box' => array('width' => 2238, 'height' => 180),
+                        'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                        'children' => array(
+                            array('id' => 'direction:footer-band-wide-large', 'type' => 'FRAME', 'name' => 'Footer Content', 'box' => array('width' => 2238, 'height' => 120), 'layout' => array('z_index' => 1), 'background' => '#444444'),
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                'id' => 'direction:wide-near', 'type' => 'FRAME', 'name' => 'Home Wide Near', 'box' => array('width' => 1800, 'height' => 900),
+                'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                'children' => array(
+                    array('id' => 'direction:marker-wide-near', 'type' => 'RECTANGLE', 'name' => 'Range Marker', 'box' => array('width' => 280, 'height' => 80), 'background' => '#444444'),
+                    array('id' => 'direction:footer-wide-near', 'type' => 'FRAME', 'name' => 'Footer', 'box' => array('width' => 1800, 'height' => 180), 'layout' => array('display' => 'flex', 'flex_direction' => 'column'), 'children' => array()),
+                ),
+            ),
+            array(
+                'id' => 'direction:narrow-tablet', 'type' => 'FRAME', 'name' => 'Home Narrow Tablet', 'box' => array('width' => 834, 'height' => 900),
+                'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                'children' => array(
+                    array('id' => 'direction:marker-narrow-tablet', 'type' => 'RECTANGLE', 'name' => 'Range Marker', 'box' => array('width' => 210, 'height' => 80), 'background' => '#555555'),
+                    array('id' => 'direction:footer-narrow-tablet', 'type' => 'FRAME', 'name' => 'Footer', 'box' => array('width' => 834, 'height' => 180), 'layout' => array('display' => 'flex', 'flex_direction' => 'column'), 'children' => array()),
+                ),
+            ),
+            array(
+                'id' => 'direction:narrow', 'type' => 'FRAME', 'name' => 'Home Narrow', 'box' => array('width' => 390, 'height' => 900),
+                'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                'children' => array(
+                    array('id' => 'direction:marker-narrow', 'type' => 'RECTANGLE', 'name' => 'Range Marker', 'box' => array('width' => 180, 'height' => 80), 'background' => '#222222'),
+                    array(
+                        'id' => 'direction:footer-narrow', 'type' => 'FRAME', 'name' => 'Footer', 'box' => array('width' => 390, 'height' => 180),
+                        'layout' => array('display' => 'flex', 'flex_direction' => 'column'),
+                        'children' => array(
+                            array('id' => 'direction:footer-band-narrow', 'type' => 'FRAME', 'name' => 'Footer Content', 'box' => array('width' => 390, 'height' => 120), 'layout' => array('z_index' => 1), 'background' => '#444444'),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+    array('pages' => array(array(
+        'frame_id' => 'direction:primary', 'name' => 'Home', 'path' => 'index.html', 'entrypoint' => true,
+        'variants' => array(
+            array('frame_id' => 'direction:primary', 'viewport_width' => 1440.0, 'primary' => true),
+            // Deliberately adverse order: each direction is least-specific last.
+            array('frame_id' => 'direction:wide-large', 'viewport_width' => 2238.0, 'primary' => false),
+            array('frame_id' => 'direction:narrow', 'viewport_width' => 390.0, 'primary' => false),
+            array('frame_id' => 'direction:wide-near', 'viewport_width' => 1800.0, 'primary' => false),
+            array('frame_id' => 'direction:narrow-tablet', 'viewport_width' => 834.0, 'primary' => false),
+        ),
+    )))
+);
+$sourceRelativeBreakpointCss = '';
+foreach ( $sourceRelativeBreakpointResult['files'] ?? array() as $sourceRelativeBreakpointFile ) {
+    if ( is_array($sourceRelativeBreakpointFile) && 'style.css' === ($sourceRelativeBreakpointFile['path'] ?? null) ) {
+        $sourceRelativeBreakpointCss = (string) ($sourceRelativeBreakpointFile['content'] ?? '');
+    }
+}
+$assert('success' === ($sourceRelativeBreakpointResult['status'] ?? null), 'source-relative-breakpoint-transform-success');
+$assert(str_contains($sourceRelativeBreakpointCss, '.figma-node-direction-marker-range-marker{width:240px;height:80px;background:#111111'), 'source-relative-breakpoint-primary-remains-base');
+$sourceRelativeTabletStart = strpos($sourceRelativeBreakpointCss, '@media (max-width:1137px)');
+$sourceRelativeMobileStart = strpos($sourceRelativeBreakpointCss, '@media (max-width:915px)');
+$sourceRelativeWideNearStart = strpos($sourceRelativeBreakpointCss, '@media (min-width:1620px)');
+$sourceRelativeWideLargeStart = strpos($sourceRelativeBreakpointCss, '@media (min-width:1839px)');
+$assert(false !== $sourceRelativeTabletStart && false !== $sourceRelativeMobileStart && $sourceRelativeTabletStart < $sourceRelativeMobileStart, 'source-relative-breakpoint-narrow-cascade-orders-tablet-before-mobile');
+$assert(false !== $sourceRelativeWideNearStart && false !== $sourceRelativeWideLargeStart && $sourceRelativeWideNearStart < $sourceRelativeWideLargeStart, 'source-relative-breakpoint-wide-cascade-orders-near-before-large');
+$assert(preg_match('/@media \(max-width:1137px\)\{[\s\S]*\.figma-node-direction-marker-range-marker\{[^}]*background:#555555/s', $sourceRelativeBreakpointCss) === 1, 'source-relative-breakpoint-tablet-boundary-uses-tablet-variant');
+$assert(preg_match('/@media \(max-width:915px\)\{[\s\S]*\.figma-node-direction-marker-range-marker\{[^}]*background:#222222/s', $sourceRelativeBreakpointCss) === 1, 'source-relative-breakpoint-mobile-boundary-uses-mobile-variant');
+$assert(preg_match('/@media \(min-width:1620px\)\{[\s\S]*\.figma-node-direction-marker-range-marker\{[^}]*background:#444444/s', $sourceRelativeBreakpointCss) === 1, 'source-relative-breakpoint-wide-near-boundary-uses-near-variant');
+$assert(preg_match('/@media \(min-width:1839px\)\{[\s\S]*\.figma-node-direction-marker-range-marker\{[^}]*background:#333333/s', $sourceRelativeBreakpointCss) === 1, 'source-relative-breakpoint-wide-large-boundary-uses-large-variant');
+$assert(preg_match('/@media \(max-width:915px\)\{[\s\S]*\.figma-node-direction-footer-band-footer-content\{[^}]*position:relative[^}]*left:auto[^}]*right:auto[^}]*top:auto[^}]*bottom:auto[^}]*margin-left:0[^}]*margin-right:0/s', $sourceRelativeBreakpointCss) === 1, 'source-relative-breakpoint-flow-release-clears-breakout');
+$assert(preg_match('/@media \(min-width:1839px\)\{[\s\S]*\.figma-node-direction-footer-band-footer-content\{[^}]*position:relative[^}]*left:auto[^}]*right:auto[^}]*top:auto[^}]*bottom:auto[^}]*margin-left:0[^}]*margin-right:0/s', $sourceRelativeBreakpointCss) === 1, 'source-relative-breakpoint-wide-flow-release-clears-breakout');
 
 $mobileSafetyBreakpointResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
     array(


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `agent-task-665bb251-1496-4012-ad43-b1e2b19a558f` into review-ready branch `fix/figma-responsive-variant-direction`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:agent-task-665bb251-1496-4012-ad43-b1e2b19a558f`
- **Homeboy run ID:** `agent-task-665bb251-1496-4012-ad43-b1e2b19a558f`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-responsive-variant-direction`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/328

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Only source-relative responsive media direction, deterministic cascade order, and full-bleed flow release change.
- **Evidence discriminators preserved:** primary 1440 with narrow 390 and wide 2238 variants
- **Nearby contracts preserved:** multiple same-direction variants remain deterministic under adverse input order

## Attempt summary
Forensic candidate corrected after independent cascade review; contracts green.

## Gate results
- contract-tests: passed (targeted)
- independent-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer --working-dir=figma-transformer test`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
- figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
- figma-transformer/tests/contract/SiteGenerationContract.php
- figma-transformer/tests/contract/run.php

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-responsive-variant-direction`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented responsive directionality from landed FSE DOM evidence with reviewed deterministic tests.
