### PR TITLE
Reset semantic element margins for Figma geometry

### DIFF
--- a/figma-transformer/src/Html/HtmlArtifactAssembler.php
+++ b/figma-transformer/src/Html/HtmlArtifactAssembler.php
@@ -28,6 +28,7 @@ final class HtmlArtifactAssembler
             'body{margin:0}',
             '.figma-root{position:relative;width:100%;display:flex;flex-direction:column;align-items:center}',
             'p,h1,h2,h3,h4,h5,h6{margin:0}',
+            'blockquote{margin:0}',
             'ul,ol{margin:0;padding:0;list-style:none}',
             'img{display:block;max-width:100%;height:auto}',
             'a.figma-link{display:contents;color:inherit;text-decoration:inherit}',

--- a/php-transformer/tools/visual-parity/package.json
+++ b/php-transformer/tools/visual-parity/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "install:browsers": "playwright install chromium",
-    "test": "node tests/smoke.mjs"
+    "test": "node tests/smoke.mjs && node tests/blockquote-margin-reset.mjs"
   },
   "devDependencies": {
     "playwright": "^1.56.0"

--- a/php-transformer/tools/visual-parity/tests/blockquote-margin-reset.mjs
+++ b/php-transformer/tools/visual-parity/tests/blockquote-margin-reset.mjs
@@ -1,0 +1,115 @@
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const toolRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const repositoryRoot = path.resolve(toolRoot, '../../..');
+const fixturePath = path.join(toolRoot, 'tests/fixtures/blockquote-margin-reset.scenegraph.json');
+const outputDir = await mkdtemp(path.join(tmpdir(), 'blocks-engine-blockquote-margin-'));
+const transformScript = `
+require $argv[1];
+$scenegraph = json_decode(file_get_contents($argv[2]), true, 512, JSON_THROW_ON_ERROR);
+$result = blocks_engine_figma_transformer_transform_scenegraph($scenegraph);
+foreach ($result['files'] as $file) {
+    $path = $argv[3] . '/' . $file['path'];
+    $directory = dirname($path);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0777, true);
+    }
+    file_put_contents($path, $file['content']);
+}
+`;
+
+const transform = spawnSync('php', [
+  '-r',
+  transformScript,
+  path.join(repositoryRoot, 'figma-transformer/figma-transformer.php'),
+  fixturePath,
+  outputDir,
+], { encoding: 'utf8' });
+
+if (transform.status !== 0) {
+  throw new Error(`Figma fixture transform failed:\n${transform.stderr}`);
+}
+
+const server = createServer(async (request, response) => {
+  const pathname = new URL(request.url, 'http://127.0.0.1').pathname;
+  const filename = pathname === '/' ? 'index.html' : pathname.slice(1);
+  if (!/^[A-Za-z0-9._/-]+$/.test(filename) || filename.includes('..')) {
+    response.writeHead(400).end();
+    return;
+  }
+
+  try {
+    const content = await readFile(path.join(outputDir, filename));
+    response.writeHead(200, { 'content-type': filename.endsWith('.css') ? 'text/css' : 'text/html' });
+    response.end(content);
+  } catch {
+    response.writeHead(404).end();
+  }
+});
+
+await new Promise((resolve, reject) => {
+  server.on('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+
+try {
+  const address = server.address();
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+    await page.goto(`http://127.0.0.1:${address.port}/`, { waitUntil: 'load' });
+    const geometry = await page.evaluate(() => {
+      const preceding = document.querySelector('[data-figma-node-id="blockquote-margin:preceding"]');
+      const quote = document.querySelector('[data-figma-node-id="blockquote-margin:quote"]');
+      const following = document.querySelector('[data-figma-node-id="blockquote-margin:following"]');
+      if (!preceding || !quote || !following) {
+        throw new Error('Generated stack nodes are missing.');
+      }
+
+      const rect = (element) => element.getBoundingClientRect();
+      const computed = getComputedStyle(quote);
+      return {
+        tag: quote.tagName,
+        margins: {
+          top: computed.marginTop,
+          right: computed.marginRight,
+          bottom: computed.marginBottom,
+          left: computed.marginLeft,
+        },
+        preceding: rect(preceding).toJSON(),
+        quote: rect(quote).toJSON(),
+        following: rect(following).toJSON(),
+      };
+    });
+
+    assert(geometry.tag === 'BLOCKQUOTE', 'the generated quote uses a blockquote element');
+    assert(geometry.margins.top === '8px', 'the generated blockquote class keeps its explicit 8px source margin over the reset');
+    assert(geometry.margins.right === '0px' && geometry.margins.bottom === '0px' && geometry.margins.left === '0px', 'the reset removes Chromium blockquote UA 40px horizontal and 16px vertical margins');
+    assert(closeTo(geometry.quote.left, geometry.preceding.left), 'the blockquote has no UA horizontal offset');
+    assert(closeTo(geometry.quote.top - geometry.preceding.bottom, 24), 'the quote position combines the 16px stack gap and generated 8px margin');
+    assert(closeTo(geometry.following.top - geometry.quote.bottom, 16), 'the following sibling remains at the generated 16px stack gap');
+  } finally {
+    await browser.close();
+  }
+} finally {
+  await new Promise((resolve) => server.close(resolve));
+  await rm(outputDir, { recursive: true, force: true });
+}
+
+console.log('Blockquote margin reset geometry test passed.');
+
+function closeTo(actual, expected) {
+  return Math.abs(actual - expected) < 0.01;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/php-transformer/tools/visual-parity/tests/fixtures/blockquote-margin-reset.scenegraph.json
+++ b/php-transformer/tools/visual-parity/tests/fixtures/blockquote-margin-reset.scenegraph.json
@@ -1,0 +1,63 @@
+{
+  "name": "Blockquote Margin Reset Geometry Fixture",
+  "nodes": [
+    {
+      "id": "blockquote-margin:root",
+      "type": "FRAME",
+      "name": "Quote Stack",
+      "width": 480,
+      "height": 168,
+      "absoluteBoundingBox": { "x": 0, "y": 0, "width": 480, "height": 168 },
+      "layoutMode": "VERTICAL",
+      "itemSpacing": 16,
+      "children": [
+        {
+          "id": "blockquote-margin:preceding",
+          "type": "TEXT",
+          "name": "Body",
+          "characters": "Preceding sibling",
+          "x": 0,
+          "y": 0,
+          "width": 480,
+          "height": 24,
+          "absoluteBoundingBox": { "x": 0, "y": 0, "width": 480, "height": 24 },
+          "fontSize": 16
+        },
+        {
+          "id": "blockquote-margin:quote",
+          "type": "FRAME",
+          "name": "Blockquote",
+          "x": 0,
+          "y": 48,
+          "width": 480,
+          "height": 64,
+          "absoluteBoundingBox": { "x": 0, "y": 48, "width": 480, "height": 64 },
+          "children": [
+            {
+              "id": "blockquote-margin:quote-text",
+              "type": "TEXT",
+              "name": "Quote",
+              "characters": "The source adds an explicit eight pixel offset after the stack gap.",
+              "width": 480,
+              "height": 24,
+              "absoluteBoundingBox": { "x": 0, "y": 48, "width": 480, "height": 24 },
+              "fontSize": 16
+            }
+          ]
+        },
+        {
+          "id": "blockquote-margin:following",
+          "type": "TEXT",
+          "name": "Body",
+          "characters": "Following sibling",
+          "x": 0,
+          "y": 128,
+          "width": 480,
+          "height": 24,
+          "absoluteBoundingBox": { "x": 0, "y": 128, "width": 480, "height": 24 },
+          "fontSize": 16
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `agent-task-211d0007-fda1-4d79-b223-8f8367c92de6` into review-ready branch `fix/figma-semantic-margin-reset`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:agent-task-211d0007-fda1-4d79-b223-8f8367c92de6`
- **Homeboy run ID:** `agent-task-211d0007-fda1-4d79-b223-8f8367c92de6`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-semantic-margin-reset`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/328

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Production reset is limited to blockquote UA margins; generated class margins remain more specific.
- **Evidence discriminators preserved:** blockquote in vertical stack with preceding/following siblings
- **Nearby contracts preserved:** explicit generated margin and sibling geometry remain authoritative

## Attempt summary
Forensic candidate strengthened after independent test review; PHP and browser geometry contracts green.

## Gate results
- contract-tests: passed (targeted)
- browser-geometry: passed (targeted)
- independent-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer --working-dir=figma-transformer test`, `npm test --prefix php-transformer/tools/visual-parity`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/src/Html/HtmlArtifactAssembler.php
- php-transformer/tools/visual-parity/package.json
- php-transformer/tools/visual-parity/tests/blockquote-margin-reset.mjs
- php-transformer/tools/visual-parity/tests/fixtures/blockquote-margin-reset.scenegraph.json

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-semantic-margin-reset`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented blockquote margin normalization from landed FSE DOM evidence with browser-computed proof.
