### PR TITLE
Preserve authored static controls as compact native blocks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/AuthoredInputBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthoredInputBlockGenerator.php
@@ -6,9 +6,9 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 /**
  * Builds the static companion block for compact, editable native input controls.
  */
-final class FormInputBlockGenerator
+final class AuthoredInputBlockGenerator
 {
-    public const NAME = 'blocks-engine/form-input';
+    public const NAME = 'blocks-engine/authored-input';
 
     /** @return array<string, mixed> */
     public function blockJson(): array
@@ -52,7 +52,7 @@ final class FormInputBlockGenerator
     function markup( attrs ) { var output = '<input'; [ 'type', 'id', 'name', 'value', 'placeholder', 'ariaLabel', 'className', 'style', 'min', 'max', 'step' ].forEach( function( key ) { if ( attrs[ key ] ) output += ' ' + ( 'className' === key ? 'class' : ( 'ariaLabel' === key ? 'aria-label' : key ) ) + '="' + escapeAttribute( attrs[ key ] ) + '"'; } ); [ 'required', 'disabled', 'readOnly', 'checked' ].forEach( function( key ) { if ( attrs[ key ] ) output += ' ' + ( 'readOnly' === key ? 'readonly' : key ); } ); return output + '>'; }
     function edit( props ) { var attrs = props.attributes; return createElement( 'input', { type: attrs.type || 'text', id: attrs.id || undefined, name: attrs.name || undefined, value: attrs.value || undefined, placeholder: attrs.placeholder || undefined, 'aria-label': attrs.ariaLabel || undefined, className: attrs.className || undefined, style: attrs.style || undefined, min: attrs.min || undefined, max: attrs.max || undefined, step: attrs.step || undefined, required: attrs.required, disabled: attrs.disabled, readOnly: attrs.readOnly, checked: attrs.checked, onChange: function( event ) { var next = { value: event.target.value }; if ( 'checkbox' === attrs.type || 'radio' === attrs.type ) next.checked = event.target.checked; props.setAttributes( next ); } } ); }
     function save( props ) { return createElement( element.RawHTML, null, markup( props.attributes ) ); }
-    blocks.registerBlockType( 'blocks-engine/form-input', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
+    blocks.registerBlockType( 'blocks-engine/authored-input', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
 } )( window.wp.blocks, window.wp.element );
 JS;
 
@@ -84,6 +84,6 @@ JS;
     /** @return array<string, mixed> */
     public function definition(): array
     {
-        return array( 'name' => 'form-input', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
+        return array( 'name' => 'authored-input', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/AuthoredSelectBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthoredSelectBlockGenerator.php
@@ -6,9 +6,9 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 /**
  * Builds the static companion block for compact, editable native select controls.
  */
-final class FormSelectBlockGenerator
+final class AuthoredSelectBlockGenerator
 {
-    public const NAME = 'blocks-engine/form-select';
+    public const NAME = 'blocks-engine/authored-select';
 
     /** @return array<string, mixed> */
     public function blockJson(): array
@@ -50,15 +50,15 @@ final class FormSelectBlockGenerator
     function markup( attrs ) { var output = '<select' + selectAttributes( attrs ) + '>'; ( attrs.options || [] ).forEach( function( option ) { var value = Object.prototype.hasOwnProperty.call( option, 'value' ) ? option.value : option.label; output += '<option value="' + escapeAttribute( value ) + '"' + ( option.selected ? ' selected' : '' ) + ( option.disabled ? ' disabled' : '' ) + '>' + ( option.label || '' ) + '</option>'; } ); return output + '</select>'; }
     function edit( props ) { var attrs = props.attributes; var options = ( attrs.options || [] ).map( function( option ) { return createElement( 'option', { value: option.value || option.label, disabled: option.disabled, selected: option.selected, key: option.value || option.label }, option.label ); } ); return createElement( 'select', { id: attrs.id || undefined, name: attrs.name || undefined, className: attrs.className || undefined, style: attrs.style || undefined, onChange: function( event ) { props.setAttributes( { options: ( attrs.options || [] ).map( function( option ) { return Object.assign( {}, option, { selected: option.value === event.target.value } ); } ) } ); } }, options ); }
     function save( props ) { return createElement( element.RawHTML, null, markup( props.attributes ) ); }
-    blocks.registerBlockType( 'blocks-engine/form-select', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
+    blocks.registerBlockType( 'blocks-engine/authored-select', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
 } )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
 JS;
 
         return array(
             'index.js' => str_replace('__BLOCK_ATTRIBUTES__', json_encode($this->blockJson()['attributes'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES), $script),
-            // The legacy core/group boundary is retained for compatibility, but
-            // must not acquire the flow spacing of a content section.
-            'style.css' => '.wp-block-group.blocks-engine-form-select-wrapper{margin-block-start:0!important;margin-block-end:0!important}',
+            // The legacy core/group boundary is retained for compatibility without
+            // introducing a layout box around the authored native control.
+            'style.css' => '.wp-block-group.blocks-engine-authored-select-wrapper{display:contents}',
         );
     }
 
@@ -91,6 +91,6 @@ JS;
     /** @return array<string, mixed> */
     public function definition(): array
     {
-        return array( 'name' => 'form-select', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
+        return array( 'name' => 'authored-select', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/FormInputBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/FormInputBlockGenerator.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/**
+ * Builds the static companion block for compact, editable native input controls.
+ */
+final class FormInputBlockGenerator
+{
+    public const NAME = 'blocks-engine/form-input';
+
+    /** @return array<string, mixed> */
+    public function blockJson(): array
+    {
+        return array(
+            'apiVersion' => 3,
+            'name' => self::NAME,
+            'title' => 'Input Field',
+            'category' => 'widgets',
+            'description' => 'An editable native input field.',
+            'editorScript' => array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ),
+            'attributes' => array(
+                'type' => array( 'type' => 'string', 'default' => 'text' ),
+                'id' => array( 'type' => 'string', 'default' => '' ),
+                'name' => array( 'type' => 'string', 'default' => '' ),
+                'value' => array( 'type' => 'string', 'default' => '' ),
+                'placeholder' => array( 'type' => 'string', 'default' => '' ),
+                'ariaLabel' => array( 'type' => 'string', 'default' => '' ),
+                'className' => array( 'type' => 'string', 'default' => '' ),
+                'style' => array( 'type' => 'string', 'default' => '' ),
+                'min' => array( 'type' => 'string', 'default' => '' ),
+                'max' => array( 'type' => 'string', 'default' => '' ),
+                'step' => array( 'type' => 'string', 'default' => '' ),
+                'required' => array( 'type' => 'boolean', 'default' => false ),
+                'disabled' => array( 'type' => 'boolean', 'default' => false ),
+                'readOnly' => array( 'type' => 'boolean', 'default' => false ),
+                'checked' => array( 'type' => 'boolean', 'default' => false ),
+            ),
+            'supports' => array( 'html' => false ),
+        );
+    }
+
+    /** @return array<string, string> */
+    public function assets(): array
+    {
+        $script = <<<'JS'
+( function( blocks, element ) {
+    var createElement = element.createElement;
+    var attributes = __BLOCK_ATTRIBUTES__;
+    function escapeAttribute( value ) { return String( value || '' ).replace( /&/g, '&amp;' ).replace( /"/g, '&quot;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' ); }
+    function markup( attrs ) { var output = '<input'; [ 'type', 'id', 'name', 'value', 'placeholder', 'ariaLabel', 'className', 'style', 'min', 'max', 'step' ].forEach( function( key ) { if ( attrs[ key ] ) output += ' ' + ( 'className' === key ? 'class' : ( 'ariaLabel' === key ? 'aria-label' : key ) ) + '="' + escapeAttribute( attrs[ key ] ) + '"'; } ); [ 'required', 'disabled', 'readOnly', 'checked' ].forEach( function( key ) { if ( attrs[ key ] ) output += ' ' + ( 'readOnly' === key ? 'readonly' : key ); } ); return output + '>'; }
+    function edit( props ) { var attrs = props.attributes; return createElement( 'input', { type: attrs.type || 'text', id: attrs.id || undefined, name: attrs.name || undefined, value: attrs.value || undefined, placeholder: attrs.placeholder || undefined, 'aria-label': attrs.ariaLabel || undefined, className: attrs.className || undefined, style: attrs.style || undefined, min: attrs.min || undefined, max: attrs.max || undefined, step: attrs.step || undefined, required: attrs.required, disabled: attrs.disabled, readOnly: attrs.readOnly, checked: attrs.checked, onChange: function( event ) { var next = { value: event.target.value }; if ( 'checkbox' === attrs.type || 'radio' === attrs.type ) next.checked = event.target.checked; props.setAttributes( next ); } } ); }
+    function save( props ) { return createElement( element.RawHTML, null, markup( props.attributes ) ); }
+    blocks.registerBlockType( 'blocks-engine/form-input', { attributes: attributes, supports: { html: false }, edit: edit, save: save } );
+} )( window.wp.blocks, window.wp.element );
+JS;
+
+        return array(
+            'index.js' => str_replace('__BLOCK_ATTRIBUTES__', json_encode($this->blockJson()['attributes'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES), $script),
+        );
+    }
+
+    /** @param array<string, mixed> $attrs */
+    public function markup(array $attrs): string
+    {
+        $escape = static fn (mixed $value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $markup = '<input';
+        foreach ( array( 'type', 'id', 'name', 'value', 'placeholder', 'ariaLabel', 'className', 'style', 'min', 'max', 'step' ) as $key ) {
+            $value = trim((string) ($attrs[$key] ?? ''));
+            if ( '' !== $value ) {
+                $markup .= ' ' . ( 'className' === $key ? 'class' : ( 'ariaLabel' === $key ? 'aria-label' : $key ) ) . '="' . $escape($value) . '"';
+            }
+        }
+        foreach ( array( 'required', 'disabled', 'readOnly', 'checked' ) as $key ) {
+            if ( ! empty($attrs[$key]) ) {
+                $markup .= ' ' . ( 'readOnly' === $key ? 'readonly' : $key );
+            }
+        }
+
+        return $markup . '>';
+    }
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return array( 'name' => 'form-input', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -293,6 +293,8 @@ final class HtmlTransformer
 
     private bool $formSelectBlockGenerated = false;
 
+    private bool $formInputBlockGenerated = false;
+
     /**
      * Block namespace for generated custom-block references. The ArtifactCompiler
      * sets this to the per-site companion-plugin namespace (`ssi-<site_slug>`) so
@@ -563,6 +565,7 @@ final class HtmlTransformer
         $this->generatedBlocks = array();
         $this->descriptionListBlockGenerated = false;
         $this->formSelectBlockGenerated = false;
+        $this->formInputBlockGenerated = false;
         $this->formControlEchoTexts = array();
         $this->generatedBlockNamespace = $this->generatedBlockNamespaceFromOptions($options);
         $this->preserveShellLandmarks = !empty($options['extract_global_shell']);
@@ -9629,6 +9632,13 @@ final class HtmlTransformer
             }
         }
 
+        if ( 'input' === $tagName ) {
+            $inputBlock = $this->readableInputBlockFromElement($element);
+            if ( null !== $inputBlock ) {
+                return $inputBlock;
+            }
+        }
+
         $summary = $this->readableFormControlText($element);
         if ( '' === $summary ) {
             return null;
@@ -9744,6 +9754,50 @@ final class HtmlTransformer
             'anchor' => $this->safeAnchor($this->attr($select, 'id')),
             'className' => 'blocks-engine-form-select-wrapper',
         )), array( $controlBlock ));
+    }
+
+    /**
+     * Return a compact native input only when authored presentation is proven by
+     * the resolved CSS cascade. The direct save shape preserves flex-child and
+     * selector semantics that a readable paragraph cannot represent.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function readableInputBlockFromElement(DOMElement $input): ?array
+    {
+        if ( array() === $this->structuralPresentationDeclarations($input) ) {
+            return null;
+        }
+        if ( ! $this->formInputBlockGenerated ) {
+            $this->generatedBlocks[] = ( new FormInputBlockGenerator() )->definition();
+            $this->formInputBlockGenerated = true;
+        }
+        $attrs = array_filter(array(
+            'type' => $this->formControlType($input),
+            'id' => $this->attr($input, 'id'),
+            'name' => $this->attr($input, 'name'),
+            'value' => $this->attr($input, 'value'),
+            'placeholder' => $this->attr($input, 'placeholder'),
+            'ariaLabel' => $this->attr($input, 'aria-label'),
+            'className' => $this->attr($input, 'class'),
+            'style' => $this->attr($input, 'style'),
+            'min' => $this->attr($input, 'min'),
+            'max' => $this->attr($input, 'max'),
+            'step' => $this->attr($input, 'step'),
+            'required' => $input->hasAttribute('required'),
+            'disabled' => $input->hasAttribute('disabled'),
+            'readOnly' => $input->hasAttribute('readonly'),
+            'checked' => $input->hasAttribute('checked'),
+        ), static fn (mixed $value): bool => is_bool($value) ? $value : '' !== $value);
+        $markup = ( new FormInputBlockGenerator() )->markup($attrs);
+
+        return array(
+            'blockName' => FormInputBlockGenerator::NAME,
+            'attrs' => $attrs,
+            'innerBlocks' => array(),
+            'innerHTML' => $markup,
+            'innerContent' => array( $markup ),
+        );
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -9725,7 +9725,7 @@ final class HtmlTransformer
             ), $select);
         }
         if ( ! $this->formSelectBlockGenerated ) {
-            $this->generatedBlocks[] = ( new FormSelectBlockGenerator() )->definition();
+            $this->generatedBlocks[] = ( new AuthoredSelectBlockGenerator() )->definition();
             $this->formSelectBlockGenerated = true;
         }
         $attrs = array_filter(array(
@@ -9738,9 +9738,9 @@ final class HtmlTransformer
             'options' => $options,
             'selectedSummary' => $this->selectedOptionSummary($options),
         ), static fn (mixed $value): bool => is_array($value) ? array() !== $value : '' !== $value);
-        $markup = ( new FormSelectBlockGenerator() )->markup($attrs);
+        $markup = ( new AuthoredSelectBlockGenerator() )->markup($attrs);
         $controlBlock = array(
-            'blockName' => FormSelectBlockGenerator::NAME,
+            'blockName' => AuthoredSelectBlockGenerator::NAME,
             'attrs' => $attrs,
             'innerBlocks' => array(),
             'innerHTML' => $markup,
@@ -9752,7 +9752,7 @@ final class HtmlTransformer
         // control, so authored select selectors never style this transparent shell.
         return $this->createBlock('core/group', array_filter(array(
             'anchor' => $this->safeAnchor($this->attr($select, 'id')),
-            'className' => 'blocks-engine-form-select-wrapper',
+            'className' => 'blocks-engine-authored-select-wrapper',
         )), array( $controlBlock ));
     }
 
@@ -9769,7 +9769,7 @@ final class HtmlTransformer
             return null;
         }
         if ( ! $this->formInputBlockGenerated ) {
-            $this->generatedBlocks[] = ( new FormInputBlockGenerator() )->definition();
+            $this->generatedBlocks[] = ( new AuthoredInputBlockGenerator() )->definition();
             $this->formInputBlockGenerated = true;
         }
         $attrs = array_filter(array(
@@ -9789,10 +9789,10 @@ final class HtmlTransformer
             'readOnly' => $input->hasAttribute('readonly'),
             'checked' => $input->hasAttribute('checked'),
         ), static fn (mixed $value): bool => is_bool($value) ? $value : '' !== $value);
-        $markup = ( new FormInputBlockGenerator() )->markup($attrs);
+        $markup = ( new AuthoredInputBlockGenerator() )->markup($attrs);
 
         return array(
-            'blockName' => FormInputBlockGenerator::NAME,
+            'blockName' => AuthoredInputBlockGenerator::NAME,
             'attrs' => $attrs,
             'innerBlocks' => array(),
             'innerHTML' => $markup,

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -994,7 +994,10 @@ $assert(array() === ($standaloneControls['fallbacks'] ?? array()), 'standalone r
 $assert('core/paragraph' === ($standaloneControlBlocks[0]['blockName'] ?? ''), 'standalone non-runtime input converts to readable paragraph');
 $assert('core/paragraph' === ($standaloneControlBlocks[1]['blockName'] ?? ''), 'source select label remains a sibling editable block');
 $assert('core/group' === ($standaloneControlBlocks[2]['blockName'] ?? ''), 'standalone static select retains the legacy structural group boundary');
-$assert('blocks-engine/form-select' === ($standaloneControlBlocks[2]['innerBlocks'][0]['blockName'] ?? ''), 'standalone non-runtime select uses a compact editable native-control block inside its compatibility wrapper');
+$assert('blocks-engine/authored-select' === ($standaloneControlBlocks[2]['innerBlocks'][0]['blockName'] ?? ''), 'standalone non-runtime select uses an authored-select editable native-control block inside its compatibility wrapper');
+$authoredSelectBlocks = array_values(array_filter($standaloneControls['source_reports']['generated_blocks'] ?? array(), static fn (array $block): bool => 'authored-select' === ($block['name'] ?? '')));
+$authoredSelectCss = (string) ($authoredSelectBlocks[0]['assets']['style.css'] ?? '');
+$assert(str_contains($authoredSelectCss, '.wp-block-group.blocks-engine-authored-select-wrapper{display:contents}') && ! str_contains($authoredSelectCss, '!important'), 'authored-select companion wrapper CSS preserves display contents without important declarations');
 $assert('core/html' === ($standaloneControlBlocks[3]['blockName'] ?? ''), 'runtime-targeted select preserves native DOM output');
 $assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<option value="" selected disabled>Choose an order</option>'), 'compact select preserves selected placeholder option state');
 $assert(str_contains((string) ($standaloneControls['serialized_blocks'] ?? ''), '<select id="product-sort" name="products" placeholder="Sort products" class="catalog-sort">'), 'compact select preserves native id, name, placeholder, and CSS selector identity');
@@ -1015,7 +1018,7 @@ $styledInputs = ( new HtmlTransformer() )->transform(
 )->toArray();
 $styledInputBlocks = $styledInputs['blocks'][0]['innerBlocks'] ?? array();
 $styledInputMarkup = (string) ($styledInputs['serialized_blocks'] ?? '');
-$assert('blocks-engine/form-input' === ($styledInputBlocks[0]['blockName'] ?? ''), 'static input with authored presentation uses a compact editable native-control block');
+$assert('blocks-engine/authored-input' === ($styledInputBlocks[0]['blockName'] ?? ''), 'static input with authored presentation uses an authored-input editable native-control block');
 $assert('core/paragraph' === ($styledInputBlocks[1]['blockName'] ?? ''), 'unstyled static input retains the readable-summary representation');
 $assert('core/html' === ($styledInputBlocks[2]['blockName'] ?? ''), 'runtime-targeted input retains native runtime-island behavior');
 $assert(str_contains($styledInputMarkup, '<input type="email" id="newsletter" name="email" value="member@example.com" placeholder="Trail updates + new kits" aria-label="Email for newsletter" class="footer-newsletter__input" required disabled readonly>'), 'compact input preserves authored type, identity, value, accessibility, state, and CSS selector attributes');
@@ -1027,7 +1030,7 @@ $unstyledSelect = ( new HtmlTransformer() )->transform(
 )->toArray();
 $unstyledSelectBlock = $unstyledSelect['blocks'][0] ?? array();
 $assert('core/group' === ($unstyledSelectBlock['blockName'] ?? '') && 'core/list' === ($unstyledSelectBlock['innerBlocks'][1]['blockName'] ?? ''), 'static select without authored presentation evidence retains the readable-list representation');
-$assert(! str_contains((string) ($unstyledSelect['serialized_blocks'] ?? ''), '<!-- wp:blocks-engine/form-select'), 'unstyled static select does not generate a compact native-control block from class identity alone');
+$assert(! str_contains((string) ($unstyledSelect['serialized_blocks'] ?? ''), '<!-- wp:blocks-engine/authored-select'), 'unstyled static select does not generate an authored-select native-control block from class identity alone');
 
 $standaloneSearch = ( new HtmlTransformer() )->transform(
     '<div class="site-search"><input type="search" name="s" placeholder="Search articles" aria-label="Search articles"></div>'
@@ -3509,6 +3512,26 @@ $assert(isset($companionBlock['assets']['index.js']), 'companion block carries e
 $assert(! isset($companionBlock['assets']['render.php']), 'render is not duplicated into the assets map');
 $assert(! isset($companionBlock['assets']['view.js']), 'view JS is not duplicated into the assets map');
 $assert(! isset($companionBlock['assets']['block.json']), 'block.json is not duplicated into the assets map');
+
+$authoredControlsCompanion = $compiler->compile(
+    array(
+        'files' => array(
+            'index.html' => '<link rel="stylesheet" href="controls.css"><main><select class="authored-select"><option>One</option></select><input class="authored-input" type="text"></main>',
+            'controls.css' => '.authored-select{appearance:none;border:1px solid}.authored-input{border:1px solid;padding:1rem}',
+        ),
+    )
+)->toArray();
+$authoredControlsPayload = $authoredControlsCompanion['source_reports']['companion_plugin_payload'] ?? array();
+$authoredControlBlocks = $authoredControlsPayload['blocks'] ?? array();
+$assert(array( 'authored-select', 'authored-input' ) === array_column($authoredControlBlocks, 'name'), 'styled authored controls compile into companion entries using only their canonical short slugs');
+$authoredSelectCompanion = $authoredControlBlocks[0] ?? array();
+$authoredInputCompanion = $authoredControlBlocks[1] ?? array();
+$assert('blocks-engine/authored-select' === ($authoredSelectCompanion['block_json']['name'] ?? null), 'authored-select companion metadata uses its canonical block name');
+$assert('blocks-engine/authored-input' === ($authoredInputCompanion['block_json']['name'] ?? null), 'authored-input companion metadata uses its canonical block name');
+preg_match_all("/registerBlockType\\(\\s*'([^']+)'/", (string) ($authoredSelectCompanion['assets']['index.js'] ?? ''), $authoredSelectRegistrations);
+preg_match_all("/registerBlockType\\(\\s*'([^']+)'/", (string) ($authoredInputCompanion['assets']['index.js'] ?? ''), $authoredInputRegistrations);
+$assert(array( 'blocks-engine/authored-select' ) === ($authoredSelectRegistrations[1] ?? array()), 'authored-select companion editor script registers only its canonical block name');
+$assert(array( 'blocks-engine/authored-input' ) === ($authoredInputRegistrations[1] ?? array()), 'authored-input companion editor script registers only its canonical block name');
 
 $scriptCompanion = $compiler->compile(
     array(

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1009,6 +1009,19 @@ $assert('.js-sort-select' === ($standaloneControls['source_reports']['runtime_is
 $assert('select' === ($standaloneControls['source_reports']['runtime_islands'][0]['control']['tag'] ?? ''), 'runtime-targeted standalone control reports control metadata');
 $assert(str_contains((string) ($standaloneControls['source_reports']['runtime_islands'][0]['source_snippet'] ?? ''), '<select class="js-sort-select"'), 'runtime-targeted standalone control preserves source snippet metadata');
 
+$styledInputs = ( new HtmlTransformer() )->transform(
+    '<main><input id="newsletter" class="footer-newsletter__input" type="email" name="email" value="member@example.com" placeholder="Trail updates + new kits" aria-label="Email for newsletter" required disabled readonly><input id="plain-input" class="plain-input" type="text" placeholder="Readable summary"><input class="js-filter" type="text" placeholder="Runtime filter"></main>',
+    array('runtime_dom_selectors' => array('.js-filter'), 'static_css' => '.footer-newsletter__input{flex:1;border:1px solid #123;padding:10px}')
+)->toArray();
+$styledInputBlocks = $styledInputs['blocks'][0]['innerBlocks'] ?? array();
+$styledInputMarkup = (string) ($styledInputs['serialized_blocks'] ?? '');
+$assert('blocks-engine/form-input' === ($styledInputBlocks[0]['blockName'] ?? ''), 'static input with authored presentation uses a compact editable native-control block');
+$assert('core/paragraph' === ($styledInputBlocks[1]['blockName'] ?? ''), 'unstyled static input retains the readable-summary representation');
+$assert('core/html' === ($styledInputBlocks[2]['blockName'] ?? ''), 'runtime-targeted input retains native runtime-island behavior');
+$assert(str_contains($styledInputMarkup, '<input type="email" id="newsletter" name="email" value="member@example.com" placeholder="Trail updates + new kits" aria-label="Email for newsletter" class="footer-newsletter__input" required disabled readonly>'), 'compact input preserves authored type, identity, value, accessibility, state, and CSS selector attributes');
+$assert(! str_contains($styledInputMarkup, '<!-- wp:html') || str_contains($styledInputMarkup, '<input class="js-filter"'), 'styled static input never uses core/html while runtime input remains compatible');
+$assert('pass' === ($styledInputs['source_reports']['wp_block_validity']['status'] ?? ''), 'compact input serialization passes canonical Gutenberg validity');
+
 $unstyledSelect = ( new HtmlTransformer() )->transform(
     '<main><select id="plain-sort" class="catalog-sort" name="products" aria-label="Sort products"><option selected>Featured</option><option>Price</option></select></main>'
 )->toArray();


### PR DESCRIPTION
## Summary
- Route standalone inputs and selects with resolved authored CSS presentation to generated `blocks-engine/authored-input` and `blocks-engine/authored-select` companion blocks.
- Preserve native control identity, values/options, accessibility, state, bounds, inline styles, and authored classes without claiming form ownership or submission behavior.
- Keep actual forms on the SSI provider-binding path, where Jetpack owns application-level submission behavior.
- Retain readable summaries for unstyled controls and runtime islands for runtime-targeted controls.
- Preserve the select compatibility wrapper with `display: contents` and no `!important` declarations.

## Verification
- `composer run test:canonical`
- `composer run test:parity` (272 fixtures)
- Companion payload contracts verify short slugs, `block.json` names, and editor registrations for both authored control blocks.

## Fixture Integrity
No tracked fixture files were changed.

Depends on #831. Closes #829.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode coordinated parallel analysis, renamed the unshipped block contracts, removed the unproven CSS overrides, expanded companion-payload coverage, and ran verification. Chris Huber reviewed and remains responsible for every line.