### PR TITLE
Preserve source open state in native Details blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -234,7 +234,7 @@ final class BlockFactory
 
         if ( 'core/details' === $name ) {
             return array(
-                'opening' => '<details' . $this->blockSupportAttrs($attrs, 'wp-block-details') . '><summary>' . ($attrs['summary'] ?? '') . '</summary>',
+                'opening' => '<details' . $this->blockSupportAttrs($attrs, 'wp-block-details') . ( ! empty($attrs['showContent']) ? ' open' : '' ) . '><summary>' . ($attrs['summary'] ?? '') . '</summary>',
                 'closing' => '</details>',
             );
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -24,7 +24,8 @@ final class DetailsPattern
         }
 
         return $createBlock('core/details', array_filter(array_merge($presentationAttributes($element), array(
-            'summary' => $summary instanceof DOMElement ? $innerHtml($summary) : '',
+            'summary'     => $summary instanceof DOMElement ? $innerHtml($summary) : '',
+            'showContent' => $element->hasAttribute('open') ? true : '',
         )), static fn ($value): bool => '' !== $value), $children, $element);
     }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -406,6 +406,24 @@ $assert(true === ($detailsAccordionItems[0]['attrs']['openByDefault'] ?? null), 
 $assert('Can I reschedule?' === ($detailsAccordionItems[0]['innerBlocks'][0]['attrs']['title'] ?? null), 'details summary text maps to accordion heading');
 $assert('Yes, with notice.' === ($detailsAccordionItems[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? null), 'details body text maps to accordion panel');
 
+$openDetailsResult = ( new HtmlTransformer() )->transform('<details open><summary>Open summary</summary><p>Open content.</p></details>')->toArray();
+$openDetailsBlock = $openDetailsResult['blocks'][0] ?? array();
+$openDetailsMarkup = (string) ($openDetailsResult['serialized_blocks'] ?? '');
+$assert('core/details' === ($openDetailsBlock['blockName'] ?? null), 'open native details converts to core/details');
+$assert(true === ($openDetailsBlock['attrs']['showContent'] ?? null), 'open native details maps to the core/details showContent attribute');
+$assert(str_contains($openDetailsMarkup, '<details class="wp-block-details" open><summary>Open summary</summary>'), 'open native details serializes the frontend open attribute before its summary');
+$assert(strpos($openDetailsMarkup, '<summary>Open summary</summary>') < strpos($openDetailsMarkup, '<p>Open content.</p>'), 'open native details preserves summary before content through final serialization');
+$assert('pass' === ($openDetailsResult['source_reports']['wp_block_validity']['status'] ?? ''), 'open native details serialization remains Gutenberg-valid');
+
+$closedDetailsResult = ( new HtmlTransformer() )->transform('<details><summary>Closed summary</summary><p>Closed content.</p></details>')->toArray();
+$closedDetailsBlock = $closedDetailsResult['blocks'][0] ?? array();
+$closedDetailsMarkup = (string) ($closedDetailsResult['serialized_blocks'] ?? '');
+$assert('core/details' === ($closedDetailsBlock['blockName'] ?? null), 'closed native details converts to core/details');
+$assert(false === ($closedDetailsBlock['attrs']['showContent'] ?? false), 'closed native details keeps the core/details default closed state');
+$assert(str_contains($closedDetailsMarkup, '<details class="wp-block-details"><summary>Closed summary</summary>'), 'closed native details serializes without the frontend open attribute');
+$assert(strpos($closedDetailsMarkup, '<summary>Closed summary</summary>') < strpos($closedDetailsMarkup, '<p>Closed content.</p>'), 'closed native details preserves summary before content through final serialization');
+$assert('pass' === ($closedDetailsResult['source_reports']['wp_block_validity']['status'] ?? ''), 'closed native details serialization remains Gutenberg-valid');
+
 // A single disclosure widget (toggle control + collapsible region) carries no
 // faq/accordion class, only the structural WAI-ARIA disclosure shape, and is
 // converted to a native zero-JS core/details block instead of leaking a dead


### PR DESCRIPTION
Closes #759.

## Root cause
The details pattern did not map the source `open` attribute to core/details `showContent`, and the block serializer never emitted the native `open` attribute.

## Tests
- `php tests/contract/run.php`

## Final combined evidence
- Exact SHA: `50309edbc004370de3f3c2468f013b0eee4fa1ce`
- Visual: `0/10,325,760`
- Native: `170/170`
- Editor: `340/340`
- `0` core/html, warnings, and findings
- Viewport: `1280x8067`

AI assistance: gpt-5.6-sol via OpenCode; used to rebuild the disclosed commit history, verify the patch scope, run tests, and prepare this PR. Chris Huber remains responsible for every line.