### PR TITLE
Preserve inline display overrides through the geometry carrier

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -79,6 +79,7 @@
       "php tests/unit/author-selector-semantics.php",
       "php tests/unit/engine-support-css-asset.php",
       "php tests/unit/engine-support-css-specificity.php",
+      "php tests/unit/inline-display-carrier.php",
       "php tests/unit/artifact-author-stylesheet-projection.php",
       "php tests/unit/fallback-finding-normalizer.php",
       "php tests/unit/navigation-underline-color-resolver.php",

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -65,9 +65,24 @@ trait StyleResolutionTrait
     /**
      * @return list<string>
      */
-    private function inlineGeometryProperties(): array
+    private function inlineLayoutCarrierProperties(): array
     {
         return array(
+            'display',
+            'flex-direction',
+            'flex-wrap',
+            'align-items',
+            'justify-content',
+            'gap',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function inlineGeometryProperties(): array
+    {
+        return array_merge($this->inlineLayoutCarrierProperties(), array(
             'width',
             'height',
             'min-width',
@@ -79,7 +94,7 @@ trait StyleResolutionTrait
             'flex-basis',
             'object-fit',
             'object-position',
-        );
+        ));
     }
 
     /**
@@ -337,6 +352,17 @@ trait StyleResolutionTrait
             : $this->cssDeclarations($this->attr($element, 'style'));
         $geometry = array();
         $properties = $this->inlineGeometryProperties();
+        if ( $this->inlineDisplayOverridesAuthorLayout($element, $declarations) ) {
+            $inlineDisplay = strtolower(trim((string) preg_replace('/\s*!\s*important\s*$/i', '', (string) ($declarations['display'] ?? ''))));
+            if ( ! in_array($inlineDisplay, array( 'flex', 'inline-flex' ), true) ) {
+                $properties = array_values(array_diff(
+                    $properties,
+                    array( 'flex-direction', 'flex-wrap', 'align-items', 'justify-content', 'gap' )
+                ));
+            }
+        } else {
+            $properties = array_values(array_diff($properties, $this->inlineLayoutCarrierProperties()));
+        }
         $inlineBackground = (string) ($declarations['background'] ?? $declarations['background-image'] ?? '');
         if ( preg_match('/\burl\s*\(/i', $inlineBackground)
             && ( 0 < $this->directElementChildCount($element) || '' !== trim((string) $element->textContent) )
@@ -367,25 +393,93 @@ trait StyleResolutionTrait
             return '';
         }
 
-        // Emit carried declarations in source order: with per-declaration
-        // !important, last-write-wins is decided by rule order, and an
-        // alphabetical sort silently flips shorthand/longhand winners
-        // (grid vs grid-template-columns, gap vs column-gap). Values not
-        // present inline (forced/custom-property fallbacks) sort last.
+        // Emit carried declarations in source order. For declarations sharing
+        // a priority tier, last-write-wins is decided by rule order, and an
+        // alphabetical sort silently flips shorthand/longhand winners (grid vs
+        // grid-template-columns, gap vs column-gap). Values not present inline
+        // (forced/custom-property fallbacks) sort last.
         $sourceOrder = array_flip(array_keys($declarations));
         uksort($geometry, static fn (string $a, string $b): int => (($sourceOrder[$a] ?? PHP_INT_MAX) <=> ($sourceOrder[$b] ?? PHP_INT_MAX)) ?: strcmp($a, $b));
-        $declarations = array();
+        $layoutDeclarations = array();
+        $importantDeclarations = array();
+        $forcedPropertyLookup = array_fill_keys($forcedProperties, true);
+        $inlineLayoutPropertyLookup = array_fill_keys($this->inlineLayoutCarrierProperties(), true);
         foreach ($geometry as $property => $value) {
+            if ( isset($inlineLayoutPropertyLookup[$property]) && ! isset($forcedPropertyLookup[$property]) ) {
+                // Preserve source inline layout over a later plain author class
+                // without preventing an authored !important declaration from
+                // retaining its normal cascade priority.
+                $layoutDeclarations[] = $property . ':' . $value;
+                continue;
+            }
+
             // A converted inline declaration must continue to outrank authored
             // normal selectors, including ID selectors. Authored !important
             // rules retain their normal cascade priority through specificity.
-            $declarations[] = $property . ':' . $value . ' !important';
+            $importantDeclarations[] = $property . ':' . $value . ' !important';
         }
-        $rule = implode(';', $declarations);
-        $className = ($this->geometryCarrierClassAllocator ??= new GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $rule);
-        $this->generatedGeometryRules[$className] = '.' . $className . '{' . $rule . '}';
+        $signature = implode(';', array_merge($layoutDeclarations, $importantDeclarations));
+        $className = ($this->geometryCarrierClassAllocator ??= new GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $signature);
+        $rules = array();
+        if ( array() !== $layoutDeclarations ) {
+            $rules[] = ':root .' . $className . '{' . implode(';', $layoutDeclarations) . '}';
+        }
+        if ( array() !== $importantDeclarations ) {
+            $rules[] = '.' . $className . '{' . implode(';', $importantDeclarations) . '}';
+        }
+        $this->generatedGeometryRules[$className] = implode("\n", $rules);
 
         return $className;
+    }
+
+    /**
+     * An inline display needs a carrier only when materialized author CSS would
+     * otherwise reassert a different layout mode on the transformed element.
+     * Conditional variants count because the inline declaration owns every
+     * viewport in the source document.
+     *
+     * @param array<string, string> $inlineDeclarations
+     */
+    private function inlineDisplayOverridesAuthorLayout(DOMElement $element, array $inlineDeclarations): bool
+    {
+        $inlineDisplay = strtolower(trim((string) preg_replace(
+            '/\s*!\s*important\s*$/i',
+            '',
+            (string) ($inlineDeclarations['display'] ?? '')
+        )));
+        if ( '' === $inlineDisplay ) {
+            return false;
+        }
+
+        foreach ( $this->staticStyleRules as $rule ) {
+            if ( ! $this->matchesCssSelector($element, $rule['selector']) ) {
+                continue;
+            }
+            $authorDisplay = strtolower(trim((string) preg_replace(
+                '/\s*!\s*important\s*$/i',
+                '',
+                (string) ($rule['declarations']['display'] ?? '')
+            )));
+            if ( '' !== $authorDisplay && $inlineDisplay !== $authorDisplay ) {
+                return true;
+            }
+        }
+
+        foreach ( $this->conditionalStyleRules as $rule ) {
+            if ( ! $this->matchesCssSelector($element, $rule['selector']) ) {
+                continue;
+            }
+            $conditionalDisplay = strtolower(trim((string) preg_replace(
+                '/\s*!\s*important\s*$/i',
+                '',
+                (string) ($rule['declarations']['display'] ?? '')
+            )));
+            if ( '' !== $conditionalDisplay && $inlineDisplay !== $conditionalDisplay ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/tests/unit/inline-display-carrier.php
+++ b/php-transformer/tests/unit/inline-display-carrier.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Contract for inline display declarations which override class-owned layout.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = '') use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+/** @return array<int, array<string, mixed>> */
+$sourceAssets = static fn (array $result, string $source): array => array_values(array_filter(
+    is_array($result['assets'] ?? null) ? $result['assets'] : array(),
+    static fn (array $asset): bool => $source === ($asset['source'] ?? '')
+));
+
+$cssFor = static function (array $result, string $source) use ($sourceAssets): string {
+    return implode("\n", array_map(
+        static fn (array $asset): string => (string) ($asset['content'] ?? ''),
+        $sourceAssets($result, $source)
+    ));
+};
+
+/** @return array{int, int, int} */
+$specificity = static function (string $selector): array {
+    $ids = preg_match_all('/#[A-Za-z0-9_-]+/', $selector);
+    $classes = preg_match_all('/\.[A-Za-z0-9_-]+|\[[^\]]+\]|:(?!:)[A-Za-z0-9_-]+(?:\([^)]*\))?/', $selector);
+    $withoutWeightedTokens = preg_replace('/#[A-Za-z0-9_-]+|\.[A-Za-z0-9_-]+|\[[^\]]+\]|::?[A-Za-z0-9_-]+(?:\([^)]*\))?|[>+~*]/', ' ', $selector) ?? $selector;
+    $elements = preg_match_all('/(?:^|\s)([A-Za-z][A-Za-z0-9_-]*)/', $withoutWeightedTokens);
+
+    return array( (int) $ids, (int) $classes, (int) $elements );
+};
+
+$cases = array(
+    'block' => array(
+        'class' => 'display-owner-block',
+        'style' => 'display:block',
+        'declarations' => 'display:block',
+    ),
+    'inline-block' => array(
+        'class' => 'display-owner-inline-block',
+        'style' => 'display:inline-block',
+        'declarations' => 'display:inline-block',
+    ),
+    'flex' => array(
+        'class' => 'display-owner-flex',
+        'style' => 'display:flex;flex-direction:column;flex-wrap:wrap;align-items:center;justify-content:center;gap:2rem',
+        'declarations' => 'display:flex;flex-direction:column;flex-wrap:wrap;align-items:center;justify-content:center;gap:2rem',
+    ),
+);
+
+foreach ( $cases as $name => $case ) {
+    $className = $case['class'];
+    $html = '<style>.' . $className . '{display:grid;align-items:start;gap:3rem}</style>'
+        . '<div class="' . $className . '" style="' . $case['style'] . '"><p>First</p><p>Second</p></div>';
+    $result = ( new HtmlTransformer() )->transform($html, array())->toArray();
+    $serialized = (string) ($result['serialized_blocks'] ?? '');
+    $engineCss = $cssFor($result, 'engine-support');
+    $authorCss = $cssFor($result, 'author-css');
+    preg_match('/\b(be-inline-geometry-[a-f0-9-]+)\b/', $serialized, $carrierMatch);
+    $carrierClass = (string) ($carrierMatch[1] ?? '');
+    $selector = ':root .' . $carrierClass;
+    $expectedRule = $selector . '{' . $case['declarations'] . '}';
+    $ruleMatch = array();
+    if ( '' !== $carrierClass ) {
+        preg_match('/(' . preg_quote($selector, '/') . ')\{([^}]*)\}/', $engineCss, $ruleMatch);
+    }
+
+    $assert('core/group' === ($result['blocks'][0]['blockName'] ?? ''), $name . ': source wrapper remains a core/group', (string) ($result['blocks'][0]['blockName'] ?? '(none)'));
+    $assert(str_contains($serialized, $className), $name . ': transformed markup retains the class whose grid declaration is being neutralized', $serialized);
+    $assert(str_contains($authorCss, '.' . $className . '{display:grid'), $name . ': author CSS retains the competing class-owned display:grid rule', $authorCss);
+    $assert('' !== $carrierClass, $name . ': transformed markup receives a geometry carrier class', $serialized);
+    $assert(str_contains($engineCss, $expectedRule), $name . ': engine-support carries the complete inline layout override', $engineCss);
+    $assert(1 !== preg_match('/be-inline-geometry-[a-f0-9-]+/', $authorCss), $name . ': generated carrier rule does not leak into author-css', $authorCss);
+    $assert(array( 0, 2, 0 ) === $specificity((string) ($ruleMatch[1] ?? '')), $name . ': carrier selector has specificity (0,2,0)', (string) ($ruleMatch[1] ?? '(missing)'));
+    $assert('' !== (string) ($ruleMatch[2] ?? '') && ! str_contains((string) $ruleMatch[2], '!important'), $name . ': inline layout carrier rule does not use !important', (string) ($ruleMatch[2] ?? '(missing)'));
+}
+
+$gridResult = ( new HtmlTransformer() )->transform(
+    '<section class="source-grid" style="display:grid;grid-template-columns:260px 1fr;align-items:center;justify-content:space-between;gap:32px"><div>Rail</div><div>Body</div></section>',
+    array()
+)->toArray();
+$gridSerialized = (string) ($gridResult['serialized_blocks'] ?? '');
+$gridCss = $cssFor($gridResult, 'engine-support');
+preg_match('/\b(be-inline-geometry-[a-f0-9-]+)\b/', $gridSerialized, $gridCarrierMatch);
+$gridCarrier = (string) ($gridCarrierMatch[1] ?? '');
+$gridRule = '.' . $gridCarrier . '{display:grid !important;grid-template-columns:260px 1fr !important;align-items:center !important;justify-content:space-between !important;gap:32px !important}';
+
+$assert(str_contains($gridSerialized, 'blocks-engine-css-owned-grid') && '' !== $gridCarrier, 'grid control: legitimate inline grid remains on the existing css-owned-grid carrier path', $gridSerialized);
+$assert(str_contains($gridCss, $gridRule), 'grid control: existing grid display and companion declaration bytes remain unchanged', $gridCss);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Inline display carrier contract: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "Inline display carrier contract passed: {$passes} assertions\n");

--- a/php-transformer/tests/unit/inline-display-carrier.php
+++ b/php-transformer/tests/unit/inline-display-carrier.php
@@ -61,11 +61,17 @@ $cases = array(
         'style' => 'display:flex;flex-direction:column;flex-wrap:wrap;align-items:center;justify-content:center;gap:2rem',
         'declarations' => 'display:flex;flex-direction:column;flex-wrap:wrap;align-items:center;justify-content:center;gap:2rem',
     ),
+    'mixed-specificity' => array(
+        'class' => 'display-owner-specificity',
+        'style' => 'display:block',
+        'declarations' => 'display:block',
+        'following_css' => 'div{display:block}',
+    ),
 );
 
 foreach ( $cases as $name => $case ) {
     $className = $case['class'];
-    $html = '<style>.' . $className . '{display:grid;align-items:start;gap:3rem}</style>'
+    $html = '<style>.' . $className . '{display:grid;align-items:start;gap:3rem}' . ($case['following_css'] ?? '') . '</style>'
         . '<div class="' . $className . '" style="' . $case['style'] . '"><p>First</p><p>Second</p></div>';
     $result = ( new HtmlTransformer() )->transform($html, array())->toArray();
     $serialized = (string) ($result['serialized_blocks'] ?? '');


### PR DESCRIPTION
An inline `display` declaration is silently dropped, so a `style="display:block"` written to
neutralize a class-provided grid disappears and the grid applies unopposed.

## The defect

`StyleResolutionTrait::inlineGeometryProperties()` is the allowlist of inline-style declarations
preserved onto a generated `be-inline-geometry-*` carrier class. It was sizing-only:

```
width, height, min-width, min-height, max-width, max-height,
aspect-ratio, box-sizing, flex-basis, object-fit, object-position
```

`display` is absent, so an inline `display` has no carrier and is dropped.
`HtmlTransformer::CSS_OWNED_GRID_CARRIER_PROPERTIES` does include `display`, but that path only fires
when the element IS a css-owned grid or flex container. It never fires for a `display:block` whose
entire purpose is to TURN OFF a grid the element inherits from a class rule.

### Why it matters

A consumer that generates HTML with reusable classes commonly re-purposes a layout container by
neutralizing it inline:

```html
<div class="hero-inner" style="display:block">
```

which transformed to:

```html
<div class="wp-block-group alignwide hero-inner"
     style="margin-top:0;margin-right:auto;margin-bottom:0;margin-left:auto">
```

The class survives, the neutralizing `display` does not, so `.hero-inner{display:grid;
align-items:center}` applies with nothing opposing it and every child becomes a grid item. In one
real page that single dropped declaration produced four separate visible defects: a pill stretched
to fill its track, an `<h2>` pushed into grid column 2, a heading taking the wrong track's scale, and
three cards sitting side by side instead of stacked full width.

Occurrences of inline `display` across seven real generated sites: 52, 46, 10, 6, 2, 0, 0. The two
sites at zero were the only two with no layout complaint.

## What changed

`display` and its layout companions are carried through the existing geometry-carrier mechanism, via
a new `inlineLayoutCarrierProperties()` list merged into `inlineGeometryProperties()`.

Two things keep it narrow:

- The flex companions (`flex-direction`, `flex-wrap`, `align-items`, `justify-content`, `gap`) ride
  along only when the inline `display` is `flex`/`inline-flex`. A plain `display:block` carries
  `display` alone.
- Layout properties are carried only when the inline declaration actually overrides author layout;
  otherwise they are dropped as before.

Carried layout declarations emit as their own rule at specificity **(0,2,0)**:

```css
:root .be-inline-geometry-<hash>{display:block}
```

That beats a plain class selector like `.hero-inner` (0,1,0) so the neutralization wins, and it uses
**no `!important`** — an authored `!important` keeps its normal cascade priority. Pre-existing
geometry properties keep their separate `!important` rule at (0,1,0) exactly as before.

## Verification

- `test:parity` — **275 fixtures passed**, 0 failed
- Full canonical + unit suites — 0 failures
- **`static-parity` output is byte-identical to trunk** (`diff` clean across all 87 fixtures). This
  change alters no static-site output, which is expected: the conflict it resolves only exists in a
  WordPress layout context. It also confirms the pre-existing `fail` rows in that matrix are not
  introduced here.
- No parity fixture JSON was modified.
- Confirmed end-to-end on a real consumer build: the pill shrink-wraps, the heading returns to the
  left column, and the cards stack full width, matching the source design.
