### PR TITLE
Fill positioned parent SVG media

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -104,23 +104,28 @@ trait SvgMaterializationTrait
         $presentation = $this->presentationDeclarations($element);
         $sourceDisplay = strtolower(trim((string) ($presentation['display'] ?? '')));
         $parent = $element->parentNode;
-        $parentDisplay = $parent instanceof DOMElement ? strtolower(trim((string) ($this->structuralPresentationDeclarations($parent)['display'] ?? ''))) : '';
+        $parentPresentation = $parent instanceof DOMElement ? $this->structuralPresentationDeclarations($parent) : array();
+        $parentDisplay = strtolower(trim((string) ($parentPresentation['display'] ?? '')));
         $isFlexOrGridItem = in_array($parentDisplay, array( 'flex', 'inline-flex', 'grid', 'inline-grid' ), true);
-        // A responsive SVG (width/height="100%") is authored to fill the media box
-        // owned by its parent, not to render at its intrinsic viewBox size. When
-        // that parent is a sized flex/grid media wrapper, make the generated
-        // core/image figure fill the wrapper and drop the default block margin, so
-        // the image occupies the true wrapper box instead of collapsing to its
-        // intrinsic viewBox with centering whitespace around it.
-        $isResponsiveFillSvg = $isFlexOrGridItem
+        $sourceObjectFit = strtolower(trim((string) ($presentation['object-fit'] ?? '')));
+        $isPositionedMediaBox = $parent instanceof DOMElement
+            && in_array(strtolower(trim((string) ($parentPresentation['position'] ?? ''))), array( 'relative', 'absolute', 'fixed', 'sticky' ), true)
+            && $this->declarationsOwnMediaBox($parentPresentation);
+        // A responsive SVG (width/height="100%") fills a sized flex/grid wrapper,
+        // or a positioned media wrapper when object-fit makes that intent explicit.
+        // Make the generated core/image figure fill that wrapper and drop its
+        // default margin instead of collapsing to intrinsic viewBox geometry.
+        $isResponsiveFillSvg = (
+            ($isFlexOrGridItem && $parent instanceof DOMElement && $this->declarationsOwnMediaBox($parentPresentation))
+            || ($isPositionedMediaBox && in_array($sourceObjectFit, array( 'contain', 'cover', 'fill', 'none', 'scale-down' ), true))
+        )
             && null !== $this->svgPercentageWidth(trim($this->attr($element, 'width')))
-            && null !== $this->svgPercentageWidth(trim($this->attr($element, 'height')))
-            && $parent instanceof DOMElement
-            && $this->structuralCssOwnsMediaBox($parent);
+            && null !== $this->svgPercentageWidth(trim($this->attr($element, 'height')));
         if ( $isResponsiveFillSvg ) {
             $dimensions = array();
             $figureRule = '{margin:0;width:100%;height:100%}';
-            $imgRule = '>img{width:100%;height:100%;-o-object-fit:contain;object-fit:contain}';
+            $objectFit = '' === $sourceObjectFit ? 'contain' : $sourceObjectFit;
+            $imgRule = '>img{width:100%;height:100%;-o-object-fit:' . $objectFit . ';object-fit:' . $objectFit . '}';
             $fillClass = ($this->geometryCarrierClassAllocator ??= new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
             $this->generatedGeometryRules[$fillClass] = '.' . $fillClass . $figureRule . '.' . $fillClass . $imgRule;
             $attrs = array(
@@ -306,16 +311,6 @@ trait SvgMaterializationTrait
     private function cssOwnsMediaBox(DOMElement $element): bool
     {
         return $this->declarationsOwnMediaBox($this->presentationDeclarations($element));
-    }
-
-    /**
-     * Resolve media-box ownership from structural context so a parent media
-     * wrapper is recognized even when it is not itself a high-value styled
-     * element (its class-based width/height/aspect-ratio still owns the box).
-     */
-    private function structuralCssOwnsMediaBox(DOMElement $element): bool
-    {
-        return $this->declarationsOwnMediaBox($this->structuralPresentationDeclarations($element));
     }
 
     /**

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-positioned-fill-desktop-mobile.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-positioned-fill-desktop-mobile.json
@@ -1,0 +1,28 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-positioned-fill-desktop-mobile",
+  "description": "A responsive inline SVG with object-fit fills an explicitly sized positioned media wrapper at desktop and mobile breakpoints through a generated geometry carrier.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-positioned-fill-desktop-mobile.json",
+    "notes": "Generic regression coverage for positioned media wrappers whose authored box dimensions change at a mobile breakpoint."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<style>.media-frame{position:relative;width:640px;height:420px;overflow:hidden}@media (max-width: 700px){.media-frame{width:320px;height:240px}}</style><main><div class=\"media-frame\"><svg class=\"media-art\" style=\"width:100%;height:100%;object-fit:cover\" viewBox=\"0 0 300 220\" width=\"100%\" height=\"100%\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"300\" height=\"220\" fill=\"#1e1410\"></rect></svg></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image" }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-image media-art be-inline-geometry-" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"width\":\"100%\"" },
+    { "path": "assets.1.content", "assert": "contains", "value": "margin:0;width:100%;height:100%" },
+    { "path": "assets.1.content", "assert": "contains", "value": "object-fit:cover" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-positioned-intrinsic-media.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-positioned-intrinsic-media.json
@@ -1,0 +1,27 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-inline-svg-positioned-intrinsic-media",
+  "description": "An intrinsic inline SVG remains intrinsic inside a positioned, explicitly sized wrapper when it does not declare a percentage fill contract.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-inline-svg-positioned-intrinsic-media.json",
+    "notes": "Negative coverage prevents positioned wrappers from stretching ordinary intrinsic SVG media."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<style>.media-frame{position:relative;width:640px;height:420px;overflow:hidden}</style><main><div class=\"media-frame\"><svg class=\"media-art\" style=\"object-fit:cover\" viewBox=\"0 0 300 220\" width=\"300\" height=\"220\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"300\" height=\"220\" fill=\"#1e1410\"></rect></svg></div></main>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0.innerBlocks.0", "name": "core/image", "attrs": { "width": "300px", "height": "220px" } }
+  ],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"lineHeight\":\"0\"" },
+    { "path": "assets.1.content", "assert": "not_contains", "value": "margin:0;width:100%;height:100%" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"width:300px;height:220px\"" }
+  ]
+}


### PR DESCRIPTION
## Summary

- recognize percentage-sized inline SVGs as fill media in explicitly sized positioned wrappers when source `object-fit` makes that contract explicit
- retain the existing flex/grid fill path and its `contain` default
- add desktop/mobile positioned-wrapper and intrinsic-media parity contracts

Fixes #787
Related to closed #624.

## Verification

- `composer run test:parity`
- `composer test`

## Expected Fixture Impact

Fixture 87 materialized SVG media will fill its authored positioned parent at desktop and mobile sizes rather than use intrinsic viewBox geometry. Ordinary intrinsic SVG media remains unstretched.

## AI Assistance

AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this SVG layout repair. Chris Huber remains responsible for every line.