### PR TITLE
fix(bindings): preserve reprojection identity

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -59,9 +59,8 @@ final class WordPressSitePlan
         $pages = $shells['pages'];
         $parts = array_merge($existingParts, $shells['parts']);
         $runtimeDeclarations = $shells['runtime_declarations'];
-        foreach ($runtimeDeclarations as &$declaration) foreach ($declaration['payload']['entities'] ?? array() as &$entity) foreach ($entity['bindings'] ?? array() as &$binding) unset($binding['position']);
-        unset($binding, $entity, $declaration);
         $runtimeDeclarations = $this->canonicalEntityBindings($runtimeDeclarations, $references, $routeMap, $pages);
+        foreach ($pages as &$page) unset($page['_projected_source_block_markup']); unset($page);
         self::assertEntityBindingsRemainPageOwned($runtimeDeclarations, $pages, $assets);
         $templates = $this->templates($pages, $parts);
         $operations = $this->operations($pages);
@@ -263,7 +262,7 @@ final class WordPressSitePlan
             $markup = $references->content($document['block_markup'], $document['source_path']);
             $canonical = $this->routeLinks($markup, $document['source_path'], $routes);
             $target = $part ? 'parts/' . self::value($document, 'slug') . '.html' : self::value($document, 'source_path');
-            $row = array('source_path' => $document['source_path'], 'slug' => self::value($document, 'slug'), 'title' => self::value($document, 'title'), 'post_type' => self::value((array) ($document['metadata'] ?? array()), 'post_type', 'page'), 'parent_source_path' => self::value((array) ($document['metadata'] ?? array()), 'parent_source_path'), 'entrypoint' => ! empty($document['entrypoint']), 'area' => $part ? self::value($document, 'area', 'uncategorized') : null, 'placement' => $part && is_array($document['placement'] ?? null) ? $document['placement'] : ($part ? array('kind' => 'unbound') : null), 'canonical_block_markup' => $canonical, 'metadata' => is_array($document['metadata'] ?? null) ? $document['metadata'] : array(), 'document_metadata' => $this->documentMetadata($document, $references, $routes), 'provenance' => is_array($document['provenance'] ?? null) ? $document['provenance'] : array(), 'reconciliation_identity' => self::identity($part ? 'template-part' : 'page', $document['source_path'], $target), 'content_hash' => self::contentHash($canonical));
+            $row = array('source_path' => $document['source_path'], 'slug' => self::value($document, 'slug'), 'title' => self::value($document, 'title'), 'post_type' => self::value((array) ($document['metadata'] ?? array()), 'post_type', 'page'), 'parent_source_path' => self::value((array) ($document['metadata'] ?? array()), 'parent_source_path'), 'entrypoint' => ! empty($document['entrypoint']), 'area' => $part ? self::value($document, 'area', 'uncategorized') : null, 'placement' => $part && is_array($document['placement'] ?? null) ? $document['placement'] : ($part ? array('kind' => 'unbound') : null), 'canonical_block_markup' => $canonical, '_projected_source_block_markup' => $document['block_markup'], 'metadata' => is_array($document['metadata'] ?? null) ? $document['metadata'] : array(), 'document_metadata' => $this->documentMetadata($document, $references, $routes), 'provenance' => is_array($document['provenance'] ?? null) ? $document['provenance'] : array(), 'reconciliation_identity' => self::identity($part ? 'template-part' : 'page', $document['source_path'], $target), 'content_hash' => self::contentHash($canonical));
             if (!$part && is_array($document['content_decision'] ?? null)) {
                 $row['content_decision'] = $document['content_decision'];
                 if (is_string($document['publication_timestamp'] ?? null)) $row['publication_timestamp'] = $document['publication_timestamp'];
@@ -923,7 +922,9 @@ final class WordPressSitePlan
                 }
                 foreach ( $entity['bindings'] as &$binding ) {
                     if ( is_array($binding) && is_string($binding['search_block_markup'] ?? null) && is_string($binding['source_path'] ?? null) ) {
-                        $markup = $references->content($binding['search_block_markup'], $binding['source_path']);
+                        $sourceMarkup = $binding['search_block_markup'];
+                        if (!is_array($binding['projected_anchor'] ?? null)) $binding['projected_anchor'] = array_filter(array('schema' => 'blocks-engine/projected-binding-anchor/v1', 'source_block_markup' => $sourceMarkup, 'source_occurrence' => $binding['occurrence'] ?? null, 'source_position' => $binding['position'] ?? null), static fn(mixed $value): bool => null !== $value);
+                        $markup = $references->content($sourceMarkup, $binding['source_path']);
                         $binding['search_block_markup'] = $this->routeLinks($markup, $binding['source_path'], $routes);
                     }
                 }
