### PR TITLE
Carry an authored auto menu margin onto the navigation host

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -88,6 +88,7 @@
       "php tests/unit/fallback-finding-normalizer.php",
       "php tests/unit/navigation-underline-color-resolver.php",
       "php tests/unit/navigation-brand-anchor-hoist.php",
+      "php tests/unit/navigation-inline-margin-carry.php",
       "php tests/unit/navigation-dropped-anchors.php",
       "php tests/unit/button-signal-classifier.php",
       "php tests/unit/button-style-resolver.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1123,6 +1123,9 @@ final class HtmlTransformer
             // navigation owns that responsive swap now, so keep the block host
             // visible and let core hide only its responsive inner container.
             $afterAuthorCssParts[] = '.wp-block-navigation.blocks-engine-list-navigation{display:flex!important}';
+            foreach ( $this->listNavigationInlineMarginRules($serializedBlocks) as $inlineMarginRule ) {
+                $afterAuthorCssParts[] = $inlineMarginRule;
+            }
             $mobileOverlayBackground = $this->sourceMobileNavigationOverlayBackground();
             if ( '' !== $mobileOverlayBackground ) {
                 $afterAuthorCssParts[] = '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation__responsive-container.is-menu-open{background:' . $mobileOverlayBackground . '!important}';
@@ -1172,6 +1175,156 @@ final class HtmlTransformer
             'hash'        => $hash,
             'source_hash' => $hash,
         );
