### PR TITLE
Collapse typography-only text wrappers to styled paragraphs (#630)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3740,6 +3740,24 @@ final class HtmlTransformer
             return null;
         }
 
+        // A pure-text styled wrapper whose CSS is typographic only (no box-model
+        // geometry) round-trips as a single styled `core/paragraph` carrying the
+        // wrapper class. The `core/group` + default inner paragraph form neither
+        // inherits the wrapper's typographic scale onto that inner paragraph nor
+        // suppresses default block spacing, so an eyebrow like `<div class="label">
+        // The Shop</div>` renders at the wrong size and pushes every following
+        // block down. The group form is retained only when the wrapper owns
+        // box-model geometry (padding/border/flex) that a block-level container
+        // must preserve.
+        if ( 0 === $this->childElementCount($element) && ! $this->hasBoxModelWrapperStyling($element) ) {
+            return $this->createBlock(
+                'core/paragraph',
+                array_merge($this->presentationAttributes($element), array( 'content' => $content )),
+                array(),
+                $element
+            );
+        }
+
         return $this->createBlock(
             'core/group',
             $this->presentationAttributes($element),
@@ -3747,6 +3765,15 @@ final class HtmlTransformer
             $element
         );
     }
+
+    /**
+     * Box-model CSS declarations that give a text wrapper block-level geometry
+     * (padding, border, explicit sizing, or flex/grid layout) which must be
+     * preserved on a `core/group` rather than flattened onto a paragraph.
+     *
+     * @var array<int, string>
+     */
+    private const BOX_MODEL_WRAPPER_PROPERTIES = array( 'display', 'gap', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'border', 'border-color', 'border-radius', 'width', 'height', 'min-width', 'max-width', 'min-height' );
 
     private function hasVisualTextWrapperSignal(DOMElement $element): bool
     {
@@ -3759,8 +3786,16 @@ final class HtmlTransformer
             return false;
         }
 
-        $declarations = $this->presentationDeclarations($element);
-        foreach ( array( 'display', 'gap', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'border', 'border-color', 'border-radius', 'width', 'height', 'min-width', 'max-width', 'min-height' ) as $property ) {
+        return $this->hasBoxModelWrapperStyling($element);
+    }
+
+    private function hasBoxModelWrapperStyling(DOMElement $element): bool
+    {
+        // Read the raw matched declarations rather than the post-projection
+        // presentation set: box-model properties such as padding are consumed
+        // into block-supports attributes and would otherwise be invisible here.
+        $declarations = $this->structuralPresentationDeclarations($element);
+        foreach ( self::BOX_MODEL_WRAPPER_PROPERTIES as $property ) {
             if ( isset($declarations[$property]) && '' !== trim((string) $declarations[$property]) ) {
                 return true;
             }

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -187,11 +187,11 @@ $labelCss = '.tag{display:inline-flex;align-items:center;gap:6px;padding:4px 12p
 $labelResult = ( new HtmlTransformer() )->transform($labelHtml, array('static_css' => $labelCss))->toArray();
 $labelMarkup = (string) ($labelResult['serialized_blocks'] ?? '');
 
-$assert(str_contains($labelMarkup, '<div class="wp-block-group tag'), '25: class-owned section badge stays a group wrapper', $labelMarkup);
-$assert(str_contains($labelMarkup, '<div class="wp-block-group tier-name'), '26: class-owned card tier label stays a group wrapper', $labelMarkup);
-$assert(str_contains($labelMarkup, '<div class="wp-block-group tier-price'), '27: class-owned card price row stays a group wrapper', $labelMarkup);
-$assert(str_contains($labelMarkup, '<div class="wp-block-group use-case-result'), '28: class-owned card result row stays a group wrapper', $labelMarkup);
-$assert(! str_contains($labelMarkup, '<p class="tier-name"'), '29: card label is not flattened into a paragraph that breaks wrapper CSS', $labelMarkup);
+$assert(str_contains($labelMarkup, '<div class="wp-block-group tag'), '25: box-model section badge stays a group wrapper', $labelMarkup);
+$assert(str_contains($labelMarkup, '<p class="tier-name">Team</p>'), '26: typography-only card tier label collapses to a styled paragraph so its font scale applies', $labelMarkup);
+$assert(str_contains($labelMarkup, '<div class="wp-block-group tier-price'), '27: box-model card price row stays a group wrapper', $labelMarkup);
+$assert(str_contains($labelMarkup, '<div class="wp-block-group use-case-result'), '28: box-model card result row stays a group wrapper', $labelMarkup);
+$assert(! preg_match('/<!-- wp:group[^>]*"className":"tier-name"/', $labelMarkup), '29: typography-only tier label does not round-trip as a group wrapping a default paragraph', $labelMarkup);
 
 $stackHtml = '<div class="hero-content"><p>Eyebrow</p><h1>Low Tide Table</h1><div></div><p>Local shrimp.</p><div><p>Next Run</p></div><div><a href="#reserve">Reserve</a></div></div>';
 $stackResult = ( new HtmlTransformer() )->transform($stackHtml, array())->toArray();


### PR DESCRIPTION
## Summary

A styled `<div>`/`<span>` whose only content is inline text and whose CSS is **typographic** (font-size, letter-spacing, text-transform, color — no box-model geometry) was round-tripped as a `core/group` wrapping a **default** `core/paragraph`. That structure has two defects:

1. **Font scale is lost** — the wrapper class (e.g. `.label{font-size:0.68rem}`) applies to the group `<div>`, but the inner default paragraph renders at the theme's base paragraph size instead of inheriting the wrapper's scale.
2. **Default block spacing is introduced** — the inner paragraph gets a default block `margin-top`, adding vertical space the source never had.

On imported artist-site routes, an eyebrow like `<div class="label">The Shop</div>` rendered at the wrong size and injected a uniform **~21px top offset** that shifted every following block down the page (measured: `page-header` inflated 458.6px → 479.7px; `merch-intro`/grid/footer all shifted +21px with no accumulation).

## Fix

`visualTextWrapperBlockFromElement()` now emits a **single styled `core/paragraph`** carrying the wrapper class when the wrapper is a pure-text leaf (no child elements) with **no box-model styling**. Wrappers that own box-model geometry — padding, border, explicit sizing, or flex/grid layout (`.tag`, `.tier-price`, `.use-case-result`) — still round-trip as `core/group` so their block-level layout is preserved.

Box-model detection reads the **raw matched declarations** via `structuralPresentationDeclarations()` rather than the post-projection presentation set, so padding consumed into block-supports attributes is still seen.

## Verification

Proven directly against the real fixture — `fixtures/websites/3-artist-music/merch.html` now compiles the eyebrow as:

```
<!-- wp:paragraph {"className":"label pl pl-d1","content":"The Shop"} --><p class="label pl pl-d1">The Shop</p><!-- /wp:paragraph -->
```

Full `php-transformer` suite green:
- **248 parity fixtures** — no regressions
- **75 block-style-support conversion tests** (box-model wrappers stay groups; typography-only `.tier-name` now collapses to a styled paragraph)
- `wordpress-site-plan` + `shared-shell-plan` contracts, HTML-to-blocks contract

The block-style-support tests were updated to encode the corrected contract: box-model wrappers stay `core/group`; typography-only text wrappers collapse to styled paragraphs.

## AI assistance disclosure

Drafted with **Claude (Sonnet 4.5)** via **opencode**, used to root-cause the offset from DOM snapshots and implement the box-model-aware collapse. Every line reviewed by Chris Huber.

Refs #630.
