### PR TITLE
Preserve source navigation list gaps

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -368,7 +368,24 @@ final class NavigationPattern implements PatternRecognizerInterface
      */
     private function navigationContainerAttributes(DOMElement $element, callable $presentationAttributes): array
     {
-        return $this->withoutCoreNavigationClasses($presentationAttributes($element));
+        $attrs = $this->withoutCoreNavigationClasses($presentationAttributes($element));
+        if ( '' !== (string) ($attrs['style']['spacing']['blockGap'] ?? '') ) {
+            return $attrs;
+        }
+
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement || ! in_array(strtolower($child->tagName), array( 'ul', 'ol' ), true) ) {
+                continue;
+            }
+
+            $listGap = (string) ($presentationAttributes($child)['style']['spacing']['blockGap'] ?? '');
+            if ( '' !== $listGap ) {
+                $attrs['style']['spacing']['blockGap'] = $listGap;
+                break;
+            }
+        }
+
+        return $attrs;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1109,6 +1109,21 @@ $assert(! str_contains((string) ($navigationLabelResult['serialized_blocks'] ?? 
 $assert(! str_contains((string) ($navigationLabelResult['serialized_blocks'] ?? ''), '<div>Guides</div>'), 'navigation serialization avoids div markup inside submenu link text');
 $assert('pass' === ($navigationLabelResult['source_reports']['wp_block_validity']['status'] ?? ''), 'navigation labels with block-level source markup pass WordPress block validity');
 
+$listGapNavigation = ( new HtmlTransformer() )->transform(
+    '<nav><ul style="gap:0"><li><a href="/one">One</a></li><li><a href="/two">Two</a></li></ul></nav>'
+)->toArray();
+$listGapNavigationBlock = $listGapNavigation['blocks'][0] ?? array();
+$listGapNavigationSerialized = (string) ($listGapNavigation['serialized_blocks'] ?? '');
+$assert('0' === ($listGapNavigationBlock['attrs']['style']['spacing']['blockGap'] ?? ''), 'direct navigation list gap projects onto core/navigation');
+$assert('pass' === ($listGapNavigation['source_reports']['semantic_parity']['status'] ?? ''), 'direct navigation list gap preserves semantic parity');
+$assert('pass' === ($listGapNavigation['source_reports']['wp_block_validity']['status'] ?? ''), 'direct navigation list gap serializes to a valid WordPress block');
+$assert(str_contains($listGapNavigationSerialized, '<!-- wp:navigation {"style":{"spacing":{"blockGap":"0"}}'), 'direct navigation list gap uses canonical dynamic navigation serialization');
+
+$outerGapNavigation = ( new HtmlTransformer() )->transform(
+    '<nav style="gap:1rem"><ul style="gap:0"><li><a href="/one">One</a></li><li><a href="/two">Two</a></li></ul></nav>'
+)->toArray();
+$assert('1rem' === ($outerGapNavigation['blocks'][0]['attrs']['style']['spacing']['blockGap'] ?? ''), 'outer navigation gap takes precedence over direct list gap');
+
 $footerNavigationSections = ( new HtmlTransformer() )->transform(
     '<footer><div class="footer-grid"><nav aria-label="Product"><h3>Product</h3><ul><li><a class="footer-link" href="/features">Features</a></li><li><a class="footer-link" href="/pricing">Pricing</a></li></ul></nav><nav aria-label="Company"><p class="nav-title">Company</p><a class="footer-link" href="/about">About</a><a class="footer-link" href="/contact">Contact</a></nav><nav class="social-links" aria-label="Social"><a class="social-link" href="https://example.com/mastodon" aria-label="Mastodon"><svg aria-hidden="true"><path d="M0 0h1v1z"></path></svg></a><a class="social-link" href="https://example.com/github" title="GitHub"><span aria-hidden="true"></span></a></nav></div></footer>'
 )->toArray();


### PR DESCRIPTION
## Summary
- Preserve the resolved gap from a direct navigation list child when the outer navigation does not define `blockGap`.
- Keep an explicit outer navigation gap authoritative.
- Add deterministic contract coverage for zero-gap projection and outer-gap precedence.

Closes https://github.com/Automattic/blocks-engine/issues/617
Relates to https://github.com/Automattic/static-site-importer/issues/489

## How to test
1. Run `composer --working-dir=php-transformer test`. Confirm all unit and contract checks, 235 parity fixtures, and package-install proof pass.
2. Review the navigation assertions in `php-transformer/tests/contract/run.php`. Confirm a direct list gap of `0` is projected and an explicit outer navigation gap retains precedence.
3. Run `git diff --check origin/trunk...HEAD`. Confirm it exits successfully with no whitespace errors.

## Backwards compatibility
Backwards compatible for callers. Existing outer navigation `blockGap` remains authoritative; output changes only when a direct list child supplies spacing that was previously dropped.

## Evidence bounds
- **Change kind:** Runtime fix
- **Discriminator:** A direct navigation list child has an explicit computed gap while the outer navigation has no mapped `blockGap`.
- **Nearby contract preserved:** Explicit outer navigation `blockGap` retains precedence.
- **Why this is bounded:** The change reads only the direct list child used as `core/navigation` content and only supplies `blockGap` when the outer navigation did not already define one.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Investigated the visual parity defect and drafted the implementation and tests; Chris reviewed and owns the change.