### PR TITLE
Consume bounded runtime presentation evidence

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -138,7 +138,7 @@ final class ArtifactCompiler
             ),
         );
         if (array() !== $normalized['runtime_presentation_evidence']) {
-            $sourceReports['artifact']['runtime_presentation_evidence'] = array(
+            $sourceReports['artifact']['artifact_runtime_presentation_evidence'] = array(
                 'schema' => RuntimePresentationEvidence::SCHEMA,
                 'provenance' => $normalized['runtime_presentation_provenance'],
                 'observations' => $normalized['runtime_presentation_evidence'],
@@ -471,7 +471,8 @@ final class ArtifactCompiler
             );
         }
 
-        $result = ( new HtmlTransformer() )->transform($this->safeHtmlDocumentHtml($html, $sourcePath, $files), array(
+        $htmlForTransform = $this->safeHtmlDocumentHtml($this->withRuntimePresentationEvidenceMarkers($html, $sourcePath, $runtimePresentationEvidence), $sourcePath, $files);
+        $result = ( new HtmlTransformer() )->transform($htmlForTransform, array(
             'source'                    => $sourcePath,
             'source_scope'              => $sourceScope,
             'declarative_state_html'    => $html,
@@ -482,7 +483,10 @@ final class ArtifactCompiler
             'runtime_script_metadata'   => $this->runtimeScriptMetadataForSource($html, $sourcePath, $files),
             'runtime_dom_selectors'     => $this->runtimeDomSelectors($html, $sourcePath, $files),
             'runtime_canvas_selectors'  => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
-            'runtime_presentation_evidence' => array_values(array_filter($runtimePresentationEvidence, static fn (mixed $observation): bool => is_array($observation) && $sourcePath === ($observation['element']['source_path'] ?? null))),
+            'runtime_presentation_evidence' => array_values(array_map(
+                static fn (array $observation): array => array_merge($observation, array('marker' => RuntimePresentationEvidence::marker($observation))),
+                array_filter($runtimePresentationEvidence, static fn (mixed $observation): bool => is_array($observation) && $sourcePath === ($observation['element']['source_path'] ?? null))
+            )),
             'generated_block_namespace' => $generatedBlockNamespace,
             'extract_global_shell'       => $extractGlobalShell,
         ))->toArray();
@@ -508,6 +512,44 @@ final class ArtifactCompiler
             'author_stylesheet_projections' => is_array($result['source_reports']['author_stylesheet_projections'] ?? null) ? $result['source_reports']['author_stylesheet_projections'] : array(),
             'shell_artifacts' => is_array($result['source_reports']['shell_artifacts'] ?? null) ? $result['source_reports']['shell_artifacts'] : array(),
         );
+    }
+
+    /**
+     * Bind evidence to the actual source node before conversion removes scripts,
+     * shells, or unsafe media that could otherwise change nth-of-type paths.
+     *
+     * @param array<int,array<string,mixed>> $evidence
+     */
+    private function withRuntimePresentationEvidenceMarkers(string $html, string $sourcePath, array $evidence): string
+    {
+        $observations = array_values(array_filter($evidence, static fn (mixed $observation): bool => is_array($observation) && $sourcePath === ($observation['element']['source_path'] ?? null)));
+        if (array() === $observations) return $html;
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $fullDocument = 1 === preg_match('/<(?:!doctype|html|head|body)\b/i', $html);
+        $source = $fullDocument ? '<?xml encoding="utf-8" ?>' . $html : '<?xml encoding="utf-8" ?><body>' . $html . '</body>';
+        $loaded = $document->loadHTML($source, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        $body = $loaded ? $document->getElementsByTagName('body')->item(0) : null;
+        if (!$body instanceof DOMElement) return $html;
+        foreach ($body->getElementsByTagName('*') as $element) {
+            if ($element instanceof DOMElement) $element->removeAttribute('data-blocks-engine-runtime-evidence');
+        }
+        foreach ($observations as $observation) {
+            $current = $body;
+            foreach (explode(' > ', (string) ($observation['element']['locator']['value'] ?? '')) as $part) {
+                if (!$current instanceof DOMElement || 1 !== preg_match('/^([a-z][a-z0-9-]*):nth-of-type\(([1-9][0-9]*)\)$/', $part, $match)) { $current = null; break; }
+                $found = null; $count = 0;
+                foreach ($current->childNodes as $child) if ($child instanceof DOMElement && strtolower($child->tagName) === $match[1] && ++$count === (int) $match[2]) { $found = $child; break; }
+                $current = $found;
+            }
+            if ($current instanceof DOMElement && 'img' === strtolower($current->tagName)) $current->setAttribute('data-blocks-engine-runtime-evidence', RuntimePresentationEvidence::marker($observation));
+        }
+        if ($fullDocument) return preg_replace('/^<\?xml[^>]*>\s*/', '', $document->saveHTML() ?: $html) ?? $html;
+        $result = '';
+        foreach ($body->childNodes as $child) $result .= $document->saveHTML($child);
+        return $result;
     }
 
     /**
@@ -3352,7 +3394,7 @@ final class ArtifactCompiler
 
     private function resolveHtmlReferencePath(string $reference, string $entryPath): string
     {
-        return ArtifactPath::resolveRelativePath($reference, $entryPath);
+        return ArtifactPath::resolveArtifactReference($reference, $entryPath);
     }
 
     /**

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -72,8 +72,8 @@ final class ArtifactCompiler
         $blockTypes = $this->detectBlockTypes($normalized['files'], $diagnostics);
         $companionPluginPayloadBuilder = new CompanionPluginPayload();
         $normalized['files'] = $this->withStylesheetOccurrenceAssets($html, $entryPath, $normalized['files']);
-        $entryBlocks = $this->compileEntryBlocks($html, $entryPath, $normalized['files'], $companionPluginPayloadBuilder->blockNamespace($artifact));
-        $compiledHtmlDocuments = $this->compileHtmlSourceDocuments($normalized['files'], $entryPath, $companionPluginPayloadBuilder->blockNamespace($artifact));
+        $entryBlocks = $this->compileEntryBlocks($html, $entryPath, $normalized['files'], $companionPluginPayloadBuilder->blockNamespace($artifact), $normalized['runtime_presentation_evidence']);
+        $compiledHtmlDocuments = $this->compileHtmlSourceDocuments($normalized['files'], $entryPath, $companionPluginPayloadBuilder->blockNamespace($artifact), $normalized['runtime_presentation_evidence']);
         $authorStylesheetProjections = $entryBlocks['author_stylesheet_projections'];
         $allDiagnostics = $this->entryTransformDiagnostics($entryBlocks['diagnostics'], $entryPath);
         $allFallbacks = $entryBlocks['fallbacks'];
@@ -137,6 +137,13 @@ final class ArtifactCompiler
                 'runtime_declarations' => $normalized['runtime_declarations'],
             ),
         );
+        if (array() !== $normalized['runtime_presentation_evidence']) {
+            $sourceReports['artifact']['runtime_presentation_evidence'] = array(
+                'schema' => RuntimePresentationEvidence::SCHEMA,
+                'provenance' => $normalized['runtime_presentation_provenance'],
+                'observations' => $normalized['runtime_presentation_evidence'],
+            );
+        }
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks, $entryBlocks['shell_artifacts'], $compiledHtmlDocuments);
         if ( array() !== $allGutenbergGaps ) {
             $sourceReports['gutenberg_gaps'] = $allGutenbergGaps;
@@ -404,9 +411,9 @@ final class ArtifactCompiler
      * @param array<int, array<string, mixed>> $files
      * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, gutenberg_gaps: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>, superseded_selectors: array<int, string>, author_stylesheet_projections: array<int, array<string, mixed>>, shell_artifacts: array<int, array<string, mixed>>}
      */
-    private function compileEntryBlocks(string $html, string $entryPath, array $files, string $generatedBlockNamespace = ''): array
+    private function compileEntryBlocks(string $html, string $entryPath, array $files, string $generatedBlockNamespace = '', array $runtimePresentationEvidence = array()): array
     {
-        $result = $this->compileHtmlDocumentBlocks($html, $entryPath, $files, 'artifact-entry', $generatedBlockNamespace, true);
+        $result = $this->compileHtmlDocumentBlocks($html, $entryPath, $files, 'artifact-entry', $generatedBlockNamespace, true, $runtimePresentationEvidence);
 
         return array(
             'blocks'            => $result['blocks'],
@@ -428,7 +435,7 @@ final class ArtifactCompiler
      * @param array<int, array<string, mixed>> $files
      * @return array{blocks: array<int, array<string, mixed>>, serialized_blocks: string, diagnostics: array<int, array<string, mixed>>, fallbacks: array<int, array<string, mixed>>, assets: array<int, array<string, mixed>>, runtime_islands: array<int, array<string, mixed>>, generated_blocks: array<int, array<string, mixed>>, gutenberg_gaps: array<int, array<string, mixed>>, interaction_candidates: array<int, array<string, mixed>>, superseded_selectors: array<int, string>, author_stylesheet_projections: array<int, array<string, mixed>>, shell_artifacts: array<int, array<string, mixed>>}
      */
-    private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope, string $generatedBlockNamespace = '', bool $extractGlobalShell = false): array
+    private function compileHtmlDocumentBlocks(string $html, string $sourcePath, array $files, string $sourceScope, string $generatedBlockNamespace = '', bool $extractGlobalShell = false, array $runtimePresentationEvidence = array()): array
     {
         if ( $this->containsBlockMarkup($html) ) {
             return array(
@@ -475,6 +482,7 @@ final class ArtifactCompiler
             'runtime_script_metadata'   => $this->runtimeScriptMetadataForSource($html, $sourcePath, $files),
             'runtime_dom_selectors'     => $this->runtimeDomSelectors($html, $sourcePath, $files),
             'runtime_canvas_selectors'  => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
+            'runtime_presentation_evidence' => array_values(array_filter($runtimePresentationEvidence, static fn (mixed $observation): bool => is_array($observation) && $sourcePath === ($observation['element']['source_path'] ?? null))),
             'generated_block_namespace' => $generatedBlockNamespace,
             'extract_global_shell'       => $extractGlobalShell,
         ))->toArray();
@@ -1068,7 +1076,7 @@ final class ArtifactCompiler
      * @param array<int, array<string, mixed>> $files
      * @return array<string, array<string, mixed>>
      */
-    private function compileHtmlSourceDocuments(array $files, string $entryPath, string $generatedBlockNamespace = ''): array
+    private function compileHtmlSourceDocuments(array $files, string $entryPath, string $generatedBlockNamespace = '', array $runtimePresentationEvidence = array()): array
     {
         $documents = array();
         foreach ( $files as $file ) {
@@ -1079,7 +1087,7 @@ final class ArtifactCompiler
             if ( '' === $path || $entryPath === $path ) {
                 continue;
             }
-            $documents[$path] = $this->compileHtmlDocumentBlocks((string) ($file['content'] ?? ''), $path, $files, 'artifact-document', $generatedBlockNamespace, true);
+            $documents[$path] = $this->compileHtmlDocumentBlocks((string) ($file['content'] ?? ''), $path, $files, 'artifact-document', $generatedBlockNamespace, true, $runtimePresentationEvidence);
         }
         return $documents;
     }
@@ -2594,6 +2602,7 @@ final class ArtifactCompiler
                 'url'       => $path,
                 'path'      => $path,
                 'mime_type' => $mimeType,
+                'hash'      => (string) ($file['provenance']['hash'] ?? ''),
             );
 
             foreach ( $this->assetLookupKeysForSource($path, $sourcePath) as $key ) {

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -164,7 +164,7 @@ final class ArtifactNormalizer
             'rejected_count' => $rejected,
             'bytes'          => $bytes,
             'entrypoints'    => array_values(array_unique($safeEntrypoints)),
-            'hash_payload'   => $this->fileHashPayload($files) . "\n" . RuntimeDeclarations::canonicalJson($runtimeDeclarations) . (array_key_exists('runtime_presentation_evidence', $artifact) ? "\n" . RuntimeDeclarations::canonicalJson(array('schema' => RuntimePresentationEvidence::SCHEMA, 'provenance' => $presentationEvidence['provenance'], 'observations' => $presentationEvidence['observations'])) : ''),
+            'hash_payload'   => $this->fileHashPayload($files) . "\n" . RuntimeDeclarations::canonicalJson($runtimeDeclarations) . (array_key_exists('artifact_runtime_presentation_evidence', $artifact) ? "\n" . RuntimeDeclarations::canonicalJson(array('schema' => RuntimePresentationEvidence::SCHEMA, 'provenance' => $presentationEvidence['provenance'], 'observations' => $presentationEvidence['observations'])) : ''),
             'runtime_declarations' => $runtimeDeclarations,
             'runtime_presentation_evidence' => $presentationEvidence['observations'],
             'runtime_presentation_provenance' => $presentationEvidence['provenance'],
@@ -475,6 +475,9 @@ final class ArtifactNormalizer
     private function mimeType(string $mimeType, string $path): string
     {
         $mimeType = strtolower(trim($mimeType));
+        if ( in_array($mimeType, array('application/octet-stream', 'binary/octet-stream'), true) ) {
+            $mimeType = '';
+        }
         if ( preg_match('#^[a-z0-9.+-]+/[a-z0-9.+-]+$#', $mimeType) ) {
             return $mimeType;
         }

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -18,7 +18,7 @@ final class ArtifactNormalizer
 
     /**
      * @param array<string, mixed> $artifact
-     * @return array{files: array<int, array<string, mixed>>, diagnostics: array<int, array<string, mixed>>, rejected_count: int, bytes: int, entrypoints: array<int, string>, hash_payload: string, runtime_declarations: array<int,array<string,mixed>>}
+     * @return array{files: array<int, array<string, mixed>>, diagnostics: array<int, array<string, mixed>>, rejected_count: int, bytes: int, entrypoints: array<int, string>, hash_payload: string, runtime_declarations: array<int,array<string,mixed>>, runtime_presentation_evidence:array<int,array<string,mixed>>,runtime_presentation_provenance:array<string,mixed>}
      */
     public function normalize(array $artifact): array
     {
@@ -155,14 +155,19 @@ final class ArtifactNormalizer
         }
 
         $runtimeDeclarations = RuntimeDeclarations::bindAssetPublications($runtimeDeclarations, $files);
+        $presentationEvidence = RuntimePresentationEvidence::normalize($artifact, $files);
+        $diagnostics = array_merge($diagnostics, $presentationEvidence['diagnostics']);
+        $rejected += $presentationEvidence['rejected_count'];
         return array(
             'files'          => $files,
             'diagnostics'    => $this->dedupeDiagnostics($diagnostics),
             'rejected_count' => $rejected,
             'bytes'          => $bytes,
             'entrypoints'    => array_values(array_unique($safeEntrypoints)),
-            'hash_payload'   => $this->fileHashPayload($files) . "\n" . RuntimeDeclarations::canonicalJson($runtimeDeclarations),
+            'hash_payload'   => $this->fileHashPayload($files) . "\n" . RuntimeDeclarations::canonicalJson($runtimeDeclarations) . (array_key_exists('runtime_presentation_evidence', $artifact) ? "\n" . RuntimeDeclarations::canonicalJson(array('schema' => RuntimePresentationEvidence::SCHEMA, 'provenance' => $presentationEvidence['provenance'], 'observations' => $presentationEvidence['observations'])) : ''),
             'runtime_declarations' => $runtimeDeclarations,
+            'runtime_presentation_evidence' => $presentationEvidence['observations'],
+            'runtime_presentation_provenance' => $presentationEvidence['provenance'],
         );
     }
 

--- a/php-transformer/src/ArtifactCompiler/RuntimePresentationEvidence.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimePresentationEvidence.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
+
+/** Validates optional browser-collected media presentation observations. */
+final class RuntimePresentationEvidence
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/runtime-presentation-evidence/v1';
+    private const MAX_OBSERVATIONS = 100;
+
+    /**
+     * @param array<string,mixed> $artifact
+     * @param array<int,array<string,mixed>> $files
+     * @return array{provenance:array<string,mixed>,observations:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,rejected_count:int}
+     */
+    public static function normalize(array $artifact, array $files): array
+    {
+        $raw = $artifact['runtime_presentation_evidence'] ?? null;
+        if (null === $raw) return array('provenance' => array(), 'observations' => array(), 'diagnostics' => array(), 'rejected_count' => 0);
+        if (!is_array($raw) || self::SCHEMA !== ($raw['schema'] ?? null) || !self::provenance($raw['provenance'] ?? null) || !is_array($raw['observations'] ?? null) || !array_is_list($raw['observations']) || count($raw['observations']) > self::MAX_OBSERVATIONS) {
+            return array('provenance' => array(), 'observations' => array(), 'diagnostics' => array(self::diagnostic('runtime_presentation_evidence_invalid_envelope', array())), 'rejected_count' => 1);
+        }
+
+        $htmlPaths = array();
+        $imageHashes = array();
+        foreach ($files as $file) {
+            if (!is_array($file)) continue;
+            if ('html' === ($file['kind'] ?? '') && is_string($file['path'] ?? null)) $htmlPaths[$file['path']] = true;
+            if (str_starts_with((string) ($file['mime_type'] ?? ''), 'image/') && is_string($file['provenance']['hash'] ?? null)) $imageHashes[$file['provenance']['hash']] = true;
+        }
+
+        $observations = array(); $diagnostics = array(); $rejected = 0; $seen = array();
+        foreach ($raw['observations'] as $index => $observation) {
+            $normalized = self::observation($observation);
+            if (null === $normalized) {
+                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_invalid_observation', array('index' => $index)); continue;
+            }
+            if (!isset($htmlPaths[$normalized['element']['source_path']])) {
+                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_unknown_source', array('index' => $index, 'source_path' => $normalized['element']['source_path'])); continue;
+            }
+            if (!isset($imageHashes[$normalized['asset_hash']])) {
+                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_asset_hash_mismatch', array('index' => $index, 'asset_hash' => $normalized['asset_hash'])); continue;
+            }
+            $key = $normalized['element']['source_path'] . "\n" . $normalized['element']['selector'];
+            if (isset($seen[$key])) {
+                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_duplicate_observation', array('index' => $index)); continue;
+            }
+            $seen[$key] = true; $observations[] = $normalized;
+        }
+        usort($observations, static fn(array $left, array $right): int => strcmp($left['element']['source_path'] . "\n" . $left['element']['selector'], $right['element']['source_path'] . "\n" . $right['element']['selector']));
+        return array('provenance' => self::normalizedProvenance($raw['provenance']), 'observations' => $observations, 'diagnostics' => $diagnostics, 'rejected_count' => $rejected);
+    }
+
+    private static function provenance(mixed $value): bool
+    {
+        if (!is_array($value) || !is_array($value['browser'] ?? null) || !is_array($value['viewport'] ?? null) || !is_array($value['lifecycle'] ?? null)) return false;
+        return self::text($value['browser']['name'] ?? null, 128) && self::text($value['browser']['version'] ?? null, 128)
+            && self::positive($value['viewport']['width'] ?? null) && self::positive($value['viewport']['height'] ?? null) && self::positive($value['viewport']['device_scale_factor'] ?? null)
+            && self::text($value['lifecycle']['phase'] ?? null, 128);
+    }
+
+    /** @param array<string,mixed> $value @return array<string,mixed> */
+    private static function normalizedProvenance(array $value): array
+    {
+        return array(
+            'browser' => array('name' => $value['browser']['name'], 'version' => $value['browser']['version']),
+            'viewport' => array('width' => $value['viewport']['width'], 'height' => $value['viewport']['height'], 'device_scale_factor' => $value['viewport']['device_scale_factor']),
+            'lifecycle' => array('phase' => $value['lifecycle']['phase']),
+        );
+    }
+
+    /** @return array<string,mixed>|null */
+    private static function observation(mixed $value): ?array
+    {
+        if (!is_array($value) || !is_array($value['element'] ?? null) || !self::text($value['element']['source_path'] ?? null, 1024) || !self::text($value['element']['selector'] ?? null, 2048) || !is_string($value['asset_hash'] ?? null) || 1 !== preg_match('/^[a-f0-9]{64}$/', $value['asset_hash']) || !self::dimensions($value['intrinsic'] ?? null) || !self::dimensions($value['rendered'] ?? null) || !self::transform($value['transform'] ?? null) || !self::clip($value['clip'] ?? null)) return null;
+        return array(
+            'element' => array('source_path' => $value['element']['source_path'], 'selector' => $value['element']['selector']),
+            'asset_hash' => $value['asset_hash'],
+            'intrinsic' => self::numbers($value['intrinsic'], array('width', 'height')),
+            'rendered' => self::numbers($value['rendered'], array('width', 'height')),
+            'transform' => array('matrix' => array_values($value['transform']['matrix']), 'origin' => self::numbers($value['transform']['origin'], array('x', 'y'))),
+            'clip' => self::numbers($value['clip'], array('x', 'y', 'width', 'height')),
+        );
+    }
+
+    private static function dimensions(mixed $value): bool { return is_array($value) && self::positive($value['width'] ?? null) && self::positive($value['height'] ?? null); }
+    private static function clip(mixed $value): bool { return is_array($value) && self::number($value['x'] ?? null) && self::number($value['y'] ?? null) && self::positive($value['width'] ?? null) && self::positive($value['height'] ?? null); }
+    private static function transform(mixed $value): bool { if (!is_array($value) || !is_array($value['matrix'] ?? null) || 6 !== count($value['matrix']) || !is_array($value['origin'] ?? null)) return false; foreach ($value['matrix'] as $number) if (!self::number($number)) return false; return self::number($value['origin']['x'] ?? null) && self::number($value['origin']['y'] ?? null); }
+    private static function text(mixed $value, int $max): bool { return is_string($value) && '' !== trim($value) && strlen($value) <= $max && !preg_match('/[\x00-\x1f\x7f]/', $value); }
+    private static function number(mixed $value): bool { return (is_int($value) || is_float($value)) && is_finite((float) $value); }
+    private static function positive(mixed $value): bool { return self::number($value) && (float) $value > 0; }
+    /** @param array<string,mixed> $value @param array<int,string> $keys @return array<string,int|float> */
+    private static function numbers(array $value, array $keys): array { $result = array(); foreach ($keys as $key) $result[$key] = $value[$key]; return $result; }
+    /** @param array<string,mixed> $context @return array<string,mixed> */
+    private static function diagnostic(string $code, array $context): array { return array('code' => $code, 'severity' => 'warning', 'message' => 'Runtime presentation evidence was ignored because its browser provenance or artifact binding could not be verified.', 'source' => ArtifactCompiler::class, 'context' => $context); }
+}

--- a/php-transformer/src/ArtifactCompiler/RuntimePresentationEvidence.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimePresentationEvidence.php
@@ -3,61 +3,48 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
-/** Validates optional browser-collected media presentation observations. */
+use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
+
+/** Validates optional, artifact-bound browser presentation observations. */
 final class RuntimePresentationEvidence
 {
-    public const SCHEMA = 'blocks-engine/php-transformer/runtime-presentation-evidence/v1';
-    private const MAX_OBSERVATIONS = 100;
+    public const SCHEMA = 'blocks-engine/artifact-runtime-presentation-evidence/v1';
+    private const MAX_OBSERVATIONS = 32;
+    private const MAX_NUMBER = 1000000;
 
-    /**
-     * @param array<string,mixed> $artifact
-     * @param array<int,array<string,mixed>> $files
-     * @return array{provenance:array<string,mixed>,observations:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,rejected_count:int}
-     */
+    /** @param array<string,mixed> $artifact @param array<int,array<string,mixed>> $files @return array{provenance:array<string,mixed>,observations:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,rejected_count:int} */
     public static function normalize(array $artifact, array $files): array
     {
-        $raw = $artifact['runtime_presentation_evidence'] ?? null;
+        $raw = $artifact['artifact_runtime_presentation_evidence'] ?? null;
         if (null === $raw) return array('provenance' => array(), 'observations' => array(), 'diagnostics' => array(), 'rejected_count' => 0);
-        if (!is_array($raw) || self::SCHEMA !== ($raw['schema'] ?? null) || !self::provenance($raw['provenance'] ?? null) || !is_array($raw['observations'] ?? null) || !array_is_list($raw['observations']) || count($raw['observations']) > self::MAX_OBSERVATIONS) {
-            return array('provenance' => array(), 'observations' => array(), 'diagnostics' => array(self::diagnostic('runtime_presentation_evidence_invalid_envelope', array())), 'rejected_count' => 1);
-        }
+        if (!is_array($raw) || !self::keys($raw, array('schema', 'provenance', 'observations')) || self::SCHEMA !== ($raw['schema'] ?? null) || !self::provenance($raw['provenance'] ?? null) || !is_array($raw['observations'] ?? null) || !array_is_list($raw['observations']) || count($raw['observations']) > self::MAX_OBSERVATIONS) return self::rejected('artifact_runtime_presentation_evidence_invalid_envelope');
 
-        $htmlPaths = array();
-        $imageHashes = array();
+        $html = array(); $images = array();
         foreach ($files as $file) {
             if (!is_array($file)) continue;
-            if ('html' === ($file['kind'] ?? '') && is_string($file['path'] ?? null)) $htmlPaths[$file['path']] = true;
-            if (str_starts_with((string) ($file['mime_type'] ?? ''), 'image/') && is_string($file['provenance']['hash'] ?? null)) $imageHashes[$file['provenance']['hash']] = true;
+            if ('html' === ($file['kind'] ?? '') && is_string($file['path'] ?? null)) $html[$file['path']] = (string) ($file['content'] ?? '');
+            if (str_starts_with((string) ($file['mime_type'] ?? ''), 'image/') && is_string($file['path'] ?? null)) $images[$file['path']] = (string) ($file['provenance']['hash'] ?? '');
         }
-
-        $observations = array(); $diagnostics = array(); $rejected = 0; $seen = array();
-        foreach ($raw['observations'] as $index => $observation) {
-            $normalized = self::observation($observation);
-            if (null === $normalized) {
-                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_invalid_observation', array('index' => $index)); continue;
-            }
-            if (!isset($htmlPaths[$normalized['element']['source_path']])) {
-                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_unknown_source', array('index' => $index, 'source_path' => $normalized['element']['source_path'])); continue;
-            }
-            if (!isset($imageHashes[$normalized['asset_hash']])) {
-                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_asset_hash_mismatch', array('index' => $index, 'asset_hash' => $normalized['asset_hash'])); continue;
-            }
-            $key = $normalized['element']['source_path'] . "\n" . $normalized['element']['selector'];
-            if (isset($seen[$key])) {
-                ++$rejected; $diagnostics[] = self::diagnostic('runtime_presentation_evidence_duplicate_observation', array('index' => $index)); continue;
-            }
-            $seen[$key] = true; $observations[] = $normalized;
+        $observations = array(); $diagnostics = array(); $seen = array(); $rejected = 0;
+        foreach ($raw['observations'] as $index => $row) {
+            $observation = self::observation($row);
+            if (null === $observation) { ++$rejected; $diagnostics[] = self::diagnostic('artifact_runtime_presentation_evidence_invalid_observation', array('index' => $index)); continue; }
+            $path = $observation['element']['source_path'];
+            if (!isset($html[$path]) || !hash_equals($observation['source_hash'], hash('sha256', $html[$path]))) { ++$rejected; $diagnostics[] = self::diagnostic('artifact_runtime_presentation_evidence_source_hash_mismatch', array('index' => $index, 'source_path' => $path)); continue; }
+            $assetPath = self::resolvedImageSource($html[$path], $observation['element']['locator']['value'], $path);
+            if (null === $assetPath) { ++$rejected; $diagnostics[] = self::diagnostic('artifact_runtime_presentation_evidence_locator_mismatch', array('index' => $index, 'source_path' => $path)); continue; }
+            if ($assetPath !== $observation['asset']['path'] || !isset($images[$assetPath]) || !hash_equals($observation['asset']['hash'], $images[$assetPath])) { ++$rejected; $diagnostics[] = self::diagnostic('artifact_runtime_presentation_evidence_asset_mismatch', array('index' => $index, 'asset_path' => $observation['asset']['path'])); continue; }
+            $key = $path . "\n" . $observation['element']['locator']['value'];
+            if (isset($seen[$key])) { ++$rejected; $diagnostics[] = self::diagnostic('artifact_runtime_presentation_evidence_duplicate_observation', array('index' => $index)); continue; }
+            $seen[$key] = true; $observations[] = $observation;
         }
-        usort($observations, static fn(array $left, array $right): int => strcmp($left['element']['source_path'] . "\n" . $left['element']['selector'], $right['element']['source_path'] . "\n" . $right['element']['selector']));
+        usort($observations, static fn(array $a, array $b): int => strcmp($a['element']['source_path'] . "\n" . $a['element']['locator']['value'], $b['element']['source_path'] . "\n" . $b['element']['locator']['value']));
         return array('provenance' => self::normalizedProvenance($raw['provenance']), 'observations' => $observations, 'diagnostics' => $diagnostics, 'rejected_count' => $rejected);
     }
 
     private static function provenance(mixed $value): bool
     {
-        if (!is_array($value) || !is_array($value['browser'] ?? null) || !is_array($value['viewport'] ?? null) || !is_array($value['lifecycle'] ?? null)) return false;
-        return self::text($value['browser']['name'] ?? null, 128) && self::text($value['browser']['version'] ?? null, 128)
-            && self::positive($value['viewport']['width'] ?? null) && self::positive($value['viewport']['height'] ?? null) && self::positive($value['viewport']['device_scale_factor'] ?? null)
-            && self::text($value['lifecycle']['phase'] ?? null, 128);
+        return is_array($value) && self::keys($value, array('browser', 'viewport', 'readiness')) && is_array($value['browser'] ?? null) && self::keys($value['browser'], array('name', 'version')) && self::text($value['browser']['name'] ?? null, 128) && self::text($value['browser']['version'] ?? null, 128) && is_array($value['viewport'] ?? null) && self::keys($value['viewport'], array('width', 'height', 'device_scale_factor')) && self::positive($value['viewport']['width'] ?? null) && self::positive($value['viewport']['height'] ?? null) && self::positive($value['viewport']['device_scale_factor'] ?? null) && is_array($value['readiness'] ?? null) && self::keys($value['readiness'], array('document', 'images')) && 'complete' === ($value['readiness']['document'] ?? null) && 'complete' === ($value['readiness']['images'] ?? null);
     }
 
     /** @param array<string,mixed> $value @return array<string,mixed> */
@@ -66,32 +53,60 @@ final class RuntimePresentationEvidence
         return array(
             'browser' => array('name' => $value['browser']['name'], 'version' => $value['browser']['version']),
             'viewport' => array('width' => $value['viewport']['width'], 'height' => $value['viewport']['height'], 'device_scale_factor' => $value['viewport']['device_scale_factor']),
-            'lifecycle' => array('phase' => $value['lifecycle']['phase']),
+            'readiness' => array('document' => $value['readiness']['document'], 'images' => $value['readiness']['images']),
         );
     }
 
     /** @return array<string,mixed>|null */
     private static function observation(mixed $value): ?array
     {
-        if (!is_array($value) || !is_array($value['element'] ?? null) || !self::text($value['element']['source_path'] ?? null, 1024) || !self::text($value['element']['selector'] ?? null, 2048) || !is_string($value['asset_hash'] ?? null) || 1 !== preg_match('/^[a-f0-9]{64}$/', $value['asset_hash']) || !self::dimensions($value['intrinsic'] ?? null) || !self::dimensions($value['rendered'] ?? null) || !self::transform($value['transform'] ?? null) || !self::clip($value['clip'] ?? null)) return null;
+        if (!is_array($value) || !self::keys($value, array('element', 'source_hash', 'asset', 'intrinsic', 'rendered', 'transform', 'clip')) || !is_array($value['element'] ?? null) || !self::keys($value['element'], array('source_path', 'locator')) || !self::text($value['element']['source_path'] ?? null, 512) || !is_array($value['element']['locator'] ?? null) || !self::keys($value['element']['locator'], array('kind', 'value')) || 'css-nth-of-type-body-path/v1' !== ($value['element']['locator']['kind'] ?? null) || !self::locator($value['element']['locator']['value'] ?? null) || !self::hash($value['source_hash'] ?? null) || !is_array($value['asset'] ?? null) || !self::keys($value['asset'], array('path', 'hash')) || !self::text($value['asset']['path'] ?? null, 512) || !self::hash($value['asset']['hash'] ?? null) || !self::dimensions($value['intrinsic'] ?? null) || !self::dimensions($value['rendered'] ?? null) || !self::transform($value['transform'] ?? null) || !self::clip($value['clip'] ?? null)) return null;
+        if ((float) $value['clip']['x'] < 0 || (float) $value['clip']['y'] < 0 || (float) $value['clip']['x'] + (float) $value['clip']['width'] > (float) $value['rendered']['width'] || (float) $value['clip']['y'] + (float) $value['clip']['height'] > (float) $value['rendered']['height']) return null;
+        $matrix = $value['transform']['matrix'];
+        // Geometry replay has one defined coordinate system: an unrotated image
+        // scaled on each axis, then translated within its clipped figure.
+        if (0.0 !== (float) $matrix[1] || 0.0 !== (float) $matrix[2] || (float) $matrix[0] <= 0 || (float) $matrix[3] <= 0) return null;
         return array(
-            'element' => array('source_path' => $value['element']['source_path'], 'selector' => $value['element']['selector']),
-            'asset_hash' => $value['asset_hash'],
-            'intrinsic' => self::numbers($value['intrinsic'], array('width', 'height')),
-            'rendered' => self::numbers($value['rendered'], array('width', 'height')),
-            'transform' => array('matrix' => array_values($value['transform']['matrix']), 'origin' => self::numbers($value['transform']['origin'], array('x', 'y'))),
-            'clip' => self::numbers($value['clip'], array('x', 'y', 'width', 'height')),
+            'element' => array('source_path' => $value['element']['source_path'], 'locator' => array('kind' => $value['element']['locator']['kind'], 'value' => $value['element']['locator']['value'])),
+            'source_hash' => $value['source_hash'],
+            'asset' => array('path' => $value['asset']['path'], 'hash' => $value['asset']['hash']),
+            'intrinsic' => array('width' => $value['intrinsic']['width'], 'height' => $value['intrinsic']['height']),
+            'rendered' => array('width' => $value['rendered']['width'], 'height' => $value['rendered']['height']),
+            'transform' => array('matrix' => array_values($matrix), 'origin' => array('x' => $value['transform']['origin']['x'], 'y' => $value['transform']['origin']['y'])),
+            'clip' => array('x' => $value['clip']['x'], 'y' => $value['clip']['y'], 'width' => $value['clip']['width'], 'height' => $value['clip']['height']),
         );
     }
 
-    private static function dimensions(mixed $value): bool { return is_array($value) && self::positive($value['width'] ?? null) && self::positive($value['height'] ?? null); }
-    private static function clip(mixed $value): bool { return is_array($value) && self::number($value['x'] ?? null) && self::number($value['y'] ?? null) && self::positive($value['width'] ?? null) && self::positive($value['height'] ?? null); }
-    private static function transform(mixed $value): bool { if (!is_array($value) || !is_array($value['matrix'] ?? null) || 6 !== count($value['matrix']) || !is_array($value['origin'] ?? null)) return false; foreach ($value['matrix'] as $number) if (!self::number($number)) return false; return self::number($value['origin']['x'] ?? null) && self::number($value['origin']['y'] ?? null); }
+    private static function dimensions(mixed $value): bool { return is_array($value) && self::keys($value, array('width', 'height')) && self::positive($value['width'] ?? null) && self::positive($value['height'] ?? null); }
+    private static function clip(mixed $value): bool { return is_array($value) && self::keys($value, array('x', 'y', 'width', 'height')) && self::number($value['x'] ?? null) && self::number($value['y'] ?? null) && self::positive($value['width'] ?? null) && self::positive($value['height'] ?? null); }
+    private static function transform(mixed $value): bool { if (!is_array($value) || !self::keys($value, array('matrix', 'origin')) || !is_array($value['matrix'] ?? null) || !array_is_list($value['matrix']) || 6 !== count($value['matrix']) || !is_array($value['origin'] ?? null) || !self::keys($value['origin'], array('x', 'y'))) return false; foreach ($value['matrix'] as $number) if (!self::number($number)) return false; return self::number($value['origin']['x'] ?? null) && self::number($value['origin']['y'] ?? null); }
+    private static function hash(mixed $value): bool { return is_string($value) && 1 === preg_match('/^[a-f0-9]{64}$/', $value); }
     private static function text(mixed $value, int $max): bool { return is_string($value) && '' !== trim($value) && strlen($value) <= $max && !preg_match('/[\x00-\x1f\x7f]/', $value); }
-    private static function number(mixed $value): bool { return (is_int($value) || is_float($value)) && is_finite((float) $value); }
+    private static function number(mixed $value): bool { return (is_int($value) || is_float($value)) && is_finite((float) $value) && abs((float) $value) <= self::MAX_NUMBER; }
     private static function positive(mixed $value): bool { return self::number($value) && (float) $value > 0; }
-    /** @param array<string,mixed> $value @param array<int,string> $keys @return array<string,int|float> */
-    private static function numbers(array $value, array $keys): array { $result = array(); foreach ($keys as $key) $result[$key] = $value[$key]; return $result; }
+    private static function locator(mixed $value): bool { return self::text($value, 2048) && 1 === preg_match('/^(?:[a-z][a-z0-9-]*:nth-of-type\([1-9][0-9]*\) > )*img:nth-of-type\([1-9][0-9]*\)$/', $value); }
+    /** @param array<string,mixed> $value @param array<int,string> $keys */
+    private static function keys(array $value, array $keys): bool { sort($keys); $actual = array_keys($value); sort($actual); return $keys === $actual; }
+
+    private static function resolvedImageSource(string $html, string $locator, string $sourcePath): ?string
+    {
+        $document = new \DOMDocument(); $previous = libxml_use_internal_errors(true);
+        $documentSource = preg_match('/<(?:!doctype|html|head|body)\b/i', $html) ? '<?xml encoding="utf-8" ?>' . $html : '<?xml encoding="utf-8" ?><body>' . $html . '</body>';
+        $loaded = $document->loadHTML($documentSource, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD); libxml_clear_errors(); libxml_use_internal_errors($previous); if (!$loaded) return null;
+        $current = $document->getElementsByTagName('body')->item(0);
+        foreach (explode(' > ', $locator) as $part) { if (!$current instanceof \DOMElement || 1 !== preg_match('/^([a-z][a-z0-9-]*):nth-of-type\(([1-9][0-9]*)\)$/', $part, $match)) return null; $found = null; $count = 0; foreach ($current->childNodes as $child) if ($child instanceof \DOMElement && strtolower($child->tagName) === $match[1] && ++$count === (int) $match[2]) { $found = $child; break; } $current = $found; }
+        if (!$current instanceof \DOMElement || 'img' !== strtolower($current->tagName) || !$current->hasAttribute('src')) return null;
+        return ArtifactPath::resolveArtifactReference($current->getAttribute('src'), $sourcePath) ?: null;
+    }
+
+    /** @param array<string,mixed> $observation */
+    public static function marker(array $observation): string
+    {
+        return 'be-runtime-evidence-' . substr(hash('sha256', RuntimeDeclarations::canonicalJson($observation)), 0, 24);
+    }
+
+    /** @return array{provenance:array<string,mixed>,observations:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,rejected_count:int} */
+    private static function rejected(string $code): array { return array('provenance' => array(), 'observations' => array(), 'diagnostics' => array(self::diagnostic($code, array())), 'rejected_count' => 1); }
     /** @param array<string,mixed> $context @return array<string,mixed> */
-    private static function diagnostic(string $code, array $context): array { return array('code' => $code, 'severity' => 'warning', 'message' => 'Runtime presentation evidence was ignored because its browser provenance or artifact binding could not be verified.', 'source' => ArtifactCompiler::class, 'context' => $context); }
+    private static function diagnostic(string $code, array $context): array { return array('code' => $code, 'severity' => 'warning', 'message' => 'Artifact runtime presentation evidence was ignored because its bounded provenance or exact artifact binding could not be verified.', 'source' => ArtifactCompiler::class, 'context' => $context); }
 }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1488,9 +1488,9 @@ final class HtmlTransformer
     {
         foreach ($matches as $image) {
             if ('img' !== strtolower($image->tagName)) continue;
-            $observation = $this->runtimePresentationEvidence[$this->elementSelector($image)] ?? null;
+            $observation = $this->runtimePresentationEvidence[$this->attr($image, 'data-blocks-engine-runtime-evidence')] ?? null;
             $asset = $this->assetMetadataForUrl($this->safeImageUrl($this->attr($image, 'src')));
-            if (!is_array($observation) || !is_array($asset) || ($observation['asset_hash'] ?? null) !== ($asset['hash'] ?? null)) continue;
+            if (!is_array($observation) || !is_array($asset) || ($observation['asset']['hash'] ?? null) !== ($asset['hash'] ?? null)) continue;
             $clip = $observation['clip'] ?? array(); $rendered = $observation['rendered'] ?? array();
             if (($clip['width'] ?? 0) < ($rendered['width'] ?? 0) || ($clip['height'] ?? 0) < ($rendered['height'] ?? 0)) return true;
         }
@@ -10034,6 +10034,10 @@ final class HtmlTransformer
 
         $attrs = array_filter(array_merge($attrs, $this->imageIdentityAttributes($image, $figure)), static fn ($value): bool => '' !== $value);
         $attrs = array_filter(array_merge($attrs, $this->assetMetadataImageAttributes($originalUrl)), static fn ($value): bool => '' !== $value);
+        $evidenceClass = $this->runtimePresentationGeometryClass($image);
+        if ('' !== $evidenceClass) {
+            $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $evidenceClass);
+        }
 
         if ( $figure instanceof DOMElement ) {
             $caption = $this->firstChildElement($figure, 'figcaption');
@@ -10553,11 +10557,30 @@ final class HtmlTransformer
         $evidence = array();
         if (!is_array($options['runtime_presentation_evidence'] ?? null)) return $evidence;
         foreach ($options['runtime_presentation_evidence'] as $observation) {
-            if (!is_array($observation) || !is_string($observation['element']['selector'] ?? null) || !is_string($observation['asset_hash'] ?? null) || !is_array($observation['clip'] ?? null) || !is_array($observation['rendered'] ?? null)) continue;
-            $evidence[$observation['element']['selector']] = $observation;
+            if (!is_array($observation) || !is_string($observation['marker'] ?? null) || !is_array($observation['asset'] ?? null) || !is_array($observation['clip'] ?? null) || !is_array($observation['rendered'] ?? null)) continue;
+            $evidence[$observation['marker']] = $observation;
         }
         ksort($evidence, SORT_STRING);
         return $evidence;
+    }
+
+    private function runtimePresentationGeometryClass(DOMElement $image): string
+    {
+        $observation = $this->runtimePresentationEvidence[$this->attr($image, 'data-blocks-engine-runtime-evidence')] ?? null;
+        $asset = $this->assetMetadataForUrl($this->safeImageUrl($this->attr($image, 'src')));
+        if (!is_array($observation) || !is_array($asset) || ($observation['asset']['hash'] ?? null) !== ($asset['hash'] ?? null)) return '';
+        $clip = $observation['clip']; $rendered = $observation['rendered']; $transform = $observation['transform'];
+        $number = static fn (int|float $value): string => rtrim(rtrim(sprintf('%.10F', $value), '0'), '.') ?: '0';
+        $class = 'be-runtime-evidence-' . substr(hash('sha256', $observation['marker']), 0, 16);
+        [$scaleX, , , $scaleY, $translateX, $translateY] = $transform['matrix'];
+        $width = $rendered['width'] / $scaleX;
+        $height = $rendered['height'] / $scaleY;
+        $left = -$clip['x'] - $translateX - $transform['origin']['x'] * (1 - $scaleX);
+        $top = -$clip['y'] - $translateY - $transform['origin']['y'] * (1 - $scaleY);
+        $matrix = implode(',', array_map($number, $transform['matrix']));
+        $this->generatedGeometryRules[$class] = '.' . $class . '{overflow:hidden!important;position:relative!important;width:' . $number($clip['width']) . 'px!important;height:' . $number($clip['height']) . 'px!important}'
+            . "\n" . '.' . $class . ' img{position:relative!important;left:' . $number($left) . 'px!important;top:' . $number($top) . 'px!important;width:' . $number($width) . 'px!important;height:' . $number($height) . 'px!important;max-width:none!important;transform:matrix(' . $matrix . ')!important;transform-origin:' . $number($transform['origin']['x']) . 'px ' . $number($transform['origin']['y']) . 'px!important}';
+        return $class;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -308,6 +308,9 @@ final class HtmlTransformer
      */
     private array $assetMetadata = array();
 
+    /** @var array<string,array<string,mixed>> Accepted browser observations keyed by source selector. */
+    private array $runtimePresentationEvidence = array();
+
     /**
      * @var array<string, array<string, mixed>>
      */
@@ -509,6 +512,7 @@ final class HtmlTransformer
         $this->fallbackEmitter->resetGeneratedBlocks();
         $this->runtimeScriptMetadata = $this->runtimeScriptMetadataFromOptions($options);
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
+        $this->runtimePresentationEvidence = $this->runtimePresentationEvidenceFromOptions($options);
         $this->generatedAssets = array();
         $this->nativeSearchTriggerCssRules = array();
         $this->nativeButtonStyleRules = array();
@@ -700,6 +704,7 @@ final class HtmlTransformer
             'semantic_parity' => $semanticParityReport,
             'content_round_trip' => $contentRoundTripReport,
             'html' => array(
+                'runtime_presentation_evidence' => array_values($this->runtimePresentationEvidence),
                 'presentation_signals' => $this->presentationProvenance,
                 'frozen_hidden_state'  => $this->frozenHiddenStateFindings,
                 'dropped_link_wrappers' => $this->droppedLinkWrapperFindings,
@@ -1171,7 +1176,7 @@ final class HtmlTransformer
             $imagePrelude = $this->projectAuthorImageSelectorPrelude($prelude);
             $imageRule = '' === $imagePrelude
                 ? ''
-                : $imagePrelude . '{' . $this->imageProjectionBridgeDeclarations($declarations) . '}';
+                : $imagePrelude . '{' . $this->imageProjectionBridgeDeclarations($declarations, $this->matchingAuthorSourceElements($prelude, $this->parsedCssSelector($prelude))) . '}';
             if ( array() === $margins ) {
                 return $this->rewriteAuthorSelectorPrelude($prelude) . '{' . $body . '}' . $imageRule;
             }
@@ -1437,15 +1442,19 @@ final class HtmlTransformer
         return implode(',', array_values(array_unique($projected)));
     }
 
-    /** @param array<string, string> $declarations */
-    private function imageProjectionBridgeDeclarations(array $declarations): string
+    /**
+     * @param array<string, string> $declarations
+     * @param list<DOMElement> $matches
+     */
+    private function imageProjectionBridgeDeclarations(array $declarations, array $matches): string
     {
         $bridge = array( 'display:block' );
         $position = strtolower(trim((string) ($declarations['position'] ?? '')));
         $width = strtolower(trim((string) ($declarations['width'] ?? '')));
         $height = strtolower(trim((string) ($declarations['height'] ?? '')));
         $ownsBox = ! in_array($width, array( '', 'auto' ), true) && ! in_array($height, array( '', 'auto' ), true);
-        if ( $ownsBox || in_array($position, array( 'absolute', 'fixed' ), true) ) {
+        $coverClippedWell = 'auto' === $width && 'auto' === $height && ($this->hasFixedClippedImageWell($matches) || $this->hasObservedClippedImageWell($matches));
+        if ( $ownsBox || $coverClippedWell || in_array($position, array( 'absolute', 'fixed' ), true) ) {
             $bridge[] = 'width:100%';
             $bridge[] = 'height:100%';
         }
@@ -1454,6 +1463,43 @@ final class HtmlTransformer
         $bridge[] = 'object-position:inherit';
         $bridge[] = 'border-radius:inherit';
         return implode(';', $bridge);
+    }
+
+    /** @param list<DOMElement> $matches */
+    private function hasFixedClippedImageWell(array $matches): bool
+    {
+        foreach ( $matches as $image ) {
+            if ( 'img' !== strtolower($image->tagName) ) {
+                continue;
+            }
+            for ( $ancestor = $image->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+                $style = $this->structuralPresentationDeclarations($ancestor);
+                $overflow = strtolower(trim((string) ($style['overflow'] ?? $style['overflow-x'] ?? '')));
+                if ( in_array($overflow, array( 'hidden', 'clip' ), true) && null !== $this->pixelLength($style['width'] ?? '') && null !== $this->pixelLength($style['height'] ?? '') ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** @param list<DOMElement> $matches */
+    private function hasObservedClippedImageWell(array $matches): bool
+    {
+        foreach ($matches as $image) {
+            if ('img' !== strtolower($image->tagName)) continue;
+            $observation = $this->runtimePresentationEvidence[$this->elementSelector($image)] ?? null;
+            $asset = $this->assetMetadataForUrl($this->safeImageUrl($this->attr($image, 'src')));
+            if (!is_array($observation) || !is_array($asset) || ($observation['asset_hash'] ?? null) !== ($asset['hash'] ?? null)) continue;
+            $clip = $observation['clip'] ?? array(); $rendered = $observation['rendered'] ?? array();
+            if (($clip['width'] ?? 0) < ($rendered['width'] ?? 0) || ($clip['height'] ?? 0) < ($rendered['height'] ?? 0)) return true;
+        }
+        return false;
+    }
+
+    private function pixelLength(string $value): ?float
+    {
+        return 1 === preg_match('/^([0-9]+(?:\.[0-9]+)?)px$/', trim($value), $matches) ? (float) $matches[1] : null;
     }
 
     /** @return array<string, mixed> */
@@ -10499,6 +10545,19 @@ final class HtmlTransformer
         }
 
         return $metadata;
+    }
+
+    /** @param array<string,mixed> $options @return array<string,array<string,mixed>> */
+    private function runtimePresentationEvidenceFromOptions(array $options): array
+    {
+        $evidence = array();
+        if (!is_array($options['runtime_presentation_evidence'] ?? null)) return $evidence;
+        foreach ($options['runtime_presentation_evidence'] as $observation) {
+            if (!is_array($observation) || !is_string($observation['element']['selector'] ?? null) || !is_string($observation['asset_hash'] ?? null) || !is_array($observation['clip'] ?? null) || !is_array($observation['rendered'] ?? null)) continue;
+            $evidence[$observation['element']['selector']] = $observation;
+        }
+        ksort($evidence, SORT_STRING);
+        return $evidence;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -184,6 +184,7 @@ trait DomHelpersTrait
     private function safeFallbackHtml(DOMElement $element): string
     {
         $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '';
+        $html = preg_replace('/\s+data-blocks-engine-runtime-evidence(?:\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+))?/i', '', $html) ?? '';
         $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
         $html = preg_replace_callback(
             '/\s+([a-zA-Z_:][\w:.-]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s>]+))/i',

--- a/php-transformer/src/Path/ArtifactPath.php
+++ b/php-transformer/src/Path/ArtifactPath.php
@@ -53,6 +53,16 @@ final class ArtifactPath
         return self::safeRelativePath(implode('/', $parts));
     }
 
+    public static function resolveArtifactReference(string $reference, string $sourcePath = ''): string
+    {
+        $reference = self::stripQueryAndFragment($reference);
+        if ( str_starts_with($reference, '/') && ! str_starts_with($reference, '//') ) {
+            return self::safeRelativePath(ltrim($reference, '/'));
+        }
+
+        return self::resolveRelativePath($reference, $sourcePath);
+    }
+
     public static function stripQueryAndFragment(string $reference): string
     {
         return strtok($reference, '?#') ?: '';

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -256,6 +256,8 @@ $assert('' === ArtifactPath::safeRelativePath('../secrets/logo.png'), 'artifact 
 $assert('assets/logo.png' === ArtifactPath::resolveRelativePath('../assets/logo.png?version=1#hash', 'pages/home.html'), 'artifact references resolve relative paths without query or fragment');
 $assert('' === ArtifactPath::resolveRelativePath('https://example.com/logo.png', 'pages/home.html'), 'artifact references reject URL references');
 $assert('' === ArtifactPath::resolveRelativePath('../../logo.png', 'pages/home.html'), 'artifact references reject traversal above the artifact root');
+$assert('assets/logo.png' === ArtifactPath::resolveArtifactReference('/assets/logo.png?version=1#hash', 'pages/home.html'), 'artifact-root references resolve independently of the source directory');
+$assert('' === ArtifactPath::resolveArtifactReference('/../secrets/logo.png', 'pages/home.html'), 'artifact-root references reject traversal');
 
 $registryDocument = new DOMDocument();
 $registryDocument->loadHTML('<div></div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
@@ -3644,46 +3646,155 @@ $octetStreamGif = ( new ArtifactNormalizer() )->normalize(
 $assert('image/gif' === ($octetStreamGif['files'][0]['mime_type'] ?? ''), 'generic binary MIME declarations defer to the GIF path extension');
 $assert('image' === ($octetStreamGif['files'][0]['role'] ?? ''), 'extension-resolved GIF assets retain their image role');
 
-// Browser-derived media evidence is optional. Accepted observations are bound to
-// both a source DOM identity and the normalized artifact asset hash before they
-// can change the media-well projection.
+// Browser-derived media evidence is optional. It is bound to one source HTML
+// revision, one body-relative image locator, and the exact resolved asset.
 $mediaAssetHash = hash('sha256', base64_encode('GIF89a'));
+$mediaHtml = '<main><div class="well"><img src="portrait.gif" alt="Portrait"></div></main>';
 $mediaEvidence = array(
-	'schema' => 'blocks-engine/php-transformer/runtime-presentation-evidence/v1',
+	'schema' => 'blocks-engine/artifact-runtime-presentation-evidence/v1',
 	'provenance' => array(
 		'browser' => array('name' => 'Chromium', 'version' => '126.0'),
 		'viewport' => array('width' => 1280, 'height' => 720, 'device_scale_factor' => 1),
-		'lifecycle' => array('phase' => 'network-idle'),
+		'readiness' => array('document' => 'complete', 'images' => 'complete'),
 	),
 	'observations' => array(array(
-		'element' => array('source_path' => 'index.html', 'selector' => 'main:nth-of-type(1) > div:nth-of-type(1) > img:nth-of-type(1)'),
-		'asset_hash' => $mediaAssetHash,
+		'element' => array('source_path' => 'index.html', 'locator' => array('kind' => 'css-nth-of-type-body-path/v1', 'value' => 'main:nth-of-type(1) > div:nth-of-type(1) > img:nth-of-type(1)')),
+		'source_hash' => hash('sha256', $mediaHtml),
+		'asset' => array('path' => 'portrait.gif', 'hash' => $mediaAssetHash),
 		'intrinsic' => array('width' => 498, 'height' => 273),
 		'rendered' => array('width' => 498, 'height' => 273),
 		'transform' => array('matrix' => array(1, 0, 0, 1, 0, 0), 'origin' => array('x' => 249, 'y' => 136.5)),
-		'clip' => array('x' => 0, 'y' => 0, 'width' => 280, 'height' => 280),
+		'clip' => array('x' => 0, 'y' => 0, 'width' => 280, 'height' => 273),
 	)),
 );
 $browserMedia = $compiler->compile(array(
 	'files' => array(
-		array('path' => 'index.html', 'kind' => 'html', 'content' => '<style>.well img{width:auto;height:auto}</style><main><div class="well"><img src="portrait.gif" alt="Portrait"></div></main>'),
+		array('path' => 'index.html', 'kind' => 'html', 'content' => $mediaHtml),
 		array('path' => 'portrait.gif', 'kind' => 'image', 'content' => 'GIF89a'),
 	),
-	'runtime_presentation_evidence' => $mediaEvidence,
+	'artifact_runtime_presentation_evidence' => $mediaEvidence,
 ))->toArray();
 $browserMediaCss = implode("\n", array_column($browserMedia['assets'] ?? array(), 'content'));
-$assert(str_contains($browserMediaCss, 'object-fit:cover;object-position:50% 0'), 'accepted browser evidence activates deterministic clipped media-well projection');
-$acceptedEvidence = $browserMedia['source_reports']['artifact']['runtime_presentation_evidence'] ?? array();
-$assert('network-idle' === ($acceptedEvidence['provenance']['lifecycle']['phase'] ?? '') && 1 === count($acceptedEvidence['observations'] ?? array()) && $mediaAssetHash === ($acceptedEvidence['observations'][0]['asset_hash'] ?? ''), 'accepted browser evidence and its provenance are exposed in the artifact report');
+$assert(str_contains($browserMediaCss, 'overflow:hidden!important') && str_contains($browserMediaCss, 'transform:matrix(1,0,0,1,0,0)!important') && str_contains($browserMediaCss, 'transform-origin:249px 136.5px!important'), 'accepted evidence preserves observed clip, transform matrix, and transform origin through scoped CSS');
+$assert(str_contains((string) ($browserMedia['serialized_blocks'] ?? ''), '<!-- wp:image') && !str_contains((string) ($browserMedia['serialized_blocks'] ?? ''), 'runtime_presentation_evidence'), 'accepted evidence retains editable core/image output without block attributes');
+$acceptedEvidence = $browserMedia['source_reports']['artifact']['artifact_runtime_presentation_evidence'] ?? array();
+$assert('complete' === ($acceptedEvidence['provenance']['readiness']['images'] ?? '') && 1 === count($acceptedEvidence['observations'] ?? array()) && $mediaAssetHash === ($acceptedEvidence['observations'][0]['asset']['hash'] ?? ''), 'accepted browser evidence and readiness are exposed in the artifact report');
+$assert(!str_contains(json_encode($browserMedia['source_reports']['wordpress_site_plan'] ?? array()), 'css-nth-of-type-body-path/v1'), 'browser evidence does not leak into the persisted WordPress site plan');
+$assert(!str_contains((string) ($browserMedia['serialized_blocks'] ?? ''), 'data-blocks-engine-runtime-evidence'), 'internal evidence markers never leak into editable core/image markup');
+$withoutEvidence = $compiler->compile(array('files' => array(array('path' => 'index.html', 'kind' => 'html', 'content' => $mediaHtml), array('path' => 'portrait.gif', 'kind' => 'image', 'content' => 'GIF89a'))))->toArray();
+
+$permutedMediaEvidence = array(
+	'observations' => array(array(
+		'clip' => $mediaEvidence['observations'][0]['clip'],
+		'transform' => $mediaEvidence['observations'][0]['transform'],
+		'rendered' => $mediaEvidence['observations'][0]['rendered'],
+		'intrinsic' => $mediaEvidence['observations'][0]['intrinsic'],
+		'asset' => $mediaEvidence['observations'][0]['asset'],
+		'source_hash' => $mediaEvidence['observations'][0]['source_hash'],
+		'element' => $mediaEvidence['observations'][0]['element'],
+	)),
+	'provenance' => array(
+		'readiness' => $mediaEvidence['provenance']['readiness'],
+		'viewport' => $mediaEvidence['provenance']['viewport'],
+		'browser' => $mediaEvidence['provenance']['browser'],
+	),
+	'schema' => $mediaEvidence['schema'],
+);
+$permutedBrowserMedia = $compiler->compile(array('files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $permutedMediaEvidence))->toArray();
+$assert($browserMedia['source_reports']['artifact']['source_hash'] === $permutedBrowserMedia['source_reports']['artifact']['source_hash'] && $browserMedia['serialized_blocks'] === $permutedBrowserMedia['serialized_blocks'] && $browserMedia['assets'] === $permutedBrowserMedia['assets'] && $browserMedia['source_reports']['artifact']['artifact_runtime_presentation_evidence'] === $permutedBrowserMedia['source_reports']['artifact']['artifact_runtime_presentation_evidence'], 'canonical evidence key ordering produces identical identity, report, blocks, and assets');
+
+$rootMediaHtml = '<main><img src="/portrait.gif?version=1#hero"></main>';
+$rootMediaEvidence = $mediaEvidence;
+$rootMediaEvidence['observations'][0]['element']['locator']['value'] = 'main:nth-of-type(1) > img:nth-of-type(1)';
+$rootMediaEvidence['observations'][0]['source_hash'] = hash('sha256', $rootMediaHtml);
+$rootMedia = $compiler->compile(array('files' => array('index.html' => $rootMediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $rootMediaEvidence))->toArray();
+$assert(1 === count($rootMedia['source_reports']['artifact']['artifact_runtime_presentation_evidence']['observations'] ?? array()) && !in_array('artifact_runtime_presentation_evidence_asset_mismatch', array_column($rootMedia['diagnostics'] ?? array(), 'code'), true), 'root-relative image references with query and fragment suffixes bind to the normalized artifact asset');
+
+$topologyHtml = '<main><img src="/unsafe.svg"><img src="portrait.gif"></main>';
+$topologyEvidence = $mediaEvidence;
+$topologyEvidence['observations'][0]['element']['locator']['value'] = 'main:nth-of-type(1) > img:nth-of-type(2)';
+$topologyEvidence['observations'][0]['source_hash'] = hash('sha256', $topologyHtml);
+$topologyMedia = $compiler->compile(array('files' => array('index.html' => $topologyHtml, 'unsafe.svg' => '<svg><script>alert(1)</script></svg>', 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $topologyEvidence))->toArray();
+$topologyCss = implode("\n", array_column($topologyMedia['assets'] ?? array(), 'content'));
+$assert(str_contains($topologyCss, 'be-runtime-evidence-') && !str_contains((string) ($topologyMedia['serialized_blocks'] ?? ''), 'unsafe.svg') && !str_contains((string) ($topologyMedia['serialized_blocks'] ?? ''), 'data-blocks-engine-runtime-evidence'), 'evidence markers retain the intended image after root-relative unsafe media is removed without leaking into output');
+
+$scaledMediaEvidence = $mediaEvidence;
+$scaledMediaEvidence['observations'][0]['transform'] = array('matrix' => array(2, 0, 0, 1.5, 10, 5), 'origin' => array('x' => 20, 'y' => 10));
+$scaledMediaEvidence['observations'][0]['rendered'] = array('width' => 400, 'height' => 300);
+$scaledMediaEvidence['observations'][0]['clip'] = array('x' => 20, 'y' => 30, 'width' => 280, 'height' => 200);
+$scaledMedia = $compiler->compile(array('files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $scaledMediaEvidence))->toArray();
+$scaledCss = implode("\n", array_column($scaledMedia['assets'] ?? array(), 'content'));
+$assert(str_contains((string) ($scaledMedia['serialized_blocks'] ?? ''), '<figure class="wp-block-image') && str_contains((string) ($scaledMedia['serialized_blocks'] ?? ''), '<img') && str_contains($scaledCss, 'left:-10px!important;top:-30px!important;width:200px!important;height:200px!important') && str_contains($scaledCss, 'transform:matrix(2,0,0,1.5,10,5)!important'), 'scale/translation replay inverts post-transform dimensions and offsets before emitting scoped core/image geometry');
+
+$fallbackHtml = '<main><math><img src="portrait.gif" alt="Fallback portrait"></math></main>';
+$fallbackEvidence = $mediaEvidence;
+$fallbackEvidence['observations'][0]['source_hash'] = hash('sha256', $fallbackHtml);
+$fallbackEvidence['observations'][0]['element']['locator']['value'] = 'main:nth-of-type(1) > math:nth-of-type(1) > img:nth-of-type(1)';
+$fallbackMedia = $compiler->compile(array('files' => array('index.html' => $fallbackHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $fallbackEvidence))->toArray();
+$assert(str_contains((string) ($fallbackMedia['serialized_blocks'] ?? ''), '<!-- wp:math') && str_contains((string) ($fallbackMedia['serialized_blocks'] ?? ''), 'Fallback portrait') && !str_contains((string) ($fallbackMedia['serialized_blocks'] ?? ''), 'data-blocks-engine-runtime-evidence'), 'internal evidence markers are stripped from preserved safe-fallback HTML content');
+
+$fullDocumentHtml = '<!doctype html><html><head><title>Evidence document</title><meta name="description" content="Preserved metadata"><style>.well{overflow:hidden}</style></head><body><main><div class="well"><img src="portrait.gif" alt="Portrait"><p>Unclosed body copy</div></main></body></html>';
+$fullDocumentEvidence = $mediaEvidence;
+$fullDocumentEvidence['observations'][0]['source_hash'] = hash('sha256', $fullDocumentHtml);
+$fullDocumentMedia = $compiler->compile(array('files' => array('index.html' => $fullDocumentHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $fullDocumentEvidence))->toArray();
+$fullDocumentOutput = json_encode($fullDocumentMedia);
+$assert(1 === count($fullDocumentMedia['source_reports']['artifact']['artifact_runtime_presentation_evidence']['observations'] ?? array()) && str_contains((string) $fullDocumentOutput, 'Evidence document') && str_contains((string) ($fullDocumentMedia['serialized_blocks'] ?? ''), 'Unclosed body copy') && !str_contains((string) $fullDocumentOutput, 'data-blocks-engine-runtime-evidence'), 'full-document evidence preserves head metadata and malformed supported body content without marker leakage');
+
+$rotatedEvidence = $scaledMediaEvidence;
+$rotatedEvidence['observations'][0]['transform']['matrix'][1] = 0.5;
+$rotatedMedia = $compiler->compile(array('files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $rotatedEvidence))->toArray();
+$assert($withoutEvidence['serialized_blocks'] === $rotatedMedia['serialized_blocks'] && $withoutEvidence['assets'] === $rotatedMedia['assets'] && in_array('artifact_runtime_presentation_evidence_invalid_observation', array_column($rotatedMedia['diagnostics'] ?? array(), 'code'), true), 'rotation evidence is rejected deterministically and preserves static fallback output');
+
+$staleEvidence = $mediaEvidence; $staleEvidence['observations'][0]['source_hash'] = str_repeat('0', 64);
+$staleMedia = $compiler->compile(array('files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $staleEvidence))->toArray();
+$assert($withoutEvidence['serialized_blocks'] === $staleMedia['serialized_blocks'] && $withoutEvidence['assets'] === $staleMedia['assets'], 'stale evidence preserves exactly the no-evidence static output');
+$assert($withoutEvidence['source_reports']['artifact']['source_hash'] !== $browserMedia['source_reports']['artifact']['source_hash'], 'accepted evidence participates in artifact identity without hashing generated output');
+$assert(in_array('artifact_runtime_presentation_evidence_source_hash_mismatch', array_column($staleMedia['diagnostics'] ?? array(), 'code'), true), 'stale source hash has a deterministic diagnostic');
 
 $rejectedEvidence = $mediaEvidence;
-$rejectedEvidence['observations'][0]['asset_hash'] = str_repeat('0', 64);
+$rejectedEvidence['observations'][0]['asset']['hash'] = str_repeat('0', 64);
 $rejectedMedia = $compiler->compile(array(
-	'files' => array('index.html' => '<main><img src="portrait.gif"></main>', 'portrait.gif' => 'GIF89a'),
-	'runtime_presentation_evidence' => $rejectedEvidence,
+	'files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'),
+	'artifact_runtime_presentation_evidence' => $rejectedEvidence,
 ))->toArray();
-$assert(in_array('runtime_presentation_evidence_asset_hash_mismatch', array_column($rejectedMedia['diagnostics'] ?? array(), 'code'), true), 'unbound browser evidence has a deterministic rejection diagnostic');
+$assert(in_array('artifact_runtime_presentation_evidence_asset_mismatch', array_column($rejectedMedia['diagnostics'] ?? array(), 'code'), true), 'unbound browser evidence has a deterministic rejection diagnostic');
 $assert(1 === ($rejectedMedia['source_reports']['artifact']['rejected_count'] ?? 0), 'rejected browser evidence increments artifact rejection accounting');
+
+$wrongLocatorEvidence = $mediaEvidence;
+$wrongLocatorEvidence['observations'][0]['element']['locator']['value'] = 'main:nth-of-type(1) > div:nth-of-type(1) > img:nth-of-type(2)';
+$wrongLocatorMedia = $compiler->compile(array('files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $wrongLocatorEvidence))->toArray();
+$assert(in_array('artifact_runtime_presentation_evidence_locator_mismatch', array_column($wrongLocatorMedia['diagnostics'] ?? array(), 'code'), true), 'wrong body-relative locator has a deterministic diagnostic');
+
+$malformedEvidence = $mediaEvidence;
+$malformedEvidence['unknown'] = true;
+$malformedMedia = $compiler->compile(array('files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $malformedEvidence))->toArray();
+$assert(in_array('artifact_runtime_presentation_evidence_invalid_envelope', array_column($malformedMedia['diagnostics'] ?? array(), 'code'), true), 'unknown envelope keys are rejected');
+$boundedEvidence = $mediaEvidence;
+$boundedEvidence['observations'][0]['clip']['x'] = -1;
+$boundedEvidence['observations'][0]['rendered']['width'] = INF;
+$boundedMedia = $compiler->compile(array('files' => array('index.html' => $mediaHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $boundedEvidence))->toArray();
+$assert(in_array('artifact_runtime_presentation_evidence_invalid_observation', array_column($boundedMedia['diagnostics'] ?? array(), 'code'), true), 'non-finite and negative geometry is rejected before static conversion');
+
+$twoImageHtml = '<main><div><img src="portrait.gif"><img src="portrait.gif"></div></main>';
+$twoImageEvidence = $mediaEvidence;
+$twoImageEvidence['observations'][0]['source_hash'] = hash('sha256', $twoImageHtml);
+$twoImageEvidence['observations'][0]['element']['locator']['value'] = 'main:nth-of-type(1) > div:nth-of-type(1) > img:nth-of-type(1)';
+$secondObservation = $twoImageEvidence['observations'][0];
+$secondObservation['element']['locator']['value'] = 'main:nth-of-type(1) > div:nth-of-type(1) > img:nth-of-type(2)';
+$twoImageEvidence['observations'][] = $secondObservation;
+$twoImageArtifact = array('files' => array('index.html' => $twoImageHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $twoImageEvidence);
+$twoImageFirst = $compiler->compile($twoImageArtifact)->toArray();
+$twoImageSecond = $compiler->compile($twoImageArtifact)->toArray();
+$assert(2 === count($twoImageFirst['source_reports']['artifact']['artifact_runtime_presentation_evidence']['observations'] ?? array()), 'equal image URLs in distinct body-relative wells retain distinct evidence identities');
+$assert($twoImageFirst['serialized_blocks'] === $twoImageSecond['serialized_blocks'] && $twoImageFirst['assets'] === $twoImageSecond['assets'] && $twoImageFirst['source_reports']['artifact']['source_hash'] === $twoImageSecond['source_reports']['artifact']['source_hash'], 'evidence compilation has deterministic replay output and artifact identity');
+
+$reservedMarkerHtml = '<main><div><img src="portrait.gif" data-blocks-engine-runtime-evidence="source-authored"><img src="portrait.gif"></div></main>';
+$reservedMarkerEvidence = $mediaEvidence;
+$reservedMarkerEvidence['observations'][0]['source_hash'] = hash('sha256', $reservedMarkerHtml);
+$reservedMarkerEvidence['observations'][0]['element']['locator']['value'] = 'main:nth-of-type(1) > div:nth-of-type(1) > img:nth-of-type(2)';
+$reservedMarkerMedia = $compiler->compile(array('files' => array('index.html' => $reservedMarkerHtml, 'portrait.gif' => 'GIF89a'), 'artifact_runtime_presentation_evidence' => $reservedMarkerEvidence))->toArray();
+$reservedMarkerCss = implode("\n", array_column($reservedMarkerMedia['assets'] ?? array(), 'content'));
+$assert(1 === substr_count($reservedMarkerCss, 'overflow:hidden!important') && !str_contains((string) ($reservedMarkerMedia['serialized_blocks'] ?? ''), 'data-blocks-engine-runtime-evidence'), 'source-authored reserved markers are cleared before evidence is bound to the validated same-hash image');
 
 assertSame('core/group', $result['blocks'][0]['blockName'], 'main wrapper should preserve multiple supported child blocks in a group.');
 assertSame('core/heading', $result['blocks'][0]['innerBlocks'][0]['blockName'], 'h1 should convert to a heading block.');

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3630,6 +3630,61 @@ $assert('success_with_warnings' === $tooLarge['status'], 'oversized files are re
 $assert(1 === ($tooLarge['source_reports']['artifact']['rejected_count'] ?? null), 'oversized file increments rejected count');
 $assert('artifact_file_too_large' === ($tooLarge['diagnostics'][0]['code'] ?? ''), 'oversized file diagnostic is exposed');
 
+$octetStreamGif = ( new ArtifactNormalizer() )->normalize(
+    array(
+        'files' => array(
+            array(
+                'path' => 'uploads/animated-avatar.gif',
+                'type' => 'application/octet-stream',
+                'content_base64' => base64_encode('GIF89a'),
+            ),
+        ),
+    )
+);
+$assert('image/gif' === ($octetStreamGif['files'][0]['mime_type'] ?? ''), 'generic binary MIME declarations defer to the GIF path extension');
+$assert('image' === ($octetStreamGif['files'][0]['role'] ?? ''), 'extension-resolved GIF assets retain their image role');
+
+// Browser-derived media evidence is optional. Accepted observations are bound to
+// both a source DOM identity and the normalized artifact asset hash before they
+// can change the media-well projection.
+$mediaAssetHash = hash('sha256', base64_encode('GIF89a'));
+$mediaEvidence = array(
+	'schema' => 'blocks-engine/php-transformer/runtime-presentation-evidence/v1',
+	'provenance' => array(
+		'browser' => array('name' => 'Chromium', 'version' => '126.0'),
+		'viewport' => array('width' => 1280, 'height' => 720, 'device_scale_factor' => 1),
+		'lifecycle' => array('phase' => 'network-idle'),
+	),
+	'observations' => array(array(
+		'element' => array('source_path' => 'index.html', 'selector' => 'main:nth-of-type(1) > div:nth-of-type(1) > img:nth-of-type(1)'),
+		'asset_hash' => $mediaAssetHash,
+		'intrinsic' => array('width' => 498, 'height' => 273),
+		'rendered' => array('width' => 498, 'height' => 273),
+		'transform' => array('matrix' => array(1, 0, 0, 1, 0, 0), 'origin' => array('x' => 249, 'y' => 136.5)),
+		'clip' => array('x' => 0, 'y' => 0, 'width' => 280, 'height' => 280),
+	)),
+);
+$browserMedia = $compiler->compile(array(
+	'files' => array(
+		array('path' => 'index.html', 'kind' => 'html', 'content' => '<style>.well img{width:auto;height:auto}</style><main><div class="well"><img src="portrait.gif" alt="Portrait"></div></main>'),
+		array('path' => 'portrait.gif', 'kind' => 'image', 'content' => 'GIF89a'),
+	),
+	'runtime_presentation_evidence' => $mediaEvidence,
+))->toArray();
+$browserMediaCss = implode("\n", array_column($browserMedia['assets'] ?? array(), 'content'));
+$assert(str_contains($browserMediaCss, 'object-fit:cover;object-position:50% 0'), 'accepted browser evidence activates deterministic clipped media-well projection');
+$acceptedEvidence = $browserMedia['source_reports']['artifact']['runtime_presentation_evidence'] ?? array();
+$assert('network-idle' === ($acceptedEvidence['provenance']['lifecycle']['phase'] ?? '') && 1 === count($acceptedEvidence['observations'] ?? array()) && $mediaAssetHash === ($acceptedEvidence['observations'][0]['asset_hash'] ?? ''), 'accepted browser evidence and its provenance are exposed in the artifact report');
+
+$rejectedEvidence = $mediaEvidence;
+$rejectedEvidence['observations'][0]['asset_hash'] = str_repeat('0', 64);
+$rejectedMedia = $compiler->compile(array(
+	'files' => array('index.html' => '<main><img src="portrait.gif"></main>', 'portrait.gif' => 'GIF89a'),
+	'runtime_presentation_evidence' => $rejectedEvidence,
+))->toArray();
+$assert(in_array('runtime_presentation_evidence_asset_hash_mismatch', array_column($rejectedMedia['diagnostics'] ?? array(), 'code'), true), 'unbound browser evidence has a deterministic rejection diagnostic');
+$assert(1 === ($rejectedMedia['source_reports']['artifact']['rejected_count'] ?? 0), 'rejected browser evidence increments artifact rejection accounting');
+
 assertSame('core/group', $result['blocks'][0]['blockName'], 'main wrapper should preserve multiple supported child blocks in a group.');
 assertSame('core/heading', $result['blocks'][0]['innerBlocks'][0]['blockName'], 'h1 should convert to a heading block.');
 assertSame(1, $result['blocks'][0]['innerBlocks'][0]['attrs']['level'], 'h1 level should be preserved.');


### PR DESCRIPTION
## Summary
- define a generic, bounded artifact runtime presentation evidence schema
- bind observations to exact source HTML, body-relative image locators, and normalized asset hashes
- replay supported clip and axis-aligned scale/translation geometry on editable `core/image` output
- preserve deterministic static output for absent, stale, malformed, or unsupported evidence
- centralize artifact-root reference resolution and protect the internal marker namespace

## Verification
- `composer test`
- PHP lint for all modified PHP files
- `git diff --check`
- 258 PHP transformer parity fixtures
- package installation proof

Closes #757.

## AI assistance
OpenAI gpt-5.6-sol through OpenCode extracted the experimental implementation, reviewed and hardened the schema and replay path, added contract coverage, and ran verification. Chris Huber remains responsible for every line.