### PR TITLE
Preserve encoded data URLs in site plans

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -642,6 +642,7 @@ final class WordPressSitePlan
     }
     private static function assertNoLocalBrowserReferences(string $content): void
     {
+        $content = html_entity_decode($content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $patterns = array('/\b(?:src|href|srcset|poster|action)\s*=\s*["\']([^"\']+)["\']/i', '/["\'](?:url|src|href|srcset|poster|action)["\']\s*:\s*["\']([^"\']+)["\']/i', '/(?:url\(\s*["\']?|@import\s+(?:url\(\s*)?["\']?)([^\s\)"\';]+)/i');
         foreach ($patterns as $pattern) if (preg_match_all($pattern, $content, $matches)) foreach ($matches[1] as $value) foreach (preg_match('~^[a-z][a-z0-9+.-]*:~i', trim((string) $value)) ? array($value) : explode(',', (string) $value) as $candidate) {
             $url = trim(preg_split('/\s+/', trim($candidate))[0] ?? '');

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -271,6 +271,8 @@ $unresolvedLocal = $plan; $unresolvedLocal['pages'][0]['canonical_block_markup']
 $throws(static fn() => WordPressSitePlan::assertValid($unresolvedLocal), 'Validation rejects unresolved local browser references.');
 $dataSvg = $plan; $dataSvg['pages'][0]['canonical_block_markup'] .= '<div style="background-image:url(data:image/svg+xml,%3Csvg%3E%3C/svg%3E)"></div>'; $dataSvg['pages'][0]['content_hash'] = WordPressSitePlan::contentHash($dataSvg['pages'][0]['canonical_block_markup']);
 WordPressSitePlan::assertValid($dataSvg); $assert(true, 'Validation preserves complete data URLs instead of treating the payload after its comma as a local reference.');
+$encodedQuotedDataSvg = $plan; $encodedQuotedDataSvg['pages'][0]['canonical_block_markup'] .= '<div style="background-image:url(&quot;data:image/svg+xml,%3Csvg%3E%3C/svg%3E&quot;)"></div>'; $encodedQuotedDataSvg['pages'][0]['content_hash'] = WordPressSitePlan::contentHash($encodedQuotedDataSvg['pages'][0]['canonical_block_markup']);
+WordPressSitePlan::assertValid($encodedQuotedDataSvg); $assert(true, 'Validation preserves data URLs with HTML-encoded CSS quotes.');
 $unresolvedSrcset = $plan; $unresolvedSrcset['pages'][0]['canonical_block_markup'] .= '<img srcset="/images/first.svg 1x, images/missing.svg 2x">'; $unresolvedSrcset['pages'][0]['content_hash'] = WordPressSitePlan::contentHash($unresolvedSrcset['pages'][0]['canonical_block_markup']);
 $throws(static fn() => WordPressSitePlan::assertValid($unresolvedSrcset), 'Validation still rejects unresolved members of comma-separated srcset references.');
 $invalidMetadata = $plan; $invalidMetadata['pages'][0]['document_metadata']['scripts'][0]['asset_reference'] = '{{wordpress-site-plan:asset:asset-0000000000000000}}';


### PR DESCRIPTION
## Summary
- decode HTML entities in the site-plan validator's inspection copy before classifying browser references
- preserve canonical payload bytes unchanged
- cover quoted data-SVG URLs whose quotes are HTML-encoded in compiled block markup

Closes #675.

## Verification
- `php php-transformer/tests/contract/wordpress-site-plan.php`

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** Traced the Relay Atlas release regression, implemented the validator fix, and added the regression contract. Chris Huber remains responsible for the change.