### PR TITLE
Preserve class-owned column max-width geometry

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -66,7 +66,7 @@ final class BlockFactory
 
         // These core save functions do not reproduce dimensions.maxWidth. Inline
         // max-width is retained by the generated geometry carrier stylesheet.
-        if ( in_array($name, array( 'core/group', 'core/columns', 'core/list-item', 'core/paragraph', 'core/separator' ), true) ) {
+        if ( in_array($name, array( 'core/group', 'core/column', 'core/columns', 'core/list-item', 'core/paragraph', 'core/separator' ), true) ) {
             unset($attrs['style']['dimensions']['maxWidth']);
             if ( empty($attrs['style']['dimensions']) ) {
                 unset($attrs['style']['dimensions']);

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -744,6 +744,19 @@ $boundedSeparatorCss = implode("\n", array_map(static fn (array $asset): string 
 $assert(array('top' => '0', 'bottom' => '0') === ($boundedSeparatorAttrs['style']['spacing']['margin'] ?? null) && ! isset($boundedSeparatorAttrs['style']['dimensions']), 'separator keeps only spacing supported by its canonical core block attributes');
 $assert(! str_contains($boundedSeparatorMarkup, 'margin-left:auto') && ! str_contains($boundedSeparatorMarkup, 'max-width:var(--max)') && str_contains($boundedSeparatorCss, 'margin-left:auto !important') && str_contains($boundedSeparatorCss, 'margin-right:auto !important') && str_contains($boundedSeparatorCss, 'max-width:var(--max) !important'), 'separator moves unsupported horizontal and width geometry to its generated carrier stylesheet');
 
+$boundedColumn = ( new HtmlTransformer() )->transform(
+    '<main><div class="column-row" style="display:flex"><article class="bounded-column"><h2>Article</h2><p>Body</p></article><aside><p>Aside</p></aside></div></main>',
+    array('static_css' => ':root{--measure:42rem}.bounded-column{max-width:var(--measure);padding:1rem}')
+)->toArray();
+$boundedColumnBlock = $boundedColumn['blocks'][0]['innerBlocks'][0] ?? array();
+$boundedColumnAttrs = $boundedColumnBlock['attrs'] ?? array();
+$boundedColumnMarkup = (string) ($boundedColumn['serialized_blocks'] ?? '');
+$boundedColumnCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $boundedColumn['assets'] ?? array()));
+$assert('core/column' === ($boundedColumnBlock['blockName'] ?? '') && 'bounded-column' === ($boundedColumnAttrs['className'] ?? ''), 'bounded source child becomes a core/column and retains its class-owned geometry selector');
+$assert(! isset($boundedColumnAttrs['style']['dimensions']['maxWidth']) && ! str_contains($boundedColumnMarkup, 'max-width:var(--measure)'), 'column omits max-width unsupported by its canonical Gutenberg save wrapper');
+$assert(str_contains($boundedColumnCss, '.bounded-column{max-width:var(--measure);padding:1rem}'), 'generated stylesheet retains the exact class-owned column max-width geometry');
+$assert('pass' === ($boundedColumn['source_reports']['wp_block_validity']['status'] ?? ''), 'bounded column serialization passes canonical Gutenberg wrapper validity');
+
 $customStateFindings = ( new CanonicalSaveShapeValidator() )->findings(array(array(
     'blockName'    => 'core/group',
     'attrs'        => array(),


### PR DESCRIPTION
## Summary
Keep class-owned max-width geometry in generated CSS instead of serializing unsupported core/column inline style.

## What changed
- Removed max-width from core/column style serialization while retaining it in generated class geometry, with a regression contract proving parsed Gutenberg validity and preserved CSS.

## How to test
1. Run `cd php-transformer && php tests/contract/run.php`; expect The transformer contract suite passes, including class-owned column max-width validity..
2. Run `cd php-transformer && composer test:canonical`; expect The canonical artifact compiler and HTML transformer suites pass..

## Compatibility
The change narrows core/column serialization to attributes supported by Gutenberg save output; class-owned max-width remains rendered through the existing generated CSS path.

## Evidence
- Base unchanged since verification: trunk remains at 0cd65716f31ef5a0ffef84ba7415e45b0fe218d3.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/blocks-engine/issues/714
- Verified finalization base: trunk at 0cd65716f31ef5a0ffef84ba7415e45b0fe218d3
- canonical-suites: passed (165 artifact compiler and 355 HTML transformer assertions) (Passed)
- transformer-contract: passed (563 assertions) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode via Homeboy)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the invalid Gutenberg serialization, implemented the focused ownership fix and regression contract, and verified the canonical transformer suites; Chris Huber remains responsible for every line.

## Source relationships
- Closes #714