@@ -934,42 +935,70 @@ final class WordPressSitePlan
         unset($declaration);
 
         $markupBySource = array_column($pages, 'canonical_block_markup', 'source_path');
-        foreach ( $declarations as &$declaration ) {
-            if ( ! is_array($declaration['payload']['entities'] ?? null) ) continue;
-            foreach ( $declaration['payload']['entities'] as &$entity ) {
-                if ( ! is_array($entity['bindings'] ?? null) ) continue;
-                foreach ( $entity['bindings'] as &$binding ) {
-                    $source = $binding['source_path'] ?? null; $search = $binding['search_block_markup'] ?? null; $position = $binding['position'] ?? null;
-                    $markup = is_string($source) ? ($markupBySource[$source] ?? null) : null;
-                    if (!is_string($source) || !is_string($search) || '' === $search || !is_int($binding['occurrence'] ?? null) || $binding['occurrence'] < 1 || !is_string($markup)) throw new InvalidArgumentException('A runtime entity binding lacks an exact emitted block anchor.');
-                    $ranges = self::blockRanges($markup); $range = null; $blockIndex = null;
-                    if (is_array($position)) {
-                        if ('blocks-engine/runtime-binding-position/v1' !== ($position['schema'] ?? null) || !is_int($position['block_index'] ?? null) || $position['block_index'] < 0) throw new InvalidArgumentException('A runtime entity binding has an invalid emitted block position.');
-                        $blockIndex = $position['block_index'];
-                        $range = $ranges[$blockIndex] ?? null;
-                        if (!is_array($range)) throw new InvalidArgumentException('A runtime entity binding position no longer identifies an emitted canonical block.');
-                    } else {
-                        $anchorOffset = self::occurrenceOffset($markup, $search, $binding['occurrence']);
-                        foreach (null === $anchorOffset ? array() : $ranges as $index => $candidate) if ($candidate['offset'] === $anchorOffset && $search === substr($markup, $candidate['offset'], $candidate['length'])) { $range = $candidate; $blockIndex = $index; break; }
-                    }
-                    if (!is_array($range)) throw new InvalidArgumentException('A runtime entity binding no longer identifies an emitted canonical block.');
-                    $canonical = substr($markup, $range['offset'], $range['length']);
-                    if (!is_string($canonical) || '' === $canonical) throw new InvalidArgumentException('A runtime entity binding resolved to empty canonical block markup.');
-                    $binding['search_block_markup'] = $canonical;
-                    $binding['occurrence'] = self::occurrenceAtOffset($markup, $canonical, $range['offset']);
-                    $binding['position'] = array('schema' => 'blocks-engine/runtime-binding-position/v1', 'block_index' => $blockIndex, 'offset' => $range['offset'], 'length' => $range['length']);
-                }
+        $sourceMarkupBySource = array_column($pages, '_projected_source_block_markup', 'source_path');
+        $groups = array();
+        foreach ($declarations as $declarationIndex => $declaration) foreach ($declaration['payload']['entities'] ?? array() as $entityIndex => $entity) foreach (is_array($entity) ? ($entity['bindings'] ?? array()) : array() as $bindingIndex => $binding) {
+            $source = $binding['source_path'] ?? null; $search = $binding['search_block_markup'] ?? null; $position = $binding['position'] ?? null;
+            $markup = is_string($source) ? ($markupBySource[$source] ?? null) : null;
+            if (!is_string($source) || !is_string($search) || '' === $search || !is_int($binding['occurrence'] ?? null) || $binding['occurrence'] < 1 || !is_string($markup)) throw new InvalidArgumentException('A runtime entity binding lacks an exact emitted block anchor.');
+            if (is_array($position) && ('blocks-engine/runtime-binding-position/v1' !== ($position['schema'] ?? null) || !is_int($position['block_index'] ?? null) || $position['block_index'] < 0 || !is_int($position['offset'] ?? null) || $position['offset'] < 0 || !is_int($position['length'] ?? null) || $position['length'] < 1)) throw new InvalidArgumentException('A runtime entity binding has an invalid emitted block position.');
+            $groups[$source . "\n" . $search][] = array('id' => $declarationIndex . ':' . $entityIndex . ':' . $bindingIndex, 'source' => $source, 'declaration' => $declarationIndex, 'entity' => $entityIndex, 'binding' => $bindingIndex, 'source_offset' => is_array($position) ? $position['offset'] : null, 'source_occurrence' => $binding['occurrence'], 'canonical_position' => false, 'markup' => $markup, 'source_markup' => $sourceMarkupBySource[$source] ?? null, 'search' => $search);
+        }
+        foreach ($groups as $bindings) {
+            usort($bindings, static fn(array $left, array $right): int => array($left['source_offset'] ?? PHP_INT_MAX, $left['source_occurrence'], $left['declaration'], $left['entity'], $left['binding']) <=> array($right['source_offset'] ?? PHP_INT_MAX, $right['source_occurrence'], $right['declaration'], $right['entity'], $right['binding']));
+            $identities = array();
+            foreach ($bindings as $identity) {
+                $key = is_int($identity['source_offset']) ? 'offset:' . $identity['source_offset'] : 'occurrence:' . $identity['source_occurrence'];
+                if (isset($identities[$key])) throw new InvalidArgumentException('A runtime entity binding has ambiguous canonical source-page anchors.');
+                $identities[$key] = true;
+            }
+            $markup = $bindings[0]['markup']; $search = $bindings[0]['search']; $ranges = array_values(array_filter(self::blockRanges($markup), static fn(array $range): bool => $search === substr($markup, $range['offset'], $range['length'])));
+            if (count($ranges) < count($bindings)) throw new InvalidArgumentException('A runtime entity binding no longer identifies one exact emitted canonical block.');
+            $claimedOffsets = array(); $claimedBindings = array(); $resolved = array();
+            foreach ($bindings as $identity) {
+                $position = $declarations[$identity['declaration']]['payload']['entities'][$identity['entity']]['bindings'][$identity['binding']]['position'] ?? null;
+                if (isset($declarations[$identity['declaration']]['payload']['entities'][$identity['entity']]['bindings'][$identity['binding']]['projected_anchor']) || true !== $identity['canonical_position'] || !self::bindingPosition($position, $markup, $search)) continue;
+                if (isset($claimedOffsets[$position['offset']])) throw new InvalidArgumentException('A runtime entity binding has ambiguous canonical source-page anchors.');
+                $claimedOffsets[$position['offset']] = true;
+                $claimedBindings[$identity['id']] = true;
+                $resolved[] = array($identity, array('offset' => $position['offset'], 'length' => $position['length']));
+            }
+            $remainingBindings = array_values(array_filter($bindings, static fn(array $identity): bool => !isset($claimedBindings[$identity['id']])));
+            $remainingRanges = array_values(array_filter($ranges, static fn(array $range): bool => !isset($claimedOffsets[$range['offset']])));
+            foreach ($remainingBindings as $identity) {
+                $anchor = $declarations[$identity['declaration']]['payload']['entities'][$identity['entity']]['bindings'][$identity['binding']]['projected_anchor'] ?? null;
+                if (!is_array($anchor) || 'blocks-engine/projected-binding-anchor/v1' !== ($anchor['schema'] ?? null) || !is_string($anchor['source_block_markup'] ?? null)) throw new InvalidArgumentException('A runtime entity binding no longer identifies one exact emitted canonical block.');
+                $sourceMarkup = $sourceMarkupBySource[$identity['source']] ?? null;
+                if (!is_string($sourceMarkup)) throw new InvalidArgumentException('A runtime entity binding no longer identifies one exact emitted canonical block.');
+                $sourceRanges = self::blockRanges($sourceMarkup); $canonicalRanges = self::blockRanges($markup);
+                $sourceMatches = array_values(array_filter($sourceRanges, static fn(array $range): bool => $anchor['source_block_markup'] === substr($sourceMarkup, $range['offset'], $range['length'])));
+                if (isset($anchor['source_occurrence_count']) && $anchor['source_occurrence_count'] !== count($sourceMatches)) throw new InvalidArgumentException('A runtime entity binding source anchor is ambiguous after reprojection.');
+                $candidates = array(); foreach ($sourceRanges as $index => $sourceRange) { $canonicalRange = $canonicalRanges[$index] ?? null; if ($anchor['source_block_markup'] === substr($sourceMarkup, $sourceRange['offset'], $sourceRange['length']) && $anchor['source_occurrence'] === self::occurrenceAtOffset($sourceMarkup, $anchor['source_block_markup'], $sourceRange['offset']) && is_array($canonicalRange) && $search === substr($markup, $canonicalRange['offset'], $canonicalRange['length']) && !isset($claimedOffsets[$canonicalRange['offset']])) $candidates[] = array('source' => $sourceRange, 'canonical' => $canonicalRange); }
+                if (array() === $candidates) { $sourceMatches = array_values(array_filter(self::blockRanges($sourceMarkup), static fn(array $range): bool => $anchor['source_block_markup'] === substr($sourceMarkup, $range['offset'], $range['length']))); $canonicalMatches = array_values(array_filter(self::blockRanges($markup), static fn(array $range): bool => $search === substr($markup, $range['offset'], $range['length']) && !isset($claimedOffsets[$range['offset']]))); if (1 === count($sourceMatches) && 1 === count($canonicalMatches)) $candidates[] = array('source' => $sourceMatches[0], 'canonical' => $canonicalMatches[0]); }
+                if (1 !== count($candidates)) throw new InvalidArgumentException('A runtime entity binding no longer identifies one exact emitted canonical block.');
+                $claimedOffsets[$candidates[0]['canonical']['offset']] = true; $resolved[] = array($identity, $candidates[0]['canonical']);
+            }
+            foreach ($resolved as $resolvedEntry) {
+                [$identity, $range] = $resolvedEntry;
+                if (!is_array($range)) throw new InvalidArgumentException('A runtime entity binding no longer identifies an emitted canonical block.');
+                $canonical = substr($markup, $range['offset'], $range['length']);
+                $blockIndex = array_search($range, self::blockRanges($markup), true);
+                if (!is_string($canonical) || '' === $canonical || !is_int($blockIndex)) throw new InvalidArgumentException('A runtime entity binding resolved to empty canonical block markup.');
+                $binding = &$declarations[$identity['declaration']]['payload']['entities'][$identity['entity']]['bindings'][$identity['binding']];
+                $binding['search_block_markup'] = $canonical;
+                $binding['occurrence'] = self::occurrenceAtOffset($markup, $canonical, $range['offset']);
+                $binding['position'] = array('schema' => 'blocks-engine/runtime-binding-position/v1', 'block_index' => $blockIndex, 'offset' => $range['offset'], 'length' => $range['length']);
                 unset($binding);
             }
-            unset($entity);
         }
-        unset($declaration);
 
         // Rewriting binding markup changes the payload, so drop the derived
         // hashes and re-normalize to recompute canonical identity and content
         // hashes; the reconciliation identity (source path + kind) is stable.
         foreach ( $declarations as &$declaration ) {
             if ( is_array($declaration) ) {
+                foreach ($declaration['payload']['entities'] ?? array() as &$entity) foreach ($entity['bindings'] ?? array() as &$binding) unset($binding['_canonical_position']);
+                unset($binding, $entity);
                 unset($declaration['payload_hash'], $declaration['content_hash']);
             }
         }

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -251,6 +251,48 @@ $projectedAnchorResult['source_reports']['compiled_site']['runtime_declarations'
 $projectedAnchorPlan = (new WordPressSitePlan())->fromResult($projectedAnchorResult);
 $projectedAnchorBindings = current(array_filter($projectedAnchorPlan['runtime_declarations'], static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)))['payload']['entities'][0]['bindings'] ?? array();
 $assert(2 === count($projectedAnchorBindings) && $projectedAnchorBindings[0]['search_block_markup'] === $projectedAnchorBindings[1]['search_block_markup'] && array(0, 1) === array_map(static fn(array $binding): int => $binding['position']['block_index'], $projectedAnchorBindings) && array(1, 2) === array_column($projectedAnchorBindings, 'occurrence'), 'Distinct positioned source anchors that route-canonicalize identically retain their block indexes and canonical occurrences.');
+$reprojectedSequenceResult = $projectedAnchorResult;
+$reprojectedSequenceResult['source_reports']['compiled_site']['pages'][0]['block_markup'] = '<!-- wp:paragraph --><p>Canonical prelude</p><!-- /wp:paragraph -->' . $firstProjectedAnchor . $secondProjectedAnchor;
+$reprojectedSequencePlan = (new WordPressSitePlan())->fromResult($reprojectedSequenceResult);
+$reprojectedSequenceBindings = current(array_filter($reprojectedSequencePlan['runtime_declarations'], static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)))['payload']['entities'][0]['bindings'] ?? array();
+$assert(array(1, 2) === array_map(static fn(array $binding): int => $binding['position']['block_index'], $reprojectedSequenceBindings) && array(1, 2) === array_column($reprojectedSequenceBindings, 'occurrence'), 'Canonical reprojection rebinds provider anchors after an emitted block sequence changes without trusting stale traversal indexes.');
+$collisionAnchorResult = $projectedAnchorResult;
+$collisionAnchorResult['source_reports']['compiled_site']['pages'][0]['block_markup'] = $firstProjectedAnchor . $firstProjectedAnchor . $secondProjectedAnchor;
+$collisionAnchorBindings = current(array_filter((new WordPressSitePlan())->fromResult($collisionAnchorResult)['runtime_declarations'], static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)))['payload']['entities'][0]['bindings'] ?? array();
+$assert(array(0, 2) === array_map(static fn(array $binding): int => $binding['position']['block_index'], $collisionAnchorBindings) && array(1, 3) === array_column($collisionAnchorBindings, 'occurrence'), 'Canonical reprojection preserves exact bound targets when an identical unbound canonical block is inserted.');
+$retainedAnchorPlan = (new WordPressSitePlan())->fromResult($projectedAnchorResult);
+$retainedAnchorResult = $projectedAnchorResult;
+$retainedAnchorResult['source_reports']['compiled_site']['runtime_declarations'] = $retainedAnchorPlan['runtime_declarations'];
+$retainedAnchorResult['source_reports']['compiled_site']['pages'][0]['block_markup'] = '<!-- wp:paragraph --><p>Canonical prelude</p><!-- /wp:paragraph -->' . $firstProjectedAnchor . $secondProjectedAnchor;
+$retainedAnchorBindings = current(array_filter((new WordPressSitePlan())->fromResult($retainedAnchorResult)['runtime_declarations'], static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)))['payload']['entities'][0]['bindings'] ?? array();
+$assert(array(1, 2) === array_map(static fn(array $binding): int => $binding['position']['block_index'], $retainedAnchorBindings) && array(1, 2) === array_column($retainedAnchorBindings, 'occurrence'), 'Retained canonical positions preserve both projected anchor identities across reprojection.');
+$retainedCollisionResult = $retainedAnchorResult;
+$retainedCollisionResult['source_reports']['compiled_site']['pages'][0]['block_markup'] = $firstProjectedAnchor . $firstProjectedAnchor . $secondProjectedAnchor;
+$retainedCollisionBindings = current(array_filter((new WordPressSitePlan())->fromResult($retainedCollisionResult)['runtime_declarations'], static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)))['payload']['entities'][0]['bindings'] ?? array();
+$assert(array(0, 2) === array_map(static fn(array $binding): int => $binding['position']['block_index'], $retainedCollisionBindings) && array(1, 3) === array_column($retainedCollisionBindings, 'occurrence'), 'Retained projected anchors preserve exact targets through identical unbound canonical blocks.');
+$ambiguousAnchorResult = $retainedCollisionResult;
+foreach ($ambiguousAnchorResult['source_reports']['compiled_site']['runtime_declarations'] as &$declaration) if ('forms' === ($declaration['type'] ?? null)) { unset($declaration['payload']['entities'][0]['bindings'][1]['projected_anchor'], $declaration['payload']['entities'][0]['bindings'][1]['position']); unset($declaration['reconciliation_identity'], $declaration['payload_hash'], $declaration['content_hash']); }
+unset($declaration);
+$ambiguousAnchorResult['source_reports']['compiled_site']['runtime_declarations'] = RuntimeDeclarations::normalizeList($ambiguousAnchorResult['source_reports']['compiled_site']['runtime_declarations']);
+$throws(static fn() => (new WordPressSitePlan())->fromResult($ambiguousAnchorResult), 'Canonical reprojection fails closed when an identical target has no retained source identity or offset.');
+$duplicateSourceAnchor = '<!-- wp:navigation-link {"url":"index.html"} /-->';
+$boundSecondDuplicateResult = $projectedAnchorResult;
+$boundSecondDuplicateResult['source_reports']['compiled_site']['pages'][0]['block_markup'] = $duplicateSourceAnchor . $duplicateSourceAnchor;
+foreach ($boundSecondDuplicateResult['source_reports']['compiled_site']['runtime_declarations'] as &$declaration) if ('forms' === ($declaration['type'] ?? null)) { $entity = $declaration['payload']['entities'][0]; $entity['bindings'] = array(array('schema' => 'generic/block-binding/v1', 'role' => 'form', 'source_path' => 'index.html', 'search_block_markup' => $duplicateSourceAnchor, 'occurrence' => 2, 'position' => array('schema' => 'blocks-engine/runtime-binding-position/v1', 'block_index' => 1, 'offset' => strlen($duplicateSourceAnchor), 'length' => strlen($duplicateSourceAnchor)))); $declaration['payload']['entities'] = array($entity); unset($declaration['reconciliation_identity'], $declaration['payload_hash'], $declaration['content_hash']); }
+unset($declaration);
+$boundSecondDuplicateResult['source_reports']['compiled_site']['runtime_declarations'] = RuntimeDeclarations::normalizeList($boundSecondDuplicateResult['source_reports']['compiled_site']['runtime_declarations']);
+$boundSecondDuplicatePlan = (new WordPressSitePlan())->fromResult($boundSecondDuplicateResult);
+$ambiguousSecondDuplicateResult = $boundSecondDuplicateResult;
+$ambiguousSecondDuplicateResult['source_reports']['compiled_site']['runtime_declarations'] = $boundSecondDuplicatePlan['runtime_declarations'];
+foreach ($ambiguousSecondDuplicateResult['source_reports']['compiled_site']['runtime_declarations'] as &$declaration) if ('forms' === ($declaration['type'] ?? null)) { $declaration['payload']['entities'][0]['bindings'][0]['projected_anchor']['source_occurrence_count'] = 2; unset($declaration['reconciliation_identity'], $declaration['payload_hash'], $declaration['content_hash']); }
+unset($declaration);
+$ambiguousSecondDuplicateResult['source_reports']['compiled_site']['runtime_declarations'] = RuntimeDeclarations::normalizeList($ambiguousSecondDuplicateResult['source_reports']['compiled_site']['runtime_declarations']);
+$ambiguousSecondDuplicateResult['source_reports']['compiled_site']['pages'][0]['block_markup'] = $duplicateSourceAnchor . $duplicateSourceAnchor . $duplicateSourceAnchor;
+$throws(static fn() => (new WordPressSitePlan())->fromResult($ambiguousSecondDuplicateResult), 'A bound second duplicate fails closed when an identical source insertion before it makes its retained identity ambiguous.');
+$partialBindingResult = $boundSecondDuplicateResult;
+$partialBindingResult['source_reports']['compiled_site']['pages'][0]['block_markup'] = '<!-- wp:paragraph --><p>Canonical prelude</p><!-- /wp:paragraph -->' . $duplicateSourceAnchor . $duplicateSourceAnchor;
+$partialBinding = current(array_filter((new WordPressSitePlan())->fromResult($partialBindingResult)['runtime_declarations'], static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)))['payload']['entities'][0]['bindings'][0] ?? array();
+$assert(2 === ($partialBinding['position']['block_index'] ?? null) && 2 === ($partialBinding['occurrence'] ?? null), 'A partial binding remains provable when its source occurrence and stable anchor identity survive reprojection.');
 $switchbackRoot = dirname(__DIR__, 3) . '/fixtures/websites/20-switchback-woocommerce-extra-hard';
 $switchbackFiles = array();
 foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($switchbackRoot, FilesystemIterator::SKIP_DOTS)) as $switchbackFile) if ($switchbackFile->isFile()) $switchbackFiles[substr($switchbackFile->getPathname(), strlen($switchbackRoot) + 1)] = file_get_contents($switchbackFile->getPathname());
