### PR TITLE
Keep positioned media layouts out of galleries

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2269,6 +2269,10 @@ final class HtmlTransformer
      */
     private function mediaGalleryBlockFromElement(DOMElement $element): ?array
     {
+        if ( ! $this->isGalleryCompatibleMediaLayout($element) ) {
+            return null;
+        }
+
         return $this->galleryPattern->match(
             $element,
             fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link),
@@ -2278,6 +2282,37 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
             fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
         );
+    }
+
+    private function isGalleryCompatibleMediaLayout(DOMElement $element): bool
+    {
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement || 'figcaption' === strtolower($child->tagName) ) {
+                continue;
+            }
+
+            $layoutElements = array( $child );
+            foreach ( $child->getElementsByTagName('*') as $descendant ) {
+                if ( $descendant instanceof DOMElement ) {
+                    $layoutElements[] = $descendant;
+                }
+            }
+
+            foreach ( $layoutElements as $layoutElement ) {
+                $declarations = $this->structuralPresentationDeclarations($layoutElement);
+                $position = strtolower(trim((string) ($declarations['position'] ?? '')));
+                if ( in_array($position, array( 'absolute', 'fixed', 'sticky' ), true) ) {
+                    return false;
+                }
+
+                $zIndex = strtolower(trim((string) ($declarations['z-index'] ?? '')));
+                if ( '' !== $zIndex && 'auto' !== $zIndex ) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -812,11 +812,13 @@ trait StyleResolutionTrait
             'padding-left',
             'padding-right',
             'padding-top',
+            'position',
             'row-gap',
             'text-align',
             'text-decoration',
             'text-transform',
             'width',
+            'z-index',
         ));
 
         return array_intersect_key($declarations, $safe);

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-positioned-collage.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-positioned-collage.json
@@ -1,0 +1,39 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-linked-css-positioned-collage",
+  "description": "Resolves class-owned positioned media from linked CSS before deciding whether sibling images are gallery-compatible.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-linked-css-positioned-collage.json",
+    "notes": "Matches generated static artifacts where collage geometry lives in a linked author stylesheet."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream artifact primitive has no downstream legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<!doctype html><html><head><link rel=\"stylesheet\" href=\"assets/site.css\"></head><body><main><div class=\"collage\"><img class=\"collage-primary\" src=\"https://example.com/primary.jpg\" alt=\"Primary\"><img class=\"collage-secondary\" src=\"https://example.com/secondary.jpg\" alt=\"Secondary\"></div></main></body></html>"
+        },
+        {
+          "path": "assets/site.css",
+          "kind": "css",
+          "content": ".collage{position:relative;overflow:hidden;isolation:isolate;width:680px;height:560px}.collage-primary{position:absolute;left:0;top:0;z-index:1;width:470px;height:505px;object-fit:cover}.collage-secondary{position:absolute;left:390px;top:225px;z-index:2;width:296px;height:340px;object-fit:cover}"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group {\"className\":\"collage\"}" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "collage-primary" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:gallery" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-positioned-image-collage-group.json
+++ b/php-transformer/tests/fixtures/parity/html-positioned-image-collage-group.json
@@ -1,0 +1,34 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-positioned-image-collage-group",
+  "description": "Preserves an authored positioned image collage as a native group instead of rewriting its overlapping geometry into core gallery columns.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-positioned-image-collage-group.json",
+    "notes": "Regression coverage for generic gallery promotion safety; class-owned absolute positioning must be resolved from source CSS."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div class=\"collage\" style=\"position:relative;overflow:hidden;isolation:isolate;width:680px;height:560px\"><img class=\"collage-primary\" style=\"position:absolute;left:0;top:0;z-index:1;width:470px;height:505px;object-fit:cover\" src=\"https://example.com/primary.jpg\" alt=\"Primary\"><img class=\"collage-secondary\" style=\"position:absolute;left:390px;top:225px;z-index:2;width:296px;height:340px;object-fit:cover\" src=\"https://example.com/secondary.jpg\" alt=\"Secondary\"></div>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "url": "https://example.com/primary.jpg", "alt": "Primary" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/image", "attrs": { "url": "https://example.com/secondary.jpg", "alt": "Secondary" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:group" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "collage-primary" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:gallery" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "coverage.0.fallback_count", "assert": "equals", "value": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- reject gallery promotion when media descendants use positioned or layered layout semantics
- retain `position` and `z-index` in structural style resolution for classification
- cover inline and linked-stylesheet positioned collages while preserving ordinary gallery behavior

## Verification
- `composer test:parity` (246 fixtures)
- `composer test`
- Fisiostetic Lab visual mismatch: 11.8963% -> 11.1467% (52,744 fewer mismatched pixels)
- positioned collage hotspot: 135,833 -> 81,908 mismatched pixels
- source images: 26/26 loaded; capture readiness: high

Fixes #668

Depends on #663.