### PR TITLE
Emit core/cover for background-image hero containers

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -62,6 +62,7 @@
       "php tests/unit/css-value-splitter.php",
       "php tests/unit/background-image-extractor.php",
       "php tests/unit/cover-block-factory.php",
+      "php tests/unit/cover-pattern.php",
       "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",
       "php tests/unit/css-selector-matcher.php",

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -61,6 +61,7 @@
       "php tests/unit/description-list-block.php",
       "php tests/unit/css-value-splitter.php",
       "php tests/unit/background-image-extractor.php",
+      "php tests/unit/cover-block-factory.php",
       "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",
       "php tests/unit/css-selector-matcher.php",

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -61,6 +61,7 @@
       "php tests/unit/description-list-block.php",
       "php tests/unit/css-value-splitter.php",
       "php tests/unit/background-image-extractor.php",
+      "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",
       "php tests/unit/css-selector-matcher.php",
       "php tests/unit/author-selector-semantics.php",

--- a/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
+++ b/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
@@ -537,14 +537,6 @@ final class CorpusDetectors
             return array();
         }
 
-        $hasCover = false;
-        foreach ( $flat as $block ) {
-            if ( 'core/cover' === ($block['blockName'] ?? null) ) {
-                $hasCover = true;
-                break;
-            }
-        }
-
         $previous = libxml_use_internal_errors(true);
         $doc = new \DOMDocument();
         $loaded = $doc->loadHTML('<?xml encoding="utf-8"?>' . $sourceHtml);
@@ -578,9 +570,6 @@ final class CorpusDetectors
             }
 
             $gate = $coverPattern->rejectionGate($style, true);
-            if ( null === $gate && $hasCover ) {
-                continue;
-            }
             if ( null === $gate ) {
                 continue;
             }

--- a/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
+++ b/php-transformer/src/CorpusDiagnostics/CorpusDetectors.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\CorpusDiagnostics;
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverStyleResolver;
 
 /**
  * Pure, read-only detectors that turn a transformer result envelope into a flat
@@ -60,6 +62,7 @@ final class CorpusDetectors
      * — they are reported for visibility but kept out of the actionable worklist.
      */
     private const INFO_BUCKETS = array(
+        'cover_gate_rejection',
         'informational_var_density',
     );
 
@@ -101,6 +104,7 @@ final class CorpusDetectors
         $richTextRisk = self::richTextInvalidRisk($flat);
         $svgLost = self::svgContentLost($result, $flat);
         $layoutMisrecognition = self::layoutDirectionMisrecognition($sourceHtml, $columnsVerifier);
+        $coverGateRejections = self::coverGateRejections($sourceHtml, $flat);
 
         $findings = array();
         foreach ( self::transformerFindings($result) as $finding ) {
@@ -119,6 +123,9 @@ final class CorpusDetectors
             $findings[] = $finding;
         }
         foreach ( $layoutMisrecognition as $finding ) {
+            $findings[] = $finding;
+        }
+        foreach ( $coverGateRejections as $finding ) {
             $findings[] = $finding;
         }
         foreach ( self::emptyCoreHtml($flat) as $finding ) {
@@ -503,6 +510,93 @@ final class CorpusDetectors
                 'severity'      => self::SEVERITY_HIGH,
                 'pattern'       => 'columns_from_vertical_flex',
                 'count'         => 1,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Informational candidates whose inline background-image container fails a
+     * source-derivable core/cover gate.
+     *
+     * Inline-style-only under-count: this source-side scan cannot see the
+     * transformer's merged cascade, so it surfaces tuning candidates rather
+     * than exact rejection rates. It reports only the style-derivable rejection
+     * keys no_background_url|not_hero_sized|repeating_background|no_text_content|
+     * multi_layer_background. Context gates columns_layout and nav_shell are
+     * intentionally absent because they cannot be reproduced from style alone.
+     *
+     * @param string                           $sourceHtml Original source HTML for the document.
+     * @param array<int, array<string, mixed>> $flat       Flattened block list.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function coverGateRejections(string $sourceHtml, array $flat): array
+    {
+        if ( '' === trim($sourceHtml) ) {
+            return array();
+        }
+
+        $hasCover = false;
+        foreach ( $flat as $block ) {
+            if ( 'core/cover' === ($block['blockName'] ?? null) ) {
+                $hasCover = true;
+                break;
+            }
+        }
+
+        $previous = libxml_use_internal_errors(true);
+        $doc = new \DOMDocument();
+        $loaded = $doc->loadHTML('<?xml encoding="utf-8"?>' . $sourceHtml);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if ( ! $loaded ) {
+            return array();
+        }
+
+        $xpath = new \DOMXPath($doc);
+        $nodes = $xpath->query('//div[@style] | //section[@style] | //article[@style]');
+        if ( false === $nodes ) {
+            return array();
+        }
+
+        $styleResolver = new CoverStyleResolver();
+        $coverPattern = new CoverPattern();
+        $findings = array();
+
+        foreach ( $nodes as $node ) {
+            if ( ! $node instanceof \DOMElement ) {
+                continue;
+            }
+
+            $style = $node->getAttribute('style');
+            if ( '' === $styleResolver->backgroundUrlFromStyle($style) ) {
+                continue;
+            }
+            if ( '' === trim($node->textContent) ) {
+                continue;
+            }
+
+            $gate = $coverPattern->rejectionGate($style, true);
+            if ( null === $gate && $hasCover ) {
+                continue;
+            }
+            if ( null === $gate ) {
+                continue;
+            }
+
+            $findings[] = array(
+                'source'        => 'detector',
+                'detector'      => 'cover_gate_rejection',
+                'repair_bucket' => 'cover_gate_rejection',
+                'severity'      => self::SEVERITY_INFO,
+                'pattern'       => $gate,
+                'count'         => 1,
+                'detail'        => array(
+                    'gate'  => $gate,
+                    'tag'   => strtolower($node->tagName),
+                    'class' => $node->getAttribute('class'),
+                ),
             );
         }
 

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -379,17 +379,31 @@ final class BlockFactory
         }
 
         $overlayClasses = array( 'wp-block-cover__background' );
-        if ( array_key_exists('dimRatio', $attrs) ) {
-            $dimRatio = (int) $attrs['dimRatio'];
+        $dimRatio = array_key_exists('dimRatio', $attrs) ? (int) $attrs['dimRatio'] : null;
+        if ( null !== $dimRatio ) {
             if ( 50 !== $dimRatio ) {
                 $overlayClasses[] = 'has-background-dim-' . (string) (10 * round($dimRatio / 10));
             }
             $overlayClasses[] = 'has-background-dim';
         }
+        $customGradient = (string) ($attrs['customGradient'] ?? '');
+        if ( '' !== $url && '' !== $customGradient && 0 !== $dimRatio ) {
+            $overlayClasses[] = 'wp-block-cover__gradient-background';
+        }
+        if ( '' !== $customGradient ) {
+            $overlayClasses[] = 'has-background-gradient';
+        }
+        $overlayStyles = array();
+        if ( '' !== (string) ($attrs['customOverlayColor'] ?? '') ) {
+            $overlayStyles[] = 'background-color:' . (string) $attrs['customOverlayColor'];
+        }
+        if ( '' !== $customGradient ) {
+            $overlayStyles[] = 'background:' . $customGradient;
+        }
         $overlayHtml = '<span' . $this->htmlAttrs(array(
             'aria-hidden' => 'true',
             'class'       => implode(' ', $overlayClasses),
-            'style'       => '' !== (string) ($attrs['customOverlayColor'] ?? '') ? 'background-color:' . (string) $attrs['customOverlayColor'] : '',
+            'style'       => implode(';', $overlayStyles),
         )) . '></span>';
 
         return array(

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -139,6 +139,9 @@ final class BlockFactory
         if ( 'core/paragraph' === $name && preg_match('/^\s*<a\b/i', (string) ($attrs['content'] ?? '')) ) {
             unset($attrs['content']);
         }
+        if ( 'core/cover' === $name && 'px' === ($attrs['minHeightUnit'] ?? null) ) {
+            unset($attrs['minHeightUnit']);
+        }
 
         return $attrs;
     }
@@ -322,12 +325,80 @@ final class BlockFactory
             return '<div class="wp-block-shortcode">' . ($attrs['text'] ?? '') . '</div>';
         }
 
+        if ( 'core/cover' === $name ) {
+            return $this->coverHtml($attrs, $innerBlocks);
+        }
+
         if ( 'core/group' === $name ) {
             $tag = $this->groupTagName($attrs['tagName'] ?? null);
             return array( 'opening' => '<' . $tag . $this->blockSupportAttrs($attrs, 'wp-block-group') . '>', 'closing' => '</' . $tag . '>' );
         }
 
         return '';
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array{opening: string, closing: string}
+     */
+    private function coverHtml(array $attrs, array $innerBlocks): array
+    {
+        unset($innerBlocks);
+
+        $wrapperAttrs = $attrs;
+        unset($wrapperAttrs['layout']);
+        if ( ! empty($attrs['minHeight']) ) {
+            $unit = '' !== (string) ($attrs['minHeightUnit'] ?? '') ? (string) $attrs['minHeightUnit'] : 'px';
+            $wrapperAttrs['inlineGeometryStyle'] = trim(
+                (string) ($wrapperAttrs['inlineGeometryStyle'] ?? '') . ';min-height:' . (string) $attrs['minHeight'] . $unit,
+                ';'
+            );
+        }
+
+        $imageHtml = '';
+        $url = (string) ($attrs['url'] ?? '');
+        if ( '' !== $url ) {
+            $imageAttrs = array(
+                'class'                => 'wp-block-cover__image-background',
+                'alt'                  => (string) ($attrs['alt'] ?? ''),
+                'src'                  => $url,
+                'style'                => '',
+                'data-object-fit'      => 'cover',
+                'data-object-position' => '',
+            );
+            if ( is_array($attrs['focalPoint'] ?? null) ) {
+                $objectPosition = (string) (int) round((float) ($attrs['focalPoint']['x'] ?? 0.5) * 100)
+                    . '% '
+                    . (string) (int) round((float) ($attrs['focalPoint']['y'] ?? 0.5) * 100)
+                    . '%';
+                $imageAttrs['style'] = 'object-position:' . $objectPosition;
+                $imageAttrs['data-object-position'] = $objectPosition;
+            }
+            $imageHtml = '<img' . $this->htmlAttrs($imageAttrs, array( 'alt' )) . '/>';
+        }
+
+        $overlayClasses = array( 'wp-block-cover__background' );
+        if ( array_key_exists('dimRatio', $attrs) ) {
+            $dimRatio = (int) $attrs['dimRatio'];
+            if ( 50 !== $dimRatio ) {
+                $overlayClasses[] = 'has-background-dim-' . (string) (10 * round($dimRatio / 10));
+            }
+            $overlayClasses[] = 'has-background-dim';
+        }
+        $overlayHtml = '<span' . $this->htmlAttrs(array(
+            'aria-hidden' => 'true',
+            'class'       => implode(' ', $overlayClasses),
+            'style'       => '' !== (string) ($attrs['customOverlayColor'] ?? '') ? 'background-color:' . (string) $attrs['customOverlayColor'] : '',
+        )) . '></span>';
+
+        return array(
+            'opening' => '<div' . $this->blockSupportAttrs($wrapperAttrs, 'wp-block-cover') . '>'
+                . $imageHtml
+                . $overlayHtml
+                . '<div class="wp-block-cover__inner-container">',
+            'closing' => '</div></div>',
+        );
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -15,6 +15,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\AccordionPatter
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\GalleryPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
@@ -147,6 +148,8 @@ final class HtmlTransformer
     private readonly CodeWindowPattern $codeWindowPattern;
 
     private readonly ColumnsPattern $columnsPattern;
+
+    private readonly CoverPattern $coverPattern;
 
     private readonly DetailsPattern $detailsPattern;
 
@@ -420,6 +423,7 @@ final class HtmlTransformer
         $this->buttonsPattern    = new ButtonsPattern();
         $this->codeWindowPattern = new CodeWindowPattern();
         $this->columnsPattern    = new ColumnsPattern();
+        $this->coverPattern      = new CoverPattern();
         $this->detailsPattern    = new DetailsPattern();
         $this->galleryPattern    = new GalleryPattern();
         $this->logoPattern       = new LogoPattern();
@@ -2513,6 +2517,20 @@ final class HtmlTransformer
                     $this->nativeDisclosureRootIds[ $element->getNodePath() ?? '' ] = true;
 
                     return $disclosure;
+                }
+
+                $cover = $this->coverPattern->match(
+                    $element,
+                    $fallbacks,
+                    fn (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported): array => $this->convertChildren($sourceElement, $sourceFallbacks, $captureUnsupported),
+                    fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
+                    fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
+                    fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
+                    fn (string $url): string => $this->resolvedAssetImageUrl($url),
+                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
+                );
+                if ( null !== $cover ) {
+                    return $cover;
                 }
             }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -1,0 +1,238 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
