### PR TITLE
Make WordPress site plans self-contained and deployable

### DIFF
--- a/.github/workflows/php-transformer.yml
+++ b/.github/workflows/php-transformer.yml
@@ -2,41 +2,40 @@ name: PHP Transformer
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/php-transformer.yml"
-      - "php-transformer/**"
   push:
-    branches:
-      - trunk
-    paths:
-      - ".github/workflows/php-transformer.yml"
-      - "php-transformer/**"
 
 jobs:
-  validate:
-    name: Composer validate and test
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: php-transformer
-
+  wordpress-site-plan:
+    name: WordPress site plan integration
+    runs-on: ubuntu-24.04
+    services:
+      mysql:
+        image: mysql:8.0.36
+        env:
+          MYSQL_DATABASE: wordpress_test
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
-          coverage: none
+          extensions: mysqli
           tools: composer:v2
-
-      - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --no-progress
-
-      - name: Validate Composer package metadata
-        run: composer validate --strict
-
-      - name: Run package tests
-        run: composer test
+      - name: Install package dependencies
+        working-directory: php-transformer
+        run: composer install --no-interaction --prefer-dist
+      - name: Provision pinned WordPress PHPUnit runtime
+        run: git clone --depth=1 --branch 6.7.4 https://github.com/WordPress/wordpress-develop.git "$RUNNER_TEMP/wordpress-develop" && "$RUNNER_TEMP/wordpress-develop/tests/phpunit/install-test-suite.sh" wordpress_test root '' 127.0.0.1:3306 6.7.4
+      - name: Run required WordPress site plan integration
+        working-directory: php-transformer
+        env:
+          REQUIRE_WP_TESTS: "1"
+          WP_TESTS_DIR: ${{ runner.temp }}/wordpress-develop/tests/phpunit
+        run: composer test:wordpress-integration

--- a/.github/workflows/php-transformer.yml
+++ b/.github/workflows/php-transformer.yml
@@ -68,7 +68,20 @@ jobs:
         working-directory: php-transformer
         run: composer install --no-interaction --prefer-dist
       - name: Provision pinned WordPress PHPUnit runtime
-        run: git clone --depth=1 --branch 6.7.4 https://github.com/WordPress/wordpress-develop.git "$RUNNER_TEMP/wordpress-develop" && "$RUNNER_TEMP/wordpress-develop/tests/phpunit/install-test-suite.sh" wordpress_test root '' 127.0.0.1:3306 6.7.4
+        env:
+          WORDPRESS_DEVELOP_DIR: ${{ runner.temp }}/wordpress-develop
+          WORDPRESS_TEST_DB: wordpress_site_plan_test
+        run: |
+          git clone --depth=1 --branch 6.7.4 https://github.com/WordPress/wordpress-develop.git "$WORDPRESS_DEVELOP_DIR"
+          composer install --working-dir="$WORDPRESS_DEVELOP_DIR" --no-interaction --prefer-dist --no-progress
+          for attempt in $(seq 1 30); do
+            if mysql --host=127.0.0.1 --port=3306 --user=root --execute='SELECT 1'; then break; fi
+            if [ "$attempt" = 30 ]; then exit 1; fi
+            sleep 2
+          done
+          mysql --host=127.0.0.1 --port=3306 --user=root --execute="DROP DATABASE IF EXISTS $WORDPRESS_TEST_DB; CREATE DATABASE $WORDPRESS_TEST_DB;"
+          cp "$WORDPRESS_DEVELOP_DIR/wp-tests-config-sample.php" "$WORDPRESS_DEVELOP_DIR/wp-tests-config.php"
+          WORDPRESS_DEVELOP_DIR="$WORDPRESS_DEVELOP_DIR" WORDPRESS_TEST_DB="$WORDPRESS_TEST_DB" php -r '$config = file_get_contents(getenv("WORDPRESS_DEVELOP_DIR") . "/wp-tests-config.php"); $config = preg_replace("/define\(\s*\x27DB_NAME\x27\s*,\s*[^)]*\);/", "define( \x27DB_NAME\x27, \x27" . getenv("WORDPRESS_TEST_DB") . "\x27 );", $config); $config = preg_replace("/define\(\s*\x27DB_USER\x27\s*,\s*[^)]*\);/", "define( \x27DB_USER\x27, \x27root\x27 );", $config); $config = preg_replace("/define\(\s*\x27DB_PASSWORD\x27\s*,\s*[^)]*\);/", "define( \x27DB_PASSWORD\x27, \x27\x27 );", $config); $config = preg_replace("/define\(\s*\x27DB_HOST\x27\s*,\s*[^)]*\);/", "define( \x27DB_HOST\x27, \x27127.0.0.1:3306\x27 );", $config); file_put_contents(getenv("WORDPRESS_DEVELOP_DIR") . "/wp-tests-config.php", $config);'
       - name: Run required WordPress site plan integration
         working-directory: php-transformer
         env:

--- a/.github/workflows/php-transformer.yml
+++ b/.github/workflows/php-transformer.yml
@@ -2,9 +2,45 @@ name: PHP Transformer
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/php-transformer.yml"
+      - "php-transformer/**"
   push:
+    branches:
+      - trunk
+    paths:
+      - ".github/workflows/php-transformer.yml"
+      - "php-transformer/**"
 
 jobs:
+  validate:
+    name: Composer validate and test
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: php-transformer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
+        with:
+          php-version: "8.1"
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Validate Composer package metadata
+        run: composer validate --strict
+
+      - name: Run package tests
+        run: composer test
+
   wordpress-site-plan:
     name: WordPress site plan integration
     runs-on: ubuntu-24.04
@@ -23,7 +59,7 @@ jobs:
           --health-retries=10
     steps:
       - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
         with:
           php-version: "8.1"
           extensions: mysqli

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Blocks Engine is a collection of tools for generating, transforming, and materia
 - [`php-transformer`](php-transformer/) - PHP primitives for converting HTML, Markdown, and generated website artifacts into WordPress-native block outputs.
 - [`figma-transformer`](figma-transformer/) - PHP primitives for converting Figma `.fig` archives and Figma-derived scenegraphs into static HTML website artifacts with parity diagnostics.
 
-Artifact compilation also emits the additive [`wordpress-site-plan/v1`](docs/contracts/wordpress-site-plan-v1.md) downstream materialization contract.
+Artifact compilation also emits the self-contained [`wordpress-site-plan/v2`](docs/contracts/wordpress-site-plan-v2.md) block-theme materialization contract.

--- a/docs/contracts/wordpress-site-plan-v1.md
+++ b/docs/contracts/wordpress-site-plan-v1.md
@@ -1,12 +1,13 @@
-# WordPress Site Plan v1
+# WordPress Site Plan v1 (Superseded)
 
 `blocks-engine/wordpress-site-plan/v1` is the additive, self-contained materialization handoff emitted at `TransformerResult.source_reports.wordpress_site_plan` for artifact compilation.
 
-The public API is `WordPressSitePlan::fromResult()` and `WordPressSitePlan::assertValid()`.
+This contract was superseded by [WordPress Site Plan v2](wordpress-site-plan-v2.md).
 
 - `pages`, `templates`, and `template_parts` carry final serialized block markup, post/parent metadata, template-part area, and deterministic reconciliation identities.
 - `assets` preserves canonical source/target identities for all compiled assets. `writes` carries materializable theme-asset payloads with a relative target path, `utf8` or `base64` payload encoding, media/hash metadata, and load metadata.
 - `routes`, navigation, menus, rewrite candidates, theme, and visual-repair data retain the materialization semantics required without consulting `compiled_site`.
 - `source`, `diagnostics`, and `quality` preserve source identity/provenance and compiler outcome metadata.
 
-The v1 projection emits an empty `templates` list because ArtifactCompiler does not currently infer reusable full templates. It does not generate base theme files. Projection fails when a compiled page or template part lacks final block markup or a safe source identity. Validation rejects unsupported schemas, unsafe POSIX/Windows/UNC paths, invalid encodings, and malformed nested rows.
+v1 emitted no block-theme scaffold or templates and left local asset URLs unresolved.
+It is retained here only as migration documentation; new consumers must use v2.

--- a/docs/contracts/wordpress-site-plan-v2.md
+++ b/docs/contracts/wordpress-site-plan-v2.md
@@ -3,6 +3,9 @@
 `blocks-engine/wordpress-site-plan/v2` is the complete, destination-independent
 block-theme materialization contract emitted at
 `TransformerResult.source_reports.wordpress_site_plan` for artifact compilation.
+The compiler emits `wordpress_site_plan_diagnostics` instead when an artifact retains
+an undeclared local browser reference and therefore cannot honestly produce this
+self-contained contract.
 
 The public API is `WordPressSitePlan::fromResult()`, `WordPressSitePlan::assertValid()`,
 and `WordPressSitePlanResolver::resolve()`.
@@ -25,6 +28,17 @@ and `WordPressSitePlanResolver::resolve()`.
   to exactly one declared asset target. Validation rejects unsafe paths, missing
   scaffold writes, duplicate targets, missing asset writes, undeclared tokens, and
   template or part writes that do not match their declarations.
+- `operations` is an ordered generic desired-state list. An entry page produces one
+  `site_reading` operation that assigns the front page by its source path and
+  reconciliation identity. Consumers apply resolved operations verbatim rather than
+  inferring front-page behavior.
+- Targets, slugs, and tokens use a case-insensitive collision policy. Producers
+  retain their declared spelling, while plans reject two values that differ only by
+  case so they materialize consistently on case-insensitive filesystems.
+- Static browser references in markup and CSS (`src`, stylesheet `href`, `srcset`,
+  `poster`, applicable `action`, `url()`, and `@import`) must be declared asset
+  tokens or absolute/root-relative URLs. Dynamic script references are explicitly
+  `not_proven`; only literal declared tokens in JavaScript are resolved.
 
 ## Runtime Resolution
 
@@ -36,10 +50,13 @@ $resolved = (new WordPressSitePlanResolver())->resolve($plan, array(
 ));
 ```
 
-`theme_uri` must be an absolute HTTP(S) URL. The resolver replaces only declared
-tokens in markup and UTF-8 write payloads. It deterministically rejects invalid
-context and residual or undeclared tokens. Materializers write `resolved['writes']`
-verbatim and must not perform HTML, CSS, or script rewriting.
+`theme_uri` must be an absolute HTTP(S) URL with authority and an optional
+unambiguous path. Credentials, query strings, fragments, control characters,
+backslashes, dot segments, and encoded path separators are rejected. The resolver
+normalizes only scheme, host, optional port, and trailing path slash. It replaces
+only declared tokens in markup and UTF-8 write payloads. Materializers write
+`resolved['writes']` and apply `resolved['operations']` verbatim; they never rewrite
+HTML, CSS, scripts, or URLs.
 
 ## Migration From v1
 
@@ -47,4 +64,5 @@ v1 was additive but incomplete: it emitted no block-theme scaffold or templates 
 left source-relative asset URLs for consumers to interpret. It is not compatible
 with v2 and consumers must switch to `canonical_block_markup`, resolve with explicit
 destination context, and materialize the resolved writes. This is a breaking public
-contract correction and warrants a major package version bump.
+contract correction from the pre-1.0 `0.3.0` release and warrants the next minor
+package version, `0.4.0`.

--- a/docs/contracts/wordpress-site-plan-v2.md
+++ b/docs/contracts/wordpress-site-plan-v2.md
@@ -1,0 +1,50 @@
+# WordPress Site Plan v2
+
+`blocks-engine/wordpress-site-plan/v2` is the complete, destination-independent
+block-theme materialization contract emitted at
+`TransformerResult.source_reports.wordpress_site_plan` for artifact compilation.
+
+The public API is `WordPressSitePlan::fromResult()`, `WordPressSitePlan::assertValid()`,
+and `WordPressSitePlanResolver::resolve()`.
+
+## Canonical Plan
+
+- `writes` declares every theme file, with unique normalized relative targets:
+  `style.css`, `theme.json`, `functions.php` when asset enqueues are required,
+  fallback `templates/index.html`, `templates/page.html` when pages exist,
+  `templates/front-page.html` when an entry page exists, and each template part
+  under `parts/`. Every materializable asset has exactly one write under `assets/`.
+- `style.css` includes a valid theme header and `theme.json` is a valid minimal
+  block-theme configuration. The generated bootstrap uses WordPress runtime APIs
+  to enqueue CSS and JavaScript assets.
+- Pages, templates, and template parts carry `canonical_block_markup`. It is
+  materialization-ready but destination-independent: every local asset reference
+  is a declared `{{wordpress-site-plan:asset:...}}` token. It is not browser-ready
+  markup. Resolution adds `resolved_block_markup` without changing canonical data.
+- `reference_tokens` is the only allowed token-to-artifact mapping. Each token maps
+  to exactly one declared asset target. Validation rejects unsafe paths, missing
+  scaffold writes, duplicate targets, missing asset writes, undeclared tokens, and
+  template or part writes that do not match their declarations.
+
+## Runtime Resolution
+
+The compiler cannot infer a deployed theme URL. Pass it explicitly:
+
+```php
+$resolved = (new WordPressSitePlanResolver())->resolve($plan, array(
+    'theme_uri' => 'https://example.test/wp-content/themes/generated-site',
+));
+```
+
+`theme_uri` must be an absolute HTTP(S) URL. The resolver replaces only declared
+tokens in markup and UTF-8 write payloads. It deterministically rejects invalid
+context and residual or undeclared tokens. Materializers write `resolved['writes']`
+verbatim and must not perform HTML, CSS, or script rewriting.
+
+## Migration From v1
+
+v1 was additive but incomplete: it emitted no block-theme scaffold or templates and
+left source-relative asset URLs for consumers to interpret. It is not compatible
+with v2 and consumers must switch to `canonical_block_markup`, resolve with explicit
+destination context, and materialize the resolved writes. This is a breaking public
+contract correction and warrants a major package version bump.

--- a/docs/contracts/wordpress-site-plan-v2.md
+++ b/docs/contracts/wordpress-site-plan-v2.md
@@ -38,7 +38,8 @@ and `WordPressSitePlanResolver::resolve()`.
 - Static browser references in markup and CSS (`src`, stylesheet `href`, `srcset`,
   `poster`, applicable `action`, `url()`, and `@import`) must be declared asset
   tokens or absolute/root-relative URLs. Dynamic script references are explicitly
-  `not_proven`; only literal declared tokens in JavaScript are resolved.
+  `not_proven`; only literal declared tokens in JavaScript are resolved. The
+  `dynamic_client_assets.materializer_may_reject` capability flag is `true`.
 
 ## Runtime Resolution
 
@@ -57,6 +58,8 @@ normalizes only scheme, host, optional port, and trailing path slash. It replace
 only declared tokens in markup and UTF-8 write payloads. Materializers write
 `resolved['writes']` and apply `resolved['operations']` verbatim; they never rewrite
 HTML, CSS, scripts, or URLs.
+Consumers requiring proven dynamic client assets pass
+`require_proven_dynamic_client_assets => true` and receive a deterministic rejection.
 
 ## Migration From v1
 

--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -149,7 +149,7 @@ Unsupported or unsafe artifact inputs are reported through diagnostics instead o
 
 Run the package contract, parity fixtures, and clean package-install proof with `composer test`. The checked-in fixtures assert current transformer behavior, and the install proof verifies that Composer can install `automattic/blocks-engine-php-transformer` from the `php-transformer/` package root without symlinking back to the working tree.
 
-Run the real WordPress materialization integration against a standard WordPress test-suite runtime with `WP_TESTS_DIR=/path/to/wordpress-tests-lib composer test:wordpress-integration`.
+Run the real WordPress materialization integration against a standard WordPress test-suite runtime with `REQUIRE_WP_TESTS=1 WP_TESTS_DIR=/path/to/wordpress-develop/tests/phpunit composer test:wordpress-integration`. Without `REQUIRE_WP_TESTS=1`, the command reports an explicit local skip when that runtime is unavailable. CI provisions WordPress `6.7.4`, MySQL `8.0.36`, and runs the required form of this command in `.github/workflows/php-transformer.yml`.
 
 ## Release Consumption
 

--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -41,6 +41,8 @@ Consumers should treat these classes and interface as the public entrypoints for
 - `FormatBridge\FormatAdapterInterface` - adapter contract for adding formats to `FormatBridge` when a consumer genuinely needs a package-level extension point.
 - `ArtifactCompiler\ArtifactCompiler` - normalizes generated website artifact bundles into the shared result envelope, including block markup, source reports, assets, components, documents, and block type artifacts.
 - `StaticSite\MaterializationView` - validates a `TransformerResult` object or canonical result array and returns a stable product-neutral array view for importer planning.
+- `WordPressSitePlan\WordPressSitePlan` - projects an artifact result to the self-contained v2 block-theme plan.
+- `WordPressSitePlan\WordPressSitePlanResolver` - resolves that plan's declared asset tokens with an explicit runtime `theme_uri`.
 - `WordPress\Runtime` - adapter for WordPress functions used by the transformer when running inside or outside WordPress.
 
 The remaining classes in `src/HtmlToBlocks`, `src/FormatBridge`, and `src/ArtifactCompiler` are implementation details. Concrete bundled adapters, registries, normalizers, and factories may change as the bridge expands.
@@ -70,6 +72,10 @@ $artifactResult = (new ArtifactCompiler())->compile(array(
 ))->toArray();
 
 $materialization = (new MaterializationView())->fromResult($artifactResult);
+$plan = (new WordPressSitePlan())->fromResult($artifactResult);
+$resolvedPlan = (new WordPressSitePlanResolver())->resolve($plan, array(
+    'theme_uri' => 'https://example.test/wp-content/themes/generated-site',
+));
 ```
 
 ### WordPress Plugin Usage

--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -149,6 +149,8 @@ Unsupported or unsafe artifact inputs are reported through diagnostics instead o
 
 Run the package contract, parity fixtures, and clean package-install proof with `composer test`. The checked-in fixtures assert current transformer behavior, and the install proof verifies that Composer can install `automattic/blocks-engine-php-transformer` from the `php-transformer/` package root without symlinking back to the working tree.
 
