### PR TITLE
Collapse nested runtime island findings

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -66,6 +66,15 @@ final class FallbackEmitter
      */
     private array $runtimeCanvasSelectors = array();
 
+    /**
+     * DOM identity for each emitted runtime island, kept aligned by index with
+     * the transformer's accumulator so nested findings can be compared without
+     * exposing implementation-only node paths in diagnostics.
+     *
+     * @var array<int, array{document: int, path: string}>
+     */
+    private array $runtimeIslandOrigins = array();
+
     private readonly SubtreeClassifier $classifier;
 
     private readonly CustomBlockGenerator $blockGenerator;
@@ -285,6 +294,7 @@ final class FallbackEmitter
         $this->fallbackProvenance     = $fallbackProvenance;
         $this->runtimeScriptMetadata  = $runtimeScriptMetadata;
         $this->runtimeCanvasSelectors = $runtimeCanvasSelectors;
+        $this->runtimeIslandOrigins   = array();
     }
 
     /**
@@ -523,7 +533,12 @@ final class FallbackEmitter
             'selector' => $island['selector'] ?? '',
             'snippet'  => $island['source_snippet'] ?? '',
         ), JSON_UNESCAPED_SLASHES);
-        foreach ( $runtimeIslands as $existing ) {
+        $origin = array(
+            'document' => $element->ownerDocument instanceof DOMDocument ? spl_object_id($element->ownerDocument) : 0,
+            'path'     => $element->getNodePath() ?? '',
+        );
+        $nestedIslandIndexes = array();
+        foreach ( $runtimeIslands as $index => $existing ) {
             $existingKey = json_encode(array(
                 'kind'     => $existing['kind'] ?? '',
                 'selector' => $existing['selector'] ?? '',
@@ -532,9 +547,32 @@ final class FallbackEmitter
             if ( $key === $existingKey ) {
                 return;
             }
+
+            $existingOrigin = $this->runtimeIslandOrigins[$index] ?? null;
+            if ( ! is_array($existingOrigin)
+                || 0 === $origin['document']
+                || $origin['document'] !== ($existingOrigin['document'] ?? 0)
+                || '' === $origin['path']
+                || '' === ($existingOrigin['path'] ?? '')
+            ) {
+                continue;
+            }
+
+            $existingPath = (string) $existingOrigin['path'];
+            if ( str_starts_with($origin['path'], $existingPath . '/') ) {
+                return;
+            }
+            if ( str_starts_with($existingPath, $origin['path'] . '/') ) {
+                $nestedIslandIndexes[] = $index;
+            }
         }
 
+        foreach ( array_reverse($nestedIslandIndexes) as $index ) {
+            array_splice($runtimeIslands, $index, 1);
+            array_splice($this->runtimeIslandOrigins, $index, 1);
+        }
         $runtimeIslands[] = $island;
+        $this->runtimeIslandOrigins[] = $origin;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -863,6 +863,30 @@ $artifactRuntimeAnchorIslands = $artifactRuntimeAnchor['source_reports']['runtim
 $assert(str_contains($artifactRuntimeAnchorMarkup, '<!-- wp:html ') && str_contains($artifactRuntimeAnchorMarkup, '<a class="event-add" href="#">Add to calendar</a>'), 'artifact compiler preserves behavior-bearing anchors as exact runtime DOM targets');
 $assert(1 === count($artifactRuntimeAnchorIslands) && '.event-add' === ($artifactRuntimeAnchorIslands[0]['selector'] ?? ''), 'artifact compiler reports a behavior-bearing anchor as one bounded runtime DOM island');
 $assert('pass' === ($artifactRuntimeAnchor['source_reports']['runtime_dependency_parity']['status'] ?? ''), 'runtime dependency parity resolves behavior-bearing anchor selectors against preserved markup');
+$runtimeMutationStateIslands = ( new ArtifactCompiler() )->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><div class="lang-toggle"><button class="on">EN</button><button>DE</button></div><div data-chip-group><button class="chip is-on">All</button><button class="chip">New</button></div><script src="js/app.js"></script></main>',
+            'js/app.js' => 'document.querySelectorAll(".lang-toggle button").forEach(btn => { btn.addEventListener("click", () => { const group = btn.closest(".lang-toggle"); group.querySelectorAll("button").forEach(b => b.classList.remove("on")); btn.classList.add("on"); }); }); document.querySelectorAll("[data-chip-group]").forEach(group => { const chips = group.querySelectorAll(".chip"); chips.forEach(chip => chip.addEventListener("click", () => { chips.forEach(c => c.classList.remove("is-on")); chip.classList.add("is-on"); })); });',
+        ),
+    )
+)->toArray();
+$runtimeMutationStateSelectors = array_map(static fn (array $island): string => (string) ($island['selector'] ?? ''), $runtimeMutationStateIslands['source_reports']['runtime_islands'] ?? array());
+$assert(in_array('.lang-toggle', $runtimeMutationStateSelectors, true), 'runtime islands retain stable language-toggle query target');
+$assert(2 === count($runtimeMutationStateSelectors), 'nested runtime targets collapse into their preserved stable query roots');
+$assert(! in_array('.on', $runtimeMutationStateSelectors, true) && ! in_array('.is-on', $runtimeMutationStateSelectors, true), 'runtime islands do not report mutation-state classes as target selectors');
+$separateRuntimeIslands = ( new ArtifactCompiler() )->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><div class="runtime-parent"><button class="runtime-child">Nested</button></div><button class="runtime-child">Separate</button><script src="js/app.js"></script></main>',
+            'js/app.js' => 'document.querySelector(".runtime-parent").addEventListener("click", () => {}); document.querySelectorAll(".runtime-child").forEach(button => button.addEventListener("click", () => {}));',
+        ),
+    )
+)->toArray();
+$separateRuntimeIslandSelectors = array_map(static fn (array $island): string => (string) ($island['selector'] ?? ''), $separateRuntimeIslands['source_reports']['runtime_islands'] ?? array());
+$assert(2 === count($separateRuntimeIslandSelectors), 'runtime island collapse retains matching controls outside the preserved parent subtree');
 $runtimeContext = ( new ArtifactCompiler() )->runtimeContextForSource(
     '<header><button class="theme-toggle">Theme</button><script src="js/app.js"></script></header>',
     'index.html',


### PR DESCRIPTION
## Summary
- collapse nested runtime findings under their preserved owning DOM island
- compare real document identity and node ancestry instead of HTML substring similarity
- retain matching controls that live outside the owning subtree

## Verification
- `cd php-transformer && php tests/contract/run.php`
- `cd php-transformer && composer test:canonical`

Closes #701.

## AI assistance
GPT-5.6 Sol via OpenCode traced runtime selector provenance, implemented the DOM-ancestry deduplication, added regression coverage, and ran the contract and canonical suites. Chris Huber remains responsible for every line.