### PR TITLE
fix: preserve packaged responsive navigation styles

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -1350,7 +1350,7 @@ final class ArtifactCompiler
                 if ( ! preg_match('/^<link\b/i', $tag) || ! preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute((string) $tag, 'rel') ) || ! $this->isCssStylesheetType($this->htmlAttribute((string) $tag, 'type')) ) {
                     continue;
                 }
-                $sourcePathForLink = $this->stylesheetPathFromHref($this->htmlAttribute((string) $tag, 'href'), $sourcePath);
+                $sourcePathForLink = $this->stylesheetPathFromHref($this->htmlAttribute((string) $tag, 'href'), $sourcePath, $files);
                 $linkOccurrences[$sourcePathForLink] = ($linkOccurrences[$sourcePathForLink] ?? 0) + 1;
                 $path = $occurrencePaths[$sourcePathForLink][$linkOccurrences[$sourcePathForLink]] ?? '';
                 $file = $byPath[$path] ?? null;
@@ -1395,7 +1395,7 @@ final class ArtifactCompiler
             if ( ! preg_match('/(?:^|\s)stylesheet(?:\s|$)/i', $this->htmlAttribute((string) $tag, 'rel')) || ! $this->isCssStylesheetType($this->htmlAttribute((string) $tag, 'type')) ) {
                 continue;
             }
-            $originalPath = $this->stylesheetPathFromHref($this->htmlAttribute((string) $tag, 'href'), $sourcePath);
+            $originalPath = $this->stylesheetPathFromHref($this->htmlAttribute((string) $tag, 'href'), $sourcePath, $files);
             if ( '' === $originalPath || ! isset($byPath[$originalPath]) || 'css' !== ($files[$byPath[$originalPath]]['kind'] ?? '') ) {
                 continue;
             }
@@ -1426,9 +1426,41 @@ final class ArtifactCompiler
         return $files;
     }
 
