### PR TITLE
Restore submenus split across responsive navigation variants

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -771,6 +771,7 @@ final class HtmlTransformer
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
+        $this->hydrateDuplicateNavigationSubmenus($body);
         $this->collectSupersededNavToggleSelectors($body);
         $shellArtifacts = !array_key_exists('extract_global_shell', $options) || !empty($options['extract_global_shell']) ? $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html')) : array();
         $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));
@@ -2352,6 +2353,97 @@ final class HtmlTransformer
         }
 
         return $count;
+    }
+
+    /**
+     * Responsive menus sometimes keep the visible desktop items shallow while a
+     * duplicate item with the same stable id owns the complete submenu tree.
+     * Reconcile that source-authored relationship before navigation conversion so
+     * the visible variant becomes one canonical core/navigation-submenu tree.
+     */
+    private function hydrateDuplicateNavigationSubmenus(DOMElement $body): void
+    {
+        $variants = array();
+        foreach ( $body->getElementsByTagName('li') as $item ) {
+            if ( ! $item instanceof DOMElement ) {
+                continue;
+            }
+
+            $id = trim($this->attr($item, 'id'));
+            $anchor = $this->directNavigationItemAnchor($item);
+            if ( '' === $id || ! $anchor instanceof DOMElement ) {
+                continue;
+            }
+
+            $label = $this->normalizedNavigationLabel($anchor->textContent ?? '');
+            if ( '' === $label ) {
+                continue;
+            }
+
+            $variants[$id . '|' . $label][] = $item;
+        }
+
+        foreach ( $variants as $items ) {
+            if ( 2 > count($items) ) {
+                continue;
+            }
+
+            $sourceCarriers = array();
+            $sourceLinkCount = 0;
+            foreach ( $items as $item ) {
+                $carriers = $this->directNavigationSubmenuCarriers($item);
+                $linkCount = 0;
+                foreach ( $carriers as $carrier ) {
+                    $linkCount += $carrier->getElementsByTagName('a')->length;
+                }
+                if ( $linkCount > $sourceLinkCount ) {
+                    $sourceCarriers = $carriers;
+                    $sourceLinkCount = $linkCount;
+                }
+            }
+
+            if ( 0 === $sourceLinkCount ) {
+                continue;
+            }
+
+            foreach ( $items as $item ) {
+                if ( array() !== $this->directNavigationSubmenuCarriers($item) ) {
+                    continue;
+                }
+                foreach ( $sourceCarriers as $carrier ) {
+                    $item->appendChild($carrier->cloneNode(true));
+                }
+            }
+        }
+    }
+
+    private function directNavigationItemAnchor(DOMElement $item): ?DOMElement
+    {
+        foreach ( $item->childNodes as $child ) {
+            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) ) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array<int, DOMElement> */
+    private function directNavigationSubmenuCarriers(DOMElement $item): array
+    {
+        $carriers = array();
+        foreach ( $item->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement || 'a' === strtolower($child->tagName) ) {
+                continue;
+            }
+            if ( 0 < $child->getElementsByTagName('a')->length
+                && ( 0 < $child->getElementsByTagName('ul')->length || 0 < $child->getElementsByTagName('ol')->length )
+            ) {
+                $carriers[] = $child;
+            }
+        }
+
+        return $carriers;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -766,12 +766,12 @@ final class HtmlTransformer
             $body->setAttribute('class', implode(' ', $sourceBodyClasses));
         }
 
+        $this->hydrateDuplicateNavigationSubmenus($body);
         $this->materializeDeclarativeCounters($body, (string) ($options['declarative_state_html'] ?? ''));
         $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
-        $this->hydrateDuplicateNavigationSubmenus($body);
         $this->collectSupersededNavToggleSelectors($body);
         $shellArtifacts = !array_key_exists('extract_global_shell', $options) || !empty($options['extract_global_shell']) ? $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html')) : array();
         $blocks      = $this->deduplicateNavigationBlocks($this->convertChildren($body, $fallbacks, true));

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -834,7 +834,11 @@ final class NavigationPattern implements PatternRecognizerInterface
             }
 
             $tagName = strtolower($child->tagName);
