### PR TITLE
Fill responsive SVG media boxes

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -105,6 +105,36 @@ trait SvgMaterializationTrait
         $parent = $element->parentNode;
         $parentDisplay = $parent instanceof DOMElement ? strtolower(trim((string) ($this->structuralPresentationDeclarations($parent)['display'] ?? ''))) : '';
         $isFlexOrGridItem = in_array($parentDisplay, array( 'flex', 'inline-flex', 'grid', 'inline-grid' ), true);
+        // A responsive SVG (width/height="100%") is authored to fill the media box
+        // owned by its parent, not to render at its intrinsic viewBox size. When
+        // that parent is a sized flex/grid media wrapper, make the generated
+        // core/image figure fill the wrapper and drop the default block margin, so
+        // the image occupies the true wrapper box instead of collapsing to its
+        // intrinsic viewBox with centering whitespace around it.
+        $isResponsiveFillSvg = $isFlexOrGridItem
+            && null !== $this->svgPercentageWidth(trim($this->attr($element, 'width')))
+            && null !== $this->svgPercentageWidth(trim($this->attr($element, 'height')))
+            && $parent instanceof DOMElement
+            && $this->structuralCssOwnsMediaBox($parent);
+        if ( $isResponsiveFillSvg ) {
+            $dimensions = array();
+            $figureRule = '{margin:0;width:100%;height:100%}';
+            $imgRule = '>img{width:100%;height:100%;-o-object-fit:contain;object-fit:contain}';
+            $fillClass = ($this->geometryCarrierClassAllocator ??= new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
+            $this->generatedGeometryRules[$fillClass] = '.' . $fillClass . $figureRule . '.' . $fillClass . $imgRule;
+            $attrs = array(
+                'url'       => $path,
+                'alt'       => $this->svgImageAlt($element),
+                'className'  => $this->mergePresentationClassNames($this->attr($element, 'class'), $fillClass),
+                'style'      => array(
+                    'typography' => array(
+                        'lineHeight' => '0',
+                    ),
+                ),
+            );
+
+            return array_filter($attrs, static fn ($value): bool => null !== $value && '' !== $value);
+        }
         $preserveInlineGeometry = ! $isFlexOrGridItem && ( '' === $sourceDisplay || in_array($sourceDisplay, array( 'inline', 'inline-block' ), true) );
         $geometryClass = '';
         if ( $preserveInlineGeometry ) {
@@ -265,7 +295,24 @@ trait SvgMaterializationTrait
 
     private function cssOwnsMediaBox(DOMElement $element): bool
     {
-        $declarations = $this->presentationDeclarations($element);
+        return $this->declarationsOwnMediaBox($this->presentationDeclarations($element));
+    }
+
+    /**
+     * Resolve media-box ownership from structural context so a parent media
+     * wrapper is recognized even when it is not itself a high-value styled
+     * element (its class-based width/height/aspect-ratio still owns the box).
+     */
+    private function structuralCssOwnsMediaBox(DOMElement $element): bool
+    {
+        return $this->declarationsOwnMediaBox($this->structuralPresentationDeclarations($element));
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     */
+    private function declarationsOwnMediaBox(array $declarations): bool
+    {
         foreach ( array( 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'aspect-ratio' ) as $property ) {
             if ( isset($declarations[$property]) && '' !== trim((string) $declarations[$property]) ) {
                 return true;

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-responsive-fill-media-box.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-responsive-fill-media-box.json
@@ -1,0 +1,31 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-responsive-fill-media-box",
+  "description": "A responsive inline SVG (width/height=100%) inside a CSS-sized flex media wrapper fills its wrapper via a generated geometry carrier (figure width/height:100%, margin:0, img object-fit:contain) instead of collapsing to its intrinsic viewBox size with centering whitespace and a default block margin.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-responsive-fill-media-box.json",
+    "notes": "Distilled from the artist-music merch product-card media box: a 4:3 flex wrapper owning the media box with a viewBox SVG authored to fill it at 100%. Uses generic class names only."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<style>.media-box{aspect-ratio:4 / 3;display:flex;align-items:center;justify-content:center;overflow:hidden}</style><main><div class=\"media-box\" aria-hidden=\"true\"><svg viewBox=\"0 0 300 220\" width=\"100%\" height=\"100%\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"300\" height=\"220\" fill=\"#1e1410\"></rect><circle cx=\"150\" cy=\"110\" r=\"60\" fill=\"#c4581a\"></circle></svg></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:html" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "is-resized" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"width\":\"100%\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-image be-inline-geometry-" },
+    { "path": "assets.1.content", "assert": "contains", "value": "margin:0;width:100%;height:100%" },
+    { "path": "assets.1.content", "assert": "contains", "value": "object-fit:contain" }
+  ]
+}


### PR DESCRIPTION
## Problem

A responsive inline SVG (`width="100%" height="100%"`) inside a CSS-sized flex/grid media wrapper was materialized as a `core/image` pinned to its intrinsic viewBox size (`is-resized`, e.g. 300×220) and centered, leaving whitespace around the image plus the default `figure` bottom margin.

Concrete impact: on an artist-music `/merch` product grid, each product-card art SVG (`viewBox="0 0 300 220" width="100%" height="100%"`) sits in a `.merch-visual` flex box with `aspect-ratio: 4/3` (360.66×270.48). The source SVG fills that box; the materialized image rendered at a fixed 300×220 centered inside it, inflating every card and cascading a large (~23.5%) visual-diff mismatch across the grid.

## Fix

When an SVG declares responsive `100%` width/height and its parent is a CSS-sized flex/grid media wrapper, emit a geometry carrier so the generated `core/image` figure fills its wrapper (`margin:0; width:100%; height:100%`) with the image `object-fit:contain`, instead of collapsing to intrinsic viewBox geometry. The wrapper's media-box ownership is resolved from structural CSS context so a class-based `aspect-ratio`/size on the parent is recognized even when the parent is not itself a high-value styled element.

## Tests

- New parity fixture `tests/fixtures/parity/html-inline-svg-responsive-fill-media-box.json` asserts the fill carrier is emitted (no `is-resized` intrinsic geometry, figure + `>img` fill rules, `object-fit:contain`).
- Full suite green on `trunk`: **248 parity fixtures**, unit/contract tests, and package-install proof all pass.

## Notes

This is the SVG-fill portion of the `3-artist-music` static-UI parity work, split out as a standalone change against current `trunk` because it is self-contained and conflict-free (the broader #630 branch has unrelated drift conflicts in other files).

## AI assistance disclosure

Claude (Anthropic) via Claude Code implemented the fill carrier, the parity fixture, and this description. Chris reviewed and is responsible for the change.