-    private function stylesheetPathFromHref(string $href, string $sourcePath): string
+    /** @param array<int, array<string, mixed>> $files */
+    private function stylesheetPathFromHref(string $href, string $sourcePath, array $files = array()): string
     {
-        return ArtifactPath::resolveRelativePath((string) preg_replace('/[?#].*$/', '', $href), $sourcePath);
+        $href = (string) preg_replace('/[?#].*$/', '', $href);
+        if ( ! str_starts_with($href, '/') ) {
+            return ArtifactPath::resolveRelativePath($href, $sourcePath);
+        }
+
+        return $this->artifactRootRelativePath($href, $sourcePath, array_fill_keys(array_column($files, 'path'), true));
+    }
+
+    /** @param array<string, true> $paths */
+    private function artifactRootRelativePath(string $reference, string $sourcePath, array $paths): string
+    {
+        $relative = ArtifactPath::safeRelativePath(ltrim($reference, '/'));
+        if ( '' === $relative || isset($paths[$relative]) ) {
+            return $relative;
+        }
+
+        $sourceSegments = explode('/', dirname($sourcePath));
+        $matches = array();
+        foreach ( array_keys($paths) as $path ) {
+            if ( ! str_ends_with($path, '/' . $relative) ) {
+                continue;
+            }
+            $candidateSegments = explode('/', dirname($path));
+            $common = 0;
+            while ( isset($sourceSegments[$common], $candidateSegments[$common]) && $sourceSegments[$common] === $candidateSegments[$common] ) {
+                ++$common;
+            }
+            $matches[] = array( 'path' => $path, 'common' => $common );
+        }
+        usort($matches, static fn (array $left, array $right): int => $right['common'] <=> $left['common'] ?: strcmp($left['path'], $right['path']));
+
+        return isset($matches[0]) && $matches[0]['common'] > 0 ? (string) $matches[0]['path'] : $relative;
     }
 
     private function stylesheetOccurrencePath(string $path, int $occurrence): string

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -2110,8 +2110,15 @@ final class ArtifactCompiler
     private function mapNavigationStructureSelector(string $selector, string $body): array
     {
         $selector = $this->selectorWithoutComments($selector);
-        if ( str_contains($selector, '.wp-block-navigation')
-            || ! preg_match('/(^|\s*[>+~]?\s*)(?:ul|ol)((?:[.#][A-Za-z_][A-Za-z0-9_-]*)+)(?=$|[\s>+~:])/', $selector, $listMatch, PREG_OFFSET_CAPTURE) ) {
+        if ( str_contains($selector, '.wp-block-navigation') ) {
+            return array();
+        }
+
+        $hasListMatch = preg_match('/(^|\s*[>+~]?\s*)(?:ul|ol)((?:[.#][A-Za-z_][A-Za-z0-9_-]*)+)(?=$|[\s>+~:])/', $selector, $listMatch, PREG_OFFSET_CAPTURE);
+        if ( 1 !== $hasListMatch ) {
+            $hasListMatch = preg_match('/(^|\s*[>+~]?\s*)((?:[.#][A-Za-z_][A-Za-z0-9_-]*)+)(?=\s+[^,{]*blocks-engine-source-li-)/', $selector, $listMatch, PREG_OFFSET_CAPTURE);
+        }
+        if ( 1 !== $hasListMatch ) {
             return array();
         }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1101,6 +1101,16 @@ final class HtmlTransformer
         if ( '' !== trim($authorCss) ) {
             $cssParts[] = $authorCss;
         }
+        if ( str_contains($serializedBlocks, 'blocks-engine-list-navigation') ) {
+            // The source mobile menu hides its desktop list container. Core
+            // navigation owns that responsive swap now, so keep the block host
+            // visible and let core hide only its responsive inner container.
+            $cssParts[] = '.wp-block-navigation.blocks-engine-list-navigation{display:flex!important}';
+            $mobileOverlayBackground = $this->sourceMobileNavigationOverlayBackground();
+            if ( '' !== $mobileOverlayBackground ) {
+                $cssParts[] = '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation__responsive-container.is-menu-open{background:' . $mobileOverlayBackground . '!important}';
+            }
+        }
         if ( array() !== $this->nativeButtonStyleRules ) {
             $cssParts[] = implode("\n", $this->nativeButtonStyleRules);
         }
@@ -1136,6 +1146,25 @@ final class HtmlTransformer
             'hash'        => $hash,
             'source_hash' => $hash,
         );
+    }
+
+    private function sourceMobileNavigationOverlayBackground(): string
+    {
+        $background = '';
+        foreach ( array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule ) {
+            $selector = strtolower((string) ($rule['selector'] ?? ''));
+            if ( ! str_contains($selector, 'nav') || ! preg_match('/(?:^|[^a-z0-9])(?:mobile|drawer|offcanvas|overlay|menu-panel|nav-panel)(?:[^a-z0-9]|$)/', $selector) ) {
+                continue;
+            }
+
+            $declarations = is_array($rule['declarations'] ?? null) ? $rule['declarations'] : array();
+            $candidate = trim((string) ($declarations['background-color'] ?? $declarations['background'] ?? ''));
+            if ( '' !== $candidate && ! in_array(strtolower($candidate), array( 'none', 'transparent', 'inherit', 'initial', 'unset' ), true) ) {
+                $background = $candidate;
+            }
+        }
+
+        return $background;
     }
 
     private function richTextMarkerResetCss(): string