+Run the real WordPress materialization integration against a standard WordPress test-suite runtime with `WP_TESTS_DIR=/path/to/wordpress-tests-lib composer test:wordpress-integration`.
+
 ## Release Consumption
 
 The package lives in a subtree of the Blocks Engine repository. Composer cannot discover a package whose `composer.json` is below the repository root from a plain monorepo VCS tag. After release, consumers need either a subtree-split/Packagist package whose root is `php-transformer/`, or an explicit Composer `package` repository that points at the release archive and maps autoloading to the subtree.

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -90,5 +90,9 @@
     "branch-alias": {
       "dev-trunk": "0.1.x-dev"
     }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.6",
+    "yoast/phpunit-polyfills": "^3.0"
   }
 }

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -77,6 +77,7 @@
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",
     "test:migration:legacy-parity": "BLOCKS_ENGINE_PARITY_LEGACY=1 php tests/parity/run.php --migration-comparison",
+    "test:wordpress-integration": "php tests/integration/wordpress-site-plan.php",
     "test:packaging": "php tests/packaging/install-proof.php"
   },
   "config": {

--- a/php-transformer/composer.lock
+++ b/php-transformer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3472ba768651b23c423f2b2e29b22c43",
+    "content-hash": "48ba9eef50af6809efd3f6a7a1752977",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -721,7 +721,1851 @@
             "time": "2026-04-10T16:19:22+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-02-09T18:36:24+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -186,7 +186,7 @@ final class ArtifactCompiler
      */
     private function compileEntryBlocks(string $html, string $entryPath, array $files, string $generatedBlockNamespace = ''): array
     {
-        $result = $this->compileHtmlDocumentBlocks($html, $entryPath, $files, 'artifact-entry', $generatedBlockNamespace);
+        $result = $this->compileHtmlDocumentBlocks($html, $entryPath, $files, 'artifact-entry', $generatedBlockNamespace, true);
 
         return array(
             'blocks'            => $result['blocks'],
@@ -207,7 +207,7 @@ final class ArtifactCompiler
      * @param array<int, array<string, mixed>> $files
      * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>, superseded_selectors: array<int, string>, author_stylesheet_projections: array<int, array<string, mixed>>, shell_artifacts: array<int, array<string, mixed>>}
      */
-    private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope, string $generatedBlockNamespace = ''): array
+    private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope, string $generatedBlockNamespace = '', bool $extractGlobalShell = false): array
     {
         if ( $this->containsBlockMarkup($html) ) {
             return array(
@@ -252,6 +252,7 @@ final class ArtifactCompiler
             'runtime_dom_selectors'     => $this->runtimeDomSelectors($html, $sourcePath, $files),
             'runtime_canvas_selectors'  => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
             'generated_block_namespace' => $generatedBlockNamespace,
+            'extract_global_shell'       => $extractGlobalShell,
         ))->toArray();
 
         return array(
@@ -1627,6 +1628,13 @@ final class ArtifactCompiler
                 }
             }
             $blockMarkup = (string) ($compiledBlocks['serialized_blocks'] ?? '');
+            if ( $path === $entryPath ) {
+                foreach ( $entryShellArtifacts as $shellArtifact ) {
+                    if ( is_array($shellArtifact) && is_string($shellArtifact['block_markup'] ?? null) ) {
+                        $blockMarkup = str_replace($shellArtifact['block_markup'], '', $blockMarkup);
+                    }
+                }
+            }
             if ( '' === $blockMarkup && '' !== trim($content) ) {
                 $blockMarkup = $this->htmlDocumentBlockMarkup($content);
             }
@@ -1680,9 +1688,14 @@ final class ArtifactCompiler
         }
 
         $templateParts = $this->compiledSiteTemplateParts($artifact['files']);
-        $explicitAreas = array_fill_keys(array_column($templateParts, 'area'), true);
+        $partSlugs = array_fill_keys(array_column($templateParts, 'slug'), true);
         foreach ( $entryShellArtifacts as $shellArtifact ) {
-            if ( is_array($shellArtifact) && ! isset($explicitAreas[(string) ($shellArtifact['area'] ?? '')]) ) {
+            if ( is_array($shellArtifact) ) {
+                $slug = (string) ($shellArtifact['slug'] ?? '');
+                if ( isset($partSlugs[$slug]) ) {
+                    $shellArtifact['slug'] = 'entry-' . $slug;
+                }
+                $partSlugs[(string) $shellArtifact['slug']] = true;
                 $templateParts[] = $shellArtifact;
             }
         }
@@ -1916,6 +1929,7 @@ final class ArtifactCompiler
                     'runtime_islands' => array(),
                     'bytes'        => $file['bytes'] ?? 0,
                     'provenance'   => $file['provenance'] ?? array(),
+                    'placement'    => array('kind' => 'unbound'),
                 ),
                 static fn (mixed $value): bool => '' !== $value && array() !== $value
             );

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -127,23 +127,27 @@ final class ArtifactCompiler
 
         // Failed compilations have no materializable source identity and no site plan.
         if ( 'failed' !== $this->statusFromDiagnostics($diagnostics) ) {
-            $sourceReports['wordpress_site_plan'] = ( new WordPressSitePlan() )->fromResult(array(
-                'schema' => TransformerResult::SCHEMA,
-                'status' => $this->statusFromDiagnostics($diagnostics),
-                'components' => $components,
-                'block_types' => $blockTypes,
-                'source_reports' => $sourceReports,
-                'blocks' => $entryBlocks['blocks'],
-                'serialized_blocks' => $serializedBlocks,
-                'documents' => $documents['documents'],
-                'assets' => $assets,
-                'diagnostics' => $diagnostics,
-                'fallbacks' => $entryBlocks['fallbacks'],
-                'provenance' => $provenance,
-                'coverage' => array(),
-                'context' => array(),
-                'metrics' => $metrics,
-            ));
+            try {
+                $sourceReports['wordpress_site_plan'] = ( new WordPressSitePlan() )->fromResult(array(
+                    'schema' => TransformerResult::SCHEMA,
+                    'status' => $this->statusFromDiagnostics($diagnostics),
+                    'components' => $components,
+                    'block_types' => $blockTypes,
+                    'source_reports' => $sourceReports,
+                    'blocks' => $entryBlocks['blocks'],
+                    'serialized_blocks' => $serializedBlocks,
+                    'documents' => $documents['documents'],
+                    'assets' => $assets,
+                    'diagnostics' => $diagnostics,
+                    'fallbacks' => $entryBlocks['fallbacks'],
+                    'provenance' => $provenance,
+                    'coverage' => array(),
+                    'context' => array(),
+                    'metrics' => $metrics,
+                ));
+            } catch (\InvalidArgumentException $exception) {
+                $sourceReports['wordpress_site_plan_diagnostics'] = array(array('code' => 'wordpress_site_plan_not_self_contained', 'message' => $exception->getMessage()));
+            }
         }
 
         return new TransformerResult(

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -521,7 +521,7 @@ final class HtmlTransformer
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
         $this->collectSupersededNavToggleSelectors($body);
-        $shellArtifacts = $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html'));
+        $shellArtifacts = !array_key_exists('extract_global_shell', $options) || !empty($options['extract_global_shell']) ? $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html')) : array();
         $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));
         $this->recordRuntimeIslandsForPreservedHtmlBlocks($blocks);
         $this->appendInteractiveControlBehaviorLossFallbacks($body, $fallbacks);
@@ -608,9 +608,10 @@ final class HtmlTransformer
      *
      * @return array<int, array<string, mixed>>
      */
-    private function globalShellArtifacts(DOMElement $body, string $source): array
+    private function globalShellArtifacts(DOMElement $body, string $source, bool $removeFromContent = false): array
     {
         $artifacts = array();
+        $removals = array();
         foreach ( $body->childNodes as $child ) {
             if ( ! $child instanceof DOMElement ) {
                 continue;
@@ -635,8 +636,14 @@ final class HtmlTransformer
                 'block_markup' => $markup,
                 'source_selector' => strtolower($child->tagName),
                 'source_hash' => hash('sha256', $this->outerHtml($child)),
+                'placement' => array('kind' => 'entry_shell', 'source_path' => $source, 'template_slugs' => array('front-page')),
             );
+            // A successfully projected global shell is owned by the template part,
+            // not duplicated in the entry page's post-content markup.
+            if ($removeFromContent) $removals[] = $child;
         }
+
+        foreach ($removals as $child) $body->removeChild($child);
 
         return $artifacts;
     }

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -25,9 +25,10 @@ final class WordPressSitePlan
 
         $assets = $this->assets($compiled['assets'] ?? null);
         $tokens = $this->tokens($assets);
