### PR TITLE
Preserve SVG fill through native image serialization

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -125,9 +125,13 @@ trait SvgMaterializationTrait
             $dimensions = array();
             $figureRule = '{margin:0;width:100%;height:100%}';
             $objectFit = '' === $sourceObjectFit ? 'contain' : $sourceObjectFit;
+            // WordPress core's `.wp-block-image img { height:auto }` is loaded
+            // after theme styles. Include the native wrapper class so the fill
+            // rule wins without forcing intrinsic media outside this explicit
+            // parent-fill path.
             $imgRule = '>img{width:100%;height:100%;-o-object-fit:' . $objectFit . ';object-fit:' . $objectFit . '}';
             $fillClass = ($this->geometryCarrierClassAllocator ??= new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
-            $this->generatedGeometryRules[$fillClass] = '.' . $fillClass . $figureRule . '.' . $fillClass . $imgRule;
+            $this->generatedGeometryRules[$fillClass] = '.' . $fillClass . $figureRule . '.wp-block-image.' . $fillClass . $imgRule;
             $attrs = array(
                 'url'       => $path,
                 'alt'       => $this->svgImageAlt($element),

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -704,6 +704,15 @@ $assert(str_contains($inlineSvgMarkup, 'alt="Album art"'), 'passive meaningful i
 $inlineSvgCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $inlineSvgArtwork['assets'] ?? array()));
 $assert(str_contains($inlineSvgMarkup, 'be-inline-geometry-') && ! str_contains($inlineSvgMarkup, 'line-height:0') && str_contains($inlineSvgCss, '>img{display:inline;vertical-align:baseline}'), 'default-inline SVG core/image restores the source baseline over WordPress image alignment');
 
+$positionedFillSvg = ( new HtmlTransformer() )->transform(
+    '<style>.hero-media{position:relative;width:1280px;height:760px}@media(max-width:700px){.hero-media{width:320px;height:240px}}</style><main><div class="hero-media"><svg class="hero-art" width="100%" height="100%" style="object-fit:cover" viewBox="0 0 1280 728.88"><rect width="1280" height="728.88" fill="#111"/></svg></div></main>'
+)->toArray();
+$positionedFillMarkup = (string) ($positionedFillSvg['serialized_blocks'] ?? '');
+$positionedFillCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $positionedFillSvg['assets'] ?? array()));
+$positionedFillRoundTrip = ( new \Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime() )->serializeBlocks(( new \Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime() )->parseBlocks($positionedFillMarkup));
+$assert(str_contains($positionedFillMarkup, 'wp-block-image hero-art be-inline-geometry-') && str_contains($positionedFillCss, '.wp-block-image.be-inline-geometry-') && str_contains($positionedFillCss, '>img{width:100%;height:100%;-o-object-fit:cover;object-fit:cover}'), 'positioned SVG fill serializes native image wrapper and image rules with greater specificity than WordPress core intrinsic-image CSS');
+$assert(str_contains($positionedFillRoundTrip, 'wp-block-image hero-art be-inline-geometry-'), 'positioned SVG fill survives the serialized WordPress block parse/save contract without dropping its native fill carrier');
+
 $flexItemSvgArtwork = ( new HtmlTransformer() )->transform(
     '<style>.signal-icon{width:26px;height:26px;display:flex;align-items:center;justify-content:center}</style><div class="signal-icon" style="background:#7657ff"><svg width="14" height="14" viewBox="0 0 14 14"><circle cx="7" cy="7" r="6"/></svg></div>'
 )->toArray();

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-positioned-fill-desktop-mobile.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-positioned-fill-desktop-mobile.json
@@ -23,6 +23,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "wp-block-image media-art be-inline-geometry-" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "\"width\":\"100%\"" },
     { "path": "assets.1.content", "assert": "contains", "value": "margin:0;width:100%;height:100%" },
+    { "path": "assets.1.content", "assert": "contains", "value": ".wp-block-image.be-inline-geometry-" },
     { "path": "assets.1.content", "assert": "contains", "value": "object-fit:cover" }
   ]
 }

--- a/php-transformer/tests/integration/wordpress-site-plan.php
+++ b/php-transformer/tests/integration/wordpress-site-plan.php
@@ -17,6 +17,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 require $testsDir . '/includes/bootstrap.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
 
 $assert = static function (bool $condition, string $message): void { if (!$condition) throw new RuntimeException($message); };
