### PR TITLE
fix(php-transformer): make markdown support optional

### DIFF
--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -39,7 +39,7 @@ Consumers should treat these classes and interface as the public entrypoints for
 
 - `Contract\TransformerResult` - stable result envelope. Use `toArray()` when passing results across process, HTTP, fixture, or compatibility boundaries.
 - `HtmlToBlocks\HtmlTransformer` - converts supported HTML elements into WordPress block arrays and serialized block markup. Unsupported top-level HTML is reported in `fallbacks`.
-- `FormatBridge\FormatBridge` - normalizes and converts declared `html`, `markdown`, and serialized `blocks` content through `convertResult()`.
+- `FormatBridge\FormatBridge` - normalizes and converts declared `html`, `markdown`, and serialized `blocks` content through `convertResult()`. Markdown support is optional: the adapter registers only when `league/commonmark` + `league/html-to-markdown` are loadable (vendored copies may omit them and `FormatBridge/MarkdownAdapter.php` entirely), otherwise markdown conversion fails cleanly as `unsupported_source_format` and `supportedFormats()` omits `markdown`.
 - `FormatBridge\FormatAdapterInterface` - adapter contract for adding formats to `FormatBridge` when a consumer genuinely needs a package-level extension point.
 - `ArtifactCompiler\ArtifactCompiler` - normalizes generated website artifact bundles into the shared result envelope, including block markup, source reports, assets, components, documents, and block type artifacts.
 - `StaticSite\MaterializationView` - validates a `TransformerResult` object or canonical result array and returns a stable product-neutral array view for importer planning.

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -47,6 +47,7 @@
     ],
     "test:canonical": [
       "php tests/contract/runtime-no-wordpress.php",
+      "php tests/contract/runtime-no-markdown.php",
       "php tests/contract/runtime-wordpress-stubs.php",
       "php tests/contract/plugin-bootstrap.php",
       "php tests/contract/run.php",

--- a/php-transformer/src/FormatBridge/AdapterRegistry.php
+++ b/php-transformer/src/FormatBridge/AdapterRegistry.php
@@ -17,7 +17,7 @@ final class AdapterRegistry
      * @param list<string> $supportedFormats
      */
     public function __construct(
-        private array $supportedFormats = array( 'blocks', 'html', 'markdown' )
+        private array $supportedFormats = array()
     ) {
     }
 

--- a/php-transformer/src/FormatBridge/FormatBridge.php
+++ b/php-transformer/src/FormatBridge/FormatBridge.php
@@ -17,7 +17,9 @@ final class FormatBridge
     ) {
         $this->registry->register(new BlocksAdapter());
         $this->registry->register(new HtmlAdapter());
-        $this->registry->register(new MarkdownAdapter());
+        if ( class_exists(MarkdownAdapter::class) && MarkdownAdapter::isAvailable() ) {
+            $this->registry->register(new MarkdownAdapter());
+        }
     }
 
     public function registerAdapter(FormatAdapterInterface $adapter): void

--- a/php-transformer/src/FormatBridge/MarkdownAdapter.php
+++ b/php-transformer/src/FormatBridge/MarkdownAdapter.php
@@ -18,6 +18,17 @@ final class MarkdownAdapter implements FormatAdapterInterface
     ) {
     }
 
