### PR TITLE
Keep height floors on responsive canvas sections

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -204,7 +204,13 @@ final class BreakpointMediaDiffBuilder
             }
             if ( null !== $height && $height > 240.0 && 'absolute' !== $position ) {
                 $declarations[] = 'height:auto';
-                if ( ! $wrapsRow && ! $this->hasContainerChild($node) ) {
+                // Canvas-positioned containers (no flex/grid layout) size every
+                // child absolutely, so `height:auto` collapses them to zero. Keep
+                // a source-height floor so relaxing the fixed height never erases
+                // the section. Flex/grid containers keep the floor only when no
+                // container child can re-establish flow height.
+                $isCanvasContainer = ! in_array($display, array('flex', 'inline-flex', 'grid', 'inline-grid'), true);
+                if ( $isCanvasContainer || ( ! $wrapsRow && ! $this->hasContainerChild($node) ) ) {
                     $declarations[] = 'min-height:' . ($this->number)(min($height, 720.0)) . 'px';
                 }
             }

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -743,6 +743,98 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
     blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap'), 'desktop-only-responsive-pricing-cards-stack-at-tablet');
     blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('min-height:360px', 'flex-wrap:wrap'), 'desktop-only-responsive-pricing-cards-have-no-fixed-min-height-floor-or-wrap-only-layout');
 
