### PR TITLE
Preserve inferred grid visual placement

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -907,7 +907,7 @@ final class StaticHtmlEmitter
                 'page_path' => $this->currentPagePath,
             );
         }
-        $children = $this->nodeList($node);
+        $children = $this->childrenInEmissionOrder($node);
         $imageElement = $this->imageElementMetadata($node, $type, $children);
         if ( null !== $imageElement ) {
             $tag = 'img';
@@ -6502,6 +6502,11 @@ final class StaticHtmlEmitter
             foreach ( $this->flexItemStyles($node, $layout, $parentNode) as $style ) {
                 $styles[] = $style;
             }
+            if ( ! $positioningStyleDecision->willPositionAbsolute ) {
+                foreach ( $this->inferredGridItemStyles($node, $parentNode) as $style ) {
+                    $styles[] = $style;
+                }
+            }
         }
 
         $styles = $this->mergeBoxShadowDeclarations(array_values(array_unique($styles)));
@@ -6585,6 +6590,76 @@ final class StaticHtmlEmitter
             LayoutIntentClassifier::LAYOUT_INTENT_ARTICLE_GRID,
             LayoutIntentClassifier::LAYOUT_INTENT_CTA,
         ), true);
+    }
+
+    /**
+     * Inferred flow layouts use source geometry to reconstruct their visual
+     * placement. Keep declared auto-layout and layered children source-ordered.
+     *
+     * @param array<string, mixed> $node
+     * @return array<int, mixed>
+     */
+    private function childrenInEmissionOrder(array $node): array
+    {
+        $children = $this->nodeList($node);
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node);
+        if (
+            ! empty($layout['display'] ?? null)
+            || ! is_array($layoutIntent)
+            || ! in_array($layoutIntent['display'] ?? null, array('grid', 'flex'), true)
+            || ('flex' === ($layoutIntent['display'] ?? null) && 'row' !== ($layoutIntent['direction'] ?? null))
+        ) {
+            return $children;
+        }
+
+        $participating = array();
+        foreach ( $children as $index => $child ) {
+            if ( ! is_array($child) || ! $this->normalFlexFlowChild($child, $node) ) {
+                continue;
+            }
+            $childLayout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( 'absolute' === ($childLayout['positioning'] ?? null) ) {
+                continue;
+            }
+
+            $stackingPlan = $this->layoutIntentClassifier()->stackingContextPlan($child, $node);
+            if ( null !== ($stackingPlan['z_index'] ?? null) ) {
+                continue;
+            }
+
+            $box = is_array($child['box'] ?? null) ? $child['box'] : $child;
+            $x = $box['x'] ?? null;
+            $y = $box['y'] ?? null;
+            if ( ! is_numeric($x) || ('grid' === ($layoutIntent['display'] ?? null) && ! is_numeric($y)) ) {
+                return $children;
+            }
+            $participating[] = array('index' => $index, 'child' => $child, 'x' => (float) $x, 'y' => is_numeric($y) ? (float) $y : 0.0);
+        }
+
+        if ( count($participating) < 2 ) {
+            return $children;
+        }
+
+        $isGrid = 'grid' === ($layoutIntent['display'] ?? null);
+        usort($participating, static function (array $left, array $right) use ($isGrid): int {
+            if ( $isGrid && $left['y'] !== $right['y'] ) {
+                return $left['y'] <=> $right['y'];
+            }
+            if ( $left['x'] !== $right['x'] ) {
+                return $left['x'] <=> $right['x'];
+            }
+
+            return $left['index'] <=> $right['index'];
+        });
+
+        $slots = array_column($participating, 'index');
+        sort($slots, SORT_NUMERIC);
+        foreach ( $slots as $position => $index ) {
+            $children[$index] = $participating[$position]['child'];
+        }
+
+        return $children;
     }
 
     /** @param array<string, mixed> $node */
@@ -7471,6 +7546,86 @@ final class StaticHtmlEmitter
         }
 
         return $styles;
