### PR TITLE
Keep desktop-only Figma layouts fluid

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -154,12 +154,13 @@ final class BreakpointMediaDiffBuilder
             }
 
             $depth = isset($base['depth']) && is_numeric($base['depth']) ? (int) $base['depth'] : 0;
-            $desktopChanged = $this->changedDeclarations($this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null), $baseMap);
+            $parentNode = is_array($base['parent_node'] ?? null) ? $base['parent_node'] : null;
+            $desktopChanged = $this->changedDeclarations($this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null, false, $parentNode, $rootWidth), $baseMap);
             if ( ! empty($desktopChanged) ) {
                 $desktopRules[] = '.' . $class . '{' . implode(';', array_values(array_unique($desktopChanged))) . '}';
             }
 
-            $mobileChanged = $this->changedDeclarations($this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null, true), $baseMap);
+            $mobileChanged = $this->changedDeclarations($this->desktopOnlyResponsiveFallbackDeclarations($node, $baseMap, $depth, 0 === $depth ? $rootWidth : null, true, $parentNode, $rootWidth), $baseMap);
             if ( ! empty($mobileChanged) ) {
                 $mobileRules[] = '.' . $class . '{' . implode(';', array_values(array_unique($mobileChanged))) . '}';
             }
@@ -185,17 +186,20 @@ final class BreakpointMediaDiffBuilder
      * @param array<string, string> $baseMap
      * @return array<int, string>
      */
