### PR TITLE
Pin solved gate to released WP Codebox workflow

### DIFF
--- a/.github/workflows/solved-fixture-regression.yml
+++ b/.github/workflows/solved-fixture-regression.yml
@@ -18,8 +18,8 @@ permissions:
 
 jobs:
   solved-site-promotion:
-    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@8b0a191dde1002663b2020ccc40ecda2e28af76a
+    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@a4f469d6b5646dfec387e0e3ea80b1215bd24e7f
     with:
-      static-site-importer-sha: 8b0a191dde1002663b2020ccc40ecda2e28af76a
+      static-site-importer-sha: a4f469d6b5646dfec387e0e3ea80b1215bd24e7f
       blocks-engine-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       blocks-engine-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
## Summary
- pin the solved-site promotion workflow to merged Static Site Importer commit `a4f469d6`
- consume the upstream workflow that installs and verifies the published WP Codebox `v0.21.0` archive

Upstream: https://github.com/Automattic/static-site-importer/pull/1041
Original gate investigation: https://github.com/Automattic/blocks-engine/pull/912

## Verification
- `actionlint .github/workflows/solved-fixture-regression.yml`
- upstream solved-site promotion gate passed against the release artifact: https://github.com/Automattic/static-site-importer/actions/runs/32499126295

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to trace the immutable upstream merge identity, update the consumer pin, and validate the workflow. Chris Huber reviewed and is responsible for the change.