### PR TITLE
Pair navigation menus once before folding carried items

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -49,8 +49,21 @@ final class SemanticParityReporter
         $sourceLandmarks = $this->sourceLandmarkReport($body);
         $blockLandmarks = $this->blockLandmarkReport($blocks, $sourceProvenance, $sourceLandmarks);
         $sourceMenus = $this->sourceNavigationMenus($body);
-        $blockMenus = $this->withCarriedItemsResolved($this->blockNavigationMenus($blocks), $sourceMenus);
-        $findings = $this->semanticParityFindings($sourceLandmarks, $blockLandmarks, $sourceMenus, $blockMenus);
+        $blockMenus = $this->blockNavigationMenus($blocks);
+        // Pair the two sides ONCE, before the carrier fold, and hand the same
+        // pairing to both the fold and the comparison. Pairing after the fold
+        // would be circular: the fold needs its paired source menu to decide
+        // whether to run, so a pairing derived from folded items could hand the
+        // fold a different menu than the comparison later reads.
+        $menuPairing = $this->sourceToBlockMenuPairing($sourceMenus, $blockMenus);
+        $blockMenus = $this->withCarriedItemsResolved($blockMenus, $sourceMenus, $menuPairing);
+        $findings = $this->semanticParityFindings($sourceLandmarks, $blockLandmarks, $sourceMenus, $blockMenus, $menuPairing);
+        // `excludes_outside_anchors` decides the carrier fold above; it is an
+        // internal aid, not part of the published `semantic-parity/v1` payload,
+        // so drop it the way the block side's `carried_sibling_items` is dropped.
+        foreach ( $sourceMenus as $index => $_sourceMenu ) {
+            unset($sourceMenus[$index]['excludes_outside_anchors']);
+        }
         $findings = array_merge(
             $findings,
             ( new TypographyParityAnalyzer() )->findings($html, $staticCss, $this->inlineHeadingFontDeclarations($body))
@@ -90,15 +103,26 @@ final class SemanticParityReporter
      *
      * @param array<int, array<string, mixed>> $blockMenus
      * @param array<int, array<string, mixed>> $sourceMenus
+     * @param array<int, int|null> $menuPairing source menu index => block menu index
      * @return array<int, array<string, mixed>>
      */
-    private function withCarriedItemsResolved(array $blockMenus, array $sourceMenus): array
+    private function withCarriedItemsResolved(array $blockMenus, array $sourceMenus, array $menuPairing): array
     {
+        $sourceIndexes = array();
+        foreach ( $menuPairing as $sourceIndex => $blockIndex ) {
+            if ( null !== $blockIndex ) {
+                $sourceIndexes[$blockIndex] = $sourceIndex;
+            }
+        }
+
         foreach ( $blockMenus as $index => $blockMenu ) {
             $carried = is_array($blockMenu['carried_sibling_items'] ?? null) ? $blockMenu['carried_sibling_items'] : array();
             unset($blockMenus[$index]['carried_sibling_items']);
 
-            if ( array() === $carried || true === ($sourceMenus[$index]['excludes_outside_anchors'] ?? false) ) {
+            // Read the flag from the source menu this block menu is actually
+            // compared against, not from the one sharing its position.
+            $pairedSource = isset($sourceIndexes[$index]) ? ( $sourceMenus[$sourceIndexes[$index]] ?? array() ) : array();
+            if ( array() === $carried || true === ($pairedSource['excludes_outside_anchors'] ?? false) ) {
                 continue;
             }
 
@@ -723,9 +747,10 @@ final class SemanticParityReporter
      * @param array{counts: array<string, int>, selectors: array<string, array<int, string>>} $blockLandmarks
      * @param array<int, array<string, mixed>> $sourceMenus
      * @param array<int, array<string, mixed>> $blockMenus
+     * @param array<int, int|null> $menuPairing source menu index => block menu index
      * @return array<int, array<string, mixed>>
      */
-    private function semanticParityFindings(array $sourceLandmarks, array $blockLandmarks, array $sourceMenus, array $blockMenus): array
+    private function semanticParityFindings(array $sourceLandmarks, array $blockLandmarks, array $sourceMenus, array $blockMenus, array $menuPairing): array
     {
         $findings = array();
         foreach ( array( 'header', 'nav', 'main', 'footer' ) as $kind ) {
@@ -744,13 +769,9 @@ final class SemanticParityReporter
             }
         }
 
-        $matchedBlockMenuIndexes = array();
         foreach ( $sourceMenus as $index => $sourceMenu ) {
-            $blockMenuIndex = $this->matchingBlockNavigationMenuIndex($sourceMenu, $blockMenus, $matchedBlockMenuIndexes, $index);
+            $blockMenuIndex = $menuPairing[$index] ?? null;
             $blockMenu = null === $blockMenuIndex ? null : ( $blockMenus[$blockMenuIndex] ?? null );
-            if ( null !== $blockMenuIndex ) {
-                $matchedBlockMenuIndexes[$blockMenuIndex] = true;
-            }
             if ( ! is_array($blockMenu) ) {
                 $sourceItems = is_array($sourceMenu['items'] ?? null) ? array_values($sourceMenu['items']) : array();
                 $findings[] = array(
@@ -990,9 +1011,34 @@ final class SemanticParityReporter
     }
 
     /**
+     * Claim one block menu per source menu, in source order. Computed once and
+     * shared by every consumer so a menu is never folded against one source
+     * record and then compared against another.
+     *
+     * @param array<int, array<string, mixed>> $sourceMenus
+     * @param array<int, array<string, mixed>> $blockMenus
+     * @return array<int, int|null> source menu index => block menu index
+     */
+    private function sourceToBlockMenuPairing(array $sourceMenus, array $blockMenus): array
+    {
+        $pairing = array();
+        $matchedBlockMenuIndexes = array();
+        foreach ( $sourceMenus as $index => $sourceMenu ) {
+            $blockMenuIndex = $this->matchingBlockNavigationMenuIndex($sourceMenu, $blockMenus, $matchedBlockMenuIndexes, $index);
+            if ( null !== $blockMenuIndex ) {
+                $matchedBlockMenuIndexes[$blockMenuIndex] = true;
+            }
+
+            $pairing[$index] = $blockMenuIndex;
+        }
+
+        return $pairing;
+    }
+
+    /**
      * @param array<string, mixed> $sourceMenu
      * @param array<int, array<string, mixed>> $blockMenus
-     * @param array<int, bool> $matchedBlockMenuIndexes
+     * @param array<int, true> $matchedBlockMenuIndexes
      */
     private function matchingBlockNavigationMenuIndex(array $sourceMenu, array $blockMenus, array $matchedBlockMenuIndexes, int $fallbackIndex): ?int
     {


### PR DESCRIPTION
## What

Follow-up to #887, from reviewing that branch after it landed. Two defects in the carried-item accounting it introduced.

**One relationship, two answers.** The carried-item fold decided whether to run by reading `excludes_outside_anchors` from the source menu sharing its **positional index**. The comparison that consumes the folded record pairs menus through `matchingBlockNavigationMenuIndex()` — item signature first, position only as a fallback. Where those disagree, the fold consults a menu it is not compared against, and the result is a false `navigation_item_count_mismatch`: either a carrier's hoisted links are added against a source menu that deliberately excludes them, or a hoisted brand goes uncounted.

The pairing was also circular. It could be derived from folded items, while the fold itself needed the pairing to decide whether to fold at all.

**An internal flag in a versioned payload.** `excludes_outside_anchors` exists only to drive that decision, but it was published on every source menu record under `blocks-engine/php-transformer/semantic-parity/v1`, while the block side's equivalent internal key, `carried_sibling_items`, was already stripped before publication. One of the two was hidden; the other was not.

## Reachability — read this before weighing the first defect

No document in the fixture corpus makes the two pairings diverge. Reaching it needs either a source menu with no block counterpart, or block menus emitted out of document order; no fixture exhibits `navigation_menu_missing`, and every shape I could construct kept the two orders aligned. So this removes a latent wrong-answer path in a diagnostic that gates promotion — it is not a fix for an observed failure. It is worth doing because the diagnostic's job is to be trusted when it disagrees with the source.

## How

- `sourceToBlockMenuPairing()` claims one block menu per source menu, in source order, using the existing matcher. `report()` calls it **once**, before the fold.
- `withCarriedItemsResolved()` takes that map, inverts it, and reads the flag from the source menu each block menu is actually compared against.
- `semanticParityFindings()` consumes the shared pairing instead of re-deriving one.
- Because the pairing is computed from **unfolded** block items, a carrier falls to the positional fallback exactly as it did before the fold existed — the pre-#887 pairing behaviour, now stated explicitly instead of emerging from ordering.
- `excludes_outside_anchors` is dropped from every source menu record after the fold, symmetric with `carried_sibling_items`.

## Tests

No new fixtures. This changes how an existing decision is routed, not what any supported shape produces, and both defects are invisible to the corpus by construction — the pairing one because no fixture diverges, the payload one because no fixture pinned the leaked key.

Verified against this branch's base:

- `php tests/parity/run.php` — 278 fixtures pass
- `php tests/contract/run.php` — pass
- `composer test:unit` — exit 0
- `php tests/unit/navigation-brand-anchor-hoist.php` — 27 assertions pass

Behaviour pinned by hand probe on both the carrier fold and the two fold-skip shapes (a landmark bearing mobile chrome, and one holding a brand and a CTA beside its list): identical item lists, identical `pass` status, and no internal keys in the payload, before and after.

## Not addressed here

Reviewing #887 also surfaced that `readsAsBrandAnchor()` accepts a much weaker brand cue than intended — any element child qualifies, including a `<br>` or an `<svg>`, and brand/logo tokens match inside `aria-label` and `title` prose. A menu item outside the list is then hoisted as branding, and semantic parity reports `pass` because the carried-item fold counts it. That implements a deliberate ruling, so it is raised for a decision rather than changed here.

Separately, a chrome-classed sibling anchor inside a nav landmark (`<a class="lang-toggle" href="/fr/">FR</a>`) is dropped from output entirely. That predates #887 — verified identical on `a393de4c8`, on current trunk, and on this branch — and the parity reporter already flags it. Worth its own issue.
