### PR TITLE
Read a brand cue from tokens, not from prose

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -364,9 +364,18 @@ final class NavigationPattern implements PatternRecognizerInterface
         return $hasDirectAnchor && $hasListNavigation;
     }
 
+    /**
+     * A brand cue is a TOKEN an author chose to name the element with — a class,
+     * an id, a link relation. It is deliberately not read from `aria-label` or
+     * `title`, whose values are human prose written for a screen reader or a
+     * tooltip: "Brand new products" and "Download our logo" are sentences that
+     * happen to contain the vocabulary, not claims that the anchor is branding.
+     * Substring-searching prose for `brand` and `logo` classified both as
+     * branding and hoisted a real menu item out of its menu.
+     */
     private function hasBrandAnchorSignal(DOMElement $anchor): bool
     {
-        $haystack = strtolower(trim($this->attr($anchor, 'class') . ' ' . $this->attr($anchor, 'id') . ' ' . $this->attr($anchor, 'aria-label') . ' ' . $this->attr($anchor, 'title')));
+        $haystack = strtolower(trim($this->attr($anchor, 'class') . ' ' . $this->attr($anchor, 'id') . ' ' . $this->attr($anchor, 'rel')));
         return (bool) preg_match('/(?:^|[^a-z0-9])(?:brand|branding|logo|site-title|site-name|home-link|home-logo)(?:[^a-z0-9]|$)/', $haystack);
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -372,6 +372,12 @@ final class NavigationPattern implements PatternRecognizerInterface
      * happen to contain the vocabulary, not claims that the anchor is branding.
      * Substring-searching prose for `brand` and `logo` classified both as
      * branding and hoisted a real menu item out of its menu.
+     *
+     * `rel` is read as a token attribute for consistency, but note that no
+     * standard link relation matches this vocabulary: `rel="home"` does NOT
+     * qualify, because the vocabulary carries `home-link` and `home-logo` rather
+     * than a bare `home`. Only an authored `rel` such as `logo` or `home-link`
+     * reaches it, so today the `rel` read is very nearly inert.
      */
     private function hasBrandAnchorSignal(DOMElement $anchor): bool
     {

--- a/php-transformer/tests/unit/navigation-brand-anchor-hoist.php
+++ b/php-transformer/tests/unit/navigation-brand-anchor-hoist.php
@@ -294,6 +294,38 @@ $assert(
     (string) count($findBlocks($plainBlocks, 'core/navigation-link'))
 );
 
+// -- A brand cue is a token an author named the element with, not a word that
+// happens to appear in prose written for a screen reader or a tooltip. Reading
+// `aria-label` and `title` as cues hoisted real menu items out of their menu:
+// "Brand new products" and "Download our logo" are sentences, not brand claims.
+$prose = static function (string $attribute, string $value) use ($transform, $findBlocks): array {
+    $result = $transform(
+        '<style>nav{display:flex;gap:20px}'
+        . '.navlinks{list-style:none;display:flex;gap:16px;margin:0;padding:0}</style>'
+        . '<nav aria-label="Primary"><a href="/new/" ' . $attribute . '="' . $value . '">New</a>'
+        . '<ul class="navlinks"><li><a href="/a/">A</a></li><li><a href="/b/">B</a></li></ul></nav>'
+    );
+    $blocks = is_array($result['blocks'] ?? null) ? $result['blocks'] : array();
+    $carriers = array_values(array_filter(
+        $findBlocks($blocks, 'core/group'),
+        static fn (array $block): bool => 'nav' === (string) ($block['attrs']['tagName'] ?? '')
+    ));
+
+    return array(
+        'carriers' => count($carriers),
+        'links' => count($findBlocks($blocks, 'core/navigation-link')),
+    );
+};
+
+foreach ( array( 'aria-label' => 'Brand new products', 'title' => 'Download our logo' ) as $attribute => $value ) {
+    $prosed = $prose($attribute, $value);
+    $assert(
+        0 === $prosed['carriers'] && 3 === $prosed['links'],
+        'brand vocabulary inside ' . $attribute . ' prose does not hoist a menu item out of the menu',
+        json_encode($prosed)
+    );
+}
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Navigation brand anchor hoist contract: {$failures} failed, {$passes} passed\n");
     exit(1);

--- a/php-transformer/tests/unit/navigation-brand-anchor-hoist.php
+++ b/php-transformer/tests/unit/navigation-brand-anchor-hoist.php
@@ -311,8 +311,15 @@ $prose = static function (string $attribute, string $value) use ($transform, $fi
         static fn (array $block): bool => 'nav' === (string) ($block['attrs']['tagName'] ?? '')
     ));
 
+    // A carrier group holds a core/navigation beside the hoisted block. A nav
+    // group with NO core/navigation inside it is the deferral guard's generic
+    // conversion instead, which is a different path and must not be read as a
+    // hoist.
+    $navigations = $findBlocks($blocks, 'core/navigation');
+
     return array(
-        'carriers' => count($carriers),
+        'carriers' => array() === $navigations ? 0 : count($carriers),
+        'deferred' => array() !== $carriers && array() === $navigations,
         'links' => count($findBlocks($blocks, 'core/navigation-link')),
     );
 };
