### PR TITLE
Preserve author-CSS-consumed inline custom properties

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -364,15 +364,77 @@ trait StyleResolutionTrait
             }
         }
 
-        if (array_filter($geometryValues, static fn (string $value): bool => str_contains($value, 'var('))) {
+        $consumedCustomProperties = $this->inlineCustomPropertiesRequired(
+            $declarations,
+            $this->inlineCustomPropertiesConsumedByAuthorStyles($element) + $this->customPropertiesReferencedByValues($geometryValues)
+        );
+        if (array() !== $consumedCustomProperties) {
             foreach ($declarations as $property => $value) {
-                if (str_starts_with($property, '--')) {
+                if (str_starts_with($property, '--') && isset($consumedCustomProperties[$property])) {
                     $style[] = $property . ':' . $value;
                 }
             }
         }
 
         return implode(';', $style);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function inlineCustomPropertiesConsumedByAuthorStyles(DOMElement $element): array
+    {
+        $consumed = array();
+        foreach (array_merge($this->staticStyleRules, $this->conditionalStyleRules, $this->staticPseudoElementStyleRules) as $rule) {
+            if (! $this->matchesCssSelector($element, $rule['selector'])) {
+                continue;
+            }
+            $consumed += $this->customPropertiesReferencedByValues($rule['declarations']);
+        }
+
+        return $consumed;
+    }
+
+    /**
+     * @param array<string|int, string> $values
+     * @return array<string, true>
+     */
+    private function customPropertiesReferencedByValues(array $values): array
+    {
+        $properties = array();
+        foreach ($values as $value) {
+            if (preg_match_all('/\bvar\(\s*(--[-_a-zA-Z0-9]+)/', $value, $matches)) {
+                foreach ($matches[1] as $property) {
+                    $properties[strtolower($property)] = true;
+                }
+            }
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @param array<string, string> $declarations
+     * @param array<string, true> $required
+     * @return array<string, true>
+     */
+    private function inlineCustomPropertiesRequired(array $declarations, array $required): array
+    {
+        $pending = array_keys($required);
+        while (array() !== $pending) {
+            $property = array_pop($pending);
+            if (! isset($declarations[$property])) {
+                continue;
+            }
+            foreach (array_keys($this->customPropertiesReferencedByValues(array($declarations[$property]))) as $dependency) {
+                if (! isset($required[$dependency])) {
+                    $required[$dependency] = true;
+                    $pending[] = $dependency;
+                }
+            }
+        }
+
+        return $required;
     }
 
     private function mergePresentationClassNames(string ...$classNames): string

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -341,6 +341,18 @@ $assert(! str_contains($css($second), 'blocks-engine-source-p-') && 1 === substr
 $third = $instance->transform('<style>.cta:hover{color:red}</style><p>Read <span class="cta">this</span>.</p>')->toArray();
 $assert(str_contains($css($third), 'blocks-engine-richtext-') && ! str_contains($css($third), '> :where(.wp-block-button__link)'), 'repeated selector text resolves against each transform source DOM');
 
+$customPropertyCards = $transform('<style>.tour-card{background:linear-gradient(135deg,var(--tone),#fff)}</style><div class="tour-card" style="width:344px;height:430px;--tone:#f06;--unused:discard">First</div><div class="tour-card" style="width:344px;height:430px;--tone:#0af;--unused:discard">Second</div>');
+$customPropertyCardsMarkup = (string) ($customPropertyCards['serialized_blocks'] ?? '');
+$assert(str_contains($customPropertyCardsMarkup, 'style="--tone:#f06"') && str_contains($customPropertyCardsMarkup, 'style="--tone:#0af"') && ! str_contains($customPropertyCardsMarkup, '--unused:discard') && str_contains($css($customPropertyCards), 'background:linear-gradient(135deg,var(--tone),#fff)'), 'author-CSS-consumed card custom properties retain distinct gradient values without unused-property or cross-card leakage');
+
+$pseudoCustomProperty = $transform('<style>.tour-card::before{content:"";background:var(--accent)}</style><div class="tour-card" style="width:344px;height:430px;--accent:#fc0;--unused:discard">Card</div>');
+$pseudoCustomPropertyMarkup = (string) ($pseudoCustomProperty['serialized_blocks'] ?? '');
+$assert(str_contains($pseudoCustomPropertyMarkup, 'style="--accent:#fc0"') && ! str_contains($pseudoCustomPropertyMarkup, '--unused:discard') && str_contains($css($pseudoCustomProperty), '::before{content:"";background:var(--accent)}'), 'pseudo-element author rules retain only their consumed inline custom properties');
+
+$geometryCustomProperty = $transform('<div style="width:var(--card-width);height:430px;--card-width:344px;--unused:discard">Card</div>');
+$geometryCustomPropertyMarkup = (string) ($geometryCustomProperty['serialized_blocks'] ?? '');
+$assert(str_contains($geometryCustomPropertyMarkup, 'style="--card-width:344px"') && ! str_contains($geometryCustomPropertyMarkup, '--unused:discard'), 'inline geometry retains only its referenced custom property');
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Author selector semantics unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary

Preserves inline custom properties only when they are required by inline geometry or consumed by an applicable retained/projected author CSS rule. The rule matches normal, conditional, and pseudo-element author selectors per source element, expands only required inline variable dependencies, and continues to omit unused declarations.

## Verification

- `php tests/unit/author-selector-semantics.php`
- `php tests/unit/block-style-support-conversion.php`
- `composer test`

Fixes #790.

AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this custom-property repair. Chris Huber remains responsible for every line.