-    private function desktopOnlyResponsiveFallbackDeclarations(array $node, array $baseMap, int $depth, ?float $fallbackWidth = null, bool $mobile = false): array
+    private function desktopOnlyResponsiveFallbackDeclarations(array $node, array $baseMap, int $depth, ?float $fallbackWidth = null, bool $mobile = false, ?array $parentNode = null, ?float $sourceViewportWidth = null): array
     {
         $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
         $width = $this->responsiveCssWidth($baseMap) ?? $this->nodeBoxDimension($node, 'width') ?? $fallbackWidth;
         $height = $this->cssPixelValue($baseMap['height'] ?? '');
+        $minHeight = $this->cssPixelValue($baseMap['min-height'] ?? '');
         $display = (string) ($baseMap['display'] ?? '');
         $position = (string) ($baseMap['position'] ?? '');
         $declarations = array();
         $wrapsRow = in_array($display, array('flex', 'inline-flex'), true) && 'row' === ($baseMap['flex-direction'] ?? null);
+        $parentLayout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        $isFlexChild = in_array((string) ($parentLayout['display'] ?? ''), array('flex', 'inline-flex'), true) && 'absolute' !== $position;
 
-        if ( $this->isOversizedDesktopOnlyFallbackContainer($type, $width) ) {
+        if ( $this->isResponsiveContainerType($type) && null !== $width && $width > ($mobile ? 340.0 : 767.0) ) {
             $declarations[] = 'width:100%';
             $declarations[] = 'max-width:100%';
             if ( 'absolute' === $position ) {
@@ -214,7 +218,11 @@ final class BreakpointMediaDiffBuilder
                     $declarations[] = 'min-height:' . ($this->number)(min($height, 720.0)) . 'px';
                 }
             }
-            if ( $wrapsRow ) {
+            if ( null !== $minHeight && $minHeight > 720.0 && in_array($display, array('flex', 'inline-flex', 'grid', 'inline-grid'), true) && $this->hasContainerChild($node) ) {
+                $declarations[] = 'min-height:0';
+            }
+            if ( $mobile && $wrapsRow ) {
+                $declarations[] = 'height:auto';
                 if ( $this->hasContainerChild($node) ) {
                     $declarations[] = 'flex-direction:column';
                     $declarations[] = 'align-items:stretch';
@@ -225,11 +233,28 @@ final class BreakpointMediaDiffBuilder
                 }
             }
 
-            if ( in_array($display, array('grid', 'inline-grid'), true) && $this->hasContainerChild($node) ) {
+            if ( $mobile && in_array($display, array('grid', 'inline-grid'), true) && $this->hasContainerChild($node) ) {
                 $declarations[] = 'grid-template-columns:1fr';
             }
 
             array_push($declarations, ...$this->responsivePaddingClampDeclarations($baseMap));
+            $gap = $this->cssPixelValue($baseMap['gap'] ?? '');
+            if ( null !== $gap && $gap > ($mobile ? 24.0 : 48.0) ) {
+                $declarations[] = 'gap:' . ($mobile ? '24px' : '48px');
+            }
+        }
+
+        if ( $isFlexChild && null !== $width && $width > 320.0 ) {
+            $declarations[] = 'max-width:100%';
+            $declarations[] = 'min-width:0';
+            $declarations[] = 'flex-shrink:1';
+            if ( $this->isEqualWidthFlexRow($parentNode) ) {
+                $declarations[] = 'flex-basis:0';
+                $declarations[] = 'flex-grow:1';
+            }
+            if ( $this->isResponsiveContainerType($type) && null !== $height && $height > 240.0 ) {
+                $declarations[] = 'height:auto';
+            }
         }
 
         if ( 'TEXT' === $type && null !== $width && $width > 320.0 ) {
@@ -250,11 +275,27 @@ final class BreakpointMediaDiffBuilder
                 $declarations[] = 'left:24px';
                 $declarations[] = 'right:24px';
             }
+            if ( null !== $sourceViewportWidth && $sourceViewportWidth > 1200.0 ) {
+                foreach ( array('font-size', 'line-height') as $property ) {
+                    $sourceValue = $this->cssPixelValue($baseMap[$property] ?? '');
+                    if ( null === $sourceValue || $sourceValue <= 16.0 ) {
+                        continue;
+                    }
+                    $minimum = max(14.0, $sourceValue * 0.55);
+                    $declarations[] = $property . ':clamp(' . ($this->number)($minimum) . 'px,' . ($this->number)($sourceValue / $sourceViewportWidth * 100.0) . 'vw,' . ($this->number)($sourceValue) . 'px)';
+                }
+            }
         }
 
-        if ( $mobile && null !== $width && $width > 340.0 && isset($baseMap['background-image']) && str_contains((string) $baseMap['background-image'], 'url(') ) {
-            $declarations[] = 'width:100%';
+        $fluidAbsoluteVisual = 'absolute' === $position && null !== $width && $width > 0.0;
+        if ( ($mobile || ($isFlexChild && null !== $width && $width > 340.0) || $fluidAbsoluteVisual) && null !== $width && isset($baseMap['background-image']) && str_contains((string) $baseMap['background-image'], 'url(') ) {
+            $absoluteFluidGeometry = $fluidAbsoluteVisual ? $this->absoluteFluidVisualGeometry($node, $parentNode, $width) : array();
+            $declarations[] = isset($absoluteFluidGeometry['width']) ? 'width:' . $absoluteFluidGeometry['width'] : 'width:100%';
             $declarations[] = 'max-width:100%';
+            if ( isset($absoluteFluidGeometry['left']) ) {
+                $declarations[] = 'left:' . $absoluteFluidGeometry['left'];
+                $declarations[] = 'right:auto';
+            }
             if ( null !== $height && $height > 0.0 ) {
                 $declarations[] = 'height:auto';
                 $declarations[] = 'aspect-ratio:' . ($this->number)($width) . ' / ' . ($this->number)($height);
@@ -265,6 +306,66 @@ final class BreakpointMediaDiffBuilder
         }
 
         return array_values(array_unique($declarations));
+    }
+
+    /**
+     * Preserve collage composition when a fixed desktop canvas is fluidized.
+     * Absolute visual children retain their source-relative width and x offset
+     * as percentages of the containing frame.
+     *
+     * @param array<string, mixed>      $node
+     * @param array<string, mixed>|null $parentNode
+     * @return array{width?: string, left?: string}
+     */
+    private function absoluteFluidVisualGeometry(array $node, ?array $parentNode, float $width): array
+    {
+        if ( null === $parentNode ) {
+            return array();
+        }
+        $parentWidth = $this->nodeBoxDimension($parentNode, 'width');
+        $box = is_array($node['box'] ?? null) ? $node['box'] : $node;
+        if ( null === $parentWidth || $parentWidth <= 0.0 || ! is_numeric($box['x'] ?? null) ) {
+            return array();
+        }
+
+        return array(
+            'width' => ($this->number)(min(100.0, $width / $parentWidth * 100.0)) . '%',
+            'left'  => ($this->number)(max(0.0, (float) $box['x'] / $parentWidth * 100.0)) . '%',
+        );
+    }
+
+    /**
+     * Equal-width source rows can share constrained viewport space without
+     * changing their desktop structure. Unequal rows retain their source
+     * proportions and only receive ordinary flex shrinking.
+     *
+     * @param array<string, mixed>|null $parentNode
+     */
+    private function isEqualWidthFlexRow(?array $parentNode): bool
+    {
+        if ( null === $parentNode ) {
+            return false;
+        }
+        $layout = is_array($parentNode['layout'] ?? null) ? $parentNode['layout'] : array();
+        if ( ! in_array((string) ($layout['display'] ?? ''), array('flex', 'inline-flex'), true) || 'row' !== ($layout['flex_direction'] ?? null) ) {
+            return false;
+        }
+
+        $widths = array();
+        foreach ( ($this->nodeList)($parentNode) as $child ) {
+            if ( ! is_array($child) || 'absolute' === ($child['layout']['positioning'] ?? null) ) {
+                continue;
+            }
+            $box = is_array($child['box'] ?? null) ? $child['box'] : $child;
+            if ( is_numeric($box['width'] ?? null) && (float) $box['width'] > 0.0 ) {
+                $widths[] = (float) $box['width'];
+            }
+        }
+        if ( count($widths) < 2 ) {
+            return false;
+        }
+
+        return max($widths) - min($widths) <= max($widths) * 0.15;
     }
 
     /**
@@ -288,11 +389,6 @@ final class BreakpointMediaDiffBuilder
         }
 
         return $changed;
-    }
-
-    private function isOversizedDesktopOnlyFallbackContainer(string $type, ?float $width): bool
-    {
-        return $this->isResponsiveContainerType($type) && null !== $width && $width > 767.0;
     }
 
     private function isResponsiveContainerType(string $type): bool

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -730,21 +730,50 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
                             array('id' => 'responsive-rows:price-c', 'type' => 'FRAME', 'name' => 'Price card', 'width' => 380, 'height' => 280),
                         ),
                     ),
+                    array(
+                        'id'       => 'responsive-rows:services',
+                        'type'     => 'FRAME',
+                        'name'     => 'Services Section',
+                        'width'    => 1440,
+                        'height'   => 900,
+                        'layoutMode' => 'VERTICAL',
+                        'children' => array(
+                            array(
+                                'id'       => 'responsive-rows:services-content',
+                                'type'     => 'FRAME',
+                                'name'     => 'Services content',
+                                'width'    => 1216,
+                                'height'   => 420,
+                                'layoutMode' => 'VERTICAL',
+                                'children' => array(
+                                    array('id' => 'responsive-rows:services-copy', 'type' => 'TEXT', 'name' => 'Services copy', 'characters' => 'Services', 'width' => 420, 'height' => 64, 'fontSize' => 48),
+                                ),
+                            ),
+                        ),
+                    ),
                 ),
             ),
         ),
     ));
     $desktopOnlyResponsiveRowsCss = $fileContent($desktopOnlyResponsiveRowsResult, 'style.css');
-    $desktopOnlyResponsiveRowsTabletBlockPosition = strpos($desktopOnlyResponsiveRowsCss, '@media (max-width:1439px)');
-    $assert(false !== $desktopOnlyResponsiveRowsTabletBlockPosition, 'desktop-only-responsive-rows-emits-tablet-safety-block');
-    $desktopOnlyResponsiveRowsTabletBlock = false === $desktopOnlyResponsiveRowsTabletBlockPosition ? '' : substr($desktopOnlyResponsiveRowsCss, $desktopOnlyResponsiveRowsTabletBlockPosition);
-    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-hero-hero-row', array('width:100%', 'max-width:100%', 'height:auto', 'flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap', 'padding-right:24px', 'padding-left:24px'), 'desktop-only-responsive-hero-row-stacks-at-tablet');
-    blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-hero-hero-row', array('min-height:420px', 'flex-wrap:wrap'), 'desktop-only-responsive-hero-row-has-no-fixed-min-height-floor-or-wrap-only-layout');
-    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap'), 'desktop-only-responsive-pricing-cards-stack-at-tablet');
-    blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsTabletBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('min-height:360px', 'flex-wrap:wrap'), 'desktop-only-responsive-pricing-cards-have-no-fixed-min-height-floor-or-wrap-only-layout');
+    $desktopOnlyResponsiveRowsFluidBlockPosition = strpos($desktopOnlyResponsiveRowsCss, '@media (max-width:1439px)');
+    $assert(false !== $desktopOnlyResponsiveRowsFluidBlockPosition, 'desktop-only-responsive-rows-emits-fluid-containment-block');
+    $desktopOnlyResponsiveRowsFluidBlock = false === $desktopOnlyResponsiveRowsFluidBlockPosition ? '' : substr($desktopOnlyResponsiveRowsCss, $desktopOnlyResponsiveRowsFluidBlockPosition, strpos($desktopOnlyResponsiveRowsCss, '@media (max-width:767px)') - $desktopOnlyResponsiveRowsFluidBlockPosition);
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsFluidBlock, '.figma-node-responsive-rows-hero-hero-row', array('width:100%', 'max-width:100%', 'height:auto', 'padding-right:24px', 'padding-left:24px'), 'desktop-only-responsive-hero-row-is-fluid-below-source-canvas-width');
+    blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsFluidBlock, '.figma-node-responsive-rows-hero-hero-row', array('flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap'), 'desktop-only-responsive-hero-row-keeps-desktop-structure-in-fluid-range');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsFluidBlock, '.figma-node-responsive-rows-price-a-price-card', array('max-width:100%', 'min-width:0', 'flex-shrink:1', 'flex-basis:0', 'flex-grow:1'), 'desktop-only-responsive-card-row-items-share-available-fluid-width');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsFluidBlock, '.figma-node-responsive-rows-services-services-section', array('min-height:0'), 'desktop-only-responsive-flow-section-releases-oversized-source-min-height');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsFluidBlock, '.figma-node-responsive-rows-hero-title-hero-title', array('font-size:clamp(26.4px,3.333vw,48px)'), 'desktop-only-responsive-text-scales-between-source-and-narrow-viewports');
+    $desktopOnlyResponsiveRowsMobileBlockPosition = strpos($desktopOnlyResponsiveRowsCss, '@media (max-width:767px)');
+    $assert(false !== $desktopOnlyResponsiveRowsMobileBlockPosition, 'desktop-only-responsive-rows-emits-mobile-safety-block');
+    $desktopOnlyResponsiveRowsMobileBlock = false === $desktopOnlyResponsiveRowsMobileBlockPosition ? '' : substr($desktopOnlyResponsiveRowsCss, $desktopOnlyResponsiveRowsMobileBlockPosition);
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsMobileBlock, '.figma-node-responsive-rows-hero-hero-row', array('width:100%', 'max-width:100%', 'height:auto', 'flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap', 'padding-right:24px', 'padding-left:24px'), 'desktop-only-responsive-hero-row-stacks-at-mobile');
+    blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsMobileBlock, '.figma-node-responsive-rows-hero-hero-row', array('min-height:420px', 'flex-wrap:wrap'), 'desktop-only-responsive-hero-row-has-no-fixed-min-height-floor-or-wrap-only-layout');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyResponsiveRowsMobileBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('flex-direction:column', 'align-items:stretch', 'flex-wrap:nowrap'), 'desktop-only-responsive-pricing-cards-stack-at-mobile');
+    blocks_engine_figma_transformer_contract_assert_css_rule_omits($assert, $desktopOnlyResponsiveRowsMobileBlock, '.figma-node-responsive-rows-pricing-pricing-cards', array('min-height:360px', 'flex-wrap:wrap'), 'desktop-only-responsive-pricing-cards-have-no-fixed-min-height-floor-or-wrap-only-layout');
 
     // Desktop-only canvas sections (no auto-layout) position every child
-    // absolutely, so the tablet `height:auto` relaxation must keep a
+    // absolutely, so the mobile `height:auto` relaxation must keep a
     // source-height floor or the whole section collapses to zero height.
     $desktopOnlyCanvasSectionsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Desktop Only Canvas Sections Fixture',
@@ -828,12 +857,16 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
         ),
     ));
     $desktopOnlyCanvasSectionsCss = $fileContent($desktopOnlyCanvasSectionsResult, 'style.css');
-    $desktopOnlyCanvasSectionsTabletBlockPosition = strpos($desktopOnlyCanvasSectionsCss, '@media (max-width:1439px)');
-    $assert(false !== $desktopOnlyCanvasSectionsTabletBlockPosition, 'desktop-only-canvas-sections-emit-tablet-safety-block');
-    $desktopOnlyCanvasSectionsTabletBlock = false === $desktopOnlyCanvasSectionsTabletBlockPosition ? '' : substr($desktopOnlyCanvasSectionsCss, $desktopOnlyCanvasSectionsTabletBlockPosition);
-    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsTabletBlock, '.figma-node-canvas-sections-hero-hero-canvas-band', array('height:auto', 'min-height:453px'), 'desktop-only-canvas-hero-band-keeps-source-height-floor-at-tablet');
-    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsTabletBlock, '.figma-node-canvas-sections-about-about-canvas-band', array('height:auto', 'min-height:720px'), 'desktop-only-canvas-about-band-keeps-capped-height-floor-at-tablet');
-    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsTabletBlock, '.figma-node-canvas-sections-cta-cta-canvas-band', array('height:auto', 'min-height:460px'), 'desktop-only-canvas-cta-band-keeps-source-height-floor-at-tablet');
+    $desktopOnlyCanvasSectionsFluidBlockPosition = strpos($desktopOnlyCanvasSectionsCss, '@media (max-width:1439px)');
+    $assert(false !== $desktopOnlyCanvasSectionsFluidBlockPosition, 'desktop-only-canvas-sections-emit-fluid-containment-block');
+    $desktopOnlyCanvasSectionsFluidBlock = false === $desktopOnlyCanvasSectionsFluidBlockPosition ? '' : substr($desktopOnlyCanvasSectionsCss, $desktopOnlyCanvasSectionsFluidBlockPosition, strpos($desktopOnlyCanvasSectionsCss, '@media (max-width:767px)') - $desktopOnlyCanvasSectionsFluidBlockPosition);
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsFluidBlock, '.figma-node-canvas-sections-hero-hero-canvas-band', array('height:auto', 'min-height:453px'), 'desktop-only-canvas-hero-band-keeps-source-height-floor-in-fluid-range');
+    $desktopOnlyCanvasSectionsMobileBlockPosition = strpos($desktopOnlyCanvasSectionsCss, '@media (max-width:767px)');
+    $assert(false !== $desktopOnlyCanvasSectionsMobileBlockPosition, 'desktop-only-canvas-sections-emit-mobile-safety-block');
+    $desktopOnlyCanvasSectionsMobileBlock = false === $desktopOnlyCanvasSectionsMobileBlockPosition ? '' : substr($desktopOnlyCanvasSectionsCss, $desktopOnlyCanvasSectionsMobileBlockPosition);
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsMobileBlock, '.figma-node-canvas-sections-hero-hero-canvas-band', array('height:auto', 'min-height:453px'), 'desktop-only-canvas-hero-band-keeps-source-height-floor-at-mobile');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsMobileBlock, '.figma-node-canvas-sections-about-about-canvas-band', array('height:auto', 'min-height:720px'), 'desktop-only-canvas-about-band-keeps-capped-height-floor-at-mobile');
+    blocks_engine_figma_transformer_contract_assert_css_rule_contains($assert, $desktopOnlyCanvasSectionsMobileBlock, '.figma-node-canvas-sections-cta-cta-canvas-band', array('height:auto', 'min-height:460px'), 'desktop-only-canvas-cta-band-keeps-source-height-floor-at-mobile');
 
     $fluidManagedStackResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Fluid Managed Stack Fixture',
@@ -2251,9 +2284,9 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(! preg_match('/\.figma-node-cards-desktop-card-a-image-card-image\{[^}]*height:auto/', $responsiveEmitMobileBlock), 'responsive-emit-mobile-leaf-image-keeps-fixed-height');
     $assert(! preg_match('/\.figma-node-cards-desktop-decor-absolute-decorative-rail\{[^}]*height:auto/', $responsiveEmitMobileBlock), 'responsive-emit-mobile-absolute-decoration-keeps-fixed-height');
     $assert(! str_contains($responsiveEmitMobileBlock, '.figma-node-frame-home-desktop-home-desktop{width:390px'), 'responsive-emit-mobile-root-does-not-pin-variant-width');
-    // The single-variant About page contributes source-width and mobile
-    // desktop-only fallback media blocks.
-    $assert(1 === preg_match('/@media \(max-width:1439px\)\{[\s\S]*figma-node-frame-about-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-source-width-fallback-media');
+    // The single-variant About page contributes a non-structural fluid
+    // containment layer plus the narrow-screen structural safety block.
+    $assert(1 === preg_match('/@media \(max-width:1439px\)\{[\s\S]*figma-node-frame-about-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-source-width-fluid-media');
     $assert(1 === preg_match('/@media \(max-width:767px\)\{[\s\S]*figma-node-frame-about-about/s', $responsiveEmitCss), 'responsive-emit-single-variant-page-desktop-fallback-media');
 
     $responsiveMismatchScenegraph = array(

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -8273,12 +8273,8 @@ foreach ( $desktopOnlyImageFallbackResult['files'] ?? array() as $desktopOnlyIma
     }
 }
 $assert('success' === ($desktopOnlyImageFallbackResult['status'] ?? null), 'desktop-only-image-fallback-transform-success');
-$desktopOnlyWideFallbackBlock = '';
-if ( preg_match('/@media \(max-width:1439px\)\{(?<block>[\s\S]*?)\n\}/', $desktopOnlyImageFallbackCss, $desktopOnlyWideFallbackMatch) ) {
-    $desktopOnlyWideFallbackBlock = (string) ($desktopOnlyWideFallbackMatch['block'] ?? '');
-}
-$assert(! str_contains($desktopOnlyWideFallbackBlock, '.figma-node-desktop-only-image-service-image{'), 'desktop-only-image-fallback-not-clamped-at-desktop');
-$assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-desktop-only-image-service-image\{[^}]*width:100%[^}]*max-width:100%[^}]*height:auto[^}]*aspect-ratio:538 \/ 381/s', $desktopOnlyImageFallbackCss) === 1, 'desktop-only-image-fallback-clamped-at-mobile');
+$assert(str_contains($desktopOnlyImageFallbackCss, '@media (max-width:1439px)'), 'desktop-only-image-fallback-emits-fluid-containment-range');
+$assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-desktop-only-image-service-image\{(?=[^}]*(?<!-)width:100%)(?=[^}]*max-width:100%)(?=[^}]*height:auto)(?=[^}]*aspect-ratio:538 \/ 381)[^}]*\}/s', $desktopOnlyImageFallbackCss) === 1, 'desktop-only-image-fallback-clamped-at-mobile');
 
 $desktopOnlyAbsoluteFallbackResult = ( new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter() )->emitSite(
     array(
@@ -8309,6 +8305,7 @@ foreach ( $desktopOnlyAbsoluteFallbackResult['files'] ?? array() as $desktopOnly
 }
 $assert('success' === ($desktopOnlyAbsoluteFallbackResult['status'] ?? null), 'desktop-only-absolute-fallback-transform-success');
 $assert(preg_match('/@media \(max-width:1439px\)\{[\s\S]*\.figma-node-desktop-absolute-panel-offset-panel\{[^}]*width:100%[^}]*max-width:100%[^}]*left:0[^}]*right:auto/s', $desktopOnlyAbsoluteFallbackCss) === 1, 'desktop-only-absolute-fallback-fluid-container-resets-left');
+$assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-desktop-absolute-panel-offset-panel\{[^}]*width:100%[^}]*max-width:100%[^}]*left:0[^}]*right:auto/s', $desktopOnlyAbsoluteFallbackCss) === 1, 'desktop-only-absolute-fallback-fluid-container-resets-left-at-mobile');
 $assert(preg_match('/@media \(max-width:767px\)\{[\s\S]*\.figma-node-desktop-absolute-text-offset-text\{[^}]*width:100%[^}]*max-width:100%[^}]*left:0[^}]*right:auto/s', $desktopOnlyAbsoluteFallbackCss) === 1, 'desktop-only-absolute-fallback-fluid-text-resets-left');
 
 if ( ! empty($failures) ) {


### PR DESCRIPTION
## Summary

- treat a wide single-frame source canvas as a fluid-containment range rather than a tablet structural breakpoint
- preserve desktop flex composition while shrinking children, clamping gaps and typography, and retaining source-relative absolute image geometry
- reserve row-to-column and grid-to-single-column restructuring for the 767px mobile safety layer
- release oversized flow-container height floors while preserving absolute-canvas section floors

Fixes #657.

## Why

Desktop-only Figma files previously emitted a synthetic media query at `source width - 1` that applied mobile-style structural collapse. A 2095px source canvas therefore stacked rows at ordinary 1280px desktop widths. This change makes the source-width layer non-structural and keeps actual narrow-screen restructuring bounded to mobile.

## How to test

1. Check out this branch.
2. Run `cd figma-transformer`.
3. Run `composer validate --strict`.
4. Run `composer test`.
5. Confirm the desktop-only responsive-row contract keeps row structure in the source-width media layer and stacks it only in the 767px layer.
6. Confirm the desktop-only canvas contract retains height floors in both fluid and mobile layers.

## Supplementary fixture evidence

A representative 2095px-wide, single-page Figma fixture transformed successfully with 222 nodes and 13 emitted files. Its static artifact rendered with document width equal to viewport width at both 1280px desktop and 390px mobile, with zero horizontal overflow-risk signals, zero missing assets, and zero vector placeholders. The downstream WP Codebox runtime attempt was interrupted by `SIGTERM` before recipe steps executed, so this PR does not claim completed WordPress visual parity.

## Compatibility

No public PHP API or extension path changes. Multi-frame responsive variant selection is unchanged. This changes generated fallback CSS behavior for desktop-only single-frame Figma inputs.

## AI disclosure

Implemented with `openai/gpt-5.6-sol`.