### PR TITLE
Agree on which image names an anchor, and keep separators chrome

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/SemanticParityReporter.php
@@ -741,11 +741,21 @@ final class SemanticParityReporter
      */
     private function markupImageAltText(string $markup): string
     {
-        if ( ! preg_match('/<img\b[^>]*\balt\s*=\s*(["\'])(.*?)\1/is', $markup, $match) ) {
+        if ( ! preg_match_all('/<img\b[^>]*\balt\s*=\s*(["\'])(.*?)\1/is', $markup, $matches, PREG_SET_ORDER) ) {
             return '';
         }
 
-        return $this->normalizedNavigationLabel(html_entity_decode($match[2], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+        // The FIRST image that actually carries a name, not the first image. A
+        // decorative `alt=""` ahead of the real one must not decide the answer,
+        // or this disagrees with the transformer's own accessible-name test.
+        foreach ( $matches as $match ) {
+            $alt = $this->normalizedNavigationLabel(html_entity_decode($match[2], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+            if ( '' !== $alt ) {
+                return $alt;
+            }
+        }
+
+        return '';
     }
 
     /**
@@ -754,12 +764,14 @@ final class SemanticParityReporter
      */
     private function anchorImageAltText(DOMElement $anchor): string
     {
-        $image = $anchor->getElementsByTagName('img')->item(0);
-        if ( ! $image instanceof DOMElement ) {
-            return '';
+        foreach ( $anchor->getElementsByTagName('img') as $image ) {
+            $alt = $this->normalizedNavigationLabel($this->attr($image, 'alt'));
+            if ( '' !== $alt ) {
+                return $alt;
+            }
         }
 
-        return $this->normalizedNavigationLabel($this->attr($image, 'alt'));
+        return '';
     }
 
     private function sourceNavigationAnchorLabel(DOMElement $anchor): string
@@ -776,12 +788,7 @@ final class SemanticParityReporter
             }
         }
 
-        $image = $anchor->getElementsByTagName('img')->item(0);
-        if ( $image instanceof DOMElement ) {
-            return $this->normalizedNavigationLabel($this->attr($image, 'alt'));
-        }
-
-        return '';
+        return $this->anchorImageAltText($anchor);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -556,8 +556,11 @@ final class NavigationPattern implements PatternRecognizerInterface
             }
         }
 
-        $image = $anchor->getElementsByTagName('img')->item(0);
-        if ( $image instanceof DOMElement ) {
+        // The first image that carries a name, not the first image: a decorative
+        // `alt=""` ahead of the real one must not decide the label, or this
+        // disagrees with anchorCarriesAccessibleName() and the anchor is kept as
+        // named content while being labelled empty.
+        foreach ( $anchor->getElementsByTagName('img') as $image ) {
             $alt = trim($this->attr($image, 'alt'));
             if ( '' !== $alt ) {
                 return htmlspecialchars($alt, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
@@ -895,6 +898,17 @@ final class NavigationPattern implements PatternRecognizerInterface
             return true;
         }
 
+        $tokens = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'id'));
+
+        // A separator or a divider is decoration by authored intent, whatever it
+        // happens to link to, so the destination escape below must not rescue
+        // it. `isSourceNavigationChromeAnchor()` in the parity reporter reads
+        // exactly these two tokens as chrome on the source side; rescuing them
+        // here would leave the two sides counting different menus.
+        if ( preg_match('/(?:^|[^a-z0-9])(?:separator|divider)(?:[^a-z0-9]|$)/', $tokens) ) {
+            return true;
+        }
+
         // An anchor that names itself AND points somewhere is content, whatever
         // its class happens to be called. The vocabulary below matches on the
         // bare word `toggle`, which an authored `lang-toggle` or `theme-toggle`
@@ -903,8 +917,7 @@ final class NavigationPattern implements PatternRecognizerInterface
             return false;
         }
 
-        $tokens = strtolower($this->attr($element, 'class') . ' ' . $this->attr($element, 'id'));
-        return (bool) preg_match('/(?:^|[^a-z0-9])(?:separator|divider|toggle|hamburger|menu-button|menu-toggle)(?:[^a-z0-9]|$)/', $tokens);
+        return (bool) preg_match('/(?:^|[^a-z0-9])(?:toggle|hamburger|menu-button|menu-toggle)(?:[^a-z0-9]|$)/', $tokens);
     }
 
     /**

--- a/php-transformer/tests/unit/navigation-dropped-anchors.php
+++ b/php-transformer/tests/unit/navigation-dropped-anchors.php
@@ -99,6 +99,12 @@ $controls = array(
     'a button menu toggle' => array( '<button class="toggle" aria-expanded="false">Menu</button>', 'aria-expanded' ),
     'a hamburger element' => array( '<div class="hamburger"><span></span></div>', 'hamburger' ),
     'a separator' => array( '<span class="divider">|</span>', 'divider' ),
+    // A separator is decoration by authored intent even when it links somewhere,
+    // so the destination escape must not rescue it. The parity reporter reads
+    // these two tokens as chrome on the source side; rescuing them here made a
+    // clean `pass` become a false count mismatch.
+    'a separator anchor with a real href' => array( '<a class="separator" href="/sep/">|</a>', '/sep/' ),
+    'a divider anchor with a real href' => array( '<a class="nav-divider" href="/x/">/</a>', '/x/' ),
 );
 
 foreach ( $controls as $label => [$markup, $needle] ) {
@@ -138,6 +144,25 @@ $assert(
     str_contains($combined['markup'], '/fr/'),
     'the switcher keeps its destination when it shares the landmark with a brand',
     substr($combined['markup'], 0, 240)
+);
+
+// -- A decorative image ahead of the named one must not decide the answer. The
+// accessible-name test scans every image for a non-empty alt, so the label
+// builders and the parity reporter have to scan the same way: taking the FIRST
+// image instead of the first NAMED image made the two sides disagree again, and
+// the block side lost its menu record entirely.
+$leadingDecorative = $outcome(
+    '<a class="mark" href="/"><img src="/deco.svg" alt=""><img src="/logo.svg" alt="Harbor"></a>'
+);
+$assert(
+    str_contains($leadingDecorative['markup'], 'Harbor'),
+    'a decorative image before the named one still leaves the anchor named by the real alt',
+    substr($leadingDecorative['markup'], 0, 240)
+);
+$assert(
+    'pass' === $leadingDecorative['status'] && 0 === $leadingDecorative['findings'],
+    'a decorative image before the named one leaves both parity sides in agreement',
+    $leadingDecorative['status'] . '/' . (string) $leadingDecorative['findings']
 );
 
 // -- The menu itself is untouched in every case above: both list anchors remain.


### PR DESCRIPTION
## What

Two defects introduced by #892, both the same failure that PR existed to fix: the transformer and the semantic-parity reporter disagreeing about which anchors a navigation landmark contains. Found by a pre-landing review of #892 and by mining an adversarial reviewer's probes after its lane died.

### A decorative image ahead of the named one decided the answer

`anchorCarriesAccessibleName()` scans **every** descendant image for a non-empty `alt`, but `anchorImageAltText()`, `markupImageAltText()` and both label builders took `getElementsByTagName('img')->item(0)` — the first image, named or not.

So `<a class="mark"><img alt=""><img alt="Harbor"></a>` was kept by the transformer as named content while the reporter read it as unnamed decoration. The source side counted 2 items and the block side **lost its menu record entirely**, reporting `warning` with two findings.

### The destination escape rescued separators

#892 exempts an anchor from token-based chrome classification when it names itself **and** points at a real URL, so an authored `lang-toggle` stops being mistaken for a menu control. That escape ran ahead of the whole vocabulary, including `separator` and `divider`.

`isSourceNavigationChromeAnchor()` still reads exactly those two tokens as chrome on the source side, so a separator anchor went from trunk's dropped-with-`pass` to kept-with-`warning` — a clean report turned into a false count mismatch. A separator is decoration by authored intent whatever it links to.

| case | before #892 | #892 as merged | this PR |
|---|---|---|---|
| `<img alt=""><img alt="Harbor">` | — | `warning`, block menu record lost | `pass`, src 3 = blk 3 |
| `<a class="separator" href="/sep/">` | dropped, `pass` | **kept, `warning`** | dropped, `pass` |
| `<a class="lang-toggle" href="/fr/">` | dropped, `warning` | kept, `pass` | kept, `pass` |
| `<a class="hamburger" href="/menu/">Menu</a>` | dropped, `warning` | kept, `pass` | kept, `pass` |

## How

- The alt lookups and both label builders take the first image that actually **carries a name**, matching the accessible-name test. `markupImageAltText()` walks every `<img>` match rather than only the first, and `sourceNavigationAnchorLabel()` delegates to `anchorImageAltText()` so one rule serves both sides.
- `separator` and `divider` are matched **before** the destination escape and stay chrome regardless of `href`. The rest of the vocabulary — `toggle`, `hamburger`, `menu-button`, `menu-toggle` — is still subject to the escape, so #892's intended fix is unchanged.

## Blast radius

Zero on real evidence: transformer output across **all 269 design documents** in the project corpus is byte-identical, 269 transformed with no errors. The comparison harness was validated against a case that *must* differ before its agreement was trusted.

## Testing

- `php tests/unit/navigation-dropped-anchors.php` — 21 assertions, **4 of which fail against #892's merged commit** (two per defect)
- `php tests/parity/run.php` — 278 fixtures pass
- `php tests/contract/run.php` — pass
- `composer test` — exit 0

Two new controls pin that a separator anchor and a divider anchor with real `href`s stay chrome, alongside the six controls #892 already had.

## Not addressed here

`markupImageAltText()`'s regex matches `alt=` inside `data-alt`, inside a `title` value, inside an HTML comment, and inside `srcset` text. Real at unit level, but unreachable through the pipeline — `data-alt` does not survive into saved markup and the emitted label is correct with `pass`. Left alone rather than hardening a regex on unreachable evidence; `(?<![-\w])alt` would close the family if it ever becomes reachable.

The menu's authored `margin:0 0 0 auto` still does not right-align the rendered menu. Pre-existing, unrelated to this change, and being picked up separately.
