### PR TITLE
Preserve painted empty figures through artifact compilation

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -53,6 +53,7 @@
       "php tests/contract/finding-contract.php",
       "php tests/contract/wordpress-site-plan.php",
       "php tests/contract/shared-shell-plan.php",
+      "php tests/contract/empty-visual-figure.php",
       "@test:unit"
     ],
     "test:unit": [

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -674,7 +674,7 @@ final class ArtifactCompiler
             return (string) $matches[0];
         }, $html) ?? $html;
 
-        return preg_replace('/<figure\b[^>]*>\s*<\/figure>/i', '', $html) ?? $html;
+        return $html;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -6993,6 +6993,10 @@ final class HtmlTransformer
         }
 
         if ( array() === $children ) {
+            if ( $this->shouldPreserveEmptyVisualFigure($figure) ) {
+                return $this->createBlock('core/group', $this->presentationAttributes($figure), array(), $figure);
+            }
+
             return null;
         }
 
@@ -7001,6 +7005,37 @@ final class HtmlTransformer
         }
 
         return $this->createBlock('core/group', $this->presentationAttributes($figure), $children, $figure);
+    }
+
+    private function shouldPreserveEmptyVisualFigure(DOMElement $figure): bool
+    {
+        if ( '' !== $this->renderedTextContent($figure) || 0 !== $this->childElementCount($figure) ) {
+            return false;
+        }
+
+        $declarations = $this->structuralPresentationDeclarations($figure);
+        $hasBoundedHeight = false;
+        foreach ( array( 'height', 'min-height' ) as $property ) {
+            if ( isset($declarations[$property]) && $this->isPositiveCssLength($this->resolveCssVariablesInValue($declarations[$property])) ) {
+                $hasBoundedHeight = true;
+                break;
+            }
+        }
+        if ( ! $hasBoundedHeight ) {
+            return false;
+        }
+
+        if ( $this->hasVisibleEmptyVisualPaint($declarations) ) {
+            return true;
+        }
+
+        foreach ( $this->staticPseudoElementStyleRules as $rule ) {
+            if ( $this->matchesCssSelector($figure, $rule['selector']) && $this->hasVisibleEmptyVisualPaint($rule['declarations']) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/tests/contract/empty-visual-figure.php
+++ b/php-transformer/tests/contract/empty-visual-figure.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$assert = static function (bool $condition, string $message): void {
+    if ( ! $condition ) {
+        fwrite(STDERR, "FAIL: {$message}\n");
+        exit(1);
+    }
+};
+
+$css = ':root{--figure-height:12rem;--figure-border:rgba(20,40,60,.5);--figure-gradient:linear-gradient(135deg,#123,#456)}.border-figure{min-height:var(--figure-height);border:1px solid var(--figure-border)}.gradient-figure{height:4rem;background:var(--figure-gradient)}.pseudo-figure{min-height:3rem}.pseudo-figure::before{content:"";display:block;height:100%;background:#345}.empty-figure{min-height:4rem}';
+$html = '<main><figure class="border-figure"></figure><figure class="gradient-figure"></figure><figure class="pseudo-figure"></figure><figure class="empty-figure"></figure></main>';
+
+$transformed = ( new HtmlTransformer() )->transform('<style>' . $css . '</style>' . $html)->toArray();
+$transformMarkup = (string) ($transformed['serialized_blocks'] ?? '');
+$assert(1 === substr_count($transformMarkup, 'wp-block-group border-figure') && 1 === substr_count($transformMarkup, 'wp-block-group gradient-figure') && 1 === substr_count($transformMarkup, 'wp-block-group pseudo-figure'), 'Transformer keeps bounded empty figures with border, custom-property gradient, or pseudo paint as native groups.');
+$assert(str_contains($transformMarkup, 'border-figure') && str_contains($transformMarkup, 'gradient-figure') && str_contains($transformMarkup, 'pseudo-figure'), 'Transformer retains each visual figure identity for projected CSS.');
+$assert(! str_contains($transformMarkup, 'empty-figure') && ! str_contains($transformMarkup, '<!-- wp:html'), 'Transformer prunes nonvisual empty figures without HTML fallback.');
+
+$compiled = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'index.html',
+    'files'      => array(
+        'index.html' => '<link rel="stylesheet" href="assets/site.css">' . $html,
+        'assets/site.css' => $css,
+    ),
+))->toArray();
+$compiledMarkup = (string) ($compiled['serialized_blocks'] ?? '');
+$assert(1 === substr_count($compiledMarkup, 'wp-block-group border-figure') && 1 === substr_count($compiledMarkup, 'wp-block-group gradient-figure') && 1 === substr_count($compiledMarkup, 'wp-block-group pseudo-figure'), 'Artifact compiler passes painted empty figures into native transformation.');
+$assert(str_contains($compiledMarkup, 'border-figure') && str_contains($compiledMarkup, 'gradient-figure') && str_contains($compiledMarkup, 'pseudo-figure'), 'Artifact compiler preserves direct, custom-property, and pseudo-element visual evidence.');
+$assert(! str_contains($compiledMarkup, 'empty-figure') && ! str_contains($compiledMarkup, '<!-- wp:html'), 'Artifact compiler continues pruning genuinely nonvisual empty figures.');
+
+fwrite(STDOUT, "Empty visual figure contracts passed.\n");


### PR DESCRIPTION
## Summary

Closes #786.

- Removes `ArtifactCompiler::safeHtmlDocumentHtml()` unconditional empty-`figure` deletion so authored CSS reaches `HtmlTransformer`.
- Emits a native `core/group` only for empty figures with positive `height` or `min-height` plus visible direct or pseudo-element paint.
- Retains custom-property-driven borders and gradients; leaves empty figures without visual paint omitted.

## Evidence

Baseline: Homeboy run `2f3826ae-1dd3-4f4a-bd4e-d044cb49f3e2`, artifacts at `/tmp/static-site-importer-fixture-matrix-fixture87-baseline-20260802T204036Z/artifacts/2f3826ae-1dd3-4f4a-bd4e-d044cb49f3e2/`. Its visual explanation shows empty `figure.photo` gallery cards with computed 260-390px min-height and visible 1px borders missing from the candidate topology.

#758 is related but closed: it owns the later empty visual-leaf transformer behavior. This PR repairs the earlier compiler deletion and supplies a figure-specific native transformation contract.

## Verification

- `php tests/contract/empty-visual-figure.php`
- `composer test`

The focused contract covers direct border paint, custom-property gradient paint, pseudo-element paint, and a nonvisual negative case for both direct transformation and artifact compilation.

Expected fixture 87 effect: the five painted, min-height gallery figures survive compiler sanitization and materialize as native editable groups with their authored classes and CSS, restoring their gallery card surfaces.

AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this visual-leaf repair. Chris Huber remains responsible for every line.