### PR TITLE
Preserve fixed shell header parity

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1207,7 +1207,6 @@ final class HtmlTransformer
 
         $rewritten = array();
         foreach ( $selectors as $selector ) {
-            $selector = $this->projectSourceBodyStateSelector($selector);
             $parsed = $this->parsedCssSelector($selector);
             if ( ! $parsed['supported'] ) {
                 $rewritten[] = $selector;
@@ -1316,17 +1315,6 @@ final class HtmlTransformer
             }
         }
         return implode(',', $rewritten);
-    }
-
-    private function projectSourceBodyStateSelector(string $selector): string
-    {
-        if ( array() === $this->sourceBodyProjectionClasses ) {
-            return $selector;
-        }
-
-        $classes = implode('|', array_map(static fn (string $class): string => preg_quote($class, '/'), $this->sourceBodyProjectionClasses));
-        $selector = preg_replace('/^\s*body((?:\.(?:' . $classes . '))+)(?:\s*>?\s*)/', '$1', $selector, 1) ?? $selector;
-        return preg_replace('/^\s*((?:\.(?:' . $classes . '))+)(?:\s*>\s*|\s+)/', '$1', $selector, 1) ?? $selector;
     }
 
     private function projectAuthorImageSelectorPrelude(string $prelude): string
@@ -2571,7 +2559,7 @@ final class HtmlTransformer
             $logo = $this->logoPattern->match(
                 $element,
                 fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
                 fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
                 fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
@@ -2962,9 +2950,17 @@ final class HtmlTransformer
     private function sourceElementStartsHidden(DOMElement $element): bool
     {
         $declarations = $this->structuralPresentationDeclarations($element);
-        return 'none' === strtolower(trim((string) ($declarations['display'] ?? '')))
-            || in_array(strtolower(trim((string) ($declarations['visibility'] ?? ''))), array( 'hidden', 'collapse' ), true)
-            || (is_numeric(trim((string) ($declarations['opacity'] ?? ''))) && 0.0 === (float) trim((string) $declarations['opacity']));
+        $display = $this->cssComparableValue((string) ($declarations['display'] ?? ''));
+        $visibility = $this->cssComparableValue((string) ($declarations['visibility'] ?? ''));
+        $opacity = $this->cssComparableValue((string) ($declarations['opacity'] ?? ''));
+        return 'none' === $display
+            || in_array($visibility, array( 'hidden', 'collapse' ), true)
+            || (is_numeric($opacity) && 0.0 === (float) $opacity);
+    }
+
+    private function cssComparableValue(string $value): string
+    {
+        return strtolower(trim(preg_replace('/\s*!important\s*$/i', '', $value) ?? $value));
     }
 
     private function hasAuthorSemanticMarker(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -222,6 +222,9 @@ final class HtmlTransformer
      */
     private array $sourceProvenance = array();
 
+    /** @var array<int, bool> */
+    private array $sourceBaseHiddenStates = array();
+
     /** @var array<string,int> */
     private array $blockBindingOccurrences = array();
 
@@ -368,6 +371,9 @@ final class HtmlTransformer
     /** @var array<string, string> Source body children that need wrapper-safe selector projection. */
     private array $sourceRootChildMarkers = array();
 
+    /** @var list<string> Source body-state classes referenced by authored CSS. */
+    private array $sourceBodyProjectionClasses = array();
+
     /** @var array<string, string> Native tables whose descendant selectors need structural projection. */
     private array $sourceTableMarkers = array();
 
@@ -455,6 +461,7 @@ final class HtmlTransformer
         $this->frozenHiddenStateFindings = array();
         $this->droppedLinkWrapperFindings = array();
         $this->sourceProvenance = array();
+        $this->sourceBaseHiddenStates = array();
         $this->blockBindingOccurrences = array();
         $this->formControlSlotPaths = array();
         $this->structureProvenance = array();
@@ -477,6 +484,7 @@ final class HtmlTransformer
         $this->sourceControlPaths = array();
         $this->sourceSemanticMarkers = array();
         $this->sourceRootChildMarkers = array();
+        $this->sourceBodyProjectionClasses = array();
         $this->sourceTableMarkers = array();
         $this->sourceTableRepresentability = array();
         $this->sourceTableDescendantPaths = array();
@@ -512,6 +520,7 @@ final class HtmlTransformer
             ), $this->fallbackProvenance),
         );
 
