### PR TITLE
Preserve CSS-significant semantic geometry

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -467,12 +467,22 @@ final class BlockFactory
         }
 
         if ( ! array_key_exists('height', $attrs) || null === $attrs['height'] ) {
-            $style[] = 'height:auto';
+            // Gutenberg's image save shape keeps percentage widths as width-only
+            // styles. The image's intrinsic dimensions (including an SVG viewBox)
+            // provide the automatic aspect ratio without serializing height:auto.
+            if ( ! $this->isPercentageWidth((string) ($attrs['width'] ?? '')) ) {
+                $style[] = 'height:auto';
+            }
         } else {
             $style[] = 'height:' . (string) $attrs['height'];
         }
 
         return implode(';', $style);
+    }
+
+    private function isPercentageWidth(string $width): bool
+    {
+        return 1 === preg_match('/%\s*$/', trim($width));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -343,6 +343,12 @@ final class HtmlTransformer
     /** @var array<string, true> Source controls that need selector projection. */
     private array $sourceControlPaths = array();
 
+    /** @var array<string, string> CSS-addressed inline leaves keyed by stable source DOM path. */
+    private array $sourceSemanticMarkers = array();
+
+    /** @var array<string, string> CSS-addressed RichText spans keyed by stable source DOM path. */
+    private array $sourceRichTextSemanticMarkers = array();
+
     private string $combinedAuthorCss = '';
 
     private ?DOMElement $authorStyleSourceBody = null;
@@ -422,6 +428,8 @@ final class HtmlTransformer
         $this->sourceTagMarkers = array();
         $this->sourceControlMarkers = array();
         $this->sourceControlPaths = array();
+        $this->sourceSemanticMarkers = array();
+        $this->sourceRichTextSemanticMarkers = array();
         $this->combinedAuthorCss = '';
         $this->authorStyleSourceBody = null;
         $this->authorMarkerSeed = '';
@@ -504,7 +512,7 @@ final class HtmlTransformer
             );
         }
 
-        $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $normalizedHtml, $options);
+        $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
@@ -647,7 +655,7 @@ final class HtmlTransformer
     }
 
     /** @param array<string, mixed> $options */
-    private function prepareAuthorSelectorSemantics(string $html, string $staticCss, string $normalizedHtml, array $options): void
+    private function prepareAuthorSelectorSemantics(string $html, string $staticCss, DOMElement $sourceBody, array $options): void
     {
         $this->authorStylesheetAssets = $this->authorStylesheetAssetsFromOptions($options);
         $this->combinedAuthorCss = array() === $this->authorStylesheetAssets
@@ -666,15 +674,7 @@ final class HtmlTransformer
             return;
         }
 
-        $document = new DOMDocument();
-        $previous = libxml_use_internal_errors(true);
-        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $normalizedHtml . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-        libxml_clear_errors();
-        libxml_use_internal_errors($previous);
-        if ( ! $loaded || ! ($document->getElementsByTagName('body')->item(0) instanceof DOMElement) ) {
-            return;
-        }
-        $this->authorStyleSourceBody = $document->getElementsByTagName('body')->item(0);
+        $this->authorStyleSourceBody = $sourceBody;
 
         $hasParagraphTypeSelector = false;
         ( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, static function (string $prelude) use (&$hasParagraphTypeSelector): string {
@@ -693,6 +693,7 @@ final class HtmlTransformer
             $this->sourceTagMarkers['p'] = $this->allocateAuthorMarker('source-p');
         }
         $this->discoverAuthorControlPaths();
+        $this->discoverAuthorInlineSemanticPaths();
     }
 
     private function discoverAuthorControlPaths(): void
