### PR TITLE
Bound DOM box asset evidence

### DIFF
--- a/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
+++ b/php-transformer/tools/visual-parity/bin/dom-box-provider.mjs
@@ -353,11 +353,40 @@ async function extractElements(page, pagePath, textSampleLimit, nodeIdAttr, node
       };
     }
 
+    // Eight fully-populated summaries plus six state keys produce at most 46
+    // recursive object keys. Nine 256-byte strings consume at most 13,824
+    // bytes when JSON escapes every byte, leaving room below the 16 KiB limit.
+    const MAX_ASSET_DESCENDANTS = 8;
+    const MAX_ASSET_STRING_BYTES = 256;
+
+    function truncateUtf8(value) {
+      const text = String(value || '');
+      const encoded = new TextEncoder().encode(text);
+      if (encoded.length <= MAX_ASSET_STRING_BYTES) {
+        return { value: text, truncated: false };
+      }
+
+      let end = 0;
+      let bytes = 0;
+      const encoder = new TextEncoder();
+      for (const character of text) {
+        const characterBytes = encoder.encode(character).length;
+        if (bytes + characterBytes > MAX_ASSET_STRING_BYTES) {
+          break;
+        }
+        bytes += characterBytes;
+        end += character.length;
+      }
+
+      return { value: text.slice(0, end), truncated: true };
+    }
+
     function assetElementSummary(assetElement) {
       const tag = assetElement.tagName.toLowerCase();
+      const source = truncateUtf8(assetElement.currentSrc || assetElement.src || assetElement.getAttribute('href') || assetElement.getAttribute('xlink:href') || null);
       const summary = {
         tag,
-        src: assetElement.currentSrc || assetElement.src || assetElement.getAttribute('href') || assetElement.getAttribute('xlink:href') || null,
+        src: source.value || null,
       };
 
       if (assetElement instanceof HTMLImageElement) {
@@ -366,7 +395,7 @@ async function extractElements(page, pagePath, textSampleLimit, nodeIdAttr, node
         summary.naturalHeight = assetElement.naturalHeight;
       }
 
-      return summary;
+      return { summary, stringsTruncated: source.truncated };
     }
 
     function serializeAssetState(element, computedStyle) {
@@ -376,10 +405,15 @@ async function extractElements(page, pagePath, textSampleLimit, nodeIdAttr, node
       }
 
       const backgroundImage = computedStyle['background-image'];
+      const background = truncateUtf8(backgroundImage);
+      const descendants = assetElements.slice(0, MAX_ASSET_DESCENDANTS).map(assetElementSummary);
       return {
         background_image_present: Boolean(backgroundImage && backgroundImage !== 'none'),
-        background_image: backgroundImage,
-        descendants: assetElements.map(assetElementSummary),
+        background_image: background.value,
+        descendants: descendants.map(({ summary }) => summary),
+        descendant_count: assetElements.length,
+        descendants_truncated: assetElements.length > MAX_ASSET_DESCENDANTS,
+        asset_strings_truncated: background.truncated || descendants.some(({ stringsTruncated }) => stringsTruncated),
       };
     }
 

--- a/php-transformer/tools/visual-parity/tests/smoke.mjs
+++ b/php-transformer/tools/visual-parity/tests/smoke.mjs
@@ -13,6 +13,13 @@ const domFixtureGeneric = path.join(outputDir, 'dom-box-generic.html');
 const screenshotDir = path.join(outputDir, 'screenshots');
 const missingPlaywrightDir = path.join(tmpdir(), `blocks-engine-dom-provider-missing-playwright-${process.pid}`);
 const missingPlaywrightProvider = path.join(missingPlaywrightDir, 'dom-box-provider.mjs');
+const longAssetValue = String.fromCodePoint(0x1f642).repeat(600);
+const escapableAssetValue = `&quot;\\${String.fromCharCode(1)}${longAssetValue}`;
+const assetDescendants = Array.from({ length: 12 }, (_, index) => index % 3 === 0
+  ? `<img alt="" src="https://example.test/${index}/${escapableAssetValue}">`
+  : index % 3 === 1
+    ? `<svg><image href="https://example.test/${index}/${escapableAssetValue}"></image></svg>`
+    : `<svg data-asset="${index}"></svg>`).join('');
 
 await mkdir(outputDir, { recursive: true });
 await mkdir(missingPlaywrightDir, { recursive: true });
@@ -58,7 +65,8 @@ await writeFile(domFixture, `<!doctype html><html><head><style>
     width: 120px;
     height: 24px;
   }
-</style></head><body><main class="hero" data-figma-node-id="12:34" data-figma-node-name="Hero" data-source-node-type="FRAME" data-source-visual-width="120" data-source-visual-height="24">Hello world <img alt="" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='2' height='3'%3E%3C/svg%3E"></main></body></html>`);
+  .asset-bounds { width: 1px; height: 1px; background-image: url("https://example.test/${longAssetValue}"); }
+</style></head><body><main class="hero" data-figma-node-id="12:34" data-figma-node-name="Hero" data-source-node-type="FRAME" data-source-visual-width="120" data-source-visual-height="24">Hello world <img alt="" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='2' height='3'%3E%3C/svg%3E"></main><section class="asset-bounds" data-figma-node-id="56:78" data-figma-node-name="Asset bounds"><img alt="" src="/loaded-image.svg">${assetDescendants}</section></body></html>`);
 await writeFile(domFixtureGeneric, `<!doctype html><html><head><style>
   body { margin: 0; }
   .hero { color: rgb(12, 34, 56); font-size: 20px; width: 120px; height: 24px; }
@@ -72,6 +80,11 @@ const server = createServer(async (request, response) => {
   if (request.url === '/dom-box-generic.html') {
     response.writeHead(200, { 'content-type': 'text/html' });
     response.end(await readFile(domFixtureGeneric));
+    return;
+  }
+  if (request.url === '/loaded-image.svg') {
+    response.writeHead(200, { 'content-type': 'image/svg+xml' });
+    response.end('<svg xmlns="http://www.w3.org/2000/svg" width="2" height="3"></svg>');
     return;
   }
   if (request.url === '/fluid-layout-2095.html') {
@@ -115,8 +128,22 @@ try {
   assert(domReport.entrypoints[0].elements[0].text_metrics.client_width > 0, 'DOM provider captures client dimensions');
   assert(domReport.entrypoints[0].elements[0].text_metrics.line_count_estimate >= 1, 'DOM provider estimates line count');
   assert(domReport.entrypoints[0].elements[0].asset_state.background_image_present === true, 'DOM provider flags background images');
+  assert(domReport.entrypoints[0].elements[0].asset_state.background_image.includes('linear-gradient'), 'DOM provider preserves ordinary background image values');
   assert(domReport.entrypoints[0].elements[0].asset_state.descendants[0].tag === 'img', 'DOM provider captures image descendants');
   assert(domReport.entrypoints[0].elements[0].asset_state.descendants[0].complete === true, 'DOM provider captures image complete state');
+  const boundedAssetState = domReport.entrypoints[0].elements.find((element) => element.node_id === '56:78').asset_state;
+  assert(boundedAssetState.descendant_count === 17, 'DOM provider records the original mixed asset descendant count');
+  assert(boundedAssetState.descendants.length === 8, 'DOM provider caps asset descendant summaries');
+  assert(boundedAssetState.descendants_truncated === true, 'DOM provider reports descendant truncation');
+  assert(boundedAssetState.asset_strings_truncated === true, 'DOM provider reports asset string truncation');
+  assert(boundedAssetState.descendants[0].complete === true, 'DOM provider preserves first descendant loaded state');
+  assert(boundedAssetState.descendants[0].naturalWidth > 0, 'DOM provider preserves first loaded image width');
+  assert(boundedAssetState.descendants[0].naturalHeight > 0, 'DOM provider preserves first loaded image height');
+  assert(assertRecursiveKeyCount(boundedAssetState) <= 64, 'DOM provider bounds recursive asset-state keys');
+  assert(Buffer.byteLength(JSON.stringify(boundedAssetState), 'utf8') <= 16384, 'DOM provider bounds serialized asset state');
+  const assetStrings = nestedStrings(boundedAssetState);
+  assert(assetStrings.every((value) => Buffer.byteLength(value, 'utf8') <= 256), 'DOM provider bounds every asset-state string to the implemented byte cap');
+  assert(assetStrings.every(isValidUnicode), 'DOM provider preserves valid Unicode when truncating asset strings');
   assert(domReport.entrypoints[0].elements[0].visibility.visible === true, 'DOM provider captures visible state');
   assert(domReport.entrypoints[0].elements[0].visibility.clipped === true, 'DOM provider captures clipped-ish overflow state');
   assert(domReport.entrypoints[0].unidentified_elements.some((element) => element.tag === 'img'), 'DOM provider reports visible elements without node ids');
@@ -260,4 +287,36 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
+}
+
+function assertRecursiveKeyCount(value) {
+  if (!value || typeof value !== 'object') {
+    return 0;
+  }
+  return Object.entries(value).reduce((count, [, child]) => count + 1 + assertRecursiveKeyCount(child), 0);
+}
+
+function nestedStrings(value) {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap(nestedStrings);
+  }
+  return [];
+}
+
+function isValidUnicode(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
+    const isLowSurrogate = code >= 0xdc00 && code <= 0xdfff;
+    if (isLowSurrogate && (index === 0 || value.charCodeAt(index - 1) < 0xd800 || value.charCodeAt(index - 1) > 0xdbff)) {
+      return false;
+    }
+    if (isHighSurrogate && (index + 1 === value.length || value.charCodeAt(index + 1) < 0xdc00 || value.charCodeAt(index + 1) > 0xdfff)) {
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
## Summary
Keep DOM-box asset evidence within the generic Homeboy envelope for asset-heavy Figma nodes.

## What changed
- Cap serialized image/SVG descendants at eight while preserving original count and truncation evidence.
- Truncate asset URLs and background-image strings to 256 UTF-8 bytes without splitting code points.
- Exercise loaded local images, multibyte and escapable values, recursive key counts, and serialized byte limits in the browser-backed smoke suite.

## How to test
1. Run `npm ci --prefix php-transformer/tools/visual-parity`; expect dependencies install.
2. Run `npm test --prefix php-transformer/tools/visual-parity`; expect visual parity smoke and blockquote geometry pass.

## Compatibility
Existing asset\_state fields remain present. Nodes with more than eight asset descendants now expose the first eight in document order plus explicit descendant\_count and truncation fields.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Automattic/blocks-engine/issues/608
- homeboy-lab: Passed
- independent-review: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed provider overflow, prepared bounded serialization and browser-backed regression coverage, reviewed the change, and used Homeboy for Lab verification and PR finalization.

## Source relationships
- Relates to Automattic/blocks-engine#608
