### PR TITLE
Preserve inherited anchor paint on native button promotion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3053,7 +3053,14 @@ final class HtmlTransformer
                 $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceTableMarkers[$this->sourceElementIdentity($sourceElement)]);
             }
             $logicalControl = $logicalSourceElement ?? $sourceElement;
-            if ( in_array($name, array( 'core/button', 'core/buttons' ), true) && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) && ( isset($this->sourceControlPaths[$logicalControl->getNodePath() ?? '']) || ( '' !== $this->combinedAuthorCss && 'a' === strtolower($logicalControl->tagName) && ( '' !== trim($this->attr($logicalControl, 'class')) || '' !== trim($this->attr($logicalControl, 'id')) ) ) ) ) {
+            $nativeButtonTextAlignment = '';
+            $hasNativeButtonStyle = false;
+            if ( 'core/button' === $name && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) ) {
+                $existingTextColor = (string) ($attrs['style']['color']['text'] ?? '');
+                $nativeButtonTextAlignment = $this->applyNativeButtonInheritedStyle($logicalControl, $attrs);
+                $hasNativeButtonStyle = '' !== $nativeButtonTextAlignment || $existingTextColor !== (string) ($attrs['style']['color']['text'] ?? '');
+            }
+            if ( in_array($name, array( 'core/button', 'core/buttons' ), true) && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) && ( $hasNativeButtonStyle || isset($this->sourceControlPaths[$logicalControl->getNodePath() ?? '']) || ( '' !== $this->combinedAuthorCss && 'a' === strtolower($logicalControl->tagName) && ( '' !== trim($this->attr($logicalControl, 'class')) || '' !== trim($this->attr($logicalControl, 'id')) ) ) ) ) {
                 $path = $logicalControl->getNodePath() ?? '';
                 if ( '' !== $path && ! isset($this->sourceControlMarkers[$path]) ) {
                     $this->sourceControlMarkers[$path] = $this->allocateAuthorMarker('control');
@@ -3061,7 +3068,7 @@ final class HtmlTransformer
                 if ( isset($this->sourceControlMarkers[$path]) ) {
                     $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceControlMarkers[$path]);
                     if ( 'core/button' === $name ) {
-                        $this->registerNativeButtonStyleRule($this->sourceControlMarkers[$path], $attrs);
+                        $this->registerNativeButtonStyleRule($this->sourceControlMarkers[$path], $attrs, $nativeButtonTextAlignment);
                     }
                 }
                 $presentationPath = $sourceElement->getNodePath() ?? '';
@@ -3097,8 +3104,47 @@ final class HtmlTransformer
         return $block;
     }
 
+    /**
+     * Project the inherited foreground because core/button supplies a default link
+     * color. Text alignment uses the same scoped link rule for direct and inherited
+     * values, so a local anchor declaration remains authoritative.
+     *
+     * @param array<string, mixed> $attrs
+     */
+    private function applyNativeButtonInheritedStyle(DOMElement $anchor, array &$attrs): string
+    {
+        $anchorDeclarations = $this->presentationDeclarations($anchor);
+        $inheritedColor = '';
+        $inheritedTextAlignment = '';
+
+        for ( $ancestor = $anchor->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+            $declarations = $this->presentationDeclarations($ancestor);
+            if ( '' === $inheritedColor && ! array_key_exists('color', $anchorDeclarations) && isset($declarations['color']) ) {
+                $inheritedColor = (string) $declarations['color'];
+            }
+            if ( '' === $inheritedTextAlignment && ! array_key_exists('text-align', $anchorDeclarations) && isset($declarations['text-align']) ) {
+                $inheritedTextAlignment = strtolower(trim((string) $declarations['text-align']));
+            }
+            if ( '' !== $inheritedColor && '' !== $inheritedTextAlignment ) {
+                break;
+            }
+        }
+
+        if ( '' !== $inheritedColor && '' === trim((string) ($attrs['style']['color']['text'] ?? '')) ) {
+            $mappedColor = $this->styleAttributeMapper()->map(array( 'color' => $inheritedColor ))['style']['color']['text'] ?? '';
+            if ( '' !== trim((string) $mappedColor) ) {
+                $attrs['style']['color']['text'] = $mappedColor;
+            }
+        }
+
+        $textAlignment = strtolower(trim((string) ($anchorDeclarations['text-align'] ?? $inheritedTextAlignment)));
+        return in_array($textAlignment, array( 'start', 'end', 'left', 'center', 'right' ), true)
+            ? $textAlignment
+            : '';
+    }
+
     /** @param array<string, mixed> $attrs */
