### PR TITLE
Refine runtime textarea workspace detection

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4641,12 +4641,47 @@ final class HtmlTransformer
 
     private function hasWorkspaceSurface(DOMElement $element): bool
     {
-		foreach ( $this->descendantElements($element) as $descendant ) {
-			$tagName = strtolower($descendant->tagName);
-			if ( in_array($tagName, array( 'canvas', 'iframe', 'template', 'textarea' ), true) ) {
-				return true;
-			}
-			if ( '' !== trim($this->attr($descendant, 'contenteditable')) ) {
+        foreach ( $this->descendantElements($element) as $descendant ) {
+            $tagName = strtolower($descendant->tagName);
+            if ( in_array($tagName, array( 'canvas', 'iframe', 'template' ), true) ) {
+                return true;
+            }
+            if ( 'textarea' === $tagName && $this->textareaIsRuntimeWorkspaceSurface($descendant, $element) ) {
+                return true;
+            }
+            if ( '' !== trim($this->attr($descendant, 'contenteditable')) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function textareaIsRuntimeWorkspaceSurface(DOMElement $textarea, DOMElement $root): bool
+    {
+        if ( ! $this->isRuntimeDomTarget($textarea) || $this->hasFormAncestor($textarea) ) {
+            return false;
+        }
+
+        // A plain wrapper that pairs data entry with a submit action is a
+        // pseudo-form, not an editor surface. Only a non-control target inside
+        // that same candidate upgrades it to a runtime workspace.
+        for ( $ancestor = $textarea->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+            if ( $this->isDivBasedPseudoForm($ancestor) ) {
+                return $ancestor === $root && $this->hasNonFormControlRuntimeTarget($ancestor);
+            }
+            if ( $ancestor === $root ) {
+                break;
+            }
+        }
+
+        return true;
+    }
+
+    private function hasNonFormControlRuntimeTarget(DOMElement $element): bool
+    {
+        foreach ( $this->descendantElements($element) as $descendant ) {
+            if ( $this->isRuntimeDomTarget($descendant) && ! $this->isFormControlElement($descendant) ) {
                 return true;
             }
         }

--- a/php-transformer/tests/fixtures/parity/html-contact-form-wrapper-not-app-shell.json
+++ b/php-transformer/tests/fixtures/parity/html-contact-form-wrapper-not-app-shell.json
@@ -1,0 +1,36 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-contact-form-wrapper-not-app-shell",
+  "description": "Converts a static contact layout containing a textarea into native columns instead of preserving the entire wrapper as a runtime application shell.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-contact-form-wrapper-not-app-shell.json",
+    "notes": "Product-neutral contact layout with runtime-targeted controls; the form remains independently classified while its static wrapper stays editable."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"contact-content\"><aside class=\"contact-sidebar\"><h2>Studio visits</h2><p>Appointments available weekdays.</p></aside><form class=\"contact-form\" action=\"/contact\" method=\"post\"><label for=\"message\">Message</label><textarea id=\"message\" name=\"message\"></textarea><button class=\"contact-submit\" type=\"submit\">Send message</button></form></section>",
+    "options": {
+      "runtime_dom_selectors": ["textarea", ".contact-submit"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/columns", "attrs": { "className": "contact-content" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/column", "attrs": { "className": "contact-sidebar" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/column", "attrs": { "className": "contact-form" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/html" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"contact-content\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:column {\"className\":\"contact-sidebar\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html {\"content\":\"\\u003csection class=\\u0022contact-content" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<form class=\"contact-form\" action=\"/contact\" method=\"post\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<textarea id=\"message\" name=\"message\"></textarea>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<button class=\"contact-submit\" type=\"submit\">Send message</button>" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nested-pseudo-form-unrelated-runtime-status.json
+++ b/php-transformer/tests/fixtures/parity/html-nested-pseudo-form-unrelated-runtime-status.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nested-pseudo-form-unrelated-runtime-status",
+  "description": "Keeps an editorial wrapper editable when a nested pseudo-form and an unrelated runtime status target are siblings.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nested-pseudo-form-unrelated-runtime-status.json",
+    "notes": "Product-neutral boundary fixture: only a preview target inside the pseudo-form can promote it to a workspace shell."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><h2>Notes</h2><div><textarea id=\"message\" name=\"message\"></textarea><button id=\"submit\" type=\"submit\">Send</button></div><span id=\"status\">Ready</span></section>",
+    "options": {
+      "runtime_dom_selectors": ["#message", "#submit", "#status"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"tagName\":\"section\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<section><h2>Notes</h2><div><textarea id=\"message\" name=\"message\"></textarea><button id=\"submit\" type=\"submit\">Send</button></div><span id=\"status\">Ready</span></section>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<span id=\"status\">Ready</span>" },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 3 },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "control" },
+    { "path": "source_reports.runtime_islands.1.kind", "assert": "equals", "value": "control" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nested-runtime-textarea-editor-shell.json
+++ b/php-transformer/tests/fixtures/parity/html-nested-runtime-textarea-editor-shell.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nested-runtime-textarea-editor-shell",
+  "description": "Keeps an editorial wrapper native while preserving its nested runtime textarea editor and preview as one bounded app-shell island.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nested-runtime-textarea-editor-shell.json",
+    "notes": "Product-neutral nested editor boundary: runtime preview evidence preserves only the tight pseudo-form candidate."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><h2>Draft notes</h2><div><textarea id=\"draft\" aria-label=\"Draft\"></textarea><button id=\"save\" type=\"submit\">Save</button><output id=\"preview\"></output></div></section>",
+    "options": {
+      "runtime_dom_selectors": ["#draft", "#save", "#preview"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "tagName": "section" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Draft notes", "level": 2 } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/html" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"tagName\":\"section\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<section><h2>Draft notes</h2><div><textarea id=\"draft\" aria-label=\"Draft\"></textarea><button id=\"save\" type=\"submit\">Save</button><output id=\"preview\"></output></div></section>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div><textarea id=\"draft\" aria-label=\"Draft\"></textarea><button id=\"save\" type=\"submit\">Save</button><output id=\"preview\"></output></div>" },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 2 },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "app_shell" },
+    { "path": "source_reports.runtime_islands.0.target_count", "assert": "equals", "value": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-runtime-pseudo-form-not-app-shell.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-pseudo-form-not-app-shell.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-runtime-pseudo-form-not-app-shell",
+  "description": "Keeps a runtime-bound div pseudo-form on the form path when all of its runtime targets are form controls.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-runtime-pseudo-form-not-app-shell.json",
+    "notes": "Product-neutral data-entry plus submit structure without a non-control runtime target."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><div><textarea id=\"message\" name=\"message\"></textarea><button id=\"submit\" type=\"submit\">Send</button></div></section>",
+    "options": {
+      "runtime_dom_selectors": ["#message", "#submit"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "fallbacks.0.diagnostic_code", "assert": "equals", "value": "html_form_fallback" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<section><div><textarea id=\"message\" name=\"message\"></textarea><button id=\"submit\" type=\"submit\">Send</button></div></section>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<textarea id=\"message\" name=\"message\"></textarea>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<button id=\"submit\" type=\"submit\">Send</button>" },
+    { "path": "source_reports.runtime_islands", "assert": "count", "count": 2 },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "control" },
+    { "path": "source_reports.runtime_islands.1.kind", "assert": "equals", "value": "control" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-runtime-textarea-editor-shell.json
+++ b/php-transformer/tests/fixtures/parity/html-runtime-textarea-editor-shell.json
@@ -1,0 +1,32 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-runtime-textarea-editor-shell",
+  "description": "Preserves a runtime-bound textarea editor surface with save and preview controls as one bounded HTML island without requiring an app-root class.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-runtime-textarea-editor-shell.json",
+    "notes": "Product-neutral editor surface recognized from runtime-bound textarea, save control, and preview target rather than source naming."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section><textarea id=\"draft\" aria-label=\"Draft\"></textarea><button id=\"save\" type=\"submit\">Save draft</button><output id=\"preview\"></output></section>",
+    "options": {
+      "runtime_dom_selectors": ["#draft", "#save", "#preview"]
+    }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/html" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<section><textarea id=\"draft\" aria-label=\"Draft\"></textarea><button id=\"save\" type=\"submit\">Save draft</button><output id=\"preview\"></output></section>" },
+    { "path": "source_reports.runtime_islands.0.kind", "assert": "equals", "value": "app_shell" },
+    { "path": "source_reports.runtime_islands.0.target_count", "assert": "equals", "value": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

- distinguish runtime textarea editors from real forms and structural pseudo-forms
- preserve only the tight JavaScript-owned editor island while keeping surrounding editorial layout native and editable
- cover real forms, pseudo-forms, standalone editors, nested editors, and unrelated runtime targets with parity fixtures

This addresses a generic transformer failure found while investigating Automattic/static-site-importer#623 under Automattic/static-site-importer#489: a runtime-targeted textarea could cause an ordinary contact or editorial wrapper to be preserved wholesale as `core/html`.

## Implementation

`hasWorkspaceSurface()` now treats a textarea as workspace evidence only when it is runtime-bound and is not part of a real form. Structural pseudo-forms remain on form semantics unless the tight pseudo-form candidate contains an internal runtime-bound non-control target, such as a preview. That editor evidence applies only to the tight candidate, so outer editorial ancestors remain native blocks.

## How to test

1. Check out this branch on a fresh clone.
2. Run `composer --working-dir=php-transformer test`.
3. Confirm the full transformer suite passes, including 235 parity fixtures.
4. Run `php -l php-transformer/src/HtmlToBlocks/HtmlTransformer.php`.
5. Confirm the syntax check reports no errors.

## Validation

- `composer --working-dir=php-transformer test` passed.
- PHP transformer parity fixtures passed: 235 fixtures.
- `php -l php-transformer/src/HtmlToBlocks/HtmlTransformer.php` passed.
- `git diff --check` passed.
- An SSI control/candidate visual matrix over six representative fixtures completed with unchanged mismatch rates, native conversion rates, fallback ratios, editor validity, and failure categories. The only delta was one additional acceptable form-graft diagnostic caused by the tighter boundary.
- A full `ArtifactCompiler` comparison compiled all 383 HTML entrypoints in the Blocks Engine fixture corpus with each site's HTML, CSS, and JavaScript bundle. 363 outputs were byte-identical. The 20 changed outputs were all textarea/form boundary cases.
- Across those 20 outputs, the candidate exposed 683 additional native blocks and reduced opaque `core/html` content by 77,558 bytes, with no aggregate increase in `core/html` block count.
- In 19 outputs, a broad section-level app shell became a bounded form-level island. The 20 newly visible fallback records describe content that was already hidden inside those broad app shells: 19 runtime forms and one unsupported `progress` element.

## Compatibility

This intentionally changes runtime-island classification for runtime-bound textareas. Real forms and structural pseudo-forms retain bounded form/control preservation, while genuine textarea editors retain bounded app-shell preservation. No public APIs or extension paths change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Investigating transformer evidence, implementing the classification boundary and parity fixtures, and reviewing regression cases. Chris Huber reviewed and remains responsible for the change.
