### PR TITLE
Fix paragraph save-shape regressions

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -64,7 +64,9 @@ final class BlockFactory
     {
         $attrs = $this->normalizeClassNameAttr($attrs);
 
-        if ( in_array($name, array( 'core/group', 'core/columns' ), true) ) {
+        // Paragraph save() does not reproduce dimensions.maxWidth. Inline
+        // max-width is retained by the generated geometry carrier stylesheet.
+        if ( in_array($name, array( 'core/group', 'core/columns', 'core/paragraph' ), true) ) {
             unset($attrs['style']['dimensions']['maxWidth']);
             if ( empty($attrs['style']['dimensions']) ) {
                 unset($attrs['style']['dimensions']);

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -822,6 +822,61 @@ $paragraphFactoryGeneratedClassLeakBlock = ( new BlockFactory() )->create('core/
 $assert('hero-tagline' === ($paragraphFactoryGeneratedClassLeakBlock['attrs']['className'] ?? ''), 'BlockFactory strips generated classes from direct paragraph className attrs');
 $assert(str_contains((string) ($paragraphFactoryGeneratedClassLeakBlock['innerHTML'] ?? ''), '<p class="has-text-color hero-tagline" style="color:red">Slow roasted daily.</p>'), 'BlockFactory paragraph innerHTML emits a single generated color class');
 
+$fixtureParagraphByContent = static function (array $blocks, string $content) use (&$fixtureParagraphByContent): ?array {
+    foreach ( $blocks as $block ) {
+        if ( ! is_array($block) ) {
+            continue;
+        }
+        if ( 'core/paragraph' === ($block['blockName'] ?? '') && str_contains((string) ($block['attrs']['content'] ?? ''), $content) ) {
+            return $block;
+        }
+        $match = $fixtureParagraphByContent(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array(), $content);
+        if ( null !== $match ) {
+            return $match;
+        }
+    }
+
+    return null;
+};
+
+$fixtureRoot = dirname(__DIR__, 3) . '/fixtures/websites';
+foreach ( array(
+    array( '10-nonprofit', 'css/style.css', 'Harbor Steps prepares coastal communities' ),
+    array( '13-realistic-small-business', 'styles.css', 'Houseplants, handmade pots' ),
+    array( '74-lumen-coffee', 'css/styles.css', 'We source single-origin lots' ),
+) as [ $fixtureName, $stylesheetPath, $paragraphContent ] ) {
+    $fixturePath = $fixtureRoot . '/' . $fixtureName;
+    $fixtureResult = ( new HtmlTransformer() )->transform(
+        (string) file_get_contents($fixturePath . '/index.html'),
+        array( 'static_css' => (string) file_get_contents($fixturePath . '/' . $stylesheetPath) )
+    )->toArray();
+    $fixtureParagraph = $fixtureParagraphByContent($fixtureResult['blocks'] ?? array(), $paragraphContent);
+    $fixtureMarkup = (string) ($fixtureParagraph['innerHTML'] ?? '');
+
+    $assert(null !== $fixtureParagraph, $fixtureName . ' fixture serializes its hero paragraph through core/paragraph');
+    $assert(! str_contains((string) ($fixtureParagraph['attrs']['className'] ?? ''), 'has-text-color'), $fixtureName . ' fixture keeps generated text color classes out of paragraph className');
+    $assert(1 === substr_count($fixtureMarkup, 'has-text-color'), $fixtureName . ' fixture emits has-text-color exactly once in paragraph markup', $fixtureMarkup);
+    $assert('pass' === ($fixtureResult['source_reports']['wp_block_validity']['status'] ?? ''), $fixtureName . ' fixture paragraph passes the serialized block validity path');
+}
+
+$smallBusinessPath = $fixtureRoot . '/13-realistic-small-business';
+$smallBusinessResult = ( new HtmlTransformer() )->transform(
+    (string) file_get_contents($smallBusinessPath . '/index.html'),
+    array( 'static_css' => (string) file_get_contents($smallBusinessPath . '/styles.css') )
+)->toArray();
+$smallBusinessInlineGeometryParagraph = $fixtureParagraphByContent($smallBusinessResult['blocks'] ?? array(), 'Birthdays, team outings');
+$smallBusinessInlineGeometryAttrs = is_array($smallBusinessInlineGeometryParagraph['attrs'] ?? null) ? $smallBusinessInlineGeometryParagraph['attrs'] : array();
+$smallBusinessInlineGeometryMarkup = (string) ($smallBusinessInlineGeometryParagraph['innerHTML'] ?? '');
+$smallBusinessGeometryClass = (string) ($smallBusinessInlineGeometryAttrs['className'] ?? '');
+$smallBusinessAssets = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $smallBusinessResult['assets'] ?? array()));
+
+$assert(null !== $smallBusinessInlineGeometryParagraph, '13-realistic-small-business fixture keeps the inline-width CTA copy as a paragraph');
+$assert(str_contains($smallBusinessGeometryClass, 'be-inline-geometry-'), '13-realistic-small-business fixture preserves inline max-width with a generated geometry class', $smallBusinessGeometryClass);
+$assert(! isset($smallBusinessInlineGeometryAttrs['style']['dimensions']['maxWidth']), 'paragraph comment attrs omit maxWidth that core save does not reproduce', json_encode($smallBusinessInlineGeometryAttrs));
+$assert(str_contains($smallBusinessInlineGeometryMarkup, 'style="margin-top:1rem"'), 'paragraph markup retains native margin-top support', $smallBusinessInlineGeometryMarkup);
+$assert(! str_contains($smallBusinessInlineGeometryMarkup, 'max-width:380px'), 'paragraph markup omits max-width that core save does not reproduce', $smallBusinessInlineGeometryMarkup);
+$assert(str_contains($smallBusinessAssets, '.' . preg_replace('/^.*\b(be-inline-geometry-[^\s]+).*$/', '$1', $smallBusinessGeometryClass) . '{max-width:380px !important}'), 'generated geometry stylesheet preserves paragraph max-width deterministically', $smallBusinessAssets);
+
 $paragraphSvgResult = ( new HtmlTransformer() )->transform(
     '<main><p class="social-link"><a class="social-link" href="#" aria-label="Follow"><svg viewBox="0 0 10 10" aria-hidden="true"><path d="M0 0h10v10H0z"></path></svg></a></p></main>'
 )->toArray();


### PR DESCRIPTION
Fixes #604.

## Summary

- Remove unsupported `style.dimensions.maxWidth` from `core/paragraph` comment attributes and rendered markup.
- Preserve paragraph max-width through the existing deterministic `be-inline-geometry-*` carrier stylesheet.
- Add fixture-derived serialized-block regressions for `10-nonprofit`, `13-realistic-small-business`, and `74-lumen-coffee`.

## Why

Gutenberg paragraph `save()` does not reproduce `dimensions.maxWidth`. Blocks Engine emitted both the geometry carrier and inline max-width, so editor validation compared core's save output against extra markup and marked the paragraph invalid. The carrier already preserves the visual width; removing the unsupported duplicate representation restores save-shape parity.

The fixture regressions also prove generated color support classes stay out of `className` and `has-text-color` appears exactly once in rendered paragraph markup.

## How to test

1. Check out this branch on a fresh clone.
2. Run `cd php-transformer`.
3. Run `composer install`.
4. Run `composer test`.
5. Confirm the contract suite exercises `10-nonprofit`, `13-realistic-small-business`, and `74-lumen-coffee`, with all 230 parity fixtures and the packaging proof passing.
6. Run `git diff --check` from the repository root.

## Backward compatibility

This changes serialized output consumed outside the package: `core/paragraph` no longer receives unsupported `style.dimensions.maxWidth` or matching inline `max-width`. The effective width remains preserved by the existing generated geometry carrier class and CSS. Supported paragraph styles, author classes, deterministic output, and public APIs are unchanged.

## Verification

- `composer test`: passed
- `git diff --check`: passed
- GitHub `Composer validate and test`: passed
- Live SSI fixture-matrix confirmation remains pending safe Lab reconnection.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode orchestrated by Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced fixture-derived paragraph save-shape failures, implemented the generic serializer correction, and added end-to-end transformer regressions with Chris.
