### PR TITLE
Ignore zero reset padding when classifying buttons

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonSignalClassifier.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonSignalClassifier.php
@@ -45,7 +45,34 @@ final class ButtonSignalClassifier
     public function hasStyleSignal(DOMElement $element, string $resolvedStyle = ''): bool
     {
         $style = strtolower('' !== trim($resolvedStyle) ? $resolvedStyle : ($element->hasAttribute('style') ? $element->getAttribute('style') : ''));
-        if ( '' === $style || ! preg_match('/(?:^|;)\s*padding(?:-[a-z]+)?\s*:\s*[^;]+/', $style) ) {
+        if ( '' === $style ) {
+            return false;
+        }
+
+        preg_match_all('/(?:^|;)\s*padding(?:-[a-z]+)?\s*:\s*([^;]+)/', $style, $paddingDeclarations);
+        $hasBoxPadding = false;
+        foreach ( $paddingDeclarations[1] ?? array() as $paddingDeclaration ) {
+            $padding = trim((string) preg_replace('/\s*!important\s*$/', '', $paddingDeclaration));
+            if ( '' === $padding || preg_match('/^(?:inherit|initial|revert(?:-layer)?|unset)$/', $padding) ) {
+                continue;
+            }
+
+            $components = preg_split('/\s+/', $padding) ?: array();
+            $allZero    = true;
+            foreach ( $components as $component ) {
+                if ( ! preg_match('/^[+-]?(?:0+(?:\.0*)?|\.0+)(?:[a-z%]+)?$/', $component) ) {
+                    $allZero = false;
+                    break;
+                }
+            }
+
+            if ( ! $allZero ) {
+                $hasBoxPadding = true;
+                break;
+            }
+        }
+
+        if ( ! $hasBoxPadding ) {
             return false;
         }
 

--- a/php-transformer/tests/unit/button-signal-classifier.php
+++ b/php-transformer/tests/unit/button-signal-classifier.php
@@ -52,6 +52,10 @@ $assert($classifier->hasStyleSignal($element('<a style="padding:12px 18px;border
 $assert(! $classifier->hasStyleSignal($element('<a style="padding:12px 18px;background:transparent" href="#">Learn more</a>')), '9: transparent background alone is not a style signal');
 $assert(! $classifier->hasStyleSignal($element('<a style="padding-bottom:8px;border-bottom:1px solid currentColor" href="#">Learn more</a>')), '10: underline border and padding are not a button surface');
 $assert(! $classifier->hasTransformSignal($element('<a href="#">Learn more</a>')), '11: plain link has no transform signal');
+$assert(! $classifier->hasStyleSignal($element('<a style="padding:0;background:#135e96" href="#">Learn more</a>')), '12: zero reset padding plus a background is not a button surface');
+$assert(! $classifier->hasStyleSignal($element('<a style="padding:0px 0rem 0%;border-radius:999px" href="#">Learn more</a>')), '13: zero unit padding plus rounding is not a button surface');
+$assert($classifier->hasStyleSignal($element('<a style="padding:0 0 1px;background:#135e96" href="#">Learn more</a>')), '14: any non-zero shorthand padding retains the style signal');
+$assert($classifier->hasStyleSignal($element('<a style="padding:var(--control-padding);background:#135e96" href="#">Learn more</a>')), '15: unresolved authored padding retains the style signal');
 
 $result = ( new HtmlTransformer() )->transform('<a style="padding:12px 18px;background:#135e96;color:#fff" href="/buy">Buy tickets</a>', array())->toArray();
 $button = $result['blocks'][0]['innerBlocks'][0] ?? array();
@@ -103,6 +107,10 @@ $assert(! str_contains($textualMarkup, 'wp-block-buttons'), '27: fixture-37 text
 $legalLinks = ( new HtmlTransformer() )->transform('<footer><a class="legal-link" href="/impressum">Impressum</a><a class="legal-link" href="/privacy">Datenschutz</a><a class="legal-link" href="/terms">AGB</a></footer>', array())->toArray();
 $legalMarkup = (string) ($legalLinks['serialized_blocks'] ?? '');
 $assert(! str_contains($legalMarkup, 'wp:button') && ! str_contains($legalMarkup, 'wp-block-buttons') && str_contains($legalMarkup, 'href="/impressum"') && str_contains($legalMarkup, 'href="/privacy"') && str_contains($legalMarkup, 'href="/terms"'), '28: fixture-37 legal link rows retain anchor semantics rather than becoming buttons', $legalMarkup);
+
+$linkedPhoto = ( new HtmlTransformer() )->transform('<style>*,*::before,*::after{padding:0}.photo{display:block;width:100%;aspect-ratio:21/9;background:#232224}</style><a href="/work" aria-label="View work"><div class="photo" role="img" aria-label="Work"><span>Installation view</span></div></a>', array())->toArray();
+$linkedPhotoMarkup = (string) ($linkedPhoto['serialized_blocks'] ?? '');
+$assert(! str_contains($linkedPhotoMarkup, 'wp:button') && str_contains($linkedPhotoMarkup, 'class="photo ') && str_contains($linkedPhotoMarkup, 'href="/work"'), '29: reset-padded linked visual media retains its authored surface and non-button link', $linkedPhotoMarkup);
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "ButtonSignalClassifier unit tests: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
## Summary

- require padding to contribute a non-zero or unresolved authored value before treating it as button box padding
- ignore explicit zero values with common CSS units and CSS-wide reset keywords
- preserve genuine non-zero shorthand and variable-driven controls
- cover Fixture 37's linked visual-surface shape end to end

Fixes #783.

## Why

Fixture 37 uses a universal `padding: 0` reset and background-painted linked `.photo` surfaces. The classifier combined those declarations into a false button signal, producing `core/button` markup and WordPress's default `9999px` radius on rectangular artwork. Seven-surface evidence: https://github.com/Automattic/static-site-importer/pull/760#issuecomment-5157627502

## Verification

- `composer test`
- `php tests/unit/button-signal-classifier.php` (`37` assertions)
- PHP transformer parity (`258` fixtures)
- package install proof

## AI assistance

Investigated and implemented with OpenCode using OpenAI gpt-5.6-sol. AI assistance compared retained source/candidate screenshots and DOM evidence, traced the classifier, wrote regression coverage, and ran the verification matrix; Chris Huber remains responsible for every line.