@@ -57,6 +58,14 @@ $wpTheme = wp_get_theme($theme);
 $assert($wpTheme->exists(), 'WordPress recognizes the materialized block theme.');
 switch_theme($theme);
 require $themeDir . '/functions.php';
+$positionedSvg = (new HtmlTransformer())->transform('<style>.hero-media{position:relative;width:1280px;height:760px}@media(max-width:700px){.hero-media{width:320px;height:240px}}</style><main><div class="hero-media"><svg class="hero-art" width="100%" height="100%" style="object-fit:cover" viewBox="0 0 1280 728.88"><rect width="1280" height="728.88" fill="#111"/></svg></div></main>')->toArray();
+$positionedSvgMarkup = (string) ($positionedSvg['serialized_blocks'] ?? '');
+$positionedSvgCss = implode("\n", array_map(static fn(array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $positionedSvg['assets'] ?? array()));
+$positionedSvgId = wp_insert_post(array('post_type' => 'page', 'post_status' => 'draft', 'post_title' => 'Positioned SVG', 'post_content' => serialize_blocks(parse_blocks($positionedSvgMarkup))), true);
+if (is_wp_error($positionedSvgId)) throw new RuntimeException($positionedSvgId->get_error_message());
+$pageIds['positioned-svg'] = $positionedSvgId;
+$positionedSvgSaved = (string) get_post_field('post_content', $positionedSvgId);
+$assert(str_contains($positionedSvgCss, '.wp-block-image.be-inline-geometry-') && str_contains($positionedSvgCss, '>img{width:100%;height:100%;-o-object-fit:cover;object-fit:cover}') && str_contains($positionedSvgSaved, 'wp-block-image hero-art be-inline-geometry-') && 'core/image' === (parse_blocks($positionedSvgSaved)[0]['innerBlocks'][0]['blockName'] ?? null), 'WordPress parses and saves positioned SVG fill as a native core/image while its desktop/mobile parent-fill CSS defeats core intrinsic-image sizing.');
 $pageDeclarations = array(); foreach ($resolved['pages'] as $page) $pageDeclarations[$page['source_path']] = $page;
 $pagesBySource = array(); foreach ($resolved['operations'] as $operation) if ('create_page' === $operation['kind']) { $page = $pageDeclarations[$operation['source_path']] ?? null; if (!is_array($page)) throw new RuntimeException('Create operation lacks a page declaration.'); $id = wp_insert_post(array('post_type' => 'page', 'post_status' => 'publish', 'post_title' => $page['title'], 'post_name' => $operation['slug'], 'post_parent' => '' === $operation['parent_source_path'] ? 0 : ($pagesBySource[$operation['parent_source_path']] ?? 0), 'post_content' => $page['resolved_block_markup']), true); if (is_wp_error($id)) throw new RuntimeException($id->get_error_message()); $pageIds[$operation['reconciliation_identity']] = $id; $pagesBySource[$operation['source_path']] = $id; }
 foreach ($resolved['operations'] as $operation) if ('site_reading' === $operation['kind']) { update_option('show_on_front', $operation['show_on_front']); update_option('page_on_front', $pageIds[$operation['front_page_reconciliation_identity']]); }


### PR DESCRIPTION
## Summary

- give the explicit positioned/flex-grid SVG fill image selector higher specificity than WordPress core intrinsic-image CSS
- preserve `width:100%; height:100%; object-fit` through native `core/image` serialization without altering intrinsic SVG media
- add desktop/mobile parity, transform round-trip, and real WordPress parse/save integration coverage

Fixes #787

## Root Cause

#789 generated `.be-inline-geometry-* > img`, which tied WordPress core’s later `.wp-block-image img { height:auto }` at specificity `(0,1,1)`. The core rule restored fixture 87’s intrinsic `1280 x 728.88` SVG image height after parent-fill had been generated. This change emits `.wp-block-image.be-inline-geometry-* > img` at `(0,2,1)`, so the intended `1280 x 760` fill box wins while preserving `object-fit:cover`.

## Verification

- `composer run test:parity -- html-inline-svg-positioned-fill-desktop-mobile`
- `composer test`
- `npm test` in `php-transformer/tools/visual-parity`
- `composer run test:wordpress-integration` is skipped locally because `WP_TESTS_DIR` is unavailable; the new integration contract runs real `parse_blocks()` and `serialize_blocks()` when the WordPress test suite is configured.

## AI Assistance

AI assistance: gpt-5.6-terra via OpenCode was used to diagnose the CSS cascade, implement the repair, and run verification. Chris Huber remains responsible for every line.