### PR TITLE
Project unmatched author p-selectors through source-tag marker; keep button rows out of navigation (#630)

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1090,7 +1090,15 @@ final class HtmlTransformer
             }
             $matches = $this->matchingAuthorSourceElements($parsed);
             if ( array() === $matches ) {
-                $rewritten[] = $selector;
+                // A type selector (e.g. `.page-header p`) that matches no source
+                // element must still be projected through its source-tag marker
+                // rather than emitted bare. Otherwise a `<div>` later collapsed to a
+                // `<p>` (an eyebrow `<div class="label">`) would be newly captured by
+                // the dormant `.page-header p` rule and lose its own type scale.
+                // Rewriting to `:where(.source-p-marker)` — carried only by elements
+                // that were `<p>` in the source — makes the rule match exactly what
+                // the author intended and nothing that was structurally promoted.
+                $rewritten[] = $this->rewriteSourceTagTypes($selector, $parsed);
                 continue;
             }
             if ( $this->isRootChildSelector($parsed) ) {
@@ -3754,6 +3762,12 @@ final class HtmlTransformer
         // decoration, which the wrapper class still applies to the paragraph. Real
         // flex containers hold child elements and are already excluded above by the
         // `childElementCount === 0` guard (e.g. `.tier-price` wrapping a `<span>`).
+        //
+        // Descendant paragraph rules the source used a non-`p` tag to escape (e.g.
+        // `.page-header p { font-size: ... }` styling body copy while an eyebrow
+        // authored as `<div class="label">` avoided it) do not capture the collapsed
+        // paragraph: author `p` type selectors are projected through the source-`p`
+        // tag marker, which only elements that were `<p>` in the source carry.
         if ( 0 === $this->childElementCount($element) && ! $this->hasBoxChromeWrapperStyling($element) ) {
             return $this->createBlock(
                 'core/paragraph',

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -30,6 +30,16 @@ final class NavigationPattern implements PatternRecognizerInterface
             return null;
         }
 
+        // A row of button-styled links (e.g. `<div class="stream-links"><a
+        // class="stream-btn">…</a>…</div>`) is a call-to-action button group, not
+        // site navigation. It matched here only because a container token like
+        // `links` looks navigational, but its anchors carry button signals and
+        // belong to the buttons pattern, which preserves their pill geometry and
+        // styling. Defer so navigation does not flatten them into menu items.
+        if ( 'nav' !== strtolower($element->tagName) && ! $this->hasDirectListNavigationSignal($element) && $this->hasButtonStyledLinkChildren($element) ) {
+            return null;
+        }
+
         if ( $this->hasDirectBrandingAnchorBesideListNavigation($element, $innerHtml) ) {
             return null;
         }
@@ -844,6 +854,34 @@ final class NavigationPattern implements PatternRecognizerInterface
                 $this->collectAnchorsExcluding($child, $anchors, $excluded);
             }
         }