+        $sourceBodyClasses = $this->documentBodyClassNames($html);
         $normalizedHtml = $this->normalizeHtml5VoidElements($this->documentBodyHtml($this->normalizeExplicitPlaintextElements($html)));
         $document = new DOMDocument();
         $previous = libxml_use_internal_errors(true);
@@ -565,6 +574,10 @@ final class HtmlTransformer
                 context: $context,
                 metrics: $metrics
             );
+        }
+
+        if ( array() !== $sourceBodyClasses ) {
+            $body->setAttribute('class', implode(' ', $sourceBodyClasses));
         }
 
         $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
@@ -881,6 +894,16 @@ final class HtmlTransformer
         $this->discoverAuthorInlineSemanticPaths();
         $this->discoverAuthorRootChildPaths();
         $this->discoverAuthorTablePaths();
+        $this->sourceBodyProjectionClasses = $this->referencedSourceBodyClasses($sourceBody);
+    }
+
+    /** @return list<string> */
+    private function referencedSourceBodyClasses(DOMElement $sourceBody): array
+    {
+        $classes = preg_split('/\s+/', trim($this->attr($sourceBody, 'class'))) ?: array();
+        return array_values(array_filter(array_unique($classes), function (string $class): bool {
+            return '' !== $class && (bool) preg_match('/\.' . preg_quote($class, '/') . '(?:\b|(?=[.#:\[]))/', $this->combinedAuthorCss);
+        }));
     }
 
     private function discoverAuthorControlPaths(): void
@@ -1184,6 +1207,7 @@ final class HtmlTransformer
 
         $rewritten = array();
         foreach ( $selectors as $selector ) {
+            $selector = $this->projectSourceBodyStateSelector($selector);
             $parsed = $this->parsedCssSelector($selector);
             if ( ! $parsed['supported'] ) {
                 $rewritten[] = $selector;
@@ -1292,6 +1316,17 @@ final class HtmlTransformer
             }
         }
         return implode(',', $rewritten);
+    }
+
+    private function projectSourceBodyStateSelector(string $selector): string
+    {
+        if ( array() === $this->sourceBodyProjectionClasses ) {
+            return $selector;
+        }
+
+        $classes = implode('|', array_map(static fn (string $class): string => preg_quote($class, '/'), $this->sourceBodyProjectionClasses));
+        $selector = preg_replace('/^\s*body((?:\.(?:' . $classes . '))+)(?:\s*>?\s*)/', '$1', $selector, 1) ?? $selector;
+        return preg_replace('/^\s*((?:\.(?:' . $classes . '))+)(?:\s*>\s*|\s+)/', '$1', $selector, 1) ?? $selector;
     }
 
     private function projectAuthorImageSelectorPrelude(string $prelude): string
