### PR TITLE
Fix visual leaves with inline CSS variables

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4942,23 +4942,23 @@ final class HtmlTransformer
     }
 
     /** @param array<string, string> $declarations */
-    private function hasVisibleEmptyVisualPaint(array $declarations): bool
+    private function hasVisibleEmptyVisualPaint(array $declarations, ?DOMElement $element = null): bool
     {
         foreach ( array( 'background', 'background-color', 'box-shadow', 'outline' ) as $property ) {
-            if ( isset($declarations[$property]) && $this->isVisibleEmptyVisualPaint($this->resolveCssVariablesInValue($declarations[$property])) ) {
+            if ( isset($declarations[$property]) && $this->isVisibleEmptyVisualPaint($this->resolveCssVariablesInValue($declarations[$property], $element)) ) {
                 return true;
             }
         }
 
         foreach ( array( 'border', 'border-top', 'border-right', 'border-bottom', 'border-left' ) as $property ) {
-            if ( isset($declarations[$property]) && $this->isVisibleEmptyVisualBorder($this->resolveCssVariablesInValue($declarations[$property])) ) {
+            if ( isset($declarations[$property]) && $this->isVisibleEmptyVisualBorder($this->resolveCssVariablesInValue($declarations[$property], $element)) ) {
                 return true;
             }
         }
 
         return isset($declarations['border-color'], $declarations['border-width'])
-            && $this->isVisibleEmptyVisualPaint($this->resolveCssVariablesInValue($declarations['border-color']))
-            && $this->isPositiveCssLength($this->resolveCssVariablesInValue($declarations['border-width']));
+            && $this->isVisibleEmptyVisualPaint($this->resolveCssVariablesInValue($declarations['border-color'], $element))
+            && $this->isPositiveCssLength($this->resolveCssVariablesInValue($declarations['border-width'], $element));
     }
 
     private function isVisibleEmptyVisualPaint(string $value): bool
@@ -7016,7 +7016,7 @@ final class HtmlTransformer
         $declarations = $this->structuralPresentationDeclarations($figure);
         $hasBoundedHeight = false;
         foreach ( array( 'height', 'min-height' ) as $property ) {
-            if ( isset($declarations[$property]) && $this->isPositiveCssLength($this->resolveCssVariablesInValue($declarations[$property])) ) {
+            if ( isset($declarations[$property]) && $this->isPositiveCssLength($this->resolveCssVariablesInValue($declarations[$property], $figure)) ) {
                 $hasBoundedHeight = true;
                 break;
             }
@@ -7025,12 +7025,12 @@ final class HtmlTransformer
             return false;
         }
 
-        if ( $this->hasVisibleEmptyVisualPaint($declarations) ) {
+        if ( $this->hasVisibleEmptyVisualPaint($declarations, $figure) ) {
             return true;
         }
 
         foreach ( $this->staticPseudoElementStyleRules as $rule ) {
-            if ( $this->matchesCssSelector($figure, $rule['selector']) && $this->hasVisibleEmptyVisualPaint($rule['declarations']) ) {
+            if ( $this->matchesCssSelector($figure, $rule['selector']) && $this->hasVisibleEmptyVisualPaint($rule['declarations'], $figure) ) {
                 return true;
             }
         }

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -370,17 +370,32 @@ trait SvgMaterializationTrait
         return '#000000';
     }
 
-    private function resolveCssVariablesInValue(string $value): string
+    private function resolveCssVariablesInValue(string $value, ?DOMElement $element = null): string
     {
         if ( false === strpos($value, 'var(') ) {
             return $value;
         }
 
+        $customProperties = $this->cssCustomProperties;
+        if ( $element instanceof DOMElement ) {
+            $ancestors = array();
+            for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null ) {
+                $ancestors[] = $current;
+            }
+            foreach ( array_reverse($ancestors) as $ancestor ) {
+                foreach ( $this->structuralPresentationDeclarations($ancestor) as $name => $propertyValue ) {
+                    if ( str_starts_with($name, '--') ) {
+                        $customProperties[$name] = $propertyValue;
+                    }
+                }
+            }
+        }
+
         for ( $pass = 0; $pass < 5; ++$pass ) {
-            $expanded = preg_replace_callback('/var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,\s*([^()]*))?\)/', function (array $matches): string {
+            $expanded = preg_replace_callback('/var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,\s*([^()]*))?\)/', static function (array $matches) use ($customProperties): string {
                 $name = (string) $matches[1];
-                if ( isset($this->cssCustomProperties[$name]) && '' !== $this->cssCustomProperties[$name] ) {
-                    return $this->cssCustomProperties[$name];
+                if ( isset($customProperties[$name]) && '' !== $customProperties[$name] ) {
+                    return $customProperties[$name];
                 }
 
                 return isset($matches[2]) && '' !== trim((string) $matches[2]) ? trim((string) $matches[2]) : (string) $matches[0];

--- a/php-transformer/tests/contract/empty-visual-figure.php
+++ b/php-transformer/tests/contract/empty-visual-figure.php
@@ -5,6 +5,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\BlockValidityValidator;
 
 $assert = static function (bool $condition, string $message): void {
     if ( ! $condition ) {
@@ -33,5 +34,26 @@ $compiledMarkup = (string) ($compiled['serialized_blocks'] ?? '');
 $assert(1 === substr_count($compiledMarkup, 'wp-block-group border-figure') && 1 === substr_count($compiledMarkup, 'wp-block-group gradient-figure') && 1 === substr_count($compiledMarkup, 'wp-block-group pseudo-figure'), 'Artifact compiler passes painted empty figures into native transformation.');
 $assert(str_contains($compiledMarkup, 'border-figure') && str_contains($compiledMarkup, 'gradient-figure') && str_contains($compiledMarkup, 'pseudo-figure'), 'Artifact compiler preserves direct, custom-property, and pseudo-element visual evidence.');
 $assert(! str_contains($compiledMarkup, 'empty-figure') && ! str_contains($compiledMarkup, '<!-- wp:html'), 'Artifact compiler continues pruning genuinely nonvisual empty figures.');
+
+$inlineCss = '.gallery{display:grid;grid-template-columns:repeat(2,1fr)}.gallery .photo{min-height:var(--h)}.gallery .photo::before{content:"";display:block;height:100%;background:linear-gradient(135deg,var(--a),var(--b))}.gallery .empty{min-height:var(--h)}';
+$inlineHtml = '<main><div class="gallery"><figure class="photo" style="--h:280px;--a:#27485f;--b:#87d8ff" aria-label="Alpine lake"></figure><figure class="photo" style="--h:390px;--a:#6f493e;--b:#ff8762" aria-label="Desert canyon"></figure><figure class="empty" style="--h:240px"></figure></div></main>';
+$inlineCompiled = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'index.html',
+    'files'      => array(
+        'index.html' => '<link rel="stylesheet" href="assets/site.css">' . $inlineHtml,
+        'assets/site.css' => $inlineCss,
+    ),
+))->toArray();
+$inlineMarkup = (string) ($inlineCompiled['serialized_blocks'] ?? '');
+$inlineValidity = ( new BlockValidityValidator() )->validateBlocks($inlineCompiled['blocks'] ?? array());
+$inlineStylesheet = '';
+foreach ( $inlineCompiled['assets'] ?? array() as $asset ) {
+    if ( 'css' === ($asset['kind'] ?? '') ) {
+        $inlineStylesheet = (string) ($asset['content'] ?? '');
+        break;
+    }
+}
+$assert(2 === substr_count($inlineMarkup, 'wp-block-group photo') && str_contains($inlineMarkup, 'min-height:var(--h);--h:280px;--a:#27485f;--b:#87d8ff') && str_contains($inlineMarkup, 'min-height:var(--h);--h:390px;--a:#6f493e;--b:#ff8762'), 'Artifact compiler preserves per-element custom properties on pseudo-painted empty figures as native groups.');
+$assert(str_contains($inlineStylesheet, '.gallery .photo::before{content:"";display:block;height:100%;background:linear-gradient(135deg,var(--a),var(--b))}') && ! str_contains($inlineMarkup, 'class="wp-block-group empty') && 'pass' === ($inlineValidity['status'] ?? ''), 'Final native blocks retain the pseudo paint contract and WordPress validity while nonvisual empty figures remain pruned.');
 
 fwrite(STDOUT, "Empty visual figure contracts passed.\n");


### PR DESCRIPTION
## Summary
- resolve CSS variables from matched ancestor and inline declarations when determining whether an empty figure has bounded visual paint
- retain pseudo-painted empty figures as native groups while continuing to prune nonvisual empties
- add an ArtifactCompiler-to-native-block contract for `min-height:var(--h)`, per-element `--h` values, pseudo paint, and block validity

## Verification
- `composer test`
- fixture87 direct ArtifactCompiler transform: 5 photo groups, all five `--h` values, block validity pass

AI assistance: gpt-5.6-terra via OpenCode was used to diagnose, implement, test, and verify this visual-leaf repair. Chris Huber remains responsible for every line.