### PR TITLE
Resolve conflicting Figma HUG text heights

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -6297,8 +6297,18 @@ final class StaticHtmlEmitter
                 }
             }
             if ( 'HUG' === $sizing ) {
-                $derivedTextSize = 'TEXT' === $type ? $this->derivedTextLayoutSize($node, $dimension) : null;
-                if ( null !== $derivedTextSize ) {
+                $derivedTextSizeDecision = 'TEXT' === $type ? $this->derivedTextLayoutSizeDecision($node, $dimension) : null;
+                if ( null !== $derivedTextSizeDecision ) {
+                    $derivedTextSize = $derivedTextSizeDecision['size'];
+                    if ( 'source_box' === $derivedTextSizeDecision['authority'] ) {
+                        $this->recordDecisionTrace('layout_geometry', 'derived_hug_text_size_conflicts_with_source_box', $node, 'emit_source_box_size', $parentNode, array(
+                            'dimension' => $dimension,
+                            'source_box' => $this->visualGeometryResolver()->nodeSourceBoxEvidence($node),
+                            'derived_text_layout_size' => $derivedTextSizeDecision['derived_size'],
+                            'agreement_tolerance' => $derivedTextSizeDecision['agreement_tolerance'],
+                            'emitted_css_box' => array($dimension => $derivedTextSize),
+                        ));
+                    }
                     if ( 'height' === $dimension && $this->textShouldAvoidTinyFixedHeight($node, $derivedTextSize) && ! $this->textShouldUseMeasuredFlexHeight($node, $parentNode) ) {
                         continue;
                     }
@@ -6994,6 +7004,37 @@ final class StaticHtmlEmitter
         }
 
         return null;
+    }
+
+    /**
+     * Chooses the authority for a HUG text dimension while preserving the
+     * derived layout measurement as diagnostic evidence.
+     *
+     * @param array<string, mixed> $node
+     * @return array{size: float, authority: string, derived_size: float, agreement_tolerance: float}|null
+     */
+    private function derivedTextLayoutSizeDecision(array $node, string $dimension): ?array
+    {
+        $derivedSize = $this->derivedTextLayoutSize($node, $dimension);
+        if ( null === $derivedSize ) {
+            return null;
+        }
+
+        $agreementTolerance = 0.5;
+        $sourceBox = $this->visualGeometryResolver()->nodeSourceBoxEvidence($node);
+        $sourceSize = isset($sourceBox[$dimension]) && is_numeric($sourceBox[$dimension]) && is_finite((float) $sourceBox[$dimension])
+            ? (float) $sourceBox[$dimension]
+            : null;
+        $sourceIsAuthoritative = 'height' === $dimension
+            && null !== $sourceSize
+            && abs($derivedSize - $sourceSize) > $agreementTolerance;
+
+        return array(
+            'size' => $sourceIsAuthoritative ? $sourceSize : $derivedSize,
+            'authority' => $sourceIsAuthoritative ? 'source_box' : 'derived_layout',
+            'derived_size' => $derivedSize,
+            'agreement_tolerance' => $agreementTolerance,
+        );
     }
 
     /**

--- a/figma-transformer/tests/contract/TextLayoutContract.php
+++ b/figma-transformer/tests/contract/TextLayoutContract.php
@@ -826,6 +826,103 @@ function blocks_engine_figma_transformer_run_text_layout_contract(callable $asse
     $assert(str_contains($derivedHugTextHeightCss, '.figma-node-text-derived-hug-text-height-trimmed-heading{') && str_contains($derivedHugTextHeightCss, 'width:320px;height:86px') && str_contains($derivedHugTextHeightCss, 'font-size:128px') && str_contains($derivedHugTextHeightCss, 'line-height:115.2px'), 'derived-hug-text-height-preserves-measured-box');
     $assert(! str_contains($derivedHugTextHeightCss, '.figma-node-text-derived-hug-text-height-trimmed-heading{width:320px;height:fit-content'), 'derived-hug-text-height-not-fit-content');
     $assert(str_contains($derivedHugTextHeightCss, '.figma-node-frame-derived-hug-text-height-measured-text-stack{width:320px;height:140px;display:flex;flex-direction:column;gap:32px}'), 'derived-hug-text-height-parent-gap-preserved');
+
+    $conflictingDerivedHugTextHeightResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'Conflicting Derived Hug Text Height Fixture',
+        'nodes' => array(
+            array(
+                'id'             => 'text:conflicting-derived-hug-height',
+                'type'           => 'TEXT',
+                'name'           => 'Conflicting Heading',
+                'characters'     => 'Measured source box',
+                'width'          => 320,
+                'height'         => 66,
+                'fontSize'       => 48,
+                'textAutoResize' => 'HEIGHT',
+                'derivedTextData' => array(
+                    'layoutSize' => array('x' => 320, 'y' => 96),
+                ),
+            ),
+        ),
+    ));
+    $conflictingDerivedHugTextHeightCss = $fileContent($conflictingDerivedHugTextHeightResult, 'style.css');
+    $conflictingDerivedHugTextHeightDiagnostics = $conflictingDerivedHugTextHeightResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $assert(str_contains($conflictingDerivedHugTextHeightCss, '.figma-node-text-conflicting-derived-hug-height-conflicting-heading{width:320px;height:66px'), 'conflicting-derived-hug-text-height-prefers-source-box');
+    $assert(! str_contains($conflictingDerivedHugTextHeightCss, '.figma-node-text-conflicting-derived-hug-height-conflicting-heading{width:320px;height:96px'), 'conflicting-derived-hug-text-height-rejects-derived-height');
+    $assert(1 === ($conflictingDerivedHugTextHeightDiagnostics['decision_traces']['reason_counts']['derived_hug_text_size_conflicts_with_source_box'] ?? null), 'conflicting-derived-hug-text-height-traces-authority-decision');
+    $conflictingDerivedHugTextHeightTrace = $conflictingDerivedHugTextHeightDiagnostics['decision_traces']['samples_by_reason']['derived_hug_text_size_conflicts_with_source_box'] ?? array();
+    $assert(96.0 === ($conflictingDerivedHugTextHeightTrace['evidence']['derived_text_layout_size'] ?? null), 'conflicting-derived-hug-text-height-retains-derived-evidence');
+    $assert(66.0 === ($conflictingDerivedHugTextHeightTrace['evidence']['source_box']['height'] ?? null), 'conflicting-derived-hug-text-height-retains-source-evidence');
+
+    $hugTextHeightToleranceResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'Hug Text Height Tolerance Fixture',
+        'nodes' => array(
+            array(
+                'id'             => 'text:hug-height-at-tolerance',
+                'type'           => 'TEXT',
+                'name'           => 'At Tolerance',
+                'characters'     => 'Derived height remains authoritative',
+                'width'          => 320,
+                'height'         => 66,
+                'fontSize'       => 24,
+                'textAutoResize' => 'HEIGHT',
+                'derivedTextData' => array('layoutSize' => array('x' => 320, 'y' => 66.5)),
+            ),
+            array(
+                'id'             => 'text:hug-height-over-tolerance',
+                'type'           => 'TEXT',
+                'name'           => 'Over Tolerance',
+                'characters'     => 'Source height becomes authoritative',
+                'width'          => 320,
+                'height'         => 66,
+                'fontSize'       => 24,
+                'textAutoResize' => 'HEIGHT',
+                'derivedTextData' => array('layoutSize' => array('x' => 320, 'y' => 66.5001)),
+            ),
+        ),
+    ));
+    $hugTextHeightToleranceCss = $fileContent($hugTextHeightToleranceResult, 'style.css');
+    $hugTextHeightToleranceDiagnostics = $hugTextHeightToleranceResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $assert(str_contains($hugTextHeightToleranceCss, '.figma-node-text-hug-height-at-tolerance-at-tolerance{width:320px;height:66.5px'), 'hug-text-height-at-exact-tolerance-keeps-derived-height');
+    $assert(str_contains($hugTextHeightToleranceCss, '.figma-node-text-hug-height-over-tolerance-over-tolerance{width:320px;height:66px'), 'hug-text-height-over-tolerance-prefers-source-height');
+    $assert(1 === ($hugTextHeightToleranceDiagnostics['decision_traces']['reason_counts']['derived_hug_text_size_conflicts_with_source_box'] ?? null), 'hug-text-height-over-tolerance-only-traces-conflict');
+
+    $widthOnlyDerivedHugTextResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'Width-Only Derived Hug Text Fixture',
+        'nodes' => array(
+            array(
+                'id'             => 'text:width-only-derived-hug',
+                'type'           => 'TEXT',
+                'name'           => 'Width Only Derived',
+                'characters'     => 'Derived width remains authoritative',
+                'width'          => 320,
+                'height'         => 66,
+                'fontSize'       => 24,
+                'textAutoResize' => 'WIDTH_AND_HEIGHT',
+                'derivedTextData' => array('layoutSize' => array('x' => 400, 'y' => 66)),
+            ),
+        ),
+    ));
+    $widthOnlyDerivedHugTextCss = $fileContent($widthOnlyDerivedHugTextResult, 'style.css');
+    $widthOnlyDerivedHugTextDiagnostics = $widthOnlyDerivedHugTextResult['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+    $assert(str_contains($widthOnlyDerivedHugTextCss, '.figma-node-text-width-only-derived-hug-width-only-derived{width:400px;height:66px'), 'width-only-derived-hug-text-keeps-derived-width');
+    $assert(! isset($widthOnlyDerivedHugTextDiagnostics['decision_traces']['reason_counts']['derived_hug_text_size_conflicts_with_source_box']), 'width-only-derived-hug-text-does-not-trace-height-conflict');
+
+    $nonTextHugResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'Non-Text Hug Fixture',
+        'nodes' => array(
+            array(
+                'id'                   => 'frame:non-text-hug',
+                'type'                 => 'FRAME',
+                'name'                 => 'Non-Text Hug',
+                'width'                => 100,
+                'height'               => 44,
+                'layoutSizingVertical' => 'HUG',
+            ),
+        ),
+    ));
+    $nonTextHugCss = $fileContent($nonTextHugResult, 'style.css');
+    $assert(str_contains($nonTextHugCss, '.figma-node-frame-non-text-hug-non-text-hug{width:100px;height:fit-content}'), 'non-text-hug-height-remains-fit-content');
     
     $derivedMeasuredLineHeightResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Derived Measured Line Height Fixture',


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `figma-wave4-fisiostetic-text-height` into review-ready branch `fix/figma-hug-text-source-height`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:figma-wave4-fisiostetic-text-height`
- **Homeboy run ID:** `figma-wave4-fisiostetic-text-height`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `trunk`
- **Head:** `fix/figma-hug-text-source-height`

## Source refs
- https://github.com/Automattic/blocks-engine/issues/608

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Only materially conflicting derived HUG text height yields to normalized source height.
- **Evidence discriminators preserved:** source and derived HUG text height disagree by more than 0.5px
- **Nearby contracts preserved:** derived width, aligned height, and non-text HUG behavior remain unchanged

## Attempt summary
Real Fisiostetic evidence clustered 31 of 32 mismatches under contradictory derived HUG text height; boundary and width behavior were independently reviewed.

## Gate results
- contracts: passed (targeted)
- independent-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer --working-dir=figma-transformer test`, `composer --working-dir=php-transformer test`, `npm test --prefix php-transformer/tools/visual-parity`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- figma-transformer/src/Html/StaticHtmlEmitter.php
- figma-transformer/tests/contract/TextLayoutContract.php

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `trunk`
- **Head:** `fix/figma-hug-text-source-height`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Analyzed Fisiostetic geometry, implemented source-height authority, and added boundary contracts.
