### PR TITLE
Add AST region-effect ownership manifest

### DIFF
--- a/packages/blocks-engine/package.json
+++ b/packages/blocks-engine/package.json
@@ -62,6 +62,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "acorn": "^8.18.0",
     "cheerio": "1.2.0",
     "domhandler": "5.0.3",
     "jsdom": "29.0.1"

--- a/packages/blocks-engine/pnpm-lock.yaml
+++ b/packages/blocks-engine/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      acorn:
+        specifier: ^8.18.0
+        version: 8.18.0
       cheerio:
         specifier: 1.2.0
         version: 1.2.0
@@ -1207,6 +1210,7 @@ packages:
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz}
@@ -1713,6 +1717,11 @@ packages:
   '@wordpress/worker-threads@1.9.0':
     resolution: {integrity: sha512-UAOns1u+ZljgJtbv07kSIWzVCUSXCxk5KDSQgw4Sx5MKOHqcuNoF9p8HorE5DiAOgJA01CxxXLs03peTF65X6Q==, tarball: https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.9.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==, tarball: https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz}
@@ -4686,6 +4695,8 @@ snapshots:
   '@wordpress/worker-threads@1.9.0':
     dependencies:
       comctx: 1.7.5
+
+  acorn@8.18.0: {}
 
   ansi-styles@5.2.0: {}
 

