### PR TITLE
Stop dropping named image anchors and classed switchers from a menu

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -88,6 +88,7 @@
       "php tests/unit/fallback-finding-normalizer.php",
       "php tests/unit/navigation-underline-color-resolver.php",
       "php tests/unit/navigation-brand-anchor-hoist.php",
+      "php tests/unit/navigation-dropped-anchors.php",
       "php tests/unit/button-signal-classifier.php",
       "php tests/unit/button-style-resolver.php",
       "php tests/unit/button-font-family-carry.php",

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -521,7 +521,14 @@ final class SemanticParityReporter
             return true;
         }
 
-        if ( '' === trim($anchor->textContent ?? '') && '' === trim($this->attr($anchor, 'aria-label') . $this->attr($anchor, 'title')) ) {
+        // An anchor named only by an image's alt text is content, not decoration.
+        // The label builder below already falls back to that alt, so excluding
+        // such an anchor here left the source side counting one item fewer than
+        // the block side represents.
+        if ( '' === trim($anchor->textContent ?? '')
+            && '' === trim($this->attr($anchor, 'aria-label') . $this->attr($anchor, 'title'))
+            && '' === $this->anchorImageAltText($anchor)
+        ) {
             return true;
         }
 
@@ -660,6 +667,14 @@ final class SemanticParityReporter
                     foreach ( $matches as $match ) {
                         $label = $this->normalizedNavigationLabel($match[3]);
                         if ( '' === $label ) {
+                            // An anchor built from an image carries its name in
+                            // the image's alt, which is what the source side
+                            // counts it by. Without this the hoisted brand is
+                            // invisible here and the two sides disagree.
+                            $label = $this->markupImageAltText($match[3]);
+                        }
+
+                        if ( '' === $label ) {
                             continue;
                         }
 
@@ -718,6 +733,33 @@ final class SemanticParityReporter
                 $this->collectBlockNavigationItems($block['innerBlocks'], $items);
             }
         }