+use DOMElement;
+use Throwable;
+
+/**
+ * Recognizes background-image hero containers and emits core/cover blocks.
+ *
+ * Gate decision tree:
+ *
+ * style = mergedPresentationStyle(element)
+ * |
+ * +-- background URL? -------- no --> null
+ * |
+ * +-- hero sized? ------------ no --> null
+ * |
+ * +-- repeating background? -- yes -> null
+ * |
+ * +-- convert children once
+ * |
+ * +-- text-bearing block? ---- no --> null
+ * |
+ * `-- core/cover
+ */
+final class CoverPattern
+{
+    private CoverStyleResolver $styleResolver;
+    private BackgroundImageExtractor $backgroundImageExtractor;
+
+    public function __construct()
+    {
+        $this->styleResolver = new CoverStyleResolver();
+        $this->backgroundImageExtractor = new BackgroundImageExtractor();
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @param callable(DOMElement, array<int, array<string, mixed>>&, bool): array<int, array<string, mixed>> $convertChildren
+     * @param callable(DOMElement, array<int, string>): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $mergedPresentationStyle
+     * @param callable(DOMElement): array<string, string> $htmlAttributes
+     * @param callable(string): string $resolveAssetUrl
+     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
+     * @return array<string, mixed>|null
+     */
+    public function match(
+        DOMElement $element,
+        array &$fallbacks,
+        callable $convertChildren,
+        callable $presentationAttributes,
+        callable $mergedPresentationStyle,
+        callable $htmlAttributes,
+        callable $resolveAssetUrl,
+        callable $createBlock
+    ): ?array {
+        try {
+            $style = $mergedPresentationStyle($element);
+        } catch ( Throwable ) {
+            return null;
+        }
+
+        $backgroundUrl = '';
+        try {
+            if ( null !== $this->styleRejectionGate($style, $backgroundUrl) ) {
+                return null;
+            }
+        } catch ( Throwable ) {
+            return null;
+        }
+
+        $localFallbacks = array();
+        try {
+            $children = $convertChildren($element, $localFallbacks, true);
+        } catch ( Throwable ) {
+            return null;
+        }
+
+        if ( null !== $this->textRejectionGate(array() !== $children && $this->containsTextBearingBlock($children)) ) {
+            return null;
+        }
+
+        $excludedProperties = array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat' );
+        try {
+            $attrs = $presentationAttributes($element, $excludedProperties);
+        } catch ( Throwable ) {
+            $attrs = array();
+        }
+        unset($attrs['layout']);
+
+        try {
+            $resolvedUrl = $resolveAssetUrl($backgroundUrl);
+            if ( '' !== $resolvedUrl ) {
+                $attrs['url'] = $resolvedUrl;
+            }
+        } catch ( Throwable ) {
+            // Keep independently derivable attributes.
+        }
+
+        $attrs['alt'] = '';
+        try {
+            $attrs['alt'] = $this->backgroundImageExtractor->altFromAttributes($htmlAttributes($element));
+        } catch ( Throwable ) {
+            // Empty alt is safe default.
+        }
+
+        $dim = array(
+            'dimRatio'           => 0,
+            'customOverlayColor' => '',
+        );
+        try {
+            $dim = $this->styleResolver->dimFromStyle($style);
+        } catch ( Throwable ) {
+            // Keep no-overlay defaults.
+        }
+        $attrs['dimRatio'] = (int) ($dim['dimRatio'] ?? 0);
+
+        $overlayColor = (string) ($dim['customOverlayColor'] ?? '');
+        if ( preg_match('/^#[0-9a-f]{6}$/', $overlayColor) ) {
+            $attrs['customOverlayColor'] = $overlayColor;
+            $this->removeConsumedGradient($attrs);
+        }
+
+        try {
+            $minHeight = $this->styleResolver->minHeightFromStyle($style);
+            if ( null !== $minHeight ) {
+                $attrs['minHeight'] = $minHeight['minHeight'];
+                $attrs['minHeightUnit'] = $minHeight['minHeightUnit'];
+            }
+        } catch ( Throwable ) {
+            // Omit underivable height attributes.
+        }
+
+        try {
+            $focalPoint = $this->styleResolver->focalPointFromStyle($style);
+            if ( null !== $focalPoint ) {
+                $attrs['focalPoint'] = $focalPoint;
+            }
+        } catch ( Throwable ) {
+            // Omit underivable focal-point attributes.
+        }
+
+        try {
+            $block = $createBlock('core/cover', $attrs, $children, $element);
+        } catch ( Throwable ) {
+            return null;
+        }
+
+        array_push($fallbacks, ...$localFallbacks);
+
+        return $block;
+    }
+
+    public function rejectionGate(string $style, bool $hasTextBearingChildren): ?string
+    {
+        $backgroundUrl = '';
+        try {
+            $styleGate = $this->styleRejectionGate($style, $backgroundUrl);
+            if ( null !== $styleGate ) {
+                return $styleGate;
+            }
+
+            return $this->textRejectionGate($hasTextBearingChildren);
+        } catch ( Throwable ) {
+            return 'no_background_url';
+        }
+    }
+
+    private function styleRejectionGate(string $style, string &$backgroundUrl): ?string
+    {
+        $backgroundUrl = $this->backgroundImageExtractor->urlFromStyle($style);
+        if ( '' === $backgroundUrl ) {
+            return 'no_background_url';
+        }
+
+        if ( ! $this->styleResolver->meetsHeroSizeGate($style) ) {
+            return 'not_hero_sized';
+        }
+
+        if ( $this->styleResolver->hasRepeatingBackground($style) ) {
+            return 'repeating_background';
+        }
+
+        return null;
+    }
+
+    private function textRejectionGate(bool $hasTextBearingChildren): ?string
+    {
+        return $hasTextBearingChildren ? null : 'no_text_content';
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     */
+    private function containsTextBearingBlock(array $blocks): bool
+    {
+        $textBearingNames = array( 'core/heading', 'core/paragraph', 'core/list', 'core/buttons', 'core/quote' );
+
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            if ( in_array($block['blockName'] ?? null, $textBearingNames, true) ) {
+                return true;
+            }
+
+            $innerBlocks = $block['innerBlocks'] ?? array();
+            if ( is_array($innerBlocks) && $this->containsTextBearingBlock($innerBlocks) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function removeConsumedGradient(array &$attrs): void
+    {
+        if ( ! isset($attrs['style']) || ! is_array($attrs['style']) ) {
+            return;
+        }
+        if ( isset($attrs['style']['color']) && is_array($attrs['style']['color']) ) {
+            unset($attrs['style']['color']['gradient']);
+            if ( array() === $attrs['style']['color'] ) {
+                unset($attrs['style']['color']);
+            }
+        }
+        if ( array() === $attrs['style'] ) {
+            unset($attrs['style']);
+        }
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use DOMElement;
 use Throwable;
 
@@ -68,6 +69,9 @@ final class CoverPattern
             if ( null !== $this->styleRejectionGate($style, $backgroundUrl) ) {
                 return null;
             }
+            if ( null !== $this->columnsRejectionGate($element, $style) ) {
+                return null;
+            }
         } catch ( Throwable ) {
             return null;
         }
@@ -79,17 +83,22 @@ final class CoverPattern
             return null;
         }
 
+        if ( null !== $this->navigationRejectionGate($children) ) {
+            return null;
+        }
+
         if ( null !== $this->textRejectionGate(array() !== $children && $this->containsTextBearingBlock($children)) ) {
             return null;
         }
 
-        $excludedProperties = array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat' );
+        $excludedProperties = array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat', 'min-height', 'height' );
         try {
             $attrs = $presentationAttributes($element, $excludedProperties);
         } catch ( Throwable ) {
             $attrs = array();
         }
         unset($attrs['layout']);
+        $this->removeConsumedDimensions($attrs);
 
         try {
             $resolvedUrl = $resolveAssetUrl($backgroundUrl);
@@ -123,6 +132,7 @@ final class CoverPattern
             $attrs['customOverlayColor'] = $overlayColor;
             $this->removeConsumedGradient($attrs);
         }
+        $this->removeBackgroundUrlLayersFromGradient($attrs);
 
         try {
             $minHeight = $this->styleResolver->minHeightFromStyle($style);
@@ -171,9 +181,13 @@ final class CoverPattern
 
     private function styleRejectionGate(string $style, string &$backgroundUrl): ?string
     {
-        $backgroundUrl = $this->backgroundImageExtractor->urlFromStyle($style);
+        $backgroundUrl = $this->styleResolver->backgroundUrlFromStyle($style);
         if ( '' === $backgroundUrl ) {
             return 'no_background_url';
+        }
+
+        if ( $this->hasMultipleBackgroundUrlLayers($style) ) {
+            return 'multi_layer_background';
         }
 
         if ( ! $this->styleResolver->meetsHeroSizeGate($style) ) {
@@ -187,9 +201,48 @@ final class CoverPattern
         return null;
     }
 
+    private function columnsRejectionGate(DOMElement $element, string $style): ?string
+    {
+        if ( $this->directElementChildCount($element) < 2 ) {
+            return null;
+        }
+
+        $declarations = $this->styleResolver->declarations($style);
+        $display      = strtolower(trim((string) ($declarations['display'] ?? '')));
+        if ( 'grid' === $display ) {
+            return 'columns_layout';
+        }
+        if ( 'flex' !== $display ) {
+            return null;
+        }
+
+        $direction = strtolower(trim((string) ($declarations['flex-direction'] ?? 'row')));
+        return in_array($direction, array( 'column', 'column-reverse' ), true) ? null : 'columns_layout';
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     */
+    private function navigationRejectionGate(array $blocks): ?string
+    {
+        return $this->containsBlockNamed($blocks, 'core/navigation') ? 'nav_shell' : null;
+    }
+
     private function textRejectionGate(bool $hasTextBearingChildren): ?string
     {
         return $hasTextBearingChildren ? null : 'no_text_content';
+    }
+
+    private function directElementChildCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+
+        return $count;
     }
 
     /**
@@ -218,6 +271,72 @@ final class CoverPattern
     }
 
     /**
+     * @param array<int, array<string, mixed>> $blocks
+     */
+    private function containsBlockNamed(array $blocks, string $blockName): bool
+    {
+        foreach ( $blocks as $block ) {
+            if ( ! is_array($block) ) {
+                continue;
+            }
+
+            if ( $blockName === ($block['blockName'] ?? null) ) {
+                return true;
+            }
+
+            $innerBlocks = $block['innerBlocks'] ?? array();
+            if ( is_array($innerBlocks) && $this->containsBlockNamed($innerBlocks, $blockName) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasMultipleBackgroundUrlLayers(string $style): bool
+    {
+        $value = $this->winningBackgroundValue($style);
+        if ( '' === $value ) {
+            return false;
+        }
+
+        $urlLayers = 0;
+        foreach ( $this->splitTopLevel($value, array( ',' )) as $layer ) {
+            if ( preg_match('/\burl\s*\(/i', $layer) && 2 <= ++$urlLayers ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function winningBackgroundValue(string $style): string
+    {
+        $declarations = $this->styleResolver->declarations($style);
+        foreach ( array_reverse(array_keys($declarations)) as $name ) {
+            if ( in_array($name, array( 'background', 'background-image' ), true) ) {
+                return (string) $declarations[ $name ];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function removeConsumedDimensions(array &$attrs): void
+    {
+        if ( ! isset($attrs['style']) || ! is_array($attrs['style']) ) {
+            return;
+        }
+        if ( isset($attrs['style']['dimensions']) && is_array($attrs['style']['dimensions']) ) {
+            unset($attrs['style']['dimensions']['minHeight']);
+        }
+        $this->pruneEmptySupportStyle($attrs);
+    }
+
+    /**
      * @param array<string, mixed> $attrs
      */
     private function removeConsumedGradient(array &$attrs): void
@@ -227,12 +346,123 @@ final class CoverPattern
         }
         if ( isset($attrs['style']['color']) && is_array($attrs['style']['color']) ) {
             unset($attrs['style']['color']['gradient']);
-            if ( array() === $attrs['style']['color'] ) {
-                unset($attrs['style']['color']);
-            }
         }
-        if ( array() === $attrs['style'] ) {
+        $this->pruneEmptySupportStyle($attrs);
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function removeBackgroundUrlLayersFromGradient(array &$attrs): void
+    {
+        $gradient = $attrs['style']['color']['gradient'] ?? null;
+        if ( ! is_string($gradient) ) {
+            return;
+        }
+
+        $layers = $this->splitTopLevel($gradient, array( ',' ));
+        $kept   = array_values(array_filter(
+            $layers,
+            static fn (string $layer): bool => ! preg_match('/\burl\s*\(/i', $layer)
+        ));
+        if ( count($kept) === count($layers) ) {
+            return;
+        }
+
+        if ( array() === $kept ) {
+            unset($attrs['style']['color']['gradient']);
+        } else {
+            $attrs['style']['color']['gradient'] = implode(',', $kept);
+        }
+        $this->pruneEmptySupportStyle($attrs);
+    }
+
+    /**
+     * @param array<string, mixed> $attrs
+     */
+    private function pruneEmptySupportStyle(array &$attrs): void
+    {
+        if ( isset($attrs['style']['dimensions']) && array() === $attrs['style']['dimensions'] ) {
+            unset($attrs['style']['dimensions']);
+        }
+        if ( isset($attrs['style']['color']) && array() === $attrs['style']['color'] ) {
+            unset($attrs['style']['color']);
+        }
+        if ( isset($attrs['style']) && array() === $attrs['style'] ) {
             unset($attrs['style']);
         }
+    }
+
+    /**
+     * @param array<int, string> $delimiters
+     * @return array<int, string>
+     */
+    private function splitTopLevel(string $input, array $delimiters): array
+    {
+        $masked = $this->maskQuotedAndEscapedCharacters($input);
+        $parts  = CssValueSplitter::splitTopLevel($masked, $delimiters);
+
+        return $this->restoreSplitParts($input, $masked, $parts);
+    }
+
+    private function maskQuotedAndEscapedCharacters(string $input): string
+    {
+        $masked = '';
+        $quote  = null;
+        $length = strlen($input);
+
+        for ( $index = 0; $index < $length; ++$index ) {
+            $character = $input[ $index ];
+            if ( '\\' === $character ) {
+                $masked .= 'x';
+                if ( $index + 1 < $length ) {
+                    $masked .= 'x';
+                    ++$index;
+                }
+                continue;
+            }
+
+            if ( null !== $quote ) {
+                if ( $quote === $character ) {
+                    $masked .= $character;
+                    $quote   = null;
+                } else {
+                    $masked .= 'x';
+                }
+                continue;
+            }
+
+            if ( '"' === $character || "'" === $character ) {
+                $quote  = $character;
+                $masked .= $character;
+                continue;
+            }
+
+            $masked .= $character;
+        }
+
+        return $masked;
+    }
+
+    /**
+     * @param array<int, string> $maskedParts
+     * @return array<int, string>
+     */
+    private function restoreSplitParts(string $input, string $masked, array $maskedParts): array
+    {
+        $parts  = array();
+        $offset = 0;
+
+        foreach ( $maskedParts as $maskedPart ) {
+            $start = strpos($masked, $maskedPart, $offset);
+            if ( false === $start ) {
+                return array();
+            }
+
+            $parts[] = substr($input, $start, strlen($maskedPart));
+            $offset  = $start + strlen($maskedPart);
+        }
+
+        return $parts;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -130,9 +130,9 @@ final class CoverPattern
         $overlayColor = (string) ($dim['customOverlayColor'] ?? '');
         if ( preg_match('/^#[0-9a-f]{6}$/', $overlayColor) ) {
             $attrs['customOverlayColor'] = $overlayColor;
-            $this->removeConsumedGradient($attrs);
         }
-        $this->removeBackgroundUrlLayersFromGradient($attrs);
+        $this->promoteDesignGradient($attrs, $dim);
+        $this->removeConsumedGradient($attrs);
 
         try {
             $minHeight = $this->styleResolver->minHeightFromStyle($style);
@@ -351,9 +351,10 @@ final class CoverPattern
     }
 
     /**
-     * @param array<string, mixed> $attrs
+     * @param array<string, mixed>                           $attrs
+     * @param array{dimRatio:int, customOverlayColor:string} $dim
      */
-    private function removeBackgroundUrlLayersFromGradient(array &$attrs): void
+    private function promoteDesignGradient(array &$attrs, array $dim): void
     {
         $gradient = $attrs['style']['color']['gradient'] ?? null;
         if ( ! is_string($gradient) ) {
@@ -361,20 +362,42 @@ final class CoverPattern
         }
 
         $layers = $this->splitTopLevel($gradient, array( ',' ));
-        $kept   = array_values(array_filter(
-            $layers,
-            static fn (string $layer): bool => ! preg_match('/\burl\s*\(/i', $layer)
-        ));
-        if ( count($kept) === count($layers) ) {
-            return;
+        $kept   = array();
+        $consumedOverlay = false;
+        foreach ( $layers as $layer ) {
+            if ( preg_match('/\burl\s*\(/i', $layer) ) {
+                continue;
+            }
+            if ( ! $consumedOverlay && $this->isConsumedOverlayGradient($layer, $dim) ) {
+                $consumedOverlay = true;
+                continue;
+            }
+            $kept[] = $layer;
+        }
+        if ( array() !== $kept ) {
+            $attrs['customGradient'] = implode(',', $kept);
+        }
+    }
+
+    /**
+     * @param array{dimRatio:int, customOverlayColor:string} $dim
+     */
+    private function isConsumedOverlayGradient(string $layer, array $dim): bool
+    {
+        $overlayColor = (string) ($dim['customOverlayColor'] ?? '');
+        $dimRatio     = (int) ($dim['dimRatio'] ?? 0);
+        if ( 0 === $dimRatio || ! preg_match('/^#[0-9a-f]{6}$/', $overlayColor) ) {
+            return false;
         }
 
-        if ( array() === $kept ) {
-            unset($attrs['style']['color']['gradient']);
-        } else {
-            $attrs['style']['color']['gradient'] = implode(',', $kept);
+        try {
+            $candidate = $this->styleResolver->dimFromStyle('background:' . $layer . ',url(cover-gradient-probe)');
+        } catch ( Throwable ) {
+            return false;
         }
-        $this->pruneEmptySupportStyle($attrs);
+
+        return $dimRatio === ($candidate['dimRatio'] ?? 0)
+            && $overlayColor === ($candidate['customOverlayColor'] ?? '');
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -361,13 +361,29 @@ final class CoverPattern
             return;
         }
 
-        $layers = $this->splitTopLevel($gradient, array( ',' ));
-        $kept   = array();
-        $consumedOverlay = false;
+        $layers         = $this->splitTopLevel($gradient, array( ',' ));
+        $gradientLayers = array();
+        $hasDesignLayer = false;
         foreach ( $layers as $layer ) {
             if ( preg_match('/\burl\s*\(/i', $layer) ) {
                 continue;
             }
+            $gradientLayers[] = $layer;
+            if ( ! $this->isUniformOverlayGradient($layer) ) {
+                $hasDesignLayer = true;
+            }
+        }
+
+        if ( $hasDesignLayer ) {
+            $attrs['dimRatio'] = 100;
+            $attrs['customGradient'] = implode(',', $gradientLayers);
+            unset($attrs['customOverlayColor']);
+            return;
+        }
+
+        $kept           = array();
+        $consumedOverlay = false;
+        foreach ( $gradientLayers as $layer ) {
             if ( ! $consumedOverlay && $this->isConsumedOverlayGradient($layer, $dim) ) {
                 $consumedOverlay = true;
                 continue;
@@ -377,6 +393,124 @@ final class CoverPattern
         if ( array() !== $kept ) {
             $attrs['customGradient'] = implode(',', $kept);
         }
+    }
+
+    private function isUniformOverlayGradient(string $layer): bool
+    {
+        try {
+            $candidate = $this->styleResolver->dimFromStyle('background:' . $layer . ',url(cover-gradient-probe)');
+        } catch ( Throwable ) {
+            return false;
+        }
+
+        if (
+            0 !== (int) ($candidate['dimRatio'] ?? 0)
+            && preg_match('/^#[0-9a-f]{6}$/', (string) ($candidate['customOverlayColor'] ?? ''))
+        ) {
+            return true;
+        }
+
+        if ( ! preg_match('/^((?:repeating-)?(linear|radial|conic))-gradient\s*\((.*)\)$/is', trim($layer), $matches) ) {
+            return false;
+        }
+
+        $type  = strtolower($matches[2]);
+        $stops = $this->splitTopLevel($matches[3], array( ',' ));
+        if ( count($stops) >= 3 && $this->isGradientPrelude($type, $stops[0]) ) {
+            array_shift($stops);
+        }
+        if ( count($stops) < 2 ) {
+            return false;
+        }
+
+        $first = $this->normalizedGradientStopColor((string) array_shift($stops));
+        if ( null === $first ) {
+            return false;
+        }
+        foreach ( $stops as $stop ) {
+            if ( $first !== $this->normalizedGradientStopColor($stop) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isGradientPrelude(string $type, string $value): bool
+    {
+        $value = trim($value);
+        if ( 'linear' === $type ) {
+            return $this->isGradientDirection($value);
+        }
+        if ( 'conic' === $type ) {
+            return (bool) preg_match('/^(?:from|at)\b/i', $value);
+        }
+
+        return (bool) preg_match(
+            '/^(?:circle|ellipse|closest-side|closest-corner|farthest-side|farthest-corner)(?:\s|$)|\bat\b|^(?:calc|min|max|clamp)\(|^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:%|[a-z]+)/i',
+            $value
+        );
+    }
+
+    private function isGradientDirection(string $value): bool
+    {
+        return (bool) preg_match(
+            '/^(?:[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:deg|grad|rad|turn)|to\s+[a-z]+(?:\s+[a-z]+)?)$/i',
+            trim($value)
+        );
+    }
+
+    private function normalizedGradientStopColor(string $stop): ?string
+    {
+        $stop = strtolower(trim($stop));
+        if ( preg_match('/^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})(?:\s|$)/', $stop, $matches) ) {
+            $hex = $matches[1];
+            if ( strlen($hex) <= 4 ) {
+                $hex = implode('', array_map(static fn (string $digit): string => $digit . $digit, str_split($hex)));
+            }
+            if ( 6 === strlen($hex) ) {
+                $hex .= 'ff';
+            }
+
+            return sprintf(
+                '%d,%d,%d,%.6F',
+                hexdec(substr($hex, 0, 2)),
+                hexdec(substr($hex, 2, 2)),
+                hexdec(substr($hex, 4, 2)),
+                hexdec(substr($hex, 6, 2)) / 255
+            );
+        }
+
+        $alpha = '(0(?:\.\d+)?|1(?:\.0+)?|\.\d+)';
+        if ( preg_match('/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*' . $alpha . ')?\s*\)/', $stop, $matches) ) {
+            $red       = (int) $matches[1];
+            $green     = (int) $matches[2];
+            $blue      = (int) $matches[3];
+            $alphaValue = isset($matches[4]) && '' !== $matches[4] ? (float) $matches[4] : 1.0;
+            if ( $red > 255 || $green > 255 || $blue > 255 ) {
+                return null;
+            }
+
+            return sprintf('%d,%d,%d,%.6F', $red, $green, $blue, $alphaValue);
+        }
+
+        if ( preg_match('/^rgba?\(\s*(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})(?:\s*\/\s*' . $alpha . ')?\s*\)/', $stop, $matches) ) {
+            $red       = (int) $matches[1];
+            $green     = (int) $matches[2];
+            $blue      = (int) $matches[3];
+            $alphaValue = isset($matches[4]) && '' !== $matches[4] ? (float) $matches[4] : 1.0;
+            if ( $red > 255 || $green > 255 || $blue > 255 ) {
+                return null;
+            }
+
+            return sprintf('%d,%d,%d,%.6F', $red, $green, $blue, $alphaValue);
+        }
+
+        if ( ! preg_match('/^([a-z][a-z0-9-]*(?:\([^)]*\))?)(?:\s|$)/', $stop, $matches) ) {
+            return null;
+        }
+
+        return 'literal:' . (string) preg_replace('/\s+/', '', $matches[1]);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 
 /**
@@ -58,6 +59,18 @@ final class CoverStyleResolver
         $this->declarationCache[ $style ] = $declarations;
 
         return $declarations;
+    }
+
+    public function backgroundUrlFromStyle(string $style): string
+    {
+        $declaration = $this->winningBackgroundDeclaration($style);
+        if ( null === $declaration || ! preg_match('/\burl\s*\(/i', $declaration['value']) ) {
+            return '';
+        }
+
+        return (new BackgroundImageExtractor())->urlFromStyle(
+            $declaration['name'] . ':' . $declaration['value']
+        );
     }
 
     /**
@@ -206,21 +219,29 @@ final class CoverStyleResolver
     public function meetsHeroSizeGate(string $style): bool
     {
         $declarations = $this->declarations($style);
-        $size         = strtolower(trim((string) ($declarations['background-size'] ?? '')));
-        foreach ( $this->splitTopLevel($size, array( ',' )) as $layerSize ) {
-            if ( array( 'cover' ) === $this->splitTopLevelWhitespace($layerSize) ) {
-                return true;
-            }
-        }
-
-        $background = (string) ($declarations['background'] ?? '');
-        foreach ( $this->splitTopLevel($background, array( ',' )) as $layer ) {
-            $slashParts = $this->splitTopLevel($layer, array( '/' ));
-            foreach ( array_slice($slashParts, 1) as $sizeAndRepeat ) {
-                $tokens = $this->splitTopLevelWhitespace(strtolower($sizeAndRepeat));
-                if ( 'cover' === ($tokens[0] ?? '') ) {
-                    return true;
+        foreach ( array_reverse(array_keys($declarations)) as $name ) {
+            if ( 'background-size' === $name ) {
+                $size = strtolower(trim((string) $declarations[ $name ]));
+                foreach ( $this->splitTopLevel($size, array( ',' )) as $layerSize ) {
+                    if ( array( 'cover' ) === $this->splitTopLevelWhitespace($layerSize) ) {
+                        return true;
+                    }
                 }
+                break;
+            }
+
+            if ( 'background' === $name ) {
+                $background = (string) $declarations[ $name ];
+                foreach ( $this->splitTopLevel($background, array( ',' )) as $layer ) {
+                    $slashParts = $this->splitTopLevel($layer, array( '/' ));
+                    foreach ( array_slice($slashParts, 1) as $sizeAndRepeat ) {
+                        $tokens = $this->splitTopLevelWhitespace(strtolower($sizeAndRepeat));
+                        if ( 'cover' === ($tokens[0] ?? '') ) {
+                            return true;
+                        }
+                    }
+                }
+                break;
             }
         }
 
@@ -262,6 +283,24 @@ final class CoverStyleResolver
         }
 
         return false;
+    }
+
+    /**
+     * @return array{name:string, value:string}|null
+     */
+    private function winningBackgroundDeclaration(string $style): ?array
+    {
+        $declarations = $this->declarations($style);
+        foreach ( array_reverse(array_keys($declarations)) as $name ) {
+            if ( in_array($name, array( 'background', 'background-image' ), true) ) {
+                return array(
+                    'name'  => $name,
+                    'value' => (string) $declarations[ $name ],
+                );
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
@@ -1,0 +1,269 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
+
+/**
+ * Derives core/cover attributes and recognition gates from resolved CSS.
+ */
+final class CoverStyleResolver
+{
+    /**
+     * @return array<string, string>
+     */
+    public function declarations(string $style): array
+    {
+        $declarations = array();
+        foreach ( CssValueSplitter::splitTopLevel($style, array( ';' )) as $declaration ) {
+            $parts = CssValueSplitter::splitTopLevel($declaration, array( ':' ));
+            if ( count($parts) < 2 ) {
+                continue;
+            }
+
+            $name  = strtolower(trim((string) array_shift($parts)));
+            $value = trim(implode(':', $parts));
+            if ( '' !== $name && '' !== $value ) {
+                $declarations[ $name ] = $value;
+            }
+        }
+
+        return $declarations;
+    }
+
+    /**
+     * @return array{dimRatio:int, customOverlayColor:string}
+     */
+    public function dimFromStyle(string $style): array
+    {
+        $default = array(
+            'dimRatio'           => 0,
+            'customOverlayColor' => '',
+        );
+
+        $declarations = $this->declarations($style);
+        foreach ( array( 'background', 'background-image' ) as $property ) {
+            $value = (string) ($declarations[ $property ] ?? '');
+            if ( '' === $value ) {
+                continue;
+            }
+
+            $layers   = CssValueSplitter::splitTopLevel($value, array( ',' ));
+            $urlIndex = null;
+            foreach ( $layers as $index => $layer ) {
+                if ( preg_match('/\burl\s*\(/i', $layer) ) {
+                    $urlIndex = $index;
+                    break;
+                }
+            }
+
+            if ( null === $urlIndex ) {
+                continue;
+            }
+
+            for ( $index = 0; $index < $urlIndex; ++$index ) {
+                if ( ! preg_match('/^linear-gradient\s*\((.*)\)$/is', trim($layers[ $index ]), $matches) ) {
+                    continue;
+                }
+
+                $stops = CssValueSplitter::splitTopLevel($matches[1], array( ',' ));
+                if ( 2 !== count($stops) ) {
+                    return $default;
+                }
+
+                $first  = $this->overlayColor($stops[0]);
+                $second = $this->overlayColor($stops[1]);
+                if ( null === $first || $first !== $second ) {
+                    return $default;
+                }
+
+                return array(
+                    'dimRatio'           => ( (int) round($first['alpha'] * 10) ) * 10,
+                    'customOverlayColor' => sprintf('#%02x%02x%02x', $first['red'], $first['green'], $first['blue']),
+                );
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * @return array{minHeight:float|int, minHeightUnit:string}|null
+     */
+    public function minHeightFromStyle(string $style): ?array
+    {
+        $declarations = $this->declarations($style);
+        $value        = array_key_exists('min-height', $declarations)
+            ? $declarations['min-height']
+            : (string) ($declarations['height'] ?? '');
+        $value        = strtolower(trim($value));
+        if ( ! preg_match('/^(\d+(?:\.\d+)?)(px|vh|rem)$/', $value, $matches) ) {
+            return null;
+        }
+
+        $number = str_contains($matches[1], '.') ? (float) $matches[1] : (int) $matches[1];
+
+        return array(
+            'minHeight'     => $number,
+            'minHeightUnit' => $matches[2],
+        );
+    }
+
+    /**
+     * @return array{x:float, y:float}|null
+     */
+    public function focalPointFromStyle(string $style): ?array
+    {
+        $declarations = $this->declarations($style);
+        $value        = strtolower(trim((string) ($declarations['background-position'] ?? '')));
+        if ( '' === $value ) {
+            return null;
+        }
+
+        $parts = CssValueSplitter::splitTopLevelWhitespace($value);
+        if ( count($parts) < 1 || count($parts) > 2 ) {
+            return null;
+        }
+
+        $x = $this->positionValue($parts[0], array(
+            'left'   => 0.0,
+            'center' => 0.5,
+            'right'  => 1.0,
+        ));
+        $y = 1 === count($parts)
+            ? 0.5
+            : $this->positionValue($parts[1], array(
+                'top'    => 0.0,
+                'center' => 0.5,
+                'bottom' => 1.0,
+            ));
+        if ( null === $x || null === $y || ( 0.5 === $x && 0.5 === $y ) ) {
+            return null;
+        }
+
+        return array(
+            'x' => $x,
+            'y' => $y,
+        );
+    }
+
+    public function meetsHeroSizeGate(string $style): bool
+    {
+        $declarations = $this->declarations($style);
+        $size         = strtolower(trim((string) ($declarations['background-size'] ?? '')));
+        foreach ( CssValueSplitter::splitTopLevel($size, array( ',' )) as $layerSize ) {
+            if ( array( 'cover' ) === CssValueSplitter::splitTopLevelWhitespace($layerSize) ) {
+                return true;
+            }
+        }
+
+        $background = (string) ($declarations['background'] ?? '');
+        foreach ( CssValueSplitter::splitTopLevel($background, array( ',' )) as $layer ) {
+            $slashParts = CssValueSplitter::splitTopLevel($layer, array( '/' ));
+            foreach ( array_slice($slashParts, 1) as $sizeAndRepeat ) {
+                $tokens = CssValueSplitter::splitTopLevelWhitespace(strtolower($sizeAndRepeat));
+                if ( 'cover' === ($tokens[0] ?? '') ) {
+                    return true;
+                }
+            }
+        }
+
+        $minHeight = $this->minHeightFromStyle($style);
+        if ( null === $minHeight ) {
+            return false;
+        }
+
+        $thresholds = array(
+            'px'  => 200,
+            'vh'  => 30,
+            'rem' => 12.5,
+        );
+
+        return $minHeight['minHeight'] >= $thresholds[ $minHeight['minHeightUnit'] ];
+    }
+
+    public function hasRepeatingBackground(string $style): bool
+    {
+        $declarations = $this->declarations($style);
+        $repeat       = strtolower(trim((string) ($declarations['background-repeat'] ?? '')));
+        foreach ( CssValueSplitter::splitTopLevel($repeat, array( ',' )) as $layerRepeat ) {
+            $tokens = CssValueSplitter::splitTopLevelWhitespace($layerRepeat);
+            foreach ( $tokens as $token ) {
+                if ( in_array($token, array( 'repeat', 'repeat-x', 'repeat-y' ), true) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{red:int, green:int, blue:int, alpha:float}|null
+     */
+    private function overlayColor(string $literal): ?array
+    {
+        $literal = strtolower(trim($literal));
+        if ( preg_match('/^#([0-9a-f]{4}|[0-9a-f]{8})$/', $literal, $matches) ) {
+            $hex = $matches[1];
+            if ( 4 === strlen($hex) ) {
+                $red   = hexdec(str_repeat($hex[0], 2));
+                $green = hexdec(str_repeat($hex[1], 2));
+                $blue  = hexdec(str_repeat($hex[2], 2));
+                $alpha = hexdec(str_repeat($hex[3], 2)) / 255;
+            } else {
+                $red   = hexdec(substr($hex, 0, 2));
+                $green = hexdec(substr($hex, 2, 2));
+                $blue  = hexdec(substr($hex, 4, 2));
+                $alpha = hexdec(substr($hex, 6, 2)) / 255;
+            }
+
+            if ( $alpha >= 1 ) {
+                return null;
+            }
+
+            return array(
+                'red'   => $red,
+                'green' => $green,
+                'blue'  => $blue,
+                'alpha' => $alpha,
+            );
+        }
+
+        if ( ! preg_match('/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*((?:0(?:\.\d+)?|1(?:\.0+)?|\.\d+))\s*\)$/', $literal, $matches) ) {
+            return null;
+        }
+
+        $red   = (int) $matches[1];
+        $green = (int) $matches[2];
+        $blue  = (int) $matches[3];
+        $alpha = (float) $matches[4];
+        if ( $red > 255 || $green > 255 || $blue > 255 || $alpha >= 1 ) {
+            return null;
+        }
+
+        return array(
+            'red'   => $red,
+            'green' => $green,
+            'blue'  => $blue,
+            'alpha' => $alpha,
+        );
+    }
+
+    /**
+     * @param array<string, float> $keywords
+     */
+    private function positionValue(string $value, array $keywords): ?float
+    {
+        if ( array_key_exists($value, $keywords) ) {
+            return $keywords[ $value ];
+        }
+
+        if ( ! preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+))%$/', $value, $matches) ) {
+            return null;
+        }
+
+        return max(0.0, min(1.0, (float) $matches[1] / 100));
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
@@ -40,8 +40,11 @@ final class CoverStyleResolver
 
             $name  = strtolower(trim((string) array_shift($parts)));
             $value = trim(implode(':', $parts));
-            $value = trim((string) preg_replace('/\s*!important\s*$/i', '', $value, 1));
+            $value = trim((string) preg_replace('/\s*!\s*important\s*$/i', '', $value, 1));
             if ( '' !== $name && '' !== $value ) {
+                if ( array_key_exists($name, $declarations) ) {
+                    unset($declarations[ $name ]);
+                }
                 $declarations[ $name ] = $value;
             }
         }
@@ -68,54 +71,59 @@ final class CoverStyleResolver
         );
 
         $declarations = $this->declarations($style);
-        foreach ( array( 'background-image', 'background' ) as $property ) {
-            $value = (string) ($declarations[ $property ] ?? '');
-            if ( '' === $value ) {
+        $property     = null;
+        foreach ( array_reverse(array_keys($declarations)) as $name ) {
+            if ( in_array($name, array( 'background', 'background-image' ), true) ) {
+                $property = $name;
+                break;
+            }
+        }
+        if ( null === $property ) {
+            return $default;
+        }
+
+        $value    = (string) $declarations[ $property ];
+        $layers   = $this->splitTopLevel($value, array( ',' ));
+        $urlIndex = null;
+        foreach ( $layers as $index => $layer ) {
+            if ( preg_match('/\burl\s*\(/i', $layer) ) {
+                $urlIndex = $index;
+                break;
+            }
+        }
+
+        if ( null === $urlIndex ) {
+            return $default;
+        }
+
+        for ( $index = 0; $index < $urlIndex; ++$index ) {
+            if ( ! preg_match('/^linear-gradient\s*\((.*)\)$/is', trim($layers[ $index ]), $matches) ) {
                 continue;
             }
 
-            $layers   = $this->splitTopLevel($value, array( ',' ));
-            $urlIndex = null;
-            foreach ( $layers as $index => $layer ) {
-                if ( preg_match('/\burl\s*\(/i', $layer) ) {
-                    $urlIndex = $index;
-                    break;
-                }
+            $stops = $this->splitTopLevel($matches[1], array( ',' ));
+            if ( 3 === count($stops) && $this->isVerticalGradientDirection($stops[0]) ) {
+                array_shift($stops);
             }
-
-            if ( null === $urlIndex ) {
+            if ( 2 !== count($stops) ) {
                 continue;
             }
 
-            for ( $index = 0; $index < $urlIndex; ++$index ) {
-                if ( ! preg_match('/^linear-gradient\s*\((.*)\)$/is', trim($layers[ $index ]), $matches) ) {
-                    continue;
-                }
-
-                $stops = $this->splitTopLevel($matches[1], array( ',' ));
-                if ( 3 === count($stops) && $this->isVerticalGradientDirection($stops[0]) ) {
-                    array_shift($stops);
-                }
-                if ( 2 !== count($stops) ) {
-                    continue;
-                }
-
-                $first  = $this->overlayColor($stops[0]);
-                $second = $this->overlayColor($stops[1]);
-                if ( null === $first || $first !== $second ) {
-                    continue;
-                }
-
-                $dimRatio = ( (int) round($first['alpha'] * 10) ) * 10;
-                if ( 0 === $dimRatio || 100 === $dimRatio ) {
-                    return $default;
-                }
-
-                return array(
-                    'dimRatio'           => $dimRatio,
-                    'customOverlayColor' => sprintf('#%02x%02x%02x', $first['red'], $first['green'], $first['blue']),
-                );
+            $first  = $this->overlayColor($stops[0]);
+            $second = $this->overlayColor($stops[1]);
+            if ( null === $first || $first !== $second ) {
+                continue;
             }
+
+            $dimRatio = ( (int) round($first['alpha'] * 10) ) * 10;
+            if ( 0 === $dimRatio || 100 === $dimRatio ) {
+                return $default;
+            }
+
+            return array(
+                'dimRatio'           => $dimRatio,
+                'customOverlayColor' => sprintf('#%02x%02x%02x', $first['red'], $first['green'], $first['blue']),
+            );
         }
 
         return $default;
@@ -237,11 +245,16 @@ final class CoverStyleResolver
     {
         $declarations = $this->declarations($style);
         foreach ( array( 'background-repeat', 'background' ) as $property ) {
-            $value = strtolower(trim((string) ($declarations[ $property ] ?? '')));
+            $value           = strtolower(trim((string) ($declarations[ $property ] ?? '')));
+            $repeatingTokens = array( 'repeat', 'repeat-x', 'repeat-y' );
+            if ( 'background' === $property ) {
+                $repeatingTokens[] = 'round';
+                $repeatingTokens[] = 'space';
+            }
             foreach ( $this->splitTopLevel($value, array( ',' )) as $layer ) {
                 $tokens = $this->splitTopLevelWhitespace($layer);
                 foreach ( $tokens as $token ) {
-                    if ( in_array($token, array( 'repeat', 'repeat-x', 'repeat-y' ), true) ) {
+                    if ( in_array($token, $repeatingTokens, true) ) {
                         return true;
                     }
                 }
@@ -297,7 +310,7 @@ final class CoverStyleResolver
 
         if (
             ! preg_match('/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*((?:0(?:\.\d+)?|1(?:\.0+)?|\.\d+))\s*\)$/', $color, $matches)
-            && ! preg_match('/^rgb\(\s*(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s*\/\s*((?:0(?:\.\d+)?|1(?:\.0+)?|\.\d+))\s*\)$/', $color, $matches)
+            && ! preg_match('/^rgba?\(\s*(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s*\/\s*((?:0(?:\.\d+)?|1(?:\.0+)?|\.\d+))\s*\)$/', $color, $matches)
         ) {
             return null;
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
@@ -10,24 +10,49 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
  */
 final class CoverStyleResolver
 {
+    private const MAX_STYLE_BYTES = 65536;
+    private const DECLARATION_CACHE_LIMIT = 32;
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $declarationCache = array();
+
     /**
      * @return array<string, string>
      */
     public function declarations(string $style): array
     {
+        if ( strlen($style) > self::MAX_STYLE_BYTES ) {
+            return array();
+        }
+
+        if ( array_key_exists($style, $this->declarationCache) ) {
+            return $this->declarationCache[ $style ];
+        }
+
         $declarations = array();
-        foreach ( CssValueSplitter::splitTopLevel($style, array( ';' )) as $declaration ) {
-            $parts = CssValueSplitter::splitTopLevel($declaration, array( ':' ));
+        foreach ( $this->splitTopLevel($style, array( ';' )) as $declaration ) {
+            $parts = $this->splitTopLevel($declaration, array( ':' ));
             if ( count($parts) < 2 ) {
                 continue;
             }
 
             $name  = strtolower(trim((string) array_shift($parts)));
             $value = trim(implode(':', $parts));
+            $value = trim((string) preg_replace('/\s*!important\s*$/i', '', $value, 1));
             if ( '' !== $name && '' !== $value ) {
                 $declarations[ $name ] = $value;
             }
         }
+
+        if ( count($this->declarationCache) >= self::DECLARATION_CACHE_LIMIT ) {
+            $oldest = array_key_first($this->declarationCache);
+            if ( null !== $oldest ) {
+                unset($this->declarationCache[ $oldest ]);
+            }
+        }
+        $this->declarationCache[ $style ] = $declarations;
 
         return $declarations;
     }
@@ -43,13 +68,13 @@ final class CoverStyleResolver
         );
 
         $declarations = $this->declarations($style);
-        foreach ( array( 'background', 'background-image' ) as $property ) {
+        foreach ( array( 'background-image', 'background' ) as $property ) {
             $value = (string) ($declarations[ $property ] ?? '');
             if ( '' === $value ) {
                 continue;
             }
 
-            $layers   = CssValueSplitter::splitTopLevel($value, array( ',' ));
+            $layers   = $this->splitTopLevel($value, array( ',' ));
             $urlIndex = null;
             foreach ( $layers as $index => $layer ) {
                 if ( preg_match('/\burl\s*\(/i', $layer) ) {
@@ -67,19 +92,27 @@ final class CoverStyleResolver
                     continue;
                 }
 
-                $stops = CssValueSplitter::splitTopLevel($matches[1], array( ',' ));
+                $stops = $this->splitTopLevel($matches[1], array( ',' ));
+                if ( 3 === count($stops) && $this->isVerticalGradientDirection($stops[0]) ) {
+                    array_shift($stops);
+                }
                 if ( 2 !== count($stops) ) {
-                    return $default;
+                    continue;
                 }
 
                 $first  = $this->overlayColor($stops[0]);
                 $second = $this->overlayColor($stops[1]);
                 if ( null === $first || $first !== $second ) {
+                    continue;
+                }
+
+                $dimRatio = ( (int) round($first['alpha'] * 10) ) * 10;
+                if ( 0 === $dimRatio || 100 === $dimRatio ) {
                     return $default;
                 }
 
                 return array(
-                    'dimRatio'           => ( (int) round($first['alpha'] * 10) ) * 10,
+                    'dimRatio'           => $dimRatio,
                     'customOverlayColor' => sprintf('#%02x%02x%02x', $first['red'], $first['green'], $first['blue']),
                 );
             }
@@ -98,7 +131,7 @@ final class CoverStyleResolver
             ? $declarations['min-height']
             : (string) ($declarations['height'] ?? '');
         $value        = strtolower(trim($value));
-        if ( ! preg_match('/^(\d+(?:\.\d+)?)(px|vh|rem)$/', $value, $matches) ) {
+        if ( ! preg_match('/^(\d+(?:\.\d+)?)(px|vh|rem|dvh|svh|lvh)$/', $value, $matches) ) {
             return null;
         }
 
@@ -121,23 +154,37 @@ final class CoverStyleResolver
             return null;
         }
 
-        $parts = CssValueSplitter::splitTopLevelWhitespace($value);
+        $parts = $this->splitTopLevelWhitespace($value);
         if ( count($parts) < 1 || count($parts) > 2 ) {
             return null;
         }
 
-        $x = $this->positionValue($parts[0], array(
+        $horizontalKeywords = array(
             'left'   => 0.0,
             'center' => 0.5,
             'right'  => 1.0,
-        ));
-        $y = 1 === count($parts)
-            ? 0.5
-            : $this->positionValue($parts[1], array(
-                'top'    => 0.0,
-                'center' => 0.5,
-                'bottom' => 1.0,
-            ));
+        );
+        $verticalKeywords = array(
+            'top'    => 0.0,
+            'center' => 0.5,
+            'bottom' => 1.0,
+        );
+
+        if ( 1 === count($parts) ) {
+            $x = $this->positionValue($parts[0], $horizontalKeywords);
+            $y = 0.5;
+            if ( null === $x ) {
+                $x = 0.5;
+                $y = $this->positionValue($parts[0], $verticalKeywords);
+            }
+        } else {
+            $x = $this->positionValue($parts[0], $horizontalKeywords);
+            $y = $this->positionValue($parts[1], $verticalKeywords);
+            if ( null === $x || null === $y ) {
+                $x = $this->positionValue($parts[1], $horizontalKeywords);
+                $y = $this->positionValue($parts[0], $verticalKeywords);
+            }
+        }
         if ( null === $x || null === $y || ( 0.5 === $x && 0.5 === $y ) ) {
             return null;
         }
@@ -152,17 +199,17 @@ final class CoverStyleResolver
     {
         $declarations = $this->declarations($style);
         $size         = strtolower(trim((string) ($declarations['background-size'] ?? '')));
-        foreach ( CssValueSplitter::splitTopLevel($size, array( ',' )) as $layerSize ) {
-            if ( array( 'cover' ) === CssValueSplitter::splitTopLevelWhitespace($layerSize) ) {
+        foreach ( $this->splitTopLevel($size, array( ',' )) as $layerSize ) {
+            if ( array( 'cover' ) === $this->splitTopLevelWhitespace($layerSize) ) {
                 return true;
             }
         }
 
         $background = (string) ($declarations['background'] ?? '');
-        foreach ( CssValueSplitter::splitTopLevel($background, array( ',' )) as $layer ) {
-            $slashParts = CssValueSplitter::splitTopLevel($layer, array( '/' ));
+        foreach ( $this->splitTopLevel($background, array( ',' )) as $layer ) {
+            $slashParts = $this->splitTopLevel($layer, array( '/' ));
             foreach ( array_slice($slashParts, 1) as $sizeAndRepeat ) {
-                $tokens = CssValueSplitter::splitTopLevelWhitespace(strtolower($sizeAndRepeat));
+                $tokens = $this->splitTopLevelWhitespace(strtolower($sizeAndRepeat));
                 if ( 'cover' === ($tokens[0] ?? '') ) {
                     return true;
                 }
@@ -178,6 +225,9 @@ final class CoverStyleResolver
             'px'  => 200,
             'vh'  => 30,
             'rem' => 12.5,
+            'dvh' => 30,
+            'svh' => 30,
+            'lvh' => 30,
         );
 
         return $minHeight['minHeight'] >= $thresholds[ $minHeight['minHeightUnit'] ];
@@ -186,12 +236,14 @@ final class CoverStyleResolver
     public function hasRepeatingBackground(string $style): bool
     {
         $declarations = $this->declarations($style);
-        $repeat       = strtolower(trim((string) ($declarations['background-repeat'] ?? '')));
-        foreach ( CssValueSplitter::splitTopLevel($repeat, array( ',' )) as $layerRepeat ) {
-            $tokens = CssValueSplitter::splitTopLevelWhitespace($layerRepeat);
-            foreach ( $tokens as $token ) {
-                if ( in_array($token, array( 'repeat', 'repeat-x', 'repeat-y' ), true) ) {
-                    return true;
+        foreach ( array( 'background-repeat', 'background' ) as $property ) {
+            $value = strtolower(trim((string) ($declarations[ $property ] ?? '')));
+            foreach ( $this->splitTopLevel($value, array( ',' )) as $layer ) {
+                $tokens = $this->splitTopLevelWhitespace($layer);
+                foreach ( $tokens as $token ) {
+                    if ( in_array($token, array( 'repeat', 'repeat-x', 'repeat-y' ), true) ) {
+                        return true;
+                    }
                 }
             }
         }
@@ -205,7 +257,19 @@ final class CoverStyleResolver
     private function overlayColor(string $literal): ?array
     {
         $literal = strtolower(trim($literal));
-        if ( preg_match('/^#([0-9a-f]{4}|[0-9a-f]{8})$/', $literal, $matches) ) {
+        $parts   = $this->splitTopLevelWhitespace($literal);
+        if ( count($parts) < 1 || count($parts) > 3 ) {
+            return null;
+        }
+
+        $color = (string) array_shift($parts);
+        foreach ( $parts as $position ) {
+            if ( ! $this->isGradientStopPosition($position) ) {
+                return null;
+            }
+        }
+
+        if ( preg_match('/^#([0-9a-f]{4}|[0-9a-f]{8})$/', $color, $matches) ) {
             $hex = $matches[1];
             if ( 4 === strlen($hex) ) {
                 $red   = hexdec(str_repeat($hex[0], 2));
@@ -231,7 +295,10 @@ final class CoverStyleResolver
             );
         }
 
-        if ( ! preg_match('/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*((?:0(?:\.\d+)?|1(?:\.0+)?|\.\d+))\s*\)$/', $literal, $matches) ) {
+        if (
+            ! preg_match('/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*((?:0(?:\.\d+)?|1(?:\.0+)?|\.\d+))\s*\)$/', $color, $matches)
+            && ! preg_match('/^rgb\(\s*(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s*\/\s*((?:0(?:\.\d+)?|1(?:\.0+)?|\.\d+))\s*\)$/', $color, $matches)
+        ) {
             return null;
         }
 
@@ -249,6 +316,103 @@ final class CoverStyleResolver
             'blue'  => $blue,
             'alpha' => $alpha,
         );
+    }
+
+    private function isVerticalGradientDirection(string $value): bool
+    {
+        return (bool) preg_match('/^(?:0deg|180deg|to\s+(?:top|bottom))$/i', trim($value));
+    }
+
+    private function isGradientStopPosition(string $value): bool
+    {
+        return (bool) preg_match(
+            '/^(?:-?(?:\d+(?:\.\d+)?|\.\d+)(?:%|[a-z]+)?|(?:calc|min|max|clamp|var)\(.*\))$/is',
+            trim($value)
+        );
+    }
+
+    /**
+     * @param array<int, string> $delimiters
+     * @return array<int, string>
+     */
+    private function splitTopLevel(string $input, array $delimiters): array
+    {
+        $masked = $this->maskQuotedAndEscapedCharacters($input);
+        $parts  = CssValueSplitter::splitTopLevel($masked, $delimiters);
+
+        return $this->restoreSplitParts($input, $masked, $parts);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function splitTopLevelWhitespace(string $input): array
+    {
+        $masked = $this->maskQuotedAndEscapedCharacters($input);
+        $parts  = CssValueSplitter::splitTopLevelWhitespace($masked);
+
+        return $this->restoreSplitParts($input, $masked, $parts);
+    }
+
+    private function maskQuotedAndEscapedCharacters(string $input): string
+    {
+        $masked = '';
+        $quote  = null;
+        $length = strlen($input);
+
+        for ( $index = 0; $index < $length; ++$index ) {
+            $character = $input[ $index ];
+            if ( '\\' === $character ) {
+                $masked .= 'x';
+                if ( $index + 1 < $length ) {
+                    $masked .= 'x';
+                    ++$index;
+                }
+                continue;
+            }
+
+            if ( null !== $quote ) {
+                if ( $quote === $character ) {
+                    $masked .= $character;
+                    $quote   = null;
+                } else {
+                    $masked .= 'x';
+                }
+                continue;
+            }
+
+            if ( '"' === $character || "'" === $character ) {
+                $quote  = $character;
+                $masked .= $character;
+                continue;
+            }
+
+            $masked .= $character;
+        }
+
+        return $masked;
+    }
+
+    /**
+     * @param array<int, string> $maskedParts
+     * @return array<int, string>
+     */
+    private function restoreSplitParts(string $input, string $masked, array $maskedParts): array
+    {
+        $parts  = array();
+        $offset = 0;
+
+        foreach ( $maskedParts as $maskedPart ) {
+            $start = strpos($masked, $maskedPart, $offset);
+            if ( false === $start ) {
+                return array();
+            }
+
+            $parts[] = substr($input, $start, strlen($maskedPart));
+            $offset  = $start + strlen($maskedPart);
+        }
+
+        return $parts;
     }
 
     /**

--- a/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
+++ b/php-transformer/src/WordPress/CanonicalSaveShapeValidator.php
@@ -58,6 +58,7 @@ final class CanonicalSaveShapeValidator
      */
     private const TARGET_BLOCKS = array(
         'core/group',
+        'core/cover',
         'core/columns',
         'core/column',
         'core/buttons',

--- a/php-transformer/src/WordPress/GeneratedGutenbergClassPolicy.php
+++ b/php-transformer/src/WordPress/GeneratedGutenbergClassPolicy.php
@@ -12,6 +12,7 @@ final class GeneratedGutenbergClassPolicy
      * @var array<string, string>
      */
     private const BASE_CLASSES = array(
+        'core/cover' => 'wp-block-cover',
         'core/group'     => 'wp-block-group',
         'core/columns'   => 'wp-block-columns',
         'core/column'    => 'wp-block-column',

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1203,8 +1203,8 @@ $backgroundContainer = ( new HtmlTransformer() )->transform(
 $serializedBackgroundContainer = (string) ($backgroundContainer['serialized_blocks'] ?? '');
 $backgroundContainerCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $backgroundContainer['assets'] ?? array()));
 $assert(! str_contains($serializedBackgroundContainer, 'blocks-engine-background-image'), 'background images on content containers do not become in-flow image children');
-$assert(str_contains($serializedBackgroundContainer, 'class="wp-block-group hero') && str_contains($serializedBackgroundContainer, 'class="wp-block-group content'), 'background content containers retain their CSS-addressable wrapper hierarchy');
-$assert(str_contains($backgroundContainerCss, 'background-image:url(assets/hero.jpg)'), 'inline background paint on content containers is retained by the generated author stylesheet');
+$assert(str_contains($serializedBackgroundContainer, 'class="wp-block-cover hero') && str_contains($serializedBackgroundContainer, 'class="wp-block-group content'), 'gated background heroes emit core/cover while retaining their CSS-addressable content wrapper');
+$assert(! str_contains($backgroundContainerCss, 'background-image:url(assets/hero.jpg)'), 'cover-consumed background paint is not duplicated in the generated author stylesheet');
 
 $emptyBackgroundVisual = ( new HtmlTransformer() )->transform(
     '<main><div class="map-image" style="width:640px;height:320px;background-image:url(assets/map.png)" aria-label="Service area"></div></main>'

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1212,6 +1212,72 @@ $emptyBackgroundVisual = ( new HtmlTransformer() )->transform(
 $serializedEmptyBackgroundVisual = (string) ($emptyBackgroundVisual['serialized_blocks'] ?? '');
 $assert(str_contains($serializedEmptyBackgroundVisual, 'blocks-engine-background-image'), 'empty background visual elements remain editable image blocks');
 
+// Slice 4 case 1: a gated hero serializes to the exact canonical core/cover
+// shape and passes the pure-PHP save-shape validator.
+$coverHero = ( new HtmlTransformer() )->transform(
+    '<section class="hero" style="background-image:url(https://example.com/hero.jpg);background-size:cover;min-height:480px"><h1>Build</h1><p>Ship faster with blocks.</p></section>'
+)->toArray();
+$coverHeroSerialized = (string) ($coverHero['serialized_blocks'] ?? '');
+$expectedCoverHeroSerialized = '<!-- wp:cover {"className":"hero","url":"https://example.com/hero.jpg","alt":"","dimRatio":0,"minHeight":480} --><div class="wp-block-cover hero" style="min-height:480px"><img class="wp-block-cover__image-background" alt="" src="https://example.com/hero.jpg" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"content":"Build","level":1} --><h1 class="wp-block-heading">Build</h1><!-- /wp:heading --><!-- wp:paragraph {"content":"Ship faster with blocks."} --><p>Ship faster with blocks.</p><!-- /wp:paragraph --></div></div><!-- /wp:cover -->';
+$assert($expectedCoverHeroSerialized === $coverHeroSerialized, 'gated hero serializes to the exact canonical core/cover golden', $coverHeroSerialized);
+$assert(array() === ( new CanonicalSaveShapeValidator() )->findings($coverHero['blocks'] ?? array()), 'canonical hero cover passes save-shape validation');
+
+// Slice 4 case 2: a uniform dim overlay moves to cover attributes and the
+// overlay span without retaining a second background paint on the hero.
+$dimCoverHero = ( new HtmlTransformer() )->transform(
+    '<section class="hero" style="background:linear-gradient(rgba(0,0,0,0.5),rgba(0,0,0,0.5)),url(https://example.com/hero.jpg) center/cover;min-height:480px"><h1>Build</h1><p>Ship faster with blocks.</p></section>'
+)->toArray();
+$dimCoverBlock = $dimCoverHero['blocks'][0] ?? array();
+$dimCoverAttrs = is_array($dimCoverBlock['attrs'] ?? null) ? $dimCoverBlock['attrs'] : array();
+$dimCoverCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $dimCoverHero['assets'] ?? array()));
+$assert(50 === ($dimCoverAttrs['dimRatio'] ?? null), 'dim overlay cover records dimRatio 50', json_encode($dimCoverAttrs));
+$assert('#000000' === ($dimCoverAttrs['customOverlayColor'] ?? null), 'dim overlay cover records the uniform custom overlay color', json_encode($dimCoverAttrs));
+$assert(str_contains((string) ($dimCoverBlock['innerHTML'] ?? ''), '<span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#000000"></span>'), 'dim overlay cover paints the overlay span with the custom color');
+$assert(! isset($dimCoverAttrs['style']['color']['gradient']) && ! isset($dimCoverAttrs['style']['color']['background']), 'dim overlay cover attrs do not retain hero background paint', json_encode($dimCoverAttrs));
+$assert(! str_contains($dimCoverCss, 'background') && ! str_contains($dimCoverCss, 'gradient') && ! str_contains($dimCoverCss, 'hero.jpg'), 'dim overlay cover generated author CSS does not double-paint the hero', $dimCoverCss);
+
+// Slice 4 case 3: a repeating texture remains byte-identical to trunk's
+// core/group serialization and never enters the cover path.
+$repeatingTexture = ( new HtmlTransformer() )->transform(
+    '<div style="background-image:url(https://example.com/texture.png);background-repeat:repeat"><h2>Pricing</h2><p>Plans</p></div>'
+)->toArray();
+$repeatingTextureSerialized = (string) ($repeatingTexture['serialized_blocks'] ?? '');
+$expectedRepeatingTextureSerialized = '<!-- wp:group {"className":"be-inline-geometry-f4d07b1703db9de9dac1e6c7827e053199fb87461a7cc50a0228652699ebb807"} --><div class="wp-block-group be-inline-geometry-f4d07b1703db9de9dac1e6c7827e053199fb87461a7cc50a0228652699ebb807"><!-- wp:heading {"content":"Pricing","level":2} --><h2 class="wp-block-heading">Pricing</h2><!-- /wp:heading --><!-- wp:paragraph {"content":"Plans"} --><p>Plans</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
+$assert($expectedRepeatingTextureSerialized === $repeatingTextureSerialized, 'repeating texture preserves byte-identical trunk core/group serialization', $repeatingTextureSerialized);
+$assert('core/group' === ($repeatingTexture['blocks'][0]['blockName'] ?? null) && ! str_contains($repeatingTextureSerialized, '<!-- wp:cover'), 'repeating texture is rejected from core/cover');
+
+// Slice 4 case 4: a cover may wrap a recognized two-column content split while
+// both wrappers retain canonical save() shapes.
+$columnsCoverHero = ( new HtmlTransformer() )->transform(
+    '<section class="hero" style="background-image:url(https://example.com/hero.jpg);background-size:cover;min-height:480px"><div class="hero-columns" style="display:flex;gap:24px"><div><h2>Build</h2><p>Plan</p></div><div><h2>Ship</h2><p>Launch</p></div></div></section>'
+)->toArray();
+$columnsCoverBlock = $columnsCoverHero['blocks'][0] ?? array();
+$assert('core/cover' === ($columnsCoverBlock['blockName'] ?? null) && 'core/columns' === ($columnsCoverBlock['innerBlocks'][0]['blockName'] ?? null), 'core/cover wraps the recognized core/columns inner block', json_encode($columnsCoverBlock));
+$assert(array() === ( new CanonicalSaveShapeValidator() )->findings($columnsCoverHero['blocks'] ?? array()), 'cover with nested columns passes save-shape validation');
+
+// Slice 4 case 5: an empty background container keeps the tagged core/image
+// projection and never enters the text-bearing cover path.
+$emptyCoverCandidate = ( new HtmlTransformer() )->transform(
+    '<div style="background-image:url(https://example.com/decor.png);background-size:cover;min-height:400px"></div>'
+)->toArray();
+$emptyCoverCandidateSerialized = (string) ($emptyCoverCandidate['serialized_blocks'] ?? '');
+$expectedEmptyCoverCandidateSerialized = '<!-- wp:group {"className":"be-inline-geometry-218c90ba931caddc1d55a64151a2f27f83f6d8e4595b0e904092ee275b5d2485","style":{"dimensions":{"minHeight":"400px"}}} --><div class="wp-block-group be-inline-geometry-218c90ba931caddc1d55a64151a2f27f83f6d8e4595b0e904092ee275b5d2485" style="min-height:400px"><!-- wp:image {"url":"https://example.com/decor.png","className":"blocks-engine-background-image","scale":"cover"} --><figure class="wp-block-image blocks-engine-background-image"><img src="https://example.com/decor.png" alt="" style="object-fit:cover;height:auto"/></figure><!-- /wp:image --></div><!-- /wp:group -->';
+$assert($expectedEmptyCoverCandidateSerialized === $emptyCoverCandidateSerialized, 'empty background container preserves exact tagged core/image serialization', $emptyCoverCandidateSerialized);
+$assert('core/image' === ($emptyCoverCandidate['blocks'][0]['innerBlocks'][0]['blockName'] ?? null) && 'blocks-engine-background-image' === ($emptyCoverCandidate['blocks'][0]['innerBlocks'][0]['attrs']['className'] ?? null) && ! str_contains($emptyCoverCandidateSerialized, '<!-- wp:cover'), 'empty background container retains the tagged core/image path without core/cover');
+
+// Slice 4 L6: support-derived color and spacing declarations retain canonical
+// wrapper attribute order before the cover-owned min-height declaration.
+$styledCoverHero = ( new HtmlTransformer() )->transform(
+    '<section class="hero" style="background-image:url(https://example.com/hero.jpg);background-size:cover;min-height:480px;padding:24px;background-color:#123456"><h1>Build</h1></section>'
+)->toArray();
+$styledCoverBlock = $styledCoverHero['blocks'][0] ?? array();
+$styledCoverOpeningContent = (string) ($styledCoverBlock['innerContent'][0] ?? '');
+$styledCoverOpeningEnd = strpos($styledCoverOpeningContent, '>');
+$styledCoverWrapperOpening = false === $styledCoverOpeningEnd ? '' : substr($styledCoverOpeningContent, 0, $styledCoverOpeningEnd + 1);
+$expectedStyledCoverWrapperOpening = '<div class="wp-block-cover has-background hero" style="background-color:#123456;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:480px">';
+$assert($expectedStyledCoverWrapperOpening === $styledCoverWrapperOpening, 'styled cover wrapper opening tag preserves exact support and min-height order', $styledCoverWrapperOpening);
+$assert(array() === ( new CanonicalSaveShapeValidator() )->findings($styledCoverHero['blocks'] ?? array()), 'styled cover passes save-shape validation');
+
 $flexIconRow = ( new HtmlTransformer() )->transform(
     '<main><div class="notice-row" style="display: flex; gap: 1rem;"><svg aria-hidden="true" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5"></circle><path d="M2 5h6"></path></svg><div><strong>Venue address</strong><br>Asheville, NC</div></div></main>'
 )->toArray();

--- a/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
+++ b/php-transformer/tests/fixtures/parity/html-background-icon-media-patterns.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-background-icon-media-patterns",
-  "description": "Keeps content-container backgrounds out of document flow and materializes icon-like SVG card media as editable core/image assets, without fallbacks.",
+  "description": "Converts a gated background hero to core/cover and materializes icon-like SVG card media as editable core/image assets, without fallbacks.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-background-icon-media-patterns.json",
@@ -16,7 +16,7 @@
     "content": "<section class=\"hero media-hero\" aria-label=\"Mountain clinic exterior\" style=\"background-image:url('/assets/clinic-hero.jpg');background-size:cover\"><div class=\"hero-copy\"><h1>Care that meets you</h1><p>Evidence-based care in a calm space.</p></div></section><div class=\"feature-card\"><div class=\"feature-icon\" aria-hidden=\"true\"><svg viewBox=\"0 0 24 24\" width=\"24\" height=\"24\" fill=\"none\" stroke=\"currentColor\"><path d=\"M4 12h16\"/><path d=\"M12 4v16\"/></svg></div><h3>Fast booking</h3><p>Choose the right visit online.</p></div>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0", "name": "core/cover" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "hero-copy" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Care that meets you", "level": 1 } },
     { "path": "blocks.1", "name": "core/group", "attrs": { "className": "feature-card" } },
@@ -29,6 +29,7 @@
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks", "assert": "count", "count": 2 },
     { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:cover" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:image" },
     { "path": "blocks.1.innerBlocks.0.innerBlocks.0.attrs.url", "assert": "contains", "value": "assets/materialized-svg/" },
     { "path": "assets.0.content", "assert": "contains", "value": "stroke=\"#000000\"" },

--- a/php-transformer/tests/fixtures/parity/html-layered-background-top-image.json
+++ b/php-transformer/tests/fixtures/parity/html-layered-background-top-image.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-layered-background-top-image",
-  "description": "Converts the top image layer of a gated hero to core/cover without introducing an in-flow media child.",
+  "description": "Preserves layered image backgrounds as generated author CSS without introducing an in-flow media child.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-layered-background-top-image.json",
@@ -16,17 +16,16 @@
     "content": "<section class=\"hero layered-image\" aria-label=\"Featured story\" style=\"width:691px;height:345.5px;overflow:hidden;background-image:url('assets/top.png'),url('assets/bottom.png');background-size:cover;background-position:center\"><h1>Featured story</h1></section>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/cover" },
+    { "path": "blocks.0", "name": "core/group" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Featured story", "level": 1 } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:cover" },
     { "path": "serialized_blocks", "assert": "contains", "value": "hero layered-image" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "blocks-engine-background-image" },
-    { "path": "assets.0.content", "assert": "not_contains", "value": "background-image" },
-    { "path": "assets.0.content", "assert": "not_contains", "value": "background-size:cover" },
+    { "path": "assets.0.content", "assert": "contains", "value": "url('assets/top.png'),url('assets/bottom.png')" },
+    { "path": "assets.0.content", "assert": "contains", "value": "background-size:cover" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-layered-background-top-image.json
+++ b/php-transformer/tests/fixtures/parity/html-layered-background-top-image.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-layered-background-top-image",
-  "description": "Preserves layered image backgrounds as generated author CSS without introducing an in-flow media child.",
+  "description": "Converts the top image layer of a gated hero to core/cover without introducing an in-flow media child.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-layered-background-top-image.json",
@@ -16,16 +16,17 @@
     "content": "<section class=\"hero layered-image\" aria-label=\"Featured story\" style=\"width:691px;height:345.5px;overflow:hidden;background-image:url('assets/top.png'),url('assets/bottom.png');background-size:cover;background-position:center\"><h1>Featured story</h1></section>"
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0", "name": "core/cover" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Featured story", "level": 1 } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:cover" },
     { "path": "serialized_blocks", "assert": "contains", "value": "hero layered-image" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "blocks-engine-background-image" },
-    { "path": "assets.0.content", "assert": "contains", "value": "url('assets/top.png'),url('assets/bottom.png')" },
-    { "path": "assets.0.content", "assert": "contains", "value": "background-size:cover" },
+    { "path": "assets.0.content", "assert": "not_contains", "value": "background-image" },
+    { "path": "assets.0.content", "assert": "not_contains", "value": "background-size:cover" },
     { "path": "fallbacks", "assert": "count", "count": 0 }
   ]
 }

--- a/php-transformer/tests/fixtures/parity/html-linked-media-background-runtime-targets.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-media-background-runtime-targets.json
@@ -1,7 +1,7 @@
 {
   "schema": "blocks-engine/php-transformer/parity-fixture/v1",
   "name": "html-linked-media-background-runtime-targets",
-  "description": "Converts linked figure/gallery media while preserving CSS background heroes and empty runtime icon targets without losing generic DOM targets.",
+  "description": "Converts linked figure/gallery media and a gated CSS background hero while preserving empty runtime icon targets without losing generic DOM targets.",
   "source_reference": {
     "repo": "php-transformer",
     "path": "tests/fixtures/parity/html-linked-media-background-runtime-targets.json",
@@ -20,7 +20,7 @@
     }
   },
   "expected_blocks": [
-    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "hero-media" } },
+    { "path": "blocks.0", "name": "core/cover", "attrs": { "className": "hero-media" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/heading", "attrs": { "content": "Retreats", "level": 1 } },
     { "path": "blocks.1", "name": "core/image", "attrs": { "url": "/assets/retreat.jpg", "alt": "Retreat house", "caption": "Explore the retreat", "href": "/retreats", "linkDestination": "custom", "linkClass": "media-link", "className": "featured-card card-image" } },
     { "path": "blocks.2", "name": "core/gallery", "attrs": { "anchor": "pattern-gallery", "className": "gallery-cards" } },
@@ -32,6 +32,7 @@
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:cover" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "blocks-engine-background-image" },
     { "path": "assets.0.content", "assert": "contains", "value": ".hero-media{background-image:url('/assets/hero-bg.jpg');background-size:cover}" },
     { "path": "serialized_blocks", "assert": "contains", "value": "href=\"/retreats\"" },

--- a/php-transformer/tests/unit/corpus-detectors.php
+++ b/php-transformer/tests/unit/corpus-detectors.php
@@ -257,6 +257,54 @@ $rate = (float) $collected['metrics']['native_rate'];
 $assert($rate >= 0.0 && $rate <= 1.0, '6: native_rate is a bounded ratio', (string) $rate);
 $assert((int) $collected['metrics']['block_count'] > 0, '6b: block_count is populated');
 
+// ---------------------------------------------------------------------------
+// 7. Cover-gate rejections: inline background-image containers rejected by a
+//    style-derived cover gate are informational tuning candidates.
+// ---------------------------------------------------------------------------
+$subThresholdHero = '<div class="short-hero" style="background-image:url(https://example.com/t.jpg);min-height:120px">'
+    . '<h2>T</h2><p>B</p></div>';
+$coverRejections = CorpusDetectors::coverGateRejections($subThresholdHero, array());
+$assert(
+    1 === count($coverRejections)
+        && 'cover_gate_rejection' === ($coverRejections[0]['repair_bucket'] ?? '')
+        && CorpusDetectors::SEVERITY_INFO === ($coverRejections[0]['severity'] ?? '')
+        && array(
+            'gate'  => 'not_hero_sized',
+            'tag'   => 'div',
+            'class' => 'short-hero',
+        ) === ($coverRejections[0]['detail'] ?? null),
+    '7: a sub-threshold background hero yields one informational cover-gate rejection',
+    json_encode($coverRejections)
+);
+
+$matchedHero = '<section class="hero" style="background-image:url(https://example.com/hero.jpg);'
+    . 'background-size:cover;min-height:480px"><h1>Build</h1><p>Ship</p></section>';
+$matchedCover = array(
+    array(
+        'blockName'   => 'core/cover',
+        'attrs'       => array(),
+        'innerBlocks' => array(),
+    ),
+);
+$matchedRejections = CorpusDetectors::coverGateRejections($matchedHero, $matchedCover);
+$assert(0 === count($matchedRejections), '7b: a matched hero emitted as core/cover yields no rejection', 'got ' . count($matchedRejections));
+
+$noBackgroundRejections = CorpusDetectors::coverGateRejections(
+    '<article class="story"><h2>Story</h2><p>Body</p></article>',
+    array()
+);
+$assert(0 === count($noBackgroundRejections), '7c: source without background containers yields no cover rejection', 'got ' . count($noBackgroundRejections));
+
+$collectedCoverRejections = $byDetector(
+    CorpusDetectors::collect(array('blocks' => array()), $subThresholdHero)['findings'],
+    'cover_gate_rejection'
+);
+$assert(
+    1 === count($collectedCoverRejections),
+    '7d: collect wires cover-gate rejection findings into the report',
+    'got ' . count($collectedCoverRejections)
+);
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "CorpusDetectors unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);

--- a/php-transformer/tests/unit/cover-block-factory.php
+++ b/php-transformer/tests/unit/cover-block-factory.php
@@ -66,6 +66,39 @@ $assertNotContains('has-background-dim-50', $dimmed['innerHTML'], 'dimRatio 50 o
 $assertContains('style="background-color:#000000"', $dimmed['innerHTML'], 'Overlay color rides the span.');
 $assertContains('style="object-position:25% 75%" data-object-fit="cover" data-object-position="25% 75%"', $dimmed['innerHTML'], 'Focal point serializes to object-position.');
 
+$designGradient = $factory->create('core/cover', array(
+    'url'            => 'https://example.com/hero.jpg',
+    'alt'            => '',
+    'dimRatio'       => 0,
+    'customGradient' => 'linear-gradient(90deg,#ff0000,#0000ff)',
+), array());
+$assertContains(
+    'class="wp-block-cover__background has-background-dim-0 has-background-dim has-background-gradient"',
+    $designGradient['innerHTML'],
+    'N3: Design gradient uses core class order without the dim compatibility class at dimRatio 0.'
+);
+$assertNotContains('wp-block-cover__gradient-background', $designGradient['innerHTML'], 'N3: dimRatio 0 omits the gradient compatibility class.');
+$assertContains('style="background:linear-gradient(90deg,#ff0000,#0000ff)"', $designGradient['innerHTML'], 'N3: customGradient paints the overlay span.');
+$assertSame('linear-gradient(90deg,#ff0000,#0000ff)', $designGradient['attrs']['customGradient'] ?? null, 'N3: customGradient rides comment attrs.');
+
+$gradientWithDim = $factory->create('core/cover', array(
+    'url'                => 'https://example.com/hero.jpg',
+    'alt'                => '',
+    'dimRatio'           => 30,
+    'customOverlayColor' => '#112233',
+    'customGradient'     => 'linear-gradient(90deg,#ff0000,#0000ff)',
+), array());
+$assertContains(
+    'class="wp-block-cover__background has-background-dim-30 has-background-dim wp-block-cover__gradient-background has-background-gradient"',
+    $gradientWithDim['innerHTML'],
+    'N3: Nonzero dim with media and gradient uses core compatibility-class order.'
+);
+$assertContains(
+    'style="background-color:#112233;background:linear-gradient(90deg,#ff0000,#0000ff)"',
+    $gradientWithDim['innerHTML'],
+    'N3: Core bgStyle order keeps custom overlay color before custom gradient.'
+);
+
 if ( 0 === $failures ) {
     echo "cover block factory ok\n";
 }

--- a/php-transformer/tests/unit/cover-block-factory.php
+++ b/php-transformer/tests/unit/cover-block-factory.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\BlockFactory;
+
+$failures = 0;
+$assertSame = static function (mixed $expected, mixed $actual, string $message) use (&$failures): void {
+    if ( $expected === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true) . PHP_EOL);
+};
+$assertContains = static function (string $needle, string $actual, string $message) use (&$failures): void {
+    if ( str_contains($actual, $needle) ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' missing=' . var_export($needle, true) . ' actual=' . var_export($actual, true) . PHP_EOL);
+};
+$assertNotContains = static function (string $needle, string $actual, string $message) use (&$failures): void {
+    if ( ! str_contains($actual, $needle) ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' unexpected=' . var_export($needle, true) . ' actual=' . var_export($actual, true) . PHP_EOL);
+};
+
+$factory = new BlockFactory();
+
+$block = $factory->create('core/cover', array(
+    'url'           => 'https://example.com/hero.jpg',
+    'alt'           => '',
+    'dimRatio'      => 0,
+    'minHeight'     => 480,
+    'minHeightUnit' => 'px',
+    'className'     => 'hero',
+), array( $factory->create('core/paragraph', array( 'content' => 'Hi' )) ));
+
+$assertSame(
+    '<div class="wp-block-cover hero" style="min-height:480px">'
+    . '<img class="wp-block-cover__image-background" alt="" src="https://example.com/hero.jpg" data-object-fit="cover"/>'
+    . '<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>'
+    . '<div class="wp-block-cover__inner-container">',
+    $block['innerContent'][0],
+    'Cover opening matches core save() for the px/no-dim case.'
+);
+$assertSame(null, $block['innerContent'][1], 'Cover innerContent reserves one inner-block slot.');
+$assertSame('</div></div>', $block['innerContent'][2], 'Cover closing.');
+$assertSame(array( 'url', 'alt', 'dimRatio', 'minHeight', 'className' ), array_keys($block['attrs']), 'px unit is not serialized; attr order stable.');
+
+$dimmed = $factory->create('core/cover', array(
+    'url'                => 'https://example.com/hero.jpg',
+    'alt'                => 'Skyline',
+    'dimRatio'           => 50,
+    'customOverlayColor' => '#000000',
+    'focalPoint'         => array( 'x' => 0.25, 'y' => 0.75 ),
+), array());
+$assertContains('has-background-dim"', $dimmed['innerHTML'], 'dimRatio 50 omits the has-background-dim-50 step class.');
+$assertNotContains('has-background-dim-50', $dimmed['innerHTML'], 'dimRatio 50 omits the step class (core dimRatioToClass).');
+$assertContains('style="background-color:#000000"', $dimmed['innerHTML'], 'Overlay color rides the span.');
+$assertContains('style="object-position:25% 75%" data-object-fit="cover" data-object-position="25% 75%"', $dimmed['innerHTML'], 'Focal point serializes to object-position.');
+
+if ( 0 === $failures ) {
+    echo "cover block factory ok\n";
+}
+
+exit(0 === $failures ? 0 : 1);

--- a/php-transformer/tests/unit/cover-block-factory.php
+++ b/php-transformer/tests/unit/cover-block-factory.php
@@ -69,17 +69,17 @@ $assertContains('style="object-position:25% 75%" data-object-fit="cover" data-ob
 $designGradient = $factory->create('core/cover', array(
     'url'            => 'https://example.com/hero.jpg',
     'alt'            => '',
-    'dimRatio'       => 0,
+    'dimRatio'       => 100,
     'customGradient' => 'linear-gradient(90deg,#ff0000,#0000ff)',
 ), array());
 $assertContains(
-    'class="wp-block-cover__background has-background-dim-0 has-background-dim has-background-gradient"',
+    'class="wp-block-cover__background has-background-dim-100 has-background-dim wp-block-cover__gradient-background has-background-gradient"',
     $designGradient['innerHTML'],
-    'N3: Design gradient uses core class order without the dim compatibility class at dimRatio 0.'
+    'P3: Design gradient uses full-opacity core class order with the compatibility class.'
 );
-$assertNotContains('wp-block-cover__gradient-background', $designGradient['innerHTML'], 'N3: dimRatio 0 omits the gradient compatibility class.');
 $assertContains('style="background:linear-gradient(90deg,#ff0000,#0000ff)"', $designGradient['innerHTML'], 'N3: customGradient paints the overlay span.');
 $assertSame('linear-gradient(90deg,#ff0000,#0000ff)', $designGradient['attrs']['customGradient'] ?? null, 'N3: customGradient rides comment attrs.');
+$assertSame(100, $designGradient['attrs']['dimRatio'] ?? null, 'P3: dimRatio 100 rides comment attrs.');
 
 $gradientWithDim = $factory->create('core/cover', array(
     'url'                => 'https://example.com/hero.jpg',

--- a/php-transformer/tests/unit/cover-pattern.php
+++ b/php-transformer/tests/unit/cover-pattern.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 
 $failures = 0;
 $assertTrue = static function (bool $actual, string $message) use (&$failures): void {
@@ -43,6 +44,37 @@ $elementFromHtml = static function (string $html, string $tagName = 'section'): 
     }
 
     return $element;
+};
+$transformHtml = static function (string $html): array {
+    return (new HtmlTransformer())->transform($html)->toArray();
+};
+$blockNames = static function (array $blocks) use (&$blockNames): array {
+    $names = array();
+    foreach ( $blocks as $block ) {
+        if ( ! is_array($block) ) {
+            continue;
+        }
+        $name = $block['blockName'] ?? null;
+        if ( is_string($name) ) {
+            $names[] = $name;
+        }
+        $innerBlocks = $block['innerBlocks'] ?? array();
+        if ( is_array($innerBlocks) ) {
+            array_push($names, ...$blockNames($innerBlocks));
+        }
+    }
+
+    return $names;
+};
+$assetCss = static function (array $result): string {
+    $css = '';
+    foreach ( $result['assets'] ?? array() as $asset ) {
+        if ( is_array($asset) && 'css' === ($asset['kind'] ?? null) ) {
+            $css .= (string) ($asset['content'] ?? '');
+        }
+    }
+
+    return $css;
 };
 
 $pattern = new CoverPattern();
@@ -124,6 +156,11 @@ $heading = array(
     'attrs'       => array( 'content' => 'Build' ),
     'innerBlocks' => array(),
 );
+$paragraph = array(
+    'blockName'   => 'core/paragraph',
+    'attrs'       => array( 'content' => 'Ship' ),
+    'innerBlocks' => array(),
+);
 
 // 1. Hero matches and converted children become cover innerBlocks.
 $fallbacks = array();
@@ -189,7 +226,7 @@ $assertSame('core/cover', $match($hero, array( $nestedHeading ), array(), array(
 
 // 8. Presentation extraction excludes all consumed background geometry.
 $assertSame(
-    array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat' ),
+    array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat', 'min-height', 'height' ),
     $record['excluded'],
     'Presentation extraction receives frozen background exclusions.'
 );
@@ -240,6 +277,72 @@ $record = array();
 $failOpenCover = $match($hero, array( $heading ), array(), array(), $fallbacks, $record, true);
 $assertSame('core/cover', $failOpenCover['blockName'] ?? null, 'Presentation failure does not throw or suppress gated cover.');
 $assertSame('resolved:https://example.com/hero.jpg', $failOpenCover['attrs']['url'] ?? null, 'Fail-open cover retains independently derivable URL.');
+
+// K3: Consumed min-height/height geometry emits exactly once through core/cover attrs.
+$minHeightResult = $transformHtml('<section class="hero" style="background-image:url(https://example.com/hero.jpg);background-size:cover;min-height:480px"><h1>Build</h1><p>Ship</p></section>');
+$minHeightCover = $minHeightResult['blocks'][0] ?? array();
+$minHeightOpening = (string) ($minHeightCover['innerContent'][0] ?? '');
+$assertSame('core/cover', $minHeightCover['blockName'] ?? null, 'K3: Min-height hero remains core/cover.');
+$assertSame(1, substr_count($minHeightOpening, 'min-height'), 'K3: Min-height hero opening markup emits min-height once.');
+$assertSame(480, $minHeightCover['attrs']['minHeight'] ?? null, 'K3: Min-height hero keeps numeric minHeight attr.');
+$assertTrue(! isset($minHeightCover['attrs']['style']['dimensions']['minHeight']), 'K3: Min-height hero removes duplicate style.dimensions.minHeight.');
+$assertTrue(! str_contains($assetCss($minHeightResult), 'min-height:480px'), 'K3: Min-height hero generates no carrier min-height rule.');
+
+$heightResult = $transformHtml('<section class="hero" style="background-image:url(https://example.com/hero.jpg);background-size:cover;height:345.5px"><h1>Build</h1><p>Ship</p></section>');
+$heightCover = $heightResult['blocks'][0] ?? array();
+$heightOpening = (string) ($heightCover['innerContent'][0] ?? '');
+$assertSame('core/cover', $heightCover['blockName'] ?? null, 'K3: Height-fallback hero remains core/cover.');
+$assertSame(1, substr_count($heightOpening, 'min-height'), 'K3: Height-fallback hero opening markup emits min-height once.');
+$assertSame(1, substr_count($heightOpening, 'height:345.5px'), 'K3: Height-fallback source height survives only inside emitted min-height.');
+$assertTrue(! isset($heightCover['attrs']['style']['dimensions']['minHeight']), 'K3: Height-fallback hero removes duplicate style.dimensions.minHeight.');
+$assertTrue(! str_contains($assetCss($heightResult), 'height:345.5px'), 'K3: Height-fallback hero generates no carrier height rule.');
+
+// K4: Background-image heroes that are columns candidates remain core/columns.
+$columnsResult = $transformHtml('<section style="display:flex;background-image:url(https://example.com/h.jpg);background-size:cover"><div style="flex:1"><h1>Left</h1></div><div style="flex:1"><p>Right</p></div></section>');
+$columnsNames = $blockNames($columnsResult['blocks'] ?? array());
+$assertTrue(in_array('core/columns', $columnsNames, true), 'K4: Flex hero candidate preserves core/columns.');
+$assertTrue(! in_array('core/cover', $columnsNames, true), 'K4: Flex hero candidate does not become core/cover.');
+
+// K5: Navigation-bearing shell wrappers never become core/cover.
+$shellResult = $transformHtml('<div style="background-image:url(https://example.com/h.jpg);background-size:cover"><nav><a href="/a">A</a><a href="/b">B</a></nav><h1>T</h1><p>Body</p></div>');
+$shellNames = $blockNames($shellResult['blocks'] ?? array());
+$assertTrue(! in_array('core/cover', $shellNames, true), 'K5: Navigation-bearing shell rejects core/cover.');
+
+$fallbacks = array( array( 'blockName' => 'existing/fallback' ) );
+$record = array();
+$navigation = array(
+    'blockName'   => 'core/group',
+    'attrs'       => array(),
+    'innerBlocks' => array(
+        array( 'blockName' => 'core/navigation', 'attrs' => array(), 'innerBlocks' => array() ),
+        $paragraph,
+    ),
+);
+$assertNull($match($hero, array( $navigation ), array(), array(), $fallbacks, $record), 'K5: Recursive core/navigation child rejects cover.');
+$assertSame(array( array( 'blockName' => 'existing/fallback' ) ), $fallbacks, 'K5: Navigation rejection discards local fallbacks.');
+
+// K6: Design gradients may survive, but URL layers never remain in cover style attrs.
+$gradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(90deg,#ff0000,#0000ff),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$designGradientCover = $gradientResult['blocks'][0] ?? array();
+$assertSame('core/cover', $designGradientCover['blockName'] ?? null, 'K6: Design-gradient hero remains core/cover.');
+$assertTrue(! str_contains((string) json_encode($designGradientCover['attrs'] ?? array()), 'url('), 'K6: Cover attrs contain no URL layer.');
+$assertTrue(! str_contains((string) ($designGradientCover['innerContent'][0] ?? ''), 'url('), 'K6: Cover opening markup contains no CSS URL layer.');
+
+// K7: Multiple image layers reject cover instead of dropping a layer.
+$multiLayerStyle = 'background-image:url(https://example.com/top.png),url(https://example.com/bottom.png);background-size:cover;min-height:480px';
+$multiLayerResult = $transformHtml('<section class="hero" style="' . $multiLayerStyle . '"><h1>T</h1><p>B</p></section>');
+$multiLayerNames = $blockNames($multiLayerResult['blocks'] ?? array());
+$assertTrue(! in_array('core/cover', $multiLayerNames, true), 'K7: Multi-layer background rejects core/cover.');
+$assertSame('multi_layer_background', $pattern->rejectionGate($multiLayerStyle, true), 'K7: rejectionGate reports multi_layer_background.');
+
+// K8: Cover URL follows source-order cascade.
+$resetResult = $transformHtml('<section class="hero" style="background-image:url(https://example.com/gone.jpg);background-size:cover;min-height:480px;background:#fff"><h1>T</h1><p>B</p></section>');
+$assertTrue(! in_array('core/cover', $blockNames($resetResult['blocks'] ?? array()), true), 'K8: Later background reset rejects core/cover.');
+
+$laterUrlResult = $transformHtml('<section class="hero" style="background:url(https://example.com/first.jpg) center/cover;background-image:url(https://example.com/second.jpg);min-height:480px"><h1>T</h1><p>B</p></section>');
+$laterUrlCover = $laterUrlResult['blocks'][0] ?? array();
+$assertSame('core/cover', $laterUrlCover['blockName'] ?? null, 'K8: Later background-image URL remains core/cover.');
+$assertSame('https://example.com/second.jpg', $laterUrlCover['attrs']['url'] ?? null, 'K8: Later background-image URL wins.');
 
 echo "cover pattern ok\n";
 

--- a/php-transformer/tests/unit/cover-pattern.php
+++ b/php-transformer/tests/unit/cover-pattern.php
@@ -321,12 +321,56 @@ $navigation = array(
 $assertNull($match($hero, array( $navigation ), array(), array(), $fallbacks, $record), 'K5: Recursive core/navigation child rejects cover.');
 $assertSame(array( array( 'blockName' => 'existing/fallback' ) ), $fallbacks, 'K5: Navigation rejection discards local fallbacks.');
 
-// K6: Design gradients may survive, but URL layers never remain in cover style attrs.
+// K6/N3: Design gradients become core customGradient attrs and render only on the overlay span.
 $gradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(90deg,#ff0000,#0000ff),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
 $designGradientCover = $gradientResult['blocks'][0] ?? array();
+$designGradientOpening = (string) ($designGradientCover['innerContent'][0] ?? '');
+$designGradientWrapper = (string) strstr($designGradientOpening, '<img', true);
 $assertSame('core/cover', $designGradientCover['blockName'] ?? null, 'K6: Design-gradient hero remains core/cover.');
 $assertTrue(! str_contains((string) json_encode($designGradientCover['attrs'] ?? array()), 'url('), 'K6: Cover attrs contain no URL layer.');
-$assertTrue(! str_contains((string) ($designGradientCover['innerContent'][0] ?? ''), 'url('), 'K6: Cover opening markup contains no CSS URL layer.');
+$assertTrue(! str_contains($designGradientOpening, 'url('), 'K6: Cover opening markup contains no CSS URL layer.');
+$assertSame('linear-gradient(90deg,#ff0000,#0000ff)', $designGradientCover['attrs']['customGradient'] ?? null, 'N3: Design gradient lands in customGradient.');
+$assertTrue(! isset($designGradientCover['attrs']['style']['color']['gradient']), 'N3: Design gradient leaves no style.color.gradient attr.');
+$assertTrue(str_contains($designGradientOpening, 'has-background-gradient'), 'N3: Overlay span carries has-background-gradient.');
+$assertTrue(str_contains($designGradientOpening, 'style="background:linear-gradient(90deg,#ff0000,#0000ff)"'), 'N3: Overlay span paints customGradient.');
+$assertTrue(! str_contains($designGradientWrapper, 'linear-gradient'), 'N3: Wrapper opening carries no design gradient.');
+
+$layeredGradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(90deg,#ff0000,#0000ff),radial-gradient(circle,#ffffff,#000000),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$layeredGradientCover = $layeredGradientResult['blocks'][0] ?? array();
+$assertSame(
+    'linear-gradient(90deg,#ff0000,#0000ff),radial-gradient(circle,#ffffff,#000000)',
+    $layeredGradientCover['attrs']['customGradient'] ?? null,
+    'N3: Multiple surviving gradient layers remain joined by a top-level comma.'
+);
+
+// N4: Uniform overlays remain dim/color attrs and never become customGradient.
+$uniformGradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(0deg, rgba(0,0,0,.5), rgba(0,0,0,.5)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$uniformGradientCover = $uniformGradientResult['blocks'][0] ?? array();
+$uniformGradientOpening = (string) ($uniformGradientCover['innerContent'][0] ?? '');
+$assertSame(50, $uniformGradientCover['attrs']['dimRatio'] ?? null, 'N4: Uniform overlay keeps dimRatio 50.');
+$assertSame('#000000', $uniformGradientCover['attrs']['customOverlayColor'] ?? null, 'N4: Uniform overlay keeps customOverlayColor.');
+$assertTrue(! isset($uniformGradientCover['attrs']['customGradient']), 'N4: Uniform overlay emits no customGradient.');
+$assertTrue(! isset($uniformGradientCover['attrs']['style']['color']['gradient']), 'N4: Uniform overlay leaves no style.color.gradient attr.');
+$assertTrue(str_contains($uniformGradientOpening, 'has-background-dim'), 'N4: Uniform overlay span carries has-background-dim.');
+$assertTrue(! str_contains($uniformGradientOpening, 'has-background-gradient'), 'N4: Uniform overlay span omits has-background-gradient.');
+
+$mixedGradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(0deg, rgba(0,0,0,.5), rgba(0,0,0,.5)),radial-gradient(circle,#ffffff,#000000),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$mixedGradientCover = $mixedGradientResult['blocks'][0] ?? array();
+$mixedGradientOpening = (string) ($mixedGradientCover['innerContent'][0] ?? '');
+$assertSame(50, $mixedGradientCover['attrs']['dimRatio'] ?? null, 'N3/N4: Mixed gradient keeps uniform overlay dimRatio.');
+$assertSame('#000000', $mixedGradientCover['attrs']['customOverlayColor'] ?? null, 'N3/N4: Mixed gradient keeps uniform overlay color.');
+$assertSame('radial-gradient(circle,#ffffff,#000000)', $mixedGradientCover['attrs']['customGradient'] ?? null, 'N3/N4: Mixed gradient promotes only surviving design layer.');
+$assertTrue(
+    str_contains($mixedGradientOpening, 'class="wp-block-cover__background has-background-dim wp-block-cover__gradient-background has-background-gradient" style="background-color:#000000;background:radial-gradient(circle,#ffffff,#000000)"'),
+    'N3/N4: Mixed overlay span uses core class and bgStyle order.'
+);
+
+$duplicateUniformGradient = 'linear-gradient(0deg, rgba(0,0,0,.5), rgba(0,0,0,.5))';
+$duplicateUniformResult = $transformHtml('<section class="hero" style="background:' . $duplicateUniformGradient . ',' . $duplicateUniformGradient . ',url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$duplicateUniformCover = $duplicateUniformResult['blocks'][0] ?? array();
+$assertSame(50, $duplicateUniformCover['attrs']['dimRatio'] ?? null, 'N3/N4: First duplicate uniform gradient becomes dimRatio.');
+$assertSame('#000000', $duplicateUniformCover['attrs']['customOverlayColor'] ?? null, 'N3/N4: First duplicate uniform gradient becomes overlay color.');
+$assertSame($duplicateUniformGradient, $duplicateUniformCover['attrs']['customGradient'] ?? null, 'N3/N4: Second duplicate uniform gradient survives as customGradient.');
 
 // K7: Multiple image layers reject cover instead of dropping a layer.
 $multiLayerStyle = 'background-image:url(https://example.com/top.png),url(https://example.com/bottom.png);background-size:cover;min-height:480px';

--- a/php-transformer/tests/unit/cover-pattern.php
+++ b/php-transformer/tests/unit/cover-pattern.php
@@ -1,0 +1,246 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverPattern;
+
+$failures = 0;
+$assertTrue = static function (bool $actual, string $message) use (&$failures): void {
+    if ( $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+};
+$assertNull = static function (mixed $actual, string $message) use (&$failures): void {
+    if ( null === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' actual=' . var_export($actual, true) . PHP_EOL);
+};
+$assertSame = static function (mixed $expected, mixed $actual, string $message) use (&$failures): void {
+    if ( $expected === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true) . PHP_EOL);
+};
+
+$elementFromHtml = static function (string $html, string $tagName = 'section'): DOMElement {
+    $document = new DOMDocument();
+    $previous = libxml_use_internal_errors(true);
+    $document->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+    $element = $document->getElementsByTagName($tagName)->item(0);
+    if ( ! $element instanceof DOMElement ) {
+        throw new RuntimeException('Fixture did not produce expected DOMElement.');
+    }
+
+    return $element;
+};
+
+$pattern = new CoverPattern();
+
+// Frozen public callback contract.
+$matchMethod = new ReflectionMethod(CoverPattern::class, 'match');
+$matchParameters = $matchMethod->getParameters();
+$assertSame(
+    array( 'element', 'fallbacks', 'convertChildren', 'presentationAttributes', 'mergedPresentationStyle', 'htmlAttributes', 'resolveAssetUrl', 'createBlock' ),
+    array_map(static fn (ReflectionParameter $parameter): string => $parameter->getName(), $matchParameters),
+    'match callback parameter names remain frozen.'
+);
+$assertSame(
+    array( 'DOMElement', 'array', 'callable', 'callable', 'callable', 'callable', 'callable', 'callable' ),
+    array_map(static fn (ReflectionParameter $parameter): string => (string) $parameter->getType(), $matchParameters),
+    'match callback parameter types remain frozen.'
+);
+$assertTrue($matchParameters[1]->isPassedByReference(), 'match fallbacks parameter remains passed by reference.');
+$assertSame('?array', (string) $matchMethod->getReturnType(), 'match nullable-array return type remains frozen.');
+
+$rejectionMethod = new ReflectionMethod(CoverPattern::class, 'rejectionGate');
+$assertSame(
+    array( 'style', 'hasTextBearingChildren' ),
+    array_map(static fn (ReflectionParameter $parameter): string => $parameter->getName(), $rejectionMethod->getParameters()),
+    'rejectionGate parameter names remain frozen.'
+);
+$assertSame('?string', (string) $rejectionMethod->getReturnType(), 'rejectionGate nullable-string return type remains frozen.');
+
+/**
+ * @param array<int, array<string, mixed>> $children
+ * @param array<string, mixed> $presentation
+ * @param array<string, string> $htmlAttributes
+ * @param array<int, array<string, mixed>> $fallbacks
+ * @param array<string, mixed> $record
+ * @return array<string, mixed>|null
+ */
+$match = static function (
+    DOMElement $element,
+    array $children,
+    array $presentation,
+    array $htmlAttributes,
+    array &$fallbacks,
+    array &$record,
+    bool $throwPresentation = false
+) use ($pattern): ?array {
+    $record = array(
+        'convertCalls' => 0,
+        'excluded'     => null,
+    );
+
+    return $pattern->match(
+        $element,
+        $fallbacks,
+        static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use (&$record, $children): array {
+            ++$record['convertCalls'];
+            $sourceFallbacks[] = array( 'blockName' => 'blocks-engine/fallback' );
+            return $children;
+        },
+        static function (DOMElement $sourceElement, array $excludedGeometryProperties) use (&$record, $presentation, $throwPresentation): array {
+            $record['excluded'] = $excludedGeometryProperties;
+            if ( $throwPresentation ) {
+                throw new RuntimeException('presentation unavailable');
+            }
+            return $presentation;
+        },
+        static fn (DOMElement $sourceElement): string => $sourceElement->getAttribute('style'),
+        static fn (DOMElement $sourceElement): array => $htmlAttributes,
+        static fn (string $url): string => 'resolved:' . $url,
+        static fn (string $name, array $attrs, array $innerBlocks, ?DOMElement $sourceElement): array => array(
+            'blockName'   => $name,
+            'attrs'       => $attrs,
+            'innerBlocks' => $innerBlocks,
+        )
+    );
+};
+
+$heading = array(
+    'blockName'   => 'core/heading',
+    'attrs'       => array( 'content' => 'Build' ),
+    'innerBlocks' => array(),
+);
+
+// 1. Hero matches and converted children become cover innerBlocks.
+$fallbacks = array();
+$record = array();
+$hero = $elementFromHtml('<section aria-label="Hero image" style="background-image:url(https://example.com/hero.jpg);background-size:cover"><h1>Build</h1></section>');
+$cover = $match($hero, array( $heading ), array( 'className' => 'hero' ), array( 'aria-label' => 'Hero image' ), $fallbacks, $record);
+$assertSame('core/cover', $cover['blockName'] ?? null, 'Hero matches core/cover.');
+$assertSame(array( $heading ), $cover['innerBlocks'] ?? null, 'Converted children become cover innerBlocks.');
+$assertSame('resolved:https://example.com/hero.jpg', $cover['attrs']['url'] ?? null, 'Background URL passes through asset resolver.');
+$assertSame('Hero image', $cover['attrs']['alt'] ?? null, 'Background image alt derives from source attributes.');
+$assertSame(0, $cover['attrs']['dimRatio'] ?? null, 'Hero without overlay carries dimRatio 0.');
+$assertSame(array( array( 'blockName' => 'blocks-engine/fallback' ) ), $fallbacks, 'Matched local fallbacks push to host accumulator.');
+
+// 2. convertChildren runs exactly once on a match.
+$assertSame(1, $record['convertCalls'], 'convertChildren runs exactly once on match.');
+
+// 3. Gate 1 rejects missing background URLs before child conversion.
+$fallbacks = array();
+$record = array();
+$noUrl = $elementFromHtml('<section style="background-size:cover"><h1>Build</h1></section>');
+$assertNull($match($noUrl, array( $heading ), array(), array(), $fallbacks, $record), 'Missing background URL rejects cover.');
+$assertSame(0, $record['convertCalls'], 'Missing background URL does not convert children.');
+
+// 4. Gate 2 rejects sub-threshold, non-cover backgrounds.
+$fallbacks = array();
+$record = array();
+$small = $elementFromHtml('<section style="background-image:url(small.jpg);background-size:auto;min-height:120px"><h1>Build</h1></section>');
+$assertNull($match($small, array( $heading ), array(), array(), $fallbacks, $record), 'Sub-threshold background rejects cover.');
+$assertSame(0, $record['convertCalls'], 'Sub-threshold background does not convert children.');
+
+// 5. Gate 2b rejects repeating backgrounds.
+$fallbacks = array();
+$record = array();
+$texture = $elementFromHtml('<section style="background-image:url(texture.png);background-size:cover;background-repeat:repeat"><h1>Build</h1></section>');
+$assertNull($match($texture, array( $heading ), array(), array(), $fallbacks, $record), 'Repeating background rejects cover.');
+$assertSame(0, $record['convertCalls'], 'Repeating background does not convert children.');
+
+// 6. Gate 3 rejects empty converted children and discards local fallbacks.
+$fallbacks = array( array( 'blockName' => 'existing/fallback' ) );
+$record = array();
+$empty = $elementFromHtml('<section style="background-image:url(empty.jpg);background-size:cover"></section>');
+$assertNull($match($empty, array(), array(), array(), $fallbacks, $record), 'Empty converted children reject cover.');
+$assertSame(array( array( 'blockName' => 'existing/fallback' ) ), $fallbacks, 'Rejected local fallbacks do not reach host accumulator.');
+
+// 7. Gate 3 rejects image-only children, including nested image-only groups.
+$fallbacks = array();
+$record = array();
+$imageOnly = array(
+    'blockName'   => 'core/group',
+    'attrs'       => array(),
+    'innerBlocks' => array( array( 'blockName' => 'core/image', 'attrs' => array(), 'innerBlocks' => array() ) ),
+);
+$assertNull($match($hero, array( $imageOnly ), array(), array(), $fallbacks, $record), 'Image-only children reject cover.');
+
+$fallbacks = array();
+$record = array();
+$nestedHeading = array(
+    'blockName'   => 'core/group',
+    'attrs'       => array(),
+    'innerBlocks' => array( $heading ),
+);
+$assertSame('core/cover', $match($hero, array( $nestedHeading ), array(), array(), $fallbacks, $record)['blockName'] ?? null, 'Text-bearing scan recurses through innerBlocks.');
+
+// 8. Presentation extraction excludes all consumed background geometry.
+$assertSame(
+    array( 'background', 'background-image', 'background-size', 'background-position', 'background-repeat' ),
+    $record['excluded'],
+    'Presentation extraction receives frozen background exclusions.'
+);
+
+// 9. Consumed gradients do not survive as style.color.gradient.
+$fallbacks = array();
+$record = array();
+$gradient = $elementFromHtml('<section style="background:linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),url(hero.jpg) center/cover"><h1>Build</h1></section>');
+$gradientCover = $match(
+    $gradient,
+    array( $heading ),
+    array( 'style' => array( 'color' => array( 'gradient' => 'linear-gradient(#0008,#0008)', 'text' => '#ffffff' ) ) ),
+    array(),
+    $fallbacks,
+    $record
+);
+$assertTrue(! isset($gradientCover['attrs']['style']['color']['gradient']), 'Consumed gradient is removed from cover style.');
+$assertSame('#ffffff', $gradientCover['attrs']['style']['color']['text'] ?? null, 'Non-gradient color support remains intact.');
+
+// 10. Dim, min-height, and focal-point derivations land in attrs.
+$fallbacks = array();
+$record = array();
+$derived = $elementFromHtml('<section style="background:linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),url(hero.jpg) center/cover;background-position:right top;min-height:480px"><h1>Build</h1></section>');
+$derivedCover = $match($derived, array( $heading ), array( 'layout' => array( 'type' => 'flex' ) ), array(), $fallbacks, $record);
+$assertSame(50, $derivedCover['attrs']['dimRatio'] ?? null, 'Uniform overlay maps to dimRatio.');
+$assertSame('#000000', $derivedCover['attrs']['customOverlayColor'] ?? null, 'Valid custom overlay color lands.');
+$assertSame(480, $derivedCover['attrs']['minHeight'] ?? null, 'Min-height value lands.');
+$assertSame('px', $derivedCover['attrs']['minHeightUnit'] ?? null, 'Min-height unit lands.');
+$assertSame(array( 'x' => 1.0, 'y' => 0.0 ), $derivedCover['attrs']['focalPoint'] ?? null, 'Focal point lands.');
+$assertTrue(! array_key_exists('layout', $derivedCover['attrs'] ?? array()), 'Cover attrs omit layout.');
+
+// 11. Unsafe URLs reject at Gate 1.
+$fallbacks = array();
+$record = array();
+$unsafe = $elementFromHtml('<section style="background-image:url(javascript:alert(1));background-size:cover"><h1>Build</h1></section>');
+$assertNull($match($unsafe, array( $heading ), array(), array(), $fallbacks, $record), 'Unsafe background URL rejects cover.');
+$assertSame(0, $record['convertCalls'], 'Unsafe background URL does not convert children.');
+
+// 12. rejectionGate reports first failing gate and null on full pass.
+$heroStyle = 'background-image:url(hero.jpg);background-size:cover';
+$assertSame('not_hero_sized', $pattern->rejectionGate('background-image:url(x.png)', true), 'rejectionGate reports hero-size failure.');
+$assertSame('no_text_content', $pattern->rejectionGate($heroStyle, false), 'rejectionGate reports missing text content.');
+$assertNull($pattern->rejectionGate($heroStyle, true), 'rejectionGate returns null when all gates pass.');
+
+// Post-gate presentation failure remains fail-open and still emits a cover.
+$fallbacks = array();
+$record = array();
+$failOpenCover = $match($hero, array( $heading ), array(), array(), $fallbacks, $record, true);
+$assertSame('core/cover', $failOpenCover['blockName'] ?? null, 'Presentation failure does not throw or suppress gated cover.');
+$assertSame('resolved:https://example.com/hero.jpg', $failOpenCover['attrs']['url'] ?? null, 'Fail-open cover retains independently derivable URL.');
+
+echo "cover pattern ok\n";
+
+exit(0 === $failures ? 0 : 1);

--- a/php-transformer/tests/unit/cover-pattern.php
+++ b/php-transformer/tests/unit/cover-pattern.php
@@ -321,7 +321,7 @@ $navigation = array(
 $assertNull($match($hero, array( $navigation ), array(), array(), $fallbacks, $record), 'K5: Recursive core/navigation child rejects cover.');
 $assertSame(array( array( 'blockName' => 'existing/fallback' ) ), $fallbacks, 'K5: Navigation rejection discards local fallbacks.');
 
-// K6/N3: Design gradients become core customGradient attrs and render only on the overlay span.
+// K6/N3/P3: Design gradients become visible core customGradient attrs on the overlay span.
 $gradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(90deg,#ff0000,#0000ff),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
 $designGradientCover = $gradientResult['blocks'][0] ?? array();
 $designGradientOpening = (string) ($designGradientCover['innerContent'][0] ?? '');
@@ -330,8 +330,13 @@ $assertSame('core/cover', $designGradientCover['blockName'] ?? null, 'K6: Design
 $assertTrue(! str_contains((string) json_encode($designGradientCover['attrs'] ?? array()), 'url('), 'K6: Cover attrs contain no URL layer.');
 $assertTrue(! str_contains($designGradientOpening, 'url('), 'K6: Cover opening markup contains no CSS URL layer.');
 $assertSame('linear-gradient(90deg,#ff0000,#0000ff)', $designGradientCover['attrs']['customGradient'] ?? null, 'N3: Design gradient lands in customGradient.');
+$assertSame(100, $designGradientCover['attrs']['dimRatio'] ?? null, 'P3: Design gradient uses full overlay opacity.');
+$assertTrue(! isset($designGradientCover['attrs']['customOverlayColor']), 'P3: Design gradient emits no customOverlayColor.');
 $assertTrue(! isset($designGradientCover['attrs']['style']['color']['gradient']), 'N3: Design gradient leaves no style.color.gradient attr.');
-$assertTrue(str_contains($designGradientOpening, 'has-background-gradient'), 'N3: Overlay span carries has-background-gradient.');
+$assertTrue(
+    str_contains($designGradientOpening, 'class="wp-block-cover__background has-background-dim-100 has-background-dim wp-block-cover__gradient-background has-background-gradient"'),
+    'P3: Design gradient span carries full-opacity core classes.'
+);
 $assertTrue(str_contains($designGradientOpening, 'style="background:linear-gradient(90deg,#ff0000,#0000ff)"'), 'N3: Overlay span paints customGradient.');
 $assertTrue(! str_contains($designGradientWrapper, 'linear-gradient'), 'N3: Wrapper opening carries no design gradient.');
 
@@ -343,7 +348,7 @@ $assertSame(
     'N3: Multiple surviving gradient layers remain joined by a top-level comma.'
 );
 
-// N4: Uniform overlays remain dim/color attrs and never become customGradient.
+// N4/P5: Uniform overlays remain dim/color attrs and never become customGradient.
 $uniformGradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(0deg, rgba(0,0,0,.5), rgba(0,0,0,.5)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
 $uniformGradientCover = $uniformGradientResult['blocks'][0] ?? array();
 $uniformGradientOpening = (string) ($uniformGradientCover['innerContent'][0] ?? '');
@@ -352,17 +357,48 @@ $assertSame('#000000', $uniformGradientCover['attrs']['customOverlayColor'] ?? n
 $assertTrue(! isset($uniformGradientCover['attrs']['customGradient']), 'N4: Uniform overlay emits no customGradient.');
 $assertTrue(! isset($uniformGradientCover['attrs']['style']['color']['gradient']), 'N4: Uniform overlay leaves no style.color.gradient attr.');
 $assertTrue(str_contains($uniformGradientOpening, 'has-background-dim'), 'N4: Uniform overlay span carries has-background-dim.');
+$assertTrue(! str_contains($uniformGradientOpening, 'has-background-dim-50'), 'P5: Uniform overlay omits the ratio-50 step class.');
 $assertTrue(! str_contains($uniformGradientOpening, 'has-background-gradient'), 'N4: Uniform overlay span omits has-background-gradient.');
 
-$mixedGradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(0deg, rgba(0,0,0,.5), rgba(0,0,0,.5)),radial-gradient(circle,#ffffff,#000000),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$degenerateUniformResult = $transformHtml('<section class="hero" style="background:linear-gradient(rgba(0,0,0,.04),rgba(0,0,0,0.04)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$degenerateUniformCover = $degenerateUniformResult['blocks'][0] ?? array();
+$assertSame(0, $degenerateUniformCover['attrs']['dimRatio'] ?? null, 'P5: Semantically equal degenerate uniform stops keep dimRatio 0.');
+$assertTrue(! isset($degenerateUniformCover['attrs']['customOverlayColor']), 'P5: Degenerate uniform overlay emits no customOverlayColor.');
+
+$sidewaysUniformResult = $transformHtml('<section class="hero" style="background:linear-gradient(90deg,rgba(0,0,0,.5),rgba(0,0,0,.5)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$sidewaysUniformCover = $sidewaysUniformResult['blocks'][0] ?? array();
+$assertSame(0, $sidewaysUniformCover['attrs']['dimRatio'] ?? null, 'P5: Uniform-only 90deg gradient keeps existing dimRatio 0 derivation.');
+$assertTrue(! isset($sidewaysUniformCover['attrs']['customOverlayColor']), 'P5: Uniform-only 90deg gradient emits no customOverlayColor.');
+
+$crossSyntaxUniformResult = $transformHtml('<section class="hero" style="background:linear-gradient(#000,rgb(0,0,0)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$crossSyntaxUniformCover = $crossSyntaxUniformResult['blocks'][0] ?? array();
+$assertSame(0, $crossSyntaxUniformCover['attrs']['dimRatio'] ?? null, 'P5: Cross-syntax uniform stops keep existing dimRatio 0 derivation.');
+$assertTrue(! isset($crossSyntaxUniformCover['attrs']['customOverlayColor']), 'P5: Cross-syntax uniform gradient emits no customOverlayColor.');
+
+$radialUniformResult = $transformHtml('<section class="hero" style="background:radial-gradient(circle,rgba(0,0,0,.04),rgba(0,0,0,0.04)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$radialUniformCover = $radialUniformResult['blocks'][0] ?? array();
+$assertSame(0, $radialUniformCover['attrs']['dimRatio'] ?? null, 'P5: Uniform-only radial gradient keeps existing dimRatio 0 derivation.');
+$assertTrue(! isset($radialUniformCover['attrs']['customOverlayColor']), 'P5: Uniform-only radial gradient emits no customOverlayColor.');
+
+$conicUniformResult = $transformHtml('<section class="hero" style="background:conic-gradient(from 45deg,rgba(0,0,0,.04),rgba(0,0,0,0.04)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
+$conicUniformCover = $conicUniformResult['blocks'][0] ?? array();
+$assertSame(0, $conicUniformCover['attrs']['dimRatio'] ?? null, 'P5: Uniform-only conic gradient keeps existing dimRatio 0 derivation.');
+$assertTrue(! isset($conicUniformCover['attrs']['customOverlayColor']), 'P5: Uniform-only conic gradient emits no customOverlayColor.');
+
+// P4: Mixed uniform and design gradients all remain in customGradient, in source order.
+$mixedGradientResult = $transformHtml('<section class="hero" style="background:linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),linear-gradient(90deg,rgba(255,0,0,.55),rgba(0,0,255,.55)),url(https://example.com/h.jpg) center/cover;min-height:480px"><h1>T</h1><p>B</p></section>');
 $mixedGradientCover = $mixedGradientResult['blocks'][0] ?? array();
 $mixedGradientOpening = (string) ($mixedGradientCover['innerContent'][0] ?? '');
-$assertSame(50, $mixedGradientCover['attrs']['dimRatio'] ?? null, 'N3/N4: Mixed gradient keeps uniform overlay dimRatio.');
-$assertSame('#000000', $mixedGradientCover['attrs']['customOverlayColor'] ?? null, 'N3/N4: Mixed gradient keeps uniform overlay color.');
-$assertSame('radial-gradient(circle,#ffffff,#000000)', $mixedGradientCover['attrs']['customGradient'] ?? null, 'N3/N4: Mixed gradient promotes only surviving design layer.');
+$assertSame(100, $mixedGradientCover['attrs']['dimRatio'] ?? null, 'P4: Mixed gradient uses full overlay opacity.');
+$assertTrue(! isset($mixedGradientCover['attrs']['customOverlayColor']), 'P4: Mixed gradient emits no customOverlayColor.');
+$assertSame(
+    'linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),linear-gradient(90deg,rgba(255,0,0,.55),rgba(0,0,255,.55))',
+    $mixedGradientCover['attrs']['customGradient'] ?? null,
+    'P4: Mixed gradient keeps every gradient layer in source order.'
+);
 $assertTrue(
-    str_contains($mixedGradientOpening, 'class="wp-block-cover__background has-background-dim wp-block-cover__gradient-background has-background-gradient" style="background-color:#000000;background:radial-gradient(circle,#ffffff,#000000)"'),
-    'N3/N4: Mixed overlay span uses core class and bgStyle order.'
+    str_contains($mixedGradientOpening, 'class="wp-block-cover__background has-background-dim-100 has-background-dim wp-block-cover__gradient-background has-background-gradient" style="background:linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),linear-gradient(90deg,rgba(255,0,0,.55),rgba(0,0,255,.55))"'),
+    'P4: Mixed overlay span carries full-opacity core classes and source-order gradient style.'
 );
 
 $duplicateUniformGradient = 'linear-gradient(0deg, rgba(0,0,0,.5), rgba(0,0,0,.5))';

--- a/php-transformer/tests/unit/cover-style-resolver.php
+++ b/php-transformer/tests/unit/cover-style-resolver.php
@@ -140,6 +140,31 @@ $assertTrue($resolver->meetsHeroSizeGate('background-image:url(h.jpg);min-height
 // Required change 9: Oversized scraped style strings are rejected without parsing.
 $assertSameArray(array(), $resolver->declarations('color:red;' . str_repeat(' ', 65527)), 'Styles over 65536 bytes are rejected.');
 
+// J5: Residual shorthand, cascade, color-syntax, and important-spacing edges.
+$assertTrue($resolver->hasRepeatingBackground('background:url(x.jpg) round'), 'Shorthand round disqualifies.');
+$assertTrue($resolver->hasRepeatingBackground('background:url(x.jpg) space'), 'Shorthand space disqualifies.');
+$assertFalse($resolver->hasRepeatingBackground('background-repeat:no-repeat'), 'Longhand no-repeat remains non-repeating.');
+$assertSameArray(
+    array( 'dimRatio' => 0, 'customOverlayColor' => '' ),
+    $resolver->dimFromStyle('background-image:linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),url(b.jpg);background:red'),
+    'Later background shorthand resets an earlier background-image overlay.'
+);
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background:red;background-image:linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),url(b.jpg)'),
+    'Later background-image overlay wins over an earlier background shorthand.'
+);
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background:linear-gradient(rgba(0 0 0 / 0.5),rgba(0 0 0 / 0.5)),url(h.jpg)'),
+    'Modern rgba slash syntax maps to dimRatio and overlay color.'
+);
+$assertSameArray(
+    array( 'minHeight' => 480, 'minHeightUnit' => 'px' ),
+    $resolver->minHeightFromStyle('min-height:480px ! important'),
+    'Spaced important min-height values parse.'
+);
+
 echo "cover style resolver ok\n";
 
 exit(0 === $failures ? 0 : 1);

--- a/php-transformer/tests/unit/cover-style-resolver.php
+++ b/php-transformer/tests/unit/cover-style-resolver.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverStyleResolver;
+
+$failures = 0;
+$assertSameArray = static function (array $expected, $actual, string $message) use (&$failures): void {
+    if ( $expected === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true) . PHP_EOL);
+};
+$assertNull = static function ($actual, string $message) use (&$failures): void {
+    if ( null === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' expected=NULL actual=' . var_export($actual, true) . PHP_EOL);
+};
+$assertTrue = static function (bool $actual, string $message) use (&$failures): void {
+    if ( true === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' expected=true actual=false' . PHP_EOL);
+};
+$assertFalse = static function (bool $actual, string $message) use (&$failures): void {
+    if ( false === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' expected=false actual=true' . PHP_EOL);
+};
+
+$resolver = new CoverStyleResolver();
+
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background:linear-gradient(rgba(0,0,0,0.5),rgba(0,0,0,0.5)),url("hero.jpg") center/cover'),
+    'Uniform rgba gradient above the image maps to dimRatio + overlay color.'
+);
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background-image:linear-gradient(#00000080,#00000080),url(hero.jpg)'),
+    '#rrggbbaa alpha 0x80 rounds to dimRatio 50.'
+);
+$assertSameArray(
+    array( 'dimRatio' => 0, 'customOverlayColor' => '' ),
+    $resolver->dimFromStyle('background:linear-gradient(#000,#fff),url(hero.jpg)'),
+    'Two-color gradients are design gradients, not dim overlays.'
+);
+
+$assertSameArray(array( 'x' => 1.0, 'y' => 0.0 ), $resolver->focalPointFromStyle('background-position:right top'), 'Keyword pair maps to corners.');
+$assertSameArray(array( 'x' => 0.25, 'y' => 0.75 ), $resolver->focalPointFromStyle('background-position:25% 75%'), 'Percentages map to 0-1.');
+$assertNull($resolver->focalPointFromStyle('background-position:center center'), 'Center is the default; omitted.');
+$assertNull($resolver->focalPointFromStyle('background-position:10px 20px'), 'Length positions are not derivable.');
+
+$assertSameArray(array( 'minHeight' => 480, 'minHeightUnit' => 'px' ), $resolver->minHeightFromStyle('min-height:480px'), 'px minHeight parses.');
+$assertSameArray(array( 'minHeight' => 80, 'minHeightUnit' => 'vh' ), $resolver->minHeightFromStyle('height:80vh'), 'height falls back when min-height absent.');
+$assertNull($resolver->minHeightFromStyle('min-height:50%'), 'Percentage heights are not derivable.');
+
+$assertTrue($resolver->meetsHeroSizeGate('background:url(h.jpg) center/cover'), 'Shorthand size cover passes.');
+$assertTrue($resolver->meetsHeroSizeGate('background-image:url(h.jpg);min-height:30vh'), '30vh threshold passes.');
+$assertFalse($resolver->meetsHeroSizeGate('background-image:url(h.jpg);min-height:120px'), 'Sub-threshold height fails.');
+$assertFalse($resolver->meetsHeroSizeGate('background-image:url(h.jpg)'), 'No size signal fails.');
+
+$assertTrue($resolver->hasRepeatingBackground('background-repeat:repeat'), 'repeat disqualifies.');
+$assertFalse($resolver->hasRepeatingBackground('background-repeat:no-repeat'), 'no-repeat does not.');
+
+echo "cover style resolver ok\n";
+
+exit(0 === $failures ? 0 : 1);

--- a/php-transformer/tests/unit/cover-style-resolver.php
+++ b/php-transformer/tests/unit/cover-style-resolver.php
@@ -74,6 +74,72 @@ $assertFalse($resolver->meetsHeroSizeGate('background-image:url(h.jpg)'), 'No si
 $assertTrue($resolver->hasRepeatingBackground('background-repeat:repeat'), 'repeat disqualifies.');
 $assertFalse($resolver->hasRepeatingBackground('background-repeat:no-repeat'), 'no-repeat does not.');
 
+// H1: Quoted URL contents cannot inject declarations or hero-size signals.
+$quotedUrlStyle = "background:url('a) ;min-height:900px;.jpg') no-repeat";
+$assertFalse(array_key_exists('min-height', $resolver->declarations($quotedUrlStyle)), 'Quoted URL semicolons do not inject min-height.');
+$assertFalse($resolver->meetsHeroSizeGate($quotedUrlStyle), 'Quoted URL contents do not pass the hero-size gate.');
+
+// H2: background-image wins over background and invalid earlier gradients do not abort scanning.
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background:linear-gradient(#000,#fff),url(a.jpg);background-image:linear-gradient(rgba(0,0,0,.5),rgba(0,0,0,.5)),url(b.jpg)'),
+    'background-image overlay wins over the background shorthand.'
+);
+
+// H3: Common uniform-overlay gradient forms are recognized.
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background:linear-gradient(0deg, rgba(0,0,0,.5), rgba(0,0,0,.5)),url(h.jpg)'),
+    'Vertical direction prefixes are ignored when comparing overlay stops.'
+);
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background:linear-gradient(rgba(0,0,0,.5) 0%, rgba(0,0,0,.5) 100%),url(h.jpg)'),
+    'Stop positions are ignored when comparing overlay colors.'
+);
+$assertSameArray(
+    array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
+    $resolver->dimFromStyle('background:linear-gradient(rgb(0 0 0 / 0.5),rgb(0 0 0 / 0.5)),url(h.jpg)'),
+    'Modern rgb alpha syntax maps to dimRatio and overlay color.'
+);
+
+// H4: A trailing !important does not alter parsed declaration values.
+$assertSameArray(
+    array( 'minHeight' => 480, 'minHeightUnit' => 'px' ),
+    $resolver->minHeightFromStyle('min-height:480px !important'),
+    'Important min-height values parse.'
+);
+$assertTrue(
+    $resolver->meetsHeroSizeGate('background-image:url(h.jpg);background-size:cover !important'),
+    'Important background-size cover values pass.'
+);
+
+// H5: Repeating tokens in the background shorthand disqualify the image.
+$assertTrue($resolver->hasRepeatingBackground('background:url(x.jpg) repeat'), 'Shorthand repeat disqualifies.');
+
+// H6: Near-transparent and near-opaque overlays collapse to the no-overlay default.
+$assertSameArray(
+    array( 'dimRatio' => 0, 'customOverlayColor' => '' ),
+    $resolver->dimFromStyle('background:linear-gradient(rgba(0,0,0,0.04),rgba(0,0,0,0.04)),url(h.jpg)'),
+    'An overlay that rounds to zero is omitted.'
+);
+$assertSameArray(
+    array( 'dimRatio' => 0, 'customOverlayColor' => '' ),
+    $resolver->dimFromStyle('background:linear-gradient(rgba(0,0,0,0.95),rgba(0,0,0,0.95)),url(h.jpg)'),
+    'An overlay that rounds to 100 is omitted.'
+);
+
+// H7: Vertical-first and single vertical background positions map correctly.
+$assertSameArray(array( 'x' => 0.5, 'y' => 0.0 ), $resolver->focalPointFromStyle('background-position:top'), 'Single top centers the horizontal axis.');
+$assertSameArray(array( 'x' => 1.0, 'y' => 0.0 ), $resolver->focalPointFromStyle('background-position:top right'), 'Vertical-first keyword pairs map to axes.');
+
+// H8: Modern viewport units parse and use the viewport hero threshold.
+$assertSameArray(array( 'minHeight' => 100, 'minHeightUnit' => 'dvh' ), $resolver->minHeightFromStyle('min-height:100dvh'), 'dvh minHeight parses.');
+$assertTrue($resolver->meetsHeroSizeGate('background-image:url(h.jpg);min-height:100dvh'), '100dvh passes the hero-size gate.');
+
+// Required change 9: Oversized scraped style strings are rejected without parsing.
+$assertSameArray(array(), $resolver->declarations('color:red;' . str_repeat(' ', 65527)), 'Styles over 65536 bytes are rejected.');
+
 echo "cover style resolver ok\n";
 
 exit(0 === $failures ? 0 : 1);

--- a/php-transformer/tests/unit/cover-style-resolver.php
+++ b/php-transformer/tests/unit/cover-style-resolver.php
@@ -38,8 +38,26 @@ $assertFalse = static function (bool $actual, string $message) use (&$failures):
     ++$failures;
     fwrite(STDERR, 'FAIL: ' . $message . ' expected=false actual=true' . PHP_EOL);
 };
+$assertSame = static function (mixed $expected, mixed $actual, string $message) use (&$failures): void {
+    if ( $expected === $actual ) {
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true) . PHP_EOL);
+};
 
 $resolver = new CoverStyleResolver();
+
+$backgroundUrlMethodExists = method_exists(CoverStyleResolver::class, 'backgroundUrlFromStyle');
+$assertTrue($backgroundUrlMethodExists, 'K8: backgroundUrlFromStyle public contract exists.');
+if ( $backgroundUrlMethodExists ) {
+    $backgroundUrlMethod = new ReflectionMethod(CoverStyleResolver::class, 'backgroundUrlFromStyle');
+    $backgroundUrlParameters = $backgroundUrlMethod->getParameters();
+    $assertSame(array( 'style' ), array_map(static fn (ReflectionParameter $parameter): string => $parameter->getName(), $backgroundUrlParameters), 'K8: backgroundUrlFromStyle parameter name remains frozen.');
+    $assertSame(array( 'string' ), array_map(static fn (ReflectionParameter $parameter): string => (string) $parameter->getType(), $backgroundUrlParameters), 'K8: backgroundUrlFromStyle parameter type remains frozen.');
+    $assertSame('string', (string) $backgroundUrlMethod->getReturnType(), 'K8: backgroundUrlFromStyle return type remains frozen.');
+}
 
 $assertSameArray(
     array( 'dimRatio' => 50, 'customOverlayColor' => '#000000' ),
@@ -163,6 +181,30 @@ $assertSameArray(
     array( 'minHeight' => 480, 'minHeightUnit' => 'px' ),
     $resolver->minHeightFromStyle('min-height:480px ! important'),
     'Spaced important min-height values parse.'
+);
+
+// K8: URL extraction follows background/background-image source-order cascade.
+if ( $backgroundUrlMethodExists ) {
+    $assertSame(
+        '',
+        $resolver->backgroundUrlFromStyle('background-image:url(https://example.com/gone.jpg);background:#fff'),
+        'K8: Later background shorthand resets an earlier background-image URL.'
+    );
+    $assertSame(
+        'https://example.com/second.jpg',
+        $resolver->backgroundUrlFromStyle('background:url(https://example.com/first.jpg);background-image:url(https://example.com/second.jpg)'),
+        'K8: Later background-image URL wins over an earlier background shorthand URL.'
+    );
+}
+
+// K9: A later background shorthand resets earlier background-size unless it carries /size.
+$assertFalse(
+    $resolver->meetsHeroSizeGate('background-size:cover;background:url(x.jpg)'),
+    'K9: Later background shorthand without /size resets earlier background-size.'
+);
+$assertTrue(
+    $resolver->meetsHeroSizeGate('background:url(x.jpg) center/cover'),
+    'K9: Background shorthand with /cover remains a hero-size signal.'
 );
 
 echo "cover style resolver ok\n";


### PR DESCRIPTION
## What

Adds `core/cover` emission to the php-transformer HtmlToBlocks pipeline. Flow containers (`div|section|article`) whose CSS background is a real image hero — background-image URL plus overlaid text content — now convert to `core/cover` instead of `core/group`, with exact save()-shape markup matching vendored `@wordpress/block-library` 10.0.0.

## How

- **`CoverStyleResolver`** (new): quote-masked CSS parsing for background URL (last-declaration-wins cascade), uniform-gradient dim ratio derivation, min-height (`px|vh|rem|dvh|svh|lvh`), focal point from `background-position`, hero size gate, and repeating-background detection. Declarations are memoized with a 64KB cap.
- **`CoverPattern`** (new): recognizer wired into the flow-container dispatch ladder (after details disclosure, before columns). Gates: background URL present → hero size gate (background-size cover OR min-height ≥ 200px/30vh/12.5rem) → not repeating → not a columns layout → children convert to text-bearing blocks → not a nav shell → not a multi-layer background. Non-matching containers keep today's `core/group` path byte-identical.
- **`BlockFactory::coverHtml`**: hand-rolled cover save markup per vendored `src/cover/save.js` — `<img class="wp-block-cover__image-background">` before the overlay `<span>`, span immediately before `wp-block-cover__inner-container` (CSS sibling selector depends on this), `dimRatioToClass` omission at 50, px `minHeightUnit` elision.
- **Gradient overlays**: uniform 2-stop gradients become `dimRatio`; design (non-uniform) gradients ride `customGradient` on the overlay span at `dimRatio: 100` — core's CSS maps dim ratio to span *opacity*, so a design gradient at dim 0 renders invisible. Mixed uniform+design stacks keep all layers in `customGradient` in source order.
- **Validation & diagnostics**: `core/cover` registered in `CanonicalSaveShapeValidator` TARGET_BLOCKS and `GeneratedGutenbergClassPolicy`; new `cover_gate_rejection` corpus detector (INFO) records background-image-with-content containers that fail the gates, so heuristic under-fire is measurable.

## Testing

- New unit suites for `CoverStyleResolver` and `CoverPattern`; corpus-detector cases extended.
- Six new contract cases: exact-equality hero golden, dim/no-double-paint, gate-rejected byte-identical fallback, cover-containing-columns, empty-container regression, style ordering.
- Parity goldens regenerated where heroes now convert to covers; multi-layer-background golden verified byte-identical (correctly rejected).
- Visual QA: real source/converted HTML pairs rendered in Chrome with the generated CSS and vendored `build-style/cover/style.css` — plain, dim-overlay, design-gradient, and mixed-stack heroes all paint identically to source. This caught (and drove the fix for) the invisible design-gradient defect.
- Corpus scan over fixtures/websites: zero covers emitted, verified correct — the only `url()` background rules present are repeating textures and a body background, all properly rejected.

Full `composer test` green.