+    // Desktop-only canvas sections (no auto-layout) position every child
+    // absolutely, so the tablet `height:auto` relaxation must keep a
+    // source-height floor or the whole section collapses to zero height.
+    $desktopOnlyCanvasSectionsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name'  => 'Desktop Only Canvas Sections Fixture',
+        'nodes' => array(
+            array(
+                'id'       => 'canvas-sections:root',
+                'type'     => 'FRAME',
+                'name'     => 'Desktop page',
+                'width'    => 1440,
+                'height'   => 1917,
+                'layoutMode' => 'VERTICAL',
+                'children' => array(
+                    array(
+                        'id'       => 'canvas-sections:hero',
+                        'type'     => 'FRAME',
+                        'name'     => 'Hero canvas band',
+                        'width'    => 1440,
+                        'height'   => 453,
+                        'children' => array(
+                            array(
+                                'id'     => 'canvas-sections:hero-copy',
+                                'type'   => 'FRAME',
+                                'name'   => 'Hero copy frame',
+                                'width'  => 644,
+                                'height' => 218,
+                                'x'      => 398,
+                                'y'      => 117,
+                                'layoutPositioning' => 'ABSOLUTE',
+                                'children' => array(
+                                    array('id' => 'canvas-sections:hero-title', 'type' => 'TEXT', 'name' => 'Hero title', 'characters' => 'Tell your story', 'width' => 644, 'height' => 64, 'fontSize' => 56),
+                                ),
+                            ),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'canvas-sections:about',
+                        'type'     => 'FRAME',
+                        'name'     => 'About canvas band',
+                        'width'    => 1440,
+                        'height'   => 732,
+                        'children' => array(
+                            array(
+                                'id'     => 'canvas-sections:about-copy',
+                                'type'   => 'FRAME',
+                                'name'   => 'About copy frame',
+                                'width'  => 441,
+                                'height' => 279,
+                                'x'      => 811,
+                                'y'      => 227,
+                                'layoutPositioning' => 'ABSOLUTE',
+                                'children' => array(
+                                    array('id' => 'canvas-sections:about-text', 'type' => 'TEXT', 'name' => 'About text', 'characters' => 'Fleurs is a flower delivery business.', 'width' => 441, 'height' => 223, 'fontSize' => 28),
+                                ),
+                            ),
+                        ),
+                    ),
+                    array(
+                        'id'       => 'canvas-sections:cta',
+                        'type'     => 'FRAME',
+                        'name'     => 'CTA canvas band',
+                        'width'    => 1440,
+                        'height'   => 460,
+                        'children' => array(
+                            array(
+                                'id'     => 'canvas-sections:cta-copy',
+                                'type'   => 'FRAME',
+                                'name'   => 'CTA copy frame',
+                                'width'  => 521,
+                                'height' => 54,
+                                'x'      => 459,
+                                'y'      => 292,
+                                'layoutPositioning' => 'ABSOLUTE',
+                                'children' => array(
+                                    array('id' => 'canvas-sections:cta-text', 'type' => 'TEXT', 'name' => 'CTA text', 'characters' => 'Sign up to get daily stories', 'width' => 487, 'height' => 54, 'fontSize' => 38),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ));
+    $desktopOnlyCanvasSectionsCss = $fileContent($desktopOnlyCanvasSectionsResult, 'style.css');
+    $desktopOnlyCanvasSectionsTabletBlockPosition = strpos($desktopOnlyCanvasSectionsCss, '@media (max-width:1439px)');
+    $assert(false !== $desktopOnlyCanvasSectionsTabletBlockPosition, 'desktop-only-canvas-sections-emit-tablet-safety-block');
+    $desktopOnlyCanvasSectionsTabletBlock = false === $desktopOnlyCanvasSectionsTabletBlockPosition ? '' : substr($desktopOnlyCanvasSectionsCss, $desktopOnlyCanvasSectionsTabletBlockPosition);
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsTabletBlock, '.figma-node-canvas-sections-hero-hero-canvas-band', array('height:auto', 'min-height:453px'), 'desktop-only-canvas-hero-band-keeps-source-height-floor-at-tablet');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsTabletBlock, '.figma-node-canvas-sections-about-about-canvas-band', array('height:auto', 'min-height:720px'), 'desktop-only-canvas-about-band-keeps-capped-height-floor-at-tablet');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsTabletBlock, '.figma-node-canvas-sections-cta-cta-canvas-band', array('height:auto', 'min-height:460px'), 'desktop-only-canvas-cta-band-keeps-source-height-floor-at-tablet');
+
     $fluidManagedStackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Fluid Managed Stack Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary

Desktop-only Figma exports frequently contain canvas-positioned sections: fixed-height frames without auto-layout whose children are all absolutely positioned. The desktop-only responsive fallback relaxed those sections to `height:auto` at viewports below the canvas width, but skipped the `min-height` floor whenever the section had a container child — assuming flow children would size the box. Canvas children are out of flow, so the sections collapsed to zero height and entire page regions (hero, about, testimonials, CTA bands) vanished at any viewport under the design canvas.

## Change

In `BreakpointMediaDiffBuilder::desktopOnlyResponsiveFallbackDeclarations`, a container whose base display is not flex/grid is treated as canvas-positioned and always keeps the capped source-height floor (`min-height:min(height, 720px)`) alongside `height:auto`. Flex/grid containers keep the existing behavior.

## Measured impact

Twenty Twenty-Five (Community) .fig front page at a 1280px viewport:

- Before: page rendered 1497px tall — hero (453px), about (732px), testimonials (733px), and CTA (460px) bands all collapsed to zero height; only the two min-height grid sections survived.
- After: all four bands render with floors (453px / 720px / 720px / 460px) and the page renders ~3850px.
- End-to-end Figma-to-WordPress visual mismatch for that fixture dropped from 28.73% to 20.90% while the compared region grew 2.4x (the comparison now covers the whole restored page).
- FSE Pilot Build Theme and Fisiostetic fixtures: no regression (16.54% / 32.03% respectively, both within noise of their prior scores), and the editor gate stayed fully green across all three (727/727 native blocks, 365/365 browser-validated blocks, zero invalid).

## How to test

1. `cd figma-transformer && composer test` — the contract suite includes a new desktop-only canvas-sections fixture asserting `height:auto` plus `min-height:453px` / `min-height:720px` / `min-height:460px` in the `@media (max-width:1439px)` block for hero/about/CTA bands whose only children are absolutely positioned.
2. Existing desktop-only flex-row assertions (`desktop-only-responsive-hero-row-has-no-fixed-min-height-floor...`) still pass, proving flex/grid containers keep the floor-free stacking behavior.

## AI disclosure

Implemented with OpenCode using `openai/gpt-5.6-sol`; the contract suite and the end-to-end fixture matrix were run locally.