--- a/packages/blocks-engine/src/__tests__/convert.test.ts
+++ b/packages/blocks-engine/src/__tests__/convert.test.ts
@@ -162,6 +162,7 @@ describe('default entry', () => {
 
     const publicRuntimeSymbols = [
       'BlocksEngineError',
+		'analyzeRuntimeRegionEffects',
       'compose',
       'convert',
       'convertReport',
@@ -198,6 +199,7 @@ describe('default entry', () => {
     expect(typeof defaultEntry.convert).toBe('function');
     expect(typeof defaultEntry.compose).toBe('function');
     expect(typeof defaultEntry.BlocksEngineError).toBe('function');
+		expect(typeof defaultEntry.analyzeRuntimeRegionEffects).toBe('function');
     expect(typeof defaultEntry.createWorker).toBe('function');
     expect(typeof defaultEntry.lintThemeJson).toBe('function');
     expect(typeof defaultEntry.siteToTheme).toBe('function');

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -3,6 +3,7 @@ export { convertReport } from './convert-report.js';
 export { compose } from './compose.js';
 export { createWorker } from './pool/pool.js';
 export { BlocksEngineError } from './errors.js';
+export { analyzeRuntimeRegionEffects } from './runtime/region-effect-manifest.js';
 export { lintThemeJson, siteToTheme, writeTheme } from './theme/index.js';
 
 export type { ConvertOptions } from './convert.js';
@@ -17,6 +18,7 @@ export type {
 } from './report/schema.js';
 export type { SiteToThemeOptions, ThemeBuildResult, ThemeJsonLintResult } from './theme/index.js';
 export type { ConversionContext, Converter, HtmlFallback } from './types.js';
+export type { RegionEffectManifest, RuntimeEffectUnit } from './runtime/region-effect-manifest.js';
 export type {
   CreateWorker,
   FixResult,

--- a/packages/blocks-engine/src/runtime/region-effect-manifest.test.ts
+++ b/packages/blocks-engine/src/runtime/region-effect-manifest.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeRuntimeRegionEffects } from './region-effect-manifest.js';
+
+describe('analyzeRuntimeRegionEffects', () => {
+  it('splits fixture87-style carousel and reveal effects without dropping either', () => {
+    const manifest = analyzeRuntimeRegionEffects(`document.querySelectorAll('.carousel .next').forEach((button) => button.addEventListener('click', () => button.closest('.carousel').classList.add('active')));\ndocument.querySelectorAll('.reveal').forEach((item) => item.addEventListener('scroll', () => item.classList.add('visible')));`);
+    expect(manifest.units.map((unit) => unit.status)).toEqual(['independently_suppressible', 'independently_suppressible']);
+    expect(manifest.units[0].targets).toEqual(['.carousel .next']);
+    expect(manifest.units[1].targets).toEqual(['.reveal']);
+  });
+
+  it('fails closed for shared state and dynamic selectors', () => {
+    const shared = analyzeRuntimeRegionEffects(`let active = 0;\ndocument.querySelector('.carousel').addEventListener('click', () => active++);`);
+    expect(shared.units.every((unit) => unit.status === 'shared_or_unsplittable')).toBe(true);
+    const dynamic = analyzeRuntimeRegionEffects(`document.querySelector(selector).addEventListener('click', () => {});`);
+    expect(dynamic.units[0].reason).toBe('dynamic_selector');
+  });
+});

--- a/packages/blocks-engine/src/runtime/region-effect-manifest.ts
+++ b/packages/blocks-engine/src/runtime/region-effect-manifest.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { parse } from 'acorn';
+
+export type RuntimeEffectUnit = {
+  id: string;
+  source: { start: number; end: number; hash: string };
+  targets: string[];
+  events: string[];
+  mutations: string[];
+  dependencies: string[];
+  status: 'independently_suppressible' | 'shared_or_unsplittable';
+  reason?: 'dynamic_selector' | 'shared_state' | 'unrecognized_pattern';
+};
+
+export type RegionEffectManifest = {
+  schema: 'blocks-engine/runtime-region-effects/v1';
+  sourceHash: string;
+  units: RuntimeEffectUnit[];
+};
+
+const hash = (value: string) => createHash('sha256').update(value).digest('hex');
+
+/**
+ * Produces an ownership manifest from top-level DOM-effect statements. This is
+ * deliberately bounded: unsupported AST shapes remain retained as a whole.
+ */
+export function analyzeRuntimeRegionEffects(source: string): RegionEffectManifest {
+  const sourceHash = hash(source);
+  let program: any;
+  try {
+    program = parse(source, { ecmaVersion: 'latest', sourceType: 'script' });
+  } catch {
+    return { schema: 'blocks-engine/runtime-region-effects/v1', sourceHash, units: [] };
+  }
+
+  const declared = new Map<string, number>();
+  for (const statement of program.body) {
+    if (statement.type === 'VariableDeclaration') {
+      for (const declaration of statement.declarations) {
+        if (declaration.id.type === 'Identifier') declared.set(declaration.id.name, (declared.get(declaration.id.name) ?? 0) + 1);
+      }
+    }
+  }
+
+  return {
+    schema: 'blocks-engine/runtime-region-effects/v1',
+    sourceHash,
+    units: program.body.map((statement: any, index: number) => unitFor(statement, index, source, declared)),
+  };
+}
+
+function unitFor(statement: any, index: number, source: string, declared: Map<string, number>): RuntimeEffectUnit {
+  const slice = source.slice(statement.start, statement.end);
+  const targets = new Set<string>();
+  const events = new Set<string>();
+  const mutations = new Set<string>();
+  const identifiers = new Set<string>();
+  let dynamicSelector = false;
+  let recognized = false;
+  walk(statement, (node) => {
+    if (node.type === 'Identifier') identifiers.add(node.name);
+    if (node.type !== 'CallExpression' || node.callee.type !== 'MemberExpression') return;
+    const name = node.callee.property.type === 'Identifier' ? node.callee.property.name : '';
+    if ((name === 'querySelector' || name === 'querySelectorAll' || name === 'getElementById') && node.arguments.length) {
+      recognized = true;
+      const argument = node.arguments[0];
+      if (argument.type !== 'Literal' || typeof argument.value !== 'string') dynamicSelector = true;
+      else targets.add(name === 'getElementById' ? `#${argument.value}` : argument.value);
+    }
+    if (name === 'addEventListener' && node.arguments[0]?.type === 'Literal' && typeof node.arguments[0].value === 'string') {
+      recognized = true;
+      events.add(node.arguments[0].value);
+    }
+    if (['add', 'remove', 'toggle', 'replace'].includes(name) && node.callee.object?.type === 'MemberExpression' && node.callee.object.property?.name === 'classList') mutations.add('class');
+    if (name === 'setAttribute' && node.arguments[0]?.type === 'Literal' && typeof node.arguments[0].value === 'string') mutations.add(`attribute:${node.arguments[0].value}`);
+  });
+  const shared = [...declared.keys()].some((name) => identifiers.has(name));
+  const reason = dynamicSelector ? 'dynamic_selector' : shared ? 'shared_state' : !recognized || !targets.size ? 'unrecognized_pattern' : undefined;
+  const unit: RuntimeEffectUnit = {
+    id: `effect_${index + 1}_${hash(slice).slice(0, 12)}`,
+    source: { start: statement.start, end: statement.end, hash: hash(slice) },
+    targets: [...targets].sort(), events: [...events].sort(), mutations: [...mutations].sort(),
+    dependencies: [...identifiers].filter((name) => declared.has(name)).sort(),
+    status: reason ? 'shared_or_unsplittable' : 'independently_suppressible',
+  };
+  return reason ? { ...unit, reason } : unit;
+}
+
+function walk(node: any, visit: (node: any) => void) {
+  if (!node || typeof node !== 'object' || typeof node.type !== 'string') return;
+  visit(node);
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) value.forEach((child) => walk(child, visit));
+    else walk(value, visit);
+  }
+}


### PR DESCRIPTION
## Summary
- add a bounded Acorn AST primitive that emits deterministic source-spanned runtime effect units
- classify static DOM effect units as independently suppressible only when target selectors are static and no top-level shared state is referenced
- retain dynamic selectors, shared state, and unrecognized shapes fail-closed

## Evidence
- `./node_modules/.bin/vitest run src/runtime/region-effect-manifest.test.ts`
- `./node_modules/.bin/tsc --noEmit`

Closes #224. SSI consumer contract work: Automattic/static-site-importer#734.

AI assistance: gpt-5.6-terra via OpenCode was used to inspect, implement, test, and verify this AST ownership primitive. Chris Huber remains responsible for every line.