### PR TITLE
build(ci): share packagist split+verify logic and pin GitHub host keys

### DIFF
--- a/.github/workflows/php-transformer-split.yml
+++ b/.github/workflows/php-transformer-split.yml
@@ -46,7 +46,13 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/mirror_deploy_key
           chmod 600 ~/.ssh/mirror_deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          # GitHub's published SSH host keys (https://api.github.com/meta),
+          # pinned instead of trusting whatever ssh-keyscan happens to see.
+          printf '%s\n' \
+            'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' \
+            'github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=' \
+            'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=' \
+            >> ~/.ssh/known_hosts
 
       - name: Split and push
         env:
@@ -54,14 +60,7 @@ jobs:
           MIRROR_URL: git@github.com:Automattic/blocks-engine-php-transformer.git
         run: |
           set -euo pipefail
-          target=$(git rev-parse "${GITHUB_SHA}^{commit}")
-          split_sha=$(git subtree split --prefix=php-transformer "$target")
-          src_tree=$(git rev-parse "${target}:php-transformer")
-          split_tree=$(git rev-parse "${split_sha}^{tree}")
-          if [ "$src_tree" != "$split_tree" ]; then
-            echo "Split tree ${split_tree} does not match source subtree ${src_tree}" >&2
-            exit 1
-          fi
+          split_sha=$(php-transformer/tools/packagist-split/split-ref.sh "$GITHUB_SHA")
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             mirror_tag="v${GITHUB_REF_NAME#php-transformer-v}"
             echo "Pushing tag ${mirror_tag} (${split_sha})"

--- a/php-transformer/tools/packagist-split/backfill.sh
+++ b/php-transformer/tools/packagist-split/backfill.sh
@@ -23,30 +23,18 @@ for arg in "$@"; do
 done
 
 cd "$(git rev-parse --show-toplevel)"
+split_ref="php-transformer/tools/packagist-split/split-ref.sh"
 
 if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
     echo "Refusing to run from a shallow clone: subtree split needs full history." >&2
     exit 1
 fi
 
-split_verified() {
-    # Subtree split output must reproduce the exact source subtree.
-    local source_rev="$1" split_sha="$2"
-    local src_tree split_tree
-    src_tree=$(git rev-parse "${source_rev}:php-transformer")
-    split_tree=$(git rev-parse "${split_sha}^{tree}")
-    if [ "$src_tree" != "$split_tree" ]; then
-        echo "Tree mismatch for ${source_rev}: split ${split_tree} != source ${src_tree}" >&2
-        return 1
-    fi
-}
-
 refspecs=()
 
 while IFS= read -r tag; do
     version="v${tag#php-transformer-v}"
-    split_sha=$(git subtree split --prefix=php-transformer "$tag")
-    split_verified "$tag" "$split_sha"
+    split_sha=$("$split_ref" "$tag")
     echo "${tag} -> ${version} (${split_sha})"
     refspecs+=("${split_sha}:refs/tags/${version}")
 done < <(git tag --list 'php-transformer-v*' | sort -V)
@@ -56,8 +44,7 @@ if [ "${#refspecs[@]}" -eq 0 ]; then
     exit 1
 fi
 
-trunk_split=$(git subtree split --prefix=php-transformer origin/trunk)
-split_verified origin/trunk "$trunk_split"
+trunk_split=$("$split_ref" origin/trunk)
 echo "origin/trunk -> trunk (${trunk_split})"
 refspecs+=("${trunk_split}:refs/heads/trunk")
 

--- a/php-transformer/tools/packagist-split/split-ref.sh
+++ b/php-transformer/tools/packagist-split/split-ref.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Split php-transformer/ out of the given source rev and print the resulting
+# commit SHA, after verifying the split tree is byte-identical to the source
+# subtree. Shared by the CI mirror workflow and backfill.sh.
+#
+# Usage: php-transformer/tools/packagist-split/split-ref.sh <source-rev>
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: split-ref.sh <source-rev>" >&2
+    exit 64
+fi
+
+source_rev="$1"
+split_sha=$(git subtree split --prefix=php-transformer "$source_rev")
+src_tree=$(git rev-parse "${source_rev}:php-transformer")
+split_tree=$(git rev-parse "${split_sha}^{tree}")
+if [ "$src_tree" != "$split_tree" ]; then
+    echo "Tree mismatch for ${source_rev}: split ${split_tree} != source ${src_tree}" >&2
+    exit 1
+fi
+
+echo "$split_sha"


### PR DESCRIPTION
## What

- Extracts the subtree-split + tree-verification logic that the mirror workflow had reimplemented inline from `backfill.sh` into a shared `php-transformer/tools/packagist-split/split-ref.sh`. Both consumers now call it; the script refuses to print a SHA whose tree is not byte-identical to the source subtree. The workflow's redundant `${GITHUB_SHA}^{commit}` peel is gone too — the script resolves any rev (verified against raw refs, tag names, and unpeeled annotated-tag SHAs).
- Pins GitHub's published SSH host keys (from `https://api.github.com/meta`) in the workflow instead of trusting whatever `ssh-keyscan` sees on the runner network at run time.

## Why

Found during a tech-debt review of the Packagist mirror commit (#802): two copies of the split+verify logic were one edit away from diverging, and the deploy-key push authenticated the remote host via trust-on-first-use.

## Testing

- `bash -n` on both scripts.
- `split-ref.sh` run locally against `trunk` and against an unpeeled `php-transformer-v0.1.0` tag object SHA; both produce verified split SHAs.
- `backfill.sh --dry-run` flow unchanged apart from the extracted call.