+    }
+
+    /**
+     * The alt text of the first image in a fragment of saved markup, normalised
+     * the same way a label is. The block-side twin of anchorImageAltText().
+     */
+    private function markupImageAltText(string $markup): string
+    {
+        if ( ! preg_match('/<img\b[^>]*\balt\s*=\s*(["\'])(.*?)\1/is', $markup, $match) ) {
+            return '';
+        }
+
+        return $this->normalizedNavigationLabel(html_entity_decode($match[2], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+    }
+
+    /**
+     * The alt text of the first image inside an anchor, normalised the same way
+     * a label is. This is what names an anchor built from an image alone.
+     */
+    private function anchorImageAltText(DOMElement $anchor): string
+    {
+        $image = $anchor->getElementsByTagName('img')->item(0);
+        if ( ! $image instanceof DOMElement ) {
+            return '';
+        }
+
+        return $this->normalizedNavigationLabel($this->attr($image, 'alt'));
     }
 
     private function sourceNavigationAnchorLabel(DOMElement $anchor): string

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -573,7 +573,17 @@ final class NavigationPattern implements PatternRecognizerInterface
         $html = preg_replace('/<span\b[^>]*>\s*<\/span>/i', '', $html) ?? $html;
         $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>\s*<\/\1>/i', '', $html) ?? $html;
         $html = preg_replace('/<\/?(?:' . self::BLOCK_LEVEL_LABEL_TAGS . ')\b[^>]*>/i', '', $html) ?? $html;
-        return trim($html);
+        $html = trim($html);
+
+        // Markup carrying no text of its own is not a label. An anchor built from
+        // an image alone would otherwise hand back the `<img>` tag as its label
+        // and emit a navigation link labelled with raw markup, instead of letting
+        // `anchorLabel()` fall through to the image's own alt text.
+        if ( '' === trim(html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')) ) {
+            return '';
+        }
+
+        return $html;
     }
 
     /**
@@ -881,12 +891,71 @@ final class NavigationPattern implements PatternRecognizerInterface
             return true;
         }
 
-        if ( 'a' === $tagName && '' === trim($element->textContent ?? '') && '' === trim($this->attr($element, 'aria-label') . $this->attr($element, 'title')) ) {
+        if ( 'a' === $tagName && ! $this->anchorCarriesAccessibleName($element) ) {
             return true;
+        }
+
+        // An anchor that names itself AND points somewhere is content, whatever
+        // its class happens to be called. The vocabulary below matches on the
+        // bare word `toggle`, which an authored `lang-toggle` or `theme-toggle`
+        // satisfies while being an ordinary link.
+        if ( 'a' === $tagName && $this->anchorNavigatesToDestination($element) ) {
+            return false;
         }
 
         $tokens = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'id'));
         return (bool) preg_match('/(?:^|[^a-z0-9])(?:separator|divider|toggle|hamburger|menu-button|menu-toggle)(?:[^a-z0-9]|$)/', $tokens);
+    }
+
+    /**
+     * Whether an anchor carries an accessible name: visible text, an explicit
+     * `aria-label`/`title`, or an image whose `alt` names it.
+     *
+     * `anchorLabel()` already falls back to a descendant image's `alt`, so the
+     * chrome test has to agree with it. While it did not, an image brand the
+     * author had named — `<a class="mark"><img alt="Harbor"></a>` — was read as
+     * decoration and dropped from the output entirely, and because such an
+     * anchor contributes no text the source menu never counted it as an item,
+     * so semantic parity reported `pass` with no findings while the brand
+     * disappeared.
+     */
+    private function anchorCarriesAccessibleName(DOMElement $anchor): bool
+    {
+        if ( '' !== trim($anchor->textContent ?? '') ) {
+            return true;
+        }
+
+        if ( '' !== trim($this->attr($anchor, 'aria-label') . $this->attr($anchor, 'title')) ) {
+            return true;
+        }
+
+        foreach ( $anchor->getElementsByTagName('img') as $image ) {
+            if ( '' !== trim($this->attr($image, 'alt')) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether an anchor points at a destination rather than driving an in-page
+     * control. A menu toggle authored as an anchor targets a fragment, a
+     * `javascript:` URL or nothing at all, and usually declares `aria-controls`
+     * or `aria-expanded`; a language or theme switcher targets a real URL.
+     */
+    private function anchorNavigatesToDestination(DOMElement $anchor): bool
+    {
+        if ( $anchor->hasAttribute('aria-controls') || $anchor->hasAttribute('aria-expanded') ) {
+            return false;
+        }
+
+        $href = trim($this->attr($anchor, 'href'));
+        if ( '' === $href || str_starts_with($href, '#') ) {
+            return false;
+        }
+
+        return ! str_starts_with(strtolower($href), 'javascript:');
     }
 
     private function isNavigationWrapperElement(DOMElement $element): bool

--- a/php-transformer/tests/unit/navigation-dropped-anchors.php
+++ b/php-transformer/tests/unit/navigation-dropped-anchors.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Contract for anchors a navigation landmark used to drop entirely.
+ *
+ * `isNavigationChromeElement()` decides which children of a navigation landmark
+ * are decoration rather than content, and decoration is skipped — it reaches the
+ * output nowhere. Two authored shapes fell through that test and vanished:
+ *
+ * - An image brand the author named: `<a class="mark"><img alt="Harbor"></a>`.
+ *   The anchor holds no text of its own, so it read as unnamed and therefore
+ *   decorative, even though `anchorLabel()` already treats a descendant image's
+ *   `alt` as the anchor's label. Worse, an anchor with no text contributes no
+ *   item to the SOURCE menu either, so the counts matched and semantic parity
+ *   reported `pass` with no findings while the brand disappeared.
+ *
+ * - A switcher whose class merely contains the word `toggle`:
+ *   `<a class="lang-toggle" href="/fr/">FR</a>`. The chrome vocabulary matches
+ *   the bare token `toggle`, so an ordinary link to an ordinary URL was read as
+ *   a menu control and dropped.
+ *
+ * The controls below pin the shapes that must STILL be treated as chrome, so the
+ * fix cannot be read as "stop dropping anything".
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = ''): void {
+    global $failures, $passes;
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$css = '<style>nav{display:flex;gap:20px;padding:22px}'
+    . '.navlinks{list-style:none;margin:0;padding:0;display:flex;gap:20px}</style>';
+$list = '<ul class="navlinks"><li><a href="/a/">A</a></li><li><a href="/b/">B</a></li></ul>';
+
+$transform = static fn (string $extra): array => ( new HtmlTransformer() )->transform(
+    $css . '<nav aria-label="Primary">' . $extra . $list . '</nav>',
+    array()
+)->toArray();
+
+/** @return array{markup: string, status: string, findings: int} */
+$outcome = static function (string $extra) use ($transform): array {
+    $result = $transform($extra);
+    $report = $result['source_reports']['semantic_parity'] ?? array();
+
+    return array(
+        'markup' => (string) ($result['serialized_blocks'] ?? ''),
+        'status' => (string) ($report['status'] ?? ''),
+        'findings' => count(is_array($report['findings'] ?? null) ? $report['findings'] : array()),
+    );
+};
+
+// -- An image brand the author gave an accessible name survives.
+$imageBrand = $outcome('<a class="mark" href="/"><img src="/logo.svg" alt="Harbor"></a>');
+$assert(
+    str_contains($imageBrand['markup'], '/logo.svg'),
+    'an image brand named by its alt text reaches the output',
+    substr($imageBrand['markup'], 0, 200)
+);
+$assert(
+    str_contains($imageBrand['markup'], 'Harbor'),
+    'the image brand keeps the accessible name the author gave it',
+    substr($imageBrand['markup'], 0, 200)
+);
+
+// -- A switcher whose class merely contains `toggle` is an ordinary link.
+foreach ( array( 'lang-toggle' => '/fr/', 'theme-toggle' => '/dark/' ) as $class => $href ) {
+    $switcher = $outcome('<a class="' . $class . '" href="' . $href . '">Switch</a>');
+    $assert(
+        str_contains($switcher['markup'], $href),
+        'an anchor classed ' . $class . ' keeps its destination instead of being dropped as chrome',
+        substr($switcher['markup'], 0, 200)
+    );
+    $assert(
+        'pass' === $switcher['status'] && 0 === $switcher['findings'],
+        'an anchor classed ' . $class . ' leaves semantic parity clean once it is represented',
+        $switcher['status'] . '/' . (string) $switcher['findings']
+    );
+}
+
+// -- CONTROLS: these must still be treated as chrome and dropped.
+$controls = array(
+    'a decorative image with an empty alt' => array( '<a class="mark" href="/"><img src="/deco.svg" alt=""></a>', '/deco.svg' ),
+    'a menu toggle anchor targeting a fragment' => array( '<a class="menu-toggle" href="#menu">Menu</a>', '#menu' ),
+    'a menu toggle anchor declaring aria-expanded' => array( '<a class="nav-toggle" href="/menu/" aria-expanded="false">Menu</a>', '/menu/' ),
+    'a button menu toggle' => array( '<button class="toggle" aria-expanded="false">Menu</button>', 'aria-expanded' ),
+    'a hamburger element' => array( '<div class="hamburger"><span></span></div>', 'hamburger' ),
+    'a separator' => array( '<span class="divider">|</span>', 'divider' ),
+);
+
+foreach ( $controls as $label => [$markup, $needle] ) {
+    $control = $outcome($markup);
+    $assert(
+        ! str_contains($control['markup'], $needle),
+        'control: ' . $label . ' is still treated as navigation chrome',
+        substr($control['markup'], 0, 200)
+    );
+}
+
+// -- An anchor named by an image alone is labelled with that alt text, not with
+// the raw `<img>` markup it is built from.
+$combined = $outcome(
+    '<a class="mark" href="/"><img src="/logo.svg" alt="Harbor"></a>'
+    . '<a class="lang-toggle" href="/fr/">FR</a>'
+);
+$assert(
+    str_contains($combined['markup'], '"label":"Harbor"'),
+    'an image-named anchor is labelled with its alt text rather than with raw markup',
+    substr($combined['markup'], 0, 240)
+);
+$assert(
+    ! str_contains($combined['markup'], '"label":"<img'),
+    'an image-named anchor never carries raw markup as its label',
+    substr($combined['markup'], 0, 240)
+);
+
+// Two anchors beside the list means the branding carrier cannot claim the
+// landmark, so both become menu items. Both sides must then count all four.
+$assert(
+    'pass' === $combined['status'] && 0 === $combined['findings'],
+    'a brand and a switcher beside the list leave semantic parity clean',
+    $combined['status'] . '/' . (string) $combined['findings']
+);
+$assert(
+    str_contains($combined['markup'], '/fr/'),
+    'the switcher keeps its destination when it shares the landmark with a brand',
+    substr($combined['markup'], 0, 240)
+);
+
+// -- The menu itself is untouched in every case above: both list anchors remain.
+$menuIntact = $outcome('<a class="mark" href="/"><img src="/logo.svg" alt="Harbor"></a>');
+$assert(
+    str_contains($menuIntact['markup'], '/a/') && str_contains($menuIntact['markup'], '/b/'),
+    'the menu keeps both of its own links while the brand is rescued',
+    substr($menuIntact['markup'], 0, 200)
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Navigation dropped anchors contract: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+echo "Navigation dropped anchors contract passed: {$passes} assertions\n";


### PR DESCRIPTION
## What

`isNavigationChromeElement()` decides which children of a navigation landmark are decoration, and decoration is **skipped** — it reaches the output nowhere. Two authored shapes fell through it and vanished from the page.

**An image brand the author named.** `<a class="mark" href="/"><img alt="Harbor Pilots"></a>` read as unnamed, because the test looked at the anchor's own text, `aria-label` and `title` and stopped there. `anchorLabel()` in the same class already falls back to a descendant image's `alt`, so the two disagreed about whether the anchor had a name. The chrome test won and the brand disappeared.

This one was **silent**. An anchor with no text contributes no item to the source menu either, so the counts agreed and semantic parity reported `pass` with **zero findings** while a brand vanished. A green parity run was not evidence the brand survived.

**A switcher whose class merely contains `toggle`.** The chrome vocabulary matches the bare token, which an authored `lang-toggle` or `theme-toggle` satisfies while being an ordinary link to an ordinary URL. Those were dropped too — visibly, at least: parity flagged the count mismatch.

Rescuing the image anchor then exposed two follow-on defects. `navigationLabel()` returned the raw `<img>` tag as a label, so a rescued brand emitted a navigation link labelled with markup. And `isSourceNavigationChromeAnchor()` in the parity reporter carried the *identical* unnamed-anchor test, so the source side refused to count the anchor the block side now represented — turning a silent loss into a false `navigation_item_count_mismatch`.

## How

- `anchorCarriesAccessibleName()` treats a descendant image's non-empty `alt` as a name, matching what `anchorLabel()` already does.
- `anchorNavigatesToDestination()` exempts an anchor from token-based chrome classification when it names itself **and** points at a real URL. A menu toggle authored as an anchor targets a fragment or a `javascript:` URL, or declares `aria-controls`/`aria-expanded`, so it stays chrome.
- `navigationLabel()` returns an empty label for markup carrying no text of its own, letting `anchorLabel()` fall through to the image's `alt` instead of emitting the `<img>` tag as the label.
- `isSourceNavigationChromeAnchor()` consults the same image `alt`, and `collectBlockAnchorItems()` gains the matching fallback on the block side, so both sides of the parity comparison count the same anchor.

## Rendered proof

Two purpose-built fixtures were pushed through the same `run-fixture-matrix` pipeline the promotion gate uses — static-site-importer → transformer → WordPress 7.0.2 → browser screenshot — run twice with **only the transformer swapped**.

| fixture | trunk `f9de01f5e` | this branch |
|---|---|---|
| image brand beside the menu | logo absent from the rendered header; parity `pass` | logo renders |
| `lang-toggle` switcher beside the menu | FR link absent | FR link renders |

## Blast radius

Zero on real evidence: transformer output across **all 269 design documents** in the project corpus is byte-identical before and after — 269 transformed, 0 errors on each side. The comparison harness was validated first against a case that *must* differ, so its agreement means the outputs match rather than that it failed to look.

The corpus does not author these shapes: of **3232 anchors**, none carries a chrome-vocabulary class token, and the **23 anchors** named only by image `alt` all sit in page content rather than inside a navigation landmark, where the chrome test never runs on them.

## Known limitations

**A logo image sharing a nav with a second anchor still loses the image.** The branding carrier can only claim the landmark when the brand is the sole anchor beside the list. With a second anchor present the brand becomes an ordinary menu item labelled with its `alt`: the destination and the accessible name survive, the image does not. Parity reports `pass`, because the *item* is represented — so parity does not see the missing image. The single-anchor case keeps the real image.

**Unrelated and pre-existing: the menu's authored `margin:0 0 0 auto` does not right-align the rendered menu.** Visible in the fixture screenshots, on trunk and on this branch equally. It is not a dropped rule — the navigation block carries `className:"navlinks blocks-engine-list-navigation"` and the emitted stylesheet still contains the declaration — so the alignment is lost downstream of the transform, most likely to core navigation styles or the engine-support margin reset on specificity. Untriaged here; being picked up as separate work.

## Testing

- `php tests/unit/navigation-dropped-anchors.php` — 17 assertions, **9 of which fail against trunk**. Six controls pin the shapes that must still be treated as chrome: an empty-`alt` image, a fragment-targeting menu toggle, an anchor declaring `aria-expanded`, a `<button>` toggle, a hamburger element and a separator.
- `php tests/parity/run.php` — 278 fixtures pass
- `php tests/contract/run.php` — pass
- `composer test` — exit 0

No fixture was modified and no threshold was relaxed.
