### PR TITLE
Match core save shapes for native media blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -64,9 +64,9 @@ final class BlockFactory
     {
         $attrs = $this->normalizeClassNameAttr($attrs);
 
-        // Paragraph save() does not reproduce dimensions.maxWidth. Inline
+        // RichText block save() does not reproduce dimensions.maxWidth. Inline
         // max-width is retained by the generated geometry carrier stylesheet.
-        if ( in_array($name, array( 'core/group', 'core/columns', 'core/paragraph' ), true) ) {
+        if ( in_array($name, array( 'core/group', 'core/columns', 'core/list-item', 'core/paragraph' ), true) ) {
             unset($attrs['style']['dimensions']['maxWidth']);
             if ( empty($attrs['style']['dimensions']) ) {
                 unset($attrs['style']['dimensions']);
@@ -252,7 +252,7 @@ final class BlockFactory
 
         if ( 'core/gallery' === $name ) {
             $caption = ! empty($attrs['caption']) ? '<figcaption class="blocks-gallery-caption wp-element-caption">' . $attrs['caption'] . '</figcaption>' : '';
-            return array( 'opening' => '<figure' . $this->blockSupportAttrs($attrs, 'wp-block-gallery') . '>', 'closing' => $caption . '</figure>' );
+            return array( 'opening' => '<figure' . $this->blockSupportAttrs($attrs, $this->galleryClasses($attrs)) . '>', 'closing' => $caption . '</figure>' );
         }
 
         if ( 'core/embed' === $name ) {
@@ -420,6 +420,10 @@ final class BlockFactory
     private function imageHtml(array $attrs): string
     {
         $figureAttrs = $attrs;
+        $baseClass = 'wp-block-image';
+        if ( ! empty($attrs['style']['border']) ) {
+            $baseClass .= ' has-custom-border';
+        }
         if ( ! empty($attrs['sizeSlug']) ) {
             $figureAttrs['className'] = $this->mergeClassNames((string) ($figureAttrs['className'] ?? ''), 'size-' . (string) $attrs['sizeSlug']);
         }
@@ -452,7 +456,23 @@ final class BlockFactory
             $img = '<a' . $this->htmlAttrs($linkAttrs) . '>' . $img . '</a>';
         }
         $caption = ! empty($attrs['caption']) ? '<figcaption class="wp-element-caption">' . $this->preserveRichTextPunctuation((string) $attrs['caption']) . '</figcaption>' : '';
-        return '<figure' . $this->blockSupportAttrs($figureAttrs, 'wp-block-image') . '>' . $img . $caption . '</figure>';
+        return '<figure' . $this->blockSupportAttrs($figureAttrs, $baseClass) . '>' . $img . $caption . '</figure>';
+    }
+
+    /**
+     * Match the structural classes emitted by core/gallery save().
+     *
+     * @param array<string, mixed> $attrs
+     */
+    private function galleryClasses(array $attrs): string
+    {
+        $columns = (int) ($attrs['columns'] ?? 0);
+        $classes = array('wp-block-gallery', 'has-nested-images', $columns > 0 ? 'columns-' . $columns : 'columns-default');
+        if ( ! array_key_exists('imageCrop', $attrs) || false !== $attrs['imageCrop'] ) {
+            $classes[] = 'is-cropped';
+        }
+
+        return implode(' ', $classes);
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3121,6 +3121,34 @@ $assert(! str_contains($listSerialized, 'blockGap'), 'core/list serialized attrs
 $assert(! str_contains($listSerialized, 'gap:'), 'core/list serialized markup does not contain unsupported gap style');
 $assert(str_contains($listSerialized, '<ul class="wp-block-list"><!-- wp:list-item'), 'core/list serialized markup preserves child placeholders inside the generated wrapper');
 
+$sizedListItem = $factory->create('core/list-item', array(
+    'content' => 'Sized item',
+    'style' => array('dimensions' => array('maxWidth' => '538.299px'), 'spacing' => array('padding' => array('bottom' => '43.646px'))),
+));
+$assert(! isset($sizedListItem['attrs']['style']['dimensions']['maxWidth']), 'core/list-item drops maxWidth that core save cannot reproduce');
+$assert(! str_contains($sizedListItem['innerHTML'], 'max-width:'), 'core/list-item saved markup omits unsupported max-width');
+$assert(str_contains($sizedListItem['innerHTML'], 'padding-bottom:43.646px'), 'core/list-item retains supported spacing styles');
+
+$galleryImages = array(
+    $factory->create('core/image', array('url' => '/one.jpg', 'alt' => 'One')),
+    $factory->create('core/image', array('url' => '/two.jpg', 'alt' => 'Two')),
+);
+$defaultGallery = $factory->create('core/gallery', array('className' => 'source-gallery'), $galleryImages);
+$assert(str_contains($defaultGallery['innerHTML'], 'class="wp-block-gallery has-nested-images columns-default is-cropped source-gallery"'), 'core/gallery emits core default structural classes');
+
+$uncroppedGallery = $factory->create('core/gallery', array('columns' => 3, 'imageCrop' => false), $galleryImages);
+$assert(str_contains($uncroppedGallery['innerHTML'], 'columns-3'), 'core/gallery emits its explicit column class');
+$assert(! str_contains($uncroppedGallery['innerHTML'], 'is-cropped'), 'core/gallery respects disabled image cropping');
+
+$borderedImage = $factory->create('core/image', array(
+    'url' => '/bordered.jpg',
+    'alt' => 'Bordered',
+    'className' => 'source-image',
+    'style' => array('border' => array('color' => '#ffffff', 'style' => 'solid')),
+));
+$assert(str_contains($borderedImage['innerHTML'], 'class="wp-block-image has-custom-border has-border-color source-image"'), 'core/image emits the custom-border class required by core save');
+$assert(str_contains($borderedImage['innerHTML'], 'style="border-color:#ffffff;border-style:solid"'), 'core/image retains canonical border support styles');
+
 $defaultTable = $factory->create(
     'core/table',
     array('body' => array(array('cells' => array(array('content' => 'A')))))


### PR DESCRIPTION
## Summary

Progresses #619.

Match current core save shapes for three native blocks exposed by the real Fisiostetic `.fig` acceptance run:

- Drop `dimensions.maxWidth` from `core/list-item` attributes because core does not reproduce it on the saved `<li>`. Geometry remains carried by generated CSS.
- Emit `core/gallery` structural classes: `has-nested-images`, `columns-{n|default}`, and default `is-cropped`.
- Emit `has-custom-border` for `core/image` when canonical border support is present.

Before this change, `wp.blocks.validateBlock` rejected one list item, one gallery, and one image. With the candidate checkout, the isolated WordPress run validates all 159 Fisiostetic blocks.

## How to test

1. Run `cd php-transformer && composer test`.
2. Confirm the canonical/unit suites, 244 parity fixtures, production matrix contract, and package install proof pass.
3. Run the real Fisiostetic editor gate with SSI and this checkout as the PHP Transformer override:
   `node tools/run-fig-fixture-e2e.mjs --blocks-engine /path/to/this-checkout --blocks-engine-php-transformer-path /path/to/this-checkout --fixture /path/to/Fisiostetic.fig --expected-fixture-count 1 --output-directory /tmp/fisiostetic-editor-validity --run --no-visual-parity`
4. Confirm the result reports one passed fixture, `native_conversion_rate: 1`, `editor_validated_block_total: 159`, and `invalid_block_count: 0`.

## Compatibility

This corrects serialized markup to match WordPress core's existing save contract. It changes generated markup for list items with unsupported max-width, galleries, and bordered images. No public PHP API, site-plan schema, or extension path changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Traced real editor-validation failures, corrected canonical block serialization, added contracts, and ran isolated WordPress verification. Chris reviews and owns the change.