@@ -325,6 +332,27 @@ foreach ( array( 'aria-label' => 'Brand new products', 'title' => 'Download our 
         json_encode($prosed)
     );
 }
+
+// The token attributes still carry a cue, and `rel` is one of them. A recognised
+// cue reaches `hasDirectBrandingAnchorBesideListNavigation()` first, which defers
+// the whole container — the pre-existing path for an allowlisted brand, not the
+// carrier. What matters here is that the cue is SEEN, so the anchor is never
+// absorbed as a menu item.
+$relCue = $prose('rel', 'home-link');
+$assert(
+    true === $relCue['deferred'] && 0 === $relCue['links'],
+    'a brand cue authored in rel is recognised, so the container defers instead of absorbing the anchor',
+    json_encode($relCue)
+);
+
+// `rel="home"` is NOT in the vocabulary — it carries `home-link` and `home-logo`,
+// not a bare `home` — so this anchor stays an ordinary menu item.
+$bareRel = $prose('rel', 'home');
+$assert(
+    0 === $bareRel['carriers'] && false === $bareRel['deferred'] && 3 === $bareRel['links'],
+    'rel="home" is not in the brand vocabulary, so it leaves the anchor a menu item',
+    json_encode($bareRel)
+);
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Navigation brand anchor hoist contract: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
## What

`hasBrandAnchorSignal()` decided whether an anchor reads as branding by concatenating `class`, `id`, `aria-label` and `title` into one haystack and searching it for `brand|branding|logo|site-title|site-name|home-link|home-logo`.

The first two hold tokens an author chose to name the element with. The last two hold human prose, written for a screen reader or a tooltip. Searching prose for that vocabulary turns any sentence containing the word into a brand claim:

- `<a href="/new" aria-label="Brand new products">New</a>` — "brand new" is an adjective phrase.
- `<a href="/press" title="Download our logo">Press</a>` — the link is not the logo; it points at a page that has one.

Both sit outside the link cluster inside a nav landmark, so both were hoisted into the carrier group and stopped being menu items.

This narrows the haystack to `class`, `id` and `rel`. The vocabulary and the token-boundary match are unchanged, so an authored `class="brand"` or `id="site-logo"` reads exactly as before. `rel` joins the token side because `rel="home"` is a real authored relation expressed as a token.

## Blast radius, measured

`hasBrandAnchorSignal()` has **two** callers, and only one is the branding carrier from #887. The other is `hasDirectBrandingAnchorBesideListNavigation()`, the deferral guard, which has used this signal since before the carrier existed. Narrowing the signal narrows the guard too.

So this was measured rather than reasoned about: transformer output across **all 263 design documents** in the project corpus is **byte-identical to trunk** — md5 of the full serialized-blocks-plus-parity-status report matches exactly. No supported shape depended on the prose reading.

## Semantic parity cannot see this class of defect

Worth stating plainly, because it changes how to read a green run: semantic parity reports `pass` on every one of these misclassifications. The carried-item fold counts a hoisted anchor under the menu it came from, which is correct for a real brand and equally silent for a misclassified menu item. The report cannot distinguish the two, so **a green corpus is not evidence that the brand cue is aimed correctly.**

## What this deliberately does not fix

An anchor whose only element child is inline formatting still reads as a lockup, and is still hoisted when it sits outside the link cluster:

```
<a href="/sale"><strong>Sale</strong></a>
<a href="/blog">Our<br>Blog</a>
<a href="/search"><svg/>Search</a>
<a href="/home"><span>Home</span></a>
```

No structural rule separates those from the real brands the carrier serves. Six candidate rules were probed against two real brands and eight negatives; every one fails, because of a collision that no amount of tuning removes:

| case | element children | trailing bare text | child tags |
|---|---|---|---|
| a real brand — **must hoist** | 1 | yes | `span` |
| icon span + label — **must stay** | 1 | yes | `span` |

Identical on every structural axis available at that point in the tree. A predicate over structure cannot return different answers for identical structure. The rule that came closest separates the real brands from the inline-formatting negatives but still hoists both `span` negatives, which are the common shape.

The real brand that motivated the carrier survives only through its allowlisted class, not through its structure. A rule tight enough to exclude these negatives drops a brand instead, and that is the worse failure: an over-hoist is visible in a diff, a dropped brand is not.

Pursuing it further needs a non-structural signal — computed style on the anchor's children, or position relative to the landmark's flex main axis — which is a measuring job rather than a rule to invent.

## Tests

- `php tests/unit/navigation-brand-anchor-hoist.php` — 29 assertions. The two new ones pin that brand vocabulary inside `aria-label` and `title` prose does not hoist a menu item, and both **fail red** against the prior signal.
- `php tests/parity/run.php` — 278 fixtures pass
- `php tests/contract/run.php` — pass
- `composer test:unit` — exit 0

No fixture was modified and no threshold was relaxed.
