### PR TITLE
Preserve semantic metadata grids

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1841,6 +1841,11 @@ final class HtmlTransformer
         }
 
         if ( 'dl' === $tagName ) {
+            $metadataGrid = $this->metadataGridBlockFromElement($element);
+            if ( null !== $metadataGrid ) {
+                return $metadataGrid;
+            }
+
             $items = $this->definitionListItems($element);
             if ( array() !== $items ) {
                 return $this->createBlock('core/list', $this->presentationAttributes($element), $items, $element);
@@ -2234,6 +2239,11 @@ final class HtmlTransformer
             }
 
             if ( in_array($tagName, array( 'div', 'section', 'article' ), true) ) {
+                $metadataGrid = $this->metadataGridBlockFromElement($element);
+                if ( null !== $metadataGrid ) {
+                    return $metadataGrid;
+                }
+
                 $disclosure = $this->detailsPattern->matchDisclosure(
                     $element,
                     fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
@@ -5493,6 +5503,188 @@ final class HtmlTransformer
         }
 
         return $items;
+    }
+
+    /**
+     * Convert compact label/value grids into native blocks without letting the
+     * paragraph block's default margins turn each record into prose flow.
+     *
+     * A definition list provides the relationship semantically. Generic wrappers
+     * need both a grid/flex layout and repeated, visually distinguished labels;
+     * this keeps ordinary text wrappers out of the recognizer.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function metadataGridBlockFromElement(DOMElement $element): ?array
+    {
+        $children = $this->directMetadataCells($element);
+        if ( count($children) < 2 || 0 !== count($children) % 2 ) {
+            return null;
+        }
+
+        $isDefinitionList = 'dl' === strtolower($element->tagName);
+        if ( $isDefinitionList ) {
+            if ( count($children) < 4 ) {
+                return null;
+            }
+            foreach ( $children as $index => $child ) {
+                if ( (0 === $index % 2 && 'dt' !== strtolower($child->tagName)) || (1 === $index % 2 && 'dd' !== strtolower($child->tagName)) ) {
+                    return null;
+                }
+            }
+        } elseif ( ! $this->isRepeatedMetadataRow($element, $children) ) {
+            return null;
+        }
+
+        $style = $this->metadataPresentationStyle($element);
+        if ( ! $this->isMetadataLayoutStyle($style) ) {
+            return null;
+        }
+
+        if ( $this->isFlexMetadataStyle($style) && ! $this->hasStrongFlexMetadataEvidence($element, $children, $isDefinitionList, $style) ) {
+            return null;
+        }
+
+        $blocks = array();
+        foreach ( $children as $child ) {
+            $content = $this->metadataCellContent($child);
+            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
+                return null;
+            }
+            $blocks[] = $this->createBlock('core/paragraph', $this->metadataCellAttributes($child, $content), array(), $child);
+        }
+
+        $attrs = $this->presentationAttributes($element);
+        // The source stylesheet owns the grid tracks and independent gaps. Core's
+        // layout support emits classes and a gap shorthand that can override both.
+        unset($attrs['layout'], $attrs['style']['spacing']['blockGap']);
+        if ( empty($attrs['style']['spacing']) ) {
+            unset($attrs['style']['spacing']);
+        }
+        if ( empty($attrs['style']) ) {
+            unset($attrs['style']);
+        }
+
+        return $this->createBlock('core/group', $attrs, $blocks, $element);
+    }
+
+    /** @return array<int, DOMElement> */
+    private function directMetadataCells(DOMElement $element): array
+    {
+        $cells = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+            if ( ! $child instanceof DOMElement ) {
+                return array();
+            }
+            if ( $this->hasBlockContentChildren($child) ) {
+                return array();
+            }
+            $cells[] = $child;
+        }
+
+        return $cells;
+    }
+
+    /** @param array<int, DOMElement> $children */
+    private function isRepeatedMetadataRow(DOMElement $element, array $children): bool
+    {
+        if ( 2 !== count($children) || ! $this->hasMetadataLabelPresentation($children[0]) ) {
+            return false;
+        }
+
+        $parent = $element->parentNode;
+        if ( ! $parent instanceof DOMElement ) {
+            return false;
+        }
+
+        $matchingRows = 0;
+        foreach ( $parent->childNodes as $sibling ) {
+            if ( ! $sibling instanceof DOMElement || ! $this->isMetadataLayoutStyle($this->metadataPresentationStyle($sibling)) ) {
+                continue;
+            }
+            $cells = $this->directMetadataCells($sibling);
+            if ( 2 === count($cells) && $this->hasMetadataLabelPresentation($cells[0]) ) {
+                ++$matchingRows;
+            }
+        }
+
+        return 2 <= $matchingRows;
+    }
+
+    private function hasMetadataLabelPresentation(DOMElement $element): bool
+    {
+        if ( in_array(strtolower($element->tagName), array( 'b', 'strong' ), true) ) {
+            return true;
+        }
+
+        $style = $this->cssDeclarations($this->metadataPresentationStyle($element));
+        $weight = (int) preg_replace('/\D.*/', '', (string) ($style['font-weight'] ?? ''));
+        if ( 600 <= $weight || in_array(strtolower(trim((string) ($style['text-transform'] ?? ''))), array( 'uppercase', 'capitalize' ), true) ) {
+            return true;
+        }
+
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && in_array(strtolower($descendant->tagName), array( 'b', 'strong' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isMetadataLayoutStyle(string $style): bool
+    {
+        return 1 === preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?(?:grid|flex)\b/i', $style);
+    }
+
+    private function isFlexMetadataStyle(string $style): bool
+    {
+        return 1 === preg_match('/(?:^|;)\s*display\s*:\s*(?:inline-)?flex\b/i', $style);
+    }
+
+    /** @param array<int, DOMElement> $children */
+    private function hasStrongFlexMetadataEvidence(DOMElement $element, array $children, bool $isDefinitionList, string $style): bool
+    {
+        if ( 1 !== preg_match('/(?:^|;)\s*flex-wrap\s*:\s*wrap(?:-reverse)?\b/i', $style) ) {
+            return false;
+        }
+
+        // A definition list supplies repeated term/description records. Generic
+        // rows additionally need the repeated labelled-row evidence above.
+        return $isDefinitionList
+            ? 4 <= count($children)
+            : $this->isRepeatedMetadataRow($element, $children);
+    }
+
+    private function metadataPresentationStyle(DOMElement $element): string
+    {
+        // Layout is structural evidence, so inspect matching stylesheet rules even
+        // when the element is not otherwise a high-value style boundary.
+        return $this->cssDeclarationString($this->structuralPresentationDeclarations($element));
+    }
+
+    /** @return array<string, mixed> */
+    private function metadataCellAttributes(DOMElement $element, string $content): array
+    {
+        $attrs = $this->presentationAttributes($element);
+        $attrs['content'] = $content;
+        $attrs['style']['spacing']['margin']['top'] = '0';
+        $attrs['style']['spacing']['margin']['bottom'] = '0';
+
+        return $attrs;
+    }
+
+    private function metadataCellContent(DOMElement $element): string
+    {
+        $content = $this->richTextContentWithMaterializedInlineStyles($element);
+        if ( in_array(strtolower($element->tagName), array( 'dt', 'b', 'strong' ), true) ) {
+            return '<strong>' . $content . '</strong>';
+        }
+
+        return $content;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -315,6 +315,36 @@ $assert('core/html' === ($colspanTableResult['blocks'][0]['blockName'] ?? null),
 $rowspanTableResult = ( new HtmlTransformer() )->transform('<table><tr><td rowspan="2">Merged</td><td>A</td></tr><tr><td>B</td></tr></table>')->toArray();
 $assert('core/html' === ($rowspanTableResult['blocks'][0]['blockName'] ?? null), 'rowspan table falls back to core/html');
 
+$metadataDefinitionList = ( new HtmlTransformer() )->transform(
+    '<style>.facts{display:grid;grid-template-columns:8rem 1fr;gap:8px 18px}</style><dl class="facts"><dt>Office</dt><dd>North Hall</dd><dt>Hours</dt><dd>Weekdays</dd></dl>'
+)->toArray();
+$metadataDefinitionListMarkup = (string) ($metadataDefinitionList['serialized_blocks'] ?? '');
+$metadataDefinitionListBlock = $metadataDefinitionList['blocks'][0] ?? array();
+$assert('core/group' === ($metadataDefinitionListBlock['blockName'] ?? null), 'grid definition lists convert to a native group grid');
+$assert(4 === count($metadataDefinitionListBlock['innerBlocks'] ?? array()), 'definition-list metadata grid preserves each label and value cell');
+$assert(str_contains($metadataDefinitionListMarkup, 'facts') && ! str_contains($metadataDefinitionListMarkup, 'is-layout-grid'), 'definition-list metadata group preserves stylesheet-owned grid tracks without Gutenberg layout classes');
+$assert(! str_contains($metadataDefinitionListMarkup, 'gap:'), 'definition-list metadata group does not collapse source gaps into a Gutenberg gap shorthand');
+$assert(4 === substr_count($metadataDefinitionListMarkup, 'margin-top:0;margin-bottom:0'), 'metadata cells suppress paragraph flow margins');
+$assert('pass' === ($metadataDefinitionList['source_reports']['wp_block_validity']['status'] ?? ''), 'definition-list metadata grid emits editor-valid native blocks');
+
+$repeatedMetadataRows = ( new HtmlTransformer() )->transform(
+    '<style>.record{display:grid;grid-template-columns:7rem 1fr;gap:6px 12px}</style><section><div class="record"><strong>Role</strong><span>Coordinator</span></div><div class="record"><strong>Location</strong><span>Remote</span></div></section>'
+)->toArray();
+$repeatedMetadataMarkup = (string) ($repeatedMetadataRows['serialized_blocks'] ?? '');
+$assert(str_contains($repeatedMetadataMarkup, 'record') && ! str_contains($repeatedMetadataMarkup, 'is-layout-grid'), 'repeated visually labelled rows preserve their stylesheet-owned grids');
+$assert(! str_contains($repeatedMetadataMarkup, '<strong>Role</strong> Coordinator'), 'repeated metadata rows do not flatten labels and values into prose');
+
+$ordinaryDefinitionList = ( new HtmlTransformer() )->transform('<dl><dt>First topic</dt><dd>A full explanatory paragraph.</dd><dt>Second topic</dt><dd>Another explanatory paragraph.</dd></dl>')->toArray();
+$assert('core/list' === ($ordinaryDefinitionList['blocks'][0]['blockName'] ?? null), 'ordinary definition lists without layout evidence remain lists');
+$ordinaryProseRows = ( new HtmlTransformer() )->transform('<section><div style="display:grid;grid-template-columns:1fr 1fr"><p>First paragraph.</p><p>Second paragraph.</p></div><div style="display:grid;grid-template-columns:1fr 1fr"><p>Third paragraph.</p><p>Fourth paragraph.</p></div></section>')->toArray();
+$assert(0 === substr_count((string) ($ordinaryProseRows['serialized_blocks'] ?? ''), 'margin-top:0;margin-bottom:0'), 'ordinary grid prose is not misclassified as metadata rows');
+$horizontalFlexDefinitionList = ( new HtmlTransformer() )->transform('<style>.terms{display:flex;flex-direction:row;gap:1rem}</style><dl class="terms"><dt>One</dt><dd>First</dd><dt>Two</dt><dd>Second</dd></dl>')->toArray();
+$assert('core/list' === ($horizontalFlexDefinitionList['blocks'][0]['blockName'] ?? null), 'ordinary horizontal flex definition lists remain lists without wrapping evidence');
+$wrappingFlexDefinitionList = ( new HtmlTransformer() )->transform('<style>.terms{display:flex;flex-wrap:wrap;column-gap:18px;row-gap:8px}</style><dl class="terms"><dt>One</dt><dd>First</dd><dt>Two</dt><dd>Second</dd></dl>')->toArray();
+$wrappingFlexMarkup = (string) ($wrappingFlexDefinitionList['serialized_blocks'] ?? '');
+$assert('core/group' === ($wrappingFlexDefinitionList['blocks'][0]['blockName'] ?? null), 'wrapping flex definition lists with repeated records convert to native groups');
+$assert(str_contains($wrappingFlexMarkup, 'terms') && ! str_contains($wrappingFlexMarkup, 'is-layout-flex') && ! str_contains($wrappingFlexMarkup, 'gap:'), 'wrapping flex metadata preserves separate source row and column gaps without Gutenberg shorthand');
+
 $navigationResult = ( new HtmlTransformer() )->transform('<nav class="primary"><a href="/about">About</a><a href="/contact">Contact</a></nav>')->toArray();
 $navigationBlock = $navigationResult['blocks'][0] ?? array();
 $assert('core/navigation' === ($navigationBlock['blockName'] ?? null), 'navigation conversion still emits a navigation block');


### PR DESCRIPTION
## Summary
- recognize semantic definition-list grids and repeated visually labelled metadata rows
- emit editor-valid native group and paragraph blocks without flattening label/value pairs into prose
- preserve stylesheet-owned tracks and asymmetric gaps while avoiding ordinary prose and horizontal-flex misclassification

## Verification
- `composer --working-dir=php-transformer test`
- 248 PHP transformer parity fixtures passed
- `git diff --check`

Closes #690

## AI assistance
OpenCode with `openai/gpt-5.6-sol` analyzed the fixture evidence, drafted the generic recognizer and adversarial contract coverage, and ran verification. Chris Huber reviewed and remains responsible for the changes.