### PR TITLE
Discover web fonts from CSS imports

### DIFF
--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -39,10 +39,10 @@ final class FontMaterializationPlanBuilder
     /**
      * Build a materialization plan from raw web-font sources.
      *
-     * Detects linked web-font stylesheets (e.g. Google Fonts `css2`/`css`
-     * `<link>` tags) in the supplied HTML and `font-family` declarations in the
-     * supplied CSS, preserving the discovered typefaces and their heading/body
-     * roles so that materialized output keeps the source typography.
+     * Detects web-font stylesheets (e.g. Google Fonts `css2`/`css` `<link>` and
+     * CSS `@import` sources) plus `font-family` declarations, preserving the
+     * discovered typefaces and their heading/body roles so that materialized
+     * output keeps the source typography.
      *
      * @return array<string,mixed>
      */
@@ -58,6 +58,7 @@ final class FontMaterializationPlanBuilder
 
         $fontUsage = array_merge(
             $this->fontUsageFromLinkedStylesheets($html),
+            $this->fontUsageFromCssImports($css),
             $this->fontUsageFromCssDeclarations($resolvedCss)
         );
         $roles = $this->fontRolesFromCss($resolvedCss);
@@ -110,6 +111,29 @@ final class FontMaterializationPlanBuilder
             if ( '' === $href ) {
                 continue;
             }
+            foreach ( $this->fontUsageFromFontHref($href) as $font ) {
+                $usage[] = $font;
+            }
+        }
+
+        return $usage;
+    }
+
+    /**
+     * Parse web-font stylesheet URLs from CSS `@import` rules.
+     *
+     * @return array<int,array{family:string,weights:array<int,int>}>
+     */
+    private function fontUsageFromCssImports(string $css): array
+    {
+        $css = preg_replace('/\/\*.*?\*\//s', '', $css) ?? $css;
+        if ( '' === trim($css) || ! preg_match_all('/@import\s+(?:url\(\s*)?(?:"([^"]+)"|\'([^\']+)\'|([^\s\)"\';]+))/i', $css, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        $usage = array();
+        foreach ( $matches as $match ) {
+            $href = (string) (($match[1] ?? '') ?: ($match[2] ?? '') ?: ($match[3] ?? ''));
             foreach ( $this->fontUsageFromFontHref($href) as $font ) {
                 $usage[] = $font;
             }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2605,6 +2605,14 @@ $assert('Oswald' === ($webFontPlan['roles']['heading'] ?? null), 'web-font detec
 $assert('Inter' === ($webFontPlan['roles']['body'] ?? null), 'web-font detection maps body typeface from font-family declaration');
 $assert('@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Oswald:wght@400;500;600;700&display=swap");' === ($webFontPlan['css'] ?? null), 'web-font detection materializes deterministic google fonts css');
 
+$importedWebFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
+    '',
+    '@import url(\'https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Noto+Sans+JP:wght@400;500;700&display=swap\'); body{font-family:"Noto Sans JP",sans-serif}h1{font-family:"EB Garamond",serif}'
+);
+$assert(array('EB Garamond', 'Noto Sans JP') === array_column($importedWebFontPlan['fonts'] ?? array(), 'family'), 'web-font detection captures families declared only by a CSS import');
+$assert(array(400, 500, 600, 700) === ($importedWebFontPlan['fonts'][0]['weights'] ?? null), 'CSS-imported web-font detection preserves italic axis tuple weights');
+$assert(array(400, 500, 700) === ($importedWebFontPlan['fonts'][1]['weights'] ?? null), 'CSS-imported web-font detection preserves repeated family weights');
+
 $rangeFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
     '<head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300..900;1,300..900&amp;family=JetBrains+Mono:wght@400&amp;display=swap"></head>',
     'body { font-family: "Crimson Pro", Georgia, serif; } .mono { font-family: "JetBrains Mono", monospace; }'

--- a/php-transformer/tests/fixtures/parity/artifact-css-import-web-font-materialization.json
+++ b/php-transformer/tests/fixtures/parity/artifact-css-import-web-font-materialization.json
@@ -1,0 +1,45 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-css-import-web-font-materialization",
+  "description": "Materializes typefaces declared by a Google Fonts CSS import with their requested weights and typography roles.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-css-import-web-font-materialization.json",
+    "notes": "Covers web-font source discovery when the provider URL exists only in a linked author stylesheet."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Web-font materialization is an upstream transformer contract with no legacy package equivalent."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "content": "<!doctype html><html><head><title>Imported Fonts</title><link rel=\"stylesheet\" href=\"styles/site.css\"></head><body><main><h1>Welcome</h1><p>Body copy.</p></main></body></html>",
+          "kind": "html",
+          "role": "entry"
+        },
+        {
+          "path": "styles/site.css",
+          "content": "@import url('https://fonts.googleapis.com/css2?family=Display+One:wght@400;500;700&family=Body+Two:wght@400;600&display=swap');h1,h2,h3{font-family:\"Display One\",system-ui,sans-serif}body{font-family:\"Body Two\",system-ui,sans-serif}",
+          "kind": "css",
+          "mime_type": "text/css"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.fonts", "assert": "count", "count": 2 },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.fonts.0.family", "assert": "equals", "value": "Body Two" },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.fonts.0.weights", "assert": "count", "count": 2 },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.fonts.1.family", "assert": "equals", "value": "Display One" },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.fonts.1.weights", "assert": "count", "count": 3 },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.roles.heading", "assert": "equals", "value": "Display One" },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.roles.body", "assert": "equals", "value": "Body Two" },
+    { "path": "source_reports.materialization_plan.theme.font_materialization.css", "assert": "contains", "value": "family=Display+One:wght@400;500;700" }
+  ]
+}


### PR DESCRIPTION
## Summary

- discover Google Fonts provider URLs declared through CSS `@import`, not only HTML `<link>` elements
- reuse the existing provider URL parser so family axes, tuples, ranges, and requested weights remain deterministic
- add direct contract and full artifact-compiler parity coverage

## Evidence

- `composer test:canonical` passes on current trunk
- all 249 PHP transformer parity fixtures pass
- Fixture 37 eight-surface run `a77629e4-0ec3-4813-90c4-087f305c47e2` had zero visual mismatches and no font-materialization failure
- Fixture 29 exposed an independent SSI resource-limit blocker tracked in https://github.com/Automattic/static-site-importer/issues/732

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** corpus analysis, implementation, contract/parity coverage, test execution, and fixture-matrix evidence analysis

Chris Huber reviewed and remains responsible for the change.