### PR TITLE
Attribute Figma acceptance across conversion layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Blocks Engine is a collection of tools for generating, transforming, and materia
 
 Artifact compilation also emits the self-contained [`wordpress-site-plan/v2`](docs/contracts/wordpress-site-plan-v2.md) block-theme materialization contract.
 
-The [Figma-to-WordPress acceptance matrix](docs/contracts/figma-wordpress-acceptance-matrix-v1.md) consumes that handoff through generic, configurable materialization providers.
+The [Figma-to-WordPress acceptance matrix](docs/contracts/figma-wordpress-acceptance-matrix-v2.md) consumes that handoff through generic, configurable materialization providers and attributes parity independently across Figma-to-HTML, HTML-to-WordPress, and end-to-end boundaries.

--- a/docs/contracts/figma-wordpress-acceptance-matrix-v1.md
+++ b/docs/contracts/figma-wordpress-acceptance-matrix-v1.md
@@ -1,5 +1,7 @@
 # Figma WordPress Acceptance Matrix v1
 
+This contract is superseded by [Figma WordPress Acceptance Matrix v2](figma-wordpress-acceptance-matrix-v2.md), which separates Figma-to-HTML, HTML-to-WordPress, and end-to-end parity and supports arbitrary manifest fixtures.
+
 Run the repository-owned acceptance gate from a fresh checkout:
 
 ```sh

--- a/docs/contracts/figma-wordpress-acceptance-matrix-v2.md
+++ b/docs/contracts/figma-wordpress-acceptance-matrix-v2.md
@@ -1,0 +1,25 @@
+# Figma WordPress Acceptance Matrix v2
+
+Run the canonical production corpus from a fresh checkout:
+
+```sh
+php scripts/production-acceptance-matrix.php --manifest=path/to/private-fixtures.json --output=artifacts/figma-wordpress-acceptance
+```
+
+Run any non-empty collection of operator-owned `.fig` files with the same fail-closed evaluator:
+
+```sh
+php scripts/production-acceptance-matrix.php --profile=manifest --manifest=path/to/private-fixtures.json --output=artifacts/ad-hoc-figma-wordpress-acceptance
+```
+
+The default `production` profile requires `fse-pilot-build-theme`, `twenty-twenty-five-community`, and `fisiostetic`. The `manifest` profile evaluates every supplied fixture in manifest order. Fixture IDs are unique lowercase slugs. Input paths may remain outside the repository; `summary.json` never includes them.
+
+Each fixture supplies a deployable `blocks-engine/wordpress-site-plan/v2` and evidence for three independently measured conversion boundaries:
+
+1. **Figma to HTML:** `decode`, `normalize`, `emit`, `figma_html_desktop_parity`, and `figma_html_mobile_parity`.
+2. **HTML to WordPress blocks:** `import`, `editor_validity`, `fallback`, `html_wordpress_desktop_parity`, and `html_wordpress_mobile_parity`.
+3. **End to end:** `figma_wordpress_desktop_parity`, `figma_wordpress_mobile_parity`, and `responsive_selection`.
+
+Parity evidence uses schema `blocks-engine/figma-wordpress-stage-evidence/v1`, exact fixture/stage/source identities, resolvable screenshot and diff references, and the corresponding `comparison` value: `figma_html`, `html_wordpress`, or `figma_wordpress`. Every diff must report zero pixel and geometry differences.
+
+All evidence stages remain mandatory. Missing inputs, malformed plans, unresolved references, invalid blocks, fallback blocks, nonzero parity differences, and incomplete fixture accounting fail closed with stable stage-specific reason codes.

--- a/php-transformer/tests/contract/production-acceptance-matrix.php
+++ b/php-transformer/tests/contract/production-acceptance-matrix.php
@@ -16,10 +16,18 @@ $assert = static function (bool $condition, string $message): void {
     }
 };
 
-$stageNames = array('decode', 'normalize', 'emit', 'import', 'editor_validity', 'fallback', 'desktop_parity', 'mobile_parity', 'responsive_selection');
+$parityStages = array(
+    'figma_html_desktop_parity' => 'figma_html',
+    'figma_html_mobile_parity' => 'figma_html',
+    'html_wordpress_desktop_parity' => 'html_wordpress',
+    'html_wordpress_mobile_parity' => 'html_wordpress',
+    'figma_wordpress_desktop_parity' => 'figma_wordpress',
+    'figma_wordpress_mobile_parity' => 'figma_wordpress',
+);
+$stageNames = array('decode', 'normalize', 'emit', 'figma_html_desktop_parity', 'figma_html_mobile_parity', 'import', 'editor_validity', 'fallback', 'html_wordpress_desktop_parity', 'html_wordpress_mobile_parity', 'figma_wordpress_desktop_parity', 'figma_wordpress_mobile_parity', 'responsive_selection');
 $fixtures = array();
 $output = $temporary . '/output';
-foreach (array('fse-pilot-build-theme', 'twenty-twenty-five-community', 'fisiostetic') as $fixtureId) {
+foreach (array('fse-pilot-build-theme', 'twenty-twenty-five-community', 'fisiostetic', 'arbitrary-community-design') as $fixtureId) {
     $fig = $temporary . '/' . $fixtureId . '.fig';
     file_put_contents($fig, 'fixture');
     $sourceHash = hash_file('sha256', $fig);
@@ -55,7 +63,8 @@ foreach (array('fse-pilot-build-theme', 'twenty-twenty-five-community', 'fisiost
             $evidence['provider_identity'] = 'generic-provider@1.0.0';
             $evidence['runtime_identity'] = 'wordpress@6.8.0';
         }
-        if (in_array($stage, array('desktop_parity', 'mobile_parity'), true)) {
+        if (isset($parityStages[$stage])) {
+            $evidence['comparison'] = $parityStages[$stage];
             $evidence['source_screenshot'] = 'artifacts/' . $fixtureId . '/' . $stage . '-source.png';
             $evidence['rendered_screenshot'] = 'artifacts/' . $fixtureId . '/' . $stage . '-rendered.png';
             $evidence['diff_report'] = 'artifacts/' . $fixtureId . '/' . $stage . '-diff.json';
@@ -86,7 +95,15 @@ exec($command, $ignored, $exitCode);
 $assert(0 === $exitCode, 'all complete fixture evidence passes the acceptance matrix');
 $summary = json_decode((string) file_get_contents($output . '/summary.json'), true);
 $assert('passed' === ($summary['status'] ?? null), 'summary reports a passing matrix');
+$assert('blocks-engine/figma-wordpress-acceptance/v2' === ($summary['schema'] ?? null), 'summary reports the layered v2 contract');
+$assert(3 === count($summary['fixtures'] ?? array()), 'production profile enforces the canonical three fixtures');
 $assert(!str_contains(json_encode($summary), $temporary), 'summary excludes private absolute input and evidence paths');
+
+$manifestCommand = $command . ' --profile=manifest';
+exec($manifestCommand, $ignored, $manifestExitCode);
+$assert(0 === $manifestExitCode, 'manifest profile accepts arbitrary fixture ids');
+$manifestSummary = json_decode((string) file_get_contents($output . '/summary.json'), true);
+$assert(4 === count($manifestSummary['fixtures'] ?? array()), 'manifest profile evaluates every supplied fixture');
 
 $runFailure = static function (array $candidate, string $stage, string $reason) use ($manifest, $command, $output, $assert): void {
     file_put_contents($manifest, json_encode(array('fixtures' => $candidate)));
@@ -112,9 +129,16 @@ $runFailure($fixtures, 'normalize', 'normalize_source_hash_mismatch');
 $normalize['source_sha256'] = hash_file('sha256', $fixtures[0]['fig']);
 file_put_contents($fixtures[0]['evidence']['normalize'], json_encode($normalize));
 
-file_put_contents($output . '/artifacts/fse-pilot-build-theme/desktop_parity-diff.json', json_encode(array('metrics' => array('pixel_difference_count' => 1, 'geometry_difference_count' => 0))));
-$runFailure($fixtures, 'desktop_parity', 'desktop_parity_nonzero_difference');
-file_put_contents($output . '/artifacts/fse-pilot-build-theme/desktop_parity-diff.json', json_encode(array('metrics' => array('pixel_difference_count' => 0, 'geometry_difference_count' => 0))));
+file_put_contents($output . '/artifacts/fse-pilot-build-theme/html_wordpress_desktop_parity-diff.json', json_encode(array('metrics' => array('pixel_difference_count' => 1, 'geometry_difference_count' => 0))));
+$runFailure($fixtures, 'html_wordpress_desktop_parity', 'html_wordpress_desktop_parity_nonzero_difference');
+file_put_contents($output . '/artifacts/fse-pilot-build-theme/html_wordpress_desktop_parity-diff.json', json_encode(array('metrics' => array('pixel_difference_count' => 0, 'geometry_difference_count' => 0))));
+
+$parity = json_decode((string) file_get_contents($fixtures[0]['evidence']['figma_html_desktop_parity']), true);
+$parity['comparison'] = 'html_wordpress';
+file_put_contents($fixtures[0]['evidence']['figma_html_desktop_parity'], json_encode($parity));
+$runFailure($fixtures, 'figma_html_desktop_parity', 'figma_html_desktop_parity_comparison_mismatch');
+$parity['comparison'] = 'figma_html';
+file_put_contents($fixtures[0]['evidence']['figma_html_desktop_parity'], json_encode($parity));
 
 $editor = json_decode((string) file_get_contents($fixtures[0]['evidence']['editor_validity']), true);
 $editor['metrics']['invalid_block_count'] = 1;

--- a/scripts/production-acceptance-matrix.php
+++ b/scripts/production-acceptance-matrix.php
@@ -3,10 +3,18 @@
 
 declare(strict_types=1);
 
-const ACCEPTANCE_SCHEMA = 'blocks-engine/figma-wordpress-acceptance/v1';
+const ACCEPTANCE_SCHEMA = 'blocks-engine/figma-wordpress-acceptance/v2';
 const SITE_PLAN_SCHEMA = 'blocks-engine/wordpress-site-plan/v2';
 const FIXTURE_IDS = array('fse-pilot-build-theme', 'twenty-twenty-five-community', 'fisiostetic');
-const STAGES = array('decode', 'normalize', 'emit', 'import', 'editor_validity', 'fallback', 'desktop_parity', 'mobile_parity', 'responsive_selection');
+const PARITY_STAGES = array(
+    'figma_html_desktop_parity' => 'figma_html',
+    'figma_html_mobile_parity' => 'figma_html',
+    'html_wordpress_desktop_parity' => 'html_wordpress',
+    'html_wordpress_mobile_parity' => 'html_wordpress',
+    'figma_wordpress_desktop_parity' => 'figma_wordpress',
+    'figma_wordpress_mobile_parity' => 'figma_wordpress',
+);
+const STAGES = array('decode', 'normalize', 'emit', 'figma_html_desktop_parity', 'figma_html_mobile_parity', 'import', 'editor_validity', 'fallback', 'html_wordpress_desktop_parity', 'html_wordpress_mobile_parity', 'figma_wordpress_desktop_parity', 'figma_wordpress_mobile_parity', 'responsive_selection');
 
 $autoload = dirname(__DIR__) . '/php-transformer/vendor/autoload.php';
 if (is_readable($autoload)) {
@@ -37,16 +45,29 @@ if (!is_dir($output) && !mkdir($output, 0777, true) && !is_dir($output)) {
     exit(2);
 }
 
-$summary = array('schema' => ACCEPTANCE_SCHEMA, 'status' => 'failed', 'fixtures' => array(), 'failure_count' => 0);
+$profile = $options['profile'] ?? 'production';
+if (!in_array($profile, array('production', 'manifest'), true)) {
+    fwrite(STDERR, "--profile must be production or manifest.\n");
+    exit(2);
+}
+$summary = array('schema' => ACCEPTANCE_SCHEMA, 'profile' => $profile, 'status' => 'failed', 'fixtures' => array(), 'failure_count' => 0);
 $fixtures = is_array($manifest['fixtures'] ?? null) ? $manifest['fixtures'] : array();
 $byId = array();
 foreach ($fixtures as $fixture) {
-    if (is_array($fixture) && is_string($fixture['id'] ?? null)) {
-        $byId[$fixture['id']] = $fixture;
+    $id = is_array($fixture) && is_string($fixture['id'] ?? null) ? $fixture['id'] : '';
+    if ('' === $id || !preg_match('/^[a-z0-9][a-z0-9-]*$/', $id) || isset($byId[$id])) {
+        fwrite(STDERR, "Fixture ids must be unique lowercase slugs.\n");
+        exit(2);
     }
+    $byId[$id] = $fixture;
+}
+$fixtureIds = 'production' === $profile ? FIXTURE_IDS : array_keys($byId);
+if (empty($fixtureIds)) {
+    fwrite(STDERR, "Manifest profile requires at least one fixture.\n");
+    exit(2);
 }
 
-foreach (FIXTURE_IDS as $fixtureId) {
+foreach ($fixtureIds as $fixtureId) {
     $fixture = $byId[$fixtureId] ?? array('id' => $fixtureId);
     $fixtureOutput = $output . '/fixtures/' . $fixtureId;
     if (!is_dir($fixtureOutput)) {
@@ -144,8 +165,11 @@ function acceptance_stage(string $stage, string $path, string $output, string $f
     if (!acceptance_references_valid($evidence['references'] ?? null, $output)) {
         return array('status' => 'failed', 'reason_code' => $stage . '_unresolvable_evidence');
     }
-    if (in_array($stage, array('desktop_parity', 'mobile_parity'), true) && !acceptance_screenshot_proof($evidence, $output)) {
+    if (isset(PARITY_STAGES[$stage]) && !acceptance_screenshot_proof($evidence, $output)) {
         return array('status' => 'failed', 'reason_code' => $stage . '_missing_screenshots');
+    }
+    if (isset(PARITY_STAGES[$stage]) && PARITY_STAGES[$stage] !== ($evidence['comparison'] ?? null)) {
+        return array('status' => 'failed', 'reason_code' => $stage . '_comparison_mismatch');
     }
     $semanticReason = acceptance_stage_semantic_reason($stage, $evidence, $output);
     if (null !== $semanticReason) {
@@ -180,7 +204,7 @@ function acceptance_stage_semantic_reason(string $stage, array $evidence, string
     if ('editor_validity' === $stage && (!acceptance_positive_metric($metrics, 'parsed_block_count') || !acceptance_positive_metric($metrics, 'native_editable_block_count') || !acceptance_zero_metric($metrics, 'invalid_block_count'))) {
         return 'editor_validity_invalid_blocks';
     }
-    if (in_array($stage, array('desktop_parity', 'mobile_parity'), true)) {
+    if (isset(PARITY_STAGES[$stage])) {
         return acceptance_parity_reason($stage, $evidence, $metrics, $output);
     }
     if ('responsive_selection' === $stage && !acceptance_responsive_selection($evidence)) {
@@ -266,11 +290,12 @@ function acceptance_failure(string $stage, string $reason): array {
 
 function acceptance_help(): void {
     echo <<<'HELP'
-Usage: php scripts/production-acceptance-matrix.php --manifest=acceptance.json [--output=artifacts/figma-wordpress-acceptance]
+Usage: php scripts/production-acceptance-matrix.php --manifest=acceptance.json [--profile=production|manifest] [--output=artifacts/figma-wordpress-acceptance]
 
 The manifest supplies private .fig inputs and generic external provider commands. Provider commands may use {fig} and {fixture_output}; they must write versioned stage evidence and a wordpress-site-plan/v2 JSON file. The generated summary contains only repository-relative evidence references, never input paths or URLs.
 
-Required fixture ids: fse-pilot-build-theme, twenty-twenty-five-community, fisiostetic.
-Required stages: decode, normalize, emit, import, editor_validity, fallback, desktop_parity, mobile_parity, responsive_selection.
+The default production profile requires fixture ids: fse-pilot-build-theme, twenty-twenty-five-community, fisiostetic.
+The manifest profile evaluates every supplied fixture id and supports arbitrary .fig files.
+Required stages: decode, normalize, emit, figma_html_desktop_parity, figma_html_mobile_parity, import, editor_validity, fallback, html_wordpress_desktop_parity, html_wordpress_mobile_parity, figma_wordpress_desktop_parity, figma_wordpress_mobile_parity, responsive_selection.
 HELP;
 }


### PR DESCRIPTION
## Summary

Progresses #619.

Make the Figma-to-WordPress acceptance harness usable for both the canonical production corpus and arbitrary operator-owned `.fig` files, while attributing parity to the conversion layer that introduced the difference.

The v2 matrix requires independent evidence for:

- Figma to HTML at desktop and mobile viewports.
- HTML to WordPress blocks at desktop and mobile viewports.
- End-to-end Figma to WordPress parity at desktop and mobile viewports.
- Decode, normalize, emit, isolated import, editor validity, zero fallback blocks, and responsive frame selection.

The default `production` profile continues to require FSE Pilot, Twenty Twenty-Five Community, and Fisiostetic. `--profile=manifest` evaluates every supplied fixture, allowing ad-hoc `.fig` files through the same fail-closed engine.

Parity evidence declares `comparison: figma_html`, `html_wordpress`, or `figma_wordpress`; mislabeled evidence fails rather than being credited to the wrong layer.

## How to test

1. Run `cd php-transformer && composer test`.
2. Confirm the canonical/unit suites, 244 parity fixtures, production matrix contract, and package install proof pass.
3. Run `php scripts/production-acceptance-matrix.php --help` from the repository root.
4. Confirm the default profile documents the canonical three fixtures and `--profile=manifest` documents arbitrary fixture support.
5. Supply a manifest containing any uniquely slugged fixture and all v2 stage evidence, then run `php scripts/production-acceptance-matrix.php --profile=manifest --manifest=/path/to/manifest.json --output=/tmp/acceptance`.
6. Confirm the arbitrary fixture is evaluated and `summary.json` reports `blocks-engine/figma-wordpress-acceptance/v2` with `profile: manifest`.

## Compatibility

This supersedes the newly introduced `blocks-engine/figma-wordpress-acceptance/v1` output contract with v2. Provider integrations must emit the six explicit layered parity stages and their `comparison` identity instead of the ambiguous `desktop_parity` and `mobile_parity` stages. No PHP Transformer runtime API, WordPress site-plan schema, or extension path changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Designed and implemented generic manifest fixtures, layered parity attribution, fail-closed validation, contract tests, and documentation. Chris reviews and owns the change.
