### PR TITLE
test(blocks-engine): assert fixture87 round-trip output, not the fixture itself

### DIFF
--- a/packages/blocks-engine/src/wp/__tests__/fixture87-real-validation.test.ts
+++ b/packages/blocks-engine/src/wp/__tests__/fixture87-real-validation.test.ts
@@ -4,11 +4,13 @@ import { setupDomGlobals } from '../dom-globals.js';
 
 const require = createRequire(import.meta.url);
 
+type ParsedBlock = { attributes: { className?: string; style?: Record<string, unknown> } };
+
 type WpRuntime = {
   registerCoreBlocks(): void;
   createBlock(name: string, attributes: Record<string, unknown>): unknown;
   serialize(blocks: unknown[]): string;
-  parse(markup: string): unknown[];
+  parse(markup: string): ParsedBlock[];
   validateBlock(block: unknown): [boolean, unknown[]];
 };
 
@@ -51,6 +53,9 @@ describe('fixture87 real WordPress validation', () => {
     expect(reloaded.map((block) => wp.validateBlock(block)[0])).toEqual(Array(8).fill(true));
     expect(persisted).not.toContain('--tone:');
     expect(persisted).not.toContain('--a:');
-    expect(fixture.map(({ carrierCss }) => carrierCss).join('\n')).toContain('--h:260px !important');
+    expect(persisted).not.toContain('--h:');
+
+    expect(reloaded.map((block) => block.attributes.className)).toEqual(fixture.map(({ className }) => className));
+    expect(reloaded.map((block) => block.attributes.style)).toEqual(fixture.map(({ style }) => style));
   });
 });


### PR DESCRIPTION
## What

The last assertion in `fixture87-real-validation.test.ts` compared a string the test had just built against itself (`fixture.map(({ carrierCss }) => carrierCss).join('\n')` vs a literal from the same arrays) — a tautology that exercised nothing in the package.

Replaced it with assertions on actual pipeline behavior:

- the persisted markup excludes all carrier `--h:` declarations (matching the existing `--tone:`/`--a:` checks);
- the reloaded blocks preserve `className` and `style` — including the `var(--h)` minHeight reference — through core serialize/parse, across all eight blocks (typed via the runtime's `parse` return instead of a cast).

## Why

Found during a tech-debt review of the recent fixture87 commits: a passing assertion that can never fail is worse than no assertion, because it reads as coverage.

## Testing

`pnpm exec vitest run src/wp/__tests__/fixture87-real-validation.test.ts` and `pnpm typecheck` pass.