### PR TITLE
Preserve plaintext content on PHP 8.5

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -406,7 +406,7 @@ final class HtmlTransformer
             ), $this->fallbackProvenance),
         );
 
-        $normalizedHtml = $this->normalizeHtml5VoidElements($this->documentBodyHtml($html));
+        $normalizedHtml = $this->normalizeHtml5VoidElements($this->documentBodyHtml($this->normalizeExplicitPlaintextElements($html)));
         $document = new DOMDocument();
         $previous = libxml_use_internal_errors(true);
         $loaded   = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $normalizedHtml . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
@@ -763,6 +763,15 @@ final class HtmlTransformer
     private function normalizeHtml5VoidElements(string $html): string
     {
         return preg_replace('/<source\b([^>]*?)(?<!\/)\s*>/i', '<source$1></source>', $html) ?? $html;
+    }
+
+    private function normalizeExplicitPlaintextElements(string $html): string
+    {
+        return preg_replace_callback(
+            '/<plaintext\b([^>]*)>(.*?)<\/plaintext\s*>/is',
+            static fn (array $matches): string => '<pre' . $matches[1] . '>' . str_replace('<', '&lt;', $matches[2]) . '</pre>',
+            $html
+        ) ?? $html;
     }
 
     private function documentBodyHtml(string $html): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -776,12 +776,26 @@ $assert('core/quote' === ($rubyQuote['blockName'] ?? ''), 'ruby phrasing content
 $assert(str_contains((string) ($rubyResult['serialized_blocks'] ?? ''), '<ruby>翻訳<rt>ほんやく</rt></ruby>'), 'ruby markup is preserved in quote content');
 
 $plaintextResult = ( new HtmlTransformer() )->transform(
-    '<main><plaintext>Plain legacy text with &lt;b&gt;literal tags&lt;/b&gt;</plaintext></main>'
+    '<p>Before</p><PLAINTEXT>Plain legacy text with &lt;b&gt;literal tags&lt;/b&gt;</PLAINTEXT><p>After</p>'
 )->toArray();
-$plaintextBlock = $plaintextResult['blocks'][0] ?? array();
+$plaintextBlocks = $plaintextResult['blocks'] ?? array();
+$plaintextBlock = $plaintextBlocks[1] ?? array();
+$plaintextInnerHtml = (string) ($plaintextBlock['innerHTML'] ?? '');
 $assert(array() === ($plaintextResult['fallbacks'] ?? array()), 'plaintext content does not create unsupported fallbacks');
-$assert('core/preformatted' === ($plaintextBlock['blockName'] ?? ''), 'plaintext content converts to a preformatted block');
-$assert(str_contains((string) ($plaintextBlock['innerHTML'] ?? ''), '&lt;b&gt;literal tags&lt;/b&gt;'), 'plaintext literal tags are escaped in preformatted content');
+$assert('core/paragraph' === ($plaintextBlocks[0]['blockName'] ?? ''), 'plaintext preserves preceding sibling content');
+$assert('core/preformatted' === ($plaintextBlock['blockName'] ?? ''), 'case-insensitive plaintext content converts to a preformatted block');
+$assert('core/paragraph' === ($plaintextBlocks[2]['blockName'] ?? ''), 'plaintext preserves following sibling content');
+$assert(str_contains($plaintextInnerHtml, '&lt;b&gt;literal tags&lt;/b&gt;'), 'plaintext literal tags are escaped once in preformatted content');
+$assert(! str_contains($plaintextInnerHtml, '&amp;lt;b'), 'plaintext entity content is not double-escaped');
+$assert(! str_contains($plaintextInnerHtml, '</body>') && ! str_contains($plaintextInnerHtml, '</main>'), 'plaintext content excludes synthetic parser wrappers');
+
+$preAndCodeResult = ( new HtmlTransformer() )->transform(
+    '<p>&lt;b&gt;ordinary text&lt;/b&gt;</p><pre>ordinary pre</pre><pre><code>ordinary code</code></pre>'
+)->toArray();
+$preAndCodeBlocks = $preAndCodeResult['blocks'] ?? array();
+$assert('core/paragraph' === ($preAndCodeBlocks[0]['blockName'] ?? '') && str_contains((string) ($preAndCodeBlocks[0]['innerHTML'] ?? ''), '&lt;b&gt;ordinary text&lt;/b&gt;'), 'documents without plaintext preserve ordinary encoded content');
+$assert('core/preformatted' === ($preAndCodeBlocks[1]['blockName'] ?? ''), 'ordinary pre content remains preformatted');
+$assert('core/code' === ($preAndCodeBlocks[2]['blockName'] ?? ''), 'ordinary pre/code content remains code');
 
 $linkedLogoResult = ( new HtmlTransformer() )->transform(
     '<main><a class="site-logo" href="/">Mara Vale</a></main>'


### PR DESCRIPTION
## Summary
Normalize explicitly closed plaintext elements before PHP 8.5 DOM parsing can absorb synthetic wrappers.

## What changed
- Convert explicitly closed plaintext elements into escaped pre elements before DOMDocument parsing.
- Preserve encoded literal tags exactly once and exclude synthetic wrapper markup.
- Cover surrounding siblings, case-insensitive plaintext tags, and unchanged pre/code behavior.

## How to test
1. Run `composer --working-dir=php-transformer test`; expect All contracts, unit tests, 235 parity fixtures, and package-install proof pass..
2. Run `git diff --check`; expect No whitespace errors are reported..

## Compatibility
Explicitly closed plaintext elements now preserve only their bounded source content instead of PHP 8.5 parser leakage. Documents without plaintext and ordinary pre/code conversion are unchanged.

## Evidence
- Reviewer-resolvable source evidence: https://github.com/Automattic/blocks-engine/issues/615
- diff\_check: Passed
- php\_transformer: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy/OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Reproduced the PHP 8.5 DOM behavior, drafted the normalization and contract coverage, and verified the final candidate with GPT-5.6 Sol; Chris reviewed and owns the change.

## Source relationships
- Closes Automattic/blocks-engine#615
