### PR TITLE
Preserve ARIA required form semantics

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -10664,7 +10664,7 @@ final class HtmlTransformer
             }
         }
 
-        if ( $control->hasAttribute('required') ) {
+        if ( $control->hasAttribute('required') || 'true' === strtolower(trim($this->attr($control, 'aria-required'))) ) {
             $metadata['required'] = true;
         }
         if ( $control->hasAttribute('disabled') ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -627,6 +627,10 @@ $assert('/contact' === ($formFallback['source_reports']['interaction_candidates'
 $formRuntimeIslands = array_values(array_filter($formFallback['source_reports']['runtime_islands'] ?? array(), static fn (array $island): bool => 'form' === ($island['kind'] ?? '')));
 $assert(1 === count($formRuntimeIslands), 'data-entry form preservation reports a form runtime island');
 $assert('server_or_client_form_handler' === ($formRuntimeIslands[0]['runtime_requirement'] ?? ''), 'form runtime island carries the server/client form-handler requirement');
+$requiredFormPlan = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><form><input name="email" required><textarea name="message" aria-required="true"></textarea><button type="submit">Send</button></form></main>')))->toArray();
+$requiredFormDeclarations = array_values(array_filter($requiredFormPlan['source_reports']['wordpress_site_plan']['runtime_declarations'] ?? array(), static fn (array $declaration): bool => 'forms' === ($declaration['type'] ?? null)));
+$requiredFormControls = $requiredFormDeclarations[0]['payload']['entities'][0]['controls'] ?? array();
+$assert(true === ($requiredFormControls[0]['required'] ?? null) && true === ($requiredFormControls[1]['required'] ?? null), 'generic form declarations normalize native and ARIA required semantics through artifact compilation');
 $boundedTopologyHtml = static function (int $extraControls): string {
     $controls = '';
     for ( $index = 0; $index < 63; ++$index ) $controls .= '<div><input name="field-' . $index . '"></div>';


### PR DESCRIPTION
## Summary

- normalize `aria-required="true"` to the provider-neutral `required: true` form control semantic
- preserve native `required` behavior unchanged
- prove both representations survive through artifact compilation into `generic/forms/v1`

Fixes #880.

## Testing

- `composer test` in `php-transformer/`
- PHP syntax checks for the changed transformer and contract test
- `git diff --check`

## Runtime evidence

This closes a real provider-materialization gap: source form HTML retained `aria-required="true"`, but the compiled generic form declaration omitted required state, causing generated Jetpack fields to render as optional.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to trace the cross-repository runtime evidence, implement the normalized semantic, and add contract coverage. Chris Huber reviewed and is responsible for every line.