### PR TITLE
Add Static Site Importer architecture fixture

### DIFF
--- a/fixtures/websites/89-static-site-importer-architecture/css/site.css
+++ b/fixtures/websites/89-static-site-importer-architecture/css/site.css
@@ -1,0 +1,180 @@
+:root {
+  --ink: #17231d;
+  --muted: #657069;
+  --paper: #f4f1e9;
+  --surface: #fffdf8;
+  --line: #d8d9d1;
+  --green: #1f6b4f;
+  --green-bright: #65d6a1;
+  --lime: #c9f27b;
+  --orange: #ff8d62;
+  --purple: #7866d5;
+  --red: #d85f56;
+  --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; color: var(--ink); background: var(--paper); font-family: var(--sans); line-height: 1.6; }
+a { color: inherit; }
+code { padding: .12em .34em; border-radius: .3em; background: #e9e8e0; font-family: var(--mono); font-size: .88em; }
+.skip-link { position: fixed; z-index: 20; top: 10px; left: 10px; padding: .7rem 1rem; color: white; background: var(--ink); transform: translateY(-160%); }
+.skip-link:focus { transform: translateY(0); }
+
+.site-header { position: relative; z-index: 5; display: flex; align-items: center; justify-content: space-between; min-height: 76px; padding: 0 clamp(24px, 5vw, 80px); border-bottom: 1px solid rgba(255,255,255,.14); color: #f8fff9; background: #173e30; }
+.brand { display: inline-flex; gap: .7rem; align-items: center; font-size: .94rem; font-weight: 750; text-decoration: none; letter-spacing: -.01em; }
+.brand-mark { display: grid; place-items: center; width: 30px; height: 30px; border: 1px solid rgba(255,255,255,.6); border-radius: 7px; color: var(--ink); background: var(--lime); font-family: Georgia, serif; font-weight: 800; }
+.site-header nav { display: flex; gap: clamp(16px, 2.6vw, 38px); align-items: center; }
+.site-header nav a { font-size: .82rem; font-weight: 650; text-decoration: none; }
+.site-header nav a:hover { color: var(--lime); }
+.site-header .nav-action { padding: .58rem .9rem; border: 1px solid rgba(255,255,255,.35); border-radius: 999px; }
+
+.hero { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(380px, .95fr); gap: clamp(50px, 8vw, 120px); align-items: center; min-height: 720px; padding: clamp(70px, 10vw, 140px) clamp(24px, 7vw, 120px); color: white; background: radial-gradient(circle at 74% 28%, rgba(101,214,161,.13), transparent 27%), linear-gradient(135deg, #173e30, #10291f); overflow: hidden; }
+.hero-copy { max-width: 770px; }
+.eyebrow { display: flex; gap: .65rem; align-items: center; margin: 0 0 1.2rem; color: var(--green); font-family: var(--mono); font-size: .72rem; font-weight: 750; letter-spacing: .12em; text-transform: uppercase; }
+.eyebrow span { width: 24px; height: 2px; background: currentColor; }
+.hero .eyebrow, .eyebrow.light { color: var(--lime); }
+.hero h1 { max-width: 820px; margin: 0; font-family: Georgia, "Times New Roman", serif; font-size: clamp(3.5rem, 7.2vw, 7.2rem); font-weight: 500; line-height: .92; letter-spacing: -.065em; }
+.hero h1 em { color: var(--lime); font-weight: inherit; }
+.lede { max-width: 680px; margin: 2rem 0 0; color: #d7e5dc; font-size: clamp(1.04rem, 1.5vw, 1.3rem); }
+.hero-actions { display: flex; flex-wrap: wrap; gap: .9rem; margin-top: 2.2rem; }
+.button { display: inline-flex; align-items: center; justify-content: center; padding: .88rem 1.2rem; border: 1px solid transparent; border-radius: 5px; font-size: .86rem; font-weight: 750; text-decoration: none; }
+.button.primary { color: var(--ink); background: var(--lime); }
+.button.secondary { border-color: rgba(255,255,255,.35); color: white; }
+.button:hover { transform: translateY(-2px); }
+
+.hero-visual { position: relative; display: grid; gap: 32px; max-width: 540px; padding: 52px 0; }
+.hero-visual::before { content: ""; position: absolute; inset: 0 13% 0 auto; width: 1px; background: linear-gradient(transparent, rgba(201,242,123,.35), transparent); }
+.artifact-card { position: relative; display: grid; grid-template-columns: 1fr auto; gap: .18rem 1rem; width: min(100%, 390px); padding: 1.35rem 1.5rem; border: 1px solid rgba(255,255,255,.15); border-radius: 12px; background: rgba(255,255,255,.075); box-shadow: 0 18px 50px rgba(0,0,0,.18); backdrop-filter: blur(8px); }
+.artifact-card strong { font-family: var(--mono); font-size: 1.05rem; }
+.artifact-card > span:not(.card-label) { grid-column: 2; color: #aebdb4; font-family: var(--mono); font-size: .7rem; }
+.artifact-card .card-label { grid-column: 1 / -1; margin-bottom: .6rem; color: var(--lime); font-family: var(--mono); font-size: .65rem; letter-spacing: .12em; text-transform: uppercase; }
+.engine-card { margin-left: 13%; border-color: rgba(201,242,123,.5); background: rgba(201,242,123,.09); }
+.wp-card { margin-left: 26%; }
+.flow-line { position: relative; height: 34px; margin: -22px 0 -22px 54%; border-left: 1px dashed rgba(201,242,123,.5); }
+.flow-line::after { content: ""; position: absolute; bottom: 0; left: -4px; width: 7px; height: 7px; border-right: 1px solid var(--lime); border-bottom: 1px solid var(--lime); transform: rotate(45deg); }
+.flow-line span { position: absolute; top: 5px; left: 13px; color: #92a79a; font-family: var(--mono); font-size: .62rem; }
+
+.principles { display: grid; grid-template-columns: repeat(3, 1fr); border-bottom: 1px solid var(--line); background: var(--surface); }
+.principles article { display: grid; grid-template-columns: auto 1fr; gap: 1.15rem; padding: 2.2rem clamp(24px, 4vw, 64px); border-right: 1px solid var(--line); }
+.principles article:last-child { border-right: 0; }
+.principles article > span { color: var(--green); font-family: var(--mono); font-size: .72rem; }
+.principles h2 { margin: 0 0 .35rem; font-size: 1rem; letter-spacing: -.02em; }
+.principles p { margin: 0; color: var(--muted); font-size: .84rem; line-height: 1.55; }
+
+.section { padding: clamp(78px, 10vw, 150px) clamp(24px, 7vw, 120px); }
+.section-heading { max-width: 830px; margin-bottom: 4.5rem; }
+.section-heading.compact { margin-bottom: 3rem; }
+.section-heading h2, .contract-copy h2, .quality-intro h2, .maintenance-copy h2, .closing h2 { margin: 0; font-family: Georgia, "Times New Roman", serif; font-size: clamp(2.5rem, 5vw, 5.1rem); font-weight: 500; line-height: 1.02; letter-spacing: -.055em; }
+.section-heading > p:last-child { max-width: 620px; margin: 1.4rem 0 0; color: var(--muted); font-size: 1.05rem; }
+
+.pipeline-section { background: var(--paper); }
+.pipeline { max-width: 1240px; margin: 0; padding: 0; list-style: none; }
+.stage { display: grid; grid-template-columns: 78px minmax(0, 1fr) minmax(190px, 260px); gap: clamp(24px, 4vw, 60px); padding: 3.2rem 0; border-top: 1px solid var(--line); }
+.stage:last-child { border-bottom: 1px solid var(--line); }
+.stage-number { display: grid; place-items: center; align-self: start; width: 54px; height: 54px; border: 1px solid var(--line); border-radius: 50%; color: var(--green); background: var(--surface); font-family: var(--mono); font-size: .8rem; font-weight: 800; }
+.stage-owner { margin: 0 0 .4rem; color: var(--green); font-family: var(--mono); font-size: .7rem; font-weight: 750; letter-spacing: .08em; text-transform: uppercase; }
+.stage h3 { margin: 0; font-size: clamp(1.45rem, 2.4vw, 2.15rem); line-height: 1.18; letter-spacing: -.035em; }
+.stage-copy > p:not(.stage-owner) { max-width: 740px; margin: 1rem 0; color: var(--muted); }
+.chips, .check-list { display: flex; flex-wrap: wrap; gap: .5rem; margin: 1.4rem 0 0; padding: 0; list-style: none; }
+.chips li { padding: .32rem .65rem; border: 1px solid var(--line); border-radius: 999px; color: #4d5c53; background: var(--surface); font-family: var(--mono); font-size: .67rem; }
+.check-list { display: grid; grid-template-columns: repeat(2, minmax(180px, 1fr)); gap: .45rem 1.2rem; }
+.check-list li { position: relative; padding-left: 1.2rem; color: #4d5c53; font-size: .8rem; }
+.check-list li::before { content: ""; position: absolute; top: .62em; left: 0; width: 6px; height: 6px; border-radius: 50%; background: var(--green-bright); }
+.stage-output { align-self: center; padding: 1.2rem; border-left: 2px solid var(--green-bright); background: rgba(255,255,255,.48); }
+.stage-output span { display: block; margin-bottom: .3rem; color: var(--muted); font-family: var(--mono); font-size: .62rem; letter-spacing: .08em; text-transform: uppercase; }
+.stage-output strong { display: block; font-size: .9rem; line-height: 1.4; }
+.stage-output code { padding: 0; background: none; font-size: .78rem; }
+.stage-output.feedback { border-left-color: var(--purple); }
+
+.contract-section { display: grid; grid-template-columns: .86fr 1.14fr; gap: clamp(50px, 9vw, 130px); align-items: center; color: white; background: var(--ink); }
+.contract-copy { max-width: 600px; }
+.contract-copy > p:not(.eyebrow) { color: #b9c5be; }
+.contract-copy blockquote { margin: 2.2rem 0 0; padding: 1.4rem 0 1.4rem 1.5rem; border-left: 2px solid var(--lime); color: #edf5ef; font-family: Georgia, serif; font-size: 1.25rem; line-height: 1.5; }
+.contract-grid { display: grid; grid-template-columns: repeat(2, 1fr); border-top: 1px solid #455048; border-left: 1px solid #455048; }
+.contract-grid article { min-height: 220px; padding: 1.6rem; border-right: 1px solid #455048; border-bottom: 1px solid #455048; }
+.contract-icon { display: grid; place-items: center; width: 42px; height: 42px; margin-bottom: 2.5rem; border-radius: 50%; color: var(--ink); background: var(--lime); font-family: var(--mono); font-size: .65rem; font-weight: 800; }
+.contract-grid h3 { margin: 0 0 .5rem; font-size: 1.1rem; }
+.contract-grid p { margin: 0; color: #aebbb3; font-size: .82rem; }
+
+.ownership-section { background: var(--surface); }
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; text-align: left; }
+th, td { padding: 1.35rem 1rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+thead th { color: var(--muted); font-family: var(--mono); font-size: .66rem; letter-spacing: .1em; text-transform: uppercase; }
+tbody th { width: 22%; font-size: .9rem; }
+tbody td { width: 39%; color: #4c5851; font-size: .86rem; }
+
+.quality-section { background: #e8ede7; }
+.quality-intro { max-width: 800px; }
+.quality-intro > p:last-child { max-width: 640px; color: var(--muted); }
+.scorecard { display: grid; grid-template-columns: repeat(4, 1fr); margin-top: 4rem; border-top: 1px solid #bdc8c0; border-left: 1px solid #bdc8c0; }
+.scorecard article { min-height: 245px; padding: 1.6rem; border-right: 1px solid #bdc8c0; border-bottom: 1px solid #bdc8c0; }
+.score { display: block; margin-bottom: 4rem; color: var(--green); font-family: var(--mono); font-size: .7rem; }
+.scorecard h3 { margin: 0 0 .5rem; font-size: 1.4rem; }
+.scorecard p { margin: 0; color: var(--muted); font-size: .84rem; }
+.fallback-model { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-top: 2.5rem; }
+.fallback-model > div { padding: 1.25rem; background: rgba(255,255,255,.6); }
+.fallback-model strong { display: block; margin: .75rem 0 .3rem; font-size: .86rem; }
+.fallback-model p { margin: 0; color: var(--muted); font-size: .76rem; }
+.signal { display: block; width: 24px; height: 4px; }
+.signal.green { background: var(--green); }.signal.amber { background: var(--orange); }.signal.purple { background: var(--purple); }.signal.red { background: var(--red); }
+
+.maintenance-section { background: var(--paper); }
+.maintenance-card { display: grid; grid-template-columns: .85fr 1.15fr; gap: clamp(50px, 9vw, 130px); padding: clamp(40px, 7vw, 90px); color: white; background: var(--green); box-shadow: 18px 18px 0 #cdd7c7; }
+.maintenance-copy > p:last-child { color: #c8ded3; }
+.maintenance-loop { margin: 0; padding: 0; list-style: none; }
+.maintenance-loop li { display: grid; grid-template-columns: 42px 1fr; gap: 1rem; padding: 1.35rem 0; border-top: 1px solid rgba(255,255,255,.2); }
+.maintenance-loop li:last-child { border-bottom: 1px solid rgba(255,255,255,.2); }
+.maintenance-loop li > span { display: grid; place-items: center; width: 30px; height: 30px; border-radius: 50%; color: var(--green); background: var(--lime); font-family: var(--mono); font-size: .7rem; font-weight: 800; }
+.maintenance-loop strong { font-size: .92rem; }
+.maintenance-loop p { margin: .25rem 0 0; color: #c8ded3; font-size: .78rem; }
+
+.questions-section { background: var(--surface); }
+.questions { max-width: 980px; border-top: 1px solid var(--line); }
+.questions details { border-bottom: 1px solid var(--line); }
+.questions summary { position: relative; padding: 1.45rem 3rem 1.45rem 0; cursor: pointer; font-size: 1rem; font-weight: 750; list-style: none; }
+.questions summary::-webkit-details-marker { display: none; }
+.questions summary::after { content: "+"; position: absolute; right: .5rem; color: var(--green); font-family: var(--mono); font-size: 1.3rem; font-weight: 400; }
+.questions details[open] summary::after { content: "−"; }
+.questions details p { max-width: 800px; margin: -.2rem 0 1.6rem; color: var(--muted); }
+
+.closing { padding: clamp(80px, 12vw, 170px) clamp(24px, 12vw, 180px); color: white; background: linear-gradient(115deg, #17231d 0 68%, #22362b 68%); }
+.closing h2 { max-width: 920px; }
+.closing > p:not(.eyebrow) { max-width: 670px; color: #b9c5be; font-size: 1.05rem; }
+.closing-links { display: flex; flex-wrap: wrap; gap: 1.4rem; align-items: center; margin-top: 2.3rem; }
+.button.inverted { color: var(--ink); background: white; }
+.closing-links > a:not(.button) { color: var(--lime); font-size: .85rem; font-weight: 750; text-decoration: none; }
+
+footer { display: flex; gap: 2rem; align-items: center; justify-content: space-between; padding: 2rem clamp(24px, 7vw, 120px); color: #b9c5be; background: #101713; font-size: .75rem; }
+.footer-brand { color: white; }
+footer > a:last-child { color: var(--lime); text-decoration: none; }
+
+@media (max-width: 980px) {
+  .site-header nav a:not(.nav-action) { display: none; }
+  .hero { grid-template-columns: 1fr; }
+  .hero-visual { width: 100%; max-width: 640px; }
+  .principles { grid-template-columns: 1fr; }
+  .principles article { border-right: 0; border-bottom: 1px solid var(--line); }
+  .contract-section, .maintenance-card { grid-template-columns: 1fr; }
+  .scorecard, .fallback-model { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 700px) {
+  .site-header { min-height: 66px; }
+  .site-header .nav-action { padding: .5rem .7rem; font-size: .7rem; }
+  .hero { min-height: auto; padding-top: 80px; }
+  .hero h1 { font-size: clamp(3.15rem, 16vw, 5rem); }
+  .artifact-card { width: 88%; }
+  .engine-card { margin-left: 6%; }
+  .wp-card { margin-left: 12%; }
+  .stage { grid-template-columns: 54px minmax(0, 1fr); gap: 1rem; }
+  .stage-output { grid-column: 2; }
+  .check-list { grid-template-columns: 1fr; }
+  .contract-grid, .scorecard, .fallback-model { grid-template-columns: 1fr; }
+  .scorecard article { min-height: auto; }
+  .score { margin-bottom: 2rem; }
+  .maintenance-card { padding: 2rem 1.4rem; box-shadow: 9px 9px 0 #cdd7c7; }
+  footer { align-items: flex-start; flex-direction: column; }
+}

--- a/fixtures/websites/89-static-site-importer-architecture/fixture.json
+++ b/fixtures/websites/89-static-site-importer-architecture/fixture.json
@@ -1,0 +1,23 @@
+{
+  "fixture_class": "docs/blog",
+  "tags": [
+    "architecture",
+    "static-site-importer",
+    "blocks-engine",
+    "wordpress",
+    "pipeline",
+    "documentation",
+    "single-page"
+  ],
+  "capabilities": [
+    "local-css",
+    "tables",
+    "details"
+  ],
+  "risk_profile": "low",
+  "complexity": 3,
+  "quality_budgets": {
+    "max_unacceptable_findings": 0,
+    "visual_mismatch_ratio": 0
+  }
+}

--- a/fixtures/websites/89-static-site-importer-architecture/index.html
+++ b/fixtures/websites/89-static-site-importer-architecture/index.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="How Static Site Importer and Blocks Engine turn static website artifacts into native, editable WordPress block themes.">
+  <title>Static Site Importer | From HTML to native WordPress</title>
+  <link rel="stylesheet" href="css/site.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to architecture</a>
+
+  <header class="site-header">
+    <a class="brand" href="#top" aria-label="Static Site Importer architecture home">
+      <span class="brand-mark" aria-hidden="true">S</span>
+      <span>Static Site Importer</span>
+    </a>
+    <nav aria-label="Page sections">
+      <a href="#pipeline">Pipeline</a>
+      <a href="#ownership">Ownership</a>
+      <a href="#quality">Quality</a>
+      <a class="nav-action" href="#maintenance">Maintenance model</a>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="hero" id="top">
+      <div class="hero-copy">
+        <p class="eyebrow"><span></span> Architecture overview</p>
+        <h1>From arbitrary HTML to <em>native WordPress.</em></h1>
+        <p class="lede">A deterministic conversion stack turns static website artifacts into editable pages and a conventional block theme. Each layer has one job, every handoff is inspectable, and quality evidence flows back into the transformer.</p>
+        <div class="hero-actions">
+          <a class="button primary" href="#pipeline">Follow the pipeline</a>
+          <a class="button secondary" href="https://github.com/Automattic/static-site-importer">View the importer</a>
+        </div>
+      </div>
+      <div class="hero-visual" aria-label="Simplified conversion flow from HTML through Blocks Engine and Static Site Importer to WordPress">
+        <div class="artifact-card source-card">
+          <span class="card-label">Input</span>
+          <strong>index.html</strong>
+          <span>styles.css</span>
+          <span>assets/</span>
+        </div>
+        <div class="flow-line" aria-hidden="true"><span>compile</span></div>
+        <div class="artifact-card engine-card">
+          <span class="card-label">Contract</span>
+          <strong>Site Plan v2</strong>
+          <span>blocks + routes</span>
+          <span>theme writes</span>
+        </div>
+        <div class="flow-line" aria-hidden="true"><span>materialize</span></div>
+        <div class="artifact-card wp-card">
+          <span class="card-label">WordPress</span>
+          <strong>Editable site</strong>
+          <span>native pages</span>
+          <span>block theme</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="principles" aria-label="Architecture principles">
+      <article><span>01</span><div><h2>HTML is the interchange format</h2><p>Generators can produce the web format they already understand. The conversion layer handles WordPress structure.</p></div></article>
+      <article><span>02</span><div><h2>Contracts separate responsibilities</h2><p>Blocks Engine describes the desired site. Static Site Importer performs WordPress mutations.</p></div></article>
+      <article><span>03</span><div><h2>Evidence drives improvement</h2><p>Fallbacks, editor validity, and visual differences become attributable findings instead of hidden compromises.</p></div></article>
+    </section>
+
+    <section class="section pipeline-section" id="pipeline">
+      <header class="section-heading">
+        <p class="eyebrow"><span></span> The conversion pipeline</p>
+        <h2>Four bounded stages. One inspectable result.</h2>
+        <p>No product-specific prompt has to understand block serialization, theme files, or WordPress mutation order.</p>
+      </header>
+
+      <ol class="pipeline">
+        <li class="stage stage-input">
+          <div class="stage-number">1</div>
+          <div class="stage-copy">
+            <p class="stage-owner">Source artifact</p>
+            <h3>Accept normal web inputs</h3>
+            <p>A single HTML document, an HTML and asset tree, a ZIP, Markdown content, or a generated website artifact enters through a bounded intake path. Figma follows the same architecture after its own transformer produces a static HTML artifact.</p>
+            <ul class="chips" aria-label="Supported source examples"><li>HTML</li><li>CSS</li><li>Assets</li><li>Markdown</li><li>Site artifact v1</li></ul>
+          </div>
+          <div class="stage-output"><span>Produces</span><strong>Normalized source tree</strong></div>
+        </li>
+        <li class="stage stage-engine">
+          <div class="stage-number">2</div>
+          <div class="stage-copy">
+            <p class="stage-owner">Blocks Engine</p>
+            <h3>Compile semantics, structure, and assets</h3>
+            <p>The generic artifact compiler separates document chrome from page content, maps representable HTML semantics to block markup, assigns canonical routes, declares assets and runtime requirements, and records conversion diagnostics.</p>
+            <ul class="check-list"><li>Core block conversion</li><li>Shared header and footer extraction</li><li>Asset and script declarations</li><li>Quality and fallback diagnostics</li></ul>
+          </div>
+          <div class="stage-output"><span>Produces</span><strong><code>wordpress-site-plan/v2</code></strong></div>
+        </li>
+        <li class="stage stage-importer">
+          <div class="stage-number">3</div>
+          <div class="stage-copy">
+            <p class="stage-owner">Static Site Importer</p>
+            <h3>Materialize the canonical plan</h3>
+            <p>The WordPress layer validates the destination before mutation, resolves declared asset tokens, writes the block theme, creates or updates pages, applies ordered site operations, prepares declared dependencies, and records exactly what changed.</p>
+            <ul class="check-list"><li>Pages store body blocks in <code>post_content</code></li><li>Theme parts own shared chrome</li><li>Templates render <code>core/post-content</code></li><li>Receipt records pages, files, and operations</li></ul>
+          </div>
+          <div class="stage-output"><span>Produces</span><strong>WordPress site + receipt</strong></div>
+        </li>
+        <li class="stage stage-proof">
+          <div class="stage-number">4</div>
+          <div class="stage-copy">
+            <p class="stage-owner">Fixture matrix and validation providers</p>
+            <h3>Measure the result in the real editor</h3>
+            <p>The imported site is evaluated as a WordPress site, not as a successful function call. Browser rendering, editor validity, native block composition, missing assets, runtime behavior, and visual parity are collected as separate evidence.</p>
+            <ul class="check-list"><li>Frontend and mobile rendering</li><li>Editor-open and block-validity checks</li><li>Native versus fallback composition</li><li>Source-to-WordPress visual comparison</li></ul>
+          </div>
+          <div class="stage-output feedback"><span>Feeds back</span><strong>Attributed findings</strong></div>
+        </li>
+      </ol>
+    </section>
+
+    <section class="section contract-section" id="contract">
+      <div class="contract-copy">
+        <p class="eyebrow"><span></span> The stable handoff</p>
+        <h2>The plan says what. The materializer decides where.</h2>
+        <p><code>blocks-engine/wordpress-site-plan/v2</code> is destination-independent. It contains canonical block markup and desired-state operations without guessing a deployed theme URL or reaching into WordPress.</p>
+        <blockquote>Blocks Engine never writes WordPress state. Static Site Importer never reverse-engineers compiler intent.</blockquote>
+      </div>
+      <div class="contract-grid" aria-label="WordPress site plan contents">
+        <article><span class="contract-icon">Aa</span><h3>Pages</h3><p>Canonical routes, hierarchy, reconciliation identities, and editable block markup.</p></article>
+        <article><span class="contract-icon">{ }</span><h3>Theme writes</h3><p>Templates, parts, styles, configuration, scripts, and materializable assets.</p></article>
+        <article><span class="contract-icon">-&gt;</span><h3>Operations</h3><p>Ordered page creation and reading-setting intent applied verbatim by consumers.</p></article>
+        <article><span class="contract-icon">OK</span><h3>Quality</h3><p>Explicit pass state, metrics, diagnostics, and fallback evidence for policy decisions.</p></article>
+      </div>
+    </section>
+
+    <section class="section ownership-section" id="ownership">
+      <header class="section-heading compact">
+        <p class="eyebrow"><span></span> Clear ownership</p>
+        <h2>Every concern has one home.</h2>
+      </header>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Layer</th><th>Owns</th><th>Does not own</th></tr></thead>
+          <tbody>
+            <tr><th>Generating product or agent</th><td>Content, visual intent, source artifact</td><td>WordPress block serialization or filesystem mutation</td></tr>
+            <tr><th>Figma transformer</th><td><code>.fig</code> scenegraph to static HTML, CSS, assets, and parity diagnostics</td><td>HTML-to-block conversion or WordPress writes</td></tr>
+            <tr><th>Blocks Engine</th><td>Generic artifact compilation, block conversion, diagnostics, and Site Plan v2</td><td>Destination URLs, WordPress APIs, or product orchestration</td></tr>
+            <tr><th>Static Site Importer</th><td>Safe intake, WordPress preflight, materialization, reconciliation, reports, and receipts</td><td>Product prompt strategy or browser-validation infrastructure</td></tr>
+            <tr><th>Validation provider</th><td>Runtime, editor, screenshot, and visual-comparison evidence</td><td>Reinterpreting or silently repairing the import</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="section quality-section" id="quality">
+      <div class="quality-intro">
+        <p class="eyebrow"><span></span> Quality is an output</p>
+        <h2>“Imported” is not the finish line.</h2>
+        <p>A useful result is editable, valid, complete, and visually faithful. The matrix keeps those dimensions separate so a green process exit cannot disguise a broken page.</p>
+      </div>
+      <div class="scorecard">
+        <article><span class="score">01</span><h3>Native</h3><p>Semantic content becomes core blocks whenever the editor can represent it faithfully.</p></article>
+        <article><span class="score">02</span><h3>Valid</h3><p>Serialized blocks open without recovery prompts or invalid-block warnings.</p></article>
+        <article><span class="score">03</span><h3>Complete</h3><p>Assets, links, scripts, routes, dependencies, and shared chrome survive materialization.</p></article>
+        <article><span class="score">04</span><h3>Faithful</h3><p>Desktop and mobile rendering are compared against the source artifact.</p></article>
+      </div>
+      <div class="fallback-model">
+        <div><span class="signal green"></span><strong>Convertible</strong><p>Improve the generic transformer until the shape maps cleanly to native blocks.</p></div>
+        <div><span class="signal amber"></span><strong>Core capability gap</strong><p>Promote recurring, evidenced patterns to a typed companion-block candidate.</p></div>
+        <div><span class="signal purple"></span><strong>Intentional runtime</strong><p>Preserve genuinely dynamic behavior as an attributed runtime island.</p></div>
+        <div><span class="signal red"></span><strong>Unresolved fallback</strong><p>Treat visible <code>core/html</code> as a quality finding, not invisible success.</p></div>
+      </div>
+    </section>
+
+    <section class="section maintenance-section" id="maintenance">
+      <div class="maintenance-card">
+        <div class="maintenance-copy">
+          <p class="eyebrow light"><span></span> Maintenance model</p>
+          <h2>Core evolves. The corpus tells us what to change.</h2>
+          <p>The system is maintained as generic conversion capabilities and versioned contracts, not a growing set of templates for individual sites. When Gutenberg gains a useful block or attribute, Blocks Engine can adopt it and replay the same fixture corpus.</p>
+        </div>
+        <ol class="maintenance-loop">
+          <li><span>1</span><div><strong>Observe</strong><p>A fixture exposes a fallback, invalid block, missing behavior, or visual mismatch.</p></div></li>
+          <li><span>2</span><div><strong>Attribute</strong><p>Evidence separates transformer defects, real Gutenberg gaps, runtime islands, and style drift.</p></div></li>
+          <li><span>3</span><div><strong>Improve upstream</strong><p>The owning generic layer gains a semantic rule, contract capability, or typed block.</p></div></li>
+          <li><span>4</span><div><strong>Replay</strong><p>The full corpus proves the improvement and protects every previously solved site.</p></div></li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="section questions-section" id="questions">
+      <header class="section-heading compact">
+        <p class="eyebrow"><span></span> Architecture questions</p>
+        <h2>The short answers.</h2>
+      </header>
+      <div class="questions">
+        <details open><summary>Is the conversion a list of hard-coded site rules?</summary><p>No. Conversion logic targets reusable HTML semantics, CSS and layout patterns, block capabilities, and typed artifact contracts. The fixture corpus is evidence and regression coverage; fixture identity is not an input to conversion.</p></details>
+        <details><summary>What happens as Gutenberg adds or changes blocks?</summary><p>The Blocks Engine mapping layer adopts the new core capability, then the corpus is replayed to measure native conversion, editor validity, and parity. The destination-independent site-plan boundary keeps that change out of product callers and materializers.</p></details>
+        <details><summary>Why generate HTML before blocks?</summary><p>HTML and CSS are broadly understood by design tools, browsers, generators, and language models. Keeping generation and conversion separate lets each improve independently while the fixture matrix measures the complete path.</p></details>
+        <details><summary>When is a custom block justified?</summary><p>Only after recurring fixture evidence shows that core blocks have no faithful semantic or behavioral path. The candidate then needs a typed schema, explicit runtime owner, provider decision, and acceptance evidence.</p></details>
+      </div>
+    </section>
+
+    <section class="closing">
+      <p class="eyebrow light"><span></span> The goal</p>
+      <h2>Generate freely. Convert deterministically. Edit natively.</h2>
+      <p>The architecture turns every import into both a WordPress site and a measurement of what the block platform can express next.</p>
+      <div class="closing-links"><a class="button inverted" href="https://github.com/Automattic/blocks-engine">Explore Blocks Engine</a><a href="https://github.com/Automattic/static-site-importer">Static Site Importer on GitHub <span aria-hidden="true">↗</span></a></div>
+    </section>
+  </main>
+
+  <footer>
+    <a class="brand footer-brand" href="#top"><span class="brand-mark" aria-hidden="true">S</span><span>Static Site Importer</span></a>
+    <p>Architecture fixture for the Blocks Engine conversion corpus.</p>
+    <a href="#top">Back to top ↑</a>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds the Static Site Importer architecture fixture as its three source artifacts: `index.html`, `css/site.css`, and `fixture.json`.

## Tests
- `php tools/static-parity/run.php --fixture 89-static-site-importer-architecture --json`
- Result: standalone fixture warning: score 0.8606, property parity 0.8822, coverage 0.9754, 135 findings. This fixture is intentionally expected to expose standalone visual-parity defects and is not a blocker.

## Combined-stack evidence
Verified combined-stack evidence at `50309edbc004370de3f3c2468f013b0eee4fa1ce`: visual `0/10,325,760`; `170/170` native; `340/340` editor; zero `core/html`, warnings, and findings; viewport `1280x8067`.

AI assistance: gpt-5.6-sol via OpenCode; used to recreate the disclosed commit series, verify the fixture scope, run tests, and prepare this PR.