@@ -712,6 +713,38 @@ final class HtmlTransformer
                     $path = $control->getNodePath() ?? '';
                     if ( '' !== $path ) {
                         $this->sourceControlPaths[$path] = true;
+                    }
+                }
+            }
+            return $prelude;
+        });
+    }
+
+    private function discoverAuthorInlineSemanticPaths(): void
+    {
+        ( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, function (string $prelude): string {
+            foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
+                $parsed = CssSelectorMatcher::parse($selector);
+                if ( ! $parsed['supported'] ) {
+                    continue;
+                }
+                foreach ( $this->matchingAuthorSourceElements($parsed) as $element ) {
+                    if ( 'span' !== strtolower($element->tagName) ) {
+                        continue;
+                    }
+                    $path = $this->sourceElementIdentity($element);
+                    if ( '' === $path ) {
+                        continue;
+                    }
+                    if ( $this->requiresIndependentSemanticWrapper($element) ) {
+                        if ( '' !== $path ) {
+                            $this->sourceSemanticMarkers[$path] ??= $this->allocateAuthorMarker('semantic');
+                        }
+                    } elseif ( $this->richTextSelectorNeedsHook($parsed) ) {
+                        $marker = $this->sourceRichTextSemanticMarkers[$path] ??= $this->allocateAuthorMarker('richtext');
+                        // Carry the generated identity through intermediate
+                        // wrapper conversions before RichText normalizes spans.
+                        $element->setAttribute('data-blocks-engine-richtext-marker', $marker);
                     }
                 }
             }
@@ -805,26 +838,41 @@ final class HtmlTransformer
             }
 
             $controls = array();
-            $hasNonControl = false;
+            $semanticLeaves = array();
+            $richTextLeaves = array();
+            $hasNonProjected = false;
             foreach ( $matches as $element ) {
                 $path = $element->getNodePath() ?? '';
                 if ( isset($this->sourceControlMarkers[$path]) ) {
                     $controls[] = $this->sourceControlMarkers[$path];
+                } elseif ( isset($this->sourceSemanticMarkers[$this->sourceElementIdentity($element)]) ) {
+                    $semanticLeaves[] = $this->sourceSemanticMarkers[$this->sourceElementIdentity($element)];
+                } elseif ( isset($this->sourceRichTextSemanticMarkers[$this->sourceElementIdentity($element)]) ) {
+                    $richTextLeaves[] = $this->sourceRichTextSemanticMarkers[$this->sourceElementIdentity($element)];
                 } else {
-                    $hasNonControl = true;
+                    $hasNonProjected = true;
                 }
             }
             $controls = array_values(array_unique($controls));
-            if ( array() === $controls ) {
+            $semanticLeaves = array_values(array_unique($semanticLeaves));
+            $richTextLeaves = array_values(array_unique($richTextLeaves));
+            if ( array() === $controls && array() === $semanticLeaves && array() === $richTextLeaves ) {
                 $rewritten[] = $this->rewriteSourceTagTypes($selector, $parsed);
                 continue;
             }
 
-            if ( $hasNonControl ) {
-                $rewritten[] = $this->rewriteSourceTagTypes($selector, $parsed, ':not(:where(.' . implode(',.', $controls) . '))');
+            $projectedMarkers = array_merge($controls, $semanticLeaves, $richTextLeaves);
+            if ( $hasNonProjected ) {
+                $rewritten[] = $this->rewriteSourceTagTypes($selector, $parsed, ':not(:where(.' . implode(',.', $projectedMarkers) . '))');
             }
             foreach ( $controls as $marker ) {
                 $rewritten[] = $this->projectControlSelector($selector, $parsed, $marker);
+            }
+            foreach ( $semanticLeaves as $marker ) {
+                $rewritten[] = $this->projectSemanticLeafSelector($selector, $parsed, $marker);
+            }
+            foreach ( $richTextLeaves as $marker ) {
+                $rewritten[] = $this->projectRichTextSemanticSelector($selector, $parsed, $marker);
             }
         }
         return implode(',', $rewritten);
@@ -865,6 +913,20 @@ final class HtmlTransformer
         // this control. Project through it rather than assuming source attributes
         // or ancestors survive canonical core/button serialization.
         return ':where(.' . $marker . ')' . $this->selectorSpecificityShims($parsed) . '> :where(.wp-block-button__link)' . $suffix;
+    }
+
+    /** @param array<string, mixed> $parsed */
+    private function projectSemanticLeafSelector(string $selector, array $parsed, string $marker): string
+    {
+        $suffix = null === $parsed['pseudo_state_suffix_span'] ? '' : substr($selector, $parsed['pseudo_state_suffix_span']['start']);
+        return ':where(.' . $marker . ')' . $this->selectorSpecificityShims($parsed) . $suffix;
+    }
+
+    /** @param array<string, mixed> $parsed */
+    private function projectRichTextSemanticSelector(string $selector, array $parsed, string $marker): string
+    {
+        $suffix = null === $parsed['pseudo_state_suffix_span'] ? '' : substr($selector, $parsed['pseudo_state_suffix_span']['start']);
+        return 'mark[style*="--blocks-engine-richtext-marker:' . $marker . '"]' . $this->selectorSpecificityShims($parsed) . $suffix;
     }
 
     /** @param array<string, mixed> $parsed */
@@ -1300,6 +1362,25 @@ final class HtmlTransformer
             $inlineSvgTextGroup = $this->inlineSvgTextGroupBlockFromElement($element);
             if ( null !== $inlineSvgTextGroup ) {
                 return $inlineSvgTextGroup;
+            }
+
+            if ( $this->hasAuthorSemanticMarker($element) ) {
+                $content = $this->innerHtml($element);
+                if ( '' !== trim($this->runtime->stripAllTags($content)) ) {
+                    return $this->createBlock('core/group', $this->presentationAttributes($element), array(
+                        $this->createBlock('core/paragraph', array( 'content' => $content )),
+                    ), $element);
+                }
+            }
+
+            $richTextMarker = $this->richTextMarkerForElement($element);
+            if ( '' !== $richTextMarker ) {
+                $content = $this->innerHtml($element);
+                if ( '' !== trim($this->runtime->stripAllTags($content)) ) {
+                    return $this->createBlock('core/paragraph', array(
+                        'content' => '<mark style="--blocks-engine-richtext-marker:' . $richTextMarker . '">' . $content . '</mark>',
+                    ), array(), $element);
+                }
             }
 
             $dynamicText = $this->dynamicTextContent($element);
@@ -1979,8 +2060,12 @@ final class HtmlTransformer
             if ( isset($this->sourceTagMarkers[$sourceTagName]) ) {
                 $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceTagMarkers[$sourceTagName]);
             }
