### PR TITLE
Do not classify fixed-position skip links as button blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -379,6 +379,8 @@ final class HtmlTransformer
 
     private const SYNTHETIC_PARAGRAPH_CLASS = 'blocks-engine-synthetic-paragraph';
 
+    private const POSITIONED_FRAGMENT_LINK_CARRIER_CLASS = 'blocks-engine-positioned-fragment-link-carrier';
+
     private const EMPTY_FLEX_ITEM_CLASS = 'blocks-engine-empty-flex-item';
 
     /** @var array<string, string> Source control DOM paths mapped to core/button wrapper classes. */
@@ -864,6 +866,11 @@ final class HtmlTransformer
             // A paragraph is required for valid block markup, but phrasing content
             // did not have paragraph margins in the source document.
             $cssParts[] = ':where(.' . self::SYNTHETIC_PARAGRAPH_CLASS . '){margin-top:0;margin-bottom:0}';
+        }
+        if ( str_contains($serializedBlocks, self::POSITIONED_FRAGMENT_LINK_CARRIER_CLASS) ) {
+            // Positioned fragment links retain their source anchor and selectors;
+            // their valid paragraph host must not create a line box in document flow.
+            $cssParts[] = ':where(.' . self::POSITIONED_FRAGMENT_LINK_CARRIER_CLASS . '){display:contents!important}';
         }
         if ( str_contains($serializedBlocks, self::EMPTY_FLEX_ITEM_CLASS) ) {
             $cssParts[] = ':where(.' . self::EMPTY_FLEX_ITEM_CLASS . '){flex:0 0 0!important;width:0!important;min-width:0!important;margin-left:0!important;margin-right:0!important}';

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -35,6 +35,10 @@ final class ButtonsPattern
             return $fileBlock;
         }
 
+        if ( $this->isPositionedFragmentNavigation($anchor, (string) $resolvedStyle($anchor)) ) {
+            return null;
+        }
+
         $surface = $this->buttonSurfaceElement($anchor);
         if ( ! $this->hasButtonSignal($anchor, (string) $resolvedStyle($anchor), null !== $surface ? (string) $resolvedStyle($surface) : '') ) {
             return null;
@@ -92,7 +96,7 @@ final class ButtonsPattern
         $buttons = array();
         foreach ( $element->childNodes as $child ) {
             $surface = $child instanceof DOMElement ? $this->buttonSurfaceElement($child) : null;
-            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') && $this->hasButtonSignal($child, (string) $resolvedStyle($child), null !== $surface ? (string) $resolvedStyle($surface) : '') ) {
+            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') && ! $this->isPositionedFragmentNavigation($child, (string) $resolvedStyle($child)) && $this->hasButtonSignal($child, (string) $resolvedStyle($child), null !== $surface ? (string) $resolvedStyle($surface) : '') ) {
                 $buttons[] = $this->buttonBlockFromAnchor($child, $presentationAttributes, $resolvedStyle, $innerHtml, $materializeSvgImages, $attr, $createBlock);
             }
         }
@@ -442,6 +446,16 @@ final class ButtonsPattern
 
         $surface = $this->buttonSurfaceElement($anchor);
         return null !== $surface && $this->signalClassifier->hasStyleSignal($surface, $surfaceStyle);
+    }
+
+    private function isPositionedFragmentNavigation(DOMElement $anchor, string $resolvedStyle): bool
+    {
+        $href = trim($anchor->getAttribute('href'));
+        if ( ! str_starts_with($href, '#') || '#' === $href || 'button' === strtolower($anchor->getAttribute('role')) ) {
+            return false;
+        }
+
+        return preg_match('/(?:^|;)\s*position\s*:\s*(?:fixed|absolute)\b/i', $resolvedStyle) === 1;
     }
 
     private function hasWrapperButtonSignal(DOMElement $element, string $resolvedStyle): bool

--- a/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
@@ -82,6 +82,13 @@ trait ButtonLinkDispatchTrait
         $attrs = $this->presentationAttributes($anchor);
         unset($attrs['anchor']);
 
+        if ( $this->isPositionedFragmentLink($anchor) ) {
+            $attrs['className'] = $this->mergeClassNames(
+                (string) ($attrs['className'] ?? ''),
+                self::POSITIONED_FRAGMENT_LINK_CARRIER_CLASS
+            );
+        }
+
         // Source class identity belongs exclusively to the saved link. Keep only
         // generated geometry classes and mapped presentation on its paragraph host.
         $sourceClasses = preg_split('/\s+/', trim($this->attr($anchor, 'class'))) ?: array();
@@ -96,6 +103,17 @@ trait ButtonLinkDispatchTrait
         }
 
         return $attrs;
