### PR TITLE
Preserve resolved grid layout semantics

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -108,9 +108,14 @@ final class ColumnsPattern
         // vertical stack. Emitting core/columns would render them horizontally —
         // the wrong direction. Decline here so the host transformer routes the
         // element to a vertical core/group instead, preserving its classes and
-        // styles. Horizontal flex (row / row-reverse / default) and grid layouts
-        // are unaffected, so legitimate horizontal columns are never disturbed.
+        // styles. Horizontal flex (row / row-reverse / default) remains eligible.
         if ( $this->isVerticalFlexContainer($style) ) {
+            return false;
+        }
+
+        // core/columns is a flex layout. Preserve resolved grid containers as
+        // groups so their source classes continue to control track geometry.
+        if ( preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?grid\b/', $style) ) {
             return false;
         }
 

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "artifact-linked-css-layout-wrapper-style-signals",
-  "description": "Applies safe visual declarations from linked class CSS to generic grid and flex layout wrappers.",
+  "description": "Applies safe visual declarations from linked class CSS while preserving grid and flex wrapper semantics.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/artifact-linked-css-layout-wrapper-style-signals.json",
-    "notes": "Covers layout wrapper class CSS used by generated static HTML fixtures, such as grid columns and flexible card rows."
+    "notes": "Covers layout wrapper class CSS used by generated static HTML fixtures, including source grid containers that must not become flex-based Columns blocks."
   },
   "legacy_comparison": {
     "skip": true,
@@ -31,8 +31,9 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "hero-grid" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:columns {\"className\":\"hero-grid\"} -->" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-columns hero-grid\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"hero-grid\",\"tagName\":\"section\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<section class=\"wp-block-group hero-grid\">" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:columns {\"className\":\"hero-grid\"}" },
     { "path": "serialized_blocks", "assert": "contains", "value": "shift-card" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"shift-card\",\"tagName\":\"section\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<section class=\"wp-block-group shift-card\">" },

--- a/php-transformer/tests/fixtures/parity/html-resolved-split-grid-stays-group.json
+++ b/php-transformer/tests/fixtures/parity/html-resolved-split-grid-stays-group.json
@@ -1,0 +1,30 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-resolved-split-grid-stays-group",
+  "description": "A two-child split container resolved as CSS grid stays a core/group so source grid tracks and alignment are not replaced by Gutenberg Columns flex geometry.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-resolved-split-grid-stays-group.json",
+    "notes": "Uses a generic split-layout class that the columns recognizer accepts without resolved-style awareness. The resolved CSS grid must take precedence over the class-name heuristic."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Covers current PHP transformer resolved-layout behavior; no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<section class=\"feature-row\" style=\"display:grid;grid-template-columns:520px 520px;gap:64px;align-items:center\"><div class=\"feature-copy\"><h2>Fast setup</h2><p>Start with a stable foundation.</p></div><div class=\"feature-visual\"><p>Preview</p></div></section>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "feature-row" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature-copy" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "feature-visual" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"feature-row\"" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:columns" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

- keep resolved CSS grid containers out of flex-based `core/columns` conversion
- preserve source grid classes and direct-child geometry through `core/group`
- cover both inline resolved grid CSS and linked artifact CSS while retaining horizontal flex-to-columns behavior

Fixes #620.

## Root cause

`ColumnsPattern::looksLikeSplitLayout()` accepted generic split-layout names such as `hero-inner` without accounting for the resolved display mode. `ColumnsPattern::match()` then emitted `core/columns` and `core/column` wrappers. Gutenberg rendered that block as flex, replacing source grid tracks and centered alignment.

In the SSI `15-saas` evidence linked from #620, this expanded the hero by 118.45px and shifted every following section. With this change, the preserved fixture source compiles the hero as `core/group`, not `core/columns`, with zero fallbacks.

## Backwards compatibility

This intentionally changes serialized block shape for source elements that both resolve to `display:grid` and match a Columns class/structure heuristic: they now emit `core/group` with directly converted children instead of `core/columns` with added `core/column` wrappers. This preserves source CSS grid semantics and direct-child selectors. Existing `wp-block-columns` markup remains Columns, and horizontal flex rows continue to emit Columns. Consumers that explicitly depended on inferred Columns wrappers for CSS grid source markup should review this behavior change.

## How to test

1. From a fresh checkout, run `cd php-transformer && composer install --no-interaction`.
2. Run `composer test`.
3. Confirm all canonical, unit, packaging, and 236 parity fixture checks pass.
4. Inspect `html-resolved-split-grid-stays-group` and confirm the resolved split grid emits `core/group` without `core/columns`.
5. Inspect `artifact-linked-css-layout-wrapper-style-signals` and confirm linked `.hero-grid` CSS emits a semantic `section` Group while the flex card wrapper remains unchanged.
6. Run or inspect `html-horizontal-flex-stays-columns` and confirm genuine horizontal flex still emits `core/columns`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI `gpt-5.6-sol`
- **Used for:** Root-cause analysis, implementation, regression fixtures, and verification.