### PR TITLE
Keep runtime-targeted Group geometry editor-valid

### DIFF
--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -154,6 +154,13 @@ final class BlockFactory
             unset($attrs['inlineGeometryStyle']);
         }
 
+        // Group save() only reproduces registered block-support styles. Arbitrary
+        // source geometry already rides on the generated carrier class, so
+        // duplicating it in saved markup makes the block invalid in Gutenberg.
+        if ( 'core/group' === $name && preg_match('/(?:^|\s)be-inline-geometry-[^\s]+(?:\s|$)/', (string) ($attrs['className'] ?? '')) ) {
+            unset($attrs['inlineGeometryStyle']);
+        }
+
         if ( 'core/separator' === $name ) {
             unset($attrs['style']['spacing']['margin']['left'], $attrs['style']['spacing']['margin']['right']);
             if ( empty($attrs['style']['spacing']['margin']) ) {

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -348,12 +348,7 @@ trait StyleResolutionTrait
                 continue;
             }
             $rawValue = trim((string) ($declarations[$property] ?? ($forcedDeclarations[$property] ?? '')));
-            if (! $carrierOwnsInlineGeometry && 1 === preg_match('/\s*!important\s*$/i', $rawValue)) {
-                continue;
-            }
-            $value = $carrierOwnsInlineGeometry
-                ? trim(preg_replace('/\s*!\s*important\s*$/i', '', $rawValue) ?? $rawValue)
-                : $rawValue;
+            $value = trim(preg_replace('/\s*!\s*important\s*$/i', '', $rawValue) ?? $rawValue);
             if ( in_array($property, array( 'background', 'background-image' ), true) ) {
                 $value = CssUrlRewriter::rewrite($value, fn (string $url): string => $this->resolvedAssetImageUrl($url));
             }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -4141,6 +4141,26 @@ $assert(null === $findBlockByClass($hiddenEmptyResult['blocks'], 'caption'), 'in
 $assert(is_array($findBlockByClass($hiddenEmptyResult['blocks'], 'responsive-panel')), 'responsive-revealed hidden empty elements remain available at their visible breakpoint');
 $assert(str_contains($hiddenEmptyResult['serialized_blocks'], 'id="runtime-panel"') && str_contains($hiddenEmptyResult['serialized_blocks'], 'id="anchor-panel"'), 'runtime-targeted and anchored hidden empty elements preserve their identifiers');
 
+$runtimeGeometryResult = (new HtmlTransformer())->transform(
+    '<main><div id="runtime-geometry" style="width:290px !important;height:62px !important"></div></main>',
+    array('runtime_dom_selectors' => array('#runtime-geometry'))
+)->toArray();
+$findBlockByAnchor = static function (array $blocks, string $anchor) use (&$findBlockByAnchor): ?array {
+    foreach ($blocks as $block) {
+        if (! is_array($block)) continue;
+        if ($anchor === ($block['attrs']['anchor'] ?? '')) return $block;
+        $found = $findBlockByAnchor($block['innerBlocks'] ?? array(), $anchor);
+        if (null !== $found) return $found;
+    }
+    return null;
+};
+$runtimeGeometryBlock = $findBlockByAnchor($runtimeGeometryResult['blocks'], 'runtime-geometry');
+$runtimeGeometryCss = implode("\n", array_column(array_filter($runtimeGeometryResult['assets'], static fn (array $asset): bool => 'css' === ($asset['kind'] ?? '')), 'content'));
+$assert(is_array($runtimeGeometryBlock) && 'core/group' === ($runtimeGeometryBlock['blockName'] ?? ''), 'runtime-targeted empty geometry remains represented as a Group');
+$assert(! str_contains((string) ($runtimeGeometryBlock['innerHTML'] ?? ''), 'style='), 'runtime Group saved markup does not duplicate arbitrary geometry that core save cannot reproduce');
+$assert(str_contains($runtimeGeometryCss, 'width:290px !important') && str_contains($runtimeGeometryCss, 'height:62px !important'), 'runtime Group geometry remains preserved by its generated carrier stylesheet');
+$assert(! str_contains($runtimeGeometryCss, '!important !important'), 'runtime Group carrier emits valid priority for source-important geometry');
+
 fwrite(STDOUT, "Canonical block style attributes contract passed.\n");
 
 fwrite(STDOUT, "HTML-to-blocks contract passed.\n");


### PR DESCRIPTION
## Summary
- carry source-important inline geometry through generated geometry classes
- omit duplicate arbitrary geometry from `core/group` saved markup when that carrier exists
- cover runtime-targeted empty Groups with source-important dimensions

Closes #871.

## Verification
- `composer test`
- Cara Jane artifact re-import: 8 pages, 1,552 Gutenberg blocks, 899 Groups, 127 empty Groups
- `wp.blocks.validateBlock`: 1,552 valid, 0 invalid, down from 14 invalid Groups
- computed signup geometry: desktop `290px x 62px`; mobile `390px x 45px`; inactive responsive counterpart remains zero-sized
- retained screenshots have identical full-page dimensions at desktop and mobile across `/`, `/family`, `/newborn`, `/boudoir`, and `/love`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode assisted with root-cause analysis, implementation, regression coverage, and local WordPress/browser verification. Chris Huber reviewed and remains responsible for the change.