### PR TITLE
Prune inert search and cart shells

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -3412,6 +3412,10 @@ final class HtmlTransformer
                 return $this->htmlPreservationBlock($element);
             }
 
+            if ( $this->isEmptyInteractiveFeatureShell($element) ) {
+                return null;
+            }
+
             $this->captureDivBasedPseudoFormFallback($element, $fallbacks);
 
             // A gallery can only contain native image blocks. Preserve the
@@ -5725,6 +5729,36 @@ final class HtmlTransformer
 
         if ( ! $this->isEmptyVisualInlineCandidate($element) ) {
             return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Empty search and cart shells are dead platform chrome, not authored layout.
+     * Content, controls, media, links, and runtime bindings keep their existing
+     * native or capability-owned conversion path.
+     */
+    private function isEmptyInteractiveFeatureShell(DOMElement $element): bool
+    {
+        $identity = strtolower(trim($this->attr($element, 'class') . ' ' . $this->attr($element, 'id') . ' ' . $this->attr($element, 'role')));
+        if ( ! preg_match('/(?:^|[^a-z0-9])(?:search|cart)(?:[^a-z0-9]|$)/', $identity)
+            || '' !== $this->renderedTextContent($element)
+            || $this->isRuntimeDomTarget($element)
+        ) {
+            return false;
+        }
+
+        foreach ( array( 'a', 'audio', 'button', 'canvas', 'iframe', 'img', 'input', 'object', 'picture', 'select', 'svg', 'textarea', 'video' ) as $tagName ) {
+            if ( 0 < $element->getElementsByTagName($tagName)->length ) {
+                return false;
+            }
+        }
+
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && $this->isRuntimeDomTarget($descendant) ) {
+                return false;
+            }
         }
 
         return true;

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -5745,6 +5745,8 @@ final class HtmlTransformer
         if ( ! preg_match('/(?:^|[^a-z0-9])(?:search|cart)(?:[^a-z0-9]|$)/', $identity)
             || '' !== $this->renderedTextContent($element)
             || $this->isRuntimeDomTarget($element)
+            || $this->isDirectChildOfStructuralLayout($element)
+            || $this->hasAuthorInlineAlignment($element)
         ) {
             return false;
         }
@@ -5762,6 +5764,26 @@ final class HtmlTransformer
         }
 
         return true;