@@ -1641,6 +1676,7 @@ final class HtmlTransformer
      */
     private function deduplicateNavigationBlocksRecursive(array $blocks, array &$seen): array
     {
+        $blocks = $this->preferVisibleSiblingNavigationBlocks($blocks);
         $deduplicated = array();
         foreach ( $blocks as $block ) {
             if ( ! is_array($block) ) {
@@ -1666,6 +1702,58 @@ final class HtmlTransformer
         }
 
         return $deduplicated;
+    }
+
+    /**
+     * Equivalent responsive variants frequently sit beside one another. When
+     * exactly one starts hidden, retain the visible source variant before the
+     * global mobile/drawer deduplication pass runs.
+     *
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<int, array<string, mixed>>
+     */
+    private function preferVisibleSiblingNavigationBlocks(array $blocks): array
+    {
+        $preferred = array();
+        $discarded = array();
+        foreach ( $blocks as $index => $block ) {
+            if ( ! is_array($block) || 'core/navigation' !== ($block['blockName'] ?? '') ) {
+                continue;
+            }
+
+            $signature = $this->navigationBlockSignature($block);
+            if ( '' === $signature ) {
+                continue;
+            }
+
+            if ( ! isset($preferred[$signature]) ) {
+                $preferred[$signature] = $index;
+                continue;
+            }
+
+            $previousIndex = $preferred[$signature];
+            $previousHidden = $this->navigationBlockStartsHidden($blocks[$previousIndex]);
+            $currentHidden = $this->navigationBlockStartsHidden($block);
+            if ( $previousHidden === $currentHidden ) {
+                continue;
+            }
+
+            if ( $previousHidden ) {
+                $discarded[$previousIndex] = true;
+                $preferred[$signature] = $index;
+            } else {
+                $discarded[$index] = true;
+            }
+        }
+
+        return array_values(array_filter($blocks, static fn (mixed $block, int $index): bool => ! isset($discarded[$index]), ARRAY_FILTER_USE_BOTH));
+    }
+
+    /** @param array<string, mixed> $block */
+    private function navigationBlockStartsHidden(array $block): bool
+    {
+        $provenanceId = $block['_source_provenance_id'] ?? null;
+        return is_int($provenanceId) && true === ($this->sourceBaseHiddenStates[$provenanceId] ?? false);
     }
 
     /**
@@ -1794,6 +1882,26 @@ final class HtmlTransformer
         }
 
         return $this->innerHtml($body);
+    }
+
+    /** @return list<string> */
+    private function documentBodyClassNames(string $html): array
+    {
+        if ( ! preg_match('/<body\b/i', $html) ) {
+            return array();
+        }
+
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?>' . $html);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
+        if ( ! $body instanceof DOMElement ) {
+            return array();
+        }
+
+        return array_values(array_filter(array_unique(preg_split('/\s+/', trim($this->attr($body, 'class'))) ?: array())));
     }
 
     /**
@@ -2796,6 +2904,11 @@ final class HtmlTransformer
             if ( isset($this->sourceTagMarkers[$sourceTagName]) ) {
                 $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceTagMarkers[$sourceTagName]);
             }
+            if ( $sourceElement->parentNode instanceof DOMElement
+                && 'body' === strtolower($sourceElement->parentNode->tagName)
+                && array() !== $this->sourceBodyProjectionClasses ) {
+                $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), ...$this->sourceBodyProjectionClasses);
+            }
             if ( 'core/table' === $name && isset($this->sourceTableMarkers[$this->sourceElementIdentity($sourceElement)]) ) {
                 $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceTableMarkers[$this->sourceElementIdentity($sourceElement)]);
             }
@@ -2828,6 +2941,7 @@ final class HtmlTransformer
                 ));
             }
             $this->sourceProvenance[$provenanceId] = $this->sourceProvenanceEntry($name, $sourceElement);
+            $this->sourceBaseHiddenStates[$provenanceId] = $this->sourceElementStartsHidden($sourceElement);
         }
 
         if ( 'core/group' === $name && $sourceElement instanceof DOMElement && ! isset($attrs['tagName']) ) {
@@ -2843,6 +2957,14 @@ final class HtmlTransformer
         }
 
         return $block;
+    }
+
+    private function sourceElementStartsHidden(DOMElement $element): bool
+    {
+        $declarations = $this->structuralPresentationDeclarations($element);
+        return 'none' === strtolower(trim((string) ($declarations['display'] ?? '')))
+            || in_array(strtolower(trim((string) ($declarations['visibility'] ?? ''))), array( 'hidden', 'collapse' ), true)
+            || (is_numeric(trim((string) ($declarations['opacity'] ?? ''))) && 0.0 === (float) trim((string) $declarations['opacity']));
     }
 
     private function hasAuthorSemanticMarker(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1139,6 +1139,7 @@ final class HtmlTransformer
 
         $rewritten = array();
         foreach ( $selectors as $selector ) {
+            $selector = $this->projectSourceBodyStateSelector($selector);
             $parsed = $this->parsedCssSelector($selector);
             if ( ! $parsed['supported'] || null !== $parsed['pseudo_state_suffix_span'] ) {
                 continue;
@@ -1161,6 +1162,16 @@ final class HtmlTransformer
         }
 
         return implode(',', $rewritten);
+    }
+
+    private function projectSourceBodyStateSelector(string $selector): string
+    {
+        if ( array() === $this->sourceBodyProjectionClasses ) {
+            return $selector;
+        }
+
+        $classes = implode('|', array_map(static fn (string $class): string => preg_quote($class, '/'), $this->sourceBodyProjectionClasses));
+        return preg_replace('/^\s*body(?=\.(?:' . $classes . ')(?:\b|[.#:\[]))/', '', $selector, 1) ?? $selector;
     }
 
     /** @return array{string, string} */
@@ -1207,6 +1218,7 @@ final class HtmlTransformer
 
         $rewritten = array();
         foreach ( $selectors as $selector ) {
+            $selector = $this->projectSourceBodyStateSelector($selector);
             $parsed = $this->parsedCssSelector($selector);
             if ( ! $parsed['supported'] ) {
                 $rewritten[] = $selector;

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1773,7 +1773,7 @@ final class HtmlTransformer
             $classNames,
         ))));
 