+    }
+
+    /**
+     * Preserve source-relative placement that equal inferred grid tracks do not
+     * represent, including asymmetric container insets and item widths.
+     *
+     * @param array<string, mixed>      $node
+     * @param array<string, mixed>|null $parentNode
+     * @return array<int, string>
+     */
+    private function inferredGridItemStyles(array $node, ?array $parentNode): array
+    {
+        if ( null === $parentNode || ! $this->normalFlexFlowChild($node, $parentNode) ) {
+            return array();
+        }
+
+        $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($parentNode);
+        if (
+            ! empty($parentLayout['display'] ?? null)
+            || true !== ($parentLayout['freeform'] ?? null)
+            || 'absolute' === ($layout['positioning'] ?? null)
+            || ! is_array($layoutIntent)
+            || 'grid' !== ($layoutIntent['display'] ?? null)
+        ) {
+            return array();
+        }
+
+        $columns = $layoutIntent['column_count'] ?? null;
+        $parentBox = is_array($parentNode['box'] ?? null) ? $parentNode['box'] : array();
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        if ( ! is_int($columns) || $columns < 2 || ! is_numeric($parentBox['width'] ?? null) ) {
+            return array();
+        }
+
+        $flowChildren = array_values(array_filter(
+            $this->childrenInEmissionOrder($parentNode),
+            function (mixed $child) use ($parentNode): bool {
+                if (
+                    ! is_array($child)
+                    || ! $this->normalFlexFlowChild($child, $parentNode)
+                    || 'absolute' === ($child['layout']['positioning'] ?? null)
+                ) {
+                    return false;
+                }
+
+                $childBox = is_array($child['box'] ?? null) ? $child['box'] : $child;
+                $stackingPlan = $this->layoutIntentClassifier()->stackingContextPlan($child, $parentNode);
+                return null === ($stackingPlan['z_index'] ?? null)
+                    && is_numeric($childBox['x'] ?? null)
+                    && is_numeric($childBox['y'] ?? null);
+            }
+        ));
+        $index = null;
+        foreach ( $flowChildren as $position => $child ) {
+            if ( (string) ($child['id'] ?? '') === (string) ($node['id'] ?? '') ) {
+                $index = $position;
+                break;
+            }
+        }
+        if ( null === $index ) {
+            return array();
+        }
+
+        $sourceOffset = $this->layoutIntentClassifier()->positionOffset($box, $parentBox, 'x', $parentNode);
+        $parentWidth = (float) $parentBox['width'];
+        $gap = is_numeric($layoutIntent['gap'] ?? null) ? (float) $layoutIntent['gap'] : 0.0;
+        $trackWidth = ($parentWidth - ($gap * ($columns - 1))) / $columns;
+        if ( null === $sourceOffset || $trackWidth <= 0.0 ) {
+            return array();
+        }
+
+        $gridOffset = ($index % $columns) * ($trackWidth + $gap);
+        $residual = $sourceOffset - $gridOffset;
+        if ( abs($residual) <= 0.5 ) {
+            return array();
+        }
+
+        return array('margin-left:' . $this->number($residual) . 'px');
     }
 
     /**

--- a/figma-transformer/tests/contract/ChildEmissionOrderContract.php
+++ b/figma-transformer/tests/contract/ChildEmissionOrderContract.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter;
+
+/**
+ * @param callable(bool, string): void $assert
+ */
+function blocks_engine_figma_transformer_run_child_emission_order_contract(callable $assert): void
+{
+    $card = static function (string $id, string $label, float $x, float $y, array $layout = array(), float $width = 180): array {
+        return array(
+            'id' => $id,
+            'type' => 'FRAME',
+            'name' => $label,
+            'box' => array('x' => $x, 'y' => $y, 'width' => $width, 'height' => 120),
+            'layout' => $layout,
+            'children' => array(array('id' => $id . ':text', 'type' => 'TEXT', 'name' => 'Title', 'characters' => $label)),
+        );
+    };
+    $emit = static function (array $children, array $layout = array()) use ($card): string {
+        $result = (new StaticHtmlEmitter())->emit(array(
+            'name' => 'Child emission order fixture',
+            'nodes' => array(array(
+                'id' => 'order:articles',
+                'type' => 'FRAME',
+                'name' => 'Articles',
+                'box' => array('x' => 0, 'y' => 0, 'width' => 400, 'height' => 300),
+                'layout' => $layout,
+                'children' => $children,
+            )),
+        ));
+        return (string) ($result['files'][0]['content'] ?? '');
+    };
+    $position = static fn (string $html, string $id): int|false => strpos($html, 'data-figma-node-id="' . $id . '"');
+
+    $inferredGridHtml = $emit(array(
+        $card('order:right', 'Right article', 210, 20),
+        $card('order:left', 'Left article', 10, 20),
+    ), array('freeform' => true));
+    $assert($position($inferredGridHtml, 'order:left') < $position($inferredGridHtml, 'order:right'), 'child-emission-order-inferred-grid-uses-visual-left-to-right-order');
+
+    $insetGridResult = (new StaticHtmlEmitter())->emit(array(
+        'name' => 'Inferred grid geometry fixture',
+        'nodes' => array(array(
+            'id' => 'order:inset-articles',
+            'type' => 'FRAME',
+            'name' => 'Articles',
+            'box' => array('x' => 0, 'y' => 0, 'width' => 500, 'height' => 300),
+            'layout' => array('freeform' => true),
+            'children' => array(
+                $card('order:inset-right', 'Right article', 330, 20, array(), 140),
+                $card('order:inset-left', 'Left article', 40, 20),
+            ),
+        )),
+    ));
+    $insetGridCss = (string) ($insetGridResult['files'][1]['content'] ?? '');
+    $leftRule = blocks_engine_figma_transformer_contract_css_rule($insetGridCss, '.figma-node-order-inset-left-left-article');
+    $rightRule = blocks_engine_figma_transformer_contract_css_rule($insetGridCss, '.figma-node-order-inset-right-right-article');
+    $assert(str_contains($leftRule, 'margin-left:40px'), 'child-emission-order-inferred-grid-preserves-leading-source-inset');
+    $assert(str_contains($rightRule, 'margin-left:25px'), 'child-emission-order-inferred-grid-preserves-unequal-track-placement');
+
+    $equalPositionHtml = $emit(array(
+        $card('order:first', 'First article', 10, 20),
+        $card('order:second', 'Second article', 10, 20),
+    ));
+    $assert($position($equalPositionHtml, 'order:first') < $position($equalPositionHtml, 'order:second'), 'child-emission-order-equal-geometry-keeps-source-order');
+
+    $explicitAutoLayoutHtml = $emit(array(
+        $card('order:explicit-right', 'Right article', 210, 20),
+        $card('order:explicit-left', 'Left article', 10, 20),
+    ), array('display' => 'flex', 'flex_direction' => 'row'));
+    $assert($position($explicitAutoLayoutHtml, 'order:explicit-right') < $position($explicitAutoLayoutHtml, 'order:explicit-left'), 'child-emission-order-explicit-auto-layout-keeps-source-order');
+
+    $absoluteHtml = $emit(array(
+        $card('order:absolute', 'Absolute article', 210, 20, array('positioning' => 'absolute')),
+        $card('order:flow-left', 'Left article', 10, 20),
+        $card('order:flow-right', 'Right article', 210, 20),
+    ));
+    $assert($position($absoluteHtml, 'order:absolute') < $position($absoluteHtml, 'order:flow-left'), 'child-emission-order-absolute-child-keeps-source-layer-position');
+
+    $decorativeHtml = $emit(array(
+        array('id' => 'order:underlay', 'type' => 'RECTANGLE', 'name' => 'Decorative underlay', 'box' => array('x' => 0, 'y' => 0, 'width' => 500, 'height' => 280)),
+        $card('order:decorative-right', 'Right article', 210, 20),
+        $card('order:decorative-left', 'Left article', 10, 20),
+    ));
+    $assert($position($decorativeHtml, 'order:underlay') < $position($decorativeHtml, 'order:decorative-right'), 'child-emission-order-decorative-child-keeps-source-layer-position');
+}

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../figma-transformer.php';
 require_once __DIR__ . '/../../scripts/figma-fixture-selection.php';
 require_once __DIR__ . '/ContractHelpers.php';
 require_once __DIR__ . '/ComponentCloneEmissionContract.php';
