### PR TITLE
Preserve inline SVG phrasing geometry

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1286,6 +1286,15 @@ final class HtmlTransformer
             return null;
         }
 
+        // Handle a safe SVG at a phrasing-to-block boundary before generic
+        // preservation rules see the SVG as an unsupported document fragment.
+        if ( 'svg' === $tagName && $this->svgNeedsPhrasingHost($element) ) {
+            $imageMarkup = $this->inlineSvgRichTextImageMarkup($element);
+            if ( null !== $imageMarkup ) {
+                return $this->createBlock('core/paragraph', array( 'content' => $imageMarkup ), array(), $element);
+            }
+        }
+
         if ( $this->shouldPreserveDataAttributeRuntimeTarget($element) ) {
             return $this->createBlock('core/html', array( 'content' => $this->outerHtml($element) ), array(), $element);
         }
@@ -1305,7 +1314,7 @@ final class HtmlTransformer
 
         if ( preg_match('/^h([1-6])$/', $tagName, $matches) ) {
             $content = $this->richTextContentWithMaterializedInlineStyles($element);
-            if ( $this->richTextRequiresHtmlFallback($content) ) {
+            if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
                 return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($this->outerHtml($element)) ), array(), $element);
             }
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
@@ -1320,7 +1329,11 @@ final class HtmlTransformer
 
         if ( 'p' === $tagName ) {
             $content = $this->richTextContentWithMaterializedInlineStyles($element);
-            if ( $this->richTextRequiresHtmlFallback($content) ) {
+            $inlineSvgContent = $this->richTextContentWithMaterializedSvgImages($element, $content);
+            if ( null !== $inlineSvgContent ) {
+                $content = $inlineSvgContent;
+            }
+            if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
                 return $this->createBlock('core/html', array( 'content' => $this->restoreSvgCasing($this->outerHtml($element)) ), array(), $element);
             }
             if ( $this->hasEmptyVisualInlineChild($element) ) {
@@ -1329,7 +1342,7 @@ final class HtmlTransformer
                     return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
                 }
             }
