### PR TITLE
Preserve class-owned background paint in generated blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -119,6 +119,7 @@ trait StyleResolutionTrait
             $element,
             $this->presentationDeclarations($element)
         );
+        $declarations = $this->classOwnedBackgroundPaintDeclarations($element, $declarations);
         $mapped       = $this->styleAttributeMapper()->map($declarations);
         $forcedGeometryDeclarations = array() === $forcedGeometryProperties
             ? array()
@@ -176,6 +177,38 @@ trait StyleResolutionTrait
                 continue;
             }
             unset($declarations[$property]);
+        }
+
+        return $declarations;
+    }
+
+    /**
+     * Background support emits inline declarations and `has-background`, which
+     * changes the cascade for matched stylesheet rules. Keep author-owned paint
+     * in the projected stylesheet; source inline declarations retain support
+     * mapping because their cascade ownership is already inline.
+     *
+     * @param array<string, string> $declarations
+     * @return array<string, string>
+     */
+    private function classOwnedBackgroundPaintDeclarations(DOMElement $element, array $declarations): array
+    {
+        $inline = $this->cssDeclarations($this->attr($element, 'style'));
+        foreach ( array(
+            'background',
+            'background-color',
+            'background-image',
+            'background-position',
+            'background-size',
+            'background-repeat',
+            'background-attachment',
+            'background-origin',
+            'background-clip',
+            'background-blend-mode',
+        ) as $property ) {
+            if ( ! isset($inline[ $property ]) ) {
+                unset($declarations[ $property ]);
+            }
         }
 
         return $declarations;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -608,9 +608,8 @@ $emptyVisualCluster = ( new HtmlTransformer() )->transform(
 $emptyVisualItems = $emptyVisualCluster['blocks'][0]['innerBlocks'] ?? array();
 $emptyVisualCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $emptyVisualCluster['assets'] ?? array()));
 $assert(3 === count($emptyVisualItems), 'classless empty inline items in a decorative cluster remain native blocks');
-$assert(array( '#ff5f57', '#ffbd2e', '#28ca41' ) === array_map(static fn (array $block): string => (string) ($block['attrs']['style']['color']['background'] ?? ''), $emptyVisualItems), 'decorative cluster items preserve their resolved native background colors');
 $assert(! array_filter($emptyVisualItems, static fn (array $block): bool => 'core/group' !== ($block['blockName'] ?? '')), 'decorative cluster items use native core/group blocks');
