### PR TITLE
Centralize deterministic row deduplication

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -78,7 +78,8 @@
       "php tests/unit/content-round-trip-reporter.php",
       "php tests/unit/content-round-trip-form-echo.php",
       "php tests/unit/corpus-detectors.php",
-      "php tests/unit/live-wp-parity-runner.php"
+      "php tests/unit/live-wp-parity-runner.php",
+      "php tests/unit/deterministic-row-deduplicator.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -14,6 +14,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBui
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
 use DOMDocument;
 use DOMElement;
@@ -634,18 +635,7 @@ final class ArtifactCompiler
      */
     private function dedupeArrayRows(array $rows): array
     {
-        $deduped = array();
-        $seen = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
+        return DeterministicRowDeduplicator::dedupe($rows);
     }
 
     /**
@@ -2661,18 +2651,7 @@ final class ArtifactCompiler
      */
     private function dedupeRows(array $rows): array
     {
-        $seen = array();
-        $deduped = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
+        return DeterministicRowDeduplicator::dedupe($rows);
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
 use DOMDocument;
 use DOMElement;
 
@@ -1280,17 +1281,6 @@ final class RuntimeDependencyParityReport
      */
     private function dedupeRows(array $rows): array
     {
-        $seen = array();
-        $deduped = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
+        return DeterministicRowDeduplicator::dedupe($rows);
     }
 }

--- a/php-transformer/src/ArtifactCompiler/RuntimeIslandPackageBuilder.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeIslandPackageBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
 
 /**
  * Generic, product-neutral producer for the runtime-island package.
@@ -387,17 +388,6 @@ final class RuntimeIslandPackageBuilder
      */
     private function dedupeRows(array $rows): array
     {
-        $seen = array();
-        $deduped = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
+        return DeterministicRowDeduplicator::dedupe($rows);
     }
 }

--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\Contract;
 
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
+
 final class ConversionReportProjection
 {
     public const SCHEMA = 'blocks-engine/php-transformer/conversion-report/v1';
@@ -595,17 +597,6 @@ final class ConversionReportProjection
      */
     private static function dedupeRows(array $rows): array
     {
-        $seen = array();
-        $deduped = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
+        return DeterministicRowDeduplicator::dedupe($rows);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
 use DOMElement;
 use DOMNode;
 
@@ -451,17 +452,6 @@ trait DomHelpersTrait
      */
     private function dedupeArrayRows(array $rows): array
     {
-        $seen = array();
-        $deduped = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
+        return DeterministicRowDeduplicator::dedupe($rows);
     }
 }

--- a/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/MaterializationPlanBuilder.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\StaticSite;
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
 
 final class MaterializationPlanBuilder
 {
@@ -552,17 +553,6 @@ final class MaterializationPlanBuilder
      */
     private function dedupeRows(array $rows): array
     {
-        $deduped = array();
-        $seen = array();
-        foreach ( $rows as $row ) {
-            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
-            if ( ! is_string($key) || isset($seen[$key]) ) {
-                continue;
-            }
-            $seen[$key] = true;
-            $deduped[] = $row;
-        }
-
-        return $deduped;
+        return DeterministicRowDeduplicator::dedupe($rows);
     }
 }

--- a/php-transformer/src/Support/DeterministicRowDeduplicator.php
+++ b/php-transformer/src/Support/DeterministicRowDeduplicator.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Support;
+
+final class DeterministicRowDeduplicator
+{
+    /**
+     * Retains first occurrences in input order, using JSON bytes as row identity.
+     * Rows that cannot be JSON encoded are excluded.
+     *
+     * @param array<int, mixed> $rows
+     * @return array<int, mixed>
+     */
+    public static function dedupe(array $rows): array
+    {
+        $seen = array();
+        $deduped = array();
+        foreach ( $rows as $row ) {
+            $key = json_encode($row, JSON_UNESCAPED_SLASHES);
+            if ( ! is_string($key) || isset($seen[$key]) ) {
+                continue;
+            }
+            $seen[$key] = true;
+            $deduped[] = $row;
+        }
+
+        return $deduped;
+    }
+}

--- a/php-transformer/tests/unit/deterministic-row-deduplicator.php
+++ b/php-transformer/tests/unit/deterministic-row-deduplicator.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\Support\DeterministicRowDeduplicator;
+
+$failures = 0;
+$passes = 0;
+
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, "FAIL: {$message}\n");
+};
+
+$first = array('id' => 1, 'meta' => array('labels' => array('featured', 'new')));
+$second = array('id' => 2, 'meta' => array('labels' => array('archived')));
+$assert(
+    array($first, $second) === DeterministicRowDeduplicator::dedupe(array($first, $second, $first)),
+    'duplicate associative and nested rows retain their first occurrence'
+);
+
+$third = array('id' => 3);
+$assert(
+    array($second, $first, $third) === DeterministicRowDeduplicator::dedupe(array($second, $first, $second, $third, $first)),
+    'unique rows retain input order'
+);
+
+$integerKey = array('id' => 1);
+$stringKey = array('id' => '1');
+$differentKey = array('identifier' => 1);
+$reorderedKeys = array('label' => 'same', 'id' => 1);
+$orderedKeys = array('id' => 1, 'label' => 'same');
+$assert(
+    array($integerKey, $stringKey, $differentKey, $reorderedKeys, $orderedKeys) === DeterministicRowDeduplicator::dedupe(array($integerKey, $stringKey, $differentKey, $reorderedKeys, $orderedKeys)),
+    'scalar values, associative keys, and key order remain part of JSON row identity'
+);
+
+$valid = array('id' => 'valid');
+$assert(
+    array($valid) === DeterministicRowDeduplicator::dedupe(array(array('id' => INF), $valid)),
+    'rows that fail JSON encoding are excluded'
+);
+
+if ( 0 < $failures ) {
+    exit(1);
+}
+
+echo "deterministic-row-deduplicator ok ({$passes} assertions)\n";


### PR DESCRIPTION
## Summary

- add one internal order-preserving deterministic row deduplicator
- migrate byte-equivalent report, compiler, runtime-island, and materialization callers
- define and test nested-row, ordering, key-difference, and encoding-failure behavior

Closes #739.

## Verification

- focused deterministic row deduplicator test: 4 assertions passed
- PHP syntax checks passed
- `composer validate` passed
- `git diff --check` passed

Full `composer test` remains unverified in this bare disk-constrained worktree because dependencies were intentionally not installed. The available run reached an existing Markdown contract failure rather than this focused change. The paired SSI solved-fixture gate remains required before merge.

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode general coding subagent
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Implemented the scoped deduplication primitive, migrated equivalent callers, added focused coverage, and ran available verification. Chris Huber owns and reviewed the submitted change.