-            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+            if ( '' === trim($this->runtime->stripAllTags($content)) && ! $this->richTextContainsNativeSvgImageObject($content) ) {
                 if ( $this->isRuntimeDomTarget($element) ) {
                     return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
                 }
@@ -1704,6 +1717,12 @@ final class HtmlTransformer
                 $isDecorativeChrome = $this->isVisualLayerElement($element)
                     || 'none' === strtolower(trim($this->attr($element, 'preserveaspectratio')));
                 if ( ! $isDecorativeChrome && $this->svgHasDrawableContent($element) ) {
+                    if ( $this->svgNeedsPhrasingHost($element) ) {
+                        $imageMarkup = $this->inlineSvgRichTextImageMarkup($element);
+                        if ( null !== $imageMarkup ) {
+                            return $this->createBlock('core/paragraph', array( 'content' => $imageMarkup ), array(), $element);
+                        }
+                    }
                     $svgBlock = $this->inlineSvgBlockFromElement($element);
                     if ( null !== $svgBlock ) {
                         return $svgBlock;
@@ -1713,6 +1732,13 @@ final class HtmlTransformer
                     return $this->createBlock('core/group', $this->presentationAttributes($element), array(), $element);
                 }
                 return null;
+            }
+
+            if ( $this->svgNeedsPhrasingHost($element) ) {
+                $imageMarkup = $this->inlineSvgRichTextImageMarkup($element);
+                if ( null !== $imageMarkup ) {
+                    return $this->createBlock('core/paragraph', array( 'content' => $imageMarkup ), array(), $element);
+                }
             }
 
             $svgBlock = $this->inlineSvgBlockFromElement($element);
@@ -2048,9 +2074,9 @@ final class HtmlTransformer
     {
         $attrs = $this->hoistContentWrappingSpans($name, $attrs);
 
-        if ( $sourceElement instanceof DOMElement && in_array($name, array( 'core/paragraph', 'core/heading' ), true) && $this->richTextRequiresHtmlFallback((string) ($attrs['content'] ?? '')) ) {
+        if ( $sourceElement instanceof DOMElement && in_array($name, array( 'core/paragraph', 'core/heading' ), true) && $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects((string) ($attrs['content'] ?? '')) ) {
             $attrs['content'] = $this->stripDecorativeSvgFromRichText((string) ($attrs['content'] ?? ''));
-            if ( $this->richTextRequiresHtmlFallback((string) ($attrs['content'] ?? '')) ) {
+            if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects((string) ($attrs['content'] ?? '')) ) {
                 return $this->blockFactory->create('core/html', array( 'content' => $this->restoreSvgCasing($this->outerHtml($sourceElement)) ));
             }
         }
@@ -3024,7 +3050,7 @@ final class HtmlTransformer
             if ( '' === trim($this->runtime->stripAllTags($content)) ) {
                 return true;
             }
-            if ( $this->richTextRequiresHtmlFallback($content) ) {
+            if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
                 return false;
             }
 
@@ -3050,18 +3076,13 @@ final class HtmlTransformer
                 continue;
             }
 
-            if ( ! $flushTextRun() ) {
+            $image = $this->inlineSvgRichTextImageMarkup($child);
+            if ( null === $image ) {
                 $this->generatedAssets = $generatedAssets;
                 return null;
             }
 
-            $image = $this->inlineSvgBlockFromElement($child);
-            if ( ! is_array($image) || 'core/image' !== ($image['blockName'] ?? '') ) {
-                $this->generatedAssets = $generatedAssets;
-                return null;
-            }
-
-            $blocks[] = $image;
+            $textRun .= $image;
         }
 
         if ( ! $flushTextRun() || ! $hasTextRun ) {
@@ -3070,6 +3091,75 @@ final class HtmlTransformer
         }
 
         return $this->createBlock('core/group', $this->presentationAttributes($element), $blocks, $element);
+    }
+
+    private function richTextContentWithMaterializedSvgImages(DOMElement $element, string $content): ?string
+    {
+        if ( 0 === $element->getElementsByTagName('svg')->length ) {
+            return $content;
+        }
+
+        $generatedAssets = $this->generatedAssets;
+        foreach ( $element->getElementsByTagName('svg') as $svg ) {
+            if ( ! $svg instanceof DOMElement ) {
+                continue;
+            }
+            $image = $this->inlineSvgRichTextImageMarkup($svg, false);
+            if ( null === $image ) {
+                $this->generatedAssets = $generatedAssets;
+                return null;
+            }
+            // RichText preparation may normalize SVG casing (viewBox -> viewbox),
+            // so the DOM serialization is not a stable replacement key.
+            $replaced = preg_replace('@<svg\b[^>]*>.*?</svg>@is', $image, $content, 1);
+            if ( ! is_string($replaced) || $replaced === $content ) {
+                $this->generatedAssets = $generatedAssets;
+                return null;
+            }
+            $content = $replaced;
+        }
+
+        return $content;
+    }
+
+    private function richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects(string $content): bool
+    {
+        // RichText stores core/image objects as <img> nodes. The generic fallback
+        // detector intentionally rejects arbitrary images, so remove only our
+        // materialized SVG image objects before applying that conservative gate.
+        $content = preg_replace_callback(
+            '@<img\b[^>]*\s*/?>@i',
+            fn (array $matches): string => $this->isGeneratedInlineSvgSource($this->imageSourceFromMarkup($matches[0])) ? '' : $matches[0],
+            $content
+        ) ?? $content;
+        return $this->richTextRequiresHtmlFallback($content);
+    }
+
+    private function richTextContainsNativeSvgImageObject(string $content): bool
+    {
+        if ( ! preg_match_all('@<img\b[^>]*\s*/?>@i', $content, $matches) ) {
+            return false;
+        }
+
+        foreach ( $matches[0] as $markup ) {
+            if ( $this->isGeneratedInlineSvgSource($this->imageSourceFromMarkup($markup)) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function imageSourceFromMarkup(string $markup): string
+    {
+        return preg_match('/\bsrc\s*=\s*(["\'])(.*?)\1/i', $markup, $matches)
+            ? html_entity_decode($matches[2], ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            : '';
+    }
+
+    private function isGeneratedInlineSvgSource(string $source): bool
+    {
+        return isset($this->generatedAssets[$source]) && 'inline-svg' === ($this->generatedAssets[$source]['source'] ?? '');
     }
 
     private function stripDecorativeSvgFromRichText(string $content): string

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -57,6 +57,21 @@ trait SvgMaterializationTrait
      */
     private function inlineSvgImageBlockFromMarkup(DOMElement $element, string $html): ?array
     {
+        $attrs = $this->inlineSvgImageAttributesFromMarkup($element, $html);
+        if ( null === $attrs ) {
+            return null;
+        }
+
+        return $this->createBlock('core/image', $attrs, array(), $element);
+    }
+
+    /**
+     * Materialize a passive SVG as the native image object accepted by RichText.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function inlineSvgImageAttributesFromMarkup(DOMElement $element, string $html): ?array
+    {
         if ( ! $this->isNativeImageCompatibleSvg($element, $html) ) {
             return null;
         }
@@ -96,7 +111,137 @@ trait SvgMaterializationTrait
             ),
         ), $dimensions), static fn ($value): bool => null !== $value && '' !== $value);
 
-        return $this->createBlock('core/image', $attrs, array(), $element);
+        return $attrs;
+    }
+
+    /**
+     * Return Gutenberg RichText's native image object markup for a passive SVG.
+     * The image is deliberately an object inside the surrounding RichText rather
+     * than a core/image block figure, which would break phrasing flow.
+     */
+    private function inlineSvgRichTextImageMarkup(DOMElement $element, bool $includeLink = true): ?string
+    {
+        if ( ! $this->svgHasDrawableContent($element) ) {
+            return null;
+        }
+
+        $html = $this->sanitizeInlineSvgMarkup($element);
+        if ( ! $this->isSafeSvgContent($html) ) {
+            return null;
+        }
+
+        $html = $this->restoreSvgCasing(
+            $this->cssOwnsMediaBox($element)
+                ? $this->ensureInlineSvgBoxStyle($html, $element)
+                : $this->ensureInlineSvgSizing($html, $element)
+        );
+        $attrs = $this->inlineSvgImageAttributesFromMarkup($element, $this->resolveMaterializedSvgColors($html, $element));
+        if ( null === $attrs ) {
+            return null;
+        }
+
+        $style = trim($this->attr($element, 'style'));
+        foreach ( array( 'width', 'height' ) as $dimension ) {
+            if ( empty($attrs[$dimension]) || preg_match('/(?:^|;)\s*' . $dimension . '\s*:/i', $style) ) {
+                continue;
+            }
+            $style = trim($style, ';') . ( '' === trim($style, ';') ? '' : ';' ) . $dimension . ':' . $attrs[$dimension];
+        }
+
+        $imageAttributes = array(
+            'src' => (string) $attrs['url'],
+            'alt' => (string) ($attrs['alt'] ?? ''),
+            'class' => (string) ($attrs['className'] ?? ''),
+            'style' => $style,
+        );
+        $markup = '<img' . $this->svgRichTextHtmlAttributes($imageAttributes, array( 'alt' )) . ' />';
+
+        if ( $includeLink ) {
+            $link = $this->svgImageLinkAttributes($element);
+            if ( array() !== $link ) {
+                $markup = '<a' . $this->svgRichTextHtmlAttributes($link) . '>' . $markup . '</a>';
+            }
+        }
+
+        return $markup;
+    }
+
+    /** @param array<string, string> $attributes */
+    private function svgRichTextHtmlAttributes(array $attributes, array $alwaysInclude = array()): string
+    {
+        $html = '';
+        foreach ( $attributes as $name => $value ) {
+            if ( '' === $value && ! in_array($name, $alwaysInclude, true) ) {
+                continue;
+            }
+            $html .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+        return $html;
+    }
+
+    /** @return array<string, string> */
+    private function svgImageLinkAttributes(DOMElement $element): array
+    {
+        $parent = $element->parentNode;
+        if ( ! $parent instanceof DOMElement || 'a' !== strtolower($parent->tagName) ) {
+            return array();
+        }
+
+        $href = trim($this->attr($parent, 'href'));
+        if ( '' === $href || preg_match('/^\s*javascript\s*:/i', $href) ) {
+            return array();
+        }
+
+        return array_filter(array(
+            'href' => $href,
+            'target' => trim($this->attr($parent, 'target')),
+            'rel' => trim($this->attr($parent, 'rel')),
+            'aria-label' => trim($this->attr($parent, 'aria-label')),
+        ), static fn (string $value): bool => '' !== $value);
+    }
+
+    private function svgNeedsPhrasingHost(DOMElement $element): bool
+    {
+        if ( $this->isVisualLayerElement($element) || 'none' === strtolower(trim($this->attr($element, 'preserveaspectratio'))) ) {
+            return false;
+        }
+
+        $parent = $element->parentNode;
+        if ( $parent instanceof DOMElement ) {
+            $parentTag = strtolower($parent->tagName);
+            if ( 'p' === $parentTag ) {
+                return true;
+            }
+            if ( 'article' === $parentTag && 'img' === strtolower(trim($this->attr($element, 'role'))) ) {
+                return false;
+            }
+            if ( ( $this->isInlineContentElement($parentTag) || 'a' === $parentTag ) && '' !== trim($this->runtime->stripAllTags($this->innerHtmlWithoutTags($parent, array( 'svg' )))) ) {
+                return true;
+            }
+        }
+
+        // A flex/grid child is a standalone layout item, even where its next
+        // sibling is a block. Keep its native image figure as the media column.
+        if ( $parent instanceof DOMElement && in_array(strtolower((string) ($this->presentationDeclarations($parent)['display'] ?? '')), array( 'flex', 'inline-flex', 'grid', 'inline-grid' ), true) ) {
+            return false;
+        }
+
+        // An SVG directly beside a block starts a phrasing-to-block transition.
+        // A paragraph is the editor-valid native host for the image object.
+        for ( $sibling = $element->previousSibling; null !== $sibling; $sibling = $sibling->previousSibling ) {
+            if ( $sibling instanceof DOMElement ) {
+                $tag = strtolower($sibling->tagName);
+                return 'svg' !== $tag && ! $this->isInlineContentElement($tag);
+            }
+        }
+        for ( $sibling = $element->nextSibling; null !== $sibling; $sibling = $sibling->nextSibling ) {
+            if ( $sibling instanceof DOMElement ) {
+                $tag = strtolower($sibling->tagName);
+                return 'svg' !== $tag && ! $this->isInlineContentElement($tag);
+            }
+        }
+
+        return false;
     }
 
     private function cssOwnsMediaBox(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -559,6 +559,18 @@ $assert(str_contains($cssSizedInlineSvgArtworkMarkup, 'class="wp-block-image alb
 $assert(! str_contains($cssSizedInlineSvgArtworkMarkup, 'is-resized album-cover'), 'CSS-sized inline SVG artwork does not add resized wrapper geometry over source CSS');
 $assert(! str_contains($cssSizedInlineSvgArtworkMarkup, 'style="width:500px;height:500px"'), 'CSS-sized inline SVG artwork does not force intrinsic SVG dimensions over source CSS sizing');
 
+$artifactInlineSvg = ( new ArtifactCompiler() )->compile(
+    array(
+        'entrypoint' => 'website/index.html',
+        'files'      => array(
+            'website/index.html' => '<main><div><svg class="feature-icon" viewBox="0 0 48 48" aria-hidden="true"><rect width="48" height="48"/></svg><h3>Feature</h3></div></main>',
+        ),
+    )
+)->toArray();
+$artifactInlineSvgMarkup = (string) ($artifactInlineSvg['serialized_blocks'] ?? '');
+$assert(str_contains($artifactInlineSvgMarkup, '<!-- wp:paragraph') && str_contains($artifactInlineSvgMarkup, 'website/assets/materialized-svg/'), 'source-relative materialized SVG remains a native RichText image object');
+$assert(! str_contains($artifactInlineSvgMarkup, '<!-- wp:html'), 'source-relative materialized SVG does not fall back to core/html');
+
 $largeCssSizedInlineSvgArtwork = ( new HtmlTransformer() )->transform(
     '<style>.hero-cover{width:100%;max-width:380px;aspect-ratio:1;display:block}</style><main><svg class="hero-cover" viewBox="0 0 500 500" role="img" aria-label="Hero cover">' . str_repeat('<rect width="500" height="500" fill="#111"/>', 2000) . '</svg></main>'
 )->toArray();
@@ -916,9 +928,10 @@ $paragraphSvgResult = ( new HtmlTransformer() )->transform(
 )->toArray();
 $paragraphSvgBlock = $paragraphSvgResult['blocks'][0] ?? array();
 $paragraphSvgSerialized = (string) ($paragraphSvgResult['serialized_blocks'] ?? '');
-$assert('core/html' === ($paragraphSvgBlock['blockName'] ?? ''), 'paragraph content with inline SVG falls back to core/html instead of invalid RichText');
-$assert(str_contains($paragraphSvgSerialized, '<!-- wp:html'), 'paragraph inline SVG serializes as a bounded custom HTML block');
-$assert(! preg_match('/<!-- wp:paragraph[^>]*-->.*<svg\b.*<!-- \/wp:paragraph -->/s', $paragraphSvgSerialized), 'paragraph inline SVG is not stored inside core/paragraph RichText');
+$assert('core/paragraph' === ($paragraphSvgBlock['blockName'] ?? ''), 'paragraph content with a safe inline SVG remains a native RichText paragraph');
+$assert(str_contains($paragraphSvgSerialized, '<!-- wp:paragraph'), 'paragraph inline SVG serializes as a native paragraph block');
+$assert(str_contains($paragraphSvgSerialized, '<a href="#" aria-label="Follow"><img src="assets/materialized-svg/'), 'paragraph inline SVG materializes as a linked RichText image object');
+$assert(! str_contains($paragraphSvgSerialized, '<svg'), 'paragraph inline SVG is not stored as unsupported SVG RichText markup');
 
 $coffeeHtml = (string) file_get_contents(dirname(__DIR__, 3) . '/fixtures/websites/2-onepager-coffee/index.html');
 $coffeeResult = ( new HtmlTransformer() )->transform($coffeeHtml, array())->toArray();

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-benefit-icon-faithful.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-benefit-icon-faithful.json
@@ -1,11 +1,11 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-benefit-icon-faithful",
-  "description": "Imported passive feature/benefit inline SVGs are represented as core/image data URI blocks so the graphic remains native and editor-valid. They are never routed through the dynamic core/icon block, which is keyed on a registry slug and discards inline SVG markup (rendering empty).",
+  "description": "An inline SVG directly before block content uses a paragraph RichText image object, preserving source flow without core/html or a custom block.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-benefit-icon-faithful.json",
-    "notes": "Regression guard: core/icon discards arbitrary inline SVG (render_block_core_icon returns empty without a registry slug), so imported passive feature icons use core/image data URIs and keep class + viewBox-derived sizing."
+    "notes": "Regression guard: arbitrary SVGs are materialized assets; a direct SVG-to-block transition uses an editor-valid paragraph host rather than a figure."
   },
   "legacy_comparison": {
     "skip": true,
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "features" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Fast", "level": 3 } }
   ],
   "expect": [
@@ -26,9 +26,8 @@
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "assets", "assert": "count", "count": 1 },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.className", "assert": "equals", "value": "benefit-icon" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.width", "assert": "equals", "value": "24px" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"width:24px;height:24px\"" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "class=\"benefit-icon\"" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "style=\"width:24px;height:24px\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "assets/materialized-svg/" },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-decorative.json
@@ -18,14 +18,14 @@
   "expected_blocks": [
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Before", "level": 2 } },
     { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "After" } },
-    { "path": "blocks.0.innerBlocks.2", "name": "core/image" }
+    { "path": "blocks.0.innerBlocks.2", "name": "core/paragraph" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
-    { "path": "blocks.0.innerBlocks.2.attrs.url", "assert": "contains", "value": "assets/materialized-svg/" },
-    { "path": "blocks.0.innerBlocks.2.attrs.alt", "assert": "equals", "value": "Acme integration" },
+    { "path": "blocks.0.innerBlocks.2.attrs.content", "assert": "contains", "value": "assets/materialized-svg/" },
+    { "path": "blocks.0.innerBlocks.2.attrs.content", "assert": "contains", "value": "alt=\"Acme integration\"" },
     { "path": "assets", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-fallback.json
@@ -17,14 +17,14 @@
   },
   "expected_blocks": [
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Icon row", "level": 2 } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/image" }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/paragraph" }
   ],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 1 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
-    { "path": "blocks.0.innerBlocks.1.attrs.url", "assert": "contains", "value": "assets/materialized-svg/" },
-    { "path": "blocks.0.innerBlocks.1.attrs.alt", "assert": "equals", "value": "Status" },
+    { "path": "blocks.0.innerBlocks.1.attrs.content", "assert": "contains", "value": "assets/materialized-svg/" },
+    { "path": "blocks.0.innerBlocks.1.attrs.content", "assert": "contains", "value": "alt=\"Status\"" },
     { "path": "assets", "assert": "count", "count": 1 },
     { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-text-token-native-decomposition.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-text-token-native-decomposition.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-inline-svg-text-token-native-decomposition",
-  "description": "Decomposes classed inline text tokens containing passive SVGs into native paragraphs and materialized images in source order rather than storing unsupported SVG markup in RichText.",
+  "description": "Represents passive SVGs in classed inline text tokens as native RichText core/image objects, preserving source order and phrasing flow.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-inline-svg-text-token-native-decomposition.json",
@@ -21,20 +21,19 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "ticker" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "ticker-item ticker-item--leading" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph", "attrs": { "content": "Open source" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph" },
     { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "ticker-item ticker-item--split" } },
-    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph", "attrs": { "content": "Before" } },
-    { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/image" },
-    { "path": "blocks.0.innerBlocks.1.innerBlocks.2", "name": "core/paragraph", "attrs": { "content": "after" } }
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/paragraph" }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "assets/materialized-svg/" },
-    { "path": "blocks.0.innerBlocks.1.innerBlocks.1.attrs.url", "assert": "contains", "value": "assets/materialized-svg/" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "assets/materialized-svg/" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.content", "assert": "contains", "value": "Open source" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.attrs.content", "assert": "contains", "value": "assets/materialized-svg/" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.attrs.content", "assert": "contains", "value": "Before" },
     { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-group ticker-item ticker-item--leading" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<p>Open source</p>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<img src=\"assets/materialized-svg/" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]

--- a/php-transformer/tests/fixtures/parity/html-logo-nav-button-classification.json
+++ b/php-transformer/tests/fixtures/parity/html-logo-nav-button-classification.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "site-logo" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image", "attrs": { "href": "/", "linkDestination": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph" },
     { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "url": "/docs", "kind": "custom" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.1", "name": "core/navigation-link", "attrs": { "url": "/pricing", "kind": "custom" } },
@@ -39,8 +39,6 @@
     { "path": "blocks", "assert": "count", "count": 4 },
     { "path": "blocks.0.innerBlocks", "assert": "count", "count": 2 },
     { "path": "serialized_blocks", "assert": "contains", "value": "site-logo" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "assets/materialized-svg/" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.attrs.href", "assert": "equals", "value": "/" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/\"><img" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/\"><span>Acme</span></a>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<svg" },

--- a/php-transformer/tests/fixtures/parity/html-saas-style-boundaries.json
+++ b/php-transformer/tests/fixtures/parity/html-saas-style-boundaries.json
@@ -21,8 +21,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "site-header", "tagName": "header" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "brand-logo" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/paragraph" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph" },
     { "path": "blocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "primary-nav" } },
     { "path": "blocks.1", "name": "core/group", "attrs": { "tagName": "main" } },
     { "path": "blocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "hero", "tagName": "section" } },
@@ -37,7 +36,7 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 2 },
     { "path": "serialized_blocks", "assert": "contains", "value": "assets/materialized-svg/" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<a href=\"/\"><span>Relay Atlas</span></a>" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<span>Relay Atlas</span></a>" },
     { "path": "serialized_blocks", "assert": "contains", "value": "beta-badge" },
     { "path": "serialized_blocks", "assert": "contains", "value": "status-orb" },
     { "path": "serialized_blocks", "assert": "contains", "value": "trusted-by" },

--- a/php-transformer/tests/fixtures/parity/html-section-runtime-animation-native-decomposition.json
+++ b/php-transformer/tests/fixtures/parity/html-section-runtime-animation-native-decomposition.json
@@ -24,7 +24,7 @@
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "Native sections", "level": 2 } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "feature-grid", "layout": { "type": "grid" } } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "feature-card reveal", "tagName": "article" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.0", "name": "core/image" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.0", "name": "core/paragraph" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "content": "One", "level": 3 } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/group", "attrs": { "className": "feature-card reveal", "tagName": "article" } }
   ],


### PR DESCRIPTION
## Summary
- materialize passive inline SVGs as native RichText image objects when they participate in phrasing flow
- preserve linked SVG semantics and source dimensions without introducing `core/html` fallback
- recognize generated SVG assets under source-relative paths such as `website/assets/materialized-svg/`
- retain standalone `core/image` output for media layout boundaries

Fixes the remaining inline SVG portion of #624.

## How to test
1. Check out this branch from a fresh clone.
2. Run `cd php-transformer && composer test`.
3. Confirm all canonical contracts, unit tests, 244 parity fixtures, and package install proof pass.
4. Inspect the artifact-level contract in `php-transformer/tests/contract/run.php` and confirm a source-relative SVG next to a heading serializes as a native paragraph image object rather than `core/html`.

## Compatibility
- No extension paths or public APIs change.
- Existing unsupported or unsafe SVGs retain their bounded fallback behavior.
- The behavioral change is limited to passive generated SVG assets that WordPress RichText can represent natively.

## Supplementary evidence
A composed Static Site Importer browser run retained 291/291 editor-valid native blocks, removed the `broken_svg` finding, and eliminated the prior -8px cumulative page offset. The exact visual gate remains tracked separately by Automattic/static-site-importer#489.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression coverage, and verification in collaboration with Chris Huber.