+    }
+
+    private function isPositionedFragmentLink(DOMElement $anchor): bool
+    {
+        $href = trim($this->attr($anchor, 'href'));
+        if ( ! str_starts_with($href, '#') || '#' === $href || 'button' === strtolower($this->attr($anchor, 'role')) ) {
+            return false;
+        }
+
+        $position = strtolower(trim((string) ($this->structuralPresentationDeclarations($anchor)['position'] ?? '')));
+        return in_array($position, array( 'absolute', 'fixed' ), true);
     }
 
     /**

--- a/php-transformer/tests/unit/button-signal-classifier.php
+++ b/php-transformer/tests/unit/button-signal-classifier.php
@@ -65,10 +65,16 @@ $assert('core/button' === ($stylesheetButton['blocks'][0]['innerBlocks'][0]['blo
 $assert(str_contains($stylesheetButtonCss, '> :where(.wp-block-button__link){padding:12px 18px') && str_contains($stylesheetButtonCss, 'border:2px solid #135e96'), '16: true button author selectors style the rendered inner anchor', $stylesheetButtonCss);
 $assert('pass' === ($stylesheetButton['source_reports']['wp_block_validity']['status'] ?? ''), '17: true button conversion remains editor-valid', json_encode($stylesheetButton['source_reports']['wp_block_validity'] ?? array()));
 
+$skipLink = ( new HtmlTransformer() )->transform('<style>.skip-link{position:fixed;top:-200px;left:0;padding:12px 18px;background:#135e96;color:#fff;border-radius:999px}.skip-link:focus{top:0}</style><a class="skip-link" href="#content">Skip to content</a><main id="content">Content</main>', array())->toArray();
+$skipLinkMarkup = (string) ($skipLink['serialized_blocks'] ?? '');
+$skipLinkCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $skipLink['assets'] ?? array()));
+$assert('core/paragraph' === ($skipLink['blocks'][0]['blockName'] ?? '') && ! str_contains($skipLinkMarkup, '<!-- wp:button') && str_contains($skipLinkMarkup, '<a class="skip-link" href="#content">Skip to content</a>'), '18: fixed fragment skip links retain native anchor content instead of gaining button wrappers', $skipLinkMarkup);
+$assert(str_contains($skipLinkCss, '.skip-link:focus{top:0}') && 'pass' === ($skipLink['source_reports']['wp_block_validity']['status'] ?? ''), '19: native skip-link focus selector and Gutenberg-valid serialization are preserved', $skipLinkCss . json_encode($skipLink['source_reports']['wp_block_validity'] ?? array()));
+
 $streamRow = ( new HtmlTransformer() )->transform('<style>.stream-btn{display:inline-flex;padding:10px 16px;background:#135e96;color:#fff;border-radius:4px}</style><div><a class="stream-btn" href="/listen">Listen live</a><a class="stream-btn" href="/schedule">View schedule</a></div>', array())->toArray();
 $streamRowCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $streamRow['assets'] ?? array()));
-$assert('core/buttons' === ($streamRow['blocks'][0]['blockName'] ?? '') && 2 === count($streamRow['blocks'][0]['innerBlocks'] ?? array()), '18: direct anchor CTA rows group explicit stylesheet surfaces as buttons', json_encode($streamRow['blocks'] ?? array()));
-$assert(2 === substr_count($streamRowCss, '> :where(.wp-block-button__link)') && str_contains($streamRowCss, '{display:inline-flex;padding:10px 16px;background:#135e96'), '19: direct anchor CTA stylesheet selectors remain on both rendered button links', $streamRowCss);
+$assert('core/buttons' === ($streamRow['blocks'][0]['blockName'] ?? '') && 2 === count($streamRow['blocks'][0]['innerBlocks'] ?? array()), '20: direct anchor CTA rows group explicit stylesheet surfaces as buttons', json_encode($streamRow['blocks'] ?? array()));
+$assert(2 === substr_count($streamRowCss, '> :where(.wp-block-button__link)') && str_contains($streamRowCss, '{display:inline-flex;padding:10px 16px;background:#135e96'), '21: direct anchor CTA stylesheet selectors remain on both rendered button links', $streamRowCss);
 
 $buttonResult = ( new HtmlTransformer() )->transform('<button style="padding:12px 18px;background:#135e96;color:#fff">Buy tickets</button>', array())->toArray();
 $nativeButton = $buttonResult['blocks'][0]['innerBlocks'][0] ?? array();

--- a/php-transformer/tests/unit/button-signal-classifier.php
+++ b/php-transformer/tests/unit/button-signal-classifier.php
@@ -69,12 +69,16 @@ $skipLink = ( new HtmlTransformer() )->transform('<style>.skip-link{position:fix
 $skipLinkMarkup = (string) ($skipLink['serialized_blocks'] ?? '');
 $skipLinkCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $skipLink['assets'] ?? array()));
 $assert('core/paragraph' === ($skipLink['blocks'][0]['blockName'] ?? '') && ! str_contains($skipLinkMarkup, '<!-- wp:button') && str_contains($skipLinkMarkup, '<a class="skip-link" href="#content">Skip to content</a>'), '18: fixed fragment skip links retain native anchor content instead of gaining button wrappers', $skipLinkMarkup);
-$assert(str_contains($skipLinkCss, '.skip-link:focus{top:0}') && 'pass' === ($skipLink['source_reports']['wp_block_validity']['status'] ?? ''), '19: native skip-link focus selector and Gutenberg-valid serialization are preserved', $skipLinkCss . json_encode($skipLink['source_reports']['wp_block_validity'] ?? array()));
+$assert(str_contains($skipLinkMarkup, 'blocks-engine-positioned-fragment-link-carrier') && str_contains($skipLinkCss, ':where(.blocks-engine-positioned-fragment-link-carrier){display:contents!important}') && str_contains($skipLinkCss, '.skip-link:focus{top:0}'), '19: positioned fragment links use a zero-flow valid carrier while focus styling remains on the native anchor', $skipLinkMarkup . $skipLinkCss);
+$assert('pass' === ($skipLink['source_reports']['wp_block_validity']['status'] ?? ''), '20: positioned fragment link serialization remains Gutenberg-valid', json_encode($skipLink['source_reports']['wp_block_validity'] ?? array()));
+
+$fragmentCta = ( new HtmlTransformer() )->transform('<a class="primary-cta" href="#pricing" style="display:inline-flex;padding:12px 18px;background:#135e96;color:#fff">See pricing</a>', array())->toArray();
+$assert('core/button' === ($fragmentCta['blocks'][0]['innerBlocks'][0]['blockName'] ?? '') && '#pricing' === ($fragmentCta['blocks'][0]['innerBlocks'][0]['attrs']['url'] ?? ''), '21: ordinary fragment CTAs retain native core/button conversion', json_encode($fragmentCta['blocks'] ?? array()));
 
 $streamRow = ( new HtmlTransformer() )->transform('<style>.stream-btn{display:inline-flex;padding:10px 16px;background:#135e96;color:#fff;border-radius:4px}</style><div><a class="stream-btn" href="/listen">Listen live</a><a class="stream-btn" href="/schedule">View schedule</a></div>', array())->toArray();
 $streamRowCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $streamRow['assets'] ?? array()));
-$assert('core/buttons' === ($streamRow['blocks'][0]['blockName'] ?? '') && 2 === count($streamRow['blocks'][0]['innerBlocks'] ?? array()), '20: direct anchor CTA rows group explicit stylesheet surfaces as buttons', json_encode($streamRow['blocks'] ?? array()));
-$assert(2 === substr_count($streamRowCss, '> :where(.wp-block-button__link)') && str_contains($streamRowCss, '{display:inline-flex;padding:10px 16px;background:#135e96'), '21: direct anchor CTA stylesheet selectors remain on both rendered button links', $streamRowCss);
+$assert('core/buttons' === ($streamRow['blocks'][0]['blockName'] ?? '') && 2 === count($streamRow['blocks'][0]['innerBlocks'] ?? array()), '22: direct anchor CTA rows group explicit stylesheet surfaces as buttons', json_encode($streamRow['blocks'] ?? array()));
+$assert(2 === substr_count($streamRowCss, '> :where(.wp-block-button__link)') && str_contains($streamRowCss, '{display:inline-flex;padding:10px 16px;background:#135e96'), '23: direct anchor CTA stylesheet selectors remain on both rendered button links', $streamRowCss);
 
 $buttonResult = ( new HtmlTransformer() )->transform('<button style="padding:12px 18px;background:#135e96;color:#fff">Buy tickets</button>', array())->toArray();
 $nativeButton = $buttonResult['blocks'][0]['innerBlocks'][0] ?? array();


### PR DESCRIPTION
## Root cause

Fixed and absolute fragment-navigation anchors can carry the same visual surface declarations as calls to action. `ButtonsPattern` therefore promoted skip links to `core/button`, moving their fixed geometry onto generated button wrappers.

## Generic fix

Classify positioned, non-button fragment links as native anchors before button matching in both single-anchor and anchor-row paths. Their valid paragraph carrier is marked `display: contents` so it does not introduce document flow, while the source anchor retains selectors and focus behavior. Ordinary styled fragment CTAs and explicit `role="button"` controls continue through core button conversion.

## Tests

- `php tests/unit/button-signal-classifier.php` (32 assertions)
- `composer test` (canonical contracts, unit suite, 258 parity fixtures, package install proof)

## Fixture-89 Evidence

Final combined SHA: `50309edbc004370de3f3c2468f013b0eee4fa1ce`

- Visual: `0/10,325,760`
- Native: `170/170`
- Editor: `340/340`
- Core/html/warnings/findings: zero
- Dimensions: `1280x8067`

Fixes #756.

## AI assistance

model gpt-5.6-sol using OpenCode analyzed the classifier path, rebuilt the commits with disclosure, implemented the generic repair, and ran verification. Chris Huber is responsible for every line.