-        $pages = $this->documents($compiled['pages'] ?? null, false, $tokens);
-        $parts = $this->documents($compiled['template_parts'] ?? null, true, $tokens);
-        $templates = $this->templates($pages);
+        $routes = is_array($materialization['routes'] ?? null) ? $materialization['routes'] : array();
+        $pages = $this->documents($compiled['pages'] ?? null, false, $tokens, $routes);
+        $parts = $this->documents($compiled['template_parts'] ?? null, true, $tokens, $routes);
+        $templates = $this->templates($pages, $parts);
         $writes = array_merge($this->scaffoldWrites($assets, $templates, $parts), $this->assetWrites($assets, $tokens));
         $plan = array(
             'schema' => self::SCHEMA,
@@ -37,11 +38,13 @@ final class WordPressSitePlan
             'template_parts' => $parts,
             'assets' => $assets,
             'reference_tokens' => $tokens,
+            'reference_semantics' => array('static_browser_references' => 'declared_tokens_only', 'dynamic_script_references' => 'not_proven'),
             'writes' => $writes,
-            'routes' => $materialization['routes'] ?? null,
+            'operations' => $this->operations($pages),
+            'routes' => $routes,
             'navigation_links' => $materialization['navigation_links'] ?? null,
             'menus' => $materialization['menus'] ?? null,
-            'theme' => array('stylesheet' => 'style.css', 'theme_json' => 'theme.json', 'bootstrap' => $this->needsBootstrap($assets) ? 'functions.php' : null),
+            'theme' => array('stylesheet' => 'style.css', 'theme_json' => 'theme.json', 'bootstrap' => self::needsBootstrap($assets) ? 'functions.php' : null),
             'visual_repair' => $compiled['visual_repair'] ?? array(),
             'diagnostics' => $data['diagnostics'],
             'quality' => array('status' => $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks']),
@@ -56,7 +59,7 @@ final class WordPressSitePlan
         if ( self::SCHEMA !== ($plan['schema'] ?? null) ) {
             throw new InvalidArgumentException('WordPress site plan has an unsupported schema.');
         }
-        foreach ( array('source', 'pages', 'templates', 'template_parts', 'assets', 'reference_tokens', 'writes', 'routes', 'navigation_links', 'menus', 'theme', 'visual_repair', 'diagnostics', 'quality') as $key ) {
+        foreach ( array('source', 'pages', 'templates', 'template_parts', 'assets', 'reference_tokens', 'reference_semantics', 'writes', 'operations', 'routes', 'navigation_links', 'menus', 'theme', 'visual_repair', 'diagnostics', 'quality') as $key ) {
             if ( ! is_array($plan[$key] ?? null) ) {
                 throw new InvalidArgumentException(sprintf('WordPress site plan %s must be an array.', $key));
             }
@@ -72,11 +75,11 @@ final class WordPressSitePlan
                 throw new InvalidArgumentException('WordPress site plan asset is structurally invalid.');
             }
             self::unique($assetTargets, $asset['target_path'], 'asset target');
-            $assetTokens[$asset['target_path']] = $asset['token'];
+            $assetTokens[strtolower($asset['target_path'])] = $asset['token'];
         }
         $tokens = array();
         foreach ( $plan['reference_tokens'] as $reference ) {
-            if ( ! is_array($reference) || ! is_string($reference['token'] ?? null) || ! self::safePath($reference['target_path'] ?? null) || ! isset($assetTargets[$reference['target_path']]) || $assetTokens[$reference['target_path']] !== $reference['token'] || ! preg_match('/^asset-[a-f0-9]{16}$/', $reference['token']) ) {
+            if ( ! is_array($reference) || ! is_string($reference['token'] ?? null) || ! self::safePath($reference['source_path'] ?? null) || ! self::safePath($reference['target_path'] ?? null) || ! isset($assetTargets[strtolower($reference['target_path'])]) || $assetTokens[strtolower($reference['target_path'])] !== $reference['token'] || ! preg_match('/^asset-[a-f0-9]{16}$/', $reference['token']) ) {
                 throw new InvalidArgumentException('WordPress site plan has an invalid reference token declaration.');
             }
             self::unique($tokens, $reference['token'], 'reference token');
@@ -94,6 +97,7 @@ final class WordPressSitePlan
             self::assertDocument($page, 'page', false, $tokens);
             self::unique($pagePaths, $page['source_path'], 'page source');
         }
+        self::assertOperations($plan['operations'], $plan['pages']);
         $templateTargets = array();
         foreach ( $plan['templates'] as $template ) {
             if ( ! is_array($template) || ! is_string($template['slug'] ?? null) || ! self::safePath($template['target_path'] ?? null) || ! is_string($template['canonical_block_markup'] ?? null) || '' === trim($template['canonical_block_markup']) ) {
@@ -101,6 +105,7 @@ final class WordPressSitePlan
             }
             self::unique($templateTargets, $template['target_path'], 'template target');
             self::assertTokens($template['canonical_block_markup'], $tokens);
+            self::assertNoLocalBrowserReferences($template['canonical_block_markup']);
         }
         $writeTargets = array();
         $writesByTarget = array();
@@ -109,19 +114,23 @@ final class WordPressSitePlan
             self::unique($writeTargets, $write['target_path'], 'write target');
             $writesByTarget[$write['target_path']] = $write;
         }
-        foreach ( array('style.css', 'theme.json', 'templates/index.html') as $required ) {
-            if ( ! isset($writeTargets[$required]) ) {
-                throw new InvalidArgumentException(sprintf('WordPress site plan lacks required theme scaffold write %s.', $required));
+        self::assertScaffold($plan, $writesByTarget);
+        foreach ( $plan['templates'] as $template ) {
+            $write = $writesByTarget[$template['target_path']] ?? null;
+            if ( ! is_array($write) || 'theme_template' !== ($write['kind'] ?? null) || $write['payload']['data'] !== $template['canonical_block_markup'] ) {
+                throw new InvalidArgumentException('WordPress site plan template lacks its canonical write.');
             }
         }
-        foreach ( $templateTargets as $target => $_ ) {
-            if ( ! isset($writeTargets[$target]) ) {
-                throw new InvalidArgumentException('WordPress site plan template lacks a write.');
+        foreach ( $plan['template_parts'] as $part ) {
+            $target = 'parts/' . $part['slug'] . '.html';
+            $write = $writesByTarget[$target] ?? null;
+            if ( ! is_array($write) || 'theme_template_part' !== ($write['kind'] ?? null) || $write['payload']['data'] !== $part['canonical_block_markup'] ) {
+                throw new InvalidArgumentException('WordPress site plan template part lacks its canonical write.');
             }
-        }
-        foreach ( $partSlugs as $slug => $_ ) {
-            if ( ! isset($writeTargets['parts/' . $slug . '.html']) ) {
-                throw new InvalidArgumentException('WordPress site plan template part lacks a write.');
+            foreach ( $plan['templates'] as $template ) {
+                if ( ! str_contains($template['canonical_block_markup'], '"slug":"' . $part['slug'] . '"') ) {
+                    throw new InvalidArgumentException('WordPress site plan template does not reference its template part.');
+                }
             }
         }
         foreach ( $plan['assets'] as $asset ) {
@@ -139,7 +148,7 @@ final class WordPressSitePlan
     }
 
     /** @param mixed $documents @param array<int,array<string,string>> $tokens @return array<int,array<string,mixed>> */
-    private function documents(mixed $documents, bool $part, array $tokens): array
+    private function documents(mixed $documents, bool $part, array $tokens, array $routes): array
     {
         if ( ! is_array($documents) ) {
             throw new InvalidArgumentException('Compiled site documents must be an array.');
@@ -149,7 +158,8 @@ final class WordPressSitePlan
             if ( ! is_array($document) || ! self::safePath($document['source_path'] ?? null) || ! is_string($document['block_markup'] ?? null) || '' === trim($document['block_markup']) ) {
                 throw new InvalidArgumentException('Compiled site document lacks a safe identity or block markup.');
             }
-            $rows[] = array('source_path' => $document['source_path'], 'slug' => self::value($document, 'slug'), 'title' => self::value($document, 'title'), 'post_type' => self::value((array) ($document['metadata'] ?? array()), 'post_type', 'page'), 'parent_source_path' => self::value((array) ($document['metadata'] ?? array()), 'parent_source_path'), 'entrypoint' => ! empty($document['entrypoint']), 'area' => $part ? self::value($document, 'area', 'uncategorized') : null, 'canonical_block_markup' => $this->tokenize($document['block_markup'], $tokens), 'metadata' => is_array($document['metadata'] ?? null) ? $document['metadata'] : array(), 'provenance' => is_array($document['provenance'] ?? null) ? $document['provenance'] : array(), 'reconciliation_identity' => hash('sha256', $document['source_path'] . "\n" . $document['block_markup']));
+            $markup = $this->tokenize($document['block_markup'], $tokens, $document['source_path']);
+            $rows[] = array('source_path' => $document['source_path'], 'slug' => self::value($document, 'slug'), 'title' => self::value($document, 'title'), 'post_type' => self::value((array) ($document['metadata'] ?? array()), 'post_type', 'page'), 'parent_source_path' => self::value((array) ($document['metadata'] ?? array()), 'parent_source_path'), 'entrypoint' => ! empty($document['entrypoint']), 'area' => $part ? self::value($document, 'area', 'uncategorized') : null, 'canonical_block_markup' => $this->routeLinks($markup, $document['source_path'], $routes), 'metadata' => is_array($document['metadata'] ?? null) ? $document['metadata'] : array(), 'provenance' => is_array($document['provenance'] ?? null) ? $document['provenance'] : array(), 'reconciliation_identity' => hash('sha256', $document['source_path'] . "\n" . $document['block_markup']));
         }
         return $rows;
     }
@@ -174,15 +184,31 @@ final class WordPressSitePlan
     }
 
     /** @param array<int,array<string,mixed>> $assets @return array<int,array<string,string>> */
-    private function tokens(array $assets): array { return array_map(static fn(array $asset): array => array('token' => $asset['token'], 'target_path' => $asset['target_path']), $assets); }
+    private function tokens(array $assets): array { return array_map(static fn(array $asset): array => array('token' => $asset['token'], 'source_path' => $asset['source_path'], 'target_path' => $asset['target_path']), $assets); }
 
     /** @param array<int,array<string,mixed>> $pages @return array<int,array<string,string>> */
-    private function templates(array $pages): array
+    private function templates(array $pages, array $parts): array
     {
-        $templates = array(array('slug' => 'index', 'target_path' => 'templates/index.html', 'canonical_block_markup' => '<!-- wp:post-content /-->'));
-        if ( array() !== $pages ) $templates[] = array('slug' => 'page', 'target_path' => 'templates/page.html', 'canonical_block_markup' => '<!-- wp:post-content /-->');
-        foreach ( $pages as $page ) if ( ! empty($page['entrypoint']) ) { $templates[] = array('slug' => 'front-page', 'target_path' => 'templates/front-page.html', 'canonical_block_markup' => '<!-- wp:post-content /-->'); break; }
+        usort($parts, static function (array $left, array $right): int {
+            $priority = array('header' => 0, 'footer' => 2);
+            return (($priority[$left['area']] ?? 1) <=> ($priority[$right['area']] ?? 1)) ?: strcmp($left['slug'], $right['slug']);
+        });
+        $markup = '';
+        foreach ($parts as $part) $markup .= '<!-- wp:template-part {"slug":"' . $part['slug'] . '","area":"' . $part['area'] . '"} /-->' . "\n";
+        $markup .= '<!-- wp:post-content /-->' . "\n";
+        $templates = array(array('slug' => 'index', 'target_path' => 'templates/index.html', 'canonical_block_markup' => $markup));
+        if ( array() !== $pages ) $templates[] = array('slug' => 'page', 'target_path' => 'templates/page.html', 'canonical_block_markup' => $markup);
+        foreach ( $pages as $page ) if ( ! empty($page['entrypoint']) ) { $templates[] = array('slug' => 'front-page', 'target_path' => 'templates/front-page.html', 'canonical_block_markup' => $markup); break; }
         return $templates;
+    }
+
+    /** @param array<int,array<string,mixed>> $pages @return array<int,array<string,mixed>> */
+    private function operations(array $pages): array
+    {
+        foreach ($pages as $page) {
+            if (!empty($page['entrypoint'])) return array(array('kind' => 'site_reading', 'order' => 0, 'show_on_front' => 'page', 'front_page_source_path' => $page['source_path'], 'front_page_reconciliation_identity' => $page['reconciliation_identity']));
+        }
+        return array();
     }
 
     /** @param array<int,array<string,mixed>> $assets @param array<int,array<string,string>> $tokens @return array<int,array<string,mixed>> */
@@ -190,7 +216,7 @@ final class WordPressSitePlan
     {
         $writes = array();
         foreach ( $assets as $asset ) {
-            $content = is_string($asset['content'] ?? null) ? $this->tokenize($asset['content'], $tokens) : null;
+            $content = is_string($asset['content'] ?? null) ? $this->tokenize($asset['content'], $tokens, $asset['source_path']) : null;
             $data = is_string($asset['content_base64'] ?? null) ? $asset['content_base64'] : (is_string($content) ? (! empty($asset['binary']) || 1 !== preg_match('//u', $content) ? base64_encode($content) : $content) : null);
             if ( ! is_string($data) ) throw new InvalidArgumentException(sprintf('Compiled site asset %s lacks a materializable payload.', $asset['source_path']));
             $writes[] = array('kind' => 'theme_asset', 'source_path' => $asset['source_path'], 'target_path' => $asset['target_path'], 'payload' => array('encoding' => is_string($asset['content_base64'] ?? null) || ! empty($asset['binary']) || 1 !== preg_match('//u', $data) ? 'base64' : 'utf8', 'data' => $data));
@@ -202,16 +228,16 @@ final class WordPressSitePlan
     private function scaffoldWrites(array $assets, array $templates, array $parts): array
     {
         $writes = array($this->write('theme_scaffold', 'style.css', "/*\nTheme Name: Blocks Engine Site\nText Domain: blocks-engine-site\n*/\n"), $this->write('theme_scaffold', 'theme.json', "{\"version\":3,\"settings\":{},\"styles\":{}}\n"));
-        if ( $this->needsBootstrap($assets) ) $writes[] = $this->write('theme_bootstrap', 'functions.php', $this->bootstrap($assets));
+        if ( self::needsBootstrap($assets) ) $writes[] = $this->write('theme_bootstrap', 'functions.php', self::bootstrap($assets));
         foreach ( $templates as $template ) $writes[] = $this->write('theme_template', $template['target_path'], $template['canonical_block_markup']);
         foreach ( $parts as $part ) $writes[] = $this->write('theme_template_part', 'parts/' . $part['slug'] . '.html', $part['canonical_block_markup']);
         return $writes;
     }
 
     /** @param array<int,array<string,mixed>> $assets */
-    private function needsBootstrap(array $assets): bool { foreach ($assets as $asset) if (in_array($asset['kind'], array('css', 'js'), true)) return true; return false; }
+    private static function needsBootstrap(array $assets): bool { foreach ($assets as $asset) if (in_array($asset['kind'], array('css', 'js'), true)) return true; return false; }
     /** @param array<int,array<string,mixed>> $assets */
-    private function bootstrap(array $assets): string
+    private static function bootstrap(array $assets): string
     {
         $lines = array("<?php", "add_action( 'wp_enqueue_scripts', static function (): void {");
         foreach ($assets as $asset) {
@@ -225,25 +251,78 @@ final class WordPressSitePlan
     /** @return array<string,mixed> */
     private function write(string $kind, string $target, string $content): array { return array('kind' => $kind, 'source_path' => 'wordpress-site-plan/' . $target, 'target_path' => $target, 'payload' => array('encoding' => 'utf8', 'data' => $content)); }
     /** @param array<int,array<string,string>> $tokens */
-    private function tokenize(string $content, array $tokens): string
+    private function tokenize(string $content, array $tokens, string $origin = ''): string
     {
         foreach ($tokens as $reference) {
-            $source = preg_replace('/^assets\//', '', $reference['target_path']);
-            foreach (array($reference['target_path'], '../' . $source, './' . $source, $source) as $candidate) {
+            $source = $reference['source_path'];
+            $shortTarget = preg_replace('/^assets\//', '', $reference['target_path']);
+            $relative = self::relativePath($origin, $source);
+            foreach (array_unique(array($reference['target_path'], $source, $relative, './' . $relative, '../' . $shortTarget, './' . $shortTarget, $shortTarget)) as $candidate) {
                 // Do not rewrite an asset-looking substring inside another URL or path.
                 $content = preg_replace('~(?<![A-Za-z0-9_.\/-])' . preg_quote($candidate, '~') . '(?![A-Za-z0-9_.\/-])~', self::TOKEN_PREFIX . $reference['token'] . '}}', $content) ?? $content;
             }
         }
         return $content;
     }
+    private static function relativePath(string $origin, string $target): string
+    {
+        $from = '' === $origin ? array() : explode('/', dirname($origin));
+        if (array('.') === $from) $from = array();
+        $to = explode('/', $target);
+        while (array() !== $from && array() !== $to && $from[0] === $to[0]) { array_shift($from); array_shift($to); }
+        return str_repeat('../', count($from)) . implode('/', $to);
+    }
+    /** @param array<int,array<string,mixed>> $routes */
+    private function routeLinks(string $content, string $origin, array $routes): string
+    {
+        foreach ($routes as $route) {
+            if (!is_array($route) || !is_string($route['source_path'] ?? null) || !is_string($route['target_path'] ?? null)) continue;
+            foreach (array_unique(array($route['source_path'], self::relativePath($origin, $route['source_path']))) as $candidate) {
+                $content = preg_replace('~(?<![A-Za-z0-9_.\/-])' . preg_quote($candidate, '~') . '(?![A-Za-z0-9_.\/-])~', $route['target_path'], $content) ?? $content;
+            }
+        }
+        return $content;
+    }
+    /** @param array<string,mixed> $plan @param array<string,array<string,mixed>> $writes */
+    private static function assertScaffold(array $plan, array $writes): void
+    {
+        $style = $writes['style.css'] ?? null;
+        $themeJson = $writes['theme.json'] ?? null;
+        if (!is_array($style) || 'theme_scaffold' !== ($style['kind'] ?? null) || 'wordpress-site-plan/style.css' !== ($style['source_path'] ?? null) || !preg_match('/^\/\*\nTheme Name:\s+[^\n]+\nText Domain:\s+[a-z0-9-]+\n\*\/\n$/', (string) ($style['payload']['data'] ?? ''))) throw new InvalidArgumentException('WordPress site plan style.css scaffold is invalid.');
+        if (!is_array($themeJson) || 'theme_scaffold' !== ($themeJson['kind'] ?? null) || 'wordpress-site-plan/theme.json' !== ($themeJson['source_path'] ?? null)) throw new InvalidArgumentException('WordPress site plan theme.json scaffold is invalid.');
+        try { $theme = json_decode((string) $themeJson['payload']['data'], true, 512, JSON_THROW_ON_ERROR); } catch (\JsonException) { throw new InvalidArgumentException('WordPress site plan theme.json is not valid JSON.'); }
+        if (!is_array($theme) || 3 !== ($theme['version'] ?? null) || !is_array($theme['settings'] ?? null) || !is_array($theme['styles'] ?? null)) throw new InvalidArgumentException('WordPress site plan theme.json shape is unsupported.');
+        $bootstrap = $writes['functions.php'] ?? null;
+        if (self::needsBootstrap($plan['assets'])) {
+            if (!is_array($bootstrap) || 'theme_bootstrap' !== ($bootstrap['kind'] ?? null) || 'wordpress-site-plan/functions.php' !== ($bootstrap['source_path'] ?? null) || self::bootstrap($plan['assets']) !== ($bootstrap['payload']['data'] ?? null)) throw new InvalidArgumentException('WordPress site plan functions.php bootstrap is invalid.');
+        } elseif (null !== ($plan['theme']['bootstrap'] ?? null) || isset($bootstrap)) throw new InvalidArgumentException('WordPress site plan declares an unnecessary bootstrap.');
+    }
+    /** @param array<int,array<string,mixed>> $operations @param array<int,array<string,mixed>> $pages */
+    private static function assertOperations(array $operations, array $pages): void
+    {
+        $pagesBySource = array(); foreach ($pages as $page) $pagesBySource[$page['source_path']] = $page;
+        foreach ($operations as $index => $operation) {
+            if (!is_array($operation) || 'site_reading' !== ($operation['kind'] ?? null) || $index !== ($operation['order'] ?? null) || 'page' !== ($operation['show_on_front'] ?? null) || !is_string($operation['front_page_source_path'] ?? null) || !is_string($operation['front_page_reconciliation_identity'] ?? null)) throw new InvalidArgumentException('WordPress site plan operation is invalid.');
+            $page = $pagesBySource[$operation['front_page_source_path']] ?? null;
+            if (!is_array($page) || empty($page['entrypoint']) || $page['reconciliation_identity'] !== $operation['front_page_reconciliation_identity']) throw new InvalidArgumentException('WordPress site plan operation references an invalid front page.');
+        }
+    }
+    private static function assertNoLocalBrowserReferences(string $content): void
+    {
+        $patterns = array('/\b(?:src|href|srcset|poster|action)\s*=\s*["\']([^"\']+)["\']/i', '/["\'](?:url|src|href|srcset|poster|action)["\']\s*:\s*["\']([^"\']+)["\']/i', '/(?:url\(\s*["\']?|@import\s+(?:url\(\s*)?["\']?)([^\s\)"\';]+)/i');
+        foreach ($patterns as $pattern) if (preg_match_all($pattern, $content, $matches)) foreach ($matches[1] as $value) foreach (explode(',', (string) $value) as $candidate) {
+            $url = trim(preg_split('/\s+/', trim($candidate))[0] ?? '');
+            if ('' !== $url && !str_starts_with($url, self::TOKEN_PREFIX) && !preg_match('~^(?:[a-z][a-z0-9+.-]*:|//|/|#|\?)~i', $url)) throw new InvalidArgumentException(sprintf('WordPress site plan contains unresolved local browser reference %s.', $url));
+        }
+    }
     /** @param array<string,string> $tokens */
-    private static function assertDocument(mixed $document, string $kind, bool $part, array $tokens): void { if (!is_array($document) || !self::safePath($document['source_path'] ?? null) || !is_string($document['slug'] ?? null) || !is_string($document['title'] ?? null) || !is_string($document['post_type'] ?? null) || !is_string($document['parent_source_path'] ?? null) || !is_bool($document['entrypoint'] ?? null) || !is_string($document['canonical_block_markup'] ?? null) || '' === trim($document['canonical_block_markup']) || !is_array($document['metadata'] ?? null) || !is_array($document['provenance'] ?? null) || !is_string($document['reconciliation_identity'] ?? null) || ($part && (!is_string($document['area'] ?? null) || '' === $document['area'])) || (!$part && null !== ($document['area'] ?? null))) throw new InvalidArgumentException("WordPress site plan {$kind} is structurally invalid."); self::assertTokens($document['canonical_block_markup'], $tokens); }
+    private static function assertDocument(mixed $document, string $kind, bool $part, array $tokens): void { if (!is_array($document) || !self::safePath($document['source_path'] ?? null) || !is_string($document['slug'] ?? null) || !is_string($document['title'] ?? null) || !is_string($document['post_type'] ?? null) || !is_string($document['parent_source_path'] ?? null) || !is_bool($document['entrypoint'] ?? null) || !is_string($document['canonical_block_markup'] ?? null) || '' === trim($document['canonical_block_markup']) || !is_array($document['metadata'] ?? null) || !is_array($document['provenance'] ?? null) || !is_string($document['reconciliation_identity'] ?? null) || ($part && (!is_string($document['area'] ?? null) || '' === $document['area'])) || (!$part && null !== ($document['area'] ?? null))) throw new InvalidArgumentException("WordPress site plan {$kind} is structurally invalid."); self::assertTokens($document['canonical_block_markup'], $tokens); self::assertNoLocalBrowserReferences($document['canonical_block_markup']); }
     /** @param array<string,string> $tokens */
-    private static function assertWrite(mixed $write, array $tokens): void { if (!is_array($write) || !is_string($write['kind'] ?? null) || !self::safePath($write['source_path'] ?? null) || !self::safePath($write['target_path'] ?? null) || !is_array($write['payload'] ?? null) || !in_array($write['payload']['encoding'] ?? null, array('utf8','base64'), true) || !is_string($write['payload']['data'] ?? null)) throw new InvalidArgumentException('WordPress site plan write is structurally invalid.'); if ('base64' === $write['payload']['encoding'] && false === base64_decode($write['payload']['data'], true)) throw new InvalidArgumentException('WordPress site plan write has invalid base64 payload.'); if ('utf8' === $write['payload']['encoding']) self::assertTokens($write['payload']['data'], $tokens); }
+    private static function assertWrite(mixed $write, array $tokens): void { if (!is_array($write) || !is_string($write['kind'] ?? null) || !self::safePath($write['source_path'] ?? null) || !self::safePath($write['target_path'] ?? null) || !is_array($write['payload'] ?? null) || !in_array($write['payload']['encoding'] ?? null, array('utf8','base64'), true) || !is_string($write['payload']['data'] ?? null)) throw new InvalidArgumentException('WordPress site plan write is structurally invalid.'); if ('base64' === $write['payload']['encoding'] && false === base64_decode($write['payload']['data'], true)) throw new InvalidArgumentException('WordPress site plan write has invalid base64 payload.'); if ('utf8' === $write['payload']['encoding']) { self::assertTokens($write['payload']['data'], $tokens); self::assertNoLocalBrowserReferences($write['payload']['data']); } }
     /** @param array<string,string> $tokens */
     private static function assertTokens(string $content, array $tokens): void { if (preg_match_all('/\{\{wordpress-site-plan:asset:([^}]+)\}\}/', $content, $matches)) foreach ($matches[1] as $token) if (!isset($tokens[$token])) throw new InvalidArgumentException('WordPress site plan contains an undeclared reference token.'); }
     /** @param array<string,bool> $values */
-    private static function unique(array &$values, string $value, string $kind): void { if (isset($values[$value])) throw new InvalidArgumentException("WordPress site plan has colliding {$kind}s."); $values[$value] = true; }
+    private static function unique(array &$values, string $value, string $kind): void { $key = strtolower($value); if (isset($values[$key])) throw new InvalidArgumentException("WordPress site plan has colliding {$kind}s."); $values[$key] = true; }
     /** @param array<string,mixed> $source */
     private static function assertSource(array $source): void { if ('blocks-engine/php-transformer/compiled-site/v1' !== ($source['schema'] ?? null) || !is_string($source['source_hash'] ?? null) || !preg_match('/^[a-f0-9]{64}$/', $source['source_hash']) || !is_string($source['entry_path'] ?? null) || !is_array($source['provenance'] ?? null)) throw new InvalidArgumentException('WordPress site plan source identity is invalid.'); }
     /** @param array<int,mixed> $rows @param array<int,string> $fields @param array<int,string> $optional */

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -38,7 +38,7 @@ final class WordPressSitePlan
             'template_parts' => $parts,
             'assets' => $assets,
             'reference_tokens' => $tokens,
-            'reference_semantics' => array('static_browser_references' => 'declared_tokens_only', 'dynamic_script_references' => 'not_proven'),
+            'reference_semantics' => array('static_browser_references' => 'declared_tokens_only', 'dynamic_script_references' => 'not_proven', 'dynamic_client_assets' => array('status' => 'not_proven', 'materializer_may_reject' => true)),
             'writes' => $writes,
             'operations' => $this->operations($pages),
             'routes' => $routes,
@@ -65,6 +65,7 @@ final class WordPressSitePlan
             }
         }
         self::assertSource($plan['source']);
+        if ('declared_tokens_only' !== ($plan['reference_semantics']['static_browser_references'] ?? null) || 'not_proven' !== ($plan['reference_semantics']['dynamic_script_references'] ?? null) || !is_array($plan['reference_semantics']['dynamic_client_assets'] ?? null) || 'not_proven' !== ($plan['reference_semantics']['dynamic_client_assets']['status'] ?? null) || true !== ($plan['reference_semantics']['dynamic_client_assets']['materializer_may_reject'] ?? null)) throw new InvalidArgumentException('WordPress site plan reference capability semantics are invalid.');
         self::assertRows($plan['routes'], 'route', array('kind', 'source_path', 'target_path', 'target_slug', 'source_relation', 'order'));
         self::assertRows($plan['navigation_links'], 'navigation link', array('kind', 'source_path', 'source_relation', 'order'), array('target_path', 'target_slug'));
         self::assertRows($plan['menus'], 'menu', array('kind', 'source_path', 'target_slug', 'source_relation', 'order', 'items'));
@@ -127,10 +128,11 @@ final class WordPressSitePlan
             if ( ! is_array($write) || 'theme_template_part' !== ($write['kind'] ?? null) || $write['payload']['data'] !== $part['canonical_block_markup'] ) {
                 throw new InvalidArgumentException('WordPress site plan template part lacks its canonical write.');
             }
+            $boundTemplates = 'entry_shell' === ($part['placement']['kind'] ?? null) ? $part['placement']['template_slugs'] : array();
             foreach ( $plan['templates'] as $template ) {
-                if ( ! str_contains($template['canonical_block_markup'], '"slug":"' . $part['slug'] . '"') ) {
-                    throw new InvalidArgumentException('WordPress site plan template does not reference its template part.');
-                }
+                $references = substr_count($template['canonical_block_markup'], '"slug":"' . $part['slug'] . '"');
+                if (in_array($template['slug'], $boundTemplates, true) && 1 !== $references) throw new InvalidArgumentException('WordPress site plan template part binding is invalid.');
+                if (!in_array($template['slug'], $boundTemplates, true) && 0 !== $references) throw new InvalidArgumentException('WordPress site plan has an unproven template part binding.');
             }
         }
         foreach ( $plan['assets'] as $asset ) {
@@ -159,7 +161,7 @@ final class WordPressSitePlan
                 throw new InvalidArgumentException('Compiled site document lacks a safe identity or block markup.');
             }
             $markup = $this->tokenize($document['block_markup'], $tokens, $document['source_path']);
-            $rows[] = array('source_path' => $document['source_path'], 'slug' => self::value($document, 'slug'), 'title' => self::value($document, 'title'), 'post_type' => self::value((array) ($document['metadata'] ?? array()), 'post_type', 'page'), 'parent_source_path' => self::value((array) ($document['metadata'] ?? array()), 'parent_source_path'), 'entrypoint' => ! empty($document['entrypoint']), 'area' => $part ? self::value($document, 'area', 'uncategorized') : null, 'canonical_block_markup' => $this->routeLinks($markup, $document['source_path'], $routes), 'metadata' => is_array($document['metadata'] ?? null) ? $document['metadata'] : array(), 'provenance' => is_array($document['provenance'] ?? null) ? $document['provenance'] : array(), 'reconciliation_identity' => hash('sha256', $document['source_path'] . "\n" . $document['block_markup']));
+            $rows[] = array('source_path' => $document['source_path'], 'slug' => self::value($document, 'slug'), 'title' => self::value($document, 'title'), 'post_type' => self::value((array) ($document['metadata'] ?? array()), 'post_type', 'page'), 'parent_source_path' => self::value((array) ($document['metadata'] ?? array()), 'parent_source_path'), 'entrypoint' => ! empty($document['entrypoint']), 'area' => $part ? self::value($document, 'area', 'uncategorized') : null, 'placement' => $part && is_array($document['placement'] ?? null) ? $document['placement'] : ($part ? array('kind' => 'unbound') : null), 'canonical_block_markup' => $this->routeLinks($markup, $document['source_path'], $routes), 'metadata' => is_array($document['metadata'] ?? null) ? $document['metadata'] : array(), 'provenance' => is_array($document['provenance'] ?? null) ? $document['provenance'] : array(), 'reconciliation_identity' => hash('sha256', $document['source_path'] . "\n" . $document['block_markup']));
         }
         return $rows;
     }
@@ -189,16 +191,19 @@ final class WordPressSitePlan
     /** @param array<int,array<string,mixed>> $pages @return array<int,array<string,string>> */
     private function templates(array $pages, array $parts): array
     {
-        usort($parts, static function (array $left, array $right): int {
+        $bound = array_values(array_filter($parts, static fn(array $part): bool => in_array($part['placement']['kind'] ?? '', array('entry_shell'), true)));
+        usort($bound, static function (array $left, array $right): int {
             $priority = array('header' => 0, 'footer' => 2);
             return (($priority[$left['area']] ?? 1) <=> ($priority[$right['area']] ?? 1)) ?: strcmp($left['slug'], $right['slug']);
         });
-        $markup = '';
-        foreach ($parts as $part) $markup .= '<!-- wp:template-part {"slug":"' . $part['slug'] . '","area":"' . $part['area'] . '"} /-->' . "\n";
-        $markup .= '<!-- wp:post-content /-->' . "\n";
-        $templates = array(array('slug' => 'index', 'target_path' => 'templates/index.html', 'canonical_block_markup' => $markup));
-        if ( array() !== $pages ) $templates[] = array('slug' => 'page', 'target_path' => 'templates/page.html', 'canonical_block_markup' => $markup);
-        foreach ( $pages as $page ) if ( ! empty($page['entrypoint']) ) { $templates[] = array('slug' => 'front-page', 'target_path' => 'templates/front-page.html', 'canonical_block_markup' => $markup); break; }
+        $markup = static function (string $templateSlug) use ($bound): string {
+            $content = '';
+            foreach ($bound as $part) if (in_array($templateSlug, $part['placement']['template_slugs'] ?? array(), true)) $content .= '<!-- wp:template-part {"slug":"' . $part['slug'] . '","area":"' . $part['area'] . '"} /-->' . "\n";
+            return $content . '<!-- wp:post-content /-->' . "\n";
+        };
+        $templates = array(array('slug' => 'index', 'target_path' => 'templates/index.html', 'canonical_block_markup' => $markup('index')));
+        if ( array() !== $pages ) $templates[] = array('slug' => 'page', 'target_path' => 'templates/page.html', 'canonical_block_markup' => $markup('page'));
+        foreach ( $pages as $page ) if ( ! empty($page['entrypoint']) ) { $templates[] = array('slug' => 'front-page', 'target_path' => 'templates/front-page.html', 'canonical_block_markup' => $markup('front-page')); break; }
         return $templates;
     }
 
@@ -316,7 +321,7 @@ final class WordPressSitePlan
         }
     }
     /** @param array<string,string> $tokens */
-    private static function assertDocument(mixed $document, string $kind, bool $part, array $tokens): void { if (!is_array($document) || !self::safePath($document['source_path'] ?? null) || !is_string($document['slug'] ?? null) || !is_string($document['title'] ?? null) || !is_string($document['post_type'] ?? null) || !is_string($document['parent_source_path'] ?? null) || !is_bool($document['entrypoint'] ?? null) || !is_string($document['canonical_block_markup'] ?? null) || '' === trim($document['canonical_block_markup']) || !is_array($document['metadata'] ?? null) || !is_array($document['provenance'] ?? null) || !is_string($document['reconciliation_identity'] ?? null) || ($part && (!is_string($document['area'] ?? null) || '' === $document['area'])) || (!$part && null !== ($document['area'] ?? null))) throw new InvalidArgumentException("WordPress site plan {$kind} is structurally invalid."); self::assertTokens($document['canonical_block_markup'], $tokens); self::assertNoLocalBrowserReferences($document['canonical_block_markup']); }
+    private static function assertDocument(mixed $document, string $kind, bool $part, array $tokens): void { if(!is_array($document)||!self::safePath($document['source_path']??null)||!is_string($document['slug']??null)||!is_string($document['title']??null)||!is_string($document['post_type']??null)||!is_string($document['parent_source_path']??null)||!is_bool($document['entrypoint']??null)||!is_string($document['canonical_block_markup']??null)||''===trim($document['canonical_block_markup'])||!is_array($document['metadata']??null)||!is_array($document['provenance']??null)||!is_string($document['reconciliation_identity']??null)||($part&&(!is_string($document['area']??null)||''===$document['area']||!is_array($document['placement']??null)))||(!$part&&(null!==($document['area']??null)||null!==($document['placement']??null))))throw new InvalidArgumentException("WordPress site plan {$kind} is structurally invalid.");if($part&&'entry_shell'===($document['placement']['kind']??null)&&(!is_string($document['placement']['source_path']??null)||!is_array($document['placement']['template_slugs']??null)||array()=== $document['placement']['template_slugs']))throw new InvalidArgumentException('WordPress site plan template part placement is invalid.');self::assertTokens($document['canonical_block_markup'],$tokens);self::assertNoLocalBrowserReferences($document['canonical_block_markup']); }
     /** @param array<string,string> $tokens */
     private static function assertWrite(mixed $write, array $tokens): void { if (!is_array($write) || !is_string($write['kind'] ?? null) || !self::safePath($write['source_path'] ?? null) || !self::safePath($write['target_path'] ?? null) || !is_array($write['payload'] ?? null) || !in_array($write['payload']['encoding'] ?? null, array('utf8','base64'), true) || !is_string($write['payload']['data'] ?? null)) throw new InvalidArgumentException('WordPress site plan write is structurally invalid.'); if ('base64' === $write['payload']['encoding'] && false === base64_decode($write['payload']['data'], true)) throw new InvalidArgumentException('WordPress site plan write has invalid base64 payload.'); if ('utf8' === $write['payload']['encoding']) { self::assertTokens($write['payload']['data'], $tokens); self::assertNoLocalBrowserReferences($write['payload']['data']); } }
     /** @param array<string,string> $tokens */

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -6,51 +6,47 @@ namespace Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use InvalidArgumentException;
 
-/** The stable, self-contained handoff for materializing compiled artifacts. */
+/** A complete, destination-independent block-theme materialization contract. */
 final class WordPressSitePlan
 {
-    public const SCHEMA = 'blocks-engine/wordpress-site-plan/v1';
+    public const SCHEMA = 'blocks-engine/wordpress-site-plan/v2';
+    public const TOKEN_PREFIX = '{{wordpress-site-plan:asset:';
 
     /** @return array<string,mixed> */
     public function fromResult(TransformerResult|array $result): array
     {
         $data = $result instanceof TransformerResult ? $result->toArray() : $result;
         TransformerResult::assertCanonicalEnvelope($data);
-        $compiledSite = $data['source_reports']['compiled_site'] ?? null;
-        $materializationPlan = $data['source_reports']['materialization_plan'] ?? null;
-        if ( ! is_array($compiledSite) || ! is_array($materializationPlan) ) {
+        $compiled = $data['source_reports']['compiled_site'] ?? null;
+        $materialization = $data['source_reports']['materialization_plan'] ?? null;
+        if ( ! is_array($compiled) || ! is_array($materialization) ) {
             throw new InvalidArgumentException('WordPress site plan requires compiled-site and materialization-plan reports.');
         }
 
+        $assets = $this->assets($compiled['assets'] ?? null);
+        $tokens = $this->tokens($assets);
+        $pages = $this->documents($compiled['pages'] ?? null, false, $tokens);
+        $parts = $this->documents($compiled['template_parts'] ?? null, true, $tokens);
+        $templates = $this->templates($pages);
+        $writes = array_merge($this->scaffoldWrites($assets, $templates, $parts), $this->assetWrites($assets, $tokens));
         $plan = array(
             'schema' => self::SCHEMA,
-            'source' => array(
-                'schema' => $compiledSite['schema'] ?? null,
-                'source_hash' => $compiledSite['source_hash'] ?? null,
-                'entry_path' => $compiledSite['entry_path'] ?? null,
-                'provenance' => $data['provenance'],
-            ),
-            'pages' => $this->documents($compiledSite['pages'] ?? null, 'page'),
-            // ArtifactCompiler does not currently infer reusable full templates.
-            'templates' => array(),
-            'template_parts' => $this->documents($compiledSite['template_parts'] ?? null, 'template_part'),
-            'assets' => $this->assets($compiledSite['assets'] ?? null),
-            'writes' => $this->writes($compiledSite['assets'] ?? null),
-            'routes' => $materializationPlan['routes'] ?? null,
-            'navigation_links' => $materializationPlan['navigation_links'] ?? null,
-            'menus' => $materializationPlan['menus'] ?? null,
-            'asset_rewrite_candidates' => $materializationPlan['asset_rewrite_candidates'] ?? null,
-            'theme' => $materializationPlan['theme'] ?? null,
-            'visual_repair' => $compiledSite['visual_repair'] ?? array(),
+            'source' => array('schema' => $compiled['schema'] ?? null, 'source_hash' => $compiled['source_hash'] ?? null, 'entry_path' => $compiled['entry_path'] ?? null, 'provenance' => $data['provenance']),
+            'pages' => $pages,
+            'templates' => $templates,
+            'template_parts' => $parts,
+            'assets' => $assets,
+            'reference_tokens' => $tokens,
+            'writes' => $writes,
+            'routes' => $materialization['routes'] ?? null,
+            'navigation_links' => $materialization['navigation_links'] ?? null,
+            'menus' => $materialization['menus'] ?? null,
+            'theme' => array('stylesheet' => 'style.css', 'theme_json' => 'theme.json', 'bootstrap' => $this->needsBootstrap($assets) ? 'functions.php' : null),
+            'visual_repair' => $compiled['visual_repair'] ?? array(),
             'diagnostics' => $data['diagnostics'],
-            'quality' => array(
-                'status' => $data['status'],
-                'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)),
-                'fallbacks' => $data['fallbacks'],
-            ),
+            'quality' => array('status' => $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks']),
         );
         self::assertValid($plan);
-
         return $plan;
     }
 
@@ -60,243 +56,199 @@ final class WordPressSitePlan
         if ( self::SCHEMA !== ($plan['schema'] ?? null) ) {
             throw new InvalidArgumentException('WordPress site plan has an unsupported schema.');
         }
-        foreach ( array('source', 'pages', 'templates', 'template_parts', 'assets', 'writes', 'routes', 'navigation_links', 'menus', 'asset_rewrite_candidates', 'theme', 'visual_repair', 'diagnostics', 'quality') as $key ) {
+        foreach ( array('source', 'pages', 'templates', 'template_parts', 'assets', 'reference_tokens', 'writes', 'routes', 'navigation_links', 'menus', 'theme', 'visual_repair', 'diagnostics', 'quality') as $key ) {
             if ( ! is_array($plan[$key] ?? null) ) {
                 throw new InvalidArgumentException(sprintf('WordPress site plan %s must be an array.', $key));
             }
         }
         self::assertSource($plan['source']);
-        foreach ( $plan['pages'] as $page ) {
-            self::assertDocument($page, 'page', false);
-        }
-        foreach ( $plan['templates'] as $template ) {
-            self::assertDocument($template, 'template', false);
-        }
-        foreach ( $plan['template_parts'] as $part ) {
-            self::assertDocument($part, 'template part', true);
-        }
-        foreach ( $plan['assets'] as $asset ) {
-            self::assertAsset($asset);
-        }
-        foreach ( $plan['writes'] as $write ) {
-            self::assertWrite($write);
-        }
         self::assertRows($plan['routes'], 'route', array('kind', 'source_path', 'target_path', 'target_slug', 'source_relation', 'order'));
         self::assertRows($plan['navigation_links'], 'navigation link', array('kind', 'source_path', 'source_relation', 'order'), array('target_path', 'target_slug'));
         self::assertRows($plan['menus'], 'menu', array('kind', 'source_path', 'target_slug', 'source_relation', 'order', 'items'));
-        self::assertRows($plan['asset_rewrite_candidates'], 'asset rewrite candidate', array('scope', 'source_path', 'asset_path'));
-        self::assertTheme($plan['theme']);
-        self::assertQuality($plan['quality']);
+        $assetTargets = array();
+        $assetTokens = array();
+        foreach ( $plan['assets'] as $asset ) {
+            if ( ! is_array($asset) || ! self::safePath($asset['source_path'] ?? null) || ! self::safePath($asset['target_path'] ?? null) || ! is_string($asset['token'] ?? null) ) {
+                throw new InvalidArgumentException('WordPress site plan asset is structurally invalid.');
+            }
+            self::unique($assetTargets, $asset['target_path'], 'asset target');
+            $assetTokens[$asset['target_path']] = $asset['token'];
+        }
+        $tokens = array();
+        foreach ( $plan['reference_tokens'] as $reference ) {
+            if ( ! is_array($reference) || ! is_string($reference['token'] ?? null) || ! self::safePath($reference['target_path'] ?? null) || ! isset($assetTargets[$reference['target_path']]) || $assetTokens[$reference['target_path']] !== $reference['token'] || ! preg_match('/^asset-[a-f0-9]{16}$/', $reference['token']) ) {
+                throw new InvalidArgumentException('WordPress site plan has an invalid reference token declaration.');
+            }
+            self::unique($tokens, $reference['token'], 'reference token');
+        }
+        if ( count($tokens) !== count($assetTargets) ) {
+            throw new InvalidArgumentException('WordPress site plan must declare exactly one token for each asset.');
+        }
+        $partSlugs = array();
+        foreach ( $plan['template_parts'] as $part ) {
+            self::assertDocument($part, 'template part', true, $tokens);
+            self::unique($partSlugs, $part['slug'], 'template part slug');
+        }
+        $pagePaths = array();
+        foreach ( $plan['pages'] as $page ) {
+            self::assertDocument($page, 'page', false, $tokens);
+            self::unique($pagePaths, $page['source_path'], 'page source');
+        }
+        $templateTargets = array();
+        foreach ( $plan['templates'] as $template ) {
+            if ( ! is_array($template) || ! is_string($template['slug'] ?? null) || ! self::safePath($template['target_path'] ?? null) || ! is_string($template['canonical_block_markup'] ?? null) || '' === trim($template['canonical_block_markup']) ) {
+                throw new InvalidArgumentException('WordPress site plan template is structurally invalid.');
+            }
+            self::unique($templateTargets, $template['target_path'], 'template target');
+            self::assertTokens($template['canonical_block_markup'], $tokens);
+        }
+        $writeTargets = array();
+        $writesByTarget = array();
+        foreach ( $plan['writes'] as $write ) {
+            self::assertWrite($write, $tokens);
+            self::unique($writeTargets, $write['target_path'], 'write target');
+            $writesByTarget[$write['target_path']] = $write;
+        }
+        foreach ( array('style.css', 'theme.json', 'templates/index.html') as $required ) {
+            if ( ! isset($writeTargets[$required]) ) {
+                throw new InvalidArgumentException(sprintf('WordPress site plan lacks required theme scaffold write %s.', $required));
+            }
+        }
+        foreach ( $templateTargets as $target => $_ ) {
+            if ( ! isset($writeTargets[$target]) ) {
+                throw new InvalidArgumentException('WordPress site plan template lacks a write.');
+            }
+        }
+        foreach ( $partSlugs as $slug => $_ ) {
+            if ( ! isset($writeTargets['parts/' . $slug . '.html']) ) {
+                throw new InvalidArgumentException('WordPress site plan template part lacks a write.');
+            }
+        }
+        foreach ( $plan['assets'] as $asset ) {
+            $target = $asset['target_path'];
+            if ( ! isset($writesByTarget[$target]) || 'theme_asset' !== ($writesByTarget[$target]['kind'] ?? null) || $writesByTarget[$target]['source_path'] !== $asset['source_path'] ) {
+                throw new InvalidArgumentException('WordPress site plan asset lacks a write.');
+            }
+        }
+        if ( ! is_string($plan['theme']['stylesheet'] ?? null) || ! is_string($plan['theme']['theme_json'] ?? null) || (null !== ($plan['theme']['bootstrap'] ?? null) && ! is_string($plan['theme']['bootstrap'])) ) {
+            throw new InvalidArgumentException('WordPress site plan theme is structurally invalid.');
+        }
+        if ( ! is_string($plan['quality']['status'] ?? null) || ! is_array($plan['quality']['metrics'] ?? null) || ! is_array($plan['quality']['fallbacks'] ?? null) ) {
+            throw new InvalidArgumentException('WordPress site plan quality is structurally invalid.');
+        }
     }
 
-    /** @param mixed $documents @return array<int,array<string,mixed>> */
-    private function documents(mixed $documents, string $kind): array
+    /** @param mixed $documents @param array<int,array<string,string>> $tokens @return array<int,array<string,mixed>> */
+    private function documents(mixed $documents, bool $part, array $tokens): array
     {
         if ( ! is_array($documents) ) {
-            throw new InvalidArgumentException(sprintf('Compiled site %ss must be an array.', $kind));
+            throw new InvalidArgumentException('Compiled site documents must be an array.');
         }
-        $projected = array();
+        $rows = array();
         foreach ( $documents as $document ) {
-            if ( ! is_array($document) ) {
-                throw new InvalidArgumentException(sprintf('Compiled site %s must be an array.', $kind));
+            if ( ! is_array($document) || ! self::safePath($document['source_path'] ?? null) || ! is_string($document['block_markup'] ?? null) || '' === trim($document['block_markup']) ) {
+                throw new InvalidArgumentException('Compiled site document lacks a safe identity or block markup.');
             }
-            $projected[] = $this->document($document, 'template_part' === $kind);
+            $rows[] = array('source_path' => $document['source_path'], 'slug' => self::value($document, 'slug'), 'title' => self::value($document, 'title'), 'post_type' => self::value((array) ($document['metadata'] ?? array()), 'post_type', 'page'), 'parent_source_path' => self::value((array) ($document['metadata'] ?? array()), 'parent_source_path'), 'entrypoint' => ! empty($document['entrypoint']), 'area' => $part ? self::value($document, 'area', 'uncategorized') : null, 'canonical_block_markup' => $this->tokenize($document['block_markup'], $tokens), 'metadata' => is_array($document['metadata'] ?? null) ? $document['metadata'] : array(), 'provenance' => is_array($document['provenance'] ?? null) ? $document['provenance'] : array(), 'reconciliation_identity' => hash('sha256', $document['source_path'] . "\n" . $document['block_markup']));
         }
-        return $projected;
-    }
-
-    /** @param array<string,mixed> $document @return array<string,mixed> */
-    private function document(array $document, bool $templatePart): array
-    {
-        $sourcePath = $document['source_path'] ?? null;
-        $markup = $document['block_markup'] ?? null;
-        $metadata = $document['metadata'] ?? array();
-        $provenance = $document['provenance'] ?? array();
-        if ( ! self::safeTargetPath($sourcePath) || ! is_string($markup) || '' === trim($markup) || ! is_array($metadata) || ! is_array($provenance) ) {
-            throw new InvalidArgumentException(sprintf('Compiled site %s lacks a safe source identity, final block markup, or metadata.', $templatePart ? 'template part' : 'page'));
-        }
-        $area = $templatePart ? ($document['area'] ?? null) : null;
-        if ( $templatePart && (! is_string($area) || '' === $area) ) {
-            throw new InvalidArgumentException('Compiled site template part lacks an area.');
-        }
-        return array(
-            'source_path' => $sourcePath,
-            'slug' => self::stringValue($document, 'slug'),
-            'title' => self::stringValue($document, 'title'),
-            'post_type' => self::stringValue($metadata, 'post_type', 'page'),
-            'parent_source_path' => self::stringValue($metadata, 'parent_source_path'),
-            'entrypoint' => ! empty($document['entrypoint']),
-            'area' => $area,
-            'final_block_markup' => $markup,
-            'metadata' => $metadata,
-            'provenance' => $provenance,
-            'reconciliation_identity' => hash('sha256', $sourcePath . "\n" . $markup),
-        );
+        return $rows;
     }
 
     /** @param mixed $assets @return array<int,array<string,mixed>> */
     private function assets(mixed $assets): array
     {
-        if ( ! is_array($assets) ) {
-            throw new InvalidArgumentException('Compiled site assets must be an array.');
-        }
-        $projected = array();
+        if ( ! is_array($assets) ) throw new InvalidArgumentException('Compiled site assets must be an array.');
+        $rows = array();
         foreach ( $assets as $asset ) {
-            if ( ! is_array($asset) || ! self::safeTargetPath($asset['path'] ?? null) || ! self::safeTargetPath($asset['target_path'] ?? null) ) {
-                throw new InvalidArgumentException('Compiled site asset lacks safe source or target identity.');
-            }
-            $projected[] = array(
-                'source_path' => $asset['path'],
-                'target_path' => $asset['target_path'],
-                'source' => self::stringValue($asset, 'source'),
-                'kind' => self::stringValue($asset, 'kind'),
-                'role' => self::stringValue($asset, 'role'),
-                'intent' => self::stringValue($asset, 'intent'),
-                'mime_type' => self::stringValue($asset, 'mime_type'),
-                'media' => self::stringValue($asset, 'media'),
-                'hash' => self::stringValue($asset, 'hash'),
-                'load' => $this->load($asset),
-            );
+            if ( ! is_array($asset) || ! self::safePath($asset['path'] ?? null) ) throw new InvalidArgumentException('Compiled site asset lacks a safe source identity.');
+            // The compiler retains rejected source assets for diagnostics. They have no
+            // payload and therefore are not materializable theme artifacts.
+            if ( ! is_string($asset['content'] ?? null) && ! is_string($asset['content_base64'] ?? null) ) continue;
+            $compiledTarget = $asset['target_path'] ?? $asset['path'];
+            if ( ! self::safePath($compiledTarget) ) throw new InvalidArgumentException('Compiled site asset lacks a safe target identity.');
+            $target = 'assets/' . str_replace('\\', '/', $compiledTarget);
+            if ( ! self::safePath($target) ) throw new InvalidArgumentException('Compiled site asset lacks a safe target identity.');
+            $rows[] = array('source_path' => $asset['path'], 'target_path' => $target, 'token' => 'asset-' . substr(hash('sha256', $target), 0, 16), 'source' => self::value($asset, 'source'), 'kind' => self::value($asset, 'kind'), 'role' => self::value($asset, 'role'), 'intent' => self::value($asset, 'intent'), 'mime_type' => self::value($asset, 'mime_type'), 'media' => self::value($asset, 'media'), 'hash' => self::value($asset, 'hash'), 'content' => $asset['content'] ?? null, 'content_base64' => $asset['content_base64'] ?? null, 'binary' => ! empty($asset['binary']));
         }
-        return $projected;
+        return $rows;
     }
 
-    /** @param mixed $assets @return array<int,array<string,mixed>> */
-    private function writes(mixed $assets): array
+    /** @param array<int,array<string,mixed>> $assets @return array<int,array<string,string>> */
+    private function tokens(array $assets): array { return array_map(static fn(array $asset): array => array('token' => $asset['token'], 'target_path' => $asset['target_path']), $assets); }
+
+    /** @param array<int,array<string,mixed>> $pages @return array<int,array<string,string>> */
+    private function templates(array $pages): array
     {
-        if ( ! is_array($assets) ) {
-            throw new InvalidArgumentException('Compiled site assets must be an array.');
-        }
+        $templates = array(array('slug' => 'index', 'target_path' => 'templates/index.html', 'canonical_block_markup' => '<!-- wp:post-content /-->'));
+        if ( array() !== $pages ) $templates[] = array('slug' => 'page', 'target_path' => 'templates/page.html', 'canonical_block_markup' => '<!-- wp:post-content /-->');
+        foreach ( $pages as $page ) if ( ! empty($page['entrypoint']) ) { $templates[] = array('slug' => 'front-page', 'target_path' => 'templates/front-page.html', 'canonical_block_markup' => '<!-- wp:post-content /-->'); break; }
+        return $templates;
+    }
+
+    /** @param array<int,array<string,mixed>> $assets @param array<int,array<string,string>> $tokens @return array<int,array<string,mixed>> */
+    private function assetWrites(array $assets, array $tokens): array
+    {
         $writes = array();
         foreach ( $assets as $asset ) {
-            if ( ! is_array($asset) ) {
-                throw new InvalidArgumentException('Compiled site asset must be an array.');
-            }
-            $base64 = $asset['content_base64'] ?? null;
-            $content = $asset['content'] ?? null;
-            if ( is_string($base64) && '' !== $base64 ) {
-                $payload = array('encoding' => 'base64', 'data' => $base64);
-            } elseif ( is_string($content) ) {
-                $payload = array('encoding' => ! empty($asset['binary']) || 1 !== preg_match('//u', $content) ? 'base64' : 'utf8', 'data' => ! empty($asset['binary']) || 1 !== preg_match('//u', $content) ? base64_encode($content) : $content);
-            } else {
-                continue;
-            }
-            $writes[] = array(
-                'kind' => 'theme_asset',
-                'source_path' => $asset['path'] ?? null,
-                'target_path' => $asset['target_path'] ?? null,
-                'payload' => $payload,
-                'mime_type' => self::stringValue($asset, 'mime_type'),
-                'media' => self::stringValue($asset, 'media'),
-                'hash' => self::stringValue($asset, 'hash'),
-                'load' => $this->load($asset),
-            );
+            $content = is_string($asset['content'] ?? null) ? $this->tokenize($asset['content'], $tokens) : null;
+            $data = is_string($asset['content_base64'] ?? null) ? $asset['content_base64'] : (is_string($content) ? (! empty($asset['binary']) || 1 !== preg_match('//u', $content) ? base64_encode($content) : $content) : null);
+            if ( ! is_string($data) ) throw new InvalidArgumentException(sprintf('Compiled site asset %s lacks a materializable payload.', $asset['source_path']));
+            $writes[] = array('kind' => 'theme_asset', 'source_path' => $asset['source_path'], 'target_path' => $asset['target_path'], 'payload' => array('encoding' => is_string($asset['content_base64'] ?? null) || ! empty($asset['binary']) || 1 !== preg_match('//u', $data) ? 'base64' : 'utf8', 'data' => $data));
         }
         return $writes;
     }
 
-    /** @param array<string,mixed> $asset @return array<string,mixed> */
-    private function load(array $asset): array
+    /** @param array<int,array<string,mixed>> $assets @param array<int,array<string,string>> $templates @param array<int,array<string,mixed>> $parts @return array<int,array<string,mixed>> */
+    private function scaffoldWrites(array $assets, array $templates, array $parts): array
     {
-        return array('placement' => self::stringValue($asset, 'placement'), 'type' => self::stringValue($asset, 'type'), 'defer' => ! empty($asset['defer']), 'async' => ! empty($asset['async']));
+        $writes = array($this->write('theme_scaffold', 'style.css', "/*\nTheme Name: Blocks Engine Site\nText Domain: blocks-engine-site\n*/\n"), $this->write('theme_scaffold', 'theme.json', "{\"version\":3,\"settings\":{},\"styles\":{}}\n"));
+        if ( $this->needsBootstrap($assets) ) $writes[] = $this->write('theme_bootstrap', 'functions.php', $this->bootstrap($assets));
+        foreach ( $templates as $template ) $writes[] = $this->write('theme_template', $template['target_path'], $template['canonical_block_markup']);
+        foreach ( $parts as $part ) $writes[] = $this->write('theme_template_part', 'parts/' . $part['slug'] . '.html', $part['canonical_block_markup']);
+        return $writes;
     }
 
+    /** @param array<int,array<string,mixed>> $assets */
+    private function needsBootstrap(array $assets): bool { foreach ($assets as $asset) if (in_array($asset['kind'], array('css', 'js'), true)) return true; return false; }
+    /** @param array<int,array<string,mixed>> $assets */
+    private function bootstrap(array $assets): string
+    {
+        $lines = array("<?php", "add_action( 'wp_enqueue_scripts', static function (): void {");
+        foreach ($assets as $asset) {
+            $handle = 'blocks-engine-' . substr(hash('sha256', $asset['target_path']), 0, 12);
+            if ('css' === $asset['kind']) $lines[] = "    wp_enqueue_style( '{$handle}', get_theme_file_uri( '{$asset['target_path']}' ), array(), null );";
+            if ('js' === $asset['kind']) $lines[] = "    wp_enqueue_script( '{$handle}', get_theme_file_uri( '{$asset['target_path']}' ), array(), null, true );";
+        }
+        $lines[] = "} );";
+        return implode("\n", $lines) . "\n";
+    }
+    /** @return array<string,mixed> */
+    private function write(string $kind, string $target, string $content): array { return array('kind' => $kind, 'source_path' => 'wordpress-site-plan/' . $target, 'target_path' => $target, 'payload' => array('encoding' => 'utf8', 'data' => $content)); }
+    /** @param array<int,array<string,string>> $tokens */
+    private function tokenize(string $content, array $tokens): string
+    {
+        foreach ($tokens as $reference) {
+            $source = preg_replace('/^assets\//', '', $reference['target_path']);
+            foreach (array($reference['target_path'], '../' . $source, './' . $source, $source) as $candidate) {
+                // Do not rewrite an asset-looking substring inside another URL or path.
+                $content = preg_replace('~(?<![A-Za-z0-9_.\/-])' . preg_quote($candidate, '~') . '(?![A-Za-z0-9_.\/-])~', self::TOKEN_PREFIX . $reference['token'] . '}}', $content) ?? $content;
+            }
+        }
+        return $content;
+    }
+    /** @param array<string,string> $tokens */
+    private static function assertDocument(mixed $document, string $kind, bool $part, array $tokens): void { if (!is_array($document) || !self::safePath($document['source_path'] ?? null) || !is_string($document['slug'] ?? null) || !is_string($document['title'] ?? null) || !is_string($document['post_type'] ?? null) || !is_string($document['parent_source_path'] ?? null) || !is_bool($document['entrypoint'] ?? null) || !is_string($document['canonical_block_markup'] ?? null) || '' === trim($document['canonical_block_markup']) || !is_array($document['metadata'] ?? null) || !is_array($document['provenance'] ?? null) || !is_string($document['reconciliation_identity'] ?? null) || ($part && (!is_string($document['area'] ?? null) || '' === $document['area'])) || (!$part && null !== ($document['area'] ?? null))) throw new InvalidArgumentException("WordPress site plan {$kind} is structurally invalid."); self::assertTokens($document['canonical_block_markup'], $tokens); }
+    /** @param array<string,string> $tokens */
+    private static function assertWrite(mixed $write, array $tokens): void { if (!is_array($write) || !is_string($write['kind'] ?? null) || !self::safePath($write['source_path'] ?? null) || !self::safePath($write['target_path'] ?? null) || !is_array($write['payload'] ?? null) || !in_array($write['payload']['encoding'] ?? null, array('utf8','base64'), true) || !is_string($write['payload']['data'] ?? null)) throw new InvalidArgumentException('WordPress site plan write is structurally invalid.'); if ('base64' === $write['payload']['encoding'] && false === base64_decode($write['payload']['data'], true)) throw new InvalidArgumentException('WordPress site plan write has invalid base64 payload.'); if ('utf8' === $write['payload']['encoding']) self::assertTokens($write['payload']['data'], $tokens); }
+    /** @param array<string,string> $tokens */
+    private static function assertTokens(string $content, array $tokens): void { if (preg_match_all('/\{\{wordpress-site-plan:asset:([^}]+)\}\}/', $content, $matches)) foreach ($matches[1] as $token) if (!isset($tokens[$token])) throw new InvalidArgumentException('WordPress site plan contains an undeclared reference token.'); }
+    /** @param array<string,bool> $values */
+    private static function unique(array &$values, string $value, string $kind): void { if (isset($values[$value])) throw new InvalidArgumentException("WordPress site plan has colliding {$kind}s."); $values[$value] = true; }
     /** @param array<string,mixed> $source */
-    private static function assertSource(array $source): void
-    {
-        if ( 'blocks-engine/php-transformer/compiled-site/v1' !== ($source['schema'] ?? null) || ! is_string($source['source_hash'] ?? null) || ! preg_match('/^[a-f0-9]{64}$/', $source['source_hash']) || ! is_string($source['entry_path'] ?? null) || ('' !== $source['entry_path'] && ! self::safeTargetPath($source['entry_path'])) || ! is_array($source['provenance'] ?? null) ) {
-            throw new InvalidArgumentException('WordPress site plan source identity is invalid.');
-        }
-    }
-
-    private static function assertDocument(mixed $document, string $kind, bool $templatePart): void
-    {
-        if ( ! is_array($document) || ! self::safeTargetPath($document['source_path'] ?? null) || ! is_string($document['slug'] ?? null) || ! is_string($document['title'] ?? null) || ! is_string($document['post_type'] ?? null) || ! is_string($document['parent_source_path'] ?? null) || ! is_bool($document['entrypoint'] ?? null) || ! is_string($document['final_block_markup'] ?? null) || '' === trim($document['final_block_markup']) || ! is_array($document['metadata'] ?? null) || ! is_array($document['provenance'] ?? null) || ! is_string($document['reconciliation_identity'] ?? null) || ! preg_match('/^[a-f0-9]{64}$/', $document['reconciliation_identity']) || ($templatePart && (! is_string($document['area'] ?? null) || '' === $document['area'])) || (! $templatePart && null !== ($document['area'] ?? null)) ) {
-            throw new InvalidArgumentException(sprintf('WordPress site plan %s is structurally invalid.', $kind));
-        }
-    }
-
-    private static function assertAsset(mixed $asset): void
-    {
-        if ( ! is_array($asset) || ! self::safeTargetPath($asset['source_path'] ?? null) || ! self::safeTargetPath($asset['target_path'] ?? null) || ! is_string($asset['source'] ?? null) || ! is_string($asset['kind'] ?? null) || ! is_string($asset['role'] ?? null) || ! is_string($asset['intent'] ?? null) || ! is_string($asset['mime_type'] ?? null) || ! is_string($asset['media'] ?? null) || ! is_string($asset['hash'] ?? null) || ! is_array($asset['load'] ?? null) ) {
-            throw new InvalidArgumentException('WordPress site plan asset is structurally invalid.');
-        }
-        self::assertLoad($asset['load']);
-    }
-
-    private static function assertWrite(mixed $write): void
-    {
-        if ( ! is_array($write) || 'theme_asset' !== ($write['kind'] ?? null) || ! self::safeTargetPath($write['source_path'] ?? null) || ! self::safeTargetPath($write['target_path'] ?? null) || ! is_array($write['payload'] ?? null) || ! is_string($write['mime_type'] ?? null) || ! is_string($write['media'] ?? null) || ! is_string($write['hash'] ?? null) || ! is_array($write['load'] ?? null) ) {
-            throw new InvalidArgumentException('WordPress site plan has a structurally invalid write.');
-        }
-        $encoding = $write['payload']['encoding'] ?? null;
-        $data = $write['payload']['data'] ?? null;
-        if ( ! in_array($encoding, array('utf8', 'base64'), true) || ! is_string($data) || ('base64' === $encoding && ('' === $data || false === base64_decode($data, true))) ) {
-            throw new InvalidArgumentException('WordPress site plan write has an invalid payload encoding.');
-        }
-        self::assertLoad($write['load']);
-    }
-
-    /** @param array<int,mixed> $rows @param array<int,string> $fields @param array<int,string> $optionalFields */
-    private static function assertRows(array $rows, string $kind, array $fields, array $optionalFields = array()): void
-    {
-        foreach ( $rows as $row ) {
-            if ( ! is_array($row) ) {
-                throw new InvalidArgumentException(sprintf('WordPress site plan %s must be an array.', $kind));
-            }
-            foreach ( $fields as $field ) {
-                if ( ! array_key_exists($field, $row) || ! is_string($row[$field]) && ! is_int($row[$field]) ) {
-                    throw new InvalidArgumentException(sprintf('WordPress site plan %s lacks %s.', $kind, $field));
-                }
-            }
-            foreach ( $optionalFields as $field ) {
-                if ( array_key_exists($field, $row) && ! is_string($row[$field]) ) {
-                    throw new InvalidArgumentException(sprintf('WordPress site plan %s has an invalid %s.', $kind, $field));
-                }
-            }
-        }
-    }
-
-    private static function assertTheme(array $theme): void
-    {
-        foreach ( array('stylesheets', 'scripts', 'fonts', 'images', 'template_parts') as $key ) {
-            if ( isset($theme[$key]) && ! is_array($theme[$key]) ) {
-                throw new InvalidArgumentException(sprintf('WordPress site plan theme %s must be an array.', $key));
-            }
-        }
-    }
-
-    private static function assertQuality(array $quality): void
-    {
-        if ( ! is_string($quality['status'] ?? null) || ! is_array($quality['metrics'] ?? null) || ! is_array($quality['fallbacks'] ?? null) ) {
-            throw new InvalidArgumentException('WordPress site plan quality is structurally invalid.');
-        }
-    }
-
-    /** @param array<string,mixed> $load */
-    private static function assertLoad(array $load): void
-    {
-        if ( ! is_string($load['placement'] ?? null) || ! is_string($load['type'] ?? null) || ! is_bool($load['defer'] ?? null) || ! is_bool($load['async'] ?? null) ) {
-            throw new InvalidArgumentException('WordPress site plan load metadata is structurally invalid.');
-        }
-    }
-
+    private static function assertSource(array $source): void { if ('blocks-engine/php-transformer/compiled-site/v1' !== ($source['schema'] ?? null) || !is_string($source['source_hash'] ?? null) || !preg_match('/^[a-f0-9]{64}$/', $source['source_hash']) || !is_string($source['entry_path'] ?? null) || !is_array($source['provenance'] ?? null)) throw new InvalidArgumentException('WordPress site plan source identity is invalid.'); }
+    /** @param array<int,mixed> $rows @param array<int,string> $fields @param array<int,string> $optional */
+    private static function assertRows(array $rows, string $kind, array $fields, array $optional = array()): void { foreach ($rows as $row) { if (!is_array($row)) throw new InvalidArgumentException("WordPress site plan {$kind} must be an array."); foreach ($fields as $field) if (!array_key_exists($field, $row) || (!is_string($row[$field]) && !is_int($row[$field]))) throw new InvalidArgumentException("WordPress site plan {$kind} lacks {$field}."); foreach ($optional as $field) if (array_key_exists($field, $row) && !is_string($row[$field])) throw new InvalidArgumentException("WordPress site plan {$kind} has invalid {$field}."); } }
     /** @param array<string,mixed> $data */
-    private static function stringValue(array $data, string $key, string $default = ''): string
-    {
-        return is_string($data[$key] ?? null) ? $data[$key] : $default;
-    }
-
-    private static function safeTargetPath(mixed $path): bool
-    {
-        if ( ! is_string($path) || '' === $path || str_contains($path, "\0") || str_starts_with($path, '/') || str_starts_with($path, '\\') || preg_match('/^[A-Za-z]:/', $path) ) {
-            return false;
-        }
-        foreach ( explode('/', str_replace('\\', '/', $path)) as $segment ) {
-            if ( '' === $segment || '.' === $segment || '..' === $segment ) {
-                return false;
-            }
-        }
-        return true;
-    }
+    private static function value(array $data, string $key, string $default = ''): string { return is_string($data[$key] ?? null) ? $data[$key] : $default; }
+    private static function safePath(mixed $path): bool { if (!is_string($path) || '' === $path || str_contains($path, "\0") || str_starts_with($path, '/') || str_starts_with($path, '\\') || preg_match('/^[A-Za-z]:/', $path)) return false; foreach (explode('/', str_replace('\\', '/', $path)) as $segment) if ('' === $segment || '.' === $segment || '..' === $segment) return false; return true; }
 }

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan;
+
+use InvalidArgumentException;
+
+/** Resolves declared asset tokens using explicit runtime destination context. */
+final class WordPressSitePlanResolver
+{
+    /** @param array<string,mixed> $plan @param array<string,mixed> $context @return array<string,mixed> */
+    public function resolve(array $plan, array $context): array
+    {
+        WordPressSitePlan::assertValid($plan);
+        $themeUri = $context['theme_uri'] ?? null;
+        if (!is_string($themeUri) || !filter_var($themeUri, FILTER_VALIDATE_URL) || !in_array(parse_url($themeUri, PHP_URL_SCHEME), array('http', 'https'), true)) {
+            throw new InvalidArgumentException('WordPress site plan resolution requires an absolute http(s) theme_uri.');
+        }
+        $themeUri = rtrim($themeUri, '/');
+        $references = array();
+        foreach ($plan['reference_tokens'] as $reference) $references['{{wordpress-site-plan:asset:' . $reference['token'] . '}}'] = $themeUri . '/' . $reference['target_path'];
+        foreach ($plan['pages'] as &$page) $page['resolved_block_markup'] = self::replace($page['canonical_block_markup'], $references);
+        unset($page);
+        foreach ($plan['template_parts'] as &$part) $part['resolved_block_markup'] = self::replace($part['canonical_block_markup'], $references);
+        unset($part);
+        foreach ($plan['templates'] as &$template) $template['resolved_block_markup'] = self::replace($template['canonical_block_markup'], $references);
+        unset($template);
+        foreach ($plan['writes'] as &$write) if ('utf8' === $write['payload']['encoding']) $write['payload']['data'] = self::replace($write['payload']['data'], $references);
+        unset($write);
+        $plan['resolution'] = array('theme_uri' => $themeUri);
+        return $plan;
+    }
+
+    /** @param array<string,string> $references */
+    private static function replace(string $content, array $references): string
+    {
+        $resolved = strtr($content, $references);
+        if (str_contains($resolved, WordPressSitePlan::TOKEN_PREFIX)) throw new InvalidArgumentException('WordPress site plan contains unresolved reference tokens.');
+        return $resolved;
+    }
+}

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
@@ -12,6 +12,7 @@ final class WordPressSitePlanResolver
     public function resolve(array $plan, array $context): array
     {
         WordPressSitePlan::assertValid($plan);
+        if (true === ($context['require_proven_dynamic_client_assets'] ?? false) && 'not_proven' === ($plan['reference_semantics']['dynamic_client_assets']['status'] ?? null)) throw new InvalidArgumentException('WordPress site plan cannot prove dynamic client asset references.');
         $themeUri = self::themeUri($context['theme_uri'] ?? null);
         $references = array();
         foreach ($plan['reference_tokens'] as $reference) $references['{{wordpress-site-plan:asset:' . $reference['token'] . '}}'] = $themeUri . '/' . $reference['target_path'];

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlanResolver.php
@@ -12,11 +12,7 @@ final class WordPressSitePlanResolver
     public function resolve(array $plan, array $context): array
     {
         WordPressSitePlan::assertValid($plan);
-        $themeUri = $context['theme_uri'] ?? null;
-        if (!is_string($themeUri) || !filter_var($themeUri, FILTER_VALIDATE_URL) || !in_array(parse_url($themeUri, PHP_URL_SCHEME), array('http', 'https'), true)) {
-            throw new InvalidArgumentException('WordPress site plan resolution requires an absolute http(s) theme_uri.');
-        }
-        $themeUri = rtrim($themeUri, '/');
+        $themeUri = self::themeUri($context['theme_uri'] ?? null);
         $references = array();
         foreach ($plan['reference_tokens'] as $reference) $references['{{wordpress-site-plan:asset:' . $reference['token'] . '}}'] = $themeUri . '/' . $reference['target_path'];
         foreach ($plan['pages'] as &$page) $page['resolved_block_markup'] = self::replace($page['canonical_block_markup'], $references);
@@ -37,5 +33,16 @@ final class WordPressSitePlanResolver
         $resolved = strtr($content, $references);
         if (str_contains($resolved, WordPressSitePlan::TOKEN_PREFIX)) throw new InvalidArgumentException('WordPress site plan contains unresolved reference tokens.');
         return $resolved;
+    }
+
+    private static function themeUri(mixed $value): string
+    {
+        if (!is_string($value) || '' === $value || preg_match('/[\x00-\x20\x7f]/', $value) || false === ($parts = parse_url($value))) throw new InvalidArgumentException('WordPress site plan resolution requires a valid theme_uri.');
+        if (isset($parts['user']) || isset($parts['pass']) || isset($parts['query']) || isset($parts['fragment']) || !isset($parts['scheme'], $parts['host']) || !in_array(strtolower($parts['scheme']), array('http', 'https'), true) || '' === $parts['host']) throw new InvalidArgumentException('WordPress site plan resolution requires an absolute http(s) theme_uri without credentials, query, or fragment.');
+        if (isset($parts['port']) && (!is_int($parts['port']) || $parts['port'] < 1 || $parts['port'] > 65535)) throw new InvalidArgumentException('WordPress site plan resolution theme_uri has an invalid port.');
+        $path = $parts['path'] ?? '';
+        if (!is_string($path) || ('' !== $path && !str_starts_with($path, '/')) || str_contains($path, '\\') || preg_match('~(?:^|/)(?:\.|\.\.)(?:/|$)|%2f|%5c|%2e~i', $path)) throw new InvalidArgumentException('WordPress site plan resolution theme_uri has an ambiguous path.');
+        $authority = strtolower($parts['host']) . (isset($parts['port']) ? ':' . $parts['port'] : '');
+        return strtolower($parts['scheme']) . '://' . $authority . rtrim($path, '/');
     }
 }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2050,8 +2050,8 @@ $canonicalShellCompiled = $canonicalShellSite['source_reports']['compiled_site']
 $canonicalShellPlan = $canonicalShellSite['source_reports']['materialization_plan'] ?? array();
 $canonicalHeaderPart = array_values(array_filter($canonicalShellCompiled['template_parts'] ?? array(), static fn (array $part): bool => 'header' === ($part['area'] ?? '')))[0] ?? array();
 $canonicalFooterPart = array_values(array_filter($canonicalShellCompiled['template_parts'] ?? array(), static fn (array $part): bool => 'footer' === ($part['area'] ?? '')))[0] ?? array();
-preg_match('/blocks-engine-control-[a-f0-9]+-\d+/', (string) ($canonicalShellSite['serialized_blocks'] ?? ''), $canonicalDocumentControlMarker);
-$assert('' !== ($canonicalDocumentControlMarker[0] ?? '') && str_contains((string) ($canonicalHeaderPart['block_markup'] ?? ''), $canonicalDocumentControlMarker[0]), 'canonical entry header part reuses the full-document control identity without fragment retransformation');
+$canonicalEntryPage = array_values(array_filter($canonicalShellCompiled['pages'] ?? array(), static fn (array $page): bool => 'index.html' === ($page['source_path'] ?? '')))[0] ?? array();
+$assert(! str_contains((string) ($canonicalEntryPage['block_markup'] ?? ''), 'Get started') && str_contains((string) ($canonicalHeaderPart['block_markup'] ?? ''), 'Get started'), 'canonical entry header is projected only to its shell part, without duplicate post-content chrome');
 $assert(str_contains((string) ($canonicalFooterPart['block_markup'] ?? ''), 'Global footer'), 'canonical entry footer part preserves global footer content');
 $assert(2 === count($canonicalShellPlan['template_part_writes'] ?? array()), 'materialization plan exposes canonical entry header and footer writes');
 

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -14,9 +14,10 @@ $writeMap = static function (array $writes): array { $map = array(); foreach ($w
 $artifact = array(
     'entrypoint' => 'index.html',
     'files' => array(
-        'index.html' => '<main><img src="assets/logo.svg"><h1>Home</h1></main>',
+        'index.html' => '<main><img src="assets/logo.svg" srcset="assets/logo.svg 1x, assets/logo.svg 2x"><h1>Home</h1></main>',
         'about.html' => '<main><img src="assets/logo.svg"><h1>About</h1></main>',
         'parts/header.html' => '<header><img src="assets/logo.svg"><p>Header</p></header>',
+        'parts/footer.html' => '<footer><p>Footer</p></footer>',
         'assets/site.css' => '@font-face{font-family:test;src:url(assets/font.woff2)}main{background:url("assets/logo.svg")}',
         'assets/site.js' => 'window.siteAsset="assets/logo.svg";',
         'assets/logo.svg' => '<svg xmlns="http://www.w3.org/2000/svg"/>',
@@ -29,8 +30,11 @@ $plan = $first['source_reports']['wordpress_site_plan'] ?? array();
 $writes = $writeMap($plan['writes']);
 
 $assert(WordPressSitePlan::SCHEMA === ($plan['schema'] ?? null), 'Compiler projects the v2 canonical WordPress site plan.');
-$assert(isset($writes['style.css'], $writes['theme.json'], $writes['functions.php'], $writes['templates/index.html'], $writes['templates/page.html'], $writes['templates/front-page.html'], $writes['parts/header.html']), 'Plan declares the complete block-theme scaffold.');
+$assert(isset($writes['style.css'], $writes['theme.json'], $writes['functions.php'], $writes['templates/index.html'], $writes['templates/page.html'], $writes['templates/front-page.html'], $writes['parts/header.html'], $writes['parts/footer.html']), 'Plan declares the complete block-theme scaffold.');
 $assert(str_contains((string) $writes['style.css']['payload']['data'], 'Theme Name:'), 'Theme stylesheet has a recognition header.');
+$assert(3 === (json_decode((string) $writes['theme.json']['payload']['data'], true)['version'] ?? null), 'Theme configuration is parseable and supported.');
+$assert(str_contains((string) $writes['templates/index.html']['payload']['data'], '"slug":"header"') && str_contains((string) $writes['templates/index.html']['payload']['data'], '"slug":"footer"'), 'Templates reference ordered header and footer parts.');
+$assert('site_reading' === ($plan['operations'][0]['kind'] ?? null) && 'index.html' === ($plan['operations'][0]['front_page_source_path'] ?? null), 'Plan declares deterministic front-page desired state.');
 $assert(str_contains((string) ($plan['pages'][1]['canonical_block_markup'] ?? ''), '{{wordpress-site-plan:asset:'), 'Canonical page markup uses declared destination-independent references.');
 $assert(!isset($plan['pages'][1]['resolved_block_markup']), 'Canonical markup is explicitly distinct from resolved markup.');
 $assert(count($plan['reference_tokens']) === count($plan['assets']), 'Every asset has one deterministic resolver token.');
@@ -52,17 +56,28 @@ foreach ($resolved['writes'] as $write) {
     if (!is_dir(dirname($path))) mkdir(dirname($path), 0777, true);
     file_put_contents($path, 'base64' === $write['payload']['encoding'] ? base64_decode($write['payload']['data'], true) : $write['payload']['data']);
 }
-foreach (array('style.css', 'theme.json', 'functions.php', 'templates/index.html', 'templates/page.html', 'templates/front-page.html', 'parts/header.html', 'assets/assets/site.css', 'assets/assets/site.js', 'assets/assets/logo.svg', 'assets/assets/font.woff2') as $required) $assert(is_file($destination . '/' . $required), "Materialization writes {$required}.");
+foreach (array('style.css', 'theme.json', 'functions.php', 'templates/index.html', 'templates/page.html', 'templates/front-page.html', 'parts/header.html', 'parts/footer.html', 'assets/assets/site.css', 'assets/assets/site.js', 'assets/assets/logo.svg', 'assets/assets/font.woff2') as $required) $assert(is_file($destination . '/' . $required), "Materialization writes {$required}.");
 $assert(false === str_contains((string) file_get_contents($destination . '/assets/assets/site.css'), WordPressSitePlan::TOKEN_PREFIX), 'Materialized assets contain no unresolved resolver tokens.');
+$runtime = array('pages' => array(), 'front_page' => null);
+foreach ($resolved['pages'] as $page) $runtime['pages'][$page['reconciliation_identity']] = $page;
+foreach ($resolved['operations'] as $operation) if ('site_reading' === $operation['kind']) $runtime['front_page'] = $runtime['pages'][$operation['front_page_reconciliation_identity']] ?? null;
+$assert('index.html' === ($runtime['front_page']['source_path'] ?? null), 'Operations apply verbatim to the deterministic runtime harness.');
 
 $throws(static fn() => $resolver->resolve($plan, array()), 'Resolution rejects missing destination context.');
 $throws(static fn() => $resolver->resolve($plan, array('theme_uri' => '/themes/site')), 'Resolution rejects relative destination context.');
+foreach (array('https://example.test/theme?x=1', 'https://example.test/theme#x', 'https://user@example.test/theme', 'ftp://example.test/theme', 'https:///theme', 'https://example.test/a/../theme', "https://example.test/theme\n") as $uri) $throws(static fn() => $resolver->resolve($plan, array('theme_uri' => $uri)), 'Resolution rejects ambiguous runtime context.');
 $undeclared = $plan; $undeclared['pages'][0]['canonical_block_markup'] .= '{{wordpress-site-plan:asset:asset-0000000000000000}}';
 $throws(static fn() => WordPressSitePlan::assertValid($undeclared), 'Validation rejects undeclared tokens.');
 $traversal = $plan; $traversal['writes'][0]['target_path'] = '../escape.css';
 $throws(static fn() => WordPressSitePlan::assertValid($traversal), 'Validation rejects traversal writes.');
 $collision = $plan; $collision['writes'][1]['target_path'] = $collision['writes'][0]['target_path'];
 $throws(static fn() => WordPressSitePlan::assertValid($collision), 'Validation rejects colliding writes.');
+$caseCollision = $plan; $caseCollision['writes'][1]['target_path'] = 'STYLE.css';
+$throws(static fn() => WordPressSitePlan::assertValid($caseCollision), 'Validation rejects case-folded collisions.');
+$invalidScaffold = $plan; $invalidScaffold['writes'][0]['kind'] = 'theme_asset';
+$throws(static fn() => WordPressSitePlan::assertValid($invalidScaffold), 'Validation rejects malformed scaffold writes.');
+$unresolvedLocal = $plan; $unresolvedLocal['pages'][0]['canonical_block_markup'] .= '<img src="images/missing.svg">';
+$throws(static fn() => WordPressSitePlan::assertValid($unresolvedLocal), 'Validation rejects unresolved local browser references.');
 $invalidCompiledAsset = $first; $invalidCompiledAsset['source_reports']['compiled_site']['assets'][0]['target_path'] = 'C:\\theme\\site.css';
 $throws(static fn() => (new WordPressSitePlan())->fromResult($invalidCompiledAsset), 'Projection rejects unsafe compiled asset targets.');
 

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -14,10 +14,9 @@ $writeMap = static function (array $writes): array { $map = array(); foreach ($w
 $artifact = array(
     'entrypoint' => 'index.html',
     'files' => array(
-        'index.html' => '<main><img src="assets/logo.svg" srcset="assets/logo.svg 1x, assets/logo.svg 2x"><h1>Home</h1></main>',
-        'about.html' => '<main><img src="assets/logo.svg"><h1>About</h1></main>',
-        'parts/header.html' => '<header><img src="assets/logo.svg"><p>Header</p></header>',
-        'parts/footer.html' => '<footer><p>Footer</p></footer>',
+        'index.html' => '<header><p>Entry Header</p></header><main><img src="assets/logo.svg" srcset="assets/logo.svg 1x, assets/logo.svg 2x"><h1>Home</h1></main><footer><p>Entry Footer</p></footer>',
+        'about.html' => '<header><p>About Chrome</p></header><main><img src="assets/logo.svg"><h1>About</h1></main>',
+        'parts/sidebar.html' => '<aside><p>Unbound Sidebar</p></aside>',
         'assets/site.css' => '@font-face{font-family:test;src:url(assets/font.woff2)}main{background:url("assets/logo.svg")}',
         'assets/site.js' => 'window.siteAsset="assets/logo.svg";',
         'assets/logo.svg' => '<svg xmlns="http://www.w3.org/2000/svg"/>',
@@ -27,24 +26,29 @@ $artifact = array(
 $first = (new ArtifactCompiler())->compile($artifact)->toArray();
 $second = (new ArtifactCompiler())->compile($artifact)->toArray();
 $plan = $first['source_reports']['wordpress_site_plan'] ?? array();
+$assert(array() !== $plan, 'Compiler emits a complete site plan: ' . json_encode(array($first['source_reports']['wordpress_site_plan_diagnostics'] ?? array(), $first['source_reports']['compiled_site']['template_parts'] ?? array())));
 $writes = $writeMap($plan['writes']);
 
 $assert(WordPressSitePlan::SCHEMA === ($plan['schema'] ?? null), 'Compiler projects the v2 canonical WordPress site plan.');
-$assert(isset($writes['style.css'], $writes['theme.json'], $writes['functions.php'], $writes['templates/index.html'], $writes['templates/page.html'], $writes['templates/front-page.html'], $writes['parts/header.html'], $writes['parts/footer.html']), 'Plan declares the complete block-theme scaffold.');
+$assert(isset($writes['style.css'], $writes['theme.json'], $writes['functions.php'], $writes['templates/index.html'], $writes['templates/page.html'], $writes['templates/front-page.html'], $writes['parts/header.html'], $writes['parts/footer.html'], $writes['parts/sidebar.html']), 'Plan declares the complete block-theme scaffold.');
 $assert(str_contains((string) $writes['style.css']['payload']['data'], 'Theme Name:'), 'Theme stylesheet has a recognition header.');
 $assert(3 === (json_decode((string) $writes['theme.json']['payload']['data'], true)['version'] ?? null), 'Theme configuration is parseable and supported.');
-$assert(str_contains((string) $writes['templates/index.html']['payload']['data'], '"slug":"header"') && str_contains((string) $writes['templates/index.html']['payload']['data'], '"slug":"footer"'), 'Templates reference ordered header and footer parts.');
+$assert(str_contains((string) $writes['templates/front-page.html']['payload']['data'], '"slug":"header"') && str_contains((string) $writes['templates/front-page.html']['payload']['data'], '"slug":"footer"'), 'Front-page template references extracted header and footer parts.');
+$assert(!str_contains((string) $writes['templates/page.html']['payload']['data'], '"slug":"header"') && !str_contains((string) $writes['templates/front-page.html']['payload']['data'], '"slug":"sidebar"'), 'Templates do not bind unproven or unbound parts.');
+$pagesBySource = array(); foreach ($plan['pages'] as $page) $pagesBySource[$page['source_path']] = $page;
+$assert(!str_contains((string) ($pagesBySource['index.html']['canonical_block_markup'] ?? ''), 'Entry Header') && str_contains((string) ($pagesBySource['about.html']['canonical_block_markup'] ?? ''), 'About Chrome'), 'Only extracted entry shell content is removed from page markup: ' . json_encode($pagesBySource));
 $assert('site_reading' === ($plan['operations'][0]['kind'] ?? null) && 'index.html' === ($plan['operations'][0]['front_page_source_path'] ?? null), 'Plan declares deterministic front-page desired state.');
-$assert(str_contains((string) ($plan['pages'][1]['canonical_block_markup'] ?? ''), '{{wordpress-site-plan:asset:'), 'Canonical page markup uses declared destination-independent references.');
-$assert(!isset($plan['pages'][1]['resolved_block_markup']), 'Canonical markup is explicitly distinct from resolved markup.');
+$assert(str_contains((string) ($plan['pages'][0]['canonical_block_markup'] ?? ''), '{{wordpress-site-plan:asset:'), 'Canonical page markup uses declared destination-independent references.');
+$assert(!isset($plan['pages'][0]['resolved_block_markup']), 'Canonical markup is explicitly distinct from resolved markup.');
 $assert(count($plan['reference_tokens']) === count($plan['assets']), 'Every asset has one deterministic resolver token.');
+$assert(true === ($plan['reference_semantics']['dynamic_client_assets']['materializer_may_reject'] ?? null), 'Plan exposes dynamic client asset capability limits.');
 $assert($plan === ($second['source_reports']['wordpress_site_plan'] ?? null), 'Canonical WordPress site plans are deterministic.');
 
 $resolver = new WordPressSitePlanResolver();
 $resolved = $resolver->resolve($plan, array('theme_uri' => 'https://example.test/wp-content/themes/site'));
 $resolvedAgain = $resolver->resolve($plan, array('theme_uri' => 'https://example.test/wp-content/themes/site/'));
 $assert($resolved === $resolvedAgain, 'Resolution is deterministic after theme URI normalization.');
-$about = (string) $resolved['pages'][1]['resolved_block_markup'];
+$about = (string) $resolved['pages'][0]['resolved_block_markup'];
 $assert(str_contains($about, 'https://example.test/wp-content/themes/site/assets/assets/logo.svg'), 'Nested page markup resolves declared assets to the explicit theme URI.');
 $resolvedWrites = $writeMap($resolved['writes']);
 $assert(str_contains((string) $resolvedWrites['assets/assets/site.css']['payload']['data'], 'https://example.test/wp-content/themes/site/assets/assets/logo.svg'), 'Stylesheet references resolve through the same declared token.');
@@ -56,7 +60,7 @@ foreach ($resolved['writes'] as $write) {
     if (!is_dir(dirname($path))) mkdir(dirname($path), 0777, true);
     file_put_contents($path, 'base64' === $write['payload']['encoding'] ? base64_decode($write['payload']['data'], true) : $write['payload']['data']);
 }
-foreach (array('style.css', 'theme.json', 'functions.php', 'templates/index.html', 'templates/page.html', 'templates/front-page.html', 'parts/header.html', 'parts/footer.html', 'assets/assets/site.css', 'assets/assets/site.js', 'assets/assets/logo.svg', 'assets/assets/font.woff2') as $required) $assert(is_file($destination . '/' . $required), "Materialization writes {$required}.");
+foreach (array('style.css', 'theme.json', 'functions.php', 'templates/index.html', 'templates/page.html', 'templates/front-page.html', 'parts/header.html', 'parts/footer.html', 'parts/sidebar.html', 'assets/assets/site.css', 'assets/assets/site.js', 'assets/assets/logo.svg', 'assets/assets/font.woff2') as $required) $assert(is_file($destination . '/' . $required), "Materialization writes {$required}.");
 $assert(false === str_contains((string) file_get_contents($destination . '/assets/assets/site.css'), WordPressSitePlan::TOKEN_PREFIX), 'Materialized assets contain no unresolved resolver tokens.');
 $runtime = array('pages' => array(), 'front_page' => null);
 foreach ($resolved['pages'] as $page) $runtime['pages'][$page['reconciliation_identity']] = $page;
@@ -65,6 +69,7 @@ $assert('index.html' === ($runtime['front_page']['source_path'] ?? null), 'Opera
 
 $throws(static fn() => $resolver->resolve($plan, array()), 'Resolution rejects missing destination context.');
 $throws(static fn() => $resolver->resolve($plan, array('theme_uri' => '/themes/site')), 'Resolution rejects relative destination context.');
+$throws(static fn() => $resolver->resolve($plan, array('theme_uri' => 'https://example.test/theme', 'require_proven_dynamic_client_assets' => true)), 'Materializers can reject unproven dynamic client assets.');
 foreach (array('https://example.test/theme?x=1', 'https://example.test/theme#x', 'https://user@example.test/theme', 'ftp://example.test/theme', 'https:///theme', 'https://example.test/a/../theme', "https://example.test/theme\n") as $uri) $throws(static fn() => $resolver->resolve($plan, array('theme_uri' => $uri)), 'Resolution rejects ambiguous runtime context.');
 $undeclared = $plan; $undeclared['pages'][0]['canonical_block_markup'] .= '{{wordpress-site-plan:asset:asset-0000000000000000}}';
 $throws(static fn() => WordPressSitePlan::assertValid($undeclared), 'Validation rejects undeclared tokens.');

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -5,77 +5,67 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
 
-$assert = static function (bool $condition, string $message): void {
-    if ( ! $condition ) {
-        throw new RuntimeException($message);
-    }
-};
-$throws = static function (callable $callback, string $message) use ($assert): void {
-    try {
-        $callback();
-    } catch (\InvalidArgumentException) {
-        return;
-    }
-    $assert(false, $message);
-};
+$assert = static function (bool $condition, string $message): void { if (! $condition) throw new RuntimeException($message); };
+$throws = static function (callable $callback, string $message) use ($assert): void { try { $callback(); } catch (InvalidArgumentException) { return; } $assert(false, $message); };
+$writeMap = static function (array $writes): array { $map = array(); foreach ($writes as $write) $map[$write['target_path']] = $write; return $map; };
 
 $artifact = array(
     'entrypoint' => 'index.html',
     'files' => array(
-        'index.html' => '<main><h1>Home</h1></main>',
-        'about.html' => '<main><h1>About</h1></main>',
-        'parts/header.html' => '<header><p>Header</p></header>',
-        'assets/site.css' => 'main{color:#123}',
-        'visual-repair.css' => '.wp-site-blocks{min-height:100vh}',
+        'index.html' => '<main><img src="assets/logo.svg"><h1>Home</h1></main>',
+        'about.html' => '<main><img src="assets/logo.svg"><h1>About</h1></main>',
+        'parts/header.html' => '<header><img src="assets/logo.svg"><p>Header</p></header>',
+        'assets/site.css' => '@font-face{font-family:test;src:url(assets/font.woff2)}main{background:url("assets/logo.svg")}',
+        'assets/site.js' => 'window.siteAsset="assets/logo.svg";',
+        'assets/logo.svg' => '<svg xmlns="http://www.w3.org/2000/svg"/>',
+        'assets/font.woff2' => 'font-data',
     ),
 );
-$first = ( new ArtifactCompiler() )->compile($artifact)->toArray();
-$second = ( new ArtifactCompiler() )->compile($artifact)->toArray();
+$first = (new ArtifactCompiler())->compile($artifact)->toArray();
+$second = (new ArtifactCompiler())->compile($artifact)->toArray();
 $plan = $first['source_reports']['wordpress_site_plan'] ?? array();
+$writes = $writeMap($plan['writes']);
 
-$assert(WordPressSitePlan::SCHEMA === ($plan['schema'] ?? null), 'Compiler projects the canonical WordPress site plan.');
-$assert(str_contains((string) ($plan['pages'][0]['final_block_markup'] ?? ''), '<!-- wp:heading'), 'Pages carry final block markup.');
-$assert('parts/header.html' === ($plan['template_parts'][0]['source_path'] ?? null), 'Template parts are projected.');
-$assert('assets/site.css' === ($plan['writes'][0]['target_path'] ?? null), 'Theme asset writes retain their safe target paths.');
-$assert('utf8' === ($plan['writes'][0]['payload']['encoding'] ?? null), 'Theme asset writes include payload encoding.');
-$assert('/' === ($plan['routes'][0]['target_path'] ?? null) && '/about' === ($plan['routes'][1]['target_path'] ?? null), 'Plan retains route target identities.');
-$assert('page' === ($plan['pages'][0]['post_type'] ?? null) && true === ($plan['pages'][0]['entrypoint'] ?? false), 'Plan retains page materialization metadata.');
-$assert('header' === ($plan['template_parts'][0]['area'] ?? null), 'Plan retains template part area.');
-$assert('assets/site.css' === ($plan['assets'][0]['source_path'] ?? null) && 'assets/site.css' === ($plan['assets'][0]['target_path'] ?? null), 'Plan retains canonical asset source and target identities.');
-$assert(str_contains((string) ($plan['visual_repair']['css'] ?? ''), 'min-height:100vh'), 'Plan retains visual repair data.');
+$assert(WordPressSitePlan::SCHEMA === ($plan['schema'] ?? null), 'Compiler projects the v2 canonical WordPress site plan.');
+$assert(isset($writes['style.css'], $writes['theme.json'], $writes['functions.php'], $writes['templates/index.html'], $writes['templates/page.html'], $writes['templates/front-page.html'], $writes['parts/header.html']), 'Plan declares the complete block-theme scaffold.');
+$assert(str_contains((string) $writes['style.css']['payload']['data'], 'Theme Name:'), 'Theme stylesheet has a recognition header.');
+$assert(str_contains((string) ($plan['pages'][1]['canonical_block_markup'] ?? ''), '{{wordpress-site-plan:asset:'), 'Canonical page markup uses declared destination-independent references.');
+$assert(!isset($plan['pages'][1]['resolved_block_markup']), 'Canonical markup is explicitly distinct from resolved markup.');
+$assert(count($plan['reference_tokens']) === count($plan['assets']), 'Every asset has one deterministic resolver token.');
 $assert($plan === ($second['source_reports']['wordpress_site_plan'] ?? null), 'Canonical WordPress site plans are deterministic.');
-$assert($first['serialized_blocks'] === $second['serialized_blocks'], 'Projection does not change existing compilation output.');
 
-$malformedSchema = $plan;
-$malformedSchema['schema'] = 'blocks-engine/wordpress-site-plan/v0';
-$throws(static fn () => WordPressSitePlan::assertValid($malformedSchema), 'Validation rejects unsupported schemas.');
-$missingMarkup = $plan;
-$missingMarkup['pages'][0]['final_block_markup'] = '';
-$throws(static fn () => WordPressSitePlan::assertValid($missingMarkup), 'Validation rejects pages without final block markup.');
-$invalidCompiledPage = $first;
-$invalidCompiledPage['source_reports']['compiled_site']['pages'][0]['block_markup'] = '';
-$throws(static fn () => ( new WordPressSitePlan() )->fromResult($invalidCompiledPage), 'Projection rejects compiled pages without final block markup.');
-$invalidCompiledPart = $first;
-$invalidCompiledPart['source_reports']['compiled_site']['template_parts'][0]['source_path'] = '';
-$throws(static fn () => ( new WordPressSitePlan() )->fromResult($invalidCompiledPart), 'Projection rejects template parts without source identity.');
-$unsafePath = $plan;
-$unsafePath['writes'][0]['target_path'] = '../escape.css';
-$throws(static fn () => WordPressSitePlan::assertValid($unsafePath), 'Validation rejects root-escaping write paths.');
-$windowsPath = $plan;
-$windowsPath['writes'][0]['target_path'] = 'C:\\theme\\site.css';
-$throws(static fn () => WordPressSitePlan::assertValid($windowsPath), 'Validation rejects Windows drive write paths.');
-$uncPath = $plan;
-$uncPath['writes'][0]['target_path'] = '\\\\server\\share\\site.css';
-$throws(static fn () => WordPressSitePlan::assertValid($uncPath), 'Validation rejects UNC write paths.');
-$invalidCompiledAsset = $first;
-$invalidCompiledAsset['source_reports']['compiled_site']['assets'][0]['target_path'] = 'C:\\theme\\site.css';
-$throws(static fn () => ( new WordPressSitePlan() )->fromResult($invalidCompiledAsset), 'Projection rejects Windows asset target paths.');
-$invalidEncoding = $plan;
-$invalidEncoding['writes'][0]['payload']['encoding'] = 'rot13';
-$throws(static fn () => WordPressSitePlan::assertValid($invalidEncoding), 'Validation rejects unsupported payload encodings.');
-$invalidWrite = $plan;
-unset($invalidWrite['writes'][0]['payload']);
-$throws(static fn () => WordPressSitePlan::assertValid($invalidWrite), 'Validation rejects structurally invalid writes.');
+$resolver = new WordPressSitePlanResolver();
+$resolved = $resolver->resolve($plan, array('theme_uri' => 'https://example.test/wp-content/themes/site'));
+$resolvedAgain = $resolver->resolve($plan, array('theme_uri' => 'https://example.test/wp-content/themes/site/'));
+$assert($resolved === $resolvedAgain, 'Resolution is deterministic after theme URI normalization.');
+$about = (string) $resolved['pages'][1]['resolved_block_markup'];
+$assert(str_contains($about, 'https://example.test/wp-content/themes/site/assets/assets/logo.svg'), 'Nested page markup resolves declared assets to the explicit theme URI.');
+$resolvedWrites = $writeMap($resolved['writes']);
+$assert(str_contains((string) $resolvedWrites['assets/assets/site.css']['payload']['data'], 'https://example.test/wp-content/themes/site/assets/assets/logo.svg'), 'Stylesheet references resolve through the same declared token.');
+$assert(str_contains((string) $resolvedWrites['assets/assets/site.js']['payload']['data'], 'https://example.test/wp-content/themes/site/assets/assets/logo.svg'), 'Script metadata references resolve through the same declared token.');
 
+$destination = sys_get_temp_dir() . '/blocks-engine-site-plan-' . bin2hex(random_bytes(6));
+foreach ($resolved['writes'] as $write) {
+    $path = $destination . '/' . $write['target_path'];
+    if (!is_dir(dirname($path))) mkdir(dirname($path), 0777, true);
+    file_put_contents($path, 'base64' === $write['payload']['encoding'] ? base64_decode($write['payload']['data'], true) : $write['payload']['data']);
+}
+foreach (array('style.css', 'theme.json', 'functions.php', 'templates/index.html', 'templates/page.html', 'templates/front-page.html', 'parts/header.html', 'assets/assets/site.css', 'assets/assets/site.js', 'assets/assets/logo.svg', 'assets/assets/font.woff2') as $required) $assert(is_file($destination . '/' . $required), "Materialization writes {$required}.");
+$assert(false === str_contains((string) file_get_contents($destination . '/assets/assets/site.css'), WordPressSitePlan::TOKEN_PREFIX), 'Materialized assets contain no unresolved resolver tokens.');
+
+$throws(static fn() => $resolver->resolve($plan, array()), 'Resolution rejects missing destination context.');
+$throws(static fn() => $resolver->resolve($plan, array('theme_uri' => '/themes/site')), 'Resolution rejects relative destination context.');
+$undeclared = $plan; $undeclared['pages'][0]['canonical_block_markup'] .= '{{wordpress-site-plan:asset:asset-0000000000000000}}';
+$throws(static fn() => WordPressSitePlan::assertValid($undeclared), 'Validation rejects undeclared tokens.');
+$traversal = $plan; $traversal['writes'][0]['target_path'] = '../escape.css';
+$throws(static fn() => WordPressSitePlan::assertValid($traversal), 'Validation rejects traversal writes.');
+$collision = $plan; $collision['writes'][1]['target_path'] = $collision['writes'][0]['target_path'];
+$throws(static fn() => WordPressSitePlan::assertValid($collision), 'Validation rejects colliding writes.');
+$invalidCompiledAsset = $first; $invalidCompiledAsset['source_reports']['compiled_site']['assets'][0]['target_path'] = 'C:\\theme\\site.css';
+$throws(static fn() => (new WordPressSitePlan())->fromResult($invalidCompiledAsset), 'Projection rejects unsafe compiled asset targets.');
+
+foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($destination, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST) as $item) $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+rmdir($destination);
 fwrite(STDOUT, "wordpress-site-plan contract passed\n");

--- a/php-transformer/tests/integration/wordpress-site-plan.php
+++ b/php-transformer/tests/integration/wordpress-site-plan.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 // WP_TESTS_DIR=/path/to/wordpress-tests-lib composer test:wordpress-integration
 $testsDir = getenv('WP_TESTS_DIR');
 if (!is_string($testsDir) || !is_file($testsDir . '/includes/bootstrap.php')) {
+    if ('1' === getenv('REQUIRE_WP_TESTS')) {
+        fwrite(STDERR, "WP_TESTS_DIR must point to a WordPress test-suite installation.\n");
+        exit(1);
+    }
     fwrite(STDOUT, "wordpress-site-plan WordPress integration skipped: WP_TESTS_DIR is unavailable.\n");
     exit(0);
 }
@@ -16,10 +20,15 @@ use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
 
 $assert = static function (bool $condition, string $message): void { if (!$condition) throw new RuntimeException($message); };
-$theme = 'blocks-engine-site-plan-contract';
+$theme = 'blocks-engine-site-plan-contract-' . substr(hash('sha256', __FILE__), 0, 8);
 $themeDir = WP_CONTENT_DIR . '/themes/' . $theme;
+$previousTheme = get_stylesheet();
+$previousTemplate = get_template();
+$previousShowOnFront = get_option('show_on_front');
+$previousPageOnFront = get_option('page_on_front');
+$pageIds = array();
+try {
 if (!is_dir($themeDir) && !mkdir($themeDir, 0777, true) && !is_dir($themeDir)) throw new RuntimeException('Could not create integration theme directory.');
-
 $result = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array(
     'index.html' => '<header><p>Integration Header</p></header><main><img src="assets/logo.svg"><h1>Home</h1></main><footer><p>Integration Footer</p></footer>',
     'assets/logo.svg' => '<svg xmlns="http://www.w3.org/2000/svg"/>',
@@ -28,19 +37,28 @@ $plan = $result['source_reports']['wordpress_site_plan'] ?? array();
 $resolved = (new WordPressSitePlanResolver())->resolve($plan, array('theme_uri' => home_url('/wp-content/themes/' . $theme)));
 foreach ($resolved['writes'] as $write) {
     $path = $themeDir . '/' . $write['target_path'];
-    if (!is_dir(dirname($path))) mkdir(dirname($path), 0777, true);
-    file_put_contents($path, 'base64' === $write['payload']['encoding'] ? base64_decode($write['payload']['data'], true) : $write['payload']['data']);
+    if (!is_dir(dirname($path)) && !mkdir(dirname($path), 0777, true) && !is_dir(dirname($path))) throw new RuntimeException('Could not create theme write directory.');
+    if (false === file_put_contents($path, 'base64' === $write['payload']['encoding'] ? base64_decode($write['payload']['data'], true) : $write['payload']['data'])) throw new RuntimeException('Could not write materialized theme file.');
 }
 wp_clean_themes_cache();
 $wpTheme = wp_get_theme($theme);
 $assert($wpTheme->exists(), 'WordPress recognizes the materialized block theme.');
 switch_theme($theme);
-$pageIds = array();
-foreach ($resolved['pages'] as $page) $pageIds[$page['reconciliation_identity']] = wp_insert_post(array('post_type' => 'page', 'post_status' => 'publish', 'post_title' => $page['title'], 'post_name' => $page['slug'], 'post_content' => $page['resolved_block_markup']), true);
+foreach ($resolved['pages'] as $page) { $id = wp_insert_post(array('post_type' => 'page', 'post_status' => 'publish', 'post_title' => $page['title'], 'post_name' => $page['slug'], 'post_content' => $page['resolved_block_markup']), true); if (is_wp_error($id)) throw new RuntimeException($id->get_error_message()); $pageIds[$page['reconciliation_identity']] = $id; }
 foreach ($resolved['operations'] as $operation) if ('site_reading' === $operation['kind']) { update_option('show_on_front', $operation['show_on_front']); update_option('page_on_front', $pageIds[$operation['front_page_reconciliation_identity']]); }
 $assert('page' === get_option('show_on_front') && $pageIds[$resolved['operations'][0]['front_page_reconciliation_identity']] === (int) get_option('page_on_front'), 'WordPress applied the front-page operation.');
-$front = file_get_contents($themeDir . '/templates/front-page.html');
-$assert(str_contains($front, '"slug":"header"') && str_contains($front, '"slug":"footer"'), 'WordPress theme template contains bound shell part references.');
-$content = get_post_field('post_content', (int) get_option('page_on_front'));
-$assert(str_contains($content, home_url('/wp-content/themes/' . $theme . '/assets/assets/logo.svg')), 'Materialized page content uses the resolved theme asset URL.');
+$front = file_get_contents($themeDir . '/templates/front-page.html'); if (false === $front) throw new RuntimeException('Could not read front-page template.');
+$post = get_post((int) get_option('page_on_front')); if (!$post) throw new RuntimeException('Could not load front page.');
+global $wp_query; $wp_query->is_front_page = true; $wp_query->is_page = true; $wp_query->post = $post; $wp_query->posts = array($post); setup_postdata($post);
+$rendered = do_blocks($front); wp_reset_postdata();
+$assert(1 === substr_count($rendered, 'Integration Header') && 1 === substr_count($rendered, 'Integration Footer'), 'WordPress renders each bound template part exactly once.');
+$assert(str_contains($rendered, 'Home') && str_contains($rendered, home_url('/wp-content/themes/' . $theme . '/assets/assets/logo.svg')), 'WordPress renders front-page content with a browser-valid resolved image URL.');
 fwrite(STDOUT, "wordpress-site-plan WordPress integration passed\n");
+} finally {
+    foreach ($pageIds as $id) wp_delete_post((int) $id, true);
+    update_option('show_on_front', $previousShowOnFront); update_option('page_on_front', $previousPageOnFront);
+    if ('' !== $previousTheme) switch_theme($previousTheme);
+    wp_clean_themes_cache();
+    if (is_dir($themeDir)) { $items = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($themeDir, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST); foreach ($items as $item) $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname()); rmdir($themeDir); }
+    wp_clean_themes_cache();
+}

--- a/php-transformer/tests/integration/wordpress-site-plan.php
+++ b/php-transformer/tests/integration/wordpress-site-plan.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+// Run with a standard WordPress test-suite installation, for example:
+// WP_TESTS_DIR=/path/to/wordpress-tests-lib composer test:wordpress-integration
+$testsDir = getenv('WP_TESTS_DIR');
+if (!is_string($testsDir) || !is_file($testsDir . '/includes/bootstrap.php')) {
+    fwrite(STDOUT, "wordpress-site-plan WordPress integration skipped: WP_TESTS_DIR is unavailable.\n");
+    exit(0);
+}
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+require $testsDir . '/includes/bootstrap.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
+
+$assert = static function (bool $condition, string $message): void { if (!$condition) throw new RuntimeException($message); };
+$theme = 'blocks-engine-site-plan-contract';
+$themeDir = WP_CONTENT_DIR . '/themes/' . $theme;
+if (!is_dir($themeDir) && !mkdir($themeDir, 0777, true) && !is_dir($themeDir)) throw new RuntimeException('Could not create integration theme directory.');
+
+$result = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array(
+    'index.html' => '<header><p>Integration Header</p></header><main><img src="assets/logo.svg"><h1>Home</h1></main><footer><p>Integration Footer</p></footer>',
+    'assets/logo.svg' => '<svg xmlns="http://www.w3.org/2000/svg"/>',
+)))->toArray();
+$plan = $result['source_reports']['wordpress_site_plan'] ?? array();
+$resolved = (new WordPressSitePlanResolver())->resolve($plan, array('theme_uri' => home_url('/wp-content/themes/' . $theme)));
+foreach ($resolved['writes'] as $write) {
+    $path = $themeDir . '/' . $write['target_path'];
+    if (!is_dir(dirname($path))) mkdir(dirname($path), 0777, true);
+    file_put_contents($path, 'base64' === $write['payload']['encoding'] ? base64_decode($write['payload']['data'], true) : $write['payload']['data']);
+}
+wp_clean_themes_cache();
+$wpTheme = wp_get_theme($theme);
+$assert($wpTheme->exists(), 'WordPress recognizes the materialized block theme.');
+switch_theme($theme);
+$pageIds = array();
+foreach ($resolved['pages'] as $page) $pageIds[$page['reconciliation_identity']] = wp_insert_post(array('post_type' => 'page', 'post_status' => 'publish', 'post_title' => $page['title'], 'post_name' => $page['slug'], 'post_content' => $page['resolved_block_markup']), true);
+foreach ($resolved['operations'] as $operation) if ('site_reading' === $operation['kind']) { update_option('show_on_front', $operation['show_on_front']); update_option('page_on_front', $pageIds[$operation['front_page_reconciliation_identity']]); }
+$assert('page' === get_option('show_on_front') && $pageIds[$resolved['operations'][0]['front_page_reconciliation_identity']] === (int) get_option('page_on_front'), 'WordPress applied the front-page operation.');
+$front = file_get_contents($themeDir . '/templates/front-page.html');
+$assert(str_contains($front, '"slug":"header"') && str_contains($front, '"slug":"footer"'), 'WordPress theme template contains bound shell part references.');
+$content = get_post_field('post_content', (int) get_option('page_on_front'));
+$assert(str_contains($content, home_url('/wp-content/themes/' . $theme . '/assets/assets/logo.svg')), 'Materialized page content uses the resolved theme asset URL.');
+fwrite(STDOUT, "wordpress-site-plan WordPress integration passed\n");


### PR DESCRIPTION
## Summary
- Replace the incomplete `blocks-engine/wordpress-site-plan/v1` handoff with an explicit v2 contract.
- Emit a complete block-theme scaffold, canonical asset references, proven template-part placement, and generic site-reading operations.
- Resolve runtime references through the upstream `WordPressSitePlanResolver` so downstream materializers apply resolved writes verbatim.
- Add required real-WordPress/MySQL integration coverage alongside the existing full Composer gate.

Closes https://github.com/Automattic/blocks-engine/issues/636
Relates to https://github.com/Automattic/blocks-engine/issues/632

## What changed
- `WordPressSitePlan` v2 emits validated `style.css`, `theme.json`, conditional bootstrap, templates, template parts, pages, assets, writes, operations, diagnostics, and capability signals.
- Canonical markup and UTF-8 writes use declared asset tokens rather than route-relative browser URLs.
- `WordPressSitePlanResolver` accepts strict HTTP(S) destination context, resolves only declared references, and returns resolved markup/writes for verbatim application.
- Validation proves scaffold payloads, target uniqueness including case-fold collisions, template/part correspondence, site-operation references, token declarations, and the absence of unresolved static local browser references.
- Only compiler-proven entry shell header/footer parts bind to `front-page`; extracted shell markup is removed from the entry page. Unproven parts remain explicitly unbound.
- Dynamic JavaScript URL construction is explicitly `not_proven` and rejectable by strict consumers rather than implied safe.

## How to test
1. Run `composer --working-dir=php-transformer validate --strict`.
2. Run `php php-transformer/tests/contract/wordpress-site-plan.php`; expect `wordpress-site-plan contract passed`.
3. Run `composer --working-dir=php-transformer test`; expect all package contracts, 244 parity fixtures, and package-install proof to pass.
4. With a standard WordPress test suite and MySQL available, run `REQUIRE_WP_TESTS=1 WP_TESTS_DIR=/path/to/wordpress-develop/tests/phpunit composer --working-dir=php-transformer test:wordpress-integration`; expect WordPress theme recognition, activation, front-page operation, rendered template parts, and resolved assets to pass.
5. Run `git diff --check origin/trunk...HEAD`.

CI provisions WordPress 6.7.4 and MySQL 8.0.36 for step 4; missing runtime is fatal in that job.

## Compatibility
This intentionally supersedes the incomplete v1 contract introduced in php-transformer v0.3.0. Existing compiler/conversion result fields remain operational, but consumers of `source_reports.wordpress_site_plan` must migrate to v2, call `WordPressSitePlanResolver`, then materialize resolved writes/operations. The appropriate pre-1.0 breaking release is `0.4.0`. No downstream product-specific behavior is included.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** openai/gpt-5.6-sol
- **Used for:** Cross-repository root-cause analysis, contract design, implementation, security hardening, deterministic tests, WordPress integration coverage, and independent review with Chris Huber.