### PR TITLE
Declare companion block script dependencies

### DIFF
--- a/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
+++ b/php-transformer/src/ArtifactCompiler/CompanionPluginPayload.php
@@ -208,6 +208,44 @@ final class CompanionPluginPayload
         if ( is_array($block['assets'] ?? null) && array() !== $block['assets'] ) {
             $normalized['assets'] = $block['assets'];
         }
+        $scriptDependencies = $this->normalizeScriptDependencies($block['script_dependencies'] ?? null, $normalized['assets'] ?? array());
+        if ( array() !== $scriptDependencies ) {
+            $normalized['script_dependencies'] = $scriptDependencies;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Retain script dependency declarations only for emitted JavaScript assets.
+     *
+     * @param mixed                $dependencies
+     * @param array<string, mixed> $assets
+     * @return array<string, array<int, string>>
+     */
+    private function normalizeScriptDependencies(mixed $dependencies, array $assets): array
+    {
+        if ( ! is_array($dependencies) ) {
+            return array();
+        }
+
+        $normalized = array();
+        foreach ( $dependencies as $path => $handles ) {
+            if ( ! is_string($path) || 1 !== preg_match('#^(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+\.js$#', $path) || ! is_scalar($assets[$path] ?? null) || ! is_array($handles) ) {
+                continue;
+            }
+
+            $validHandles = array();
+            foreach ( $handles as $handle ) {
+                if ( ! is_string($handle) || 1 !== preg_match('/^[A-Za-z0-9_-]+$/', $handle) || isset($validHandles[$handle]) ) {
+                    continue;
+                }
+                $validHandles[$handle] = true;
+            }
+            if ( array() !== $validHandles ) {
+                $normalized[$path] = array_keys($validHandles);
+            }
+        }
 
         return $normalized;
     }

--- a/php-transformer/src/HtmlToBlocks/AuthorLayoutBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthorLayoutBlockGenerator.php
@@ -17,7 +17,7 @@ final class AuthorLayoutBlockGenerator
             'title' => 'Author Layout',
             'category' => 'design',
             'description' => 'An editable semantic container whose layout remains owned by author CSS.',
-            'editorScript' => array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ),
+            'editorScript' => 'file:./index.js',
             'attributes' => array(
                 'anchor' => array( 'type' => 'string', 'default' => '' ),
                 'className' => array( 'type' => 'string', 'default' => '' ),
@@ -78,6 +78,6 @@ JS;
     /** @return array<string, mixed> */
     public function definition(): array
     {
-        return array( 'name' => 'author-layout', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
+        return array( 'name' => 'author-layout', 'block_json' => $this->blockJson(), 'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ), 'assets' => $this->assets() );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/AuthoredInputBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthoredInputBlockGenerator.php
@@ -19,7 +19,7 @@ final class AuthoredInputBlockGenerator
             'title' => 'Input Field',
             'category' => 'widgets',
             'description' => 'An editable native input field.',
-            'editorScript' => array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ),
+            'editorScript' => 'file:./index.js',
             'attributes' => array(
                 'type' => array( 'type' => 'string', 'default' => 'text' ),
                 'id' => array( 'type' => 'string', 'default' => '' ),
@@ -84,6 +84,6 @@ JS;
     /** @return array<string, mixed> */
     public function definition(): array
     {
-        return array( 'name' => 'authored-input', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
+        return array( 'name' => 'authored-input', 'block_json' => $this->blockJson(), 'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ), 'assets' => $this->assets() );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/AuthoredSelectBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthoredSelectBlockGenerator.php
@@ -19,7 +19,7 @@ final class AuthoredSelectBlockGenerator
             'title' => 'Select Field',
             'category' => 'widgets',
             'description' => 'An editable native select field.',
-            'editorScript' => array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ),
+            'editorScript' => 'file:./index.js',
             'style' => 'file:./style.css',
             'attributes' => array(
                 'id' => array( 'type' => 'string', 'default' => '' ),
@@ -91,6 +91,6 @@ JS;
     /** @return array<string, mixed> */
     public function definition(): array
     {
-        return array( 'name' => 'authored-select', 'block_json' => $this->blockJson(), 'assets' => $this->assets() );
+        return array( 'name' => 'authored-select', 'block_json' => $this->blockJson(), 'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ), 'assets' => $this->assets() );
     }
 }

--- a/php-transformer/src/HtmlToBlocks/DescriptionListBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/DescriptionListBlockGenerator.php
@@ -22,9 +22,7 @@ final class DescriptionListBlockGenerator
             'title' => 'Description List',
             'category' => 'text',
             'description' => 'A semantic description list with terms and descriptions.',
-            // Companion plugins only materialize static assets. WordPress accepts
-            // script handles alongside a file reference, avoiding index.asset.php.
-            'editorScript' => array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ),
+            'editorScript' => 'file:./index.js',
             'attributes' => array(
                 'className' => array( 'type' => 'string', 'default' => '' ),
                 'style' => array( 'type' => 'string', 'default' => '' ),
@@ -132,6 +130,7 @@ JS;
         return array(
             'name' => 'description-list',
             'block_json' => $this->blockJson(),
+            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ),
             'assets' => $this->assets(),
         );
     }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3731,6 +3731,8 @@ $authoredSelectCompanion = $authoredControlBlocks[0] ?? array();
 $authoredInputCompanion = $authoredControlBlocks[1] ?? array();
 $assert('blocks-engine/authored-select' === ($authoredSelectCompanion['block_json']['name'] ?? null), 'authored-select companion metadata uses its canonical block name');
 $assert('blocks-engine/authored-input' === ($authoredInputCompanion['block_json']['name'] ?? null), 'authored-input companion metadata uses its canonical block name');
+$assert(array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ) === ($authoredSelectCompanion['script_dependencies'] ?? null), 'authored-select companion dependency metadata survives payload compilation');
+$assert(array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ) === ($authoredInputCompanion['script_dependencies'] ?? null), 'authored-input companion dependency metadata survives payload compilation');
 preg_match_all("/registerBlockType\\(\\s*'([^']+)'/", (string) ($authoredSelectCompanion['assets']['index.js'] ?? ''), $authoredSelectRegistrations);
 preg_match_all("/registerBlockType\\(\\s*'([^']+)'/", (string) ($authoredInputCompanion['assets']['index.js'] ?? ''), $authoredInputRegistrations);
 $assert(array( 'blocks-engine/authored-select' ) === ($authoredSelectRegistrations[1] ?? array()), 'authored-select companion editor script registers only its canonical block name');
@@ -4446,6 +4448,7 @@ $descriptionListBlocks = $descriptionListPayload['blocks'] ?? array();
 $assert(1 === count($descriptionListBlocks), 'multi-page description lists project one deduplicated companion definition');
 $assert('blocks-engine/description-list' === ($descriptionListBlocks[0]['block_json']['name'] ?? null), 'companion payload projects the generated description-list block metadata');
 $assert(str_contains((string) ($descriptionListBlocks[0]['assets']['index.js'] ?? ''), 'registerBlockType'), 'companion payload projects the installable editor asset');
+$assert(array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ) === ($descriptionListBlocks[0]['script_dependencies'] ?? null), 'description-list companion dependency metadata survives payload compilation');
 $assert('semantic-description-list' === ($descriptionListArtifact['source_reports']['gutenberg_gaps'][0]['id'] ?? null), 'multi-page artifacts aggregate the Gutenberg gap once');
 $assert('https://github.com/WordPress/gutenberg/pull/20760' === ($descriptionListArtifact['source_reports']['gutenberg_gaps'][0]['references'][1] ?? null), 'gap diagnostic records the stalled Gutenberg implementation context');
 

--- a/php-transformer/tests/unit/description-list-block.php
+++ b/php-transformer/tests/unit/description-list-block.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\AuthorLayoutBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\AuthoredInputBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\AuthoredSelectBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\DescriptionListBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CompanionPluginPayload;
 
 $failures = 0;
 $passes = 0;
@@ -23,7 +26,7 @@ $definition = $generator->definition();
 $assert(DescriptionListBlockGenerator::NAME === ($definition['block_json']['name'] ?? null), 'block metadata uses the stable companion name');
 $assert(3 === ($definition['block_json']['apiVersion'] ?? null), 'block metadata uses apiVersion 3');
 $assert(false === ($definition['block_json']['supports']['html'] ?? null), 'block metadata disables raw HTML editing');
-$assert(array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ) === ($definition['block_json']['editorScript'] ?? null), 'block metadata declares WordPress editor dependencies and the editor asset');
+$assert('file:./index.js' === ($definition['block_json']['editorScript'] ?? null), 'block metadata uses a single editor asset reference');
 $assert(str_contains((string) ($definition['assets']['index.js'] ?? ''), 'RawHTML'), 'editor asset serializes semantic static markup');
 $assert(str_contains((string) ($definition['assets']['index.js'] ?? ''), 'escapeAttribute'), 'editor asset escapes presentation attributes');
 $assert(str_contains((string) ($definition['assets']['index.js'] ?? ''), 'attributes: attributes'), 'client registration declares the block attribute schema');
@@ -45,17 +48,67 @@ $isSafeCompanionAsset = static function (mixed $path, mixed $content): bool {
     return in_array($extension, array( 'js', 'mjs', 'css', 'json', 'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'ico', 'woff', 'woff2', 'ttf', 'otf', 'eot' ), true)
         && ! preg_match('/<\\?(?:php|=|[[:space:]])/i', (string) $content);
 };
-$assert(array( 'index.js' ) === array_keys($assets), 'description-list emits only its package-relative editor asset');
+$assert(array( 'index.js' ) === array_keys($assets), 'description-list emits only its static editor asset');
 $assert(array_reduce(array_keys($assets), static fn (bool $safe, string $path): bool => $safe && $isSafeCompanionAsset($path, $assets[$path]), true), 'description-list emitted assets satisfy SSI companion safe-path and static-content validation');
-$editorScript = $definition['block_json']['editorScript'] ?? array();
-$editorAsset = is_array($editorScript) ? end($editorScript) : '';
+$editorAsset = $definition['block_json']['editorScript'] ?? '';
 $editorPath = is_string($editorAsset) && str_starts_with($editorAsset, 'file:./') ? substr($editorAsset, 7) : '';
 $assert('index.js' === $editorPath && array_key_exists($editorPath, $assets), 'description-list editor metadata resolves to a materializable package-relative asset');
 $authorLayout = ( new AuthorLayoutBlockGenerator() )->definition();
 $authorAssets = $authorLayout['assets'] ?? array();
-$assert(array( 'index.js' ) === array_keys($authorAssets), 'author-layout emits only its package-relative editor asset');
+$assert(array( 'index.js' ) === array_keys($authorAssets), 'author-layout emits only its static editor asset');
 $assert(array_reduce(array_keys($authorAssets), static fn (bool $safe, string $path): bool => $safe && $isSafeCompanionAsset($path, $authorAssets[$path]), true), 'author-layout emitted assets satisfy SSI companion safe-path and static-content validation');
-$assert(array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'file:./index.js' ) === ($authorLayout['block_json']['editorScript'] ?? null), 'author-layout metadata declares WordPress editor dependencies and the editor asset');
+$assert('file:./index.js' === ($authorLayout['block_json']['editorScript'] ?? null), 'author-layout metadata uses a single editor asset reference');
+
+$companionGenerators = array(
+    new AuthoredInputBlockGenerator(),
+    new AuthoredSelectBlockGenerator(),
+    new DescriptionListBlockGenerator(),
+    new AuthorLayoutBlockGenerator(),
+);
+$nodeRegistrationRunner = <<<'JS'
+const vm = require( 'node:vm' );
+const registered = [];
+const context = {
+    window: { wp: {
+        blocks: { registerBlockType: ( name ) => registered.push( name ) },
+        blockEditor: {},
+        element: {}
+    } }
+};
+vm.runInNewContext( Buffer.from( process.argv[ 1 ], 'base64' ).toString(), context );
+process.stdout.write( JSON.stringify( registered ) );
+JS;
+foreach ( $companionGenerators as $companionGenerator ) {
+    $companionDefinition = $companionGenerator->definition();
+    $companionAssets = $companionDefinition['assets'];
+    $expectedBlockName = $companionDefinition['block_json']['name'];
+    $registered = shell_exec('node -e ' . escapeshellarg($nodeRegistrationRunner) . ' ' . escapeshellarg(base64_encode($companionAssets['index.js'])));
+    $payload = ( new CompanionPluginPayload() )->fromBlockTypes(array(), array(), array(), array( $companionDefinition ));
+
+    $assert('file:./index.js' === ($companionDefinition['block_json']['editorScript'] ?? null), $expectedBlockName . ' editorScript is a single WordPress file reference');
+    $assert(array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ) === ($companionDefinition['script_dependencies'] ?? null), $expectedBlockName . ' declares its editor dependencies for SSI without emitting server code');
+    $assert(array_reduce(array_keys($companionAssets), static fn (bool $safe, string $path): bool => $safe && $isSafeCompanionAsset($path, $companionAssets[$path]), true), $expectedBlockName . ' emits only static companion assets');
+    $assert(array( $expectedBlockName ) === json_decode((string) $registered, true), $expectedBlockName . ' editor script registers after WordPress dependencies are loaded');
+    $assert($companionDefinition['script_dependencies'] === ($payload['blocks'][0]['script_dependencies'] ?? null), $expectedBlockName . ' dependency metadata survives companion payload normalization');
+}
+$dependencyPayload = ( new CompanionPluginPayload() )->fromBlockTypes(
+    array(),
+    array(),
+    array(),
+    array(
+        array(
+            'name' => 'dependency-test',
+            'block_json' => array( 'name' => 'blocks-engine/dependency-test' ),
+            'assets' => array( 'index.js' => 'window.test = true;' ),
+            'script_dependencies' => array(
+                'index.js' => array( 'wp-blocks', 'wp-blocks', 'invalid handle' ),
+                '../outside.js' => array( 'wp-element' ),
+                'missing.js' => array( 'wp-element' ),
+            ),
+        ),
+    )
+);
+$assert(array( 'index.js' => array( 'wp-blocks' ) ) === ($dependencyPayload['blocks'][0]['script_dependencies'] ?? null), 'companion payload retains only deduplicated dependencies for emitted safe script assets');
 
 $html = '<dl class="facts &amp; figures" style="display:grid"><dt class="term"><strong>Office</strong> <em>location</em></dt><dt>Alias</dt><dd class="definition">North <a href="/hall">Hall</a></dd><dd>Weekdays</dd><dt>Hours</dt><dd>09:00 &amp; 17:00</dd></dl>';
 $result = ( new HtmlTransformer() )->transform($html)->toArray();


### PR DESCRIPTION
## Summary

- make generated companion block metadata reference one editor script file
- declare WordPress package dependencies as static payload metadata
- preserve the dependency contract through companion payload normalization
- cover all generated companion block types with executable registration checks

## Why

The previous `editorScript` array treated `wp-blocks`, `wp-block-editor`, and `wp-element` as independent scripts, not dependencies. In a real editor, `authored-input/index.js` ran before `window.wp.blocks` existed and the block never entered the client registry.

The paired SSI PR safely converts this static declaration into trusted WordPress `.asset.php` metadata.

## Verification

- `cd php-transformer && composer test`
- 278 parity fixtures pass
- Live disposable WordPress editor acceptance reports `blocks-engine/authored-input` as `isValid: true`, with a 1.0 editor-valid block rate and zero warnings.

## Dependency

Merge Automattic/static-site-importer#1039 first.

Closes #829.

## AI assistance

GPT-5.6 Sol via OpenCode was used to reproduce the browser registration race, design the declarative cross-repo contract, implement the producer change and tests, and run live WordPress editor acceptance. Chris Huber reviewed the approach and is responsible for every line.