-    private function registerNativeButtonStyleRule(string $marker, array $attrs): void
+    private function registerNativeButtonStyleRule(string $marker, array $attrs, string $inheritedTextAlignment = ''): void
     {
         $style = is_array($attrs['style'] ?? null) ? $attrs['style'] : array();
         $declarations = array();
@@ -3123,6 +3169,9 @@ final class HtmlTransformer
             if ( '' !== $value && ! preg_match('/[{}<>;]/', $value) ) {
                 $declarations[] = $property . ':' . $value . '!important';
             }
+        }
+        if ( '' !== $inheritedTextAlignment ) {
+            $declarations[] = 'text-align:' . $inheritedTextAlignment . '!important';
         }
         if ( array() === $declarations ) {
             return;

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3114,15 +3114,17 @@ final class HtmlTransformer
     private function applyNativeButtonInheritedStyle(DOMElement $anchor, array &$attrs): string
     {
         $anchorDeclarations = $this->presentationDeclarations($anchor);
+        $anchorColorInherits = ! isset($anchorDeclarations['color']) || $this->isInheritedCssWideValue((string) $anchorDeclarations['color']);
+        $anchorTextAlignmentInherits = ! isset($anchorDeclarations['text-align']) || $this->isInheritedCssWideValue((string) $anchorDeclarations['text-align']);
         $inheritedColor = '';
         $inheritedTextAlignment = '';
 
         for ( $ancestor = $anchor->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
             $declarations = $this->presentationDeclarations($ancestor);
-            if ( '' === $inheritedColor && ! array_key_exists('color', $anchorDeclarations) && isset($declarations['color']) ) {
+            if ( '' === $inheritedColor && $anchorColorInherits && isset($declarations['color']) ) {
                 $inheritedColor = (string) $declarations['color'];
             }
-            if ( '' === $inheritedTextAlignment && ! array_key_exists('text-align', $anchorDeclarations) && isset($declarations['text-align']) ) {
+            if ( '' === $inheritedTextAlignment && $anchorTextAlignmentInherits && isset($declarations['text-align']) ) {
                 $inheritedTextAlignment = strtolower(trim((string) $declarations['text-align']));
             }
             if ( '' !== $inheritedColor && '' !== $inheritedTextAlignment ) {
@@ -3130,17 +3132,24 @@ final class HtmlTransformer
             }
         }
 
-        if ( '' !== $inheritedColor && '' === trim((string) ($attrs['style']['color']['text'] ?? '')) ) {
+        if ( '' !== $inheritedColor && ( '' === trim((string) ($attrs['style']['color']['text'] ?? '')) || $this->isInheritedCssWideValue((string) $attrs['style']['color']['text']) ) ) {
             $mappedColor = $this->styleAttributeMapper()->map(array( 'color' => $inheritedColor ))['style']['color']['text'] ?? '';
             if ( '' !== trim((string) $mappedColor) ) {
                 $attrs['style']['color']['text'] = $mappedColor;
             }
         }
 
-        $textAlignment = strtolower(trim((string) ($anchorDeclarations['text-align'] ?? $inheritedTextAlignment)));
+        $textAlignment = $anchorTextAlignmentInherits
+            ? $inheritedTextAlignment
+            : strtolower(trim((string) $anchorDeclarations['text-align']));
         return in_array($textAlignment, array( 'start', 'end', 'left', 'center', 'right' ), true)
             ? $textAlignment
             : '';
+    }
+
+    private function isInheritedCssWideValue(string $value): bool
+    {
+        return in_array(strtolower(trim($value)), array( 'inherit', 'unset' ), true);
     }
 
     /** @param array<string, mixed> $attrs */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3053,29 +3053,38 @@ final class HtmlTransformer
                 $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceTableMarkers[$this->sourceElementIdentity($sourceElement)]);
             }
             $logicalControl = $logicalSourceElement ?? $sourceElement;
+            $logicalControlPath = $logicalControl->getNodePath() ?? '';
             $nativeButtonTextAlignment = '';
+            $hasNativeButtonColor = false;
             $hasNativeButtonStyle = false;
             if ( 'core/button' === $name && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) ) {
                 $existingTextColor = (string) ($attrs['style']['color']['text'] ?? '');
-                $nativeButtonTextAlignment = $this->applyNativeButtonInheritedStyle($logicalControl, $attrs);
-                $hasNativeButtonStyle = '' !== $nativeButtonTextAlignment || $existingTextColor !== (string) ($attrs['style']['color']['text'] ?? '');
+                $nativeButtonTextAlignment = $this->applyNativeButtonInheritedStyle($logicalControl, $attrs, 'a' === strtolower($logicalControl->tagName) && ($sourceElement === $logicalControl || $sourceElement->parentNode === $logicalControl));
+                $hasNativeButtonColor = $existingTextColor !== (string) ($attrs['style']['color']['text'] ?? '');
+                $hasNativeButtonStyle = '' !== $nativeButtonTextAlignment || $hasNativeButtonColor;
             }
-            if ( in_array($name, array( 'core/button', 'core/buttons' ), true) && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) && ( $hasNativeButtonStyle || isset($this->sourceControlPaths[$logicalControl->getNodePath() ?? '']) || ( '' !== $this->combinedAuthorCss && 'a' === strtolower($logicalControl->tagName) && ( '' !== trim($this->attr($logicalControl, 'class')) || '' !== trim($this->attr($logicalControl, 'id')) ) ) ) ) {
-                $path = $logicalControl->getNodePath() ?? '';
-                if ( '' !== $path && ! isset($this->sourceControlMarkers[$path]) ) {
-                    $this->sourceControlMarkers[$path] = $this->allocateAuthorMarker('control');
+            if ( in_array($name, array( 'core/button', 'core/buttons' ), true) && in_array(strtolower($logicalControl->tagName), array( 'a', 'button' ), true) && ( isset($this->sourceControlPaths[$logicalControlPath]) || ( '' !== $this->combinedAuthorCss && 'a' === strtolower($logicalControl->tagName) && ( '' !== trim($this->attr($logicalControl, 'class')) || '' !== trim($this->attr($logicalControl, 'id')) ) ) ) ) {
+                if ( '' !== $logicalControlPath && ! isset($this->sourceControlMarkers[$logicalControlPath]) ) {
+                    $this->sourceControlMarkers[$logicalControlPath] = $this->allocateAuthorMarker('control');
                 }
-                if ( isset($this->sourceControlMarkers[$path]) ) {
-                    $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceControlMarkers[$path]);
+                if ( isset($this->sourceControlMarkers[$logicalControlPath]) ) {
+                    $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $this->sourceControlMarkers[$logicalControlPath]);
                     if ( 'core/button' === $name ) {
-                        $this->registerNativeButtonStyleRule($this->sourceControlMarkers[$path], $attrs, $nativeButtonTextAlignment);
+                        $this->registerNativeButtonStyleRule($this->sourceControlMarkers[$logicalControlPath], $attrs, $nativeButtonTextAlignment);
                     }
                 }
                 $presentationPath = $sourceElement->getNodePath() ?? '';
-                if ( '' !== $presentationPath && $presentationPath !== $path ) {
-                    $this->sourceControlMarkers[$presentationPath] = $this->sourceControlMarkers[$path];
-                    $this->sourceButtonPresentationMarkers[$presentationPath] = $this->sourceControlMarkers[$path];
+                if ( '' !== $presentationPath && $presentationPath !== $logicalControlPath ) {
+                    $this->sourceControlMarkers[$presentationPath] = $this->sourceControlMarkers[$logicalControlPath];
+                    $this->sourceButtonPresentationMarkers[$presentationPath] = $this->sourceControlMarkers[$logicalControlPath];
                 }
+            }
+            if ( 'core/button' === $name && $hasNativeButtonStyle && ! isset($this->sourceControlMarkers[$logicalControlPath]) ) {
+                $nativeButtonMarker = $hasNativeButtonColor
+                    ? $this->allocateAuthorMarker('native-button')
+                    : 'blocks-engine-native-button-alignment-' . $nativeButtonTextAlignment;
+                $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $nativeButtonMarker);
+                $this->registerNativeButtonStyleRule($nativeButtonMarker, $hasNativeButtonColor ? $attrs : array(), $nativeButtonTextAlignment);
             }
             $provenanceId = $this->nextSourceProvenanceId++;
             $this->recordPresentationProvenance($name, $attrs, $sourceElement);
@@ -3111,7 +3120,7 @@ final class HtmlTransformer
      *
      * @param array<string, mixed> $attrs
      */
-    private function applyNativeButtonInheritedStyle(DOMElement $anchor, array &$attrs): string
+    private function applyNativeButtonInheritedStyle(DOMElement $anchor, array &$attrs, bool $useInitialTextAlignment): string
     {
         $anchorDeclarations = $this->presentationDeclarations($anchor);
         $anchorColorInherits = ! isset($anchorDeclarations['color']) || $this->isInheritedCssWideValue((string) $anchorDeclarations['color']);
@@ -3142,6 +3151,9 @@ final class HtmlTransformer
         $textAlignment = $anchorTextAlignmentInherits
             ? $inheritedTextAlignment
             : strtolower(trim((string) $anchorDeclarations['text-align']));
+        if ( '' === $textAlignment || 'initial' === $textAlignment ) {
+            return $useInitialTextAlignment ? 'start' : '';
+        }
         return in_array($textAlignment, array( 'start', 'end', 'left', 'center', 'right' ), true)
             ? $textAlignment
             : '';

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -846,7 +846,7 @@ $fullWidthButton = ( new HtmlTransformer() )->transform(
 )->toArray();
 $fullWidthButtonMarkup = (string) ($fullWidthButton['serialized_blocks'] ?? '');
 $assert(100 === ($fullWidthButton['blocks'][0]['innerBlocks'][0]['attrs']['width'] ?? null), '100% source button width maps to the native core/button width attribute');
-$assert(str_contains($fullWidthButtonMarkup, '<div class="wp-block-button has-custom-width wp-block-button__width-100 btn tier-cta">'), '100% source button width emits canonical core/button width wrapper classes');
+$assert(str_contains($fullWidthButtonMarkup, '<div class="wp-block-button has-custom-width wp-block-button__width-100 btn tier-cta blocks-engine-native-button-'), '100% source button width emits canonical core/button width wrapper classes plus its scoped native style marker');
 $assert('pass' === ($fullWidthButton['source_reports']['wp_block_validity']['status'] ?? ''), 'full-width button serialization passes generated WordPress block validity checks');
 
 $cssVariableButton = ( new HtmlTransformer() )->transform(

--- a/php-transformer/tests/fixtures/parity/html-button-block-label-inline-richtext.json
+++ b/php-transformer/tests/fixtures/parity/html-button-block-label-inline-richtext.json
@@ -17,13 +17,13 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "primary-button", "text": "Reserve now", "url": "/book" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "primary-button blocks-engine-native-button-alignment-start", "text": "Reserve now", "url": "/book" } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button primary-button\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button primary-button blocks-engine-native-button-alignment-start\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<a class=\"wp-block-button__link has-background wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "href=\"/book\">Reserve now</a>" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "<h3>Reserve now</h3>" },

--- a/php-transformer/tests/fixtures/parity/html-button-custom-filled-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-custom-filled-cta-style.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Get started", "url": "/start", "className": "hero-cta brand-primary", "style": { "color": { "background": "#135e96", "text": "#fff" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700", "textTransform": "uppercase" } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Get started", "url": "/start", "className": "hero-cta brand-primary blocks-engine-native-button-alignment-start", "style": { "color": { "background": "#135e96", "text": "#fff" }, "border": { "width": "2px", "style": "solid", "color": "#135e96", "radius": "999px" }, "spacing": { "padding": { "top": "14px", "right": "28px", "bottom": "14px", "left": "28px" } }, "typography": { "fontWeight": "700", "textTransform": "uppercase" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button hero-cta brand-primary\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button hero-cta brand-primary blocks-engine-native-button-alignment-start\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:#135e96;border-style:solid;border-width:2px;border-radius:999px;color:#fff;background-color:#135e96;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px;font-weight:700;text-transform:uppercase" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "background-color:#f7f7f7" }

--- a/php-transformer/tests/fixtures/parity/html-button-decorative-svg-label-valid.json
+++ b/php-transformer/tests/fixtures/parity/html-button-decorative-svg-label-valid.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "cta-phone", "url": "tel:+16165550182" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "cta-phone blocks-engine-native-button-alignment-start", "url": "tel:+16165550182" } }
   ],
   "expected_fallbacks": [],
   "expect": [

--- a/php-transformer/tests/fixtures/parity/html-button-generic-class-and-style-signal.json
+++ b/php-transformer/tests/fixtures/parity/html-button-generic-class-and-style-signal.json
@@ -17,15 +17,15 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "See the Teams", "url": "/teams", "className": "btnPrimary" } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Sign up today", "url": "/signup", "style": { "color": { "background": "#0a66c2", "text": "#ffffff" }, "border": { "radius": "6px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } },
-    { "path": "blocks.0.innerBlocks.2", "name": "core/button", "attrs": { "text": "Donate", "url": "/donate" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "See the Teams", "url": "/teams", "className": "btnPrimary blocks-engine-native-button-alignment-start" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/button", "attrs": { "text": "Sign up today", "url": "/signup", "className": "blocks-engine-native-button-alignment-start", "style": { "color": { "background": "#0a66c2", "text": "#ffffff" }, "border": { "radius": "6px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } } } } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/button", "attrs": { "text": "Donate", "url": "/donate", "className": "blocks-engine-native-button-alignment-start" } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:buttons -->" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btnPrimary\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button btnPrimary blocks-engine-native-button-alignment-start\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-radius:6px;color:#ffffff;background-color:#0a66c2;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "wp:paragraph" }

--- a/php-transformer/tests/fixtures/parity/html-button-label-presentational-span-unwrapped.json
+++ b/php-transformer/tests/fixtures/parity/html-button-label-presentational-span-unwrapped.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn", "text": "Listen Now", "url": "/listen" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn blocks-engine-native-button-alignment-start", "text": "Listen Now", "url": "/listen" } }
   ],
   "expected_fallbacks": [],
   "expect": [

--- a/php-transformer/tests/fixtures/parity/html-button-label-preserves-inline-format.json
+++ b/php-transformer/tests/fixtures/parity/html-button-label-preserves-inline-format.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn", "text": "<strong>Go</strong> now", "url": "/go" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "btn blocks-engine-native-button-alignment-start", "text": "<strong>Go</strong> now", "url": "/go" } }
   ],
   "expected_fallbacks": [],
   "expect": [

--- a/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
+++ b/php-transformer/tests/fixtures/parity/html-button-outline-ghost-cta-style.json
@@ -17,12 +17,12 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "Learn more", "url": "/learn", "className": "is-style-outline blocks-engine-native-button-alignment-start", "style": { "color": { "text": "#135e96", "background": "transparent" }, "border": { "width": "2px", "style": "solid", "color": "currentColor", "radius": "8px" }, "spacing": { "padding": { "top": "12px", "right": "24px", "bottom": "12px", "left": "24px" } }, "typography": { "fontWeight": "600", "textTransform": "none" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline\">" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<div class=\"wp-block-button is-style-outline blocks-engine-native-button-alignment-start\">" },
     { "path": "serialized_blocks", "assert": "contains", "value": "class=\"wp-block-button__link has-text-color has-background has-border-color wp-element-button\"" },
     { "path": "serialized_blocks", "assert": "contains_style_declarations", "value": "border-color:currentColor;border-style:solid;border-width:2px;border-radius:8px;color:#135e96;background-color:transparent;padding-top:12px;padding-right:24px;padding-bottom:12px;padding-left:24px;font-weight:600;text-transform:none" }
   ]

--- a/php-transformer/tests/fixtures/parity/html-icon-only-button-accessible-label.json
+++ b/php-transformer/tests/fixtures/parity/html-icon-only-button-accessible-label.json
@@ -17,7 +17,7 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "icon-button", "title": "Email us", "url": "mailto:hello@example.com" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/button", "attrs": { "className": "icon-button blocks-engine-native-button-alignment-start", "title": "Email us", "url": "mailto:hello@example.com" } }
   ],
   "expected_fallbacks": [],
   "expect": [

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-sized-html-valid.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-sized-html-valid.json
@@ -20,7 +20,7 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/image" },
     { "path": "blocks.0.innerBlocks.1", "name": "core/image" },
     { "path": "blocks.0.innerBlocks.2", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/button", "attrs": { "className": "icon-cta", "url": "/reserve" } }
+    { "path": "blocks.0.innerBlocks.2.innerBlocks.0", "name": "core/button", "attrs": { "className": "icon-cta blocks-engine-native-button-alignment-start", "url": "/reserve" } }
   ],
   "expected_fallbacks": [],
   "expect": [

--- a/php-transformer/tests/fixtures/parity/html-logo-nav-button-classification.json
+++ b/php-transformer/tests/fixtures/parity/html-logo-nav-button-classification.json
@@ -25,7 +25,7 @@
     { "path": "blocks.1", "name": "core/group" },
     { "path": "blocks.1.innerBlocks.0", "name": "core/paragraph" },
     { "path": "blocks.1.innerBlocks.1", "name": "core/buttons" },
-    { "path": "blocks.1.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "text": "Start now", "url": "/start", "className": "cta" } },
+    { "path": "blocks.1.innerBlocks.1.innerBlocks.0", "name": "core/button", "attrs": { "text": "Start now", "url": "/start", "className": "cta blocks-engine-native-button-alignment-start" } },
     { "path": "blocks.2", "name": "core/navigation" },
     { "path": "blocks.2.innerBlocks.0", "name": "core/navigation-link", "attrs": { "url": "/privacy", "kind": "custom" } },
     { "path": "blocks.2.innerBlocks.1", "name": "core/navigation-link", "attrs": { "url": "/terms", "kind": "custom" } },

--- a/php-transformer/tests/fixtures/parity/html-pricing-card-grid-featured-tier.json
+++ b/php-transformer/tests/fixtures/parity/html-pricing-card-grid-featured-tier.json
@@ -20,7 +20,7 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "pricing-card featured-tier" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "tier-price-row" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.3.innerBlocks.0", "name": "core/button", "attrs": { "className": "cta-button", "text": "Get started", "url": "/checkout/pro" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.3.innerBlocks.0", "name": "core/button", "attrs": { "className": "cta-button blocks-engine-native-button-alignment-start", "text": "Get started", "url": "/checkout/pro" } },
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/group", "attrs": { "className": "tier-price-row" } }
   ],
   "expected_fallbacks": [],

--- a/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-product-card-svg-price-grid.json
@@ -22,7 +22,7 @@
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/heading", "attrs": { "className": "product-name", "content": "Ceramic Bowl", "level": 3 } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/paragraph", "attrs": { "className": "product-price", "content": "$42" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.3", "name": "core/buttons" },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.3.innerBlocks.0", "name": "core/button", "attrs": { "className": "product-cta", "text": "Buy now", "url": "/products/bowl" } }
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.3.innerBlocks.0", "name": "core/button", "attrs": { "className": "product-cta blocks-engine-native-button-alignment-start", "text": "Buy now", "url": "/products/bowl" } }
   ],
   "expected_fallbacks": [
     { "type": "html", "reason": "commerce_product_grid_detected", "tag": "div", "diagnostic_code": "html_product_grid_fallback", "kind": "html_product_grid_fallback", "product_count": 2 },

--- a/php-transformer/tests/unit/button-style-resolver.php
+++ b/php-transformer/tests/unit/button-style-resolver.php
@@ -68,6 +68,22 @@ $assert(str_contains($cssWideInheritedMarkup, 'color:#f8fff9'), 'color:inherit r
 $assert(str_contains($cssWideInheritedCss, 'color:#f8fff9!important') && str_contains($cssWideInheritedCss, 'text-align:start!important'), 'color:inherit and text-align:inherit resolve through the native button rule', $cssWideInheritedCss);
 $assert('pass' === ($cssWideInheritedButton['source_reports']['wp_block_validity']['status'] ?? ''), 'CSS-wide inherited native button remains editor-valid', json_encode($cssWideInheritedButton['source_reports']['wp_block_validity'] ?? array()));
 
+$defaultHeaderBrand = ( new HtmlTransformer() )->transform(
+    '<header><a class="button" style="padding:10px 18px;background:#1d2230" href="/"><span class="brand-mark"><span class="brand-glyph">H</span></span> Header brand</a></header>'
+)->toArray();
+$defaultHeaderBrandMarkup = (string) ($defaultHeaderBrand['serialized_blocks'] ?? '');
+$defaultHeaderBrandCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $defaultHeaderBrand['assets'] ?? array()));
+$assert(str_contains($defaultHeaderBrandCss, 'text-align:start!important'), 'header brand with no text-align projects CSS initial start to the native button link', $defaultHeaderBrandCss);
+$assert(str_contains($defaultHeaderBrandMarkup, 'brand-mark') && str_contains($defaultHeaderBrandMarkup, 'brand-glyph') && ! str_contains($defaultHeaderBrandMarkup, '<!-- wp:html') && 'pass' === ($defaultHeaderBrand['source_reports']['wp_block_validity']['status'] ?? ''), 'header brand mark and glyph remain native editor-valid button content', $defaultHeaderBrandMarkup);
+
+$defaultFooterBrand = ( new HtmlTransformer() )->transform(
+    '<footer><a class="button" style="padding:8px 14px;background:#18212b" href="/"><span class="brand-mark"><span class="brand-glyph">F</span></span> Footer brand</a></footer>'
+)->toArray();
+$defaultFooterBrandMarkup = (string) ($defaultFooterBrand['serialized_blocks'] ?? '');
+$defaultFooterBrandCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $defaultFooterBrand['assets'] ?? array()));
+$assert(str_contains($defaultFooterBrandCss, 'text-align:start!important'), 'footer brand with no text-align projects CSS initial start to the native button link', $defaultFooterBrandCss);
+$assert(str_contains($defaultFooterBrandMarkup, 'brand-mark') && str_contains($defaultFooterBrandMarkup, 'brand-glyph') && ! str_contains($defaultFooterBrandMarkup, '<!-- wp:html') && 'pass' === ($defaultFooterBrand['source_reports']['wp_block_validity']['status'] ?? ''), 'footer brand mark and glyph remain native editor-valid button content', $defaultFooterBrandMarkup);
+
 $inheritedFooterButton = ( new HtmlTransformer() )->transform(
     '<footer style="color:#d4e5ff;text-align:end"><a class="button" style="padding:8px 14px;background:#18212b" href="/">Brand</a></footer>'
 )->toArray();

