### PR TITLE
Make Figma layout parity viewport-aware

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -211,12 +211,14 @@ foreach ( $fixtures as $fixture ) {
     if ( 0 === $exitCode && $captureDomBoxes ) {
         $domBoxesPath = $fixtureOutputDir . '/dom-boxes.json';
         $entrypoints = matrix_html_entrypoints($fixtureOutputDir);
-        $captureCommand = matrix_dom_box_capture_command($homeboyCommand, $domBoxProviderCommand, $fixtureOutputDir, $entrypoints, $domBoxesPath);
+        $captureTargets = matrix_dom_box_capture_targets($resultPath, $entrypoints);
+        $captureCommand = matrix_dom_box_capture_command($homeboyCommand, $domBoxProviderCommand, $fixtureOutputDir, $entrypoints, $domBoxesPath, $captureTargets);
         $record['dom_box_capture'] = array(
             'status' => empty($entrypoints) ? 'no_html_entrypoints' : 'running',
             'command' => $captureCommand,
             'report_path' => $domBoxesPath,
             'entrypoints' => $entrypoints,
+            'targets' => $captureTargets,
         );
         if ( ! empty($entrypoints) ) {
             passthru($captureCommand, $captureExitCode);
@@ -227,6 +229,7 @@ foreach ( $fixtures as $fixture ) {
                 $record['status'] = 'dom_box_capture_failed';
             }
             if ( 0 === $captureExitCode && is_file($domBoxesPath) ) {
+                matrix_annotate_dom_box_capture($domBoxesPath, $captureTargets);
                 $domBoxQualityPath = $fixtureOutputDir . '/dom-box-quality.json';
                 $domBoxQuality = matrix_dom_box_quality_report($domBoxesPath);
                 if ( is_array($domBoxQuality) ) {
@@ -927,7 +930,7 @@ function matrix_html_entrypoints(string $root): array
 /**
  * @param array<int, string> $entrypoints
  */
-function matrix_dom_box_capture_command(string $homeboyCommand, string $domBoxProviderCommand, string $root, array $entrypoints, string $reportPath): string
+function matrix_dom_box_capture_command(string $homeboyCommand, string $domBoxProviderCommand, string $root, array $entrypoints, string $reportPath, array $captureTargets = array()): string
 {
     $parts = array(
         escapeshellarg($homeboyCommand),
@@ -947,7 +950,117 @@ function matrix_dom_box_capture_command(string $homeboyCommand, string $domBoxPr
         return $command;
     }
 
-    return 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg($domBoxProviderCommand) . ' ' . $command;
+    $environment = 'HOMEBOY_DOM_BOX_CAPTURE_COMMAND=' . escapeshellarg($domBoxProviderCommand);
+    if ( ! empty($captureTargets) ) {
+        $environment .= ' HOMEBOY_DOM_BOX_CAPTURE_TARGETS_JSON=' . escapeshellarg((string) json_encode($captureTargets, JSON_UNESCAPED_SLASHES));
+    }
+
+    return $environment . ' ' . $command;
+}
+
+/**
+ * Build one native source-layout capture and retain responsive variants as
+ * separately labeled evidence for each emitted page.
+ *
+ * @param array<int, string> $entrypoints
+ * @return array<int, array<string, mixed>>
+ */
+function matrix_dom_box_capture_targets(string $resultPath, array $entrypoints): array
+{
+    if ( ! is_file($resultPath) ) {
+        return array();
+    }
+    $result = json_decode((string) file_get_contents($resultPath), true);
+    if ( ! is_array($result) ) {
+        return array();
+    }
+
+    $pagePlan = $result['source_reports']['figma']['pages']['pages'] ?? array();
+    $htmlPages = $result['source_reports']['figma']['html']['pages'] ?? array();
+    $planByFrame = array();
+    foreach ( is_array($pagePlan) ? $pagePlan : array() as $page ) {
+        if ( is_array($page) && isset($page['frame_id']) && is_scalar($page['frame_id']) ) {
+            $planByFrame[(string) $page['frame_id']] = $page;
+        }
+    }
+
+    $entrypointSet = array_fill_keys(array_map(static fn (string $path): string => ltrim($path, '/'), $entrypoints), true);
+    $targets = array();
+    foreach ( is_array($htmlPages) ? $htmlPages : array() as $htmlPage ) {
+        if ( ! is_array($htmlPage) ) {
+            continue;
+        }
+        $frameId = isset($htmlPage['frame_id']) && is_scalar($htmlPage['frame_id']) ? (string) $htmlPage['frame_id'] : '';
+        $page = $planByFrame[$frameId] ?? array();
+        $paths = array_merge(array((string) ($htmlPage['path'] ?? '')), is_array($htmlPage['template_aliases'] ?? null) ? $htmlPage['template_aliases'] : array());
+        $variants = is_array($page['variants'] ?? null) && ! empty($page['variants'])
+            ? $page['variants']
+            : array(array('frame_id' => $frameId, 'viewport_width' => $page['width'] ?? null, 'primary' => true));
+
+        foreach ( $paths as $path ) {
+            $path = ltrim((string) $path, '/');
+            if ( '' === $path || ! isset($entrypointSet[$path]) ) {
+                continue;
+            }
+            foreach ( $variants as $variant ) {
+                if ( ! is_array($variant) || ! is_numeric($variant['viewport_width'] ?? null) || (float) $variant['viewport_width'] <= 0 ) {
+                    continue;
+                }
+                $primary = true === ($variant['primary'] ?? false) || (string) ($variant['frame_id'] ?? '') === $frameId;
+                $width = max(1, (int) round((float) $variant['viewport_width']));
+                $targets[] = array(
+                    'page_path' => $path,
+                    'viewport' => array('width' => $width, 'height' => 900),
+                    'source_frame' => array('id' => (string) ($variant['frame_id'] ?? $frameId), 'width' => $width),
+                    'comparison_role' => $primary ? 'source_layout' : 'responsive_evidence',
+                );
+            }
+        }
+    }
+
+    return $targets;
+}
+
+/**
+ * Homeboy normalizes provider output to its stable DOM-box schema. Reattach the
+ * matrix-owned source relationship to that normalized evidence by path/viewport.
+ *
+ * @param array<int, array<string, mixed>> $captureTargets
+ */
+function matrix_annotate_dom_box_capture(string $reportPath, array $captureTargets): void
+{
+    if ( empty($captureTargets) || ! is_file($reportPath) ) {
+        return;
+    }
+    $report = json_decode((string) file_get_contents($reportPath), true);
+    if ( ! is_array($report) || ! is_array($report['entrypoints'] ?? null) ) {
+        return;
+    }
+
+    $usedTargets = array();
+    foreach ( $report['entrypoints'] as $index => $entrypoint ) {
+        if ( ! is_array($entrypoint) ) {
+            continue;
+        }
+        $pagePath = ltrim((string) ($entrypoint['page_path'] ?? ''), '/');
+        $viewportWidth = is_numeric($entrypoint['viewport']['width'] ?? null) ? (int) round((float) $entrypoint['viewport']['width']) : null;
+        foreach ( $captureTargets as $targetIndex => $target ) {
+            if ( isset($usedTargets[$targetIndex]) || ! is_array($target) ) {
+                continue;
+            }
+            $targetPath = ltrim((string) ($target['page_path'] ?? ''), '/');
+            $targetWidth = is_numeric($target['viewport']['width'] ?? null) ? (int) round((float) $target['viewport']['width']) : null;
+            if ( $pagePath !== $targetPath || $viewportWidth !== $targetWidth ) {
+                continue;
+            }
+            $report['entrypoints'][$index]['source_frame'] = is_array($target['source_frame'] ?? null) ? $target['source_frame'] : array();
+            $report['entrypoints'][$index]['comparison_role'] = (string) ($target['comparison_role'] ?? 'responsive_evidence');
+            $usedTargets[$targetIndex] = true;
+            break;
+        }
+    }
+    $report['capture_targets'] = $captureTargets;
+    file_put_contents($reportPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
 }
 
 function matrix_slug(string $value): string

--- a/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
+++ b/figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
@@ -24,12 +24,16 @@ final class LayoutMismatchReportBuilder
         $sizeThreshold = $this->numericOption($options, 'size_threshold', $threshold);
         $limit = max(1, (int) $this->numericOption($options, 'limit', 100.0));
         $sourceNodes = $this->sourceNodesById($htmlSourceReport);
-        $generatedNodes = $this->generatedNodesById($evidence);
+        $comparison = $this->comparisonContext($htmlSourceReport, $evidence, $options);
+        if ( ! empty($comparison['source_nodes']) ) {
+            $sourceNodes = $comparison['source_nodes'];
+        }
+        $generatedNodes = $this->generatedNodesById($evidence, $comparison['entrypoint_index']);
         $diagnostics = array();
         $matched = 0;
         $unmatchedSource = 0;
 
-        foreach ( $sourceNodes as $nodeId => $sourceNode ) {
+        foreach ( true === $comparison['comparable'] ? $sourceNodes : array() as $nodeId => $sourceNode ) {
             $generatedNode = $generatedNodes[$nodeId] ?? null;
             if ( null === $generatedNode ) {
                 $unmatchedSource++;
@@ -98,7 +102,8 @@ final class LayoutMismatchReportBuilder
         return array(
             'schema' => self::SCHEMA,
             'input_schema' => isset($evidence['schema']) && is_scalar($evidence['schema']) ? (string) $evidence['schema'] : self::DOM_BOXES_SCHEMA,
-            'status' => empty($generatedNodes) ? 'not_run' : (empty($diagnostics) ? 'pass' : 'fail'),
+            'status' => empty($generatedNodes) ? 'not_run' : (true !== $comparison['comparable'] ? 'not_comparable' : (empty($diagnostics) ? 'pass' : 'fail')),
+            'comparison' => $comparison['evidence'],
             'threshold' => $threshold,
             'size_threshold' => $sizeThreshold,
             'summary' => array(
@@ -518,7 +523,7 @@ final class LayoutMismatchReportBuilder
      * @param array<string, mixed> $evidence
      * @return array<string, array<string, mixed>>
      */
-    private function generatedNodesById(array $evidence): array
+    private function generatedNodesById(array $evidence, ?int $entrypointIndex = null): array
     {
         $nodes = array();
         foreach ( array('boxes', 'nodes', 'dom_boxes', 'elements') as $key ) {
@@ -527,7 +532,10 @@ final class LayoutMismatchReportBuilder
             }
         }
 
-        foreach ( is_array($evidence['entrypoints'] ?? null) ? $evidence['entrypoints'] : array() as $entrypoint ) {
+        foreach ( is_array($evidence['entrypoints'] ?? null) ? $evidence['entrypoints'] : array() as $index => $entrypoint ) {
+            if ( null !== $entrypointIndex && $index !== $entrypointIndex ) {
+                continue;
+            }
             if ( is_array($entrypoint) && is_array($entrypoint['elements'] ?? null) ) {
                 $nodes = array_merge($nodes, $entrypoint['elements']);
             }
@@ -538,6 +546,116 @@ final class LayoutMismatchReportBuilder
         }
 
         return $this->nodesById($nodes);
+    }
+
+    /**
+     * Positional source coordinates are only meaningful at their source width.
+     * A responsive capture needs its own supplied source geometry; a variant
+     * frame identifier alone does not make the primary visual map comparable.
+     *
+     * @param array<string, mixed> $htmlSourceReport
+     * @param array<string, mixed> $evidence
+     * @param array<string, mixed> $options
+     * @return array{comparable:bool,entrypoint_index:int|null,evidence:array<string,mixed>,source_nodes:array<string,array<string,mixed>>}
+     */
+    private function comparisonContext(array $htmlSourceReport, array $evidence, array $options): array
+    {
+        $sourceFrameId = $this->scalarString($options['source_frame_id'] ?? null)
+            ?? $this->scalarString($htmlSourceReport['source_frame_identity']['primary_frame_id'] ?? null);
+        $sourceWidth = $this->numericValue($options['source_frame_width'] ?? null)
+            ?? $this->numericValue($htmlSourceReport['source_frame_identity']['width'] ?? null);
+        $pagePath = $this->scalarString($options['page_path'] ?? null);
+        $entrypoints = is_array($evidence['entrypoints'] ?? null) ? $evidence['entrypoints'] : array();
+        $entrypointIndex = null;
+        $capture = array();
+
+        foreach ( $entrypoints as $index => $entrypoint ) {
+            if ( ! is_array($entrypoint) || ! $this->samePagePath($pagePath, $this->scalarString($entrypoint['page_path'] ?? null)) ) {
+                continue;
+            }
+            $entrypointSource = is_array($entrypoint['source_frame'] ?? null) ? $entrypoint['source_frame'] : array();
+            if ( null !== $sourceFrameId && $sourceFrameId === $this->scalarString($entrypointSource['id'] ?? null) ) {
+                $entrypointIndex = $index;
+                $capture = $entrypoint;
+                break;
+            }
+            if ( null === $entrypointIndex && 'responsive_evidence' !== ($entrypoint['comparison_role'] ?? null) ) {
+                $entrypointIndex = $index;
+                $capture = $entrypoint;
+            }
+        }
+
+        if ( null === $entrypointIndex ) {
+            foreach ( $entrypoints as $index => $entrypoint ) {
+                if ( is_array($entrypoint) && $this->samePagePath($pagePath, $this->scalarString($entrypoint['page_path'] ?? null)) ) {
+                    $entrypointIndex = $index;
+                    $capture = $entrypoint;
+                    break;
+                }
+            }
+        }
+
+        if ( null === $entrypointIndex && 1 === count($entrypoints) && is_array($entrypoints[0] ?? null) ) {
+            $entrypointIndex = 0;
+            $capture = $entrypoints[0];
+        }
+
+        $viewport = is_array($capture['viewport'] ?? null) ? $capture['viewport'] : (is_array($evidence['viewport'] ?? null) ? $evidence['viewport'] : array());
+        $captureWidth = $this->numericValue($viewport['width'] ?? null);
+        $captureFrameId = $this->scalarString($capture['source_frame']['id'] ?? null);
+        $widthsMatch = null === $sourceWidth || null === $captureWidth || abs($sourceWidth - $captureWidth) < 0.5;
+        $variantSourceNodes = $this->variantSourceNodes($capture, $options, $captureFrameId);
+        $hasVariantSourceGeometry = ! empty($variantSourceNodes);
+        $comparable = $widthsMatch || $hasVariantSourceGeometry;
+        $reason = $comparable ? ($widthsMatch ? 'matching_source_width' : 'responsive_source_geometry_supplied') : 'incompatible_viewport_width';
+
+        return array(
+            'comparable' => $comparable,
+            'entrypoint_index' => $entrypointIndex,
+            'source_nodes' => $variantSourceNodes,
+            'evidence' => array_filter(array(
+                'status' => $comparable ? 'comparable' : 'not_comparable',
+                'position_status' => $comparable ? 'comparable' : 'not_comparable',
+                'size_status' => $comparable ? 'comparable' : 'not_comparable',
+                'reason' => $reason,
+                'source_frame_id' => $sourceFrameId,
+                'source_frame_width' => $sourceWidth,
+                'captured_viewport' => empty($viewport) ? null : $viewport,
+                'captured_entrypoint_index' => $entrypointIndex,
+                'responsive_evidence_capture_count' => count(array_filter($entrypoints, static fn (mixed $entrypoint): bool => is_array($entrypoint) && 'responsive_evidence' === ($entrypoint['comparison_role'] ?? null))),
+            ), static fn (mixed $value): bool => null !== $value),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $capture
+     * @param array<string, mixed> $options
+     * @return array<string, array<string, mixed>>
+     */
+    private function variantSourceNodes(array $capture, array $options, ?string $captureFrameId): array
+    {
+        $nodes = is_array($capture['source_visual_node_map'] ?? null) ? $capture['source_visual_node_map'] : array();
+        if ( empty($nodes) && null !== $captureFrameId ) {
+            $maps = is_array($options['source_frame_variant_visual_node_maps'] ?? null) ? $options['source_frame_variant_visual_node_maps'] : array();
+            $nodes = is_array($maps[$captureFrameId] ?? null) ? $maps[$captureFrameId] : array();
+        }
+
+        return $this->nodesById($nodes);
+    }
+
+    private function numericValue(mixed $value): ?float
+    {
+        return is_numeric($value) ? (float) $value : null;
+    }
+
+    private function scalarString(mixed $value): ?string
+    {
+        return is_scalar($value) && '' !== trim((string) $value) ? (string) $value : null;
+    }
+
+    private function samePagePath(?string $expected, ?string $actual): bool
+    {
+        return null === $expected || null === $actual || ltrim($expected, '/') === ltrim($actual, '/');
     }
 
     /**

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -680,6 +680,8 @@ final class FigmaTransformer
             $pageOptions['frame_id'] = $frameId;
             $pageOptions['layout_mismatch_options'] = is_array($pageOptions['layout_mismatch_options'] ?? null) ? $pageOptions['layout_mismatch_options'] : array();
             $pageOptions['layout_mismatch_options']['page_path'] = $path;
+            $pageOptions['layout_mismatch_options']['source_frame_id'] = $frameId;
+            $pageOptions['layout_mismatch_options']['source_frame_width'] = $page['width'] ?? null;
             $pageOptions['render_style_mismatch_options'] = is_array($pageOptions['render_style_mismatch_options'] ?? null) ? $pageOptions['render_style_mismatch_options'] : array();
             $pageOptions['render_style_mismatch_options']['page_path'] = $path;
             $pageOptions['static_site_page_path'] = $path;
@@ -788,6 +790,7 @@ final class FigmaTransformer
                 'path'       => $path,
                 'entrypoint' => true === ($page['entrypoint'] ?? false),
                 'page_type'  => $pageType,
+                'source_frame_identity' => is_array($page['source_frame_identity'] ?? null) ? $page['source_frame_identity'] : array(),
                 'canonical_template_path' => $emitTemplateAliases ? ($this->canonicalTemplatePath($pageType) ?: null) : null,
                 'template_aliases' => ($emitTemplateAliases && '' !== $this->canonicalTemplatePath($pageType) && $this->canonicalTemplatePath($pageType) !== $path) ? array($this->canonicalTemplatePath($pageType)) : array(),
                 'node_count' => (int) ($pageResult['metrics']['node_count'] ?? 0),
@@ -1288,6 +1291,9 @@ final class FigmaTransformer
         if ( $count > 0 ) {
             $signals[] = array('severity' => 'warning', 'code' => 'layout_mismatch', 'count' => $count);
         }
+        if ( 'not_comparable' === ($layoutMismatch['status'] ?? null) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'layout_mismatch_not_comparable');
+        }
         $artifactQuality['signals'] = $signals;
         $summary = is_array($artifactQuality['summary'] ?? null) ? $artifactQuality['summary'] : array();
         $summary['layout_mismatch_count'] = $count;
@@ -1296,7 +1302,7 @@ final class FigmaTransformer
         $summary['element_size_mismatch_count'] = (int) ($layoutMismatch['summary']['code_counts']['element_size_mismatch'] ?? 0);
         $summary['element_outside_parent_bounds_count'] = (int) ($layoutMismatch['summary']['code_counts']['element_outside_parent_bounds'] ?? 0);
         $artifactQuality['summary'] = $summary;
-        if ( $count > 0 ) {
+        if ( $count > 0 || 'not_comparable' === ($layoutMismatch['status'] ?? null) ) {
             $artifactQuality['status'] = 'needs_review';
             $artifactQuality['quality_status'] = 'warn';
         }
@@ -1661,7 +1667,10 @@ final class FigmaTransformer
             $pageLayoutMismatchDiagnostics = is_array($pageLayoutMismatch['diagnostics'] ?? null) ? $pageLayoutMismatch['diagnostics'] : array();
             $layout['layout_mismatch_count'] += (int) ($pageLayoutMismatch['summary']['diagnostic_count'] ?? count($pageLayoutMismatchDiagnostics));
             if ( ! empty($pageLayoutMismatch) ) {
-                $layout['layout_mismatch_status'] = 'fail' === ($pageLayoutMismatch['status'] ?? null) ? 'fail' : ('not_evaluated' === $layout['layout_mismatch_status'] ? (string) ($pageLayoutMismatch['status'] ?? 'not_run') : $layout['layout_mismatch_status']);
+                $pageLayoutMismatchStatus = (string) ($pageLayoutMismatch['status'] ?? 'not_run');
+                if ( 'fail' === $pageLayoutMismatchStatus || ( 'not_comparable' === $pageLayoutMismatchStatus && 'fail' !== $layout['layout_mismatch_status'] ) || 'not_evaluated' === $layout['layout_mismatch_status'] ) {
+                    $layout['layout_mismatch_status'] = $pageLayoutMismatchStatus;
+                }
             }
             foreach ( $pageLayoutMismatchDiagnostics as $item ) {
                 if ( is_array($item) ) {
@@ -1884,6 +1893,9 @@ final class FigmaTransformer
         }
         if ( ! empty($layout['layout_mismatch_count']) ) {
             $signals[] = array('severity' => 'warning', 'code' => 'layout_mismatch', 'count' => (int) $layout['layout_mismatch_count']);
+        }
+        if ( 'not_comparable' === ($layout['layout_mismatch_status'] ?? null) ) {
+            $signals[] = array('severity' => 'warning', 'code' => 'layout_mismatch_not_comparable');
         }
         if ( ! empty($layout['render_style_mismatch_count']) ) {
             $signals[] = array('severity' => 'warning', 'code' => 'render_style_mismatch', 'count' => (int) $layout['render_style_mismatch_count']);

--- a/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
@@ -877,6 +877,8 @@ final class ScenegraphPagePlanner
             'slug'                     => $slug,
             'entrypoint'               => $entrypoint,
             'device_hint'              => (string) ($detectionById[$primaryId]['device_hint'] ?? 'unknown'),
+            'width'                    => $candidate['dimensions']['width'] ?? null,
+            'height'                   => $candidate['dimensions']['height'] ?? null,
             'role'                     => (string) ($classification['role'] ?? ScenegraphFrameClassifier::ROLE_PAGE),
             'page_type'                => (string) ($classification['page_type'] ?? ScenegraphFrameClassifier::PAGE_TYPE_UNKNOWN),
         );

--- a/figma-transformer/tests/contract/LayoutMismatchContract.php
+++ b/figma-transformer/tests/contract/LayoutMismatchContract.php
@@ -58,4 +58,99 @@ function blocks_engine_figma_transformer_run_layout_mismatch_contract(callable $
     $assert(1 === ($fontRendering['computed_font_family_mismatch_count'] ?? null), 'layout-mismatch-font-rendering-computed-family-mismatch');
     $assert(1 === ($fontRendering['document_fonts_check_failure_count'] ?? null), 'layout-mismatch-font-rendering-font-check-failure');
     $assert(3200 === ($fontRendering['source_font_usage'][0]['visible_text_area_px'] ?? null), 'layout-mismatch-font-rendering-source-usage-area');
+
+    $fluidSource = array(
+        'visual_node_map' => array(
+            array('id' => 'fluid:band', 'name' => 'Fluid band', 'type' => 'FRAME', 'rect' => array('x' => 0, 'y' => 0, 'width' => 2095, 'height' => 276)),
+            array('id' => 'fluid:primary', 'name' => 'Primary column', 'type' => 'FRAME', 'parent_id' => 'fluid:band', 'rect' => array('x' => 168, 'y' => 48, 'width' => 1205, 'height' => 180)),
+            array('id' => 'fluid:secondary', 'name' => 'Secondary column', 'type' => 'FRAME', 'parent_id' => 'fluid:band', 'rect' => array('x' => 1421, 'y' => 48, 'width' => 506, 'height' => 180)),
+        ),
+    );
+    $nativeBoxes = array(
+        array('node_id' => 'fluid:band', 'rect' => array('x' => 0, 'y' => 0, 'width' => 2095, 'height' => 276)),
+        array('node_id' => 'fluid:primary', 'rect' => array('x' => 168, 'y' => 48, 'width' => 1205, 'height' => 180)),
+        array('node_id' => 'fluid:secondary', 'rect' => array('x' => 1421, 'y' => 48, 'width' => 506, 'height' => 180)),
+    );
+    $responsiveBoxes = array(
+        array('node_id' => 'fluid:band', 'rect' => array('x' => 0, 'y' => 0, 'width' => 1440, 'height' => 504)),
+        array('node_id' => 'fluid:primary', 'rect' => array('x' => 115, 'y' => 48, 'width' => 1210, 'height' => 180)),
+        array('node_id' => 'fluid:secondary', 'rect' => array('x' => 115, 'y' => 276, 'width' => 1210, 'height' => 180)),
+    );
+    $fluidOptions = array('page_path' => 'index.html', 'source_frame_id' => 'fluid:2095', 'source_frame_width' => 2095);
+    $nativeReport = ( new LayoutMismatchReportBuilder() )->build($fluidSource, array('entrypoints' => array(
+        array('page_path' => 'index.html', 'viewport' => array('width' => 2095, 'height' => 900), 'source_frame' => array('id' => 'fluid:2095', 'width' => 2095), 'comparison_role' => 'source_layout', 'elements' => $nativeBoxes),
+        array('page_path' => 'index.html', 'viewport' => array('width' => 1440, 'height' => 900), 'source_frame' => array('id' => 'fluid:1440', 'width' => 1440), 'comparison_role' => 'responsive_evidence', 'elements' => $responsiveBoxes),
+    )), $fluidOptions);
+    $assert('pass' === ($nativeReport['status'] ?? null), 'layout-mismatch-native-width-comparison-runs');
+    $assert(2095.0 === ($nativeReport['comparison']['source_frame_width'] ?? null), 'layout-mismatch-persists-source-frame-width');
+    $assert(2095 === ($nativeReport['comparison']['captured_viewport']['width'] ?? null), 'layout-mismatch-persists-captured-viewport');
+    $assert(1 === ($nativeReport['comparison']['responsive_evidence_capture_count'] ?? null), 'layout-mismatch-preserves-responsive-capture-evidence');
+
+    $incompatibleReport = ( new LayoutMismatchReportBuilder() )->build($fluidSource, array('entrypoints' => array(
+        array('page_path' => 'index.html', 'viewport' => array('width' => 1440, 'height' => 900), 'source_frame' => array('id' => 'fluid:1440', 'width' => 1440), 'comparison_role' => 'responsive_evidence', 'elements' => $responsiveBoxes),
+    )), $fluidOptions);
+    $assert('not_comparable' === ($incompatibleReport['status'] ?? null), 'layout-mismatch-incompatible-width-is-not-comparable');
+    $assert('not_comparable' === ($incompatibleReport['comparison']['position_status'] ?? null), 'layout-mismatch-incompatible-position-is-not-comparable');
+    $assert('not_comparable' === ($incompatibleReport['comparison']['size_status'] ?? null), 'layout-mismatch-incompatible-size-is-not-comparable');
+    $assert('incompatible_viewport_width' === ($incompatibleReport['comparison']['reason'] ?? null), 'layout-mismatch-incompatible-width-reason');
+    $assert(0 === ($incompatibleReport['summary']['diagnostic_count'] ?? null), 'layout-mismatch-incompatible-width-does-not-create-failures');
+
+    $variantGeometryReport = ( new LayoutMismatchReportBuilder() )->build($fluidSource, array('entrypoints' => array(
+        array('page_path' => 'index.html', 'viewport' => array('width' => 1440, 'height' => 900), 'source_frame' => array('id' => 'fluid:1440', 'width' => 1440), 'comparison_role' => 'responsive_evidence', 'source_visual_node_map' => $responsiveBoxes, 'elements' => $responsiveBoxes),
+    )), $fluidOptions);
+    $assert('pass' === ($variantGeometryReport['status'] ?? null), 'layout-mismatch-responsive-geometry-can-be-compared');
+    $assert('responsive_source_geometry_supplied' === ($variantGeometryReport['comparison']['reason'] ?? null), 'layout-mismatch-responsive-geometry-reason');
+
+    $nativeMismatchBoxes = $nativeBoxes;
+    $nativeMismatchBoxes[2]['rect']['x'] = 1300;
+    $nativeMismatchReport = ( new LayoutMismatchReportBuilder() )->build($fluidSource, array('entrypoints' => array(
+        array('page_path' => 'index.html', 'viewport' => array('width' => 2095, 'height' => 900), 'source_frame' => array('id' => 'fluid:2095', 'width' => 2095), 'comparison_role' => 'source_layout', 'elements' => $nativeMismatchBoxes),
+    )), $fluidOptions);
+    $assert('fail' === ($nativeMismatchReport['status'] ?? null), 'layout-mismatch-native-width-mismatch-still-fails');
+    $assert(0 < ($nativeMismatchReport['summary']['diagnostic_count'] ?? 0), 'layout-mismatch-native-width-mismatch-remains-visible');
+
+    $multiPageScenegraph = array(
+        'name' => 'Matrix rerun fixture',
+        'nodes' => array(
+            array('id' => 'matrix:native', 'type' => 'FRAME', 'name' => 'Native page', 'width' => 1200, 'height' => 320),
+            array('id' => 'matrix:responsive', 'type' => 'FRAME', 'name' => 'Responsive page', 'width' => 960, 'height' => 320),
+        ),
+    );
+    $transformer = new \Automattic\BlocksEngine\FigmaTransformer\FigmaTransformer();
+    $targetResult = $transformer->transformScenegraph($multiPageScenegraph, array('frame_ids' => array('matrix:native', 'matrix:responsive')))->toArray();
+    $targetPages = $targetResult['source_reports']['figma']['html']['pages'] ?? array();
+    $nativePage = is_array($targetPages[0] ?? null) ? $targetPages[0] : array();
+    $responsivePage = is_array($targetPages[1] ?? null) ? $targetPages[1] : array();
+    $nativeNode = is_array($nativePage['visual_node_map'][0] ?? null) ? $nativePage['visual_node_map'][0] : array();
+
+    // This mirrors the DOM provider's entrypoint payload after matrix targeting.
+    $rerunResult = $transformer->transformScenegraph($multiPageScenegraph, array(
+        'frame_ids' => array('matrix:native', 'matrix:responsive'),
+        'generated_dom_boxes' => array(
+            'schema' => 'homeboy/static-artifact-dom-boxes/v1',
+            'entrypoints' => array(
+                array(
+                    'page_path' => $nativePage['path'] ?? '',
+                    'viewport' => array('width' => 1200, 'height' => 900),
+                    'source_frame' => array('id' => 'matrix:native', 'width' => 1200),
+                    'comparison_role' => 'source_layout',
+                    'elements' => array(array('node_id' => $nativeNode['id'] ?? '', 'rect' => $nativeNode['rect'] ?? array())),
+                ),
+                array(
+                    'page_path' => $responsivePage['path'] ?? '',
+                    'viewport' => array('width' => 720, 'height' => 900),
+                    'source_frame' => array('id' => 'matrix:responsive-capture', 'width' => 720),
+                    'comparison_role' => 'responsive_evidence',
+                    'elements' => array(array('node_id' => 'matrix:responsive', 'rect' => array('x' => 0, 'y' => 0, 'width' => 720, 'height' => 320))),
+                ),
+            ),
+        ),
+    ))->toArray();
+    $rerunDiagnostics = $rerunResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $rerunPages = $rerunResult['source_reports']['figma']['html']['pages'] ?? array();
+    $assert('pass' === ($rerunPages[0]['transform_diagnostics']['layout']['layout_mismatch_status'] ?? null), 'layout-mismatch-matrix-rerun-native-page-passes');
+    $assert('not_comparable' === ($rerunPages[1]['transform_diagnostics']['layout']['layout_mismatch_status'] ?? null), 'layout-mismatch-matrix-rerun-wrong-width-is-not-comparable');
+    $assert('not_comparable' === ($rerunDiagnostics['layout']['layout_mismatch_status'] ?? null), 'layout-mismatch-matrix-rerun-aggregate-preserves-not-comparable');
+    $assert('needs_review' === ($rerunDiagnostics['artifact_quality']['status'] ?? null), 'layout-mismatch-matrix-rerun-aggregate-requires-review');
+    $assert('warn' === ($rerunDiagnostics['artifact_quality']['quality_status'] ?? null), 'layout-mismatch-matrix-rerun-aggregate-quality-warn');
 }

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -1913,6 +1913,7 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(3 === ($responsiveHomePage['breakpoint_count'] ?? null), 'page-plan-responsive-home-three-breakpoints');
     $assert('frame:home-desktop' === ($responsiveHomePage['source_frame_identity']['selected_frame_id'] ?? null), 'page-plan-source-frame-identity-selected-frame');
     $assert('frame:home-desktop' === ($responsiveHomePage['source_frame_identity']['primary_frame_id'] ?? null), 'page-plan-source-frame-identity-primary-frame');
+    $assert(1440.0 === ($responsiveHomePage['source_frame_identity']['width'] ?? null), 'page-plan-source-frame-identity-width');
     $assert(array('frame:home-tablet', 'frame:home-mobile') === ($responsiveHomePage['source_frame_identity']['variant_sibling_frame_ids'] ?? null), 'page-plan-source-frame-identity-variant-siblings');
     // A responsive page's slug reflects the PAGE, not its widest variant: the
     // breakpoint token ("Desktop") is stripped so desktop+mobile collapse to one

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -1426,6 +1426,34 @@ $layoutNotEvaluatedQuality = $layoutNotEvaluatedResult['source_reports']['figma'
 $assert(0 === ($layoutNotEvaluatedQuality['layout_mismatch_count'] ?? null), 'layout-not-evaluated-count-zero');
 $assert('not_evaluated' === ($layoutNotEvaluatedQuality['layout_mismatch_status'] ?? null), 'layout-not-evaluated-status');
 
+$layoutNotComparableResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+    'name' => 'Layout Not Comparable Fixture',
+    'nodes' => array(
+        array('id' => 'layout:not-comparable', 'type' => 'FRAME', 'name' => 'Simple Page', 'width' => 1200, 'height' => 320),
+    ),
+), array(
+    'generated_dom_boxes' => array(
+        'schema' => 'homeboy/static-artifact-dom-boxes/v1',
+        'entrypoints' => array(
+            array(
+                'page_path' => 'index.html',
+                'viewport' => array('width' => 960, 'height' => 900),
+                'source_frame' => array('id' => 'layout:mobile', 'width' => 960),
+                'comparison_role' => 'responsive_evidence',
+                'elements' => array(array('node_id' => 'layout:not-comparable', 'rect' => array('x' => 0, 'y' => 0, 'width' => 960, 'height' => 320))),
+            ),
+        ),
+    ),
+    'layout_mismatch_options' => array('source_frame_id' => 'layout:not-comparable', 'source_frame_width' => 1200),
+));
+$layoutNotComparableDiagnostics = $layoutNotComparableResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+$layoutNotComparableQuality = $layoutNotComparableDiagnostics['artifact_quality'] ?? array();
+$layoutNotComparableCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), $layoutNotComparableQuality['signals'] ?? array());
+$assert('not_comparable' === ($layoutNotComparableDiagnostics['layout']['layout_mismatch_status'] ?? null), 'layout-not-comparable-status');
+$assert('needs_review' === ($layoutNotComparableQuality['status'] ?? null), 'layout-not-comparable-quality-needs-review');
+$assert('warn' === ($layoutNotComparableQuality['quality_status'] ?? null), 'layout-not-comparable-quality-warn');
+$assert(in_array('layout_mismatch_not_comparable', $layoutNotComparableCodes, true), 'layout-not-comparable-quality-signal');
+
 blocks_engine_figma_transformer_run_site_generation_planning_contract($assert, $fileContent, $externalizedVectorPath);
 
 blocks_engine_figma_transformer_run_text_layout_contract($assert, $fileContent, $quadraticCommandBlob);

--- a/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
+++ b/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
@@ -72,6 +72,7 @@ async function main() {
   const textSampleLimit = parseTextSampleLimit(process.env.HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT ?? '160');
   const nodeIdAttr = resolveNodeIdAttr(cli);
   const nodeNameAttrs = resolveNodeNameAttrs(cli);
+  const captureTargets = parseCaptureTargets(process.env.HOMEBOY_DOM_BOX_CAPTURE_TARGETS_JSON);
   const { chromium } = await loadPlaywright();
 
   let browser;
@@ -81,23 +82,27 @@ async function main() {
     throw withPlaywrightSetupHelp(error);
   }
   try {
-    const context = await browser.newContext({
-      viewport: { width: DEFAULT_VIEWPORT.width, height: DEFAULT_VIEWPORT.height },
-      deviceScaleFactor: DEFAULT_VIEWPORT.device_scale_factor,
-    });
+    const context = await browser.newContext({ deviceScaleFactor: DEFAULT_VIEWPORT.device_scale_factor });
     const entrypoints = [];
 
     for (const pagePath of pagePaths) {
-      const page = await context.newPage();
-      const pageUrl = `${baseUrl}${String(pagePath).startsWith('/') ? pagePath : `/${pagePath}`}`;
-      await page.goto(pageUrl, { waitUntil: 'load' });
-      entrypoints.push({
-        page_path: pagePath,
-        page_url: page.url(),
-        viewport: DEFAULT_VIEWPORT,
-        ...(await extractElements(page, pagePath, textSampleLimit, nodeIdAttr, nodeNameAttrs)),
-      });
-      await page.close();
+      const targets = targetsForPage(captureTargets, pagePath);
+      for (const target of targets) {
+        const viewport = target.viewport ?? DEFAULT_VIEWPORT;
+        const page = await context.newPage();
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        const pageUrl = `${baseUrl}${String(pagePath).startsWith('/') ? pagePath : `/${pagePath}`}`;
+        await page.goto(pageUrl, { waitUntil: 'load' });
+        entrypoints.push({
+          page_path: pagePath,
+          page_url: page.url(),
+          viewport: { ...viewport, device_scale_factor: DEFAULT_VIEWPORT.device_scale_factor },
+          ...(target.source_frame ? { source_frame: target.source_frame } : {}),
+          ...(target.comparison_role ? { comparison_role: target.comparison_role } : {}),
+          ...(await extractElements(page, pagePath, textSampleLimit, nodeIdAttr, nodeNameAttrs)),
+        });
+        await page.close();
+      }
     }
 
     process.stdout.write(`${JSON.stringify({ entrypoints }, null, 2)}\n`);
@@ -227,8 +232,37 @@ function resolveNodeNameAttrs(cli) {
   return names;
 }
 
+function parseCaptureTargets(raw) {
+  if (raw === undefined || raw === '') {
+    return [];
+  }
+  let targets;
+  try {
+    targets = JSON.parse(raw);
+  } catch {
+    throw new Error('HOMEBOY_DOM_BOX_CAPTURE_TARGETS_JSON must be valid JSON.');
+  }
+  if (!Array.isArray(targets)) {
+    throw new Error('HOMEBOY_DOM_BOX_CAPTURE_TARGETS_JSON must be a JSON array.');
+  }
+  return targets.map((target) => {
+    const width = Number(target?.viewport?.width);
+    const height = Number(target?.viewport?.height ?? DEFAULT_VIEWPORT.height);
+    if (typeof target?.page_path !== 'string' || !Number.isInteger(width) || width <= 0 || !Number.isInteger(height) || height <= 0) {
+      throw new Error('Each DOM capture target requires page_path and positive integer viewport width/height.');
+    }
+    return { ...target, viewport: { width, height } };
+  });
+}
+
+function targetsForPage(targets, pagePath) {
+  const normalizedPath = String(pagePath).replace(/^\/+/, '');
+  const matches = targets.filter((target) => String(target.page_path).replace(/^\/+/, '') === normalizedPath);
+  return matches.length > 0 ? matches : [{}];
+}
+
 function printHelp() {
-  process.stdout.write(`Capture DOM boxes for Homeboy artifact-origin dom-boxes.\n\nNode identity is keyed off a configurable attribute so the tool is product-neutral.\nThe figma-transformer's data-figma-* attributes remain the backward-compatible default.\n\nEnvironment:\n  HOMEBOY_DOM_BOX_BASE_URL             Static artifact origin base URL.\n  HOMEBOY_DOM_BOX_PAGE_PATHS_JSON      JSON array of page paths to capture.\n  HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT    Optional positive integer, default 160.\n  HOMEBOY_DOM_BOX_NODE_ID_ATTR         Node identity attribute, default ${DEFAULT_NODE_ID_ATTR}.\n  HOMEBOY_DOM_BOX_NODE_NAME_ATTR       Comma-separated node name attributes, default ${DEFAULT_NODE_NAME_ATTRS.join(',')} (aria-label is always a final fallback).\n\nFlags (override the matching environment variable):\n  --node-id-attr=<attr>                Node identity attribute used for enumeration, selectors, and id reads.\n  --node-name-attr=<attr>[,<attr>...]  Node name attributes, tried in order before aria-label.\n  --preflight                          Verify Playwright and Chromium are installed, then exit.\n\nOutput:\n  JSON browser payload on stdout for Homeboy to shape as homeboy/static-artifact-dom-boxes/v1.\n`);
+  process.stdout.write(`Capture DOM boxes for Homeboy artifact-origin dom-boxes.\n\nNode identity is keyed off a configurable attribute so the tool is product-neutral.\nThe figma-transformer's data-figma-* attributes remain the backward-compatible default.\n\nEnvironment:\n  HOMEBOY_DOM_BOX_BASE_URL             Static artifact origin base URL.\n  HOMEBOY_DOM_BOX_PAGE_PATHS_JSON      JSON array of page paths to capture.\n  HOMEBOY_DOM_BOX_TEXT_SAMPLE_LIMIT    Optional positive integer, default 160.\n  HOMEBOY_DOM_BOX_NODE_ID_ATTR         Node identity attribute, default ${DEFAULT_NODE_ID_ATTR}.\n  HOMEBOY_DOM_BOX_NODE_NAME_ATTR       Comma-separated node name attributes, default ${DEFAULT_NODE_NAME_ATTRS.join(',')} (aria-label is always a final fallback).\n  HOMEBOY_DOM_BOX_CAPTURE_TARGETS_JSON Optional page/source-frame viewport capture targets.\n\nFlags (override the matching environment variable):\n  --node-id-attr=<attr>                Node identity attribute used for enumeration, selectors, and id reads.\n  --node-name-attr=<attr>[,<attr>...]  Node name attributes, tried in order before aria-label.\n  --preflight                          Verify Playwright and Chromium are installed, then exit.\n\nOutput:\n  JSON browser payload on stdout for Homeboy to shape as homeboy/static-artifact-dom-boxes/v1.\n`);
 }
 
 async function extractElements(page, pagePath, textSampleLimit, nodeIdAttr, nodeNameAttrs) {

--- a/php-transformer/tools/visual-parity/tests/fixtures/fluid-layout-2095.html
+++ b/php-transformer/tools/visual-parity/tests/fixtures/fluid-layout-2095.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+    .band { width: 100%; padding: 48px max(32px, 8vw); background: #eef2f5; }
+    .columns { display: grid; grid-template-columns: 2fr 1fr; gap: 48px; }
+    .column { min-height: 180px; background: #fff; }
+    @media (max-width: 1600px) {
+      .columns { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main class="band" data-figma-node-id="fluid:band" data-figma-node-name="Fluid band">
+    <div class="columns" data-figma-node-id="fluid:columns" data-figma-node-name="Two columns">
+      <section class="column" data-figma-node-id="fluid:primary" data-figma-node-name="Primary column"></section>
+      <aside class="column" data-figma-node-id="fluid:secondary" data-figma-node-name="Secondary column"></aside>
+    </div>
+  </main>
+</body>
+</html>

--- a/php-transformer/tools/visual-parity/tests/smoke.mjs
+++ b/php-transformer/tools/visual-parity/tests/smoke.mjs
@@ -74,6 +74,11 @@ const server = createServer(async (request, response) => {
     response.end(await readFile(domFixtureGeneric));
     return;
   }
+  if (request.url === '/fluid-layout-2095.html') {
+    response.writeHead(200, { 'content-type': 'text/html' });
+    response.end(await readFile(path.join(root, 'tests/fixtures/fluid-layout-2095.html')));
+    return;
+  }
   response.writeHead(404, { 'content-type': 'application/json' });
   response.end('{"error":"not_found"}');
 });
@@ -137,6 +142,24 @@ try {
   assert(genericFlagReport.entrypoints[0].elements[0].node_id === 'n-1', 'DOM provider reads node id from configured generic attribute (flag)');
   assert(genericFlagReport.entrypoints[0].elements[0].node_name === 'Generic Hero', 'DOM provider reads node name from configured generic attribute (flag)');
   assert(genericFlagReport.entrypoints[0].elements[0].selector === 'main[data-node-id="n-1"]', 'DOM provider keys selector off configured generic attribute (flag)');
+
+  const fluidReport = await runJson(process.execPath, [path.join(root, 'bin/dom-box-provider.mjs')], root, {
+    ...process.env,
+    HOMEBOY_DOM_BOX_BASE_URL: `http://127.0.0.1:${address.port}`,
+    HOMEBOY_DOM_BOX_PAGE_PATHS_JSON: JSON.stringify(['/fluid-layout-2095.html']),
+    HOMEBOY_DOM_BOX_CAPTURE_TARGETS_JSON: JSON.stringify([
+      { page_path: '/fluid-layout-2095.html', viewport: { width: 2095, height: 900 }, source_frame: { id: 'fluid:2095', width: 2095 }, comparison_role: 'source_layout' },
+      { page_path: '/fluid-layout-2095.html', viewport: { width: 1440, height: 900 }, source_frame: { id: 'fluid:1440', width: 1440 }, comparison_role: 'responsive_evidence' },
+    ]),
+  });
+  assert(fluidReport.entrypoints.length === 2, 'DOM provider preserves native and responsive captures separately');
+  assert(fluidReport.entrypoints[0].viewport.width === 2095, 'DOM provider captures native source width');
+  assert(fluidReport.entrypoints[0].source_frame.id === 'fluid:2095', 'DOM provider persists native source frame identity');
+  assert(fluidReport.entrypoints[1].viewport.width === 1440, 'DOM provider captures responsive evidence width');
+  assert(fluidReport.entrypoints[1].comparison_role === 'responsive_evidence', 'DOM provider labels responsive evidence separately');
+  const nativeSecondary = fluidReport.entrypoints[0].elements.find((element) => element.node_id === 'fluid:secondary');
+  const responsiveSecondary = fluidReport.entrypoints[1].elements.find((element) => element.node_id === 'fluid:secondary');
+  assert(nativeSecondary.boundingClientRect.y < responsiveSecondary.boundingClientRect.y, 'reduced fixture reflows two columns at the responsive width');
 
   const screenshotReport = await runJson(process.execPath, [
     path.join(root, 'bin/screenshot-provider.mjs'),


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `agent-task-121b6fc3-c6b4-4130-a30f-ac289df44054` into review-ready branch `fix/figma-layout-parity-viewports`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:agent-task-121b6fc3-c6b4-4130-a30f-ac289df44054`
- **Homeboy run ID:** `agent-task-121b6fc3-c6b4-4130-a30f-ac289df44054`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-layout-parity-viewports`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/328

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Native source-layout comparison requires matching source/capture viewport; incompatible responsive evidence remains explicit needs-review.
- **Evidence discriminators preserved:** 2095px source frame captured at native and incompatible 1440 widths
- **Nearby contracts preserved:** genuine native-width mismatches still fail and multi-page non-comparable state cannot be masked

## Attempt summary
Forensic candidate corrected after independent safety review; PHP and browser contracts green.

## Gate results
- contract-tests: passed (targeted)
- browser-smoke: passed (targeted)
- independent-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer --working-dir=figma-transformer test`, `npm test --prefix php-transformer/tools/visual-parity`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/scripts/figma-fixture-matrix.php
- figma-transformer/src/Diagnostics/LayoutMismatchReportBuilder.php
- figma-transformer/src/FigmaTransformer.php
- figma-transformer/src/Scenegraph/ScenegraphPagePlanner.php
- figma-transformer/tests/contract/LayoutMismatchContract.php
- figma-transformer/tests/contract/SiteGenerationContract.php
- figma-transformer/tests/contract/run.php
- php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
- php-transformer/tools/visual-parity/tests/fixtures/fluid-layout-2095.html
- php-transformer/tools/visual-parity/tests/smoke.mjs

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-layout-parity-viewports`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Implemented viewport-safe parity from landed Fisiostetic DOM evidence with reviewed integration tests.
