### PR TITLE
Preserve canonical HTML bridge results

### DIFF
--- a/php-transformer/src/FormatBridge/FormatBridge.php
+++ b/php-transformer/src/FormatBridge/FormatBridge.php
@@ -136,6 +136,13 @@ final class FormatBridge
             $output = $from === $to ? $normalizedContent : $targetAdapter->fromBlocks($blocks, $options);
             $assets = is_array($adapterResult['assets'] ?? null) ? $adapterResult['assets'] : array();
             $fallbacks = is_array($adapterResult['fallbacks'] ?? null) ? $adapterResult['fallbacks'] : array();
+            $diagnostics = array_merge(is_array($adapterResult['diagnostics'] ?? null) ? $adapterResult['diagnostics'] : array(), array(
+                array(
+                    'code'    => 'format_bridge_conversion_completed',
+                    'message' => sprintf('Converted %s content to %s through the format bridge.', $from, $to),
+                    'source'  => self::class,
+                ),
+            ));
             $metrics = array(
                 'input_bytes'      => strlen($content),
                 'output_bytes'     => strlen($output),
@@ -143,6 +150,17 @@ final class FormatBridge
                 'fallback_count'   => count($fallbacks),
                 'diagnostic_count' => 1,
             );
+            $status = 'success';
+            if ( $sourceAdapter instanceof HtmlAdapter ) {
+                $status = (string) ($adapterResult['status'] ?? 'success');
+                $metrics = array_merge(is_array($adapterResult['metrics'] ?? null) ? $adapterResult['metrics'] : array(), array(
+                    'input_bytes'      => strlen($content),
+                    'output_bytes'     => strlen($output),
+                    'block_count'      => $this->countBlocks($blocks),
+                    'fallback_count'   => count($fallbacks),
+                    'diagnostic_count' => count($diagnostics),
+                ));
+            }
             $sourceReports = is_array($adapterResult['source_reports'] ?? null) ? $adapterResult['source_reports'] : array();
             $sourceReports['format_bridge'] = array(
                     'source_format' => $from,
@@ -153,6 +171,7 @@ final class FormatBridge
             $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts($from, $blocks, $fallbacks, $sourceReports, array(), $provenance, $metrics);
 
             return new TransformerResult(
+                status: $status,
                 sourceReports: $sourceReports,
                 blocks: $blocks,
                 serializedBlocks: 'blocks' === $to ? $output : '',
@@ -163,13 +182,7 @@ final class FormatBridge
                     ),
                 ),
                 assets: $assets,
-                diagnostics: array_merge(is_array($adapterResult['diagnostics'] ?? null) ? $adapterResult['diagnostics'] : array(), array(
-                    array(
-                        'code'    => 'format_bridge_conversion_completed',
-                        'message' => sprintf('Converted %s content to %s through the format bridge.', $from, $to),
-                        'source'  => self::class,
-                    ),
-                )),
+                diagnostics: $diagnostics,
                 fallbacks: $fallbacks,
                 provenance: $provenance,
                 context: $context,
@@ -219,5 +232,21 @@ final class FormatBridge
             context: $context,
             metrics: $metrics
         );
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     */
+    private function countBlocks(array $blocks): int
+    {
+        $count = 0;
+        foreach ( $blocks as $block ) {
+            ++$count;
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $count += $this->countBlocks($block['innerBlocks']);
+            }
+        }
+
+        return $count;
     }
 }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3864,6 +3864,20 @@ assertSame('blocks', $htmlToBlocksResult['documents'][0]['format'], 'Format brid
 $htmlAssetResult = $bridge->convertResult('<style>.logo{display:inline-flex}</style><a class="logo" href="/"><span class="logo-mark"></span><span>Logo</span></a>', 'html', 'blocks')->toArray();
 assertStringContains('> :where(.wp-block-button__link){display:inline-flex}', (string) ($htmlAssetResult['assets'][0]['content'] ?? ''), 'HTML format conversion should preserve generated author stylesheet assets.');
 assertSame('blocks-engine/php-transformer/wp-block-validity-report/v1', $htmlAssetResult['source_reports']['wp_block_validity']['schema'] ?? '', 'HTML format conversion should preserve source transformer reports.');
+$strictHtmlResult = $bridge->convertResult(
+    '<main><applet code="clock.class"></applet></main>',
+    'html',
+    'blocks',
+    array('context' => array('strict' => true, 'allow_fallbacks' => false))
+)->toArray();
+assertSame('failed', $strictHtmlResult['status'], 'Strict unsupported HTML conversion should remain failed through the format bridge.');
+assertSame(count($strictHtmlResult['diagnostics']), $strictHtmlResult['metrics']['diagnostic_count'], 'HTML bridge diagnostics metric should include the completion diagnostic.');
+assertSame($strictHtmlResult['metrics'], $strictHtmlResult['source_reports']['conversion_report']['metrics'], 'HTML bridge conversion-report metrics should match top-level metrics.');
+$nestedHtml = '<main><h2>Nested</h2><p>Content</p></main>';
+$nestedHtmlTransformerResult = ( new HtmlTransformer() )->transform($nestedHtml)->toArray();
+$nestedHtmlBridgeResult = $bridge->convertResult($nestedHtml, 'html', 'blocks')->toArray();
+$assert($nestedHtmlBridgeResult['metrics']['block_count'] > count($nestedHtmlBridgeResult['blocks']), 'HTML bridge metrics should recursively count nested blocks.');
+assertSame($nestedHtmlTransformerResult['metrics']['block_count'], $nestedHtmlBridgeResult['metrics']['block_count'], 'HTML bridge should preserve the transformer recursive block count.');
 $unsupportedSourceResult = $bridge->convertResult('<p>Hello</p>', 'xml', 'html')->toArray();
 assertSame('failed', $unsupportedSourceResult['status'], 'Unsupported source formats should fail through diagnostics.');
 assertSame('unsupported_source_format', $unsupportedSourceResult['diagnostics'][0]['code'], 'Unsupported source diagnostics should identify the source format.');


### PR DESCRIPTION
## Summary

- preserve canonical `HtmlTransformer` status through `FormatBridge::convertResult()`
- derive recursive block, fallback, and diagnostic metrics from the final HTML result
- keep conversion-report and top-level metrics aligned
- add strict-failure and nested-metric contract coverage

Closes #740.

## Verification

- focused HTML bridge contract passed
- PHP syntax checks passed
- `git diff --check` passed

Full `composer test` remains unverified because this bare disk-constrained worktree has no `vendor/autoload.php`. The paired SSI solved-fixture gate remains required before merge.

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode general coding subagent
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Implemented canonical result preservation, added focused contract coverage, and ran available verification. Chris Huber owns and reviewed the submitted change.