@@ -269,6 +311,7 @@ $switchbackResolvedPages = array_column($switchbackResolved['pages'] ?? array(),
 $switchbackResolvedProducts = current(array_filter($switchbackResolved['runtime_declarations'] ?? array(), static fn(array $declaration): bool => 'products' === ($declaration['type'] ?? null)));
 $switchbackResolvedBindings = array_merge(...array_map(static fn(array $entity): array => $entity['bindings'] ?? array(), $switchbackResolvedProducts['payload']['entities'] ?? array()));
 $assert(array() !== $switchbackResolvedBindings && array_reduce($switchbackResolvedBindings, static fn(bool $valid, array $binding): bool => $valid && ($binding['occurrence'] ?? 0) === substr_count(substr((string) ($switchbackResolvedPages[$binding['source_path']] ?? ''), 0, (int) ($binding['position']['offset'] ?? -1) + (int) ($binding['position']['length'] ?? 0)), (string) ($binding['search_block_markup'] ?? '')), true), 'Fixture 20 provider bindings resolve to exact source-page occurrences for materializers.');
+$assert(true === (static function () use ($switchbackPlan): bool { WordPressSitePlan::assertValid($switchbackPlan); return true; })(), 'Fixture 20 independently validates its canonical binding positions and occurrences.');
 $unsafeFormScript = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><h1>Home</h1></main>', 'contact.html' => '<main><form id="contact"><input id="email" type="email" name="email"><button type="submit">Send</button></form></main><script data-blocks-engine-superseded-by="#contact">const form = document.getElementById("contact"); fetch("/track"); if (form) form.addEventListener("submit", function (event) { event.preventDefault(); });</script>')))->toArray()['source_reports']['wordpress_site_plan'];
 $unsafeFormDeclarations = array(); foreach ($unsafeFormScript['runtime_declarations'] as $declaration) $unsafeFormDeclarations[$declaration['kind'] . ':' . ($declaration['type'] ?? $declaration['capability'])] = $declaration;
 $unsafeSupersededScripts = array_merge(...array_map(static fn(array $entity): array => $entity['superseded_scripts'] ?? array(), $unsafeFormDeclarations['entity_collection:forms']['payload']['entities']));


### PR DESCRIPTION
## Summary

- preserve projected binding anchor identity across canonical reprojection instead of trusting stale block indexes or offsets
- support provable partial bindings among identical unbound blocks
- fail closed when occurrence identity becomes ambiguous rather than silently retargeting providers

## Verification

- `composer test`
- 275 parity fixtures
- fixture 20 and independent fixture plan validation
- inserted-identical, partial-binding, occurrence, and ambiguity contracts

Closes #873

## AI assistance

OpenAI gpt-5.6-sol via OpenCode implemented and independently reviewed canonical binding identity, collision behavior, fail-close semantics, and tests. Chris Huber reviewed and owns every line.