### PR TITLE
Deduplicate generated assets across HTML routes

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -1671,7 +1671,7 @@ final class ArtifactCompiler
                 ? array('serialized_blocks' => $serializedBlocks, 'assets' => array(), 'shell_artifacts' => $entryShellArtifacts)
                 : $this->compileHtmlDocumentBlocks($content, $path, $artifact['files'], 'artifact-document', '', true);
             foreach ( $compiledBlocks['assets'] ?? array() as $generatedAsset ) {
-                if ( is_array($generatedAsset) ) {
+                if ( is_array($generatedAsset) && ! in_array($generatedAsset, $assets, true) ) {
                     $assets[] = $generatedAsset;
                 }
             }

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -60,6 +60,18 @@ $typeAssets = $types['assets'] ?? array();
 $typeContents = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $typeAssets));
 $assert(str_contains($typeContents, '.style-ok{color:red}') && str_contains($typeContents, '.link-ok{color:green}') && ! str_contains($typeContents, '.style-bad{color:red}') && ! str_contains($typeContents, '.link-bad{color:blue}'), 'CSS MIME parsing accepts case-insensitive text/css parameters and rejects non-MIME prefixes for style and link occurrences');
 
+$multiPage = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'index.html',
+    'files' => array(
+        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="shared.css"><main><p><span class="quote-mark">&quot;</span>Home</p></main>' ),
+        array( 'path' => 'about.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="shared.css"><main><p><span class="quote-mark">&quot;</span>About</p></main>' ),
+        array( 'path' => 'shared.css', 'kind' => 'css', 'content' => '.quote-mark{color:#e8a020}' ),
+    ),
+) )->toArray();
+$multiPageAuthorAssets = array_values(array_filter($multiPage['assets'] ?? array(), static fn (array $asset): bool => 'author-css' === ($asset['source'] ?? '')));
+$assert(1 === count($multiPageAuthorAssets), 'identical generated author stylesheets are emitted once across HTML routes');
+$assert('blocks-engine/wordpress-site-plan/v2' === ($multiPage['source_reports']['wordpress_site_plan']['schema'] ?? null), 'deduplicated multi-route assets produce a canonical WordPress site plan');
+
 if ( $failures > 0 ) {
     exit(1);
 }


### PR DESCRIPTION
Fixes #670.

## Summary

- deduplicate identical route-level generated assets before WordPress site-plan construction
- preserve fail-closed handling for non-identical source-identity collisions
- cover shared multi-route author CSS with a canonical site-plan regression

## Verification

- `composer test`
- 244 PHP transformer parity fixtures
- PHP syntax checks
- FSE Pilot Build Theme artifact progresses from duplicate source-identity rejection to the next independently diagnosed local form-route reference check