-        return (bool) preg_match('/(?:^|[^a-z0-9])(?:mobile|drawer|offcanvas|overlay|hamburger|menu-panel|nav-panel)(?:[^a-z0-9]|$)/', $haystack);
+        return (bool) preg_match('/(?:^|[^a-z0-9])(?:mobile|drawer|offcanvas|overlay|collapsed|hamburger|menu-panel|nav-panel)(?:[^a-z0-9]|$)/', $haystack);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use DOMDocument;
 use DOMElement;
 
 final class LogoPattern
@@ -93,6 +94,7 @@ final class LogoPattern
         $html = preg_replace('/<img\b[^>]*>/is', '', $html) ?? $html;
         $html = $materializeSvgImages($element, $html) ?? (preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html);
         $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>\s*<\/\1>/i', '', $html) ?? $html;
+        $html = $this->semanticMarkerSpansAsMarks($html);
         $html = trim($html);
         $text = $this->plainText($html);
         if ( '' === $text ) {
@@ -105,6 +107,44 @@ final class LogoPattern
         }
 
         return $html;
+    }
+
+    private function semanticMarkerSpansAsMarks(string $html): string
+    {
+        if ( ! str_contains($html, '--blocks-engine-richtext-marker:') ) {
+            return $html;
+        }
+
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
+        if ( ! $body instanceof DOMElement ) {
+            return $html;
+        }
+
+        $spans = array();
+        foreach ( $body->getElementsByTagName('span') as $span ) {
+            if ( $span instanceof DOMElement && str_contains($span->getAttribute('style'), '--blocks-engine-richtext-marker:') ) {
+                $spans[] = $span;
+            }
+        }
+        foreach ( $spans as $span ) {
+            $mark = $document->createElement('mark');
+            $mark->setAttribute('style', $span->getAttribute('style'));
+            while ( null !== $span->firstChild ) {
+                $mark->appendChild($span->firstChild);
+            }
+            $span->parentNode?->replaceChild($mark, $span);
+        }
+
+        $content = '';
+        foreach ( $body->childNodes as $child ) {
+            $content .= $document->saveHTML($child);
+        }
+        return $content;
     }
 
     private function unwrapPresentationalSpan(string $html): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -101,7 +101,13 @@ final class LogoPattern
             return '';
         }
 
