### PR TITLE
Filter CSS-wide font keywords

### DIFF
--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization;
 final class FontMaterializationPlanBuilder
 {
     public const SCHEMA = 'blocks-engine/php-transformer/font-materialization-plan/v1';
+    private const CSS_WIDE_KEYWORDS = array('inherit', 'initial', 'revert', 'revert-layer', 'unset');
 
     /**
      * @param array<int,array<string,mixed>> $fontUsage
@@ -365,7 +366,10 @@ final class FontMaterializationPlanBuilder
      */
     private function isInvalidFontFamily(string $family): bool
     {
-        return str_contains($family, '(') || str_contains($family, ')') || str_starts_with($family, '--');
+        return str_contains($family, '(')
+            || str_contains($family, ')')
+            || str_starts_with($family, '--')
+            || in_array(strtolower($family), self::CSS_WIDE_KEYWORDS, true);
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2571,9 +2571,15 @@ $fontMaterializationPlan = ( new FontMaterializationPlanBuilder() )->googleFonts
     array('family' => 'Open Sans', 'weights' => array(400, 700)),
     array('family' => 'Poppins', 'weights' => array(500)),
     array('family' => 'Arial', 'weights' => array(400)),
+    array('family' => 'inherit', 'weights' => array(400)),
+    array('family' => 'INITIAL', 'weights' => array(400)),
+    array('family' => 'unset', 'weights' => array(400)),
+    array('family' => 'revert', 'weights' => array(400)),
+    array('family' => 'revert-layer', 'weights' => array(400)),
 ));
 $assert('blocks-engine/php-transformer/font-materialization-plan/v1' === ($fontMaterializationPlan['schema'] ?? null), 'font materialization exposes schema');
 $assert('@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Poppins:wght@500&display=swap");' === ($fontMaterializationPlan['css'] ?? null), 'font materialization builds deterministic google fonts css');
+$assert(array('Open Sans', 'Poppins') === array_column($fontMaterializationPlan['fonts'] ?? array(), 'family'), 'font materialization excludes web-safe and CSS-wide family keywords');
 $assert('assets/css/fonts.css' === ($fontMaterializationPlan['stylesheets'][0]['path'] ?? null), 'font materialization emits stylesheet asset plan');
 
 $fontAwarePlan = ( new MaterializationPlanBuilder() )->fromCompiledSite(array(


### PR DESCRIPTION
## Summary

- exclude CSS-wide control values from downloadable font materialization plans
- preserve real quoted and multi-word typeface families
- cover `inherit`, `initial`, `unset`, `revert`, and `revert-layer` case-insensitively

Closes #697.

## Verification

- `composer --working-dir=php-transformer test`
- 248 parity fixtures
- package-install proof
- `git diff --check`
- real university plan no longer emits `inherit` as a Google Fonts family when composed onto the #659 integration baseline

## Compatibility

The font materialization schema is unchanged. CSS-wide values were never valid provider family names, so removing them only prevents malformed provider requests and noisy evidence.

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** cross-stack reproduction, implementation, tests, and university runtime verification with Chris Huber.