### PR TITLE
fix(transformer): make artifact normalization idempotent for staged flows

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -58,6 +58,7 @@
       "@test:unit"
     ],
     "test:unit": [
+      "php tests/unit/artifact-normalizer-idempotence.php",
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/custom-block-generator.php",
       "php tests/unit/description-list-block.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -361,9 +361,17 @@ final class ArtifactCompiler
     {
         $ownership = $file['metadata']['compilation'] ?? null;
         if (null === $ownership) {
-            return 'html' === ($file['kind'] ?? null)
-                ? array('scope' => 'page', 'id' => (string) $file['path'])
-                : array('scope' => 'shared', 'id' => '');
+            if ('html' === ($file['kind'] ?? null)) {
+                return array('scope' => 'page', 'id' => (string) $file['path']);
+            }
+            // Inline styles/scripts expanded out of an unannotated page must
+            // follow that page: parking page-varying content in the immutable
+            // shared plan would invalidate every page plan on a page edit.
+            $inlineSource = ArtifactNormalizer::inlineExpansionSourcePath($file);
+            if ('' !== $inlineSource) {
+                return array('scope' => 'page', 'id' => $inlineSource);
+            }
+            return array('scope' => 'shared', 'id' => '');
         }
         if (!is_array($ownership) || !is_string($ownership['scope'] ?? null) || !in_array($ownership['scope'], array('shared', 'page'), true)) {
             throw new \InvalidArgumentException('File compilation ownership requires a shared or page scope.');

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -259,10 +259,14 @@ final class ArtifactNormalizer
      */
     private function withInlineStyleFiles(array $files, array &$reservedPaths): array
     {
+        $expandedSources = $this->inlineExpandedSourcePaths($files, 'inline-style');
         $expanded = array();
         foreach ( $files as $file ) {
             $expanded[] = $file;
 
+            if ( isset($expandedSources[ArtifactPath::safeRelativePath((string) ($file['path'] ?? ''))]) ) {
+                continue;
+            }
             $content = $this->payload($file, (string) ($file['path'] ?? ''))['content'];
             if ( '' === trim($content) || ! $this->isHtmlLikeFile($file) || ! preg_match_all('@<style\b([^>]*)>(.*?)</style>@is', $content, $matches, PREG_SET_ORDER) ) {
                 continue;
@@ -279,7 +283,7 @@ final class ArtifactNormalizer
             }
             foreach ( $styles as $index => $style ) {
                 $path = $this->allocateGeneratedPath($this->inlineStylePath((string) ($file['path'] ?? 'index.html'), count($styles), $index + 1), $reservedPaths);
-                $expanded[] = array(
+                $expanded[] = $this->withInheritedCompilation($file, array(
                     'path'      => $path,
                     'content'   => $style['content'],
                     'kind'      => 'css',
@@ -287,14 +291,11 @@ final class ArtifactNormalizer
                     'role'      => 'stylesheet',
                     'intent'    => 'style',
                     'source'    => 'inline-style',
-                    'source_path' => (string) ($file['path'] ?? 'index.html'),
+                    'source_path' => ArtifactPath::safeRelativePath((string) ($file['path'] ?? 'index.html')),
                     'stylesheet_index' => $index + 1,
                     'media' => $style['media'],
                     'type' => $style['type'],
-                );
-                if ( is_array($file['metadata']['compilation'] ?? null) ) {
-                    $expanded[array_key_last($expanded)]['metadata'] = array('compilation' => $file['metadata']['compilation']);
-                }
+                ));
             }
         }
 
@@ -313,6 +314,62 @@ final class ArtifactNormalizer
         return ( in_array($kind, array( '', 'html' ), true) || str_contains($kind, 'html') )
             && ( '' === $mimeType || str_contains($mimeType, 'html') )
             && ( '' === $path || preg_match('/\.html?$/', $path) || 'index.html' === $path );
+    }
+
+    /**
+     * The source path of the file an inline style/script row was expanded
+     * from, or '' when the row is not an inline expansion. Expansion rows
+     * are recognizable by the source marker and source_path normalization
+     * itself emits.
+     *
+     * @param array<string, mixed> $file
+     */
+    public static function inlineExpansionSourcePath(array $file): string
+    {
+        if ( ! in_array((string) ($file['source'] ?? ''), array( 'inline-style', 'inline-script' ), true) ) {
+            return '';
+        }
+        return (string) ($file['source_path'] ?? '');
+    }
+
+    /**
+     * Source paths whose inline assets of the given kind were already
+     * expanded by a previous normalize() pass. Skipping them keeps
+     * normalize() idempotent: the staged compilation flow re-normalizes
+     * already-normalized file lists, which must not re-expand the same
+     * inline assets into duplicate generated files.
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @return array<string, bool>
+     */
+    private function inlineExpandedSourcePaths(array $files, string $source): array
+    {
+        $sources = array();
+        foreach ( $files as $file ) {
+            if ( $source !== (string) ($file['source'] ?? '') ) {
+                continue;
+            }
+            $sourcePath = self::inlineExpansionSourcePath($file);
+            if ( '' !== $sourcePath ) {
+                $sources[$sourcePath] = true;
+            }
+        }
+        return $sources;
+    }
+
+    /**
+     * Inline-expanded files inherit the parent file's compilation ownership.
+     *
+     * @param array<string,mixed> $file
+     * @param array<string,mixed> $expandedFile
+     * @return array<string,mixed>
+     */
+    private function withInheritedCompilation(array $file, array $expandedFile): array
+    {
+        if ( is_array($file['metadata']['compilation'] ?? null) ) {
+            $expandedFile['metadata'] = array( 'compilation' => $file['metadata']['compilation'] );
+        }
+        return $expandedFile;
     }
 
     private function inlineStylePath(string $htmlPath, int $count = 1, int $index = 1): string
@@ -355,10 +412,14 @@ final class ArtifactNormalizer
      */
     private function withInlineScriptFiles(array $files): array
     {
+        $expandedSources = $this->inlineExpandedSourcePaths($files, 'inline-script');
         $expanded = array();
         foreach ( $files as $file ) {
             $expanded[] = $file;
 
+            if ( isset($expandedSources[ArtifactPath::safeRelativePath((string) ($file['path'] ?? ''))]) ) {
+                continue;
+            }
             $content = $this->payload($file, (string) ($file['path'] ?? ''))['content'];
             if ( '' === trim($content) || ! $this->isHtmlLikeFile($file) || ! preg_match_all('@<script\b([^>]*)>(.*?)</script>@is', $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE) ) {
                 continue;
@@ -373,7 +434,7 @@ final class ArtifactNormalizer
                     continue;
                 }
 
-                $expanded[] = array(
+                $expanded[] = $this->withInheritedCompilation($file, array(
                     'path'        => $this->inlineScriptPath((string) ($file['path'] ?? 'index.html'), $scriptIndex),
                     'content'     => $body,
                     'kind'        => 'js',
@@ -388,10 +449,7 @@ final class ArtifactNormalizer
                     'superseded_by' => $this->htmlAttribute($attributes, 'data-blocks-engine-superseded-by'),
                     'source_path' => ArtifactPath::safeRelativePath((string) ($file['path'] ?? 'index.html')),
                     'selector'    => 'script:nth-of-type(' . $scriptIndex . ')',
-                );
-                if ( is_array($file['metadata']['compilation'] ?? null) ) {
-                    $expanded[array_key_last($expanded)]['metadata'] = array('compilation' => $file['metadata']['compilation']);
-                }
+                ));
             }
         }
 

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -19,6 +19,15 @@ $artifact = array(
 $compiler = new ArtifactCompiler();
 $shared = $compiler->prepareShared($artifact);
 $assert(ArtifactCompiler::SHARED_PLAN_SCHEMA === $shared['schema'] && 1 === $shared['summary']['file_count'] && preg_match('/^[a-f0-9]{64}$/', $shared['digest']), 'Shared preparation emits a bounded immutable shared plan and digest.');
+// Inline assets expanded out of an unannotated page follow that page, not the
+// immutable shared plan: parking page-varying content in the shared plan would
+// invalidate every page plan on a page edit.
+$inlineArtifact = $artifact;
+$inlineArtifact['files'][1]['content'] .= '<style>main{gap:1rem}</style><script>console.log("about");</script>';
+$inlineShared = $compiler->prepareShared($inlineArtifact);
+$assert(1 === $inlineShared['summary']['file_count'], 'Shared preparation excludes page-owned inline expansions.');
+$assert(3 === $compiler->preparePage($inlineArtifact, $inlineShared, 'about.html')['summary']['file_count'], 'Page preparation owns the page html plus its inline expansions.');
+
 $pageIds = array('index.html', 'about.html', 'contact.html');
 $pages = array();
 foreach ($pageIds as $pageId) $pages[$pageId] = $compiler->preparePage($artifact, $shared, $pageId);

--- a/php-transformer/tests/unit/artifact-normalizer-idempotence.php
+++ b/php-transformer/tests/unit/artifact-normalizer-idempotence.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * The staged compilation flow re-normalizes already-normalized file lists
+ * (prepareShared/preparePage envelopes, compose digest verification, the
+ * final compile), so normalize() must be a fixed point on its own output:
+ * re-normalizing must not re-expand inline assets into duplicate generated
+ * files, rename paths, or change hashes.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactNormalizer;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$artifact = array(
+    'entrypoints' => array( 'index.html' ),
+    'files'       => array(
+        array(
+            'path'     => 'index.html',
+            'content'  => '<style>main{color:#123}</style><main><h1>Home</h1></main><script>document.title="Home";</script><script>console.log("second");</script>',
+            'metadata' => array( 'compilation' => array( 'scope' => 'page', 'id' => 'index.html' ) ),
+        ),
+        array(
+            'path'     => 'assets/site.css',
+            'content'  => 'body{margin:0}',
+            'metadata' => array( 'compilation' => array( 'scope' => 'shared' ) ),
+        ),
+    ),
+);
+
+$first = (new ArtifactNormalizer())->normalize($artifact);
+$again = (new ArtifactNormalizer())->normalize(array( 'entrypoints' => $first['entrypoints'], 'files' => $first['files'] ));
+
+$paths = array_column($first['files'], 'path');
+$assert(count($paths) > count($artifact['files']), 'Inline styles and scripts are expanded into generated files.', implode(', ', $paths));
+$assert($again['files'] === $first['files'], 'Re-normalizing normalized files does not re-expand, rename, or reorder them.', implode(', ', array_column($again['files'], 'path')));
+$assert($again['entrypoints'] === $first['entrypoints'], 'Entrypoints are stable across re-normalization.');
+$assert($again['bytes'] === $first['bytes'], 'Byte accounting is stable across re-normalization.');
+$assert($again['hash_payload'] === $first['hash_payload'], 'The source-identity hash payload is stable across re-normalization.');
+
+foreach ( $first['files'] as $file ) {
+    if ( ! str_starts_with((string) $file['path'], 'index.inline') ) {
+        continue;
+    }
+    $assert(
+        array( 'compilation' => array( 'scope' => 'page', 'id' => 'index.html' ) ) === ($file['metadata'] ?? null),
+        'Inline-expanded files inherit the parent file\'s compilation ownership.',
+        (string) $file['path']
+    );
+}
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, sprintf('artifact-normalizer-idempotence: %d passed, %d failed%s', $passes, $failures, PHP_EOL));
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf('artifact-normalizer-idempotence: %d passed%s', $passes, PHP_EOL));


### PR DESCRIPTION
## What

Started as a tech-debt cleanup (the duplicated `metadata.compilation` propagation in the normalizer) and surfaced two real staged-compilation bugs while writing the test the cleanup deserved:

- **`normalize()` was not idempotent.** Re-normalizing already-normalized files re-expanded every inline `<style>`/`<script>` into *new* duplicate generated files under dedupe-renamed paths (`index.inline-generated-1.css`, `index.inline-2.js`, …). The staged flow re-normalizes at every step (`prepareShared`/`preparePage` envelopes, `compose` digest verification, the final staged compile), so staged compilation of any page containing inline assets silently diverged from whole compilation. The existing contract fixtures dodge this because none carried inline assets. Expansion rows are now recognized by the markers normalization itself emits (`source: inline-style|inline-script` + `source_path`) and their source files are not re-expanded. A new unit test pins `normalize()` as a fixed point on its own output.
- **Inline expansions of unannotated pages landed in the shared plan.** They come out of expansion as plain css/js rows with no `metadata.compilation`, so `fileOwnership()` defaulted them to shared — meaning any page edit would have changed the *immutable* shared plan and invalidated every page plan's digest binding. They now follow their source page's implicit ownership. Contract test pins the partition.
- **`withInheritedCompilation()`** replaces the compilation-metadata propagation block duplicated across the style and script expansion paths.

## Known bound (intentionally out of scope)

With inline assets, whole and staged compilation still order generated inline-asset rows differently (whole preserves insertion order `html, js, css`; staged sorts by path), which shows up as asset ordering in the materialization report. Fixing that needs a canonical file ordering shared by both flows (and count-aware inline-script naming — `x.inline-2.js` currently sorts before `x.inline.js`); it is a behavior change beyond this PR. The duplicate-file divergence — the part that corrupted output — is what this PR fixes.

## Testing

- New `tests/unit/artifact-normalizer-idempotence.php` (registered in `test:unit`).
- Contract additions in `staged-artifact-compilation.php`: shared plan excludes page-owned inline expansions; page plan owns its html plus expansions.
- Full `composer test` passes.
