### PR TITLE
Advance solved fixture SSI pin to v0.18.4 contract

### DIFF
--- a/.github/workflows/solved-fixture-regression.yml
+++ b/.github/workflows/solved-fixture-regression.yml
@@ -18,8 +18,8 @@ permissions:
 
 jobs:
   solved-site-promotion:
-    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@0ca3e608a37cff28d15881a105b790e3f4accf3d
+    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@14b85ad98824e0c1830bb6e7c9fe82f760e89654
     with:
-      static-site-importer-sha: 0ca3e608a37cff28d15881a105b790e3f4accf3d
+      static-site-importer-sha: 14b85ad98824e0c1830bb6e7c9fe82f760e89654
       blocks-engine-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       blocks-engine-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
## Change

Advances only the two immutable Static Site Importer references in `.github/workflows/solved-fixture-regression.yml` from `0ca3e608a37cff28d15881a105b790e3f4accf3d` to merged SSI main commit `14b85ad98824e0c1830bb6e7c9fe82f760e89654`. The reusable workflow ref and `static-site-importer-sha` remain the same exact immutable pair.

SSI commit `14b85ad98824e0c1830bb6e7c9fe82f760e89654` is Static Site Importer [#800](https://github.com/Automattic/static-site-importer/pull/800), which closes [#799](https://github.com/Automattic/static-site-importer/issues/799) and pins the WP Codebox v0.18.4 published workspace asset with its SHA-256 verification contract.

No threshold relaxation: exact-zero visual parity, promotion acceptance, and all existing workflow gates are unchanged.

Related: [Blocks Engine #780](https://github.com/Automattic/blocks-engine/issues/780), [Static Site Importer #799](https://github.com/Automattic/static-site-importer/issues/799), [Static Site Importer #800](https://github.com/Automattic/static-site-importer/pull/800), and [Blocks Engine promotion #779](https://github.com/Automattic/blocks-engine/pull/779).

## Validation

- `actionlint .github/workflows/solved-fixture-regression.yml`
- Ruby YAML parse of `.github/workflows/solved-fixture-regression.yml`
- Consumer immutable-pair assertion: exactly two matching `14b85ad…` references, with the candidate SHA contract retained
- Direct GitHub verification that SSI merge `14b85ad…` contains the v0.18.4 asset, SHA-256, and fail-closed checksum contract

AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this control-plane repair. Chris Huber remains responsible for every line.