### PR TITLE
Aggregate repeated conversion diagnostics

### DIFF
--- a/packages/blocks-engine/src/__tests__/cli.test.ts
+++ b/packages/blocks-engine/src/__tests__/cli.test.ts
@@ -40,6 +40,12 @@ function themeResult(outDir: string, written: string[] = ['theme.json']): ThemeB
     diagnostics: {
       conversion: {
         pages: [],
+        groups: [],
+        occurrenceCount: 0,
+        repairFamilyCount: 0,
+        repairFamilyCountTruncated: false,
+        unrepresentedFallbackOccurrenceCount: 0,
+        unrepresentedFallbackDistinctCount: 0,
         totalFallbacks: 0,
         pagesWithFallbacks: 0,
         degradedPages: 0,

--- a/packages/blocks-engine/src/__tests__/pool-test-helpers.ts
+++ b/packages/blocks-engine/src/__tests__/pool-test-helpers.ts
@@ -70,6 +70,9 @@ export function canonicalizeSentinelFor(html: string): FixResult {
     blockCount: 0,
     htmlIslands: [],
     htmlIslandCount: 0,
+    htmlIslandOccurrences: [],
+    htmlIslandDistinctCount: 0,
+    htmlIslandOccurrencesTruncated: false,
     degraded: true,
   };
 }

--- a/packages/blocks-engine/src/__tests__/pool.contract.test.ts
+++ b/packages/blocks-engine/src/__tests__/pool.contract.test.ts
@@ -51,6 +51,13 @@ describe('worker pool contract', () => {
         html: string;
       }[];
       htmlIslandCount: number;
+      htmlIslandOccurrences?: {
+        fingerprint: string;
+        html: string;
+        count: number;
+      }[];
+      htmlIslandDistinctCount?: number;
+      htmlIslandOccurrencesTruncated?: boolean;
       degraded: boolean;
     }>();
 

--- a/packages/blocks-engine/src/__tests__/theme-contracts.test.ts
+++ b/packages/blocks-engine/src/__tests__/theme-contracts.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { WorkerPool } from '../pool/types.js';
+import type { ConversionFinding } from '../report/schema.js';
 import {
   assemble,
   applyHoistSwaps,
@@ -55,6 +56,7 @@ import {
   type TemplatePlan,
   type ThemeBuildResult,
   type ThemeConversionDiagnostics,
+  type ThemeConversionDiagnosticGroup,
   type ThemeConversionPageDiagnostic,
   type ThemeDiagnostics,
   type ThemeMeta,
@@ -324,12 +326,20 @@ type CompileOnlyThemeContractAssignments = {
       status: 'success';
       fallbackCount: number;
       degraded: boolean;
+      findings: ConversionFinding[];
+      findingsTruncated: boolean;
     }
   >;
   themeConversionDiagnostics: Satisfies<
     ThemeConversionDiagnostics,
     {
       pages: ThemeConversionPageDiagnostic[];
+      groups: ThemeConversionDiagnosticGroup[];
+      occurrenceCount: number;
+      repairFamilyCount: number;
+      repairFamilyCountTruncated: boolean;
+      unrepresentedFallbackOccurrenceCount: number;
+      unrepresentedFallbackDistinctCount: number;
       totalFallbacks: number;
       pagesWithFallbacks: number;
       degradedPages: number;

--- a/packages/blocks-engine/src/pool/pool.ts
+++ b/packages/blocks-engine/src/pool/pool.ts
@@ -131,6 +131,9 @@ function canonicalizeSentinel(html: string): FixResult {
     blockCount: 0,
     htmlIslands: [],
     htmlIslandCount: 0,
+    htmlIslandOccurrences: [],
+    htmlIslandDistinctCount: 0,
+    htmlIslandOccurrencesTruncated: false,
     degraded: true,
   };
 }

--- a/packages/blocks-engine/src/pool/types.ts
+++ b/packages/blocks-engine/src/pool/types.ts
@@ -1,3 +1,4 @@
+import type { HtmlIslandOccurrence } from '../wp/canonicalize.js';
 import type { PoolEvent } from './events.js';
 
 export interface RawConvertResult {
@@ -17,6 +18,9 @@ export interface FixResult {
   blockCount: number;
   htmlIslands: HtmlIsland[];
   htmlIslandCount: number;
+  htmlIslandOccurrences?: HtmlIslandOccurrence[];
+  htmlIslandDistinctCount?: number;
+  htmlIslandOccurrencesTruncated?: boolean;
   degraded: boolean;
 }
 

--- a/packages/blocks-engine/src/theme/__tests__/conversion-diagnostics.test.ts
+++ b/packages/blocks-engine/src/theme/__tests__/conversion-diagnostics.test.ts
@@ -72,21 +72,13 @@ describe('deriveThemeConversionDiagnostics', () => {
       pageOneBlocks,
       '<!-- wp:html --><div>Fallback</div><!-- /wp:html -->',
     ]);
-    expect(diagnostics).toEqual({
-      pages: [
-        {
-          slug: 'clean',
-          status: 'success',
-          fallbackCount: 0,
-          degraded: false,
-        },
-        {
-          slug: 'fallback',
-          status: 'success_with_warnings',
-          fallbackCount: 3,
-          degraded: true,
-        },
-      ],
+    expect(diagnostics.pages).toMatchObject([
+      { slug: 'clean', status: 'success', fallbackCount: 0, degraded: false, findings: [], findingsTruncated: false },
+      { slug: 'fallback', status: 'success_with_warnings', fallbackCount: 3, degraded: true, findingsTruncated: false },
+    ]);
+    expect(diagnostics).toMatchObject({
+      occurrenceCount: 3,
+      repairFamilyCount: 3,
       totalFallbacks: 3,
       pagesWithFallbacks: 1,
       degradedPages: 1,
@@ -114,18 +106,129 @@ describe('deriveThemeConversionDiagnostics', () => {
 
     expect(pool.canonicalize).toHaveBeenCalledWith(['']);
     expect(pool.stop).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      pages: [
-        {
-          slug: 'empty-output',
-          status: 'success_with_warnings',
-          fallbackCount: 0,
-          degraded: false,
-        },
-      ],
+    expect(result.pages).toMatchObject([
+      { slug: 'empty-output', status: 'success_with_warnings', fallbackCount: 0, degraded: false, findingsTruncated: false },
+    ]);
+    expect(result).toMatchObject({
+      occurrenceCount: 1,
+      repairFamilyCount: 1,
       totalFallbacks: 0,
       pagesWithFallbacks: 0,
       degradedPages: 0,
     });
+  });
+
+  it('groups 25 equivalent findings deterministically regardless of route order', async () => {
+    const pages = Array.from({ length: 25 }, (_, index) => ({
+      slug: `route-${String(index + 1).padStart(2, '0')}`,
+      inputHtml: '<main><a href="route.html" class="active">Shared navigation</a></main>',
+      sections: [section('<!-- wp:html --><div>Fallback</div><!-- /wp:html -->')],
+    }));
+    const results = pages.map(() =>
+      fixResult({
+        html: '<!-- wp:html --><div>Fallback</div><!-- /wp:html -->',
+        htmlIslands: [{ index: 0, html: '<div>Fallback</div>' }],
+        htmlIslandCount: 1,
+      }),
+    );
+
+    const forward = await buildThemeConversionDiagnostics(pages, poolReturning(results));
+    const reverse = await buildThemeConversionDiagnostics([...pages].reverse(), poolReturning(results));
+
+    expect(forward.groups).toEqual(reverse.groups);
+    expect(forward).toMatchObject({ occurrenceCount: 25, repairFamilyCount: 1 });
+    expect(forward.groups).toEqual([
+      expect.objectContaining({
+        occurrenceCount: 25,
+        affectedSourceCount: 25,
+        sourceExamples: ['route-01', 'route-02', 'route-03', 'route-04', 'route-05'],
+        sharedShell: true,
+        truncated: true,
+      }),
+    ]);
+  });
+
+  it('keeps structurally distinct findings in separate repair families', async () => {
+    const pages = ['one', 'two'].map((slug) => ({
+      slug,
+      sections: [section('<!-- wp:html --><div>Fallback</div><!-- /wp:html -->')],
+    }));
+    const diagnostics = await buildThemeConversionDiagnostics(
+      pages,
+      poolReturning([
+        fixResult({ htmlIslands: [{ index: 0, html: '<form><input name="email"></form>' }], htmlIslandCount: 1 }),
+        fixResult({ htmlIslands: [{ index: 0, html: '<nav><a href="about.html">About</a></nav>' }], htmlIslandCount: 1 }),
+      ]),
+    );
+
+    expect(diagnostics).toMatchObject({ occurrenceCount: 2, repairFamilyCount: 2 });
+  });
+
+  it('counts more than the evidence cap of equivalent fallback islands exactly', async () => {
+    const total = 125;
+    const result = await buildThemeConversionDiagnostics(
+      [{ slug: 'many-fallbacks', sections: [section('<!-- wp:html --><div>Fallback</div><!-- /wp:html -->')] }],
+      poolReturning([
+        fixResult({
+          htmlIslands: Array.from({ length: 100 }, (_value, index) => ({ index, html: '<div>Shared fallback</div>' })),
+          htmlIslandCount: total,
+          htmlIslandOccurrences: [{ fingerprint: 'shared', html: '<div>Shared fallback</div>', count: total }],
+        }),
+      ]),
+    );
+
+    expect(result).toMatchObject({
+      occurrenceCount: total + 1,
+      repairFamilyCount: 2,
+      repairFamilyCountTruncated: false,
+      unrepresentedFallbackOccurrenceCount: 0,
+      unrepresentedFallbackDistinctCount: 0,
+    });
+    expect(result.pages[0]).toMatchObject({ findingsTruncated: true });
+    expect(result.pages[0]?.findings).toHaveLength(100);
+    expect(result.groups).toContainEqual(expect.objectContaining({ occurrenceCount: total, affectedSourceCount: 1, sourceExamples: ['many-fallbacks'], truncated: false }));
+  });
+
+  it('bounds distinct fallback samples while preserving exact aggregate totals', async () => {
+    const total = 125;
+    const occurrences = Array.from({ length: 100 }, (_value, index) => ({ fingerprint: `fallback-${index}`, html: `<div>Fallback ${index}</div>`, count: 1 }));
+    const page = { slug: 'many-distinct-fallbacks', sections: [section('<!-- wp:html --><div>Fallback</div><!-- /wp:html -->')] };
+    const makeResult = () => fixResult({
+      htmlIslands: occurrences.map(({ html }, index) => ({ index, html })),
+      htmlIslandCount: total,
+      htmlIslandOccurrences: occurrences,
+      htmlIslandDistinctCount: total,
+      htmlIslandOccurrencesTruncated: true,
+    });
+    const forward = await buildThemeConversionDiagnostics([page], poolReturning([makeResult()]));
+    const reverse = await buildThemeConversionDiagnostics([page], poolReturning([makeResult()]));
+
+    expect(forward.groups).toEqual(reverse.groups);
+    expect(forward).toMatchObject({
+      occurrenceCount: total + 1,
+      repairFamilyCount: 101,
+      repairFamilyCountTruncated: true,
+      unrepresentedFallbackOccurrenceCount: 25,
+      unrepresentedFallbackDistinctCount: 25,
+    });
+    expect(forward.groups.filter((group) => group.repairBucket === 'fallback')).toHaveLength(100);
+  });
+
+  it('keeps capped-prefix variants as complete distinct repair families', async () => {
+    const result = await buildThemeConversionDiagnostics(
+      [{ slug: 'long-variants', sections: [section('<!-- wp:html --><div>Fallback</div><!-- /wp:html -->')] }],
+      poolReturning([fixResult({
+        htmlIslandCount: 2,
+        htmlIslandOccurrences: [
+          { fingerprint: 'first-full-hash', html: '<div>shared capped prefix</div>', count: 1 },
+          { fingerprint: 'second-full-hash', html: '<div>shared capped prefix</div>', count: 1 },
+        ],
+        htmlIslandDistinctCount: 2,
+        htmlIslandOccurrencesTruncated: false,
+      })]),
+    );
+
+    expect(result).toMatchObject({ repairFamilyCount: 3, repairFamilyCountTruncated: false, unrepresentedFallbackDistinctCount: 0 });
+    expect(result.groups.filter((group) => group.repairBucket === 'fallback')).toHaveLength(2);
   });
 });

--- a/packages/blocks-engine/src/theme/__tests__/site-to-theme-conversion-diagnostics.test.ts
+++ b/packages/blocks-engine/src/theme/__tests__/site-to-theme-conversion-diagnostics.test.ts
@@ -172,7 +172,7 @@ describe('siteToTheme conversion diagnostics', () => {
         variationHoist: false,
       });
 
-      expect(result.diagnostics.conversion).toEqual({
+      expect(result.diagnostics.conversion).toMatchObject({
         pages: [
           {
             slug: 'about',
@@ -190,6 +190,8 @@ describe('siteToTheme conversion diagnostics', () => {
         totalFallbacks: 2,
         pagesWithFallbacks: 2,
         degradedPages: 1,
+        occurrenceCount: 3,
+        repairFamilyCount: 3,
       });
       expect(result.warnings).toEqual(
         expect.arrayContaining([
@@ -230,7 +232,7 @@ describe('siteToTheme conversion diagnostics', () => {
         variationHoist: false,
       });
 
-      expect(result.diagnostics.conversion).toEqual({
+      expect(result.diagnostics.conversion).toMatchObject({
         pages: [
           {
             slug: 'about',
@@ -248,6 +250,8 @@ describe('siteToTheme conversion diagnostics', () => {
         totalFallbacks: 0,
         pagesWithFallbacks: 0,
         degradedPages: 0,
+        occurrenceCount: 0,
+        repairFamilyCount: 0,
       });
       expect(result.warnings.filter((warning) => /core\/html|fallback|raw HTML|conversion degraded/i.test(warning))).toEqual([]);
     });

--- a/packages/blocks-engine/src/theme/conversion-diagnostics.ts
+++ b/packages/blocks-engine/src/theme/conversion-diagnostics.ts
@@ -1,12 +1,18 @@
 import { performance } from 'node:perf_hooks';
+import { createHash } from 'node:crypto';
 
 import { buildReport } from '../report/findings.js';
 import type { WorkerPool } from '../pool/types.js';
+import { FALLBACK_INVENTORY_CAP, type ConversionFinding } from '../report/schema.js';
+import type { HtmlIslandOccurrence } from '../wp/canonicalize.js';
 import type {
   SectionBlocks,
   ThemeConversionDiagnostics,
+  ThemeConversionDiagnosticGroup,
   ThemeConversionPageDiagnostic,
 } from './types.js';
+
+const SOURCE_EXAMPLE_CAP = 5;
 
 export interface ThemeConversionDiagnosticsInputPage {
   slug: string;
@@ -37,7 +43,7 @@ export async function buildThemeConversionDiagnostics(
   const fixResults = await pool.canonicalize(pageBlockMarkup);
   const transformDurationMs = (performance.now() - startedAt) / pages.length;
 
-  const diagnostics = pages.map((page, index): ThemeConversionPageDiagnostic => {
+  const reports = pages.map((page, index) => {
     const blockMarkup = pageBlockMarkup[index] ?? '';
     const fixResult = fixResults[index];
     if (!fixResult) {
@@ -55,16 +61,28 @@ export async function buildThemeConversionDiagnostics(
       (finding) => finding.code === 'conversion_degraded',
     );
 
+    return { slug: page.slug, report };
+  });
+
+  const diagnostics = reports.map(({ slug, report }): ThemeConversionPageDiagnostic => {
+    const findings = [...report.fallbacks, ...report.diagnostics];
+    const keptFindings = findings.slice(0, FALLBACK_INVENTORY_CAP);
+
     return {
-      slug: page.slug,
+      slug,
       status: report.status,
       fallbackCount: report.metrics.fallbackCount,
-      degraded,
+      degraded: report.diagnostics.some(
+        (finding) => finding.code === 'conversion_degraded',
+      ),
+      findings: keptFindings,
+      findingsTruncated: findings.length > keptFindings.length,
     };
   });
 
   return {
     pages: diagnostics,
+    ...buildDiagnosticGroups(reports, fixResults),
     totalFallbacks: diagnostics.reduce((total, page) => total + page.fallbackCount, 0),
     pagesWithFallbacks: diagnostics.filter((page) => page.fallbackCount > 0).length,
     degradedPages: diagnostics.filter((page) => page.degraded).length,
@@ -74,10 +92,133 @@ export async function buildThemeConversionDiagnostics(
 function emptyConversionDiagnostics(): ThemeConversionDiagnostics {
   return {
     pages: [],
+    groups: [],
+    occurrenceCount: 0,
+    repairFamilyCount: 0,
+    repairFamilyCountTruncated: false,
+    unrepresentedFallbackOccurrenceCount: 0,
+    unrepresentedFallbackDistinctCount: 0,
     totalFallbacks: 0,
     pagesWithFallbacks: 0,
     degradedPages: 0,
   };
+}
+
+function buildDiagnosticGroups(
+  reports: Array<{ slug: string; report: { fallbacks: ConversionFinding[]; diagnostics: ConversionFinding[] } }>,
+  fixResults: Array<{
+    htmlIslandCount: number;
+    htmlIslandOccurrences?: HtmlIslandOccurrence[];
+    htmlIslandDistinctCount?: number;
+    htmlIslandOccurrencesTruncated?: boolean;
+  }>,
+): Pick<ThemeConversionDiagnostics, 'groups' | 'occurrenceCount' | 'repairFamilyCount' | 'repairFamilyCountTruncated' | 'unrepresentedFallbackOccurrenceCount' | 'unrepresentedFallbackDistinctCount'> {
+  const groups = new Map<string, ThemeConversionDiagnosticGroup & { sources: Set<string> }>();
+  let fallbackOccurrenceCount = 0;
+  let unrepresentedFallbackOccurrenceCount = 0;
+  let unrepresentedFallbackDistinctCount = 0;
+
+  for (const [{ slug, report }, fixResult] of reports.map((report, index) => [report, fixResults[index]] as const)) {
+    const fallbackOccurrences = fixResult?.htmlIslandOccurrences;
+    if (fallbackOccurrences) {
+      fallbackOccurrenceCount += fixResult.htmlIslandCount;
+      const sampledOccurrenceCount = fallbackOccurrences.reduce((total, occurrence) => total + occurrence.count, 0);
+      unrepresentedFallbackOccurrenceCount += fixResult.htmlIslandCount - sampledOccurrenceCount;
+      unrepresentedFallbackDistinctCount += (fixResult.htmlIslandDistinctCount ?? fallbackOccurrences.length) - fallbackOccurrences.length;
+      for (const occurrence of fallbackOccurrences) {
+        addFindingToGroup(groups, slug, {
+          code: 'unconverted_html',
+          severity: 'warning',
+          snippet: occurrence.html,
+          structuralFingerprint: occurrence.fingerprint,
+        }, 'fallback', occurrence.count);
+      }
+    } else {
+      fallbackOccurrenceCount += report.fallbacks.length;
+      for (const finding of report.fallbacks) {
+        addFindingToGroup(groups, slug, finding, 'fallback');
+      }
+    }
+    for (const finding of report.diagnostics) {
+      addFindingToGroup(groups, slug, finding, `diagnostic:${finding.code}`);
+    }
+  }
+
+  const grouped = [...groups.values()]
+    .map(({ sources, ...group }) => ({
+      ...group,
+      sourceExamples: [...sources].sort().slice(0, SOURCE_EXAMPLE_CAP),
+      sharedShell: group.affectedSourceCount > 1,
+    }))
+    .sort((a, b) => a.fingerprint.localeCompare(b.fingerprint));
+
+  return {
+    groups: grouped,
+    occurrenceCount: fallbackOccurrenceCount + reports.reduce((total, { report }) => total + report.diagnostics.length, 0),
+    repairFamilyCount: grouped.length,
+    repairFamilyCountTruncated: unrepresentedFallbackDistinctCount > 0,
+    unrepresentedFallbackOccurrenceCount,
+    unrepresentedFallbackDistinctCount,
+  };
+}
+
+function addFindingToGroup(
+  groups: Map<string, ThemeConversionDiagnosticGroup & { sources: Set<string> }>,
+  slug: string,
+  finding: ConversionFinding,
+  repairBucket: string,
+  occurrenceCount = 1,
+): void {
+  const fingerprint = findingFingerprint(finding, repairBucket);
+  const group = groups.get(fingerprint);
+  if (group) {
+    group.occurrenceCount += occurrenceCount;
+    if (!group.sources.has(slug)) {
+      group.affectedSourceCount += 1;
+      group.sources.add(slug);
+      group.truncated = group.affectedSourceCount > SOURCE_EXAMPLE_CAP;
+    }
+    return;
+  }
+
+  groups.set(fingerprint, {
+    fingerprint,
+    repairBucket,
+    code: finding.code,
+    occurrenceCount,
+    affectedSourceCount: 1,
+    sourceExamples: [slug],
+    sharedShell: false,
+    truncated: false,
+    sources: new Set([slug]),
+  });
+}
+
+function findingFingerprint(finding: ConversionFinding, repairBucket: string): string {
+  const { message: _message, snippet, ...sourceAttributes } = finding;
+  const structure = JSON.stringify({
+    repairBucket,
+    sourceAttributes: sortObject(sourceAttributes),
+    snippet: normalizeStructure(snippet),
+  });
+  return createHash('sha256').update(structure).digest('hex');
+}
+
+function normalizeStructure(snippet: unknown): string | undefined {
+  if (typeof snippet !== 'string') return undefined;
+  return snippet
+    .replace(/\s+/gu, ' ')
+    .replace(/(\b(?:href|data-page-path))=(['"]).*?\2/giu, '$1="{route}"')
+    .replace(/\b(?:current-menu-item|current_page_item|active)\b/giu, '{active}')
+    .trim();
+}
+
+function sortObject(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => [key, item && typeof item === 'object' && !Array.isArray(item) ? sortObject(item as Record<string, unknown>) : item]),
+  );
 }
 
 function joinSectionBlocks(sections: SectionBlocks[]): string {

--- a/packages/blocks-engine/src/theme/types.ts
+++ b/packages/blocks-engine/src/theme/types.ts
@@ -1,5 +1,5 @@
 import type { WorkerPool } from '../pool/types.js';
-import type { ConvertReportStatus } from '../report/schema.js';
+import type { ConversionFinding, ConvertReportStatus } from '../report/schema.js';
 import type { RegionSelectionReport } from './region-audit.js';
 import type { SectionSpec } from './section-spec.js';
 import type { FormRemainder, SectionRenderOptions } from './native-reconstruct-types.js';
@@ -88,10 +88,29 @@ export interface ThemeConversionPageDiagnostic {
   status: ConvertReportStatus;
   fallbackCount: number;
   degraded: boolean;
+  findings: ConversionFinding[];
+  findingsTruncated: boolean;
+}
+
+export interface ThemeConversionDiagnosticGroup {
+  fingerprint: string;
+  repairBucket: string;
+  code: string;
+  occurrenceCount: number;
+  affectedSourceCount: number;
+  sourceExamples: string[];
+  sharedShell: boolean;
+  truncated: boolean;
 }
 
 export interface ThemeConversionDiagnostics {
   pages: ThemeConversionPageDiagnostic[];
+  groups: ThemeConversionDiagnosticGroup[];
+  occurrenceCount: number;
+  repairFamilyCount: number;
+  repairFamilyCountTruncated: boolean;
+  unrepresentedFallbackOccurrenceCount: number;
+  unrepresentedFallbackDistinctCount: number;
   totalFallbacks: number;
   pagesWithFallbacks: number;
   degradedPages: number;

--- a/packages/blocks-engine/src/wp/__tests__/canonicalize-inventory.test.ts
+++ b/packages/blocks-engine/src/wp/__tests__/canonicalize-inventory.test.ts
@@ -108,7 +108,38 @@ describe('canonicalize inventory metadata', () => {
       index: FALLBACK_INVENTORY_CAP - 1,
       html: `\n<div>Fallback ${FALLBACK_INVENTORY_CAP - 1}</div>\n`,
     });
+    expect(result.htmlIslandOccurrences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ html: '\n<div>Fallback 0</div>\n', count: 1 }),
+      ]),
+    );
+    expect(result).toMatchObject({ htmlIslandDistinctCount: total, htmlIslandOccurrencesTruncated: true });
     expect(result.degraded).toBe(false);
+  });
+
+  it('retains exact counts for repeated islands beyond the evidence cap', () => {
+    const total = FALLBACK_INVENTORY_CAP + 25;
+    const result = canonicalize(Array.from({ length: total }, () => htmlBlock('<div>Shared fallback</div>')).join(''));
+
+    expect(result.htmlIslands).toHaveLength(FALLBACK_INVENTORY_CAP);
+    expect(result.htmlIslandOccurrences).toEqual([expect.objectContaining({ html: '\n<div>Shared fallback</div>\n', count: total })]);
+    expect(result).toMatchObject({ htmlIslandDistinctCount: 1, htmlIslandOccurrencesTruncated: false });
+  });
+
+  it('keeps capped-prefix variants structurally distinct without retaining their tails', () => {
+    const prefix = `<div>${'x'.repeat(HTML_FINDING_CHAR_CAP)}`;
+    const result = canonicalize(`${htmlBlock(`${prefix}first-tail</div>`)}${htmlBlock(`${prefix}second-tail</div>`)}`);
+
+    expect(result.htmlIslandOccurrences).toHaveLength(2);
+    expect(result.htmlIslandOccurrences.map((occurrence) => occurrence.html)).toEqual([
+      result.htmlIslandOccurrences[0]?.html,
+      result.htmlIslandOccurrences[0]?.html,
+    ]);
+    expect(result.htmlIslandOccurrences[0]?.html).toHaveLength(HTML_FINDING_CHAR_CAP);
+    expect(result.htmlIslandOccurrences[0]?.html).not.toContain('first-tail');
+    expect(result.htmlIslandOccurrences[0]?.html).not.toContain('second-tail');
+    expect(new Set(result.htmlIslandOccurrences.map((occurrence) => occurrence.fingerprint)).size).toBe(2);
+    expect(result).toMatchObject({ htmlIslandDistinctCount: 2, htmlIslandOccurrencesTruncated: false });
   });
 
   it('truncates each html island before returning inventory over IPC', () => {
@@ -144,6 +175,9 @@ describe('canonicalize inventory metadata', () => {
             blockCount: 0,
             htmlIslands: [],
             htmlIslandCount: 0,
+            htmlIslandOccurrences: [],
+            htmlIslandDistinctCount: 0,
+            htmlIslandOccurrencesTruncated: false,
             degraded: true,
           },
         ]);

--- a/packages/blocks-engine/src/wp/canonicalize.ts
+++ b/packages/blocks-engine/src/wp/canonicalize.ts
@@ -1,12 +1,20 @@
 import { walkBlocks } from '../block-tree.js';
+import { createHash } from 'node:crypto';
 import { HTML_FINDING_CHAR_CAP } from '../report/limits.js';
 import { FALLBACK_INVENTORY_CAP } from '../report/schema.js';
+import { sanitize } from '../sanitize.js';
 import { bootstrap } from './bootstrap.js';
 import { requireWp } from './require-wp.js';
 
 export type HtmlIsland = {
   index: number;
   html: string;
+};
+
+export type HtmlIslandOccurrence = {
+  fingerprint: string;
+  html: string;
+  count: number;
 };
 
 export type CanonicalizeResult = {
@@ -16,6 +24,9 @@ export type CanonicalizeResult = {
   blockCount: number;
   htmlIslands: HtmlIsland[];
   htmlIslandCount: number;
+  htmlIslandOccurrences: HtmlIslandOccurrence[];
+  htmlIslandDistinctCount: number;
+  htmlIslandOccurrencesTruncated: boolean;
   degraded: boolean;
 };
 
@@ -377,10 +388,15 @@ function collectInventory(rawBlocks: RawBlock[]): {
   blockCount: number;
   htmlIslands: HtmlIsland[];
   htmlIslandCount: number;
+  htmlIslandOccurrences: HtmlIslandOccurrence[];
+  htmlIslandDistinctCount: number;
+  htmlIslandOccurrencesTruncated: boolean;
 } {
   let blockCount = 0;
   let htmlIslandCount = 0;
   const htmlIslands: HtmlIsland[] = [];
+  const distinctOccurrenceHashes = new Set<string>();
+  const sampledOccurrences = new Map<string, { html: string; count: number }>();
 
   walkBlocks(rawBlocks, (block) => {
     blockCount++;
@@ -393,6 +409,16 @@ function collectInventory(rawBlocks: RawBlock[]): {
       index: htmlIslandCount,
       html: truncateHtmlIsland(block.innerHTML || ''),
     };
+    const sanitizedHtml = sanitize(block.innerHTML || '');
+    const fingerprint = createHash('sha256').update(sanitizedHtml).digest('hex');
+    distinctOccurrenceHashes.add(fingerprint);
+    if (sampledOccurrences.has(fingerprint) || sampledOccurrences.size < FALLBACK_INVENTORY_CAP) {
+      const occurrence = sampledOccurrences.get(fingerprint);
+      sampledOccurrences.set(fingerprint, {
+        html: occurrence?.html ?? truncateHtmlIsland(sanitizedHtml),
+        count: (occurrence?.count ?? 0) + 1,
+      });
+    }
     if (htmlIslands.length < FALLBACK_INVENTORY_CAP) {
       htmlIslands.push(island);
     }
@@ -403,6 +429,9 @@ function collectInventory(rawBlocks: RawBlock[]): {
     blockCount,
     htmlIslands,
     htmlIslandCount,
+    htmlIslandOccurrences: [...sampledOccurrences].map(([fingerprint, occurrence]) => ({ fingerprint, ...occurrence })),
+    htmlIslandDistinctCount: distinctOccurrenceHashes.size,
+    htmlIslandOccurrencesTruncated: distinctOccurrenceHashes.size > sampledOccurrences.size,
   };
 }
 
@@ -495,6 +524,9 @@ export function canonicalize(markup: string): CanonicalizeResult {
       blockCount: 0,
       htmlIslands: [],
       htmlIslandCount: 0,
+      htmlIslandOccurrences: [],
+      htmlIslandDistinctCount: 0,
+      htmlIslandOccurrencesTruncated: false,
       degraded: true,
     };
   }


### PR DESCRIPTION
## Summary
- group repeated diagnostics by stable structural identity
- retain exact occurrence and distinct-family totals with bounded evidence
- expose explicit truncation and unrepresented fallback metadata across worker IPC

Closes #858

## Verification
- focused diagnostics, canonicalization, pool, and theme contract suites
- `pnpm typecheck`
- stress coverage for repeated and distinct fallback islands

The full worker suite retains pre-existing timing-sensitive pool/e2e failures in this environment; all changed-area tests pass.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed this change with parallel coding and review agents. Chris Huber reviewed and remains responsible for every line.