+    }
+
+    private function hasAuthorInlineAlignment(DOMElement $element): bool
+    {
+        $declarations = $this->presentationDeclarations($element);
+        ( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, function (string $prelude, string $body) use ($element, &$declarations): string {
+            foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
+                $parsed = $this->parsedCssSelector($selector);
+                if ( $parsed['supported'] && CssSelectorMatcher::matches($element, $parsed, true)['matches'] ) {
+                    $declarations = $this->mergeCssDeclarationMaps($declarations, $this->cssDeclarations($body));
+                    break;
+                }
+            }
+            return $prelude;
+        });
+
+        $display = strtolower(trim((string) ($declarations['display'] ?? '')));
+        $verticalAlign = strtolower(trim((string) ($declarations['vertical-align'] ?? '')));
+        return in_array($display, array( 'inline', 'inline-block', 'inline-flex', 'inline-grid', 'inline-table' ), true)
+            && ! in_array($verticalAlign, array( '', 'baseline', 'inherit', 'initial', 'revert', 'revert-layer', 'unset' ), true);
     }
 
     private function isInertHiddenEmptyElement(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -4218,6 +4218,19 @@ $assert(null === $findBlockByClass($hiddenEmptyResult['blocks'], 'caption'), 'in
 $assert(is_array($findBlockByClass($hiddenEmptyResult['blocks'], 'responsive-panel')), 'responsive-revealed hidden empty elements remain available at their visible breakpoint');
 $assert(str_contains($hiddenEmptyResult['serialized_blocks'], 'id="runtime-panel"') && str_contains($hiddenEmptyResult['serialized_blocks'], 'id="anchor-panel"'), 'runtime-targeted and anchored hidden empty elements preserve their identifiers');
 
+$emptyFeatureShellResult = (new HtmlTransformer())->transform(
+    '<header><div class="empty-search-shell"><div class="container"><span></span></div></div>'
+    . '<div class="mini-cart"></div><div class="real-search-shell"><input type="search" aria-label="Search"></div>'
+    . '<div class="cart-status">2 items</div><div id="runtime-cart" class="cart"></div></header>',
+    array('runtime_dom_selectors' => array('#runtime-cart'))
+)->toArray();
+$emptyFeatureShellSerialized = (string) ($emptyFeatureShellResult['serialized_blocks'] ?? '');
+$assert(! str_contains($emptyFeatureShellSerialized, 'empty-search-shell'), 'empty search chrome and its wrapper subtree are pruned');
+$assert(! str_contains($emptyFeatureShellSerialized, 'mini-cart'), 'empty cart chrome is pruned instead of becoming an empty group');
+$assert(str_contains($emptyFeatureShellSerialized, 'real-search-shell') && str_contains($emptyFeatureShellSerialized, 'aria-label=\"Search\"'), 'a real search control remains on its existing safe conversion path');
+$assert(str_contains($emptyFeatureShellSerialized, '2 items'), 'cart chrome carrying visible state remains authored content');
+$assert(str_contains($emptyFeatureShellSerialized, 'runtime-cart'), 'runtime-bound empty cart shells remain available to their behavior owner');
+
 $runtimeGeometryResult = (new HtmlTransformer())->transform(
     '<main><div id="runtime-geometry" style="width:290px !important;height:62px !important"></div></main>',
     array('runtime_dom_selectors' => array('#runtime-geometry'))

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -4231,6 +4231,14 @@ $assert(str_contains($emptyFeatureShellSerialized, 'real-search-shell') && str_c
 $assert(str_contains($emptyFeatureShellSerialized, '2 items'), 'cart chrome carrying visible state remains authored content');
 $assert(str_contains($emptyFeatureShellSerialized, 'runtime-cart'), 'runtime-bound empty cart shells remain available to their behavior owner');
 
+$layoutFeatureShellResult = (new HtmlTransformer())->transform(
+    '<header class="toolbar"><div class="empty-search-shell"></div><nav><a href="/">Home</a></nav><div class="mini-cart"></div></header>',
+    array('static_css' => '.toolbar{display:flex;justify-content:space-between}.mini-cart{display:inline-block;vertical-align:middle}')
+)->toArray();
+$layoutFeatureShellSerialized = (string) ($layoutFeatureShellResult['serialized_blocks'] ?? '');
+$assert(str_contains($layoutFeatureShellSerialized, 'empty-search-shell'), 'empty feature chrome participating in author-owned layout remains available to preserve sibling placement');
+$assert(str_contains($layoutFeatureShellSerialized, 'mini-cart'), 'empty inline feature chrome with explicit vertical alignment remains available to preserve the inline baseline');
+
 $runtimeGeometryResult = (new HtmlTransformer())->transform(
     '<main><div id="runtime-geometry" style="width:290px !important;height:62px !important"></div></main>',
     array('runtime_dom_selectors' => array('#runtime-geometry'))


### PR DESCRIPTION
## Summary

- prune empty search and cart feature shells before they become nested Groups
- retain shells with content, controls, media, links, runtime bindings, structural-layout participation, or authored inline alignment
- inspect the full projected author stylesheet for baseline-affecting alignment rules, including rules outside bounded presentation analysis

## Verification

- `composer test`: all canonical, unit, packaging, and 278 parity fixtures pass
- repeated import of the same https://www.carajane.ca artifact: 720 -> 685 blocks and 383 -> 356 Groups
- empty Groups: 40 -> 31; single-Group wrapper chains: 103 -> 94; max depth remains 14
- desktop and mobile pixel comparison is exact after normalizing one rotating image state
- all eight imported Gutenberg editors report zero invalid blocks
- all four Portfolio submenu routes remain visible and return HTTP 200

## AI Assistance

GPT-5.6-sol via OpenCode was used to inspect the transformer, implement the change, and run fixture, import, editor, navigation, and visual validation.