### PR TITLE
Fix core block custom property style ordering

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
@@ -159,14 +159,23 @@ final class StyleAttributeMapper
             $classes[]      = 'has-border-color';
             $declarations[] = 'border-color:' . trim((string) $border['color']);
         }
-        if ( '' !== trim((string) ($border['width'] ?? '')) ) {
-            $declarations[] = 'border-width:' . trim((string) $border['width']);
-        }
         if ( '' !== trim((string) ($border['style'] ?? '')) ) {
             $declarations[] = 'border-style:' . trim((string) $border['style']);
         }
+        if ( '' !== trim((string) ($border['width'] ?? '')) ) {
+            $declarations[] = 'border-width:' . trim((string) $border['width']);
+        }
         if ( '' !== trim((string) ($border['radius'] ?? '')) ) {
             $declarations[] = 'border-radius:' . trim((string) $border['radius']);
+        }
+
+        // Match the core style engine: dimensions precede spacing in save().
+        $dimensions = is_array($style['dimensions'] ?? null) ? $style['dimensions'] : array();
+        if ( '' !== trim((string) ($dimensions['minHeight'] ?? '')) ) {
+            $declarations[] = 'min-height:' . trim((string) $dimensions['minHeight']);
+        }
+        if ( '' !== trim((string) ($dimensions['maxWidth'] ?? '')) ) {
+            $declarations[] = 'max-width:' . trim((string) $dimensions['maxWidth']);
         }
 
         $spacing = is_array($style['spacing'] ?? null) ? $style['spacing'] : array();
@@ -182,14 +191,6 @@ final class StyleAttributeMapper
         $blockGap = trim((string) ($spacing['blockGap'] ?? ''));
         if ( '' !== $blockGap ) {
             $declarations[] = 'gap:' . $blockGap;
-        }
-
-        $dimensions = is_array($style['dimensions'] ?? null) ? $style['dimensions'] : array();
-        if ( '' !== trim((string) ($dimensions['minHeight'] ?? '')) ) {
-            $declarations[] = 'min-height:' . trim((string) $dimensions['minHeight']);
-        }
-        if ( '' !== trim((string) ($dimensions['maxWidth'] ?? '')) ) {
-            $declarations[] = 'max-width:' . trim((string) $dimensions['maxWidth']);
         }
 
         $typography    = is_array($style['typography'] ?? null) ? $style['typography'] : array();

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -369,10 +369,15 @@ trait StyleResolutionTrait
             $this->inlineCustomPropertiesConsumedByAuthorStyles($element) + $this->customPropertiesReferencedByValues($geometryValues)
         );
         if (array() !== $consumedCustomProperties) {
+            $customProperties = array();
             foreach ($declarations as $property => $value) {
                 if (str_starts_with($property, '--') && isset($consumedCustomProperties[$property])) {
-                    $style[] = $property . ':' . $value;
+                    $customProperties[$property] = $value;
                 }
+            }
+            ksort($customProperties, SORT_STRING);
+            foreach ($customProperties as $property => $value) {
+                $style[] = $property . ':' . $value;
             }
         }
 

--- a/php-transformer/tests/fixtures/parity/artifact-linked-css-button-card-style-signals.json
+++ b/php-transformer/tests/fixtures/parity/artifact-linked-css-button-card-style-signals.json
@@ -36,7 +36,7 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "nav-cta" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "style=\"background-color:#101827;color:white;padding:10px 16px;border-radius:8px\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "product-card" },
-    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-color:#d8dee9;border-width:1px;border-style:solid;border-radius:16px;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-color:#d8dee9;border-style:solid;border-width:1px;border-radius:16px;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "style=\"border-radius:6px;color:#ffffff;background-color:#0f766e;padding-top:11px;padding-right:18px;padding-bottom:11px;padding-left:18px\"" }
   ]
 }

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -353,6 +353,15 @@ $geometryCustomProperty = $transform('<div style="width:var(--card-width);height
 $geometryCustomPropertyMarkup = (string) ($geometryCustomProperty['serialized_blocks'] ?? '');
 $assert(str_contains($geometryCustomPropertyMarkup, 'style="--card-width:344px"') && ! str_contains($geometryCustomPropertyMarkup, '--unused:discard'), 'inline geometry retains only its referenced custom property');
 
+$customPropertyRoundTrip = $transform('<style>.tour-card{background:linear-gradient(135deg,var(--tone),var(--accent))}</style><div class="tour-card" style="--tone:#315b74;border-color:var(--line);border-width:1px;border-style:solid;border-radius:var(--radius);padding:1.2rem;min-height:430px;--accent:#d9b86c">Card</div>');
+$customPropertyRoundTripMarkup = (string) ($customPropertyRoundTrip['serialized_blocks'] ?? '');
+$assert(
+    str_contains($customPropertyRoundTripMarkup, 'style="border-color:var(--line);border-style:solid;border-width:1px;border-radius:var(--radius);min-height:430px;padding-top:1.2rem;padding-right:1.2rem;padding-bottom:1.2rem;padding-left:1.2rem;--accent:#d9b86c;--tone:#315b74"')
+    && 'pass' === ($customPropertyRoundTrip['source_reports']['wp_block_validity']['status'] ?? ''),
+    'multiple retained custom properties follow the core save order after supported styles and retain a valid block round trip',
+    $customPropertyRoundTripMarkup
+);
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Author selector semantics unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary
- serialize block support styles in WordPress core order: border color/style/width/radius, dimensions, then spacing
- append retained consumed custom properties in deterministic lexical order without dropping values
- cover a `core/group` save/parse/validation round trip with multiple retained custom properties and style supports

Fixes #790.

## Evidence
- Round-two fixture evidence: [#790 comment](https://github.com/Automattic/blocks-engine/issues/790#issuecomment-5160761844)
- `87-travel-tours` card paint remains preserved; this repair addresses its three `core/group` editor-validation failures caused by style declaration ordering. The round-two visual-parity mismatch remains separately tracked in the issue evidence.

## Tests
- `composer test` in `php-transformer`
- `vitest run` in `packages/blocks-engine` (478 tests)

AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this serialization repair. Chris Huber remains responsible for every line.