### PR TITLE
Emit real Figma acceptance evidence

### DIFF
--- a/docs/contracts/figma-wordpress-acceptance-matrix-v2.md
+++ b/docs/contracts/figma-wordpress-acceptance-matrix-v2.md
@@ -23,3 +23,16 @@ Each fixture supplies a deployable `blocks-engine/wordpress-site-plan/v2` and ev
 Parity evidence uses schema `blocks-engine/figma-wordpress-stage-evidence/v1`, exact fixture/stage/source identities, resolvable screenshot and diff references, and the corresponding `comparison` value: `figma_html`, `html_wordpress`, or `figma_wordpress`. Every diff must report zero pixel and geometry differences.
 
 All evidence stages remain mandatory. Missing inputs, malformed plans, unresolved references, invalid blocks, fallback blocks, nonzero parity differences, and incomplete fixture accounting fail closed with stable stage-specific reason codes.
+
+## Figma Producer
+
+Run the Figma-side producer into the same repository-artifact root used by the evaluator:
+
+```sh
+cd figma-transformer
+php scripts/figma-fixture-matrix.php --fixture=/path/to/private.fig --output-dir=../artifacts/figma-wordpress-acceptance --parity-report=../artifacts/figma-wordpress-acceptance/figures/{fixture}-parity.json
+```
+
+Completed fixture records retain their existing output and add `acceptance_readiness` (`blocks-engine/figma-transformer/acceptance-readiness/v1`). Its stage files are written to `<output-dir>/<fixture>/acceptance-readiness/{decode,normalize,emit,figma_html_desktop_parity,figma_html_mobile_parity,responsive_selection}.json`. Use those paths for the corresponding `evidence` entries in the evaluator manifest.
+
+The matrix emits only Figma facts. It derives decode, normalize, emit, responsive source-frame, and Figma-to-HTML parity evidence from transform diagnostics and an explicit operator-provided parity report. That report carries distinct `breakpoints` entries for desktop and mobile; each entry has `viewport.device_hint`, `source.screenshot_path`, `generated.screenshot_path`, and `artifacts.report_path`. The referenced exact diff report contains integer `pixel_difference_count` and `geometry_difference_count` metrics. Acceptance evidence records hashes for all three artifacts. Unscoped single-viewport evidence cannot satisfy both stages. Screenshots and exact diff reports are supplied by external browser tooling; generated HTML captures are never source screenshots. SSI supplies import, editor, fallback, HTML-to-WordPress, and Figma-to-WordPress stages.