+            $semanticMarkers = $this->authorSemanticMarkersForElement($sourceElement);
+            if ( array() !== $semanticMarkers ) {
+                $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), ...$semanticMarkers);
+            }
             $logicalControl = $logicalSourceElement ?? $sourceElement;
-            if ( 'core/button' === $name && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) && isset($this->sourceControlPaths[$logicalControl->getNodePath() ?? '']) ) {
+            if ( 'core/button' === $name && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) && ( isset($this->sourceControlPaths[$logicalControl->getNodePath() ?? '']) || ( '' !== $this->combinedAuthorCss && 'a' === strtolower($logicalControl->tagName) && ( '' !== trim($this->attr($logicalControl, 'class')) || '' !== trim($this->attr($logicalControl, 'id')) ) ) ) ) {
                 $path = $logicalControl->getNodePath() ?? '';
                 if ( '' !== $path && ! isset($this->sourceControlMarkers[$path]) ) {
                     $this->sourceControlMarkers[$path] = $this->allocateAuthorMarker('control');
@@ -2014,6 +2099,106 @@ final class HtmlTransformer
         }
 
         return $block;
+    }
+
+    private function hasAuthorSemanticMarker(DOMElement $element): bool
+    {
+        return array() !== $this->authorSemanticMarkersForElement($element);
+    }
+
+    /** @return list<string> */
+    private function authorSemanticMarkersForElement(DOMElement $element): array
+    {
+        if ( 'span' !== strtolower($element->tagName) ) {
+            return array();
+        }
+
+        $marker = $this->sourceSemanticMarkers[$this->sourceElementIdentity($element)] ?? '';
+        return '' === $marker ? array() : array( $marker );
+    }
+
+    private function requiresIndependentSemanticWrapper(DOMElement $element): bool
+    {
+        if ( 'span' !== strtolower($element->tagName) || $this->isRichTextInlineContext($element) ) {
+            return false;
+        }
+
+        $parent = $element->parentNode instanceof DOMElement ? $element->parentNode : null;
+        if ( ! $parent instanceof DOMElement || ! $this->isStructuralLayoutElement($parent) ) {
+            return false;
+        }
+
+        $declarations = array_merge($this->presentationDeclarations($element), $this->authorSemanticDeclarations($element));
+        $display = strtolower(trim((string) ($declarations['display'] ?? 'inline')));
+        if ( ! in_array($display, array( '', 'inline', 'inherit', 'initial', 'unset' ), true) ) {
+            return true;
+        }
+
+        foreach ( array( 'font-size', 'line-height', 'letter-spacing', 'text-transform', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'border', 'border-width', 'border-color', 'border-radius', 'margin', 'width', 'height', 'min-width', 'min-height', 'max-width', 'max-height' ) as $property ) {
+            if ( '' !== trim((string) ($declarations[$property] ?? '')) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isStructuralLayoutElement(DOMElement $element): bool
+    {
+        $declarations = array_merge($this->presentationDeclarations($element), $this->authorSemanticDeclarations($element));
+        return in_array(strtolower(trim((string) ($declarations['display'] ?? ''))), array( 'flex', 'inline-flex', 'grid', 'inline-grid' ), true);
+    }
+
+    /** @param array<string, mixed> $parsed */
+    private function richTextSelectorNeedsHook(array $parsed): bool
+    {
+        foreach ( $parsed['compounds'] as $compound ) {
+            if ( array() !== $compound['classes'] || array() !== $compound['ids'] || array() !== $compound['attributes'] ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return array<string, string> */
+    private function authorSemanticDeclarations(DOMElement $element): array
+    {
+        $declarations = array();
+        foreach ( $this->staticStyleRules as $rule ) {
+            $parsed = CssSelectorMatcher::parse($rule['selector']);
+            if ( $parsed['supported'] && CssSelectorMatcher::matches($element, $parsed, true)['matches'] ) {
+                $declarations = array_merge($declarations, $rule['declarations']);
+            }
+        }
+
+        return $declarations;
+    }
+
+    private function isRichTextInlineContext(DOMElement $element): bool
+    {
+        for ( $parent = $element->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
+            if ( in_array(strtolower($parent->tagName), array( 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function sourceElementIdentity(DOMElement $element): string
+    {
+        return $element->getNodePath() ?? '';
+    }
+
+    private function richTextMarkerForElement(DOMElement $element): string
+    {
+        $marker = trim($this->attr($element, 'data-blocks-engine-richtext-marker'));
+        if ( '' !== $marker ) {
+            return $marker;
+        }
+
+        return $this->sourceRichTextSemanticMarkers[$this->sourceElementIdentity($element)] ?? '';
     }
 
     /**
@@ -2192,7 +2377,7 @@ final class HtmlTransformer
         $hasStyling = false;
         foreach ( $element->attributes ?? array() as $attribute ) {
             $attributeName = strtolower($attribute->nodeName);
-            if ( 'class' !== $attributeName && 'style' !== $attributeName ) {
+            if ( ! in_array($attributeName, array( 'class', 'style', 'data-blocks-engine-richtext-marker' ), true) ) {
                 return false;
             }
             if ( '' !== trim($attribute->nodeValue ?? '') ) {
@@ -2327,6 +2512,10 @@ final class HtmlTransformer
             }
 
             $inline = $this->richTextInlineVisualDeclarations($sourceInline);
+            $marker = $this->richTextMarkerForElement($sourceInline);
+            if ( '' !== $marker ) {
+                $inline['--blocks-engine-richtext-marker'] = $marker;
+            }
             if ( array() === $inline ) {
                 continue;
             }
@@ -2375,8 +2564,14 @@ final class HtmlTransformer
         }
 
         $declarations = $this->richTextInlineVisualDeclarations($element);
-        if ( array() === $declarations ) {
+        $existingDeclarations = $this->cssDeclarations($this->attr($element, 'style'));
+        $marker = trim((string) ($existingDeclarations['--blocks-engine-richtext-marker'] ?? ''));
+        if ( '' === $marker && array() === $declarations ) {
             return false;
+        }
+
+        if ( '' !== $marker ) {
+            $declarations['--blocks-engine-richtext-marker'] = $marker;
         }
 
         if ( ! isset($declarations['background-color']) ) {
@@ -2980,6 +3175,10 @@ final class HtmlTransformer
             return null;
         }
 
+        if ( $this->hasAuthorSemanticMarkedChild($element) || $this->hasRichTextMarkedDescendant($element) ) {
+            return null;
+        }
+
         $content = $this->richTextContentWithMaterializedInlineStyles($element);
         if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextRequiresHtmlFallback($content) ) {
             return null;
@@ -3028,17 +3227,46 @@ final class HtmlTransformer
             return null;
         }
 
+        // A CSS-addressed inline leaf needs an independent native wrapper. Do
+        // not absorb it into this parent RichText paragraph, where its selector
+        // path and flex/grid item geometry would be lost.
+        if ( $this->hasAuthorSemanticMarkedChild($element) || $this->hasRichTextMarkedDescendant($element) ) {
+            return null;
+        }
+
         $structuredInlineItems = $this->structuredInlineItemBlocks($element);
         if ( null !== $structuredInlineItems ) {
             return $this->createBlock('core/group', $this->presentationAttributes($element), $structuredInlineItems, $element);
         }
 
-        $content = $this->innerHtml($element);
+        $content = $this->richTextContentWithMaterializedInlineStyles($element);
         if ( '' === trim($this->runtime->stripAllTags($content)) ) {
             return null;
         }
 
         return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
+    }
+
+    private function hasAuthorSemanticMarkedChild(DOMElement $element): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && $this->hasAuthorSemanticMarker($child) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasRichTextMarkedDescendant(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('span') as $span ) {
+            if ( $span instanceof DOMElement && '' !== $this->richTextMarkerForElement($span) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function hasOnlyPhrasingChildren(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -266,7 +266,15 @@ trait SvgMaterializationTrait
      */
     private function svgImageDimensions(DOMElement $element, string $html): array
     {
-        $width = $this->svgLengthAttributeForImage($this->attr($element, 'width'));
+        $sourceWidth = trim($this->attr($element, 'width'));
+        // A percentage SVG width has a used size from its containing block. Keep
+        // that responsive width on the native image and let its viewBox provide
+        // the intrinsic aspect ratio instead of pinning a viewBox-height value.
+        if ( null !== $this->svgPercentageWidth($sourceWidth) ) {
+            return array( 'width' => $sourceWidth );
+        }
+
+        $width = $this->svgLengthAttributeForImage($sourceWidth);
         $height = $this->svgLengthAttributeForImage($this->attr($element, 'height'));
         if ( '' !== $width && '' !== $height ) {
             return array( 'width' => $width, 'height' => $height );
@@ -283,6 +291,19 @@ trait SvgMaterializationTrait
         }
 
         return array_filter(array( 'width' => $width, 'height' => $height ), static fn (string $value): bool => '' !== $value);
+    }
+
+    private function svgPercentageWidth(string $value): ?float
+    {
+        if ( 1 !== preg_match('/^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?%$/', $value) ) {
+            return null;
+        }
+
+        $number = (float) substr($value, 0, -1);
+        // SVG width is a non-negative length. Keep valid signed/exponent CSS
+        // numbers when usable, and fall back to intrinsic dimensions for a
+        // negative used width rather than emitting invalid image geometry.
+        return is_finite($number) && $number >= 0 ? $number : null;
     }
 
     private function svgLengthAttributeForImage(string $value): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -566,6 +566,26 @@ $largeCssSizedInlineSvgArtworkMarkup = (string) ($largeCssSizedInlineSvgArtwork[
 $assert(str_contains($largeCssSizedInlineSvgArtworkMarkup, '<!-- wp:image'), 'large CSS-sized inline SVG artwork materializes as native image without a data URI budget');
 $assert(! str_contains($largeCssSizedInlineSvgArtworkMarkup, '<svg class="hero-cover" viewBox="0 0 500 500" role="img" aria-label="Hero cover" width="500" height="500"'), 'large CSS-sized inline SVG artwork does not inject intrinsic SVG dimensions over source CSS sizing');
 
+$percentageWidthSvg = ( new HtmlTransformer() )->transform('<main><svg width="100%" viewBox="0 0 620 380" role="img" aria-label="Responsive map"><rect width="620" height="380" fill="#111"/></svg></main>')->toArray();
+$percentageWidthSvgMarkup = (string) ($percentageWidthSvg['serialized_blocks'] ?? '');
+$assert(str_contains($percentageWidthSvgMarkup, 'style="width:100%"') && ! str_contains($percentageWidthSvgMarkup, 'height:auto') && ! str_contains($percentageWidthSvgMarkup, 'height:380px') && str_contains((string) ($percentageWidthSvg['assets'][0]['content'] ?? ''), 'viewBox="0 0 620 380"'), 'percentage-width inline SVG core/image uses canonical width-only markup while the SVG viewBox supplies its intrinsic aspect ratio');
+
+$fractionalPercentageWidthSvg = ( new HtmlTransformer() )->transform('<main><svg width=".5%" viewBox="0 0 620 380" role="img" aria-label="Fractional responsive map"><rect width="620" height="380" fill="#111"/></svg></main>')->toArray();
+$fractionalPercentageWidthSvgMarkup = (string) ($fractionalPercentageWidthSvg['serialized_blocks'] ?? '');
+$assert(str_contains($fractionalPercentageWidthSvgMarkup, 'style="width:.5%"') && ! str_contains($fractionalPercentageWidthSvgMarkup, 'height:auto') && ! str_contains($fractionalPercentageWidthSvgMarkup, 'height:380px'), 'fractional percentage-width inline SVG core/image uses canonical width-only responsive markup');
+
+$signedPercentageWidthSvg = ( new HtmlTransformer() )->transform('<main><svg width="+.5%" viewBox="0 0 620 380" role="img" aria-label="Signed responsive map"><rect width="620" height="380" fill="#111"/></svg></main>')->toArray();
+$signedPercentageWidthSvgMarkup = (string) ($signedPercentageWidthSvg['serialized_blocks'] ?? '');
+$assert(str_contains($signedPercentageWidthSvgMarkup, 'style="width:+.5%"') && ! str_contains($signedPercentageWidthSvgMarkup, 'height:auto') && ! str_contains($signedPercentageWidthSvgMarkup, 'height:380px'), 'signed fractional percentage-width inline SVG core/image uses canonical width-only responsive markup');
+
+$exponentPercentageWidthSvg = ( new HtmlTransformer() )->transform('<main><svg width="1e2%" viewBox="0 0 620 380" role="img" aria-label="Exponent responsive map"><rect width="620" height="380" fill="#111"/></svg></main>')->toArray();
+$exponentPercentageWidthSvgMarkup = (string) ($exponentPercentageWidthSvg['serialized_blocks'] ?? '');
+$assert(str_contains($exponentPercentageWidthSvgMarkup, 'style="width:1e2%"') && ! str_contains($exponentPercentageWidthSvgMarkup, 'height:auto') && ! str_contains($exponentPercentageWidthSvgMarkup, 'height:380px'), 'exponent percentage-width inline SVG core/image uses canonical width-only responsive markup');
+
+$negativePercentageWidthSvg = ( new HtmlTransformer() )->transform('<main><svg width="-1%" viewBox="0 0 620 380" role="img" aria-label="Invalid negative responsive map"><rect width="620" height="380" fill="#111"/></svg></main>')->toArray();
+$negativePercentageWidthSvgMarkup = (string) ($negativePercentageWidthSvg['serialized_blocks'] ?? '');
+$assert(! str_contains($negativePercentageWidthSvgMarkup, 'width:-1%') && str_contains($negativePercentageWidthSvgMarkup, 'height:380px'), 'negative SVG percentage width is rejected as invalid non-negative SVG geometry');
+
 $fixedBackgroundLayer = ( new HtmlTransformer() )->transform(
     '<style>.page-bg{position:fixed;inset:0;z-index:-1;background:linear-gradient(180deg,#211,#000)}</style><main><div class="page-bg" aria-hidden="true"></div><section class="hero"><h1>Hero</h1></section></main>'
 )->toArray();

--- a/php-transformer/tests/fixtures/parity/html-author-selector-provenance.json
+++ b/php-transformer/tests/fixtures/parity/html-author-selector-provenance.json
@@ -5,7 +5,7 @@
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-author-selector-provenance.json",
-    "notes": "Source p type selectors use a zero-specificity provenance marker; standalone spans remain ordinary canonical blocks."
+    "notes": "Source p type selectors use a zero-specificity provenance marker; ordinary inline spans remain canonical paragraph content."
   },
   "legacy_comparison": {
     "skip": true,

--- a/php-transformer/tests/fixtures/parity/html-richtext-partial-span-visual-mark.json
+++ b/php-transformer/tests/fixtures/parity/html-richtext-partial-span-visual-mark.json
@@ -5,7 +5,7 @@
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-richtext-partial-span-visual-mark.json",
-    "notes": "Generic RichText fidelity coverage for headings with styled line segments where class hooks are not safe to keep in RichText content."
+    "notes": "Generic RichText fidelity coverage for headings with styled line segments carried by valid mark formatting and a selector projection marker."
   },
   "legacy_comparison": {
     "skip": true,
@@ -22,7 +22,7 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<mark style=\"display:block;color:#b8893a;background-color:transparent\">Roasters</mark>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<mark style=\"display:block;color:#b8893a;--blocks-engine-richtext-marker:blocks-engine-richtext-aa1434d6fce3-3;background-color:transparent\">Roasters</mark>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "class=\"accent\"" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -65,6 +65,50 @@ $wrapperCss = $css($wrapper);
 $wrapperButton = $wrapper['blocks'][0]['innerBlocks'][0] ?? array();
 $assert('core/button' === ($wrapperButton['blockName'] ?? '') && str_contains((string) ($wrapperButton['attrs']['className'] ?? ''), 'blocks-engine-control-') && 2 === substr_count($wrapperCss, '> :where(.wp-block-button__link)') && str_contains($wrapperCss, ':hover') && str_contains($wrapperCss, ':focus') && 'pass' === ($wrapper['source_reports']['wp_block_validity']['status'] ?? ''), 'wrapper-driven role=button promotion retains logical anchor selectors, presentation wrapper attributes, and valid blocks');
 
+$navCta = $transform('<style>a.btn.btn-primary.nav-cta{display:inline-flex;align-items:center;gap:8px;font-family:monospace;font-size:12px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;padding:9px 20px;border-radius:6px;background:#e8a020;color:#050d1a}.nav-cta:hover{background:#f0ac22}.nav-cta:focus{outline:2px solid #fff}</style><main><a class="btn btn-primary nav-cta" href="#cta">Get Early Access</a></main>');
+$navCtaMarkup = (string) ($navCta['serialized_blocks'] ?? '');
+$navCtaCss = $css($navCta);
+$assert(str_contains($navCtaMarkup, 'blocks-engine-control-') && str_contains($navCtaCss, '> :where(.wp-block-button__link){display:inline-flex') && str_contains($navCtaCss, 'font-family:monospace') && str_contains($navCtaCss, 'padding:9px 20px') && str_contains($navCtaCss, 'background:#e8a020') && str_contains($navCtaCss, ':hover{background:#f0ac22}') && str_contains($navCtaCss, ':focus{outline:2px solid #fff}') && 'pass' === ($navCta['source_reports']['wp_block_validity']['status'] ?? ''), 'class-bearing source anchors project compound, typography, paint, and pseudo-state selectors onto valid core/button links');
+
+$inlineLeaves = $transform('<style>.meta{display:flex;gap:10px}.eyebrow{display:flex;gap:10px}.meta span{font:10px monospace;border:1px solid #999;padding:2px 8px}.eyebrow span{font-size:11px;letter-spacing:.1em}</style><div class="eyebrow"><span>Beta</span></div><div class="meta"><span>One</span><span>Two</span></div>');
+$inlineMarkup = (string) ($inlineLeaves['serialized_blocks'] ?? '');
+$inlineCss = $css($inlineLeaves);
+$assert(3 === substr_count($inlineMarkup, '<div class="wp-block-group blocks-engine-semantic-') && 3 === substr_count($inlineCss, ':where(.blocks-engine-semantic-') && 'pass' === ($inlineLeaves['source_reports']['wp_block_validity']['status'] ?? ''), 'CSS-addressed sibling spans retain independent native wrapper identities and projected selector paths without HTML fallback');
+
+$repeatedParents = $transform('<style>.row{display:flex}.row .pill{padding:2px 8px;border:1px solid #999}.other .pill{color:red}</style><div class="row"><span class="pill">First</span></div><div class="row"><span class="pill">Second</span></div><div class="other"><span class="pill">Third</span></div>');
+$repeatedMarkup = (string) ($repeatedParents['serialized_blocks'] ?? '');
+$repeatedCss = $css($repeatedParents);
+preg_match_all('/blocks-engine-semantic-[a-f0-9]+-\d+/', $repeatedMarkup . "\n" . $repeatedCss, $repeatedMarkers);
+$assert(2 === count(array_unique($repeatedMarkers[0] ?? array())) && 2 === substr_count($repeatedCss, ':where(.blocks-engine-semantic-') && str_contains($repeatedMarkup, '--blocks-engine-richtext-marker:blocks-engine-richtext-') && str_contains($repeatedCss, 'mark[style*="--blocks-engine-richtext-marker:blocks-engine-richtext-'), 'repeated structural parents allocate unique source-path markers without leaking their box styles into an unrelated inline sibling');
+
+$richTextPill = $transform('<style>p .pill{padding:2px 8px;border:1px solid #999}</style><p>Read <span class="pill">more</span>.</p>');
+$richTextPillMarkup = (string) ($richTextPill['serialized_blocks'] ?? '');
+$richTextPillCss = $css($richTextPill);
+$assert(str_contains($richTextPillMarkup, '<mark style="') && str_contains($richTextPillMarkup, '--blocks-engine-richtext-marker:blocks-engine-richtext-') && str_contains($richTextPillCss, 'mark[style*="--blocks-engine-richtext-marker:blocks-engine-richtext-') && 'pass' === ($richTextPill['source_reports']['wp_block_validity']['status'] ?? ''), 'RichText-contained selector hooks survive through valid mark formatting and projected CSS');
+
+$richTextStates = $transform('<style>p .pill:hover{color:red}p .pill:focus{color:blue}p .pill:active{color:green}p .pill:visited{color:purple}</style><p>Read <span class="pill">more</span>.</p>');
+$richTextStatesMarkup = (string) ($richTextStates['serialized_blocks'] ?? '');
+$richTextStatesCss = $css($richTextStates);
+$assert(str_contains($richTextStatesMarkup, '--blocks-engine-richtext-marker:blocks-engine-richtext-') && 4 === substr_count($richTextStatesCss, 'mark[style*="--blocks-engine-richtext-marker:blocks-engine-richtext-') && str_contains($richTextStatesCss, ':hover{color:red}') && str_contains($richTextStatesCss, ':focus{color:blue}') && str_contains($richTextStatesCss, ':active{color:green}') && str_contains($richTextStatesCss, ':visited{color:purple}') && ! str_contains($richTextStatesMarkup, ':hover') && ! str_contains($richTextStatesMarkup, ':focus') && ! str_contains($richTextStatesMarkup, ':active') && ! str_contains($richTextStatesMarkup, ':visited'), 'RichText marker projections retain dynamic pseudo-state suffixes without inlining a permanent state');
+
+$nestedLeaf = $transform('<style>.meta{display:flex}.pill{padding:2px 8px;border:1px solid #999}.meta > .item .pill{color:red}</style><div class="meta"><div class="item"><span class="pill">Nested</span></div></div>');
+$nestedLeafMarkup = (string) ($nestedLeaf['serialized_blocks'] ?? '');
+$nestedLeafCss = $css($nestedLeaf);
+$assert(! str_contains($nestedLeafMarkup, 'blocks-engine-semantic-') && str_contains($nestedLeafMarkup, '--blocks-engine-richtext-marker:blocks-engine-richtext-') && str_contains($nestedLeafCss, 'mark[style*="--blocks-engine-richtext-marker:blocks-engine-richtext-') && 'pass' === ($nestedLeaf['source_reports']['wp_block_validity']['status'] ?? ''), 'nested selector-addressable leaves retain a valid inline marker instead of becoming a structural group');
+
+$proseBadge = $transform('<style>.card{display:flex}.badge{padding:2px 8px;border:1px solid #999}.card .badge{color:red}</style><div class="card"><div class="copy">Read <span class="badge">new</span> notes.</div></div>');
+$proseBadgeMarkup = (string) ($proseBadge['serialized_blocks'] ?? '');
+$proseBadgeCss = $css($proseBadge);
+$assert(! str_contains($proseBadgeMarkup, 'blocks-engine-semantic-') && str_contains($proseBadgeMarkup, '--blocks-engine-richtext-marker:blocks-engine-richtext-') && str_contains($proseBadgeCss, 'mark[style*="--blocks-engine-richtext-marker:blocks-engine-richtext-') && 'pass' === ($proseBadge['source_reports']['wp_block_validity']['status'] ?? ''), 'a padded badge inside prose in a flex card remains an inline RichText marker');
+
+$ordinaryInline = $transform('<style>span{color:red}</style><p>Read <span>this</span> now.</p>');
+$ordinaryInlineMarkup = (string) ($ordinaryInline['serialized_blocks'] ?? '');
+$assert(! str_contains($ordinaryInlineMarkup, 'blocks-engine-semantic-') && 'core/paragraph' === ($ordinaryInline['blocks'][0]['blockName'] ?? '') && 'pass' === ($ordinaryInline['source_reports']['wp_block_validity']['status'] ?? ''), 'ordinary inline span styling remains RichText flow rather than becoming a group wrapper');
+
+$structural = $transform('<style>.product-layout{display:grid;grid-template-columns:1fr 20rem;gap:3rem}.product-layout > .detail-pane{min-width:0}</style><div class="product-layout"><div>Primary</div><aside class="detail-pane">Secondary</aside></div>');
+$structuralMarkup = (string) ($structural['serialized_blocks'] ?? '');
+$assert(str_contains($structuralMarkup, 'product-layout') && str_contains($structuralMarkup, 'detail-pane') && str_contains($css($structural), '.product-layout > .detail-pane') && 'pass' === ($structural['source_reports']['wp_block_validity']['status'] ?? ''), 'CSS-significant structural group and child classes survive native grid materialization');
+
 $instance = new HtmlTransformer();
 $first = $instance->transform('<style>p{color:red}</style><p>First</p>')->toArray();
 $second = $instance->transform('<style>.cta:hover{padding:1rem}</style><a class="cta" href="/go" style="padding:1px;background:#000">Go</a>')->toArray();


### PR DESCRIPTION
## Summary
- preserve independently styled inline semantic leaves when paragraph/RichText lowering would lose selector identity or flex/grid item geometry
- retain selector-compatible inline hooks in valid Gutenberg RichText, including dynamic pseudo-state projection
- preserve responsive SVG width and intrinsic viewBox aspect ratio using Gutenberg-canonical image save markup
- strengthen source-anchor selector projection for native Button blocks

Refs #624. This is a measured intermediate improvement for Automattic/static-site-importer#489; it does not claim exact visual parity or make `15-saas` eligible for solved-fixture promotion.

## Results
- post-#623 aligned mismatch: 24.89%
- this PR aligned mismatch: 18.34%
- raw mismatch: 25.48% -> 18.66%
- editor validity: 291/291 native blocks
- `core/html`: 0
- global alignment offset: 0px, 0px

Supplementary Lab evidence: [run summary](https://homeboy-artifacts-tunnel.dev.chubes.net/a46d40a2-9752-45f9-b565-2857ec7fb629/bd7caaab-c4f2-4fde-bdeb-8b45fcc1ff6d-summary.json). The exact-parity gate still fails because lower-page attribution is truncated by the current 160-element visual-compare capture.

## How to test
1. Check out this branch in a fresh clone.
2. Run `cd php-transformer && composer test`.
3. Run `php tests/unit/author-selector-semantics.php`; confirm all 21 assertions pass.
4. Run `php tests/contract/run.php`.
5. Run `php tests/parity/run.php`; confirm all 244 fixtures pass.
6. Run Static Site Importer's documented fixture-matrix wrapper against this checkout with the authored `saas` tag and exact visual gating.
7. Confirm all 291 blocks are editor-valid and native, no `core/html` blocks are emitted, and the aligned mismatch is 18.34%.

## Backwards compatibility
This changes generated block markup and projected author CSS for selector-addressed inline leaves, responsive materialized SVGs, and promoted Button controls. It does not change the public PHP API. Consumers comparing generated markup byte-for-byte may observe intentional output changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed browser evidence, implemented and reviewed generic transformer primitives, added deterministic coverage, and prepared the PR.