-        if ( preg_match('/<\/?(?!em\b|i\b|strong\b|b\b|mark\b|small\b|sub\b|sup\b|br\b)[a-z][a-z0-9]*\b[^>]*>/i', $html) ) {
+        $unsupported = '/<\/?(?!a\b|em\b|i\b|strong\b|b\b|mark\b|small\b|sub\b|sup\b|br\b)[a-z][a-z0-9]*\b[^>]*>/i';
+        if ( preg_match($unsupported, $html) ) {
+            $unwrapped = trim(preg_replace_callback($unsupported, static fn (array $match): string => str_starts_with($match[0], '</') ? '' : ' ', $html) ?? $html);
+            if ( '' !== $unwrapped && ! preg_match($unsupported, $unwrapped) ) {
+                return $unwrapped;
+            }
+
             $flattened = $this->plainText(preg_replace('/<\/?[a-z][a-z0-9]*\b[^>]*>/i', ' ', $html) ?? $html);
             return htmlspecialchars('' !== $flattened ? $flattened : $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         }

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -17,7 +17,8 @@ trait NavigationToggleSuppressionTrait
      * by a specific class string — so any framework's hamburger is recognized:
      * a <button> (or <a role="button">) carrying aria-controls and/or
      * aria-expanded whose visible content is empty/decorative bars (only empty
-     * spans or an icon, no text label). It is suppressed when it opens, lives
+     * spans or an icon, no text label), or an input-free <label> containing a
+     * nested stack of CSS-drawn bars. It is suppressed when it opens, lives
      * inside, or sits beside a source navigation menu. A converted menu already
      * ships its own responsive overlay hamburger; a menu that does NOT convert
      * still must not gain an always-visible dead hamburger the source hid behind
@@ -160,6 +161,10 @@ trait NavigationToggleSuppressionTrait
     private function isHamburgerMenuToggleControl(DOMElement $element): bool
     {
         $tagName = strtolower($element->tagName);
+        if ( 'label' === $tagName ) {
+            return $this->isNestedHamburgerBarLabel($element);
+        }
+
         $isButton = 'button' === $tagName;
         $isButtonRoleAnchor = 'a' === $tagName && 'button' === strtolower($this->attr($element, 'role'));
         if ( ! $isButton && ! $isButtonRoleAnchor ) {
@@ -184,6 +189,42 @@ trait NavigationToggleSuppressionTrait
         // it. Recognizing that shape (never a class string) lets these toggles be
         // dropped too, instead of surfacing as an empty, always-visible button.
         return $this->isHamburgerBarStackControl($element);
+    }
+
+    private function isNestedHamburgerBarLabel(DOMElement $element): bool
+    {
+        if ( $element->hasAttribute('for')
+            || 0 !== $element->getElementsByTagName('input')->length
+            || 0 !== $element->getElementsByTagName('select')->length
+            || 0 !== $element->getElementsByTagName('textarea')->length ) {
+            return false;
+        }
+
+        foreach ( $element->getElementsByTagName('*') as $container ) {
+            if ( ! $container instanceof DOMElement ) {
+                continue;
+            }
+
+            $bars = 0;
+            foreach ( $container->childNodes as $child ) {
+                if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                    continue;
+                }
+                if ( ! $child instanceof DOMElement
+                    || ! in_array(strtolower($child->tagName), array( 'div', 'span' ), true)
+                    || '' !== trim($child->textContent ?? '')
+                    || 0 !== $child->childNodes->length ) {
+                    $bars = 0;
+                    break;
+                }
+                ++$bars;
+            }
+            if ( $bars >= 2 ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1386,13 +1386,13 @@ $assert(str_contains($visibleVariantSerialized, 'primary') && ! str_contains($vi
 $assert(! str_contains($visibleVariantSerialized, '>menu<') && ! str_contains($visibleVariantSerialized, '>close<'), 'input-free label hamburger chrome is superseded by native navigation controls');
 
 $bodyStateProjection = ( new HtmlTransformer() )->transform(
-    '<!doctype html><html><body class="fixed-shell no-header-page"><div class="main-wrap"><p>Content</p></div></body></html>',
+    '<!doctype html><html><body class="fixed-shell no-header-page"><div class="wrapper"><div class="main-wrap"><p>Content</p></div></div></body></html>',
     array( 'static_css' => '.no-header-page .main-wrap{padding-top:80px}' )
 )->toArray();
 $bodyStateSerialized = (string) ($bodyStateProjection['serialized_blocks'] ?? '');
 $bodyStateCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $bodyStateProjection['assets'] ?? array()));
-$assert(str_contains($bodyStateSerialized, 'main-wrap no-header-page'), 'stylesheet-referenced body state projects onto converted root blocks');
-$assert(str_contains($bodyStateCss, '.no-header-page.main-wrap{padding-top:80px}'), 'body-state descendant selectors fuse onto the projected root block state');
+$assert(str_contains($bodyStateSerialized, 'wrapper no-header-page') && str_contains($bodyStateSerialized, 'main-wrap'), 'stylesheet-referenced body state projects onto converted root blocks');
+$assert(str_contains($bodyStateCss, '.no-header-page .main-wrap{padding-top:80px}'), 'body-state descendant selectors continue matching beneath the projected root block state');
 
 $styledLogo = ( new HtmlTransformer() )->transform(
     '<style>#wordmark{font-family:Fjalla One,sans-serif;font-size:36px}</style><a class="logo" href="/"><span id="wordmark">Brand Name</span></a>'
@@ -1400,6 +1400,12 @@ $styledLogo = ( new HtmlTransformer() )->transform(
 $styledLogoSerialized = (string) ($styledLogo['serialized_blocks'] ?? '');
 $assert(str_contains($styledLogoSerialized, '<mark style="') && str_contains($styledLogoSerialized, 'Brand Name</mark>'), 'selector-addressed logo labels retain a valid RichText semantic marker instead of flattening to plain text');
 $assert('pass' === ($styledLogo['source_reports']['wp_block_validity']['status'] ?? ''), 'selector-addressed logo label markers remain editor-valid');
+
+$nestedStyledLogo = ( new HtmlTransformer() )->transform(
+    '<style>.header #wordmark{font-family:Fjalla One,sans-serif;font-size:36px}</style><div class="header"><div class="logo"><span><a href="/"><span id="wordmark">Nested Brand</span></a></span></div></div>'
+)->toArray();
+$nestedStyledLogoSerialized = (string) ($nestedStyledLogo['serialized_blocks'] ?? '');
+$assert(str_contains($nestedStyledLogoSerialized, '<a href="/"><mark style="') && str_contains($nestedStyledLogoSerialized, 'Nested Brand</mark></a>'), 'nested logo chrome unwraps presentational containers while preserving the styled semantic label and link');
 
 $brandedHeaderNavigation = ( new HtmlTransformer() )->transform(
     '<header><div class="container"><nav class="nav-inner" aria-label="Main navigation"><a href="/" class="nav-logo" aria-label="Acme home"><svg aria-hidden="true"><path d="M0 0h1v1z"></path></svg><span>Acme</span></a><ul class="nav-links"><li><a href="/work">Work</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/about">About</a></li></ul><div class="nav-actions"><a href="/start" class="button">Get Started</a><button class="nav-toggle" aria-label="Open menu" aria-expanded="false"><span></span><span></span></button></div></nav></div></header>'

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1387,12 +1387,13 @@ $assert(! str_contains($visibleVariantSerialized, '>menu<') && ! str_contains($v
 
 $bodyStateProjection = ( new HtmlTransformer() )->transform(
     '<!doctype html><html><body class="fixed-shell no-header-page"><div class="wrapper"><div class="main-wrap"><p>Content</p></div></div></body></html>',
-    array( 'static_css' => '.no-header-page .main-wrap{padding-top:80px}' )
+    array( 'static_css' => '.no-header-page .main-wrap{padding-top:80px}body.fixed-shell .main-wrap{background:#fff}' )
 )->toArray();
 $bodyStateSerialized = (string) ($bodyStateProjection['serialized_blocks'] ?? '');
 $bodyStateCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $bodyStateProjection['assets'] ?? array()));
-$assert(str_contains($bodyStateSerialized, 'wrapper no-header-page') && str_contains($bodyStateSerialized, 'main-wrap'), 'stylesheet-referenced body state projects onto converted root blocks');
+$assert(str_contains($bodyStateSerialized, 'wrapper fixed-shell no-header-page') && str_contains($bodyStateSerialized, 'main-wrap'), 'stylesheet-referenced body state projects onto converted root blocks');
 $assert(str_contains($bodyStateCss, '.no-header-page .main-wrap{padding-top:80px}'), 'body-state descendant selectors continue matching beneath the projected root block state');
+$assert(str_contains($bodyStateCss, '.fixed-shell .main-wrap{background:#fff}') && ! str_contains($bodyStateCss, 'body.fixed-shell'), 'explicit body-state selectors retarget the projected root state while retaining descendant structure');
 
 $styledLogo = ( new HtmlTransformer() )->transform(
     '<style>#wordmark{font-family:Fjalla One,sans-serif;font-size:36px}</style><a class="logo" href="/"><span id="wordmark">Brand Name</span></a>'

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1377,6 +1377,30 @@ $assert(5 === ($complexHeaderBlockMenus[0]['item_count'] ?? null), 'complex head
 $assert('Cart' === ($complexHeaderBlockMenus[0]['items'][4]['label'] ?? ''), 'icon-only header navigation links use accessible labels');
 $assert(! str_contains((string) ($complexHeaderNavigation['serialized_blocks'] ?? ''), 'drawer-nav'), 'complex header navigation removes duplicate mobile drawer core/navigation children');
 
+$visibleVariantNavigation = ( new HtmlTransformer() )->transform(
+    '<header><nav class="placeholder" style="display:none"><a href="/">Home</a><a href="/about">About</a></nav><nav class="primary"><a href="/">Home</a><a href="/about">About</a></nav><label><span><div></div><div></div><div></div></span><span>menu</span><span>close</span></label></header>'
+)->toArray();
+$visibleVariantSerialized = (string) ($visibleVariantNavigation['serialized_blocks'] ?? '');
+$assert(1 === substr_count($visibleVariantSerialized, '<!-- wp:navigation {'), 'equivalent sibling navigation variants retain only the visible source variant');
+$assert(str_contains($visibleVariantSerialized, 'primary') && ! str_contains($visibleVariantSerialized, 'placeholder'), 'navigation deduplication prefers the visible source variant over a hidden placeholder');
+$assert(! str_contains($visibleVariantSerialized, '>menu<') && ! str_contains($visibleVariantSerialized, '>close<'), 'input-free label hamburger chrome is superseded by native navigation controls');
+
+$bodyStateProjection = ( new HtmlTransformer() )->transform(
+    '<!doctype html><html><body class="fixed-shell no-header-page"><div class="main-wrap"><p>Content</p></div></body></html>',
+    array( 'static_css' => '.no-header-page .main-wrap{padding-top:80px}' )
+)->toArray();
+$bodyStateSerialized = (string) ($bodyStateProjection['serialized_blocks'] ?? '');
+$bodyStateCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $bodyStateProjection['assets'] ?? array()));
+$assert(str_contains($bodyStateSerialized, 'main-wrap no-header-page'), 'stylesheet-referenced body state projects onto converted root blocks');
+$assert(str_contains($bodyStateCss, '.no-header-page.main-wrap{padding-top:80px}'), 'body-state descendant selectors fuse onto the projected root block state');
+
+$styledLogo = ( new HtmlTransformer() )->transform(
+    '<style>#wordmark{font-family:Fjalla One,sans-serif;font-size:36px}</style><a class="logo" href="/"><span id="wordmark">Brand Name</span></a>'
+)->toArray();
+$styledLogoSerialized = (string) ($styledLogo['serialized_blocks'] ?? '');
+$assert(str_contains($styledLogoSerialized, '<mark style="') && str_contains($styledLogoSerialized, 'Brand Name</mark>'), 'selector-addressed logo labels retain a valid RichText semantic marker instead of flattening to plain text');
+$assert('pass' === ($styledLogo['source_reports']['wp_block_validity']['status'] ?? ''), 'selector-addressed logo label markers remain editor-valid');
+
 $brandedHeaderNavigation = ( new HtmlTransformer() )->transform(
     '<header><div class="container"><nav class="nav-inner" aria-label="Main navigation"><a href="/" class="nav-logo" aria-label="Acme home"><svg aria-hidden="true"><path d="M0 0h1v1z"></path></svg><span>Acme</span></a><ul class="nav-links"><li><a href="/work">Work</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/about">About</a></li></ul><div class="nav-actions"><a href="/start" class="button">Get Started</a><button class="nav-toggle" aria-label="Open menu" aria-expanded="false"><span></span><span></span></button></div></nav></div></header>'
 )->toArray();

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1378,11 +1378,11 @@ $assert('Cart' === ($complexHeaderBlockMenus[0]['items'][4]['label'] ?? ''), 'ic
 $assert(! str_contains((string) ($complexHeaderNavigation['serialized_blocks'] ?? ''), 'drawer-nav'), 'complex header navigation removes duplicate mobile drawer core/navigation children');
 
 $visibleVariantNavigation = ( new HtmlTransformer() )->transform(
-    '<header><nav class="placeholder" style="display:none"><a href="/">Home</a><a href="/about">About</a></nav><nav class="primary"><a href="/">Home</a><a href="/about">About</a></nav><label><span><div></div><div></div><div></div></span><span>menu</span><span>close</span></label></header>'
+    '<header><nav class="placeholder" style="display:none"><a href="/">Home</a><a href="/about">About</a></nav><nav class="primary"><a href="/">Home</a><a href="/about">About</a></nav><label><span><div></div><div></div><div></div></span><span>menu</span><span>close</span></label></header><nav class="collapsed-nav" style="display:none"><a href="/">Home</a><a href="/about">About</a></nav>'
 )->toArray();
 $visibleVariantSerialized = (string) ($visibleVariantNavigation['serialized_blocks'] ?? '');
 $assert(1 === substr_count($visibleVariantSerialized, '<!-- wp:navigation {'), 'equivalent sibling navigation variants retain only the visible source variant');
-$assert(str_contains($visibleVariantSerialized, 'primary') && ! str_contains($visibleVariantSerialized, 'placeholder'), 'navigation deduplication prefers the visible source variant over a hidden placeholder');
+$assert(str_contains($visibleVariantSerialized, 'primary') && ! str_contains($visibleVariantSerialized, 'placeholder') && ! str_contains($visibleVariantSerialized, 'collapsed-nav'), 'navigation deduplication prefers the visible source variant over hidden placeholder and collapsed variants');
 $assert(! str_contains($visibleVariantSerialized, '>menu<') && ! str_contains($visibleVariantSerialized, '>close<'), 'input-free label hamburger chrome is superseded by native navigation controls');
 
 $bodyStateProjection = ( new HtmlTransformer() )->transform(


### PR DESCRIPTION
## Summary

- preserve stylesheet-referenced body state on converted root blocks and retarget explicit `body.<state>` selectors to those projected classes
- prefer visible desktop navigation over hidden or collapsed siblings and suppress input-free CSS hamburger labels
- preserve selector-addressed logo styling while unwrapping presentational containers into valid RichText output
- add contract coverage for fixed-shell state, selector retargeting, responsive navigation variants, toggle suppression, and logo markers

## Verification

- `composer test`
- immutable WP Codebox replay of commit `e5461add50ddaf72da9ec6929381b981ebd7f4be` against the four-page `mrfoxtalbot.weebly.com` fixture
- all replay commands succeeded and all four imported editor surfaces reported zero invalid blocks
- Home: 8.9360% full-surface mismatch, 7.3149% overlap mismatch
- Contact: 5.1847% full-surface mismatch
- Services: 17.2866% full-surface mismatch, 14.4968% overlap mismatch
- Team: 17.2095% full-surface mismatch
- Services DOM verification confirms both source and candidate `.main-wrap` receive the expected `padding-top: 80px`

## Residual differences

The fixed-header state, logo, duplicate collapsed navigation, and invalid-block defects are repaired. Remaining visual mismatch is concentrated in existing downstream content geometry and navigation-list class projection rather than the fixed shell header behavior covered here.

## AI assistance

OpenAI `gpt-5.6-sol` through OpenCode was used to inspect the transformer, implement the changes and regression coverage, run the test suite, and execute/analyze the WP Codebox parity replay. Chris Huber reviewed and remains responsible for the submitted changes.