+    }
+
+    /**
+     * Re-assert an authored inline-axis `auto` margin on the navigation block
+     * host, after author CSS.
+     *
+     * A menu authored as `.navlinks{margin:0 0 0 auto}` inside `nav{display:flex}`
+     * sits at the far end of its landmark. The class survives onto the promoted
+     * navigation, but core's own navigation stylesheet owns the inner list —
+     * `.wp-block-navigation ul{margin-left:0}`, specificity 0,1,1 — and outranks
+     * the authored 0,1,0 class, so the menu snaps back to the start of the
+     * landmark and the authored end-alignment is lost.
+     *
+     * The block host is the flex item that actually moves, so the margin is
+     * restated there. The selector is self-limiting: it matches only an element
+     * that is both a promoted list navigation and carries the authored class.
+     *
+     * Only `auto` is carried. An authored length is left to the author rule,
+     * which core does not contest on the host.
+     *
+     * @return array<int, string>
+     */
+    private function listNavigationInlineMarginRules(string $serializedBlocks): array
+    {
+        if ( ! str_contains($serializedBlocks, 'blocks-engine-list-navigation') ) {
+            return array();
+        }
+
+        $navigationClasses = $this->listNavigationHostClasses($serializedBlocks);
+        if ( array() === $navigationClasses ) {
+            return array();
+        }
+
+        $rules = array();
+        foreach ( array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule ) {
+            $selector = trim((string) ($rule['selector'] ?? ''));
+            if ( 1 !== preg_match('/^\.([A-Za-z_][A-Za-z0-9_-]*)$/', $selector, $match) ) {
+                continue;
+            }
+
+            $class = $match[1];
+            // The class has to sit on a promoted navigation host, not merely
+            // appear somewhere in the document. A page wrapper's `.wrap{margin:0
+            // auto}` is not a statement about a menu, and emitting a rule for it
+            // would be dead CSS on every page that has one.
+            if ( ! isset($navigationClasses[$class]) ) {
+                continue;
+            }
+
+            $margins = $this->inlineAxisAutoMargins(is_array($rule['declarations'] ?? null) ? $rule['declarations'] : array());
+            if ( array() === $margins ) {
+                continue;
+            }
+
+            $declarations = array();
+            foreach ( $margins as $side => $value ) {
+                $declarations[] = 'margin-' . $side . ':' . $value . '!important';
+            }
+
+            $selectorText = '.wp-block-navigation.blocks-engine-list-navigation.' . $class;
+            $rules[$selectorText] = $selectorText . '{' . implode(';', $declarations) . '}';
+        }
+
+        return array_values($rules);
+    }
+
+    /**
+     * Classes carried by promoted list-navigation hosts in the serialized
+     * output, as a lookup.
+     *
+     * @return array<string, true>
+     */
+    private function listNavigationHostClasses(string $serializedBlocks): array
+    {
+        if ( ! preg_match_all('/<!--\s*wp:navigation\s*(\{.*?\})\s*-->/s', $serializedBlocks, $matches, PREG_SET_ORDER) ) {
+            return array();
+        }
+
+        $classes = array();
+        foreach ( $matches as $match ) {
+            $attrs = json_decode($match[1], true);
+            if ( ! is_array($attrs) ) {
+                continue;
+            }
+
+            $className = (string) ($attrs['className'] ?? '');
+            if ( ! str_contains($className, 'blocks-engine-list-navigation') ) {
+                continue;
+            }
+
+            foreach ( preg_split('/\s+/', trim($className)) ?: array() as $candidate ) {
+                if ( '' !== $candidate && ! str_starts_with($candidate, 'blocks-engine-') ) {
+                    $classes[$candidate] = true;
+                }
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * The authored inline-axis margins of a rule, but only when at least one
+     * side is `auto` — that is the declaration that positions a flex item, and
+     * the one core's list reset destroys. The opposite side rides along so a
+     * one-sided `auto` cannot be read as centring once both sides are restated.
+     *
+     * @param array<string, mixed> $declarations
+     * @return array<string, string>
+     */
+    private function inlineAxisAutoMargins(array $declarations): array
+    {
+        $sides = array( 'left' => '', 'right' => '' );
+
+        $shorthand = trim((string) ($declarations['margin'] ?? ''));
+        if ( '' !== $shorthand ) {
+            $parts = preg_split('/\s+/', $shorthand) ?: array();
+            $count = count($parts);
+            if ( 4 === $count ) {
+                $sides['right'] = $parts[1];
+                $sides['left'] = $parts[3];
+            } elseif ( 2 === $count || 3 === $count ) {
+                $sides['right'] = $parts[1];
+                $sides['left'] = $parts[1];
+            } elseif ( 1 === $count ) {
+                $sides['right'] = $parts[0];
+                $sides['left'] = $parts[0];
+            }
+        }
+
+        foreach ( array( 'left' => array( 'margin-left', 'margin-inline-start' ), 'right' => array( 'margin-right', 'margin-inline-end' ) ) as $side => $properties ) {
+            foreach ( $properties as $property ) {
+                $value = trim((string) ($declarations[$property] ?? ''));
+                if ( '' !== $value ) {
+                    $sides[$side] = $value;
+                }
+            }
+        }
+
+        if ( 'auto' !== strtolower($sides['left']) && 'auto' !== strtolower($sides['right']) ) {
+            return array();
+        }
+
+        $carried = array();
+        foreach ( $sides as $side => $value ) {
+            if ( '' !== $value ) {
+                $carried[$side] = 'auto' === strtolower($value) ? 'auto' : $value;
+            }
+        }
+
+        return $carried;
     }
 
     private function sourceMobileNavigationOverlayBackground(): string

--- a/php-transformer/tests/unit/navigation-inline-margin-carry.php
+++ b/php-transformer/tests/unit/navigation-inline-margin-carry.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Contract for carrying an authored inline-axis `auto` margin onto the promoted
+ * navigation host.
+ *
+ * A menu authored as `.navlinks{margin:0 0 0 auto}` inside `nav{display:flex}`
+ * sits at the far end of its landmark. The class survives onto the navigation
+ * block and the declaration reaches the page — the rendered menu still shows the
+ * authored `gap` and `padding` from the same rule set — but core's own
+ * navigation stylesheet owns the inner list. `.wp-block-navigation ul{margin-left:0}`
+ * is specificity 0,1,1 and outranks the authored `.navlinks` at 0,1,0, so the
+ * menu snapped back to the start of the landmark.
+ *
+ * The block host is the flex item that actually moves, so the authored margin is
+ * restated there after author CSS. The rule must stay narrow: only an `auto`
+ * margin positions a flex item, and only a class that genuinely sits on a
+ * navigation host may produce one — a page wrapper's `.wrap{margin:0 auto}` is
+ * not a statement about a menu.
+ */
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = ''): void {
+    global $failures, $passes;
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+/** @return array{after: string, all: string} */
+$stylesheets = static function (string $html): array {
+    $result = ( new HtmlTransformer() )->transform($html, array())->toArray();
+    $after = '';
+    $all = '';
+    foreach ( (is_array($result['assets'] ?? null) ? $result['assets'] : array()) as $asset ) {
+        if ( ! is_array($asset) ) {
+            continue;
+        }
+
+        $content = (string) ($asset['content'] ?? '');
+        $all .= $content;
+        if ( 'after-author' === (string) ($asset['stylesheet_placement'] ?? '') ) {
+            $after .= $content;
+        }
+    }
+
+    return array( 'after' => $after, 'all' => $all );
+};
+
+$list = '<ul class="navlinks"><li><a href="/a/">A</a></li><li><a href="/b/">B</a></li></ul>';
+
+// -- An authored end-aligned menu keeps its alignment on the block host.
+$endAligned = $stylesheets(
+    '<style>nav{display:flex;gap:20px}'
+    . '.navlinks{list-style:none;display:flex;gap:16px;padding:0}'
+    . '.navlinks{margin:0 0 0 auto}</style>'
+    . '<nav aria-label="Primary"><a class="mark" href="/"><span>Harbor</span><span>Pilots</span></a>' . $list . '</nav>'
+);
+$assert(
+    str_contains($endAligned['after'], '.wp-block-navigation.blocks-engine-list-navigation.navlinks{margin-left:auto!important'),
+    'an authored auto inline margin is restated on the navigation host after author CSS',
+    substr($endAligned['after'], 0, 260)
+);
+$assert(
+    str_contains($endAligned['after'], 'margin-right:0!important'),
+    'the opposite side rides along so a one-sided auto cannot read as centring',
+    substr($endAligned['after'], 0, 260)
+);
+
+// -- A page wrapper that centres itself is not a statement about a menu.
+$wrapper = $stylesheets(
+    '<style>nav{display:flex;gap:20px}.wrap{max-width:60rem;margin:0 auto}'
+    . '.navlinks{list-style:none;display:flex;gap:16px;margin:0;padding:0}</style>'
+    . '<div class="wrap"><nav aria-label="Primary">' . $list . '</nav></div>'
+);
+$assert(
+    ! str_contains($wrapper['all'], 'blocks-engine-list-navigation.wrap'),
+    'a page wrapper class never produces a navigation margin rule',
+    substr($wrapper['all'], -260)
+);
+
+// -- Only `auto` is carried: an authored length is left to the author rule.
+$explicitLength = $stylesheets(
+    '<style>nav{display:flex;gap:20px}'
+    . '.navlinks{list-style:none;display:flex;gap:16px;padding:0;margin-left:24px}</style>'
+    . '<nav aria-label="Primary">' . $list . '</nav>'
+);
+$assert(
+    ! str_contains($explicitLength['all'], 'blocks-engine-list-navigation.navlinks{margin'),
+    'an authored length margin is not restated, only auto is',
+    substr($explicitLength['all'], -260)
+);
+
+// -- A menu with no authored inline margin emits no rule at all.
+$plain = $stylesheets(
+    '<style>nav{display:flex;gap:20px}'
+    . '.navlinks{list-style:none;display:flex;gap:16px;margin:0;padding:0}</style>'
+    . '<nav aria-label="Primary">' . $list . '</nav>'
+);
+$assert(
+    ! str_contains($plain['all'], 'blocks-engine-list-navigation.navlinks{margin'),
+    'a menu with no authored inline margin emits no margin rule',
+    substr($plain['all'], -260)
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Navigation inline margin carry contract: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+echo "Navigation inline margin carry contract passed: {$passes} assertions\n";


### PR DESCRIPTION
## What

A header authored as `nav{display:flex}` with `.navlinks{margin:0 0 0 auto}` puts its menu at the opposite end from the brand. The transformed page put it back at the start.

**The authored rule was not lost.** The class rides onto the navigation block and the stylesheet reaches the page — the rendered menu still takes `gap` and `padding` from the very same rule set, so only `margin` failed. Core's own navigation stylesheet owns the inner list:

```css
.wp-block-navigation ul{margin-left:0}   /* specificity 0,1,1 */
.navlinks{margin:0 0 0 auto}             /* authored, 0,1,0 */
```

An authored margin can never win on that element. The block **host** is the flex item that actually moves, so that is where it has to be restated.

Emitting it as a block attribute is not available: `core/navigation` declares `supports.spacing` as `blockGap` only — checked in both vendored copies of its `block.json` — so a margin attribute would never serialize.

## How

Collect the classes carried by promoted list-navigation hosts from the serialized output, then for each authored bare-class rule whose class sits on one of those hosts and whose inline-axis margin is `auto`, emit after author CSS:

```css
.wp-block-navigation.blocks-engine-list-navigation.navlinks{margin-left:auto!important;margin-right:0!important}
```

This is the mechanism the file already uses to reassert `display:flex` on the same host. The selector is self-limiting — it matches only an element that is both a promoted list navigation and carries the authored class.

Two deliberate limits:

- **Only `auto` is carried.** That is the declaration which positions a flex item and the one core's list reset destroys. An authored length is left to the author rule, which core does not contest on the host.
- **The class must sit on a navigation host.** Matching any bare-class rule with an auto margin made real projects emit `.wrap{margin:0 auto}` (a page wrapper) and `.brand{margin-right:auto}` (a brand) as navigation rules — dead CSS on **54** corpus documents. Reading the classes off the `wp:navigation` attributes took that to **10**.

## Verified in a render, not by reasoning

Re-rendered through the same `run-fixture-matrix` pipeline the promotion gate uses, WordPress 7.0.2, with only the transformer swapped. From the captured DOM:

| | source | before | after |
|---|---|---|---|
| menu `margin-left` | 665.547px | 0px | **665.547px** |
| menu `x` | 965.55 | 300 | **965.55** |
| items `x` | 965.55 / 1037.08 / 1102.47 | — | **965.55 / 1037.08 / 1102.47** |

## Blast radius

**10 of 269** corpus design documents gain CSS. **No document changes block markup** — this is a stylesheet-only change. Unlike the neighbouring navigation fixes this one does not get to claim "nothing changed" as a safety argument, so the render is the evidence.

## Known gaps

- What zeroes `margin-left` on the navigation **root** specifically is still unidentified. The inner-list override is proven; the root's is not. `!important` sidesteps that question rather than answering it.
- The fixture's menu still sits ~3.8px lower vertically than the source (`y` 30 vs 26.2). Unrelated to inline-axis alignment and not addressed here, but the promotion gate runs at `--pixel-threshold 0`, so that fixture can still register a difference.

## Testing

- `php tests/unit/navigation-inline-margin-carry.php` — 5 assertions, **2 fail against trunk**. Covers the carry, the opposite side riding along, a page wrapper producing no rule, an authored length producing no rule, and a plain menu producing no rule.
- `php tests/parity/run.php` — 278 fixtures pass
- `php tests/contract/run.php` — pass
- `composer test` — exit 0

No fixture was modified and no threshold was relaxed.
