### PR TITLE
Prune inert hidden empty elements

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -5180,6 +5180,10 @@ final class HtmlTransformer
             return false;
         }
 
+        if ( $this->isInertHiddenEmptyElement($element) ) {
+            return false;
+        }
+
         if ( $this->shouldPreserveWrapper($element) ) {
             return true;
         }
@@ -5190,6 +5194,28 @@ final class HtmlTransformer
 
         if ( ! $this->isEmptyVisualInlineCandidate($element) ) {
             return false;
+        }
+
+        return true;
+    }
+
+    private function isInertHiddenEmptyElement(DOMElement $element): bool
+    {
+        if ( 0 !== $this->childElementCount($element)
+            || '' !== trim($element->textContent ?? '')
+            || ! $this->sourceElementStartsHidden($element)
+            || $this->isRuntimeDomTarget($element)
+            || $this->hasConditionalStyleFamily($element, 'layout')
+            || $this->hasConditionalStyleFamily($element, 'visibility')
+            || $this->hasConditionalStyleFamily($element, 'opacity')
+        ) {
+            return false;
+        }
+
+        foreach ( array( 'id', 'role', 'title', 'aria-label', 'aria-labelledby', 'aria-describedby' ) as $attribute ) {
+            if ( '' !== trim($this->attr($element, $attribute)) ) {
+                return false;
+            }
         }
 
         return true;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -4127,6 +4127,20 @@ $assert(! (is_array($navStyle) && isset($navStyle['display'])), 'navigation must
 $frozen = $canonicalStyleResult['source_reports']['html']['frozen_hidden_state'] ?? array();
 $assert(is_array($frozen) && array() !== $frozen, 'frozen hidden state finding is surfaced for the hidden nav');
 
+$hiddenEmptyResult = (new HtmlTransformer())->transform(
+    '<main><div class="caption" style="display:none;font-size:90%"></div>'
+    . '<div id="runtime-panel" style="display:none"></div>'
+    . '<div id="anchor-panel" style="display:none"></div>'
+    . '<div class="responsive-panel" style="display:none"></div></main>',
+    array(
+        'runtime_dom_selectors' => array('#runtime-panel'),
+        'static_css' => '@media (min-width:600px){.responsive-panel{display:block}}',
+    )
+)->toArray();
+$assert(null === $findBlockByClass($hiddenEmptyResult['blocks'], 'caption'), 'inert hidden empty elements are pruned instead of becoming empty groups');
+$assert(is_array($findBlockByClass($hiddenEmptyResult['blocks'], 'responsive-panel')), 'responsive-revealed hidden empty elements remain available at their visible breakpoint');
+$assert(str_contains($hiddenEmptyResult['serialized_blocks'], 'id="runtime-panel"') && str_contains($hiddenEmptyResult['serialized_blocks'], 'id="anchor-panel"'), 'runtime-targeted and anchored hidden empty elements preserve their identifiers');
+
 fwrite(STDOUT, "Canonical block style attributes contract passed.\n");
 
 fwrite(STDOUT, "HTML-to-blocks contract passed.\n");


### PR DESCRIPTION
## Summary

- stop materializing structurally empty, inert hidden HTML nodes as empty Group blocks
- preserve hidden empty nodes when runtime selectors, stable identifiers/semantics, or conditional styles can make them meaningful
- add contract coverage for inert captions, responsive reveal behavior, runtime targeting, and anchored nodes

Tracks #868. This is the first generic optimization informed by the report introduced in #869.

## Cara Jane Evidence

The source repeats empty hidden gallery captions such as:

```html
<div style="display:none;font-size:90%"></div>
```

Artifact recompilation produced the following deterministic before/after report:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Empty wrappers | `463` | `127` | `-336` (`-72.6%`) |
| Wrapper blocks | `1,235` | `899` | `-336` |
| Total blocks | `1,862` | `1,526` | `-336` |
| Wrapper/content ratio | `1.9697` | `1.4338` | `-27.2%` |
| Serialized bytes | `629,742` | `552,798` | `-76,944` |

Content blocks remain `627`, generated geometry classes remain `412`, maximum nesting depth remains `13`, raw HTML remains `2`, and opaque HTML metrics remain unchanged. This is the expected signature for removing only hidden inert leaves.

Gallery-page empty-wrapper counts improve as follows:

- Family: `126 → 12`
- Newborn: `106 → 14`
- Boudoir: `96 → 14`
- Love: `58 → 12`

## Verification

- `composer test`
- 275 PHP transformer parity fixtures
- package installation proof
- focused hidden-state contract assertions
- Cara Jane artifact recompilation through `ArtifactCompiler`
- PHP syntax checks
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol was used through OpenCode to trace the Cara Jane report signals to source HTML and transformer decisions, implement and test the generic pruning rule, run the before/after artifact baseline, and draft this pull request. Chris Huber reviewed and remains responsible for the change.