--- a/php-transformer/tests/unit/button-style-resolver.php
+++ b/php-transformer/tests/unit/button-style-resolver.php
@@ -49,6 +49,35 @@ $assert(str_contains($themedMarkup, 'background:linear-gradient(135deg,#2c63ff,#
 $assert(str_contains($themedMarkup, 'color:#1d2230'), 'default root custom properties are not replaced by conditional theme overrides', $themedMarkup);
 $assert(! str_contains($themedMarkup, 'color:#f3f1ea'), 'inactive dark-theme custom properties do not leak into canonical button paint', $themedMarkup);
 
+$inheritedHeaderButton = ( new HtmlTransformer() )->transform(
+    '<header style="color:#f8fff9;text-align:start"><a class="button" style="padding:10px 18px;background:#1d2230" href="/start">Start</a></header>'
+)->toArray();
+$inheritedHeaderMarkup = (string) ($inheritedHeaderButton['serialized_blocks'] ?? '');
+$inheritedHeaderCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $inheritedHeaderButton['assets'] ?? array()));
+$assert(str_contains($inheritedHeaderMarkup, 'color:#f8fff9'), 'header-inherited button foreground maps to canonical core/button color', $inheritedHeaderMarkup);
+$assert(str_contains($inheritedHeaderCss, 'text-align:start!important'), 'header-inherited start alignment overrides the core/button link default', $inheritedHeaderCss);
+$assert('pass' === ($inheritedHeaderButton['source_reports']['wp_block_validity']['status'] ?? ''), 'header-inherited native button remains editor-valid', json_encode($inheritedHeaderButton['source_reports']['wp_block_validity'] ?? array()));
+$assert(! str_contains($inheritedHeaderMarkup, '<!-- wp:html'), 'header-inherited native button needs no HTML fallback', $inheritedHeaderMarkup);
+
+$inheritedFooterButton = ( new HtmlTransformer() )->transform(
+    '<footer style="color:#d4e5ff;text-align:end"><a class="button" style="padding:8px 14px;background:#18212b" href="/">Brand</a></footer>'
+)->toArray();
+$inheritedFooterMarkup = (string) ($inheritedFooterButton['serialized_blocks'] ?? '');
+$inheritedFooterCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $inheritedFooterButton['assets'] ?? array()));
+$assert(str_contains($inheritedFooterMarkup, 'color:#d4e5ff'), 'footer-inherited button foreground maps to canonical core/button color', $inheritedFooterMarkup);
+$assert(str_contains($inheritedFooterCss, 'text-align:end!important'), 'footer-inherited end alignment overrides the core/button link default', $inheritedFooterCss);
+$assert('pass' === ($inheritedFooterButton['source_reports']['wp_block_validity']['status'] ?? ''), 'footer-inherited native button remains editor-valid', json_encode($inheritedFooterButton['source_reports']['wp_block_validity'] ?? array()));
+
+$explicitButton = ( new HtmlTransformer() )->transform(
+    '<header style="color:#f8fff9;text-align:start"><a class="button" style="padding:10px 18px;background:#1d2230;color:#102030;text-align:end" href="/start">Start</a></header>'
+)->toArray();
+$explicitMarkup = (string) ($explicitButton['serialized_blocks'] ?? '');
+$explicitCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $explicitButton['assets'] ?? array()));
+$explicitButtonAttrs = $explicitButton['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['attrs'] ?? array();
+$assert('#102030' === ($explicitButtonAttrs['style']['color']['text'] ?? null), 'explicit anchor color remains authoritative over inherited color', $explicitMarkup);
+$assert(str_contains($explicitCss, 'text-align:end!important') && ! str_contains($explicitCss, 'text-align:start!important'), 'explicit anchor alignment remains authoritative over inherited alignment', $explicitCss);
+$assert('pass' === ($explicitButton['source_reports']['wp_block_validity']['status'] ?? ''), 'explicit native button remains editor-valid', json_encode($explicitButton['source_reports']['wp_block_validity'] ?? array()));
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Button style resolver tests: {$failures} failed, {$passes} passed\n");
     exit(1);

--- a/php-transformer/tests/unit/button-style-resolver.php
+++ b/php-transformer/tests/unit/button-style-resolver.php
@@ -59,6 +59,15 @@ $assert(str_contains($inheritedHeaderCss, 'text-align:start!important'), 'header
 $assert('pass' === ($inheritedHeaderButton['source_reports']['wp_block_validity']['status'] ?? ''), 'header-inherited native button remains editor-valid', json_encode($inheritedHeaderButton['source_reports']['wp_block_validity'] ?? array()));
 $assert(! str_contains($inheritedHeaderMarkup, '<!-- wp:html'), 'header-inherited native button needs no HTML fallback', $inheritedHeaderMarkup);
 
+$cssWideInheritedButton = ( new HtmlTransformer() )->transform(
+    '<style>a{color:inherit;text-align:inherit}.site-header{color:#f8fff9;text-align:start}</style><header class="site-header"><a class="button" style="padding:10px 18px;background:#1d2230" href="/start">Start</a></header>'
+)->toArray();
+$cssWideInheritedMarkup = (string) ($cssWideInheritedButton['serialized_blocks'] ?? '');
+$cssWideInheritedCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $cssWideInheritedButton['assets'] ?? array()));
+$assert(str_contains($cssWideInheritedMarkup, 'color:#f8fff9'), 'color:inherit resolves the header foreground into canonical core/button color', $cssWideInheritedMarkup);
+$assert(str_contains($cssWideInheritedCss, 'color:#f8fff9!important') && str_contains($cssWideInheritedCss, 'text-align:start!important'), 'color:inherit and text-align:inherit resolve through the native button rule', $cssWideInheritedCss);
+$assert('pass' === ($cssWideInheritedButton['source_reports']['wp_block_validity']['status'] ?? ''), 'CSS-wide inherited native button remains editor-valid', json_encode($cssWideInheritedButton['source_reports']['wp_block_validity'] ?? array()));
+
 $inheritedFooterButton = ( new HtmlTransformer() )->transform(
     '<footer style="color:#d4e5ff;text-align:end"><a class="button" style="padding:8px 14px;background:#18212b" href="/">Brand</a></footer>'
 )->toArray();


### PR DESCRIPTION
## Root cause

Promoting an anchor to `core/button` allowed WordPress button defaults to replace inherited foreground paint and text alignment when those properties were not explicitly authored on the anchor.

Refs #765.

## Verification

- Replayed the archived three-commit series onto current `origin/trunk`; the rebuilt tree exactly matches the archived intended tree.
- `composer test` passed: contracts, unit suites, 258 PHP transformer parity fixtures, and package-install proof.
- Final combined evidence: `50309edbc004370de3f3c2468f013b0eee4fa1ce`; visual `0/10,325,760`; `170/170` native; `340/340` editor; zero core/html, warnings, and findings; `1280x8067`.

## AI assistance

gpt-5.6-sol via OpenCode replayed the verified patch series onto current trunk, normalized the required commit disclosures, ran tests, and prepared this PR. Chris Huber is responsible for every line.