--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -730,6 +730,7 @@ final class FontMaterializationPlanBuilder
 
     private function normalizeFamily(string $family): string
     {
+        $family = preg_replace('/\s*!important\s*$/i', '', $family) ?? $family;
         return trim($family, " \t\n\r\0\x0B\"'");
     }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2613,7 +2613,7 @@ $artifactNavStructureCss = $compiler->compile(
         'entry' => 'index.html',
         'files' => array(
             'index.html' => '<!doctype html><html><head><link rel="stylesheet" href="styles.css"></head><body class="menu-ready"><header><nav class="desktop-nav"><ul class="site-menu"><li><a href="#one">One</a></li></ul></nav></header></body></html>',
-            'styles.css' => '@media screen and (min-width:1025px){body.menu-ready .desktop-nav ul.site-menu{visibility:hidden;opacity:0}body.menu-ready .desktop-nav ul.site-menu.visible{visibility:visible;opacity:1}body.menu-ready .desktop-nav/* menu, desktop */ ul.site-menu>li{display:flex;align-items:center;margin-right:30px}body.menu-ready .desktop-nav ul.site-menu>li a{font-family:Montserrat,sans-serif;font-size:16px;color:#000;text-transform:lowercase;padding-bottom:7px}.nav\\,alternate ul.site-menu>li{gap:4px}.desktop-nav ul.site-menu:has([data-kind="/* promoted */"])>li{order:2}}',
+            'styles.css' => '.desktop-nav li{float:left}@media(max-width:700px){.site-menu{display:none!important}}@media screen and (min-width:1025px){body.menu-ready .desktop-nav ul.site-menu{visibility:hidden;opacity:0}body.menu-ready .desktop-nav ul.site-menu.visible{visibility:visible;opacity:1}body.menu-ready .desktop-nav/* menu, desktop */ ul.site-menu>li{display:flex;align-items:center;margin-right:30px}body.menu-ready .desktop-nav ul.site-menu>li a{font-family:Montserrat,sans-serif;font-size:16px;color:#000;text-transform:lowercase;padding-bottom:7px}.nav\\,alternate ul.site-menu>li{gap:4px}.desktop-nav ul.site-menu:has([data-kind="/* promoted */"])>li{order:2}}',
         ),
     )
 )->toArray();
@@ -2627,9 +2627,24 @@ $assert(str_contains($artifactNavStructureStaticCss, '.nav\\,alternate.site-menu
 $assert(str_contains($artifactNavStructureStaticCss, '[data-kind="/* promoted */"]') && str_contains($artifactNavStructureStaticCss, 'order:2'), 'artifact navigation projection preserves comment-like text inside quoted selector values');
 $artifactNavStructureCompatOffset = strpos($artifactNavStructureStaticCss, 'wp-compat: project source list navigation structure');
 $artifactNavStructureCompatCss = false === $artifactNavStructureCompatOffset ? '' : substr($artifactNavStructureStaticCss, $artifactNavStructureCompatOffset);
+$artifactNavStructureAssetCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $artifactNavStructureCss['assets'] ?? array()));
 $assert(str_contains($artifactNavStructureStaticCss, '.wp-block-navigation__container>.wp-block-navigation-item') && ! str_contains($artifactNavStructureCompatCss, 'blocks-engine-source-li-'), 'artifact navigation projection replaces non-serialized source list markers with core navigation item selectors');
+$assert(str_contains($artifactNavStructureCompatCss, '.desktop-nav.wp-block-navigation .wp-block-navigation__container .wp-block-navigation-item { float:left }'), 'artifact navigation projection maps classed navigation ancestor item selectors onto core navigation structure', $artifactNavStructureCompatCss);
+$assert(str_contains($artifactNavStructureAssetCss, '.wp-block-navigation.blocks-engine-list-navigation{display:flex!important}'), 'list navigation keeps the core responsive host visible when source mobile CSS hides its legacy menu container', $artifactNavStructureAssetCss);
 $assert(! str_contains($artifactNavStructureCompatCss, '.wp-block-navigation__container { visibility:hidden }'), 'artifact navigation projection leaves script-driven list container visibility to core navigation');
 $assert(str_contains($artifactNavStructureCompatCss, '.menu-ready .desktop-nav.site-menu.wp-block-navigation .wp-block-navigation__container { visibility:visible;opacity:1 }'), 'artifact navigation projection materializes the source list stable visible state for core navigation', $artifactNavStructureCompatCss);
