### PR TITLE
Keep separator geometry block-valid

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -64,12 +64,25 @@ final class BlockFactory
     {
         $attrs = $this->normalizeClassNameAttr($attrs);
 
-        // RichText block save() does not reproduce dimensions.maxWidth. Inline
+        // These core save functions do not reproduce dimensions.maxWidth. Inline
         // max-width is retained by the generated geometry carrier stylesheet.
-        if ( in_array($name, array( 'core/group', 'core/columns', 'core/list-item', 'core/paragraph' ), true) ) {
+        if ( in_array($name, array( 'core/group', 'core/columns', 'core/list-item', 'core/paragraph', 'core/separator' ), true) ) {
             unset($attrs['style']['dimensions']['maxWidth']);
             if ( empty($attrs['style']['dimensions']) ) {
                 unset($attrs['style']['dimensions']);
+            }
+            if ( empty($attrs['style']) ) {
+                unset($attrs['style']);
+            }
+        }
+
+        if ( 'core/separator' === $name ) {
+            unset($attrs['style']['spacing']['margin']['left'], $attrs['style']['spacing']['margin']['right']);
+            if ( empty($attrs['style']['spacing']['margin']) ) {
+                unset($attrs['style']['spacing']['margin']);
+            }
+            if ( empty($attrs['style']['spacing']) ) {
+                unset($attrs['style']['spacing']);
             }
             if ( empty($attrs['style']) ) {
                 unset($attrs['style']);

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2094,7 +2094,7 @@ final class HtmlTransformer
         }
 
         if ( 'hr' === $tagName ) {
-            return $this->createBlock('core/separator', $this->presentationAttributes($element), array(), $element);
+            return $this->createBlock('core/separator', $this->presentationAttributes($element, array(), array( 'margin-left', 'margin-right' )), array(), $element);
         }
 
         if ( 'br' === $tagName ) {

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -108,9 +108,9 @@ trait StyleResolutionTrait
      *
      * @return array<string, mixed>
      */
-    private function presentationAttributes(DOMElement $element, array $excludedGeometryProperties = array()): array
+    private function presentationAttributes(DOMElement $element, array $excludedGeometryProperties = array(), array $forcedGeometryProperties = array()): array
     {
-        $cacheKey = $this->presentationCacheKey($element) . ':' . implode(',', $excludedGeometryProperties);
+        $cacheKey = $this->presentationCacheKey($element) . ':' . implode(',', $excludedGeometryProperties) . ':' . implode(',', $forcedGeometryProperties);
         if ( isset($this->presentationAttributesCache[$cacheKey]) ) {
             return $this->presentationAttributesCache[$cacheKey];
         }
@@ -120,12 +120,15 @@ trait StyleResolutionTrait
             $this->presentationDeclarations($element)
         );
         $mapped       = $this->styleAttributeMapper()->map($declarations);
+        $forcedGeometryDeclarations = array() === $forcedGeometryProperties
+            ? array()
+            : $this->cssDeclarations((string) ($this->styleAttributeMapper()->serialize($mapped['style'] ?? array())['style'] ?? ''));
 
         $attrs = array_filter(array_merge($mapped['attrs'] ?? array(), array(
             'anchor'    => $this->safeAnchor($this->attr($element, 'id')),
             'className' => $this->mergePresentationClassNames(
                 $this->promotedClassName($this->attr($element, 'class')),
-                $this->inlineGeometryClassName($element, $excludedGeometryProperties)
+                $this->inlineGeometryClassName($element, $excludedGeometryProperties, $forcedGeometryProperties, $forcedGeometryDeclarations)
             ),
             'inlineGeometryStyle' => $this->inlineGeometryStyle($element, $excludedGeometryProperties),
             'style'     => $mapped['style'],
@@ -230,15 +233,15 @@ trait StyleResolutionTrait
      * inline geometry in a generated stylesheet; class-owned declarations are
      * already retained by author stylesheet materialization.
      */
-    private function inlineGeometryClassName(DOMElement $element, array $excludedProperties = array()): string
+    private function inlineGeometryClassName(DOMElement $element, array $excludedProperties = array(), array $forcedProperties = array(), array $forcedDeclarations = array()): string
     {
         $declarations = $this->cssDeclarations($this->attr($element, 'style'));
         $geometry = array();
-        foreach ($this->inlineGeometryProperties() as $property) {
+        foreach (array_values(array_unique(array_merge($this->inlineGeometryProperties(), $forcedProperties))) as $property) {
             if (in_array($property, $excludedProperties, true)) {
                 continue;
             }
-            $rawValue = trim((string) ($declarations[$property] ?? ''));
+            $rawValue = trim((string) ($declarations[$property] ?? ($forcedDeclarations[$property] ?? '')));
             if (1 === preg_match('/\s*!important\s*$/i', $rawValue)) {
                 continue;
             }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -738,6 +738,13 @@ $assert(1 === substr_count($separatorMarkup, 'has-alpha-channel-opacity'), 'sepa
 $assert(1 === substr_count($separatorMarkup, 'has-css-opacity'), 'separator serialization emits has-css-opacity exactly once');
 $assert(! str_contains($separatorMarkup, 'wp-block-separator divider wp-block-separator'), 'separator serialization does not duplicate generated classes');
 
+$boundedSeparator = ( new HtmlTransformer() )->transform('<main><hr class="rule" style="max-width:var(--max);margin:0 auto"></main>')->toArray();
+$boundedSeparatorAttrs = $boundedSeparator['blocks'][0]['attrs'] ?? array();
+$boundedSeparatorMarkup = (string) ($boundedSeparator['serialized_blocks'] ?? '');
+$boundedSeparatorCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $boundedSeparator['assets'] ?? array()));
+$assert(array('top' => '0', 'bottom' => '0') === ($boundedSeparatorAttrs['style']['spacing']['margin'] ?? null) && ! isset($boundedSeparatorAttrs['style']['dimensions']), 'separator keeps only spacing supported by its canonical core block attributes');
+$assert(! str_contains($boundedSeparatorMarkup, 'margin-left:auto') && ! str_contains($boundedSeparatorMarkup, 'max-width:var(--max)') && str_contains($boundedSeparatorCss, 'margin-left:auto !important') && str_contains($boundedSeparatorCss, 'margin-right:auto !important') && str_contains($boundedSeparatorCss, 'max-width:var(--max) !important'), 'separator moves unsupported horizontal and width geometry to its generated carrier stylesheet');
+
 $customStateFindings = ( new CanonicalSaveShapeValidator() )->findings(array(array(
     'blockName'    => 'core/group',
     'attrs'        => array(),


### PR DESCRIPTION
## Summary

- retain only top/bottom margins supported by `core/separator` in canonical block attributes
- move source horizontal auto margins and max-width into the generated geometry carrier stylesheet
- preserve exact rendering while matching Gutenberg save output

## Evidence

- `composer test:canonical` passes on current trunk
- Fixture 37 front-page editor validity improved from `183/184` to `184/184`
- all seven editor-validated surfaces report zero invalid blocks
- eight captured surfaces retain zero visual mismatches
- Before: Homeboy run `a77629e4-0ec3-4813-90c4-087f305c47e2`; after: `5aedff96-df46-466e-b2db-e7e84e88b347`

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** editor-failure diagnosis, implementation, regression coverage, canonical testing, and rendered/editor evidence analysis

Chris Huber reviewed and remains responsible for the change.