+    }
+
+    /**
+     * Whether the container's direct link children are button-styled call-to-
+     * action anchors rather than navigation links. Requires every direct anchor
+     * to carry a button signal so a genuine nav menu with one incidental
+     * button-classed link is not misclassified.
+     */
+    private function hasButtonStyledLinkChildren(DOMElement $element): bool
+    {
+        $classifier = new ButtonSignalClassifier();
+        $anchors = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) ) {
+                $anchors[] = $child;
+            }
+        }
+        if ( 2 > count($anchors) ) {
+            return false;
+        }
+
+        foreach ( $anchors as $anchor ) {
+            if ( ! $classifier->hasTransformSignal($anchor) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function hasNavigationSignal(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -322,6 +322,16 @@ $assert(2 === count($navigationBlock['innerBlocks'] ?? array()), 'navigation con
 $assert('About' === ($navigationBlock['innerBlocks'][0]['attrs']['label'] ?? null), 'navigation conversion still preserves link labels');
 $assert('/about' === ($navigationBlock['innerBlocks'][0]['attrs']['url'] ?? null), 'navigation conversion still preserves link URLs');
 
+// A row of button-styled links whose container merely carries a `links` token is
+// a call-to-action button group, not site navigation. It must convert to
+// core/buttons (preserving pill geometry) instead of being flattened into a
+// core/navigation menu of half-height text links.
+$ctaLinkRowResult = ( new HtmlTransformer() )->transform('<div class="stream-links"><a class="stream-btn" href="#">Spotify</a><a class="stream-btn" href="#">Bandcamp</a><a class="stream-btn" href="#">Apple Music</a></div>')->toArray();
+$ctaSerialized = (string) ($ctaLinkRowResult['serialized_blocks'] ?? '');
+$assert(str_contains($ctaSerialized, '<!-- wp:buttons'), 'button-styled link row converts to core/buttons instead of navigation');
+$assert(! str_contains($ctaSerialized, '<!-- wp:navigation'), 'button-styled link row is not misclassified as core/navigation');
+$assert(str_contains($ctaSerialized, 'stream-links'), 'the converted button group preserves the container class');
+
 $accordionResult = ( new HtmlTransformer() )->transform('<section class="faq"><div class="faq-item active"><button class="faq-question" aria-expanded="true" aria-controls="answer-a">What is covered?</button><div id="answer-a" class="faq-answer"><p>Assessment and treatment planning.</p></div></div><div class="faq-item"><button class="faq-question" aria-expanded="false" aria-controls="answer-b">How long is a visit?</button><div id="answer-b" class="faq-answer"><p>Most visits take 45 minutes.</p></div></div></section>')->toArray();
 $accordionBlock = $accordionResult['blocks'][0] ?? array();
 $accordionItems = $accordionBlock['innerBlocks'] ?? array();

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -117,6 +117,26 @@ $multiPageAuthorAssets = array_values(array_filter($multiPage['assets'] ?? array
 $assert(1 === count($multiPageAuthorAssets), 'identical generated author stylesheets are emitted once across HTML routes');
 $assert('blocks-engine/wordpress-site-plan/v2' === ($multiPage['source_reports']['wordpress_site_plan']['schema'] ?? null), 'deduplicated multi-route assets produce a canonical WordPress site plan');
 
+// Collapsed-paragraph cascade isolation via the source-`p` tag marker. A shared
+// stylesheet carries a descendant-`p` body-copy rule (`.page-header p`) and an
+// eyebrow (`.label`) that collapses to a paragraph. The projected `.page-header
+// p` rule must target the source-`p` marker — carried only by elements that were
+// `<p>` in the source — so it styles the real intro paragraph but never captures
+// the collapsed eyebrow, which keeps its own class-owned type scale. No bare
+// `.page-header p` may survive to capture the promoted paragraph.
+$collapse = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'index.html',
+    'files' => array(
+        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="shared.css"><header class="page-header"><div class="label">Home Eyebrow</div><h1>Home</h1><p>Home intro copy.</p></header>' ),
+        array( 'path' => 'about.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="shared.css"><header class="page-header"><div class="label">About Eyebrow</div><h1>About</h1><p>About intro copy.</p></header>' ),
+        array( 'path' => 'shared.css', 'kind' => 'css', 'content' => '*,*::before,*::after{margin:0;padding:0}.label{display:inline-flex;gap:.5rem;font-size:.68rem;letter-spacing:.2em;text-transform:uppercase}.page-header p{font-size:1.2rem;font-style:italic}' ),
+    ),
+) )->toArray();
+$collapseCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), array_values(array_filter($collapse['assets'] ?? array(), static fn (array $asset): bool => 'css' === ($asset['kind'] ?? '') && str_contains((string) ($asset['content'] ?? ''), 'page-header')))));
+$assert(str_contains($collapseCss, 'font-size:.68rem'), 'collapsed eyebrow keeps its own class-owned font-size rule');
+$assert(! preg_match('/(?:^|[\s>~+])\.page-header p\s*\{/', $collapseCss), 'no bare .page-header p rule survives to capture the collapsed eyebrow');
+$assert(preg_match('/\.page-header\s+:where\(\.blocks-engine-source-p-[a-f0-9]+-\d+\)/', $collapseCss) === 1, 'descendant .page-header p is projected through the source-p tag marker so it matches only real source paragraphs');
+
 if ( $failures > 0 ) {
     exit(1);
 }


### PR DESCRIPTION
## Summary

Two focused fidelity fixes for imported sites, both using existing BE mechanisms.

### 1. Project unmatched author type selectors through their source-tag marker

An author rule whose selector matched no source element — e.g. `.page-header p` in a fixture whose `.page-header` contains no source `<p>` (the intro paragraph lives elsewhere) — was emitted verbatim. Once a sibling `<div>` such as an eyebrow `<div class="label">` collapses to a paragraph, that dormant `.page-header p` rule suddenly captures it at higher specificity and overrides its own class-owned type scale, inflating the element and shifting the whole page down.

BE already projects descendant `p`/`li`/`nav` type selectors through a **source-tag marker** carried only by elements that were that tag in the source (this is how `.benefit-card p` correctly avoids capturing a promoted `.benefit-num` eyebrow in the solved `15-saas` fixture). That rewrite was simply **skipped on the no-match branch**, leaving the selector bare. This routes the no-match case through the same `rewriteSourceTagTypes()` path, so `.page-header p` becomes `.page-header :where(.blocks-engine-source-p-…)` and matches only real source paragraphs.

> Note: an earlier revision of this PR added a *parallel* collapsed-paragraph exclusion mechanism. It duplicated the source-tag-marker system and regressed the already-solved `15-saas` fixture (added markers, shifted the marker counter). That approach is removed. `15-saas`'s transform is now **byte-identical to trunk**, while the `3-artist-music` eyebrow keeps its `0.68rem` scale.

### 2. Keep button-styled link rows out of core/navigation

A row of button-styled links whose container carries an incidental navigational token (e.g. `<div class="stream-links"><a class="stream-btn">…</a>…</div>`, matched only because `links` looks navigational) was flattened into a `core/navigation` menu — halving the controls' height (39.7px pills → 20.5px text links). `NavigationPattern` now defers when a non-`nav`, non-list container's direct link children all carry button signals, so the row converts to `core/buttons` and keeps its pill geometry. Genuine nav menus, list navigation, and single incidental button-classed links are unaffected.

## Verification

- `15-saas` (solved fixture) transform is byte-identical to trunk — no regression.
- `3-artist-music`: eyebrow keeps its type scale; streaming-links row restored to source parity.
- Full `php-transformer` suite green: **248 parity fixtures, 77 block-style-support tests**, navigation + button unit suites, projection unit coverage, all contracts.

## AI assistance disclosure

Drafted with **Claude (Sonnet 4.5)** via **opencode**, used to trace the cascade through in-sandbox CSS/DOM inspection, root-cause a self-introduced regression against the solved-fixture gate, and re-implement through the existing source-tag-marker mechanism. Every line reviewed by Chris Huber.

Refs #630.