+
+$artifactMobileNavOverlay = $compiler->compile(
+    array(
+        'entry' => 'index.html',
+        'files' => array(
+            'index.html' => '<!doctype html><html><head><link rel="stylesheet" href="styles.css"></head><body><nav class="desktop-nav"><ul><li><a href="/">Home</a></li><li><a href="/about">About</a></li></ul></nav><div class="mobile-nav"><nav><ul><li><a href="/">Home</a></li><li><a href="/about">About</a></li></ul></nav></div></body></html>',
+            'styles.css' => '.desktop-nav a{color:#fff}@media(max-width:700px){.desktop-nav{display:none}.mobile-nav{background:rgba(0,0,0,.9)}}',
+        ),
+    )
+)->toArray();
+$artifactMobileNavOverlayAssetCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $artifactMobileNavOverlay['assets'] ?? array()));
+$assert(str_contains($artifactMobileNavOverlayAssetCss, '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation__responsive-container.is-menu-open{background:rgba(0,0,0,.9)!important}'), 'deduplicated mobile navigation projects its authored background authoritatively over the core overlay default', $artifactMobileNavOverlayAssetCss);
 
 $artifactHeaderRuntimeCss = $compiler->compile(
     array(
@@ -3328,6 +3343,9 @@ $assert(array(400, 500, 600, 700) === ($webFontPlan['fonts'][1]['weights'] ?? nu
 $assert('Oswald' === ($webFontPlan['roles']['heading'] ?? null), 'web-font detection maps heading typeface from font-family declaration');
 $assert('Inter' === ($webFontPlan['roles']['body'] ?? null), 'web-font detection maps body typeface from font-family declaration');
 $assert('@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Oswald:wght@400;500;600;700&display=swap");' === ($webFontPlan['css'] ?? null), 'web-font detection materializes deterministic google fonts css');
+$importantWebFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources('', 'body{font-family:"Poppins",sans-serif}h2{font-family:"Quicksand" !important}.menu{font-family:"Muli" !IMPORTANT}');
+$assert(array('Muli', 'Poppins', 'Quicksand') === array_column($importantWebFontPlan['fonts'] ?? array(), 'family'), 'web-font detection strips CSS important priority from family names');
+$assert(array('heading' => 'Quicksand', 'body' => 'Poppins') === ($importantWebFontPlan['roles'] ?? null), 'web-font role discovery strips CSS important priority from family names');
 
 $importedWebFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
     '',

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -289,16 +289,18 @@ $directNestedList = ( new HtmlTransformer() )->transform('<ol><li>Stage<ul><li>L
 $assert(2 === count($findBlocks($directNestedList['blocks'] ?? array(), 'core/list')) && 2 === count($findBlocks($directNestedList['blocks'] ?? array(), 'core/list-item')), 'direct-child nested lists continue to serialize as native nested list blocks');
 
 $nativeTable = ( new ArtifactCompiler() )->compile(array(
+    'entrypoint' => 'website/index.html',
     'files' => array(
-        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="table.css"><main><table><thead><tr><th>Layer</th><th>Owns</th></tr></thead><tbody><tr><th>Blocks Engine</th><td>Compilation</td></tr><tr><th>Importer</th><td><div class="paragraph">Materialization</div></td></tr></tbody></table></main>' ),
-        array( 'path' => 'table.css', 'kind' => 'css', 'content' => 'th,td{padding:1.35rem 1rem;vertical-align:top}thead th{font-size:.66rem;text-transform:uppercase}tbody th{width:22%;font-size:.9rem}tbody td{width:39%;color:#4c5851;font-size:.86rem}div.paragraph{padding-bottom:20px}' ),
+        array( 'path' => 'website/index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="/table.css"><main><table><thead><tr><th>Layer</th><th>Owns</th></tr></thead><tbody><tr><th>Blocks Engine</th><td class="stack-cell">Compilation</td></tr><tr><th>Importer</th><td class="stack-cell"><div class="paragraph">Materialization</div></td></tr></tbody></table></main>' ),
+        array( 'path' => 'website/table.css', 'kind' => 'css', 'content' => 'th,td{padding:1.35rem 1rem;vertical-align:top}thead th{font-size:.66rem;text-transform:uppercase}tbody th{width:22%;font-size:.9rem}tbody td{width:39%;color:#4c5851;font-size:.86rem}div.paragraph{padding-bottom:20px}@media(max-width:600px){td.stack-cell{display:block;width:100%;padding:10px 0}}' ),
     ),
 ) )->toArray();
 $nativeTableMarkup = (string) ($nativeTable['serialized_blocks'] ?? '');
-$nativeTableCss = implode("\n", array_column(array_filter($nativeTable['assets'] ?? array(), static fn (array $asset): bool => 'table.css' === ($asset['path'] ?? '')), 'content'));
+$nativeTableCss = implode("\n", array_column(array_filter($nativeTable['assets'] ?? array(), static fn (array $asset): bool => 'website/table.css' === ($asset['path'] ?? '')), 'content'));
 $assert(preg_match('/<figure class="wp-block-table (blocks-engine-table-[^"]+)"><table/', $nativeTableMarkup, $nativeTableMarker) === 1 && str_contains($nativeTableMarkup, '<!-- wp:table'), 'external table stylesheet retains a native core/table with an isolated projection marker');
 $assert(str_contains($nativeTableCss, '.' . ($nativeTableMarker[1] ?? '') . '>table>thead>tr:nth-child(1)>th:nth-child(1):not(blocks-engine-specificity-') && str_contains($nativeTableCss, '.' . ($nativeTableMarker[1] ?? '') . '>table>tbody>tr:nth-child(1)>td:nth-child(2):not(blocks-engine-specificity-') && ! str_contains($nativeTableCss, ':where(.' . ($nativeTableMarker[1] ?? '') . '>table>') && str_contains($nativeTableCss, 'padding:1.35rem 1rem'), 'direct th and td selectors use an isolated table class and exact path that beats .wp-block-table td/th defaults');
 $assert(str_contains($nativeTableCss, 'font-size:.66rem') && str_contains($nativeTableCss, 'width:22%') && str_contains($nativeTableCss, 'width:39%'), 'thead and tbody cell selectors retain their external stylesheet presentation');
+$assert(str_contains($nativeTableCss, '@media(max-width:600px)') && str_contains($nativeTableCss, '.' . ($nativeTableMarker[1] ?? '') . '>table>tbody>tr:nth-child(1)>td:nth-child(2)') && str_contains($nativeTableCss, 'display:block;width:100%;padding:10px 0'), 'external responsive cell selectors project through the isolated native table marker');
 $assert(preg_match('/<div class="paragraph (blocks-engine-source-div-[^"]+)">Materialization<\/div>/', $nativeTableMarkup, $nativeTableDescendantMarker) === 1 && str_contains($nativeTableCss, ':where(.' . ($nativeTableDescendantMarker[1] ?? '') . ')') && str_contains($nativeTableCss, 'padding-bottom:20px'), 'preserved table-cell descendants retain source-tag selector markers');
 $assert('pass' === ( new Runtime() )->validateBlockSerialization($nativeTableMarkup)['status'], 'projected artifact table markup remains editor-valid');
 


### PR DESCRIPTION
## Summary

- resolve root-relative stylesheets against their packaged artifact root
- project authored navigation structure and responsive host behavior onto core navigation blocks
- preserve authored mobile overlay backgrounds and responsive table descendant styles
- normalize `!important` priority out of discovered font family names

Related integration: Automattic/studio#3952

## Verification

- `cd php-transformer && composer test`
- all canonical contracts and unit suites passed
- 275 parity fixtures passed
- package installation proof passed
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode investigated artifact fidelity failures, implemented the stylesheet and responsive projection fixes, added contract coverage, and ran verification. Chris Huber reviewed and owns every line.