+    /**
+     * Markdown support is optional: vendored copies of src/ may ship without
+     * the League packages (or without this file entirely). FormatBridge only
+     * registers this adapter when the conversion dependencies are loadable.
+     */
+    public static function isAvailable(): bool
+    {
+        return class_exists(GithubFlavoredMarkdownConverter::class)
+            && class_exists(HtmlConverter::class);
+    }
+
     public function slug(): string
     {
         return 'markdown';

--- a/php-transformer/tests/contract/runtime-no-markdown.php
+++ b/php-transformer/tests/contract/runtime-no-markdown.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+// Markdown support is optional: consumers that vendor src/ in-tree may ship it
+// without league/commonmark + league/html-to-markdown, and may omit
+// MarkdownAdapter.php entirely. This contract runs WITHOUT the composer
+// autoloader so League is never loadable, and exercises both degraded shapes:
+//
+//   A) MarkdownAdapter.php absent  — the class itself cannot autoload.
+//   B) MarkdownAdapter.php present — the class loads but its League
+//      dependencies do not.
+//
+// In both shapes FormatBridge must construct, refuse markdown as a format,
+// keep html/blocks conversions working, and ArtifactCompiler must degrade
+// markdown documents to the core/html fallback with a diagnostic.
+
+$GLOBALS['a8c_be_skip_markdown_adapter'] = true;
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'Automattic\\BlocksEngine\\PhpTransformer\\';
+    if ( ! str_starts_with($class, $prefix) ) {
+        return;
+    }
+
+    if ( ! empty($GLOBALS['a8c_be_skip_markdown_adapter']) && str_ends_with($class, 'FormatBridge\\MarkdownAdapter') ) {
+        return;
+    }
+
+    $path = dirname(__DIR__, 2) . '/src/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+    if ( is_file($path) ) {
+        require $path;
+    }
+});
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
+use Automattic\BlocksEngine\PhpTransformer\FormatBridge\MarkdownAdapter;
+
+assertSame(false, class_exists('League\\CommonMark\\GithubFlavoredMarkdownConverter'), 'This contract must run without the League markdown dependencies.');
+
+// Shape A: MarkdownAdapter.php is not vendored at all.
+$bridge = new FormatBridge();
+assertSame(array( 'blocks', 'html' ), $bridge->supportedFormats(), 'Without the markdown adapter, supported formats should advertise only blocks and html.');
+assertSame(false, $bridge->supports('markdown'), 'Without the markdown adapter, markdown should be unsupported.');
+
+$markdownResult = $bridge->convertResult("# Title\n\nBody", 'markdown', 'blocks')->toArray();
+assertSame('failed', $markdownResult['status'] ?? null, 'Markdown conversion should fail cleanly without the adapter.');
+assertSame('unsupported_source_format', $markdownResult['diagnostics'][0]['code'] ?? null, 'Markdown conversion failure should report the unsupported source format.');
+
+$htmlResult = $bridge->convertResult('<p>Hello</p>', 'html', 'blocks')->toArray();
+assertSame('success', $htmlResult['status'] ?? null, 'HTML to blocks conversion should keep working without the markdown adapter.');
+assertSame('core/paragraph', $htmlResult['blocks'][0]['blockName'] ?? null, 'HTML to blocks conversion should still produce blocks.');
+
+$compiled = ( new ArtifactCompiler() )->compile(
+    array(
+        'files' => array(
+            'content/about.md' => "# About\n\nMarkdown body.",
+        ),
+    )
+)->toArray();
+$document = $compiled['documents'][0] ?? array();
+assertSame('content/about.md', $document['source_path'] ?? null, 'Markdown source documents should still be compiled without the adapter.');
+assertSame(true, str_contains((string) ($document['block_markup'] ?? ''), '<!-- wp:html -->'), 'Markdown documents should degrade to the core/html fallback without the adapter.');
+assertSame(true, str_contains((string) ($document['block_markup'] ?? ''), 'Markdown body.'), 'The core/html fallback should preserve the source markdown.');
+$diagnosticCodes = array_map(
+    static fn (array $diagnostic): string => (string) ($diagnostic['code'] ?? ''),
+    is_array($document['diagnostics'] ?? null) ? $document['diagnostics'] : array()
+);
+assertSame(true, in_array('markdown_adapter_unavailable', $diagnosticCodes, true), 'Markdown degradation should surface the markdown_adapter_unavailable diagnostic.');
+
+// Shape B: MarkdownAdapter.php is vendored but League is missing.
+$GLOBALS['a8c_be_skip_markdown_adapter'] = false;
+
+assertSame(true, class_exists(MarkdownAdapter::class), 'Shape B expects the markdown adapter class itself to load.');
+assertSame(false, MarkdownAdapter::isAvailable(), 'The markdown adapter should report unavailability when League is missing.');
+
+$bridge = new FormatBridge();
+assertSame(false, $bridge->supports('markdown'), 'A dependency-less markdown adapter should not register, rather than silently returning empty output.');
+assertSame(array( 'blocks', 'html' ), $bridge->supportedFormats(), 'A dependency-less markdown adapter should not advertise markdown support.');
+
+$markdownResult = $bridge->convertResult("# Title\n\nBody", 'markdown', 'blocks')->toArray();
+assertSame('failed', $markdownResult['status'] ?? null, 'Markdown conversion should fail cleanly when League is missing.');
+assertSame('unsupported_source_format', $markdownResult['diagnostics'][0]['code'] ?? null, 'Markdown conversion failure should report the unsupported source format when League is missing.');
+
+fwrite(STDOUT, "Markdown-optional runtime contract passed.\n");
+
+function assertSame(mixed $expected, mixed $actual, string $message): void
+{
+    if ( $expected !== $actual ) {
+        fwrite(STDERR, $message . "\nExpected: " . var_export($expected, true) . "\nActual: " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}


### PR DESCRIPTION
## Summary

Makes markdown conversion an optional feature of the PHP transformer. `FormatBridge` registers `MarkdownAdapter` only when the adapter class and its League dependencies are loadable, and a new runtime contract pins the degraded behavior. Copies of `src/` vendored in-tree can omit `league/commonmark`, `league/html-to-markdown`, and `MarkdownAdapter.php` entirely without fataling or carrying dangling `League\` references for static analysis to flag.

## Why

Consumers that vendor `src/` in-tree without composer's `vendor/` shipped `MarkdownAdapter.php` with unresolvable `League\` references, and `FormatBridge`'s unconditional `new MarkdownAdapter()` made dropping the file impossible. Worse, with the file present but League absent, the adapter's `catch (Throwable)` blocks swallowed the class-not-found `Error` and silently returned empty markdown output instead of failing visibly.

## How

- `MarkdownAdapter::isAvailable()` reports whether both League entry classes are loadable.
- `FormatBridge` registers the adapter only when `class_exists(MarkdownAdapter::class)` and `isAvailable()` both hold, so markdown requests fail cleanly as `unsupported_source_format` and `ArtifactCompiler`'s existing `core/html` + `markdown_adapter_unavailable` document fallback engages.
- `AdapterRegistry` derives its supported-format list from registered adapters instead of hardcoding markdown, keeping `supportedFormats()` and `Normalizer` consistent with what is actually registered.
- `tests/contract/runtime-no-markdown.php` runs without the composer autoloader and pins both degraded shapes: adapter file absent entirely, and adapter present with League missing.

Composer keeps the League packages in `require` — standalone/Packagist consumers get markdown out of the box; optionality is enforced at the code seam, not the manifest.

## Testing

- `composer test:canonical` (includes the new `runtime-no-markdown` contract) — green
- `composer test:parity` — 272 fixtures pass
- `composer test:packaging` — install proof passes
- Verified an in-tree vendored copy of `src/` without the adapter file: `FormatBridge` constructs, reports markdown unsupported, and markdown artifacts compile to the `core/html` fallback with the `markdown_adapter_unavailable` diagnostic.