-            if ( in_array($tagName, array( 'nav', 'ul', 'ol' ), true) || $this->hasSubmenuSignal($child) ) {
+            if ( in_array($tagName, array( 'nav', 'ul', 'ol' ), true)
+                || $this->hasSubmenuSignal($child)
+                || ( $this->isNavigationWrapperElement($child)
+                    && ( 0 < $child->getElementsByTagName('ul')->length || 0 < $child->getElementsByTagName('ol')->length ) )
+            ) {
                 $containers[] = $child;
             }
         }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1866,7 +1866,7 @@ $assert(! str_contains($visibleVariantSerialized, '>menu<') && ! str_contains($v
 
 $splitResponsiveSubmenu = ( new HtmlTransformer() )->transform(
     '<header><div class="desktop"><ul class="menu"><li id="home"><a href="/">Home</a></li><li id="portfolio"><a>Portfolio</a></li><li id="about"><a href="/about">About</a></li></ul></div>'
-    . '<div class="mobile" style="display:none"><ul class="menu"><li id="home"><a href="/">Home</a></li><li id="portfolio" class="has-submenu"><a>Portfolio</a><div class="submenu-wrap"><ul><li><a href="/portraits">Portraits</a></li><li><a href="/families">Families</a></li></ul></div></li><li id="about"><a href="/about">About</a></li></ul></div></header>'
+    . '<div class="mobile" style="display:none"><ul class="menu"><li id="home"><a href="/">Home</a></li><li id="portfolio" class="has-submenu"><a>Portfolio</a><div class="menu-wrap"><ul><li><a href="/portraits">Portraits</a></li><li><a href="/families">Families</a></li></ul></div></li><li id="about"><a href="/about">About</a></li></ul></div></header>'
 )->toArray();
 $splitResponsiveSubmenuSerialized = (string) ($splitResponsiveSubmenu['serialized_blocks'] ?? '');
 $splitResponsiveSubmenuMenus = $splitResponsiveSubmenu['source_reports']['semantic_parity']['navigation_menus']['blocks'] ?? array();

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1864,6 +1864,18 @@ $assert(1 === substr_count($visibleVariantSerialized, '<!-- wp:navigation {'), '
 $assert(str_contains($visibleVariantSerialized, 'primary') && ! str_contains($visibleVariantSerialized, 'placeholder') && ! str_contains($visibleVariantSerialized, 'collapsed-nav'), 'navigation deduplication prefers the visible source variant over hidden placeholder and collapsed variants');
 $assert(! str_contains($visibleVariantSerialized, '>menu<') && ! str_contains($visibleVariantSerialized, '>close<'), 'input-free label hamburger chrome is superseded by native navigation controls');
 
+$splitResponsiveSubmenu = ( new HtmlTransformer() )->transform(
+    '<header><div class="desktop"><ul class="menu"><li id="home"><a href="/">Home</a></li><li id="portfolio"><a>Portfolio</a></li><li id="about"><a href="/about">About</a></li></ul></div>'
+    . '<div class="mobile" style="display:none"><ul class="menu"><li id="home"><a href="/">Home</a></li><li id="portfolio" class="has-submenu"><a>Portfolio</a><div class="submenu-wrap"><ul><li><a href="/portraits">Portraits</a></li><li><a href="/families">Families</a></li></ul></div></li><li id="about"><a href="/about">About</a></li></ul></div></header>'
+)->toArray();
+$splitResponsiveSubmenuSerialized = (string) ($splitResponsiveSubmenu['serialized_blocks'] ?? '');
+$splitResponsiveSubmenuMenus = $splitResponsiveSubmenu['source_reports']['semantic_parity']['navigation_menus']['blocks'] ?? array();
+$assert(1 === substr_count($splitResponsiveSubmenuSerialized, '<!-- wp:navigation {'), 'split responsive menu variants reconcile into one canonical navigation block');
+$assert(1 === substr_count($splitResponsiveSubmenuSerialized, '<!-- wp:navigation-submenu '), 'visible shallow navigation item adopts the duplicate responsive submenu');
+$assert(str_contains($splitResponsiveSubmenuSerialized, '"label":"Portfolio"') && str_contains($splitResponsiveSubmenuSerialized, '"label":"Portraits","url":"/portraits"') && str_contains($splitResponsiveSubmenuSerialized, '"label":"Families","url":"/families"'), 'reconciled submenu preserves the parent label and ordered child destinations');
+$assert(5 === ($splitResponsiveSubmenuMenus[0]['item_count'] ?? null), 'reconciled responsive navigation reports every parent and submenu item');
+$assert('pass' === ($splitResponsiveSubmenu['source_reports']['wp_block_validity']['status'] ?? ''), 'reconciled responsive submenu remains WordPress block-valid');
+
 $bodyStateProjection = ( new HtmlTransformer() )->transform(
     '<!doctype html><html><body class="fixed-shell no-header-page"><div class="wrapper"><div class="main-wrap"><p>Content</p></div></div></body></html>',
     array( 'static_css' => '.no-header-page .main-wrap{padding-top:80px}body.fixed-shell .main-wrap{background:#fff}' )


### PR DESCRIPTION
## Summary
- reconcile duplicate responsive menu items when the visible variant is shallow and another variant owns the submenu tree
- recognize list-backed submenu wrappers structurally instead of requiring `submenu` or `dropdown` naming tokens
- emit one canonical `core/navigation` tree with native `core/navigation-submenu` children

## Root cause
Responsive source sites can split navigation semantics across variants. The visible desktop menu on https://www.carajane.ca carries the top-level Portfolio item, while a duplicate responsive item with the same stable identity owns the Love, Newborn, Family, and Boudoir submenu. Blocks Engine selected the shallow visible variant and did not recognize the richer `menu-wrap > ul` structure as a submenu. Static Site Importer then correctly persisted that incomplete canonical markup.

## Evidence
- Before: Portfolio persisted as a `core/navigation-link` with no URL and no children.
- After: Portfolio persists as `core/navigation-submenu` with four working local routes.
- Live WordPress 7.0.4 editor verification: zero invalid blocks across all 8 imported pages (712 blocks).
- Closed-page visual comparison against the unpatched import: 0 mismatched mobile pixels; 1.05% desktop mismatch localized to the now-functional submenu control. Full-page dimensions remain identical.
- Development package provenance: Static Site Importer `f04c7de7ffb0`, Blocks Engine `dd78832d48e6`.

The broader wrapper-heavy authoring model is separate and remains tracked by #868.

## Testing
- `composer test` (278 parity fixtures plus canonical, unit, and packaging contracts)
- direct transform of the captured Cara Jane homepage: 1 navigation, 1 submenu, 8 child links, block validity pass
- Studio PR 3952 artifact re-import using current Static Site Importer `main` and this branch
- browser verification of submenu hover and all four destinations
- browser editor verification across all imported pages

## AI assistance
- **Model/tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause analysis, implementation, regression coverage, package construction, live Studio import verification, browser interaction checks, and visual comparison.
- Chris Huber reviewed and remains responsible for the change.