### PR TITLE
Report block-tree editability metrics

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -61,6 +61,7 @@
     "test:unit": [
       "php tests/unit/runtime-declarations-streaming-hash.php",
       "php tests/unit/asset-reference-canonicalizer-memory.php",
+      "php tests/unit/editability-report.php",
       "php tests/unit/artifact-normalizer-idempotence.php",
       "php tests/unit/artifact-normalizer-source-budget.php",
       "php tests/unit/subtree-classifier.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
 use Automattic\BlocksEngine\PhpTransformer\Contract\CoreHtmlFallbackEvidence;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
@@ -243,6 +244,14 @@ final class ArtifactCompiler
             ),
         );
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks, $entryBlocks['shell_artifacts'], $compiledHtmlDocuments);
+        $editabilityDocuments = array($entryPath => array('blocks' => $entryBlocks['blocks'], 'serialized_blocks' => $entryBlocks['serialized_blocks']));
+        foreach ($compiledHtmlDocuments as $sourcePath => $compiledHtmlDocument) {
+            $editabilityDocuments[(string) $sourcePath] = array(
+                'blocks' => is_array($compiledHtmlDocument['blocks'] ?? null) ? $compiledHtmlDocument['blocks'] : array(),
+                'serialized_blocks' => is_string($compiledHtmlDocument['serialized_blocks'] ?? null) ? $compiledHtmlDocument['serialized_blocks'] : '',
+            );
+        }
+        $sourceReports['editability_report'] = (new EditabilityReport())->fromDocuments($editabilityDocuments);
         if ( array() !== $allGutenbergGaps ) {
             $sourceReports['gutenberg_gaps'] = $allGutenbergGaps;
         }

--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -34,6 +34,7 @@ final class ConversionReportProjection
             'asset_refs'            => self::assetReferences($blocks, $sourceReports),
             'navigation_candidates' => self::navigationCandidates($blocks, $sourceReports),
             'semantic_parity'       => self::semanticParity($sourceReports),
+            'editability_report'    => is_array($sourceReports['editability_report'] ?? null) ? $sourceReports['editability_report'] : array(),
             'runtime_dependency_parity' => self::runtimeDependencyParity($sourceReports),
             'runtime_islands'      => self::runtimeIslands($sourceReports),
             'interaction_candidates' => self::interactionCandidates($sourceReports),