+require_once __DIR__ . '/ChildEmissionOrderContract.php';
 require_once __DIR__ . '/DiagnosticsEvidenceContract.php';
 require_once __DIR__ . '/EffectsContract.php';
 require_once __DIR__ . '/FixtureMatrixContract.php';
@@ -205,6 +206,8 @@ blocks_engine_figma_transformer_run_html_validity_contract($assert, $fileContent
 blocks_engine_figma_transformer_run_semantic_accessibility_contract($assert, $fileContent);
 
 blocks_engine_figma_transformer_run_stacking_context_policy_contract($assert);
+
+blocks_engine_figma_transformer_run_child_emission_order_contract($assert);
 
 blocks_engine_figma_transformer_run_vector_command_blob_contract($assert, $oversizedCommandBlob, $longStrokeCommandBlob);
 


### PR DESCRIPTION
## Summary
Order inferred flow children by stable source geometry and preserve source-relative placement for inferred freeform grids.

## What changed
- Added stable inferred grid/row child ordering while preserving declared auto-layout and layered children.
- Added bounded residual grid-item margins for inferred freeform grids whose asymmetric source geometry cannot be represented by equal CSS tracks.
- Added contracts for visual order, stable ties, explicit auto-layout, absolute/decorative exclusions, source insets, and unequal item placement.

## How to test
1. Run `cd figma-transformer && composer test`; expect Contract suite passes.
2. Run `git diff --check`; expect No whitespace errors are reported.

## Compatibility
Backwards compatibility: declared Figma auto-layout, non-inferred containers, and absolute/decorative/layered child behavior are unchanged.

## Evidence
- CI expected: Repository pull request checks
- Reviewer-resolvable source evidence: https://github.com/Automattic/blocks-engine/issues/608
- contracts: Passed
- diff-check: Passed
- fixture-matrix: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Recovered the Homeboy candidate, diagnosed its real-fixture gap, implemented the bounded geometry correction and contracts, and verified the fixture matrix with Chris.

## Source relationships
- Closes Automattic/blocks-engine#608