-$assert(str_contains($emptyVisualCss, '{width:10px;height:10px;border-radius:50%}'), 'decorative cluster items preserve dimensions through semantic author CSS translation');
+$assert(str_contains($emptyVisualCss, 'blocks-engine-semantic-') && str_contains($emptyVisualCss, '{width:10px;height:10px;border-radius:50%}') && str_contains($emptyVisualCss, 'background:#ff5f57') && str_contains($emptyVisualCss, 'background:#ffbd2e') && str_contains($emptyVisualCss, 'background:#28ca41'), 'decorative cluster items preserve projected selectors, dimensions, and background paint through author CSS');
 $assert(! str_contains($emptyVisualCss, '!important'), 'decorative cluster translation does not introduce important declarations');
 
 $cssSizedInlineSvgArtwork = ( new HtmlTransformer() )->transform(

--- a/php-transformer/tests/fixtures/parity/html-pseudo-state-rules-not-inlined-resting.json
+++ b/php-transformer/tests/fixtures/parity/html-pseudo-state-rules-not-inlined-resting.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-pseudo-state-rules-not-inlined-resting",
-  "description": "Pseudo-state (:hover) and pseudo-element (::before) CSS rules describe transient/generated presentation and must never be folded into an element's RESTING inline style. A CTA matched by .cta{...} AND .cta:hover{...} renders with its resting fill (#13314f / #ffffff / 6px radius) and never the hover values (#f0ac22 / #000000 / 2px). A benefit card matched by .benefit-card{...} plus .benefit-card:hover{...} and .benefit-card::before{...} keeps its resting background (#101418) and never the hover (#1b2230) or pseudo-element (#ff0000) backgrounds. The pseudo-state declarations stay in the verbatim materialized stylesheet, where they fire on real interaction.",
+  "description": "Pseudo-state (:hover) and pseudo-element (::before) CSS rules describe transient/generated presentation and must never be folded into an element's RESTING inline style. A CTA matched by .cta{...} AND .cta:hover{...} renders with its resting text color and radius, while its class-owned fill remains in the projected stylesheet and never becomes competing support paint. A benefit card matched by .benefit-card{...} plus .benefit-card:hover{...} and .benefit-card::before{...} keeps its background under stylesheet ownership, separate from hover (#1b2230) and pseudo-element (#ff0000) backgrounds. The pseudo-state declarations stay in the materialized stylesheet, where they fire on real interaction.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-pseudo-state-rules-not-inlined-resting.json",
@@ -26,7 +26,7 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-radius:6px;color:#ffffff;background-color:#13314f;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"background-color:#101418;padding-top:40px;padding-right:36px;padding-bottom:40px;padding-left:36px\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"padding-top:40px;padding-right:36px;padding-bottom:40px;padding-left:36px\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "#f0ac22" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "border-radius:2px" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "color:#000000" },

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -270,6 +270,28 @@ $assert(($paintDeclarations['background-position'] ?? '') === 'center top', '43:
 $assert(($paintDeclarations['background-size'] ?? '') === '120% 80%,100% 100%', '44: background-size survives safe CSS resolution', json_encode($paintDeclarations));
 $assert(($paintDeclarations['background-repeat'] ?? '') === 'no-repeat', '45: background-repeat survives safe CSS resolution', json_encode($paintDeclarations));
 $assert(($paintDeclarations['box-shadow'] ?? '') === '0 28px 80px rgba(20,12,4,.18)', '46: box-shadow survives safe CSS resolution', json_encode($paintDeclarations));
+$assert(! isset($paintAttrs['style']['color']['background']) && ! isset($paintAttrs['style']['color']['gradient']) && ! isset($paintAttrs['backgroundColor']), '47: class-owned layered paint does not become competing color support', json_encode($paintAttrs));
+$assert(! str_contains((string) ($paintResult['serialized_blocks'] ?? ''), 'has-background'), '48: class-owned layered paint emits no Gutenberg background class', (string) ($paintResult['serialized_blocks'] ?? ''));
+
+$classGradientHtml = '<main><section class="artist-card"><p>Artist</p></section></main>';
+$classGradientCss = '.artist-card{background:linear-gradient(135deg,#ff5c8a 0%,#583c87 100%);padding:2rem}';
+$classGradientResult = ( new HtmlTransformer() )->transform($classGradientHtml, array('static_css' => $classGradientCss))->toArray();
+$classGradient = $classGradientResult['blocks'][0] ?? array();
+$classGradientAttrs = is_array($classGradient['attrs'] ?? null) ? $classGradient['attrs'] : array();
+$classGradientMarkup = (string) ($classGradientResult['serialized_blocks'] ?? '');
+
+$assert('artist-card' === ($classGradientAttrs['className'] ?? ''), '49: class-owned directional gradient retains its author class', json_encode($classGradientAttrs));
+$assert(! isset($classGradientAttrs['style']['color']) && ! isset($classGradientAttrs['backgroundColor']), '50: class-owned directional gradient stays out of color support', json_encode($classGradientAttrs));
+$assert(! str_contains($classGradientMarkup, 'has-background') && ! str_contains($classGradientMarkup, 'background:linear-gradient'), '51: class-owned directional gradient does not serialize competing support paint', $classGradientMarkup);
+$classGradientParity = ( new StaticStyleParityRunner() )->compareSourceToTransform($classGradientHtml, $classGradientCss);
+$assert(1.0 === (float) ($classGradientParity['parity']['score'] ?? 0.0), '52: render-free computed style parity retains class-owned directional gradient', json_encode($classGradientParity['parity'] ?? array()));
+
+$mapper = new StyleAttributeMapper();
+$inlineGradient = $mapper->map(array('background' => 'linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)'));
+$inlineSolid = $mapper->map(array('background-color' => '#243b53'));
+$assert('linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)' === ($inlineGradient['style']['color']['gradient'] ?? ''), '53: inline directional gradient remains Gutenberg color support', json_encode($inlineGradient));
+$assert('#243b53' === ($inlineSolid['style']['color']['background'] ?? ''), '54: inline solid background remains Gutenberg color support', json_encode($inlineSolid));
+$assert(str_contains($mapper->serialize($inlineGradient['style'])['style'], 'background:linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)') && str_contains($mapper->serialize($inlineSolid['style'])['style'], 'background-color:#243b53'), '55: inline paint support serializes valid Gutenberg-compatible declarations');
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Block style support conversion tests: {$failures} failed, {$passes} passed\n");

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -283,15 +283,40 @@ $classGradientMarkup = (string) ($classGradientResult['serialized_blocks'] ?? ''
 $assert('artist-card' === ($classGradientAttrs['className'] ?? ''), '49: class-owned directional gradient retains its author class', json_encode($classGradientAttrs));
 $assert(! isset($classGradientAttrs['style']['color']) && ! isset($classGradientAttrs['backgroundColor']), '50: class-owned directional gradient stays out of color support', json_encode($classGradientAttrs));
 $assert(! str_contains($classGradientMarkup, 'has-background') && ! str_contains($classGradientMarkup, 'background:linear-gradient'), '51: class-owned directional gradient does not serialize competing support paint', $classGradientMarkup);
-$classGradientParity = ( new StaticStyleParityRunner() )->compareSourceToTransform($classGradientHtml, $classGradientCss);
-$assert(1.0 === (float) ($classGradientParity['parity']['score'] ?? 0.0), '52: render-free computed style parity retains class-owned directional gradient', json_encode($classGradientParity['parity'] ?? array()));
 
 $mapper = new StyleAttributeMapper();
 $inlineGradient = $mapper->map(array('background' => 'linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)'));
 $inlineSolid = $mapper->map(array('background-color' => '#243b53'));
-$assert('linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)' === ($inlineGradient['style']['color']['gradient'] ?? ''), '53: inline directional gradient remains Gutenberg color support', json_encode($inlineGradient));
-$assert('#243b53' === ($inlineSolid['style']['color']['background'] ?? ''), '54: inline solid background remains Gutenberg color support', json_encode($inlineSolid));
-$assert(str_contains($mapper->serialize($inlineGradient['style'])['style'], 'background:linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)') && str_contains($mapper->serialize($inlineSolid['style'])['style'], 'background-color:#243b53'), '55: inline paint support serializes valid Gutenberg-compatible declarations');
+$assert('linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)' === ($inlineGradient['style']['color']['gradient'] ?? ''), '52: inline directional gradient remains Gutenberg color support', json_encode($inlineGradient));
+$assert('#243b53' === ($inlineSolid['style']['color']['background'] ?? ''), '53: inline solid background remains Gutenberg color support', json_encode($inlineSolid));
+$assert(str_contains($mapper->serialize($inlineGradient['style'])['style'], 'background:linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)') && str_contains($mapper->serialize($inlineSolid['style'])['style'], 'background-color:#243b53'), '54: inline paint support serializes valid Gutenberg-compatible declarations');
+
+$inlineSolidResult = ( new HtmlTransformer() )->transform('<main><section style="background-color:#243b53"><p>Solid</p></section></main>', array())->toArray();
+$inlineSolidBlock = $inlineSolidResult['blocks'][0] ?? array();
+$inlineSolidMarkup = (string) ($inlineSolidResult['serialized_blocks'] ?? '');
+$assert('#243b53' === ($inlineSolidBlock['attrs']['style']['color']['background'] ?? ''), '55: HtmlTransformer maps inline solid background to native color support', json_encode($inlineSolidBlock));
+$assert(str_contains($inlineSolidMarkup, 'has-background') && str_contains($inlineSolidMarkup, 'background-color:#243b53'), '56: inline solid background serializes Gutenberg support markup', $inlineSolidMarkup);
+
+$inlineGradientResult = ( new HtmlTransformer() )->transform('<main><section style="background:linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)"><p>Gradient</p></section></main>', array())->toArray();
+$inlineGradientBlock = $inlineGradientResult['blocks'][0] ?? array();
+$inlineGradientMarkup = (string) ($inlineGradientResult['serialized_blocks'] ?? '');
+$assert('linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)' === ($inlineGradientBlock['attrs']['style']['color']['gradient'] ?? ''), '57: HtmlTransformer maps inline directional gradient to native color support', json_encode($inlineGradientBlock));
+$assert(str_contains($inlineGradientMarkup, 'has-background') && str_contains($inlineGradientMarkup, 'background:linear-gradient(135deg,#ff5c8a 0%,#583c87 100%)'), '58: inline directional gradient serializes Gutenberg support markup', $inlineGradientMarkup);
+
+$compoundPaintCss = '.gallery{--card-overlay:#203040;--card-start:#ff5c8a;--card-end:#583c87}.gallery .artist-card{background:radial-gradient(circle at 20% 10%,rgba(255,255,255,.8),transparent 40%),linear-gradient(135deg,var(--card-start),var(--card-end));background-position:center top;background-size:120% 80%,100% 100%;background-repeat:no-repeat}';
+$compoundPaintHtml = '<main class="gallery"><section class="artist-card" style="background-color:var(--card-overlay)"><p>Artist</p></section></main>';
+$compoundPaintResult = ( new HtmlTransformer() )->transform($compoundPaintHtml, array('static_css' => $compoundPaintCss))->toArray();
+$compoundPaintBlock = $compoundPaintResult['blocks'][0]['innerBlocks'][0] ?? array();
+$compoundPaintMarkup = (string) ($compoundPaintResult['serialized_blocks'] ?? '');
+$compoundPaintCssAsset = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $compoundPaintResult['assets'] ?? array()));
+
+$assert('var(--card-overlay)' === ($compoundPaintBlock['attrs']['style']['color']['background'] ?? ''), '59: inherited CSS variable used by inline background-color remains the only mapped paint override', json_encode($compoundPaintBlock));
+$assert(! isset($compoundPaintBlock['attrs']['style']['color']['gradient']) && str_contains($compoundPaintMarkup, 'has-background') && str_contains($compoundPaintMarkup, 'background-color:var(--card-overlay)'), '60: inline background-color support does not consume class-owned layers', $compoundPaintMarkup);
+$assert(str_contains($compoundPaintCssAsset, '.gallery{--card-overlay:#203040;--card-start:#ff5c8a;--card-end:#583c87}') && str_contains($compoundPaintCssAsset, 'artist-card') && str_contains($compoundPaintCssAsset, 'background:radial-gradient(circle at 20% 10%,rgba(255,255,255,.8),transparent 40%),linear-gradient(135deg,var(--card-start),var(--card-end))') && str_contains($compoundPaintCssAsset, 'background-position:center top') && str_contains($compoundPaintCssAsset, 'background-size:120% 80%,100% 100%') && str_contains($compoundPaintCssAsset, 'background-repeat:no-repeat'), '61: projected compound selector preserves inherited variables and layered background shorthand', $compoundPaintCssAsset);
+
+$compoundSourceProbe = ( new StaticStyleParityProbe() )->extract($compoundPaintHtml, $compoundPaintCss);
+$compoundCandidateProbe = ( new StaticStyleParityProbe() )->extract(StaticStyleParityRunner::candidateHtmlFromSerializedBlocks($compoundPaintMarkup), $compoundPaintCssAsset);
+$assert(0 < (int) ($compoundSourceProbe['summary']['styled_total'] ?? 0) && 0 < (int) ($compoundCandidateProbe['summary']['styled_total'] ?? 0), '62: layered background cascade case produces nonzero source and candidate style probes', json_encode(array($compoundSourceProbe['summary'] ?? array(), $compoundCandidateProbe['summary'] ?? array())));
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Block style support conversion tests: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
## Summary

- keep class-owned background colors, gradients, images, and layers in projected author CSS
- avoid emitting competing Gutenberg `has-background` support for class-derived paint
- retain inline solid/gradient block support when exactly representable
- strengthen canonical cascade and parity coverage for selectors, variables, layered backgrounds, and inline overrides

## Verification

- `composer test`
- `composer test:unit`
- `composer test:parity` (249 fixtures)
- `composer validate --no-check-publish`
- PHP lint and `git diff --check`

## Compatibility

No block schema change. Authored stylesheet cascade remains authoritative for class-owned paint; inline paint retains existing Gutenberg support behavior.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented the cascade repair and strengthened it through independent contract/parity review. Chris Huber reviewed and remains responsible for every line.

Fixes #710.