### PR TITLE
Reserve artifact budget for declared source assets

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -62,6 +62,7 @@
       "php tests/unit/runtime-declarations-streaming-hash.php",
       "php tests/unit/asset-reference-canonicalizer-memory.php",
       "php tests/unit/artifact-normalizer-idempotence.php",
+      "php tests/unit/artifact-normalizer-source-budget.php",
       "php tests/unit/subtree-classifier.php",
       "php tests/unit/custom-block-generator.php",
       "php tests/unit/description-list-block.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -55,7 +55,10 @@ final class ArtifactNormalizer
                 $reservedPaths[$path] = true;
             }
         }
-        $rawFiles = $this->withInlineScriptFiles($this->withInlineStyleFiles($rawFiles, $reservedPaths));
+        $rawFiles = $this->sourceFilesBeforeGeneratedExpansions(
+            $this->withInlineScriptFiles($this->withInlineStyleFiles($rawFiles, $reservedPaths)),
+            $limits['max_files']
+        );
         $safeEntrypoints = array();
         foreach ( array_unique($entrypoints) as $entrypoint ) {
             $path = ArtifactPath::safeRelativePath($entrypoint);
@@ -305,6 +308,22 @@ final class ArtifactNormalizer
         }
 
         return $expanded;
+    }
+
+    /** @param array<int,array<string,mixed>> $files @return array<int,array<string,mixed>> */
+    private function sourceFilesBeforeGeneratedExpansions(array $files, int $maxFiles): array
+    {
+        if (count($files) <= $maxFiles) return $files;
+        $sourceFiles = array();
+        $generatedFiles = array();
+        foreach ($files as $file) {
+            if (in_array((string) ($file['source'] ?? ''), array('inline-style', 'inline-script'), true)) {
+                $generatedFiles[] = $file;
+            } else {
+                $sourceFiles[] = $file;
+            }
+        }
+        return array_merge($sourceFiles, $generatedFiles);
     }
 
     /**

--- a/php-transformer/tests/unit/artifact-normalizer-source-budget.php
+++ b/php-transformer/tests/unit/artifact-normalizer-source-budget.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactNormalizer;
+
+$assert = static function (bool $condition, string $message): void {
+    if (!$condition) throw new RuntimeException($message);
+};
+
+$html = '<!doctype html><html><head>' . str_repeat('<style>.x{color:red}</style>', 100) . '<link rel="preload" href="/_runtimes/site.js" as="script"></head><body></body></html>';
+$result = (new ArtifactNormalizer())->normalize(array(
+    'entrypoint' => 'website/index.html',
+    'compiler_limits' => array('max_files' => 100),
+    'files' => array(
+        array('path' => 'website/index.html', 'content' => $html),
+        array('path' => 'website/_runtimes/site.js', 'content' => 'export const site = true;'),
+    ),
+));
+
+$paths = array_column($result['files'], 'path');
+$assert(in_array('website/index.html', $paths, true), 'The declared entrypoint retains admission priority.');
+$assert(in_array('website/_runtimes/site.js', $paths, true), 'A declared runtime asset cannot be starved by generated inline expansions.');
+$assert(count($result['files']) === 100, 'The configured file limit remains enforced.');
+$assert(in_array('file_limit_exceeded', array_column($result['diagnostics'], 'code'), true), 'Generated overflow remains observable.');
+
+echo "artifact normalizer source budget: ok\n";


### PR DESCRIPTION
## Summary

- preserve declared source-file admission when inline style/script expansion exceeds `max_files`
- defer generated expansions only in over-budget artifacts, retaining normal ordering otherwise
- add contract coverage for a runtime asset after 100 inline style declarations

Fixes #849.

## Verification

- `composer test`
- 275 PHP transformer parity fixtures
- package installation proof

## Context

The BET-19 investigation exposed this independent normalization-order risk while tracing a separate SSI client-script filtering failure. The included unit contract is the direct reproduction for this PR.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode analyzed the normalization contract, implemented the bounded ordering change, and ran the verification suite. Chris Huber reviewed and remains responsible for every line.