### PR TITLE
Preserve compact styled select controls

### DIFF
--- a/php-transformer/src/HtmlToBlocks/FormSelectBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/FormSelectBlockGenerator.php
@@ -57,8 +57,9 @@ JS;
         return array(
             'index.js' => str_replace('__BLOCK_ATTRIBUTES__', json_encode($this->blockJson()['attributes'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES), $script),
             // The legacy core/group boundary is retained for compatibility, but
-            // must not acquire the flow spacing of a content section.
-            'style.css' => '.wp-block-group.blocks-engine-form-select-wrapper{margin-block-start:0!important;margin-block-end:0!important}',
+            // must not become an extra flow, grid, or flex item. Flatten it so
+            // the native select receives the authored layout slot directly.
+            'style.css' => '.wp-block-group.blocks-engine-form-select-wrapper{display:contents;margin-block-start:0!important;margin-block-end:0!important}',
         );
     }
 

--- a/php-transformer/src/HtmlToBlocks/FormSelectBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/FormSelectBlockGenerator.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/**
+ * Builds the static companion block for compact, editable native select controls.
+ */
+final class FormSelectBlockGenerator
+{
+    public const NAME = 'blocks-engine/form-select';
+
+    /** @return array<string, mixed> */
+    public function blockJson(): array
+    {
+        return array(
+            'apiVersion' => 3,
+            'name' => self::NAME,
+            'title' => 'Select Field',
+            'category' => 'widgets',
+            'description' => 'An editable native select field.',
+            'editorScript' => array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ),
+            'style' => 'file:./style.css',
+            'attributes' => array(
+                'id' => array( 'type' => 'string', 'default' => '' ),
+                'name' => array( 'type' => 'string', 'default' => '' ),
+                'ariaLabel' => array( 'type' => 'string', 'default' => '' ),
+                'placeholder' => array( 'type' => 'string', 'default' => '' ),
+                'className' => array( 'type' => 'string', 'default' => '' ),
+                'style' => array( 'type' => 'string', 'default' => '' ),
+                'options' => array( 'type' => 'array', 'default' => array() ),
+                // Compatibility metadata for consumers of the former readable
+                // approximation. It has no rendered geometry.
+                'selectedSummary' => array( 'type' => 'string', 'default' => '' ),
+            ),
+            'supports' => array( 'html' => false ),
+        );
+    }
+
+    /** @return array<string, string> */
+    public function assets(): array
+    {
+        $script = <<<'JS'
+( function( blocks, blockEditor, element ) {
+    var createElement = element.createElement;
+    var RichText = blockEditor.RichText;
+    var attributes = __BLOCK_ATTRIBUTES__;
+    function escapeAttribute( value ) { return String( value || '' ).replace( /&/g, '&amp;' ).replace( /"/g, '&quot;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' ); }
+    function selectAttributes( attrs ) { var output = ''; [ 'id', 'name', 'ariaLabel', 'placeholder', 'className', 'style' ].forEach( function( key ) { if ( attrs[ key ] ) { output += ' ' + ( 'className' === key ? 'class' : ( 'ariaLabel' === key ? 'aria-label' : key ) ) + '="' + escapeAttribute( attrs[ key ] ) + '"'; } } ); return output; }
+    function markup( attrs ) { var output = '<select' + selectAttributes( attrs ) + '>'; ( attrs.options || [] ).forEach( function( option ) { var value = Object.prototype.hasOwnProperty.call( option, 'value' ) ? option.value : option.label; output += '<option value="' + escapeAttribute( value ) + '"' + ( option.selected ? ' selected' : '' ) + ( option.disabled ? ' disabled' : '' ) + '>' + ( option.label || '' ) + '</option>'; } ); return output + '</select>'; }
+    function edit( props ) { var attrs = props.attributes; var options = ( attrs.options || [] ).map( function( option ) { return createElement( 'option', { value: option.value || option.label, disabled: option.disabled, selected: option.selected, key: option.value || option.label }, option.label ); } ); return createElement( 'select', { id: attrs.id || undefined, name: attrs.name || undefined, className: attrs.className || undefined, style: attrs.style || undefined, onChange: function( event ) { props.setAttributes( { options: ( attrs.options || [] ).map( function( option ) { return Object.assign( {}, option, { selected: option.value === event.target.value } ); } ) } ); } }, options ); }
+    function save( props ) { return createElement( element.RawHTML, null, markup( props.attributes ) ); }
+    blocks.registerBlockType( 'blocks-engine/form-select', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
+JS;
+
+        return array(
+            'index.js' => str_replace('__BLOCK_ATTRIBUTES__', json_encode($this->blockJson()['attributes'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES), $script),
+            // The legacy core/group boundary is retained for compatibility, but
+            // must not acquire the flow spacing of a content section.
+            'style.css' => '.wp-block-group.blocks-engine-form-select-wrapper{margin-block-start:0!important;margin-block-end:0!important}',
+        );
+    }
+
+    /** @param array<string, mixed> $attrs */
+    public function markup(array $attrs): string
+    {
+        $escape = static fn (mixed $value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $select = '';
+        foreach ( array( 'id', 'name', 'ariaLabel', 'placeholder', 'className', 'style' ) as $key ) {
+            $value = trim((string) ($attrs[$key] ?? ''));
+            if ( '' !== $value ) {
+                $select .= ' ' . ( 'className' === $key ? 'class' : ( 'ariaLabel' === $key ? 'aria-label' : $key ) ) . '="' . $escape($value) . '"';
+            }
+        }
+        $markup = '<select' . $select . '>';
+        foreach ( $attrs['options'] ?? array() as $option ) {
+            if ( ! is_array($option) || '' === trim((string) ($option['label'] ?? '')) ) {
+                continue;
+            }
+            $value = array_key_exists('value', $option) ? (string) $option['value'] : (string) $option['label'];
+            $markup .= '<option value="' . $escape($value) . '"'
+                . ( ! empty($option['selected']) ? ' selected' : '' )
+                . ( ! empty($option['disabled']) ? ' disabled' : '' )
+                . '>' . $escape($option['label']) . '</option>';
+        }
+
+        return $markup . '</select>';
+    }
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return array( 'name' => 'form-select', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -291,6 +291,8 @@ final class HtmlTransformer
 
     private bool $descriptionListBlockGenerated = false;
 
+    private bool $formSelectBlockGenerated = false;
+
     /**
      * Block namespace for generated custom-block references. The ArtifactCompiler
      * sets this to the per-site companion-plugin namespace (`ssi-<site_slug>`) so
@@ -560,6 +562,7 @@ final class HtmlTransformer
         $this->nativeDisclosureRootIds = array();
         $this->generatedBlocks = array();
         $this->descriptionListBlockGenerated = false;
+        $this->formSelectBlockGenerated = false;
         $this->formControlEchoTexts = array();
         $this->generatedBlockNamespace = $this->generatedBlockNamespaceFromOptions($options);
         $this->preserveShellLandmarks = !empty($options['extract_global_shell']);
@@ -3186,6 +3189,15 @@ final class HtmlTransformer
             );
             if ( null !== $buttons ) {
                 return $buttons;
+            }
+
+            // A select's option text is not prose. Route it before generic text
+            // flow can flatten the control into a paragraph.
+            if ( 'select' === $tagName ) {
+                $selectBlock = $this->readableFormControlBlockFromElement($element);
+                if ( null !== $selectBlock ) {
+                    return $selectBlock;
+                }
             }
 
             $textFlow = $this->textFlowBlockFromElement($element);
@@ -9676,30 +9688,77 @@ final class HtmlTransformer
     {
         $label = $this->readableFormControlLabel($select);
         $this->registerFormControlEcho($label);
-        $optionBlocks = array();
-
-        foreach ( $this->selectOptions($select) as $option ) {
-            $optionLabel = trim((string) ($option['label'] ?? ''));
-            if ( '' === $optionLabel ) {
-                continue;
-            }
-
-            if ( true === ($option['selected'] ?? false) ) {
-                $optionLabel .= ' (selected)';
-            }
-
-            $this->registerFormControlEcho($optionLabel);
-            $optionBlocks[] = $this->createBlock('core/list-item', array( 'content' => $this->runtime->escapeHtml($optionLabel) ));
-        }
-
-        if ( array() === $optionBlocks ) {
+        $options = $this->selectOptions($select);
+        if ( array() === $options ) {
             return null;
         }
+        // Form controls are below the general high-value style boundary, so use
+        // the selector-resolved author cascade directly as the representation
+        // gate. Class/id presence alone is never sufficient.
+        if ( array() === $this->structuralPresentationDeclarations($select) ) {
+            $optionBlocks = array();
+            foreach ( $options as $option ) {
+                $optionLabel = trim((string) ($option['label'] ?? ''));
+                if ( '' === $optionLabel ) {
+                    continue;
+                }
+                if ( true === ($option['selected'] ?? false) ) {
+                    $optionLabel .= ' (selected)';
+                }
+                $this->registerFormControlEcho($optionLabel);
+                $optionBlocks[] = $this->createBlock('core/list-item', array( 'content' => $this->runtime->escapeHtml($optionLabel) ));
+            }
 
-        return $this->createBlock('core/group', $this->presentationAttributes($select), array(
-            $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $select),
-            $this->createBlock('core/list', array(), $optionBlocks, $select),
-        ), $select);
+            return $this->createBlock('core/group', $this->presentationAttributes($select), array(
+                $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($label) ), array(), $select),
+                $this->createBlock('core/list', array(), $optionBlocks, $select),
+            ), $select);
+        }
+        if ( ! $this->formSelectBlockGenerated ) {
+            $this->generatedBlocks[] = ( new FormSelectBlockGenerator() )->definition();
+            $this->formSelectBlockGenerated = true;
+        }
+        $attrs = array_filter(array(
+            'id' => $this->attr($select, 'id'),
+            'name' => $this->attr($select, 'name'),
+            'ariaLabel' => $this->attr($select, 'aria-label'),
+            'placeholder' => $this->attr($select, 'placeholder'),
+            'className' => $this->attr($select, 'class'),
+            'style' => $this->attr($select, 'style'),
+            'options' => $options,
+            'selectedSummary' => $this->selectedOptionSummary($options),
+        ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== $value);
+        $markup = ( new FormSelectBlockGenerator() )->markup($attrs);
+        $controlBlock = array(
+            'blockName' => FormSelectBlockGenerator::NAME,
+            'attrs' => $attrs,
+            'innerBlocks' => array(),
+            'innerHTML' => $markup,
+            'innerContent' => array( $markup ),
+        );
+
+        // Keep the long-standing group/anchor contract for callers that address
+        // the converted field structurally. Source identity lives on the native
+        // control, so authored select selectors never style this transparent shell.
+        return $this->createBlock('core/group', array_filter(array(
+            'anchor' => $this->safeAnchor($this->attr($select, 'id')),
+            'className' => 'blocks-engine-form-select-wrapper',
+        )), array( $controlBlock ));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $options
+     */
+    private function selectedOptionSummary(array $options): string
+    {
+        $selected = array();
+        foreach ( $options as $option ) {
+            if ( ! empty($option['selected']) && '' !== trim((string) ($option['label'] ?? '')) ) {
+                $selected[] = (string) $option['label'];
+            }
+        }
+
+        return array() === $selected ? '' : implode(', ', $selected) . ' (selected)';
     }
 
     /**
@@ -10431,7 +10490,9 @@ final class HtmlTransformer
             $value = $this->attr($option, 'value');
             $optionMetadata = array(
                 'label' => trim(preg_replace('/\s+/', ' ', $option->textContent ?? '') ?? ''),
-                'value' => '' !== $value ? $value : trim($option->textContent ?? ''),
+                // An explicit empty value is a select placeholder semantic, not
+                // a missing value to replace with the visible option label.
+                'value' => $option->hasAttribute('value') ? $value : trim($option->textContent ?? ''),
             );
             if ( $option->hasAttribute('selected') ) {
                 $optionMetadata['selected'] = true;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -986,15 +986,20 @@ $assert(str_contains($rangeControlText, 'Density: 28'), 'range input summary pre
 $assert(str_contains($rangeControlText, 'min 6, max 60, step 2'), 'range input summary preserves bounds');
 
 $standaloneControls = ( new HtmlTransformer() )->transform(
-    '<main><input id="donation" type="number" aria-label="Custom donation amount" placeholder="Enter amount"><select aria-label="Sort products"><option selected>Featured</option><option>Price: Low to High</option></select><select class="js-sort-select" aria-label="Runtime sort"><option>Newest</option></select></main>',
-    array('runtime_dom_selectors' => array('.js-sort-select'))
+    '<main><input id="donation" type="number" aria-label="Custom donation amount" placeholder="Enter amount"><label for="product-sort">Sort products</label><select id="product-sort" name="products" class="catalog-sort" placeholder="Sort products"><option value="" selected disabled>Choose an order</option><option value="featured">Featured</option><option value="price">Price: Low to High</option></select><select class="js-sort-select" aria-label="Runtime sort"><option>Newest</option></select></main>',
+    array('runtime_dom_selectors' => array('.js-sort-select'), 'static_css' => '.catalog-sort{appearance:none;border:2px solid #123;padding:8px}')
 )->toArray();
 $standaloneControlBlocks = $standaloneControls['blocks'][0]['innerBlocks'] ?? array();
 $assert(array() === ($standaloneControls['fallbacks'] ?? array()), 'standalone readable controls convert without unsupported-element fallback');
 $assert('core/paragraph' === ($standaloneControlBlocks[0]['blockName'] ?? ''), 'standalone non-runtime input converts to readable paragraph');
-$assert('core/list' === ($standaloneControlBlocks[1]['innerBlocks'][1]['blockName'] ?? ''), 'standalone non-runtime select options convert to readable list');
-$assert('core/html' === ($standaloneControlBlocks[2]['blockName'] ?? ''), 'runtime-targeted select preserves native DOM output');
-$assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), 'Featured (selected)'), 'readable select summary preserves selected option state');
+$assert('core/paragraph' === ($standaloneControlBlocks[1]['blockName'] ?? ''), 'source select label remains a sibling editable block');
+$assert('core/group' === ($standaloneControlBlocks[2]['blockName'] ?? ''), 'standalone static select retains the legacy structural group boundary');
+$assert('blocks-engine/form-select' === ($standaloneControlBlocks[2]['innerBlocks'][0]['blockName'] ?? ''), 'standalone non-runtime select uses a compact editable native-control block inside its compatibility wrapper');
+$assert('core/html' === ($standaloneControlBlocks[3]['blockName'] ?? ''), 'runtime-targeted select preserves native DOM output');
+$assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<option value="" selected disabled>Choose an order</option>'), 'compact select preserves selected placeholder option state');
+$assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<select id="product-sort" name="products" placeholder="Sort products" class="catalog-sort">'), 'compact select preserves native id, name, placeholder, and CSS selector identity');
+$assert(1 === substr_count((string) ($standaloneControls['serialized_blocks'] ?? ''), '>Sort products</p>') && ! str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<label'), 'styled select emits its source label exactly once without a duplicate custom-block label');
+$assert(! str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<!-- wp:html') || str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<select class="js-sort-select"'), 'only the runtime-targeted select uses core/html');
 $assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<select class="js-sort-select"'), 'runtime-targeted select preserves native markup in serialized blocks');
 $assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), 'id="donation"'), 'readable input output preserves source id as a block anchor');
 $assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), 'js-sort-select'), 'runtime-targeted select keeps behavior-hook class on native markup');
@@ -1003,6 +1008,13 @@ $assert('control' === ($standaloneControls['source_reports']['runtime_islands'][
 $assert('.js-sort-select' === ($standaloneControls['source_reports']['runtime_islands'][0]['selector'] ?? ''), 'runtime-targeted standalone control reports selector metadata');
 $assert('select' === ($standaloneControls['source_reports']['runtime_islands'][0]['control']['tag'] ?? ''), 'runtime-targeted standalone control reports control metadata');
 $assert(str_contains((string) ($standaloneControls['source_reports']['runtime_islands'][0]['source_snippet'] ?? ''), '<select class="js-sort-select"'), 'runtime-targeted standalone control preserves source snippet metadata');
+
+$unstyledSelect = ( new HtmlTransformer() )->transform(
+    '<main><select id="plain-sort" class="catalog-sort" name="products" aria-label="Sort products"><option selected>Featured</option><option>Price</option></select></main>'
+)->toArray();
+$unstyledSelectBlock = $unstyledSelect['blocks'][0] ?? array();
+$assert('core/group' === ($unstyledSelectBlock['blockName'] ?? '') && 'core/list' === ($unstyledSelectBlock['innerBlocks'][1]['blockName'] ?? ''), 'static select without authored presentation evidence retains the readable-list representation');
+$assert(! str_contains((string) ($unstyledSelect['serialized_blocks'] ?? ''), '<!-- wp:blocks-engine/form-select'), 'unstyled static select does not generate a compact native-control block from class identity alone');
 
 $standaloneSearch = ( new HtmlTransformer() )->transform(
     '<div class="site-search"><input type="search" name="s" placeholder="Search articles" aria-label="Search articles"></div>'
@@ -1040,7 +1052,7 @@ $artifactControlSelectors = ( new ArtifactCompiler() )->compile(
 )->toArray();
 $artifactControlMarkup = (string) ($artifactControlSelectors['serialized_blocks'] ?? '');
 $assert(! str_contains($artifactControlMarkup, '<input id="newsletter-email"'), 'artifact compiler converts generically queried static input to readable block output');
-$assert(! str_contains($artifactControlMarkup, '<select id="sort-select"'), 'artifact compiler converts generically queried static select to readable block output');
+$assert(! str_contains($artifactControlMarkup, '<select id="sort-select"'), 'artifact compiler retains readable static select output without authored presentation evidence');
 $assert(str_contains($artifactControlMarkup, 'you@example.com'), 'artifact static input readable output preserves placeholder text');
 $assert(str_contains($artifactControlMarkup, 'Featured (selected)'), 'artifact static select readable output preserves selected option state');
 $assert(str_contains($artifactControlMarkup, '<input id="live-filter"'), 'artifact compiler preserves behavior-bearing control native DOM in serialized blocks');

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1016,6 +1016,15 @@ $unstyledSelectBlock = $unstyledSelect['blocks'][0] ?? array();
 $assert('core/group' === ($unstyledSelectBlock['blockName'] ?? '') && 'core/list' === ($unstyledSelectBlock['innerBlocks'][1]['blockName'] ?? ''), 'static select without authored presentation evidence retains the readable-list representation');
 $assert(! str_contains((string) ($unstyledSelect['serialized_blocks'] ?? ''), '<!-- wp:blocks-engine/form-select'), 'unstyled static select does not generate a compact native-control block from class identity alone');
 
+$gridSelect = ( new HtmlTransformer() )->transform(
+    '<main><div class="control-grid"><select id="grid-sort" class="catalog-sort"><option>Featured</option></select></div></main>',
+    array('static_css' => '.control-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.catalog-sort{width:100%;padding:8px}')
+)->toArray();
+$gridSelectBlock = $gridSelect['blocks'][0]['innerBlocks'][0] ?? array();
+$gridSelectDefinition = $gridSelect['source_reports']['generated_blocks'][0] ?? array();
+$assert('core/group' === ($gridSelectBlock['blockName'] ?? '') && 'blocks-engine/form-select' === ($gridSelectBlock['innerBlocks'][0]['blockName'] ?? ''), 'styled select retains the valid compatibility group while its native control remains the authored grid child');
+$assert(str_contains((string) ($gridSelectDefinition['assets']['style.css'] ?? ''), 'display:contents'), 'compact select wrapper stylesheet flattens the compatibility group for authored grid and flex item sizing');
+
 $standaloneSearch = ( new HtmlTransformer() )->transform(
     '<div class="site-search"><input type="search" name="s" placeholder="Search articles" aria-label="Search articles"></div>'
 )->toArray();


### PR DESCRIPTION
## Summary
- Route static selects with resolved authored CSS presentation to a registered compact native blocks-engine/form-select companion block.
- Retain the existing readable group/list representation for unstyled selects and preserve runtime-targeted controls.
- Keep the legacy group/anchor boundary while moving authored select identity onto the native control.
- Avoid duplicate labels by rendering only the select in the companion block; the source label remains its editable sibling.
- Flatten the compatibility wrapper in frontend CSS so its native select receives authored grid/flex item sizing without changing valid block serialization.

## Verification
- composer run test:canonical
- composer run test:parity (272 fixtures)
- Direct fixture20 combined input/select/flex candidate: Gutenberg validation passed 802/802 blocks.
- Fixture20 visual remains 1.53% (132,084/8,654,080 pixels); 48,498 pixels are classified restyle_geometry. The wrapper change did not move this residual, and the full-width submit remains covered by the separate flex-button candidate.

## Fixture Integrity
No tracked fixture files were changed.

## AI assistance
OpenAI gpt-5.6-terra via OpenCode implemented the transformer and companion-block changes, added contracts, and ran the listed verification. Chris Huber remains responsible for every line.