--- a/figma-transformer/scripts/figma-fixture-matrix-acceptance.php
+++ b/figma-transformer/scripts/figma-fixture-matrix-acceptance.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+const MATRIX_ACCEPTANCE_READINESS_SCHEMA = 'blocks-engine/figma-transformer/acceptance-readiness/v1';
+const MATRIX_ACCEPTANCE_STAGE_SCHEMA = 'blocks-engine/figma-wordpress-stage-evidence/v1';
+
+/**
+ * Projects completed Figma transforms into the Figma-owned portion of the
+ * production acceptance contract. WordPress stages deliberately remain absent.
+ *
+ * @param array<string, mixed> $result
+ * @return array<string, mixed>
+ */
+function matrix_acceptance_readiness(string $fixtureId, string $fixturePath, array $result, string $artifactRoot, string $resultPath): array
+{
+    $sourceHash = is_file($fixturePath) ? hash_file('sha256', $fixturePath) : false;
+    $sourceHash = is_string($sourceHash) ? $sourceHash : '';
+    $resultReference = matrix_acceptance_reference($resultPath, $artifactRoot);
+    $diagnostics = is_array($result['source_reports']['figma']['html']['transform_diagnostics'] ?? null)
+        ? $result['source_reports']['figma']['html']['transform_diagnostics']
+        : array();
+    $quality = is_array($diagnostics['artifact_quality']['summary'] ?? null)
+        ? $diagnostics['artifact_quality']['summary']
+        : array();
+    $metrics = is_array($result['metrics'] ?? null) ? $result['metrics'] : array();
+    $pages = is_array($result['source_reports']['figma']['pages'] ?? null) ? $result['source_reports']['figma']['pages'] : array();
+
+    // These are distinct canonical facts: empty decoded text, unresolved source
+    // assets, vector decode placeholders, normalized nodes, and emitted coverage.
+    $decodeMetrics = array(
+        'missing_text_count' => matrix_acceptance_int($quality, 'empty_decoded_text_nodes'),
+        'missing_asset_count' => matrix_acceptance_int($quality, 'missing_asset_nodes'),
+        'vector_placeholder_count' => matrix_acceptance_int($quality, 'vector_placeholders'),
+    );
+    $normalizeMetrics = array('normalized_node_count' => matrix_acceptance_int($metrics, 'node_count'));
+    $emitMetrics = array(
+        'emitted_route_count' => matrix_acceptance_int($metrics, 'page_count'),
+        'missing_emitted_asset_count' => matrix_acceptance_nested_int($quality, array('source_loss_coverage', 'domains', 'images', 'node_coverage', 'uncovered_source_nodes')),
+        'missing_emitted_text_count' => matrix_acceptance_int($quality, 'missing_emitted_text_nodes'),
+    );
+
+    $stages = array(
+        'decode' => matrix_acceptance_metric_stage($fixtureId, $sourceHash, 'decode', $decodeMetrics, $resultReference, 'decode_incomplete_output'),
+        'normalize' => matrix_acceptance_metric_stage($fixtureId, $sourceHash, 'normalize', $normalizeMetrics, $resultReference, 'normalize_missing_nodes'),
+        'emit' => matrix_acceptance_metric_stage($fixtureId, $sourceHash, 'emit', $emitMetrics, $resultReference, 'emit_incomplete_artifact'),
+    );
+    $responsive = matrix_acceptance_responsive_stage($fixtureId, $sourceHash, $pages, $resultReference);
+    $stages['responsive_selection'] = $responsive;
+    $parity = matrix_acceptance_parity_stages($fixtureId, $sourceHash, $result, $artifactRoot, $resultReference, $responsive);
+    $stages += $parity;
+
+    return array(
+        'schema' => MATRIX_ACCEPTANCE_READINESS_SCHEMA,
+        'status' => matrix_acceptance_all_passed($stages) ? 'passed' : 'unavailable',
+        'stages' => $stages,
+    );
+}
+
+/** @param array<string, mixed> $readiness */
+function matrix_write_acceptance_readiness(array $readiness, string $fixtureOutputDir): array
+{
+    $directory = $fixtureOutputDir . '/acceptance-readiness';
+    if (!is_dir($directory)) {
+        mkdir($directory, 0777, true);
+    }
+    $paths = array();
+    foreach ($readiness['stages'] as $stage => $evidence) {
+        $path = $directory . '/' . $stage . '.json';
+        file_put_contents($path, json_encode($evidence, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+        $paths[$stage] = $path;
+    }
+    return $paths;
+}
+
+/** @param array<string, mixed> $metrics */
+function matrix_acceptance_metric_stage(string $fixtureId, string $sourceHash, string $stage, array $metrics, string $resultReference, string $failure): array
+{
+    $passed = 'decode' === $stage
+        ? 0 === $metrics['missing_text_count'] && 0 === $metrics['missing_asset_count'] && 0 === $metrics['vector_placeholder_count']
+        : ('normalize' === $stage
+            ? $metrics['normalized_node_count'] > 0
+            : $metrics['emitted_route_count'] > 0 && 0 === $metrics['missing_emitted_asset_count'] && 0 === $metrics['missing_emitted_text_count']);
+    return matrix_acceptance_stage($fixtureId, $sourceHash, $stage, $passed ? 'passed' : 'failed', $passed ? 'ok' : $failure, $metrics, array($resultReference));
+}
+
+/** @param array<string, mixed> $pages */
+function matrix_acceptance_responsive_stage(string $fixtureId, string $sourceHash, array $pages, string $resultReference): array
+{
+    $selection = $pages['selection_source'] ?? null;
+    $routes = array();
+    foreach (is_array($pages['pages'] ?? null) ? $pages['pages'] : array() as $page) {
+        if (!is_array($page) || !is_array($page['variants'] ?? null)) {
+            continue;
+        }
+        $desktop = null;
+        $mobile = null;
+        foreach ($page['variants'] as $variant) {
+            if (!is_array($variant) || !is_string($variant['frame_id'] ?? null) || '' === $variant['frame_id']) {
+                continue;
+            }
+            if ('desktop' === ($variant['device_hint'] ?? null)) {
+                $desktop = $variant;
+            }
+            if ('mobile' === ($variant['device_hint'] ?? null)) {
+                $mobile = $variant;
+            }
+        }
+        if (is_array($desktop) && is_array($mobile) && is_numeric($desktop['viewport_width'] ?? null) && is_numeric($mobile['viewport_width'] ?? null) && (int) $mobile['viewport_width'] < (int) $desktop['viewport_width']) {
+            $routes[] = array('output_route' => (string) ($page['path'] ?? ''), 'desktop_source_frame' => $desktop['frame_id'], 'mobile_source_frame' => $mobile['frame_id'], 'breakpoint_min_width' => (int) $mobile['viewport_width'], 'breakpoint_max_width' => (int) $desktop['viewport_width']);
+        }
+    }
+    if (!in_array($selection, array('dev_status', 'heuristic'), true) || empty($routes)) {
+        $reason = 'heuristic' === $selection ? 'responsive_selection_mobile_source_unavailable' : 'responsive_selection_incomplete_boundaries';
+        return matrix_acceptance_stage($fixtureId, $sourceHash, 'responsive_selection', 'failed', $reason, array(), array($resultReference));
+    }
+    $evidence = matrix_acceptance_stage($fixtureId, $sourceHash, 'responsive_selection', 'passed', 'ok', array(), array($resultReference));
+    $evidence['selection_source'] = 'dev_status' === $selection ? 'dev_status' : 'heuristic_fallback';
+    $evidence['responsive_routes'] = $routes;
+    return $evidence;
+}
+
+/** @param array<string, mixed> $result @param array<string, mixed> $responsive */
+function matrix_acceptance_parity_stages(string $fixtureId, string $sourceHash, array $result, string $artifactRoot, string $resultReference, array $responsive): array
+{
+    $parity = is_array($result['parity'] ?? null) ? $result['parity'] : array();
+    $breakpoints = is_array($parity['breakpoints'] ?? null) ? $parity['breakpoints'] : array();
+    $stages = array();
+    foreach (array('desktop', 'mobile') as $viewport) {
+        $stage = 'figma_html_' . $viewport . '_parity';
+        $breakpoint = matrix_acceptance_parity_breakpoint($breakpoints, $viewport);
+        $source = matrix_acceptance_reference((string) ($breakpoint['source']['screenshot_path'] ?? ''), $artifactRoot);
+        $rendered = matrix_acceptance_reference((string) ($breakpoint['generated']['screenshot_path'] ?? ''), $artifactRoot);
+        $diff = matrix_acceptance_reference((string) ($breakpoint['artifacts']['report_path'] ?? ''), $artifactRoot);
+        $proof = '' !== $source && '' !== $rendered && '' !== $diff && is_file($artifactRoot . '/' . $source) && is_file($artifactRoot . '/' . $rendered) && is_file($artifactRoot . '/' . $diff);
+        $report = $proof ? json_decode((string) file_get_contents($artifactRoot . '/' . $diff), true) : null;
+        $reportMetrics = is_array($report['metrics'] ?? null) ? $report['metrics'] : $report;
+        $exactDiff = is_array($reportMetrics) && is_int($reportMetrics['pixel_difference_count'] ?? null) && is_int($reportMetrics['geometry_difference_count'] ?? null);
+        $zeroDiff = $exactDiff && 0 === $reportMetrics['pixel_difference_count'] && 0 === $reportMetrics['geometry_difference_count'];
+        $mobileUnavailable = 'mobile' === $viewport && 'passed' !== ($responsive['status'] ?? null);
+        $reason = !$proof ? $stage . '_missing_screenshots' : (!$exactDiff ? $stage . '_missing_metrics' : (!$zeroDiff ? $stage . '_nonzero_difference' : ($mobileUnavailable ? 'responsive_selection_mobile_source_unavailable' : 'ok')));
+        $evidence = matrix_acceptance_stage($fixtureId, $sourceHash, $stage, 'ok' === $reason ? 'passed' : 'failed', $reason, is_array($reportMetrics) ? $reportMetrics : array(), array_values(array_filter(array($resultReference, $source, $rendered, $diff))));
+        $evidence['comparison'] = 'figma_html';
+        if ($proof) {
+            $evidence['source_screenshot'] = $source;
+            $evidence['rendered_screenshot'] = $rendered;
+            $evidence['diff_report'] = $diff;
+            $evidence['artifact_sha256'] = array(
+                'source_screenshot' => hash_file('sha256', $artifactRoot . '/' . $source),
+                'rendered_screenshot' => hash_file('sha256', $artifactRoot . '/' . $rendered),
+                'diff_report' => hash_file('sha256', $artifactRoot . '/' . $diff),
+            );
+        }
+        $stages[$stage] = $evidence;
+    }
+    return $stages;
+}
+
+/** @param array<int, mixed> $breakpoints @return array<string, mixed> */
+function matrix_acceptance_parity_breakpoint(array $breakpoints, string $viewport): array
+{
+    foreach ($breakpoints as $breakpoint) {
+        if (is_array($breakpoint) && $viewport === ($breakpoint['viewport']['device_hint'] ?? null)) {
+            return $breakpoint;
+        }
+    }
+    return array();
+}
+
+/** @param array<string, mixed> $metrics @param array<int, string> $references */
+function matrix_acceptance_stage(string $fixtureId, string $sourceHash, string $stage, string $status, string $reason, array $metrics, array $references): array
+{
+    return array_filter(array('schema' => MATRIX_ACCEPTANCE_STAGE_SCHEMA, 'status' => $status, 'reason_code' => $reason, 'fixture_id' => $fixtureId, 'stage' => $stage, 'source_sha256' => $sourceHash, 'metrics' => $metrics, 'references' => array_values(array_filter($references))), static fn (mixed $value): bool => array() !== $value);
+}
+
+function matrix_acceptance_int(array $values, string $key): int { return is_int($values[$key] ?? null) ? $values[$key] : -1; }
+function matrix_acceptance_nested_int(array $values, array $keys): int { foreach ($keys as $key) { if (!is_array($values) || !array_key_exists($key, $values)) { return -1; } $values = $values[$key]; } return is_int($values) ? $values : -1; }
+function matrix_acceptance_reference(string $path, string $root): string { if ('' === $path) { return ''; } $root = rtrim(str_replace('\\', '/', $root), '/'); $path = str_replace('\\', '/', $path); return str_starts_with($path, $root . '/') ? substr($path, strlen($root) + 1) : (!str_starts_with($path, '/') && !str_contains($path, '..') ? $path : ''); }
+function matrix_acceptance_all_passed(array $stages): bool { foreach ($stages as $stage) { if ('passed' !== ($stage['status'] ?? null)) { return false; } } return true; }

--- a/figma-transformer/scripts/figma-fixture-matrix.php
+++ b/figma-transformer/scripts/figma-fixture-matrix.php
@@ -7,6 +7,7 @@ $root = dirname(__DIR__, 2);
 $figmaRoot = $root . '/figma-transformer';
 require_once __DIR__ . '/figma-fixture-selection.php';
 require_once __DIR__ . '/figma-fixture-matrix-quality.php';
+require_once __DIR__ . '/figma-fixture-matrix-acceptance.php';
 
 $options = matrix_options($argv);
 if ( true === ($options['help'] ?? false) ) {
@@ -269,6 +270,8 @@ foreach ( $fixtures as $fixture ) {
             $record['result_status'] = $result['status'] ?? null;
             $record['parity'] = matrix_parity_summary(is_array($result['parity'] ?? null) ? $result['parity'] : array());
             $record['metrics'] = $result['metrics'] ?? array();
+            $record['acceptance_readiness'] = matrix_acceptance_readiness($record['id'], $fixturePath, $result, $outputDir, $resultPath);
+            $record['acceptance_readiness']['stage_paths'] = matrix_write_acceptance_readiness($record['acceptance_readiness'], $fixtureOutputDir);
             $diagnostics = $result['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
             if ( is_array($diagnostics) ) {
                 $record['diagnostic_codes'] = $diagnostics['diagnostic_codes'] ?? array();
@@ -1224,6 +1227,10 @@ function matrix_merge_parity_report(array $parity, array $report): array
         if ( isset($report[$key]) && is_array($report[$key]) ) {
             $parity[$key] = array_merge(is_array($parity[$key] ?? null) ? $parity[$key] : array(), $report[$key]);
         }
+    }
+
+    if ( isset($report['breakpoints']) && is_array($report['breakpoints']) ) {
+        $parity['breakpoints'] = array_values($report['breakpoints']);
     }
 
     foreach ( array('pixel_mismatch_count', 'pixel_mismatch_ratio') as $key ) {

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../scripts/figma-fixture-matrix-quality.php';
+require_once __DIR__ . '/../../scripts/figma-fixture-matrix-acceptance.php';
 
 /**
  * @param callable(bool, string): void $assert
@@ -891,6 +892,51 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(str_contains($matrixScreenshotCommand, '--parity-source-screenshot-path=' . escapeshellarg($matrixFixtureDir . '/screenshots/alias/alias-source.png')), 'fixture-matrix-source-screenshot-transform-argument');
     $assert(str_contains($matrixScreenshotCommand, '--parity-generated-screenshot-path=' . escapeshellarg($matrixFixtureDir . '/screenshots/alias/alias-generated.png')), 'fixture-matrix-generated-screenshot-transform-argument');
     $assert(str_contains($matrixScreenshotCommand, '--parity-diff-image-path=' . escapeshellarg($matrixFixtureDir . '/screenshots/alias/alias-diff.png')), 'fixture-matrix-diff-image-transform-argument');
+
+    $acceptanceRoot = $matrixFixtureDir . '/acceptance';
+    mkdir($acceptanceRoot . '/artifacts', 0777, true);
+    $acceptanceResultPath = $acceptanceRoot . '/transform-result.json';
+    file_put_contents($acceptanceResultPath, '{}');
+    foreach (array('desktop-source.png', 'desktop-rendered.png', 'mobile-source.png', 'mobile-rendered.png') as $artifact) {
+        file_put_contents($acceptanceRoot . '/artifacts/' . $artifact, 'image');
+    }
+    foreach (array('desktop', 'mobile') as $viewport) {
+        file_put_contents($acceptanceRoot . '/artifacts/' . $viewport . '-diff.json', json_encode(array('metrics' => array('pixel_difference_count' => 0, 'geometry_difference_count' => 0))));
+    }
+    $acceptanceResult = array(
+        'metrics' => array('node_count' => 9, 'page_count' => 1),
+        'source_reports' => array('figma' => array(
+            'pages' => array('selection_source' => 'dev_status', 'pages' => array(array('path' => 'index.html', 'variants' => array(array('frame_id' => 'desktop', 'device_hint' => 'desktop', 'viewport_width' => 1440), array('frame_id' => 'mobile', 'device_hint' => 'mobile', 'viewport_width' => 375))))),
+            'html' => array('transform_diagnostics' => array('artifact_quality' => array('summary' => array('empty_decoded_text_nodes' => 0, 'missing_asset_nodes' => 0, 'vector_placeholders' => 0, 'missing_emitted_text_nodes' => 0, 'source_loss_coverage' => array('domains' => array('images' => array('node_coverage' => array('uncovered_source_nodes' => 0)))))))),
+        )),
+        'parity' => array('breakpoints' => array(
+            array('viewport' => array('device_hint' => 'desktop', 'width' => 1440), 'source' => array('screenshot_path' => $acceptanceRoot . '/artifacts/desktop-source.png'), 'generated' => array('screenshot_path' => $acceptanceRoot . '/artifacts/desktop-rendered.png'), 'artifacts' => array('report_path' => $acceptanceRoot . '/artifacts/desktop-diff.json')),
+            array('viewport' => array('device_hint' => 'mobile', 'width' => 375), 'source' => array('screenshot_path' => $acceptanceRoot . '/artifacts/mobile-source.png'), 'generated' => array('screenshot_path' => $acceptanceRoot . '/artifacts/mobile-rendered.png'), 'artifacts' => array('report_path' => $acceptanceRoot . '/artifacts/mobile-diff.json')),
+        )),
+    );
+    $acceptanceReadiness = matrix_acceptance_readiness('acceptance-fixture', $matrixFixtureDir . '/alias.fig', $acceptanceResult, $acceptanceRoot, $acceptanceResultPath);
+    $assert(MATRIX_ACCEPTANCE_READINESS_SCHEMA === ($acceptanceReadiness['schema'] ?? null), 'fixture-matrix-acceptance-readiness-schema');
+    $assert('passed' === ($acceptanceReadiness['status'] ?? null), 'fixture-matrix-acceptance-readiness-passes-complete-real-facts');
+    $assert(0 === ($acceptanceReadiness['stages']['decode']['metrics']['missing_text_count'] ?? null), 'fixture-matrix-acceptance-decode-metric-is-explicit');
+    $assert(9 === ($acceptanceReadiness['stages']['normalize']['metrics']['normalized_node_count'] ?? null), 'fixture-matrix-acceptance-normalize-metric-is-explicit');
+    $assert('mobile' === ($acceptanceReadiness['stages']['responsive_selection']['responsive_routes'][0]['mobile_source_frame'] ?? null), 'fixture-matrix-acceptance-responsive-keeps-real-mobile-frame');
+    $assert('artifacts/desktop-source.png' === ($acceptanceReadiness['stages']['figma_html_desktop_parity']['source_screenshot'] ?? null), 'fixture-matrix-acceptance-desktop-uses-desktop-proof');
+    $assert('artifacts/mobile-source.png' === ($acceptanceReadiness['stages']['figma_html_mobile_parity']['source_screenshot'] ?? null), 'fixture-matrix-acceptance-mobile-uses-mobile-proof');
+    $assert(hash_file('sha256', $acceptanceRoot . '/artifacts/mobile-source.png') === ($acceptanceReadiness['stages']['figma_html_mobile_parity']['artifact_sha256']['source_screenshot'] ?? null), 'fixture-matrix-acceptance-source-proof-is-hashable');
+    $missingSource = $acceptanceResult;
+    unset($missingSource['parity']['breakpoints'][0]['source']['screenshot_path']);
+    $missingSourceReadiness = matrix_acceptance_readiness('acceptance-fixture', $matrixFixtureDir . '/alias.fig', $missingSource, $acceptanceRoot, $acceptanceResultPath);
+    $assert('failed' === ($missingSourceReadiness['stages']['figma_html_desktop_parity']['status'] ?? null), 'fixture-matrix-acceptance-missing-source-cannot-pass');
+    $assert('figma_html_desktop_parity_missing_screenshots' === ($missingSourceReadiness['stages']['figma_html_desktop_parity']['reason_code'] ?? null), 'fixture-matrix-acceptance-missing-source-reason');
+    $unscopedParity = $acceptanceResult;
+    $unscopedParity['parity'] = array('source' => array('screenshot_path' => $acceptanceRoot . '/artifacts/desktop-source.png'), 'generated' => array('screenshot_path' => $acceptanceRoot . '/artifacts/desktop-rendered.png'), 'artifacts' => array('report_path' => $acceptanceRoot . '/artifacts/desktop-diff.json'));
+    $unscopedParityReadiness = matrix_acceptance_readiness('acceptance-fixture', $matrixFixtureDir . '/alias.fig', $unscopedParity, $acceptanceRoot, $acceptanceResultPath);
+    $assert('failed' === ($unscopedParityReadiness['stages']['figma_html_desktop_parity']['status'] ?? null), 'fixture-matrix-acceptance-unscoped-parity-cannot-pass');
+    $incompleteResponsive = $acceptanceResult;
+    $incompleteResponsive['source_reports']['figma']['pages']['selection_source'] = 'heuristic';
+    $incompleteResponsive['source_reports']['figma']['pages']['pages'][0]['variants'] = array(array('frame_id' => 'desktop', 'device_hint' => 'desktop', 'viewport_width' => 1440));
+    $incompleteResponsiveReadiness = matrix_acceptance_readiness('acceptance-fixture', $matrixFixtureDir . '/alias.fig', $incompleteResponsive, $acceptanceRoot, $acceptanceResultPath);
+    $assert('responsive_selection_mobile_source_unavailable' === ($incompleteResponsiveReadiness['stages']['responsive_selection']['reason_code'] ?? null), 'fixture-matrix-acceptance-heuristic-never-invents-mobile-frame');
     $assert(0 !== $missingHomeboyExitCode, 'fixture-matrix-capture-preflight-missing-homeboy-fails');
     $missingHomeboyMessage = implode("\n", $missingHomeboyOutput);
     $assert(str_contains($missingHomeboyMessage, 'DOM box capture requires a runnable Homeboy command'), 'fixture-matrix-capture-preflight-missing-homeboy-message');

--- a/tests/contract/production-acceptance-matrix.php
+++ b/tests/contract/production-acceptance-matrix.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 $root = dirname(__DIR__, 2);
 require $root . '/php-transformer/vendor/autoload.php';
+require_once $root . '/figma-transformer/scripts/figma-fixture-matrix-acceptance.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 
@@ -98,6 +99,40 @@ $assert('passed' === ($summary['status'] ?? null), 'summary reports a passing ma
 $assert('blocks-engine/figma-wordpress-acceptance/v2' === ($summary['schema'] ?? null), 'summary reports the layered v2 contract');
 $assert(3 === count($summary['fixtures'] ?? array()), 'production profile enforces the canonical three fixtures');
 $assert(!str_contains(json_encode($summary), $temporary), 'summary excludes private absolute input and evidence paths');
+
+// The fixture matrix emits the Figma-owned stages from actual transform facts;
+// SSI-owned stages below remain the truthful downstream provider fixtures.
+foreach ($fixtures as $index => $fixture) {
+    $fixtureId = $fixture['id'];
+    $matrixRoot = $output . '/figma-matrix/' . $fixtureId;
+    mkdir($matrixRoot . '/artifacts', 0777, true);
+    file_put_contents($matrixRoot . '/result.json', '{}');
+    foreach (array('desktop-source.png', 'desktop-rendered.png', 'mobile-source.png', 'mobile-rendered.png') as $artifact) {
+        file_put_contents($matrixRoot . '/artifacts/' . $artifact, 'image');
+    }
+    foreach (array('desktop', 'mobile') as $viewport) {
+        file_put_contents($matrixRoot . '/artifacts/' . $viewport . '-diff.json', json_encode(array('metrics' => array('pixel_difference_count' => 0, 'geometry_difference_count' => 0))));
+    }
+    $result = array(
+        'metrics' => array('node_count' => 2, 'page_count' => 1),
+        'source_reports' => array('figma' => array(
+            'pages' => array('selection_source' => 'dev_status', 'pages' => array(array('path' => 'index.html', 'variants' => array(array('frame_id' => 'desktop', 'device_hint' => 'desktop', 'viewport_width' => 1440), array('frame_id' => 'mobile', 'device_hint' => 'mobile', 'viewport_width' => 375))))),
+            'html' => array('transform_diagnostics' => array('artifact_quality' => array('summary' => array('empty_decoded_text_nodes' => 0, 'missing_asset_nodes' => 0, 'vector_placeholders' => 0, 'missing_emitted_text_nodes' => 0, 'source_loss_coverage' => array('domains' => array('images' => array('node_coverage' => array('uncovered_source_nodes' => 0)))))))),
+        )),
+        'parity' => array('breakpoints' => array(
+            array('viewport' => array('device_hint' => 'desktop', 'width' => 1440), 'source' => array('screenshot_path' => $matrixRoot . '/artifacts/desktop-source.png'), 'generated' => array('screenshot_path' => $matrixRoot . '/artifacts/desktop-rendered.png'), 'artifacts' => array('report_path' => $matrixRoot . '/artifacts/desktop-diff.json')),
+            array('viewport' => array('device_hint' => 'mobile', 'width' => 375), 'source' => array('screenshot_path' => $matrixRoot . '/artifacts/mobile-source.png'), 'generated' => array('screenshot_path' => $matrixRoot . '/artifacts/mobile-rendered.png'), 'artifacts' => array('report_path' => $matrixRoot . '/artifacts/mobile-diff.json')),
+        )),
+    );
+    $readiness = matrix_acceptance_readiness($fixtureId, $fixture['fig'], $result, $output, $matrixRoot . '/result.json');
+    $stagePaths = matrix_write_acceptance_readiness($readiness, $matrixRoot);
+    foreach (array('decode', 'normalize', 'emit', 'figma_html_desktop_parity', 'figma_html_mobile_parity', 'responsive_selection') as $stage) {
+        $fixtures[$index]['evidence'][$stage] = $stagePaths[$stage];
+    }
+}
+file_put_contents($manifest, json_encode(array('fixtures' => $fixtures)));
+exec($command, $ignored, $matrixProducerExitCode);
+$assert(0 === $matrixProducerExitCode, 'fixture-matrix Figma stage evidence is accepted alongside downstream stages');
 
 $manifestCommand = $command . ' --profile=manifest';
 exec($manifestCommand, $ignored, $manifestExitCode);


### PR DESCRIPTION
## Summary
- project decode, normalize, and emit acceptance metrics from existing transform diagnostics
- write versioned Figma-side stage evidence directly from completed fixture-matrix runs
- require distinct desktop and mobile breakpoint screenshots and exact diff reports, with reviewer-resolvable references and SHA-256 hashes
- fail closed when responsive source selection, authoritative screenshots, or exact parity metrics are unavailable
- prove the generated evidence is accepted by the canonical production evaluator

Real fixture runs remain unavailable rather than inferred when authoritative Figma screenshots or a real mobile source frame are absent.

## Tests
- `php figma-transformer/tests/contract/run.php`
- `php tests/contract/production-acceptance-matrix.php`
- PHP syntax checks for all changed PHP files

Closes #677

## AI assistance
Homeboy/OpenCode with `openai/gpt-5.6-terra` drafted the initial implementation. OpenCode with `openai/gpt-5.6-sol` reviewed it, corrected the viewport-specific parity contract, and expanded the tests and documentation. Chris Huber remains responsible for every line.