### PR TITLE
Report artifact truncation impact

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -225,6 +225,7 @@ final class ArtifactCompiler
                 'files_by_mime'   => $this->countBy($normalized['files'], 'mime_type'),
                 'files_by_source' => $this->countBy($normalized['files'], 'source'),
                 'files_by_intent' => $this->countBy($normalized['files'], 'intent'),
+                'truncation_impact' => $normalized['truncation_impact'],
                 'limits'          => array(
                     'max_files'       => $normalized['limits']['max_files'],
                     'max_file_bytes'  => $normalized['limits']['max_file_bytes'],

--- a/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactNormalizer.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
+use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 
 /**
@@ -21,7 +22,7 @@ final class ArtifactNormalizer
 
     /**
      * @param array<string, mixed> $artifact
-     * @return array{files: array<int, array<string, mixed>>, diagnostics: array<int, array<string, mixed>>, rejected_count: int, bytes: int, limits: array{max_files:int,max_file_bytes:int,max_total_bytes:int}, entrypoints: array<int, string>, source_hash: string, hash_payload: string, runtime_declarations: array<int,array<string,mixed>>}
+     * @return array{files: array<int, array<string, mixed>>, diagnostics: array<int, array<string, mixed>>, rejected_count: int, bytes: int, limits: array{max_files:int,max_file_bytes:int,max_total_bytes:int}, entrypoints: array<int, string>, source_hash: string, hash_payload: string, runtime_declarations: array<int,array<string,mixed>>, truncation_impact: array<string,mixed>|null}
      */
     public function normalize(array $artifact): array
     {
@@ -31,6 +32,7 @@ final class ArtifactNormalizer
         $entrypoints = array();
         $rejected = 0;
         $bytes = 0;
+        $truncationImpact = null;
         $seenPaths = array();
         $limits = $this->limits($artifact);
 
@@ -72,7 +74,8 @@ final class ArtifactNormalizer
         foreach ( $rawFiles as $index => $file ) {
             if ( count($files) >= $limits['max_files'] ) {
                 ++$rejected;
-                $diagnostics[] = $this->diagnostic('file_limit_exceeded', 'warning', 'Additional artifact files were ignored because the file limit was reached.', array('max_files' => $limits['max_files']));
+                $truncationImpact = $this->truncationImpact(array_slice($rawFiles, $index), $files);
+                $diagnostics[] = $this->diagnostic('file_limit_exceeded', 'warning', 'Additional artifact files were ignored because the file limit was reached.', array('max_files' => $limits['max_files'], 'truncation_impact' => $truncationImpact));
                 break;
             }
 
@@ -188,7 +191,91 @@ final class ArtifactNormalizer
             'source_hash'    => $sourceHash,
             'hash_payload'   => $sourceHash,
             'runtime_declarations' => $runtimeDeclarations,
+            'truncation_impact' => $truncationImpact,
         );
+    }
+
+    /**
+     * Bounded evidence for files omitted solely because the file limit was
+     * reached. Only references from admitted files can affect the compiled
+     * output, so those determine whether the omission is a gating loss.
+     *
+     * @param array<int,array<string,mixed>> $omittedFiles
+     * @param array<int,array<string,mixed>> $admittedFiles
+     * @return array<string,mixed>
+     */
+    private function truncationImpact(array $omittedFiles, array $admittedFiles): array
+    {
+        $byClass = array(
+            'generated' => array('count' => 0, 'bytes' => 0),
+            'source' => array('count' => 0, 'bytes' => 0),
+        );
+        $omittedPaths = array();
+        $pathSamples = array();
+        $seenPaths = array_fill_keys(array_column($admittedFiles, 'path'), true);
+        foreach ( $omittedFiles as $file ) {
+            $path = ArtifactPath::safeRelativePath((string) ($file['path'] ?? ''));
+            if ( '' === $path ) {
+                continue;
+            }
+            $payload = $this->payload($file, $path);
+            if ( ! $payload['accepted'] ) {
+                continue;
+            }
+            // Omitted rows share the same canonical namespace as admitted rows.
+            // A later duplicate becomes assets/logo-2.svg, not assets/logo.svg.
+            $path = $this->dedupePath($path, $seenPaths);
+            $seenPaths[$path] = true;
+            $class = in_array((string) ($file['source'] ?? ''), array('inline-style', 'inline-script'), true) ? 'generated' : 'source';
+            ++$byClass[$class]['count'];
+            $byClass[$class]['bytes'] += $payload['bytes'];
+            $omittedPaths[$path] = $class;
+            $pathSamples[] = array('path' => $path, 'source_class' => $class, 'bytes' => $payload['bytes']);
+        }
+        usort($pathSamples, static fn(array $left, array $right): int => strcmp($left['path'], $right['path']));
+
+        $referenceSamples = array();
+        $references = new ReferenceAnalyzer();
+        foreach ( $admittedFiles as $file ) {
+            if ( ! empty($file['binary']) ) {
+                continue;
+            }
+            $path = (string) ($file['path'] ?? '');
+            $candidates = 'css' === ($file['kind'] ?? '')
+                ? $references->cssReferenceCandidates((string) ($file['content'] ?? ''), $path)
+                : (in_array($file['kind'] ?? '', array('html', 'blocks'), true) ? $references->htmlReferenceCandidates((string) ($file['content'] ?? ''), $path) : array());
+            foreach ( $candidates as $candidate ) {
+                $resolvedPath = ArtifactPath::resolveRelativePath($candidate['url'], $path);
+                if ( ! isset($omittedPaths[$resolvedPath]) ) {
+                    continue;
+                }
+                $referenceSamples[] = array(
+                    'source_path' => $path,
+                    'selector' => $candidate['selector'],
+                    'attribute' => $candidate['attribute'],
+                    'resolved_path' => $resolvedPath,
+                    'source_class' => $omittedPaths[$resolvedPath],
+                );
+            }
+        }
+        usort($referenceSamples, static fn(array $left, array $right): int => strcmp(json_encode($left) ?: '', json_encode($right) ?: ''));
+
+        $omittedCount = $byClass['generated']['count'] + $byClass['source']['count'];
+        $omittedBytes = $byClass['generated']['bytes'] + $byClass['source']['bytes'];
+        $impact = array(
+            'schema' => 'blocks-engine/artifact-truncation-impact/v1',
+            'completeness' => array() === $referenceSamples ? 'warning' : 'gating_loss',
+            'omitted_count' => $omittedCount,
+            'omitted_bytes' => $omittedBytes,
+            'omitted_by_source_class' => $byClass,
+            'omitted_path_samples' => array_slice($pathSamples, 0, 10),
+            'reference_reachability' => array(
+                'referenced_omitted_count' => count(array_unique(array_column($referenceSamples, 'resolved_path'))),
+                'reference_samples' => array_slice($referenceSamples, 0, 10),
+            ),
+        );
+        $impact['evidence_hash'] = hash('sha256', RuntimeDeclarations::canonicalJson($impact));
+        return $impact;
     }
 
     /** @param array<string,mixed> $artifact @return array{max_files:int,max_file_bytes:int,max_total_bytes:int} */

--- a/php-transformer/tests/unit/artifact-normalizer-source-budget.php
+++ b/php-transformer/tests/unit/artifact-normalizer-source-budget.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactNormalizer;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 
 $assert = static function (bool $condition, string $message): void {
     if (!$condition) throw new RuntimeException($message);
 };
 
 $html = '<!doctype html><html><head>' . str_repeat('<style>.x{color:red}</style>', 100) . '<link rel="preload" href="/_runtimes/site.js" as="script"></head><body></body></html>';
-$result = (new ArtifactNormalizer())->normalize(array(
+$normalizer = new ArtifactNormalizer();
+$result = $normalizer->normalize(array(
     'entrypoint' => 'website/index.html',
     'compiler_limits' => array('max_files' => 100),
     'files' => array(
@@ -24,5 +26,55 @@ $assert(in_array('website/index.html', $paths, true), 'The declared entrypoint r
 $assert(in_array('website/_runtimes/site.js', $paths, true), 'A declared runtime asset cannot be starved by generated inline expansions.');
 $assert(count($result['files']) === 100, 'The configured file limit remains enforced.');
 $assert(in_array('file_limit_exceeded', array_column($result['diagnostics'], 'code'), true), 'Generated overflow remains observable.');
+$impact = $result['truncation_impact'];
+$assert('warning' === ($impact['completeness'] ?? null), 'Unreferenced generated omissions remain warning-level.');
+$assert(2 === ($impact['omitted_count'] ?? null), 'Generated overflow reports the complete omitted file count.');
+$assert(2 === ($impact['omitted_by_source_class']['generated']['count'] ?? null), 'Generated overflow is classified separately from source files.');
+$assert(0 === ($impact['reference_reachability']['referenced_omitted_count'] ?? null), 'Unreferenced generated omissions report no reachable references.');
+$assert(64 === strlen((string) ($impact['evidence_hash'] ?? '')), 'Truncation evidence has a bounded SHA-256 digest.');
+$assert($impact === $normalizer->normalize(array(
+    'entrypoint' => 'website/index.html',
+    'compiler_limits' => array('max_files' => 100),
+    'files' => array(
+        array('path' => 'website/index.html', 'content' => $html),
+        array('path' => 'website/_runtimes/site.js', 'content' => 'export const site = true;'),
+    ),
+))['truncation_impact'], 'Truncation evidence has deterministic ordering and content.');
+
+$referenced = $normalizer->normalize(array(
+    'compiler_limits' => array('max_files' => 2),
+    'files' => array(
+        array('path' => 'index.html', 'content' => '<main><img src="assets/logo.svg"></main>'),
+        array('path' => 'assets/site.css', 'content' => 'main{display:block}'),
+        array('path' => 'assets/logo.svg', 'content' => '<svg/>'),
+    ),
+));
+$referencedImpact = $referenced['truncation_impact'];
+$assert('gating_loss' === ($referencedImpact['completeness'] ?? null), 'An admitted canonical write referencing an omitted file is an explicit gating loss.');
+$assert(1 === ($referencedImpact['reference_reachability']['referenced_omitted_count'] ?? null), 'Referenced omissions report reachable omitted files.');
+$assert('assets/logo.svg' === ($referencedImpact['reference_reachability']['reference_samples'][0]['resolved_path'] ?? null), 'Referenced omission samples identify the omitted target deterministically.');
+
+$duplicate = $normalizer->normalize(array(
+    'compiler_limits' => array('max_files' => 2),
+    'files' => array(
+        array('path' => 'index.html', 'content' => '<main><img src="assets/logo.svg"></main>'),
+        array('path' => 'assets/logo.svg', 'content' => '<svg id="admitted"/>'),
+        array('path' => 'assets/logo.svg', 'content' => '<svg id="omitted-duplicate"/>'),
+    ),
+));
+$duplicateImpact = $duplicate['truncation_impact'];
+$assert('warning' === ($duplicateImpact['completeness'] ?? null), 'A truncated duplicate does not shadow an admitted canonical asset as a gating loss.');
+$assert('assets/logo-2.svg' === ($duplicateImpact['omitted_path_samples'][0]['path'] ?? null), 'Truncated duplicate paths use the canonical deduplicated artifact namespace.');
+$assert(0 === ($duplicateImpact['reference_reachability']['referenced_omitted_count'] ?? null), 'References resolve against the admitted canonical asset, not the omitted duplicate.');
+
+$qualityResult = (new ArtifactCompiler())->compile(array(
+    'compiler_limits' => array('max_files' => 2),
+    'files' => array(
+        array('path' => 'index.html', 'content' => '<main><img src="assets/logo.svg"></main>'),
+        array('path' => 'assets/site.css', 'content' => 'main{display:block}'),
+        array('path' => 'assets/logo.svg', 'content' => '<svg/>'),
+    ),
+))->toArray();
+$assert('gating_loss' === ($qualityResult['source_reports']['artifact']['truncation_impact']['completeness'] ?? null), 'Quality consumers receive the reachable truncation gating loss in the artifact report.');
 
 echo "artifact normalizer source budget: ok\n";


### PR DESCRIPTION
## Summary
- classify omitted artifact reachability as warning or gating loss
- preserve source/generated counts, bytes, samples, and deterministic evidence hashes
- canonicalize duplicate paths before evaluating omitted references

Closes #856

## Verification
- `composer --working-dir=php-transformer test`
- artifact source-budget and duplicate-path regressions

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed this change with parallel coding and review agents. Chris Huber reviewed and remains responsible for every line.