--- a/php-transformer/src/Contract/EditabilityReport.php
+++ b/php-transformer/src/Contract/EditabilityReport.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Contract;
+
+/** Observes block-tree complexity without changing or grading compiler output. */
+final class EditabilityReport
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/editability-report/v1';
+    private const MAX_REPORTED_SIGNALS = 100;
+    private const INLINE_RICH_TEXT_TAGS = array('a', 'abbr', 'b', 'br', 'cite', 'code', 'del', 'em', 'i', 'img', 'ins', 'kbd', 'mark', 's', 'small', 'span', 'strong', 'sub', 'sup', 'time', 'u');
+
+    /** @param array<int,array<string,mixed>> $blocks @return array<string,mixed> */
+    public function fromBlocks(array $blocks, string $sourcePath = '', string $serializedBlocks = ''): array
+    {
+        $metrics = array(
+            'block_count' => 0,
+            'leaf_block_count' => 0,
+            'content_block_count' => 0,
+            'wrapper_block_count' => 0,
+            'empty_wrapper_count' => 0,
+            'max_nesting_depth' => 0,
+            'raw_html_block_count' => 0,
+            'html_bearing_attribute_count' => 0,
+            'html_bearing_table_cell_count' => 0,
+            'source_marker_class_count' => 0,
+            'generated_geometry_class_count' => 0,
+            'serialized_bytes' => '' === $serializedBlocks ? 0 : strlen($serializedBlocks),
+        );
+        $blockTypes = array();
+        $signals = array();
+        $this->walk($blocks, 1, array(), $metrics, $blockTypes, $signals, $sourcePath);
+        ksort($blockTypes, SORT_STRING);
+        $metrics['wrapper_to_content_ratio'] = 0 === $metrics['content_block_count']
+            ? (float) $metrics['wrapper_block_count']
+            : round($metrics['wrapper_block_count'] / $metrics['content_block_count'], 4);
+
+        $signalCount = count($signals);
+        return array(
+            'schema' => self::SCHEMA,
+            'status' => 'observed',
+            'enforcement' => 'report_only',
+            'scope' => array_filter(array('source_path' => $sourcePath), static fn(string $value): bool => '' !== $value),
+            'metrics' => $metrics,
+            'block_types' => $blockTypes,
+            'signals' => array_slice($signals, 0, self::MAX_REPORTED_SIGNALS),
+            'signal_totals' => array(
+                'observed' => $signalCount,
+                'reported' => min($signalCount, self::MAX_REPORTED_SIGNALS),
+                'omitted' => max(0, $signalCount - self::MAX_REPORTED_SIGNALS),
+                'truncated' => $signalCount > self::MAX_REPORTED_SIGNALS,
+            ),
+        );
+    }
+
+    /** @param array<string,array<string,mixed>> $documents @return array<string,mixed> */
+    public function fromDocuments(array $documents): array
+    {
+        ksort($documents, SORT_STRING);
+        $reports = array();
+        $totals = array();
+        $blockTypes = array();
+        $signals = array();
+        $signalCount = 0;
+        foreach ($documents as $sourcePath => $document) {
+            $report = $this->fromBlocks(
+                is_array($document['blocks'] ?? null) ? $document['blocks'] : array(),
+                (string) $sourcePath,
+                is_string($document['serialized_blocks'] ?? null) ? $document['serialized_blocks'] : ''
+            );
+            $reports[] = array(
+                'source_path' => (string) $sourcePath,
+                'metrics' => $report['metrics'],
+                'block_types' => $report['block_types'],
+                'signals' => $report['signals'],
+                'signal_totals' => $report['signal_totals'],
+            );
+            foreach ($report['metrics'] as $key => $value) {
+                if ('max_nesting_depth' === $key) {
+                    $totals[$key] = max((int) ($totals[$key] ?? 0), (int) $value);
+                } elseif ('wrapper_to_content_ratio' !== $key) {
+                    $totals[$key] = ($totals[$key] ?? 0) + $value;
+                }
+            }
+            foreach ($report['block_types'] as $name => $count) $blockTypes[$name] = ($blockTypes[$name] ?? 0) + $count;
+            $signals = array_merge($signals, $report['signals']);
+            $signalCount += $report['signal_totals']['observed'];
+        }
+        $totals['document_count'] = count($reports);
+        $totals['wrapper_to_content_ratio'] = 0 === ($totals['content_block_count'] ?? 0)
+            ? (float) ($totals['wrapper_block_count'] ?? 0)
+            : round($totals['wrapper_block_count'] / $totals['content_block_count'], 4);
+        ksort($blockTypes, SORT_STRING);
+
+        return array(
+            'schema' => self::SCHEMA,
+            'status' => 'observed',
+            'enforcement' => 'report_only',
+            'metrics' => $totals,
+            'block_types' => $blockTypes,
+            'documents' => $reports,
+            'signals' => array_slice($signals, 0, self::MAX_REPORTED_SIGNALS),
+            'signal_totals' => array(
+                'observed' => $signalCount,
+                'reported' => min($signalCount, self::MAX_REPORTED_SIGNALS),
+                'omitted' => max(0, $signalCount - self::MAX_REPORTED_SIGNALS),
+                'truncated' => $signalCount > self::MAX_REPORTED_SIGNALS,
+            ),
+        );
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $blocks
+     * @param array<int,int> $path
+     * @param array<string,int|float> $metrics
+     * @param array<string,int> $blockTypes
+     * @param array<int,array<string,mixed>> $signals
+     */
+    private function walk(array $blocks, int $depth, array $path, array &$metrics, array &$blockTypes, array &$signals, string $sourcePath): void
+    {
+        foreach ($blocks as $index => $block) {
+            if (!is_array($block)) continue;
+            $blockPath = array_merge($path, array($index));
+            $name = is_string($block['blockName'] ?? null) && '' !== $block['blockName'] ? $block['blockName'] : 'core/freeform';
+            $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : array();
+            $innerBlocks = is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array();
+            $metrics['block_count']++;
+            $metrics['max_nesting_depth'] = max($metrics['max_nesting_depth'], $depth);
+            $blockTypes[$name] = ($blockTypes[$name] ?? 0) + 1;
+            if (array() === $innerBlocks) $metrics['leaf_block_count']++;
+            if ($this->isWrapper($name)) {
+                $metrics['wrapper_block_count']++;
+                if (array() === $innerBlocks && '' === trim(strip_tags((string) ($block['innerHTML'] ?? '')))) {
+                    $metrics['empty_wrapper_count']++;
+                    $signals[] = $this->signal('empty_wrapper', $sourcePath, $blockPath, $name);
+                }
+            } else {
+                $metrics['content_block_count']++;
+            }
+            if ('core/html' === $name || 'core/freeform' === $name) {
+                $metrics['raw_html_block_count']++;
+                $signals[] = $this->signal('raw_html_block', $sourcePath, $blockPath, $name);
+            }
+            $className = is_string($attrs['className'] ?? null) ? $attrs['className'] : '';
+            foreach (preg_split('/\s+/', trim($className)) ?: array() as $class) {
+                if (str_starts_with($class, 'blocks-engine-source-')) $metrics['source_marker_class_count']++;
+                if (str_starts_with($class, 'be-inline-geometry-')) $metrics['generated_geometry_class_count']++;
+            }
+            $this->inspectAttributes($attrs, $name, $sourcePath, $blockPath, $metrics, $signals);
+            if (array() !== $innerBlocks) $this->walk($innerBlocks, $depth + 1, $blockPath, $metrics, $blockTypes, $signals, $sourcePath);
+        }
+    }
+
+    private function isWrapper(string $name): bool
+    {
+        return in_array($name, array('core/group', 'core/columns', 'core/column', 'core/buttons'), true);
+    }
+
+    /** @param array<string,mixed> $attrs @param array<int,int> $path @param array<string,int|float> $metrics @param array<int,array<string,mixed>> $signals */
+    private function inspectAttributes(array $attrs, string $blockName, string $sourcePath, array $path, array &$metrics, array &$signals): void
+    {
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($attrs), \RecursiveIteratorIterator::LEAVES_ONLY);
+        foreach ($iterator as $key => $value) {
+            if (!is_string($value) || !$this->containsStructuralHtml($value)) continue;
+            $metrics['html_bearing_attribute_count']++;
+            $kind = 'html_bearing_attribute';
+            if ('core/table' === $blockName && 'content' === (string) $key) {
+                $metrics['html_bearing_table_cell_count']++;
+                $kind = 'html_bearing_table_cell';
+            }
+            $signals[] = $this->signal($kind, $sourcePath, $path, $blockName, (string) $key);
+        }
+    }
+
+    private function containsStructuralHtml(string $value): bool
+    {
+        if (!preg_match_all('/<\/?([a-z][a-z0-9:-]*)\b[^>]*>/i', $value, $matches)) return false;
+        foreach ($matches[1] as $tag) if (!in_array(strtolower((string) $tag), self::INLINE_RICH_TEXT_TAGS, true)) return true;
+        return false;
+    }
+
+    /** @param array<int,int> $path @return array<string,mixed> */
+    private function signal(string $kind, string $sourcePath, array $path, string $blockName, string $attribute = ''): array
+    {
+        return array_filter(array(
+            'kind' => $kind,
+            'source_path' => $sourcePath,
+            'block_path' => implode('.', $path),
+            'block_name' => $blockName,
+            'attribute' => $attribute,
+        ), static fn(string $value): bool => '' !== $value);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
 use Automattic\BlocksEngine\PhpTransformer\Contract\CoreHtmlFallbackEvidence;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformationOptions;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
@@ -807,6 +808,7 @@ final class HtmlTransformer
             'wp_block_validity' => $blockValidityReport,
             'semantic_parity' => $semanticParityReport,
             'content_round_trip' => $contentRoundTripReport,
+            'editability_report' => (new EditabilityReport())->fromBlocks($blocks, (string) ($options['source'] ?? ''), $serializedBlocks),
             'html' => array(
                 'presentation_signals' => $this->presentationProvenance,
                 'frozen_hidden_state'  => $this->frozenHiddenStateFindings,

--- a/php-transformer/tests/unit/editability-report.php
+++ b/php-transformer/tests/unit/editability-report.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
+
+$blocks = array(array(
+    'blockName' => 'core/group',
+    'attrs' => array('className' => 'blocks-engine-source-div-a be-inline-geometry-b'),
+    'innerBlocks' => array(
+        array('blockName' => 'core/group', 'attrs' => array(), 'innerBlocks' => array(), 'innerHTML' => ''),
+        array('blockName' => 'core/paragraph', 'attrs' => array('content' => 'Editable <strong>copy</strong>'), 'innerBlocks' => array(), 'innerHTML' => '<p>Editable <strong>copy</strong></p>'),
+        array('blockName' => 'core/table', 'attrs' => array('body' => array(array('cells' => array(array('content' => '<div><img src="image.jpg"></div>'))))), 'innerBlocks' => array(), 'innerHTML' => '<figure></figure>'),
+    ),
+    'innerHTML' => '<div></div>',
+));
+
+$report = (new EditabilityReport())->fromBlocks($blocks, 'website/index.html', str_repeat('x', 120));
+$metrics = $report['metrics'];
+if (EditabilityReport::SCHEMA !== $report['schema'] || 'report_only' !== $report['enforcement']) throw new RuntimeException('Editability report must be versioned and observational.');
+if (4 !== $metrics['block_count'] || 2 !== $metrics['wrapper_block_count'] || 1 !== $metrics['empty_wrapper_count'] || 2 !== $metrics['max_nesting_depth']) throw new RuntimeException('Editability report must measure block-tree complexity deterministically.');
+if (1 !== $metrics['html_bearing_table_cell_count'] || 1 !== $metrics['source_marker_class_count'] || 1 !== $metrics['generated_geometry_class_count'] || 120 !== $metrics['serialized_bytes']) throw new RuntimeException('Editability report must expose opaque HTML and generated-class signals.');
+if (1 !== $metrics['html_bearing_attribute_count']) throw new RuntimeException('Supported RichText inline markup must not be classified as opaque structural HTML.');
+if (2 !== count($report['signals']) || 'empty_wrapper' !== $report['signals'][0]['kind'] || 'html_bearing_table_cell' !== $report['signals'][1]['kind']) throw new RuntimeException('Editability signals must retain deterministic source and block attribution.');
+
+$aggregate = (new EditabilityReport())->fromDocuments(array('b.html' => array('blocks' => $blocks, 'serialized_blocks' => 'bb'), 'a.html' => array('blocks' => array(), 'serialized_blocks' => 'a')));
+if (2 !== $aggregate['metrics']['document_count'] || 3 !== $aggregate['metrics']['serialized_bytes'] || 'a.html' !== $aggregate['documents'][0]['source_path']) throw new RuntimeException('Artifact editability reports must aggregate documents in stable source order.');
+
+$emptyGroups = array_fill(0, 101, array('blockName' => 'core/group', 'attrs' => array(), 'innerBlocks' => array(), 'innerHTML' => ''));
+$bounded = (new EditabilityReport())->fromDocuments(array('large.html' => array('blocks' => $emptyGroups)));
+if (101 !== $bounded['signal_totals']['observed'] || 100 !== $bounded['signal_totals']['reported'] || 1 !== $bounded['signal_totals']['omitted'] || !$bounded['signal_totals']['truncated'] || 100 !== count($bounded['signals'])) throw new RuntimeException('Editability reports must bound evidence without losing aggregate signal totals.');
+
+fwrite(STDOUT, "editability report contract passed\n");


### PR DESCRIPTION
## Summary

- add a versioned `editability-report/v1` for standalone HTML transformations and compiled site artifacts
- measure block-tree complexity, wrapper overhead, opaque HTML, generated classes, serialized size, and deterministic source/block-path signals
- expose the report through conversion-report projection while keeping this first slice strictly observational (`status: observed`, `enforcement: report_only`)
- bound evidence rows at 100 while preserving complete observed/reported/omitted totals

Tracks #868. Thresholds and enforcement remain follow-up work after broader corpus calibration.

## Baseline Evidence

The report was run against 87 generated fixture home pages and the captured eight-document Cara Jane artifact.

| Metric | Fixture baseline | Cara Jane |
| --- | ---: | ---: |
| Wrapper-to-content ratio | median `0.6812`, max `1.4848` | `1.9697` |
| Maximum nesting depth | p90 `9`, max `10` | `13` |
| Empty wrappers | p90 `11`, max `17` | `463` |
| Source-marker classes | p90 `0`, max `33` | `1,252` |
| Generated geometry classes | p90 `7`, max `29` | `412` |
| Serialized bytes | p90 `74,180`, max `211,934` | `629,742` |

This establishes that the report distinguishes the structurally poor real-world import without changing compiler output. It does not yet establish a universal pass/fail threshold, and visual fidelity remains an independent metric.

## Verification

- `composer test`
- 275 PHP transformer parity fixtures
- package installation proof
- `php tests/unit/editability-report.php`
- `php tests/contract/run.php`
- `php tests/contract/wordpress-site-plan.php`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol was used through OpenCode to inspect the transformer contracts, implement and test the report, run corpus baselines, and draft this pull request. Chris Huber reviewed and remains responsible for the change.