### PR TITLE
Preserve runtime-targeted anchors

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
@@ -13,6 +13,10 @@ trait ButtonLinkDispatchTrait
      */
     private function convertAnchorDispatchElement(DOMElement $element, array &$fallbacks): ?array
     {
+        if ( $this->isRuntimeDomTarget($element) ) {
+            return $this->htmlPreservationBlock($element);
+        }
+
         $linkedLogo = $this->linkedSvgLogoBlockFromAnchor($element, $fallbacks);
         if ( null !== $linkedLogo ) {
             return $linkedLogo;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -842,6 +842,20 @@ $assert('#live-filter' === ($artifactControlIslands[0]['selector'] ?? ''), 'arti
 $assert(str_contains((string) ($artifactControlIslands[0]['source_snippet'] ?? ''), '<input id="live-filter"'), 'artifact runtime control island preserves source snippet metadata');
 $artifactControlRuntimeReport = $artifactControlSelectors['source_reports']['runtime_dependency_parity'] ?? array();
 $assert('pass' === ($artifactControlRuntimeReport['status'] ?? ''), 'runtime parity does not flag readable static controls as missing runtime targets');
+$artifactRuntimeAnchor = ( new ArtifactCompiler() )->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><div class="event"><a class="event-add" href="#">Add to calendar</a></div><script src="js/app.js"></script></main>',
+            'js/app.js'  => 'document.querySelectorAll(".event-add").forEach(function (link) { link.addEventListener("click", function (event) { event.preventDefault(); }); });',
+        ),
+    )
+)->toArray();
+$artifactRuntimeAnchorMarkup = (string) ($artifactRuntimeAnchor['serialized_blocks'] ?? '');
+$artifactRuntimeAnchorIslands = $artifactRuntimeAnchor['source_reports']['runtime_islands'] ?? array();
+$assert(str_contains($artifactRuntimeAnchorMarkup, '<!-- wp:html ') && str_contains($artifactRuntimeAnchorMarkup, '<a class="event-add" href="#">Add to calendar</a>'), 'artifact compiler preserves behavior-bearing anchors as exact runtime DOM targets');
+$assert(1 === count($artifactRuntimeAnchorIslands) && '.event-add' === ($artifactRuntimeAnchorIslands[0]['selector'] ?? ''), 'artifact compiler reports a behavior-bearing anchor as one bounded runtime DOM island');
+$assert('pass' === ($artifactRuntimeAnchor['source_reports']['runtime_dependency_parity']['status'] ?? ''), 'runtime dependency parity resolves behavior-bearing anchor selectors against preserved markup');
 $runtimeContext = ( new ArtifactCompiler() )->runtimeContextForSource(
     '<header><button class="theme-toggle">Theme</button><script src="js/app.js"></script></header>',
     'index.html',


### PR DESCRIPTION
## Summary

- preserve behavior-bearing anchors as exact bounded runtime DOM before logo/button/native-link dispatch rewrites them
- retain selector identity for source scripts and runtime dependency parity
- add artifact-level coverage for one runtime anchor island without duplicate diagnostics

## Evidence

- `composer test:canonical` passes on current trunk
- University eight-surface run `e46ab296-3f5c-4794-b6e8-979ceecdcfca` improved Events from `14.00% / -106px` to `8.92% / -9px`; the other seven routes remained at their validated baseline
- Runtime dependency parity resolves `.event-add` against preserved markup

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** source investigation, implementation, regression coverage, canonical testing, and rendered evidence analysis

Chris Huber reviewed and remains responsible for the change.