### PR TITLE
Unblock pinned WordPress test runtime

### DIFF
--- a/.github/workflows/php-transformer.yml
+++ b/.github/workflows/php-transformer.yml
@@ -107,6 +107,7 @@ jobs:
           WORDPRESS_TEST_DB: wordpress_site_plan_test
         run: |
           git clone --depth=1 --branch 6.7.4 https://github.com/WordPress/wordpress-develop.git "$WORDPRESS_DEVELOP_DIR"
+          composer config --working-dir="$WORDPRESS_DEVELOP_DIR" --json policy.advisories.ignore-id '{"PKSA-mh9b-91zm-m1gy":{"on-block":false,"reason":"Pinned WordPress 6.7.4 test runtime; WPCS is not loaded by the integration test."}}'
           composer install --working-dir="$WORDPRESS_DEVELOP_DIR" --no-interaction --prefer-dist --no-progress
           for attempt in $(seq 1 30); do
             if mysql --host=127.0.0.1 --port=3306 --user=root --execute='SELECT 1'; then break; fi

--- a/.github/workflows/php-transformer.yml
+++ b/.github/workflows/php-transformer.yml
@@ -107,7 +107,7 @@ jobs:
           WORDPRESS_TEST_DB: wordpress_site_plan_test
         run: |
           git clone --depth=1 --branch 6.7.4 https://github.com/WordPress/wordpress-develop.git "$WORDPRESS_DEVELOP_DIR"
-          composer config --working-dir="$WORDPRESS_DEVELOP_DIR" --json policy.advisories.ignore-id '{"PKSA-mh9b-91zm-m1gy":{"on-block":false,"reason":"Pinned WordPress 6.7.4 test runtime; WPCS is not loaded by the integration test."}}'
+          composer config --working-dir="$WORDPRESS_DEVELOP_DIR" --json policy.advisories.ignore-id '{"PKSA-mh9b-91zm-m1gy":{"on-audit":false,"reason":"Pinned WordPress 6.7.4 test runtime; WPCS is not loaded by the integration test."}}'
           composer install --working-dir="$WORDPRESS_DEVELOP_DIR" --no-interaction --prefer-dist --no-progress
           for attempt in $(seq 1 30); do
             if mysql --host=127.0.0.1 --port=3306 --user=root --execute='SELECT 1'; then break; fi


### PR DESCRIPTION
## Summary
- allow only advisory `PKSA-mh9b-91zm-m1gy` during dependency blocking in the disposable WordPress 6.7.4 test checkout
- keep the advisory reportable and preserve repository-wide Composer policy
- leave every other security advisory blocking dependency resolution

Closes #720.

## Evidence
The failure occurs before repository code runs at the pinned WordPress checkout's dependency install:
https://github.com/Automattic/blocks-engine/actions/runs/30374905280/job/90327941128

## Verification
- workflow YAML parses successfully
- `actionlint` introduces no new finding; the existing `SC2016` finding is unchanged from `trunk`
- this PR's WordPress site plan integration job exercises the exact Composer/runtime path

## AI assistance
OpenCode with OpenAI GPT-5.6 Sol diagnosed the Composer 2.10 policy change and drafted the scoped workflow repair under Chris Huber's direction. Chris remains responsible for every line.