### PR TITLE
Optimize repeated DOM and CSS analysis

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -564,6 +564,12 @@ final class HtmlTransformer
     /** @var list<array{selector:string,parsed:array<string,mixed>}> */
     private array $authorSelectors = array();
 
+    /** @var list<array{order: int, declarations: array<string, string>, selectors: list<array{selector: string, parsed: array<string, mixed>, direct_child_parsed: array<string, mixed>}>}> */
+    private array $authorStyleRules = array();
+
+    /** @var array<string, array<string, mixed>> */
+    private array $authorStyleRuleCandidateIndexes = array();
+
     private string $authorMarkerSeed = '';
 
     private int $authorMarkerCounter = 0;
@@ -685,6 +691,8 @@ final class HtmlTransformer
         $this->parsedCssSelectors = array();
         $this->authorSelectorMatchCache = null;
         $this->authorSelectors = array();
+        $this->authorStyleRules = array();
+        $this->authorStyleRuleCandidateIndexes = array();
         $this->authorMarkerSeed = '';
         $this->authorMarkerCounter = 0;
         $this->authorMarkerCollisionText = '';
@@ -2607,14 +2615,19 @@ final class HtmlTransformer
             $authorAnalysis = $this->analysisCache->authorSelectorAnalyses[$authorAnalysisKey];
             $sourceTagSelectorNames = $authorAnalysis['source_tags'];
             $authorSelectors = $authorAnalysis['selectors'];
+            $authorStyleRules = $authorAnalysis['rules'];
         } else {
 			++$this->analysisCache->authorSelectorBuilds;
 			$sourceTagSelectorNames = array();
 			$authorSelectors = array();
-			( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, function (string $prelude) use (&$sourceTagSelectorNames, &$authorSelectors): string {
+			$authorStyleRules = array();
+			( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, function (string $prelude, string $body) use (&$sourceTagSelectorNames, &$authorSelectors, &$authorStyleRules): string {
+				$ruleSelectors = array();
 				foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
 					$parsed = $this->parsedCssSelector($selector);
 					$authorSelectors[] = array('selector' => $selector, 'parsed' => $parsed);
+					$directSelector = preg_replace('/::[a-z-]+(?:\([^)]*\))?$/i', '', trim($selector)) ?? $selector;
+					$ruleSelectors[] = array('selector' => $selector, 'parsed' => $parsed, 'direct_child_parsed' => $this->parsedCssSelector($directSelector));
 					foreach ( $parsed['type_spans'] ?? array() as $typeSpan ) {
 						$tagName = strtolower($typeSpan['name']);
 						if ( in_array($tagName, array( 'div', 'li', 'nav', 'p' ), true) ) {
@@ -2622,11 +2635,16 @@ final class HtmlTransformer
 						}
 					}
 				}
+				if ( array() !== $ruleSelectors ) {
+					$authorStyleRules[] = array('order' => count($authorStyleRules), 'declarations' => $this->cssDeclarations($body), 'selectors' => $ruleSelectors);
+				}
 				return $prelude;
 			});
+			++$this->analysisCache->authorStyleRuleBuilds;
             $this->analysisCache->rememberAuthorSelectors($authorAnalysisKey, array(
                 'source_tags' => $sourceTagSelectorNames,
                 'selectors' => $authorSelectors,
+				'rules' => $authorStyleRules,
             ));
         }
         foreach ( array_keys($sourceTagSelectorNames) as $tagName ) {
@@ -2634,6 +2652,7 @@ final class HtmlTransformer
         }
 		$this->discoverAuthorControlPaths($authorSelectors);
 		$this->authorSelectors = $authorSelectors;
+		$this->authorStyleRules = $authorStyleRules;
 		$this->discoverAuthorInlineSemanticPaths($authorSelectors);
 		$this->discoverAuthorRootChildPaths($authorSelectors);
 		$this->discoverAuthorTablePaths($authorSelectors);
@@ -5620,33 +5639,18 @@ final class HtmlTransformer
             return false;
         }
 
-        $matches = false;
-        ( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, function (string $prelude) use ($element, $directChildren, &$matches): string {
-            if ( $matches ) {
-                return $prelude;
-            }
-            foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
-                // Pseudo-elements describe paint on the direct child rather than
-                // a DOM node of their own. Match their owning element to retain
-                // the source parent/child topology for rules such as
-                // `.overlay > strong::before`.
-                $matchSelector = preg_replace('/::[a-z-]+(?:\([^)]*\))?$/i', '', trim($selector)) ?? $selector;
-                $parsed = $this->parsedCssSelector($matchSelector);
+        foreach ( $directChildren as $child ) {
+            foreach ( $this->authorStyleRuleCandidates($child) as $selector ) {
+                $parsed = $selector['direct_child_parsed'];
                 $last = count($parsed['compounds'] ?? array()) - 1;
-                if ( ! $parsed['supported'] || $last < 1 || '>' !== ($parsed['combinators'][$last - 1] ?? '') ) {
-                    continue;
-                }
-                foreach ( $directChildren as $child ) {
-                    if ( CssSelectorMatcher::matches($child, $parsed, true)['matches'] ) {
-                        $matches = true;
-                        return $prelude;
-                    }
+                if ( $parsed['supported'] && $last >= 1 && '>' === ($parsed['combinators'][$last - 1] ?? '')
+                    && ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $parsed, true)['matches'] ) {
+                    return true;
                 }
             }
-            return $prelude;
-        });
+        }
 
-        return $matches;
+        return false;
     }
 
     /**
@@ -5729,7 +5733,7 @@ final class HtmlTransformer
             return true;
         }
 
-        foreach ( $this->conditionalStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'conditional') as $rule ) {
             if ( $this->matchesCssSelector($element, $rule['selector']) && in_array(strtolower(trim((string) ($rule['declarations']['display'] ?? ''))), array( 'flex', 'inline-flex', 'grid', 'inline-grid' ), true) ) {
                 return true;
             }
@@ -6222,9 +6226,8 @@ final class HtmlTransformer
     private function authorSemanticDeclarations(DOMElement $element): array
     {
         $declarations = array();
-        foreach ( $this->staticStyleRules as $rule ) {
-            $parsed = $this->parsedCssSelector($rule['selector']);
-            if ( $parsed['supported'] && CssSelectorMatcher::matches($element, $parsed, true)['matches'] ) {
+        foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
+            if ( $this->matchesCssSelector($element, $rule['selector']) ) {
                 $declarations = array_merge($declarations, $rule['declarations']);
             }
         }
@@ -6441,7 +6444,7 @@ final class HtmlTransformer
             return true;
         }
 
-        foreach ( $this->staticStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
             if ( $this->matchesCssSelector($element, $rule['selector']) ) {
                 return true;
             }
@@ -7052,17 +7055,66 @@ final class HtmlTransformer
     private function matchingAuthorDeclarations(DOMElement $element): array
     {
         $declarations = $this->presentationDeclarations($element);
-        ( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, function (string $prelude, string $body) use ($element, &$declarations): string {
-            foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
-                $parsed = $this->parsedCssSelector($selector);
-                if ( $parsed['supported'] && CssSelectorMatcher::matches($element, $parsed, true)['matches'] ) {
-                    $declarations = $this->mergeCssDeclarationMaps($declarations, $this->cssDeclarations($body));
-                    break;
-                }
+        $matchedRules = array();
+        foreach ( $this->authorStyleRuleCandidates($element) as $selector ) {
+            $ruleOrder = $selector['rule_order'];
+            if ( isset($matchedRules[$ruleOrder]) || ! $selector['parsed']['supported'] ) {
+                continue;
             }
-            return $prelude;
-        });
+            if ( ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $selector['selector'], $selector['parsed'], true)['matches'] ) {
+                $matchedRules[$ruleOrder] = true;
+                $declarations = $this->mergeCssDeclarationMaps($declarations, $selector['declarations']);
+            }
+        }
         return $declarations;
+    }
+
+    /** @return list<array{key: string, selector: string, parsed: array<string, mixed>, direct_child_parsed: array<string, mixed>, declarations: array<string, string>, rule_order: int}> */
+    private function authorStyleRuleCandidates(DOMElement $element): array
+    {
+        $index = $this->authorStyleRuleCandidateIndexes['rules'] ??= $this->authorStyleRuleCandidateIndex();
+        return ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, 'author-rules', $index);
+    }
+
+    /** @return array{universal: list<array<string, mixed>>, ids: array<string, list<array<string, mixed>>>, classes: array<string, list<array<string, mixed>>>, tags: array<string, list<array<string, mixed>>>, total: int} */
+    private function authorStyleRuleCandidateIndex(): array
+    {
+        $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'total' => 0);
+        $sequence = 0;
+        foreach ( $this->authorStyleRules as $rule ) {
+            foreach ( $rule['selectors'] as $selectorIndex => $selector ) {
+                $parsed = $selector['parsed'];
+                $compounds = $parsed['compounds'] ?? array();
+                $rightmost = array() === $compounds ? null : $compounds[array_key_last($compounds)];
+                $target = 'universal';
+                $key = '';
+                if ( $parsed['supported'] && is_array($rightmost) ) {
+                    if ( array() !== ($rightmost['ids'] ?? array()) ) {
+                        $target = 'ids';
+                        $key = (string) $rightmost['ids'][0];
+                    } elseif ( array() !== ($rightmost['classes'] ?? array()) ) {
+                        $target = 'classes';
+                        $key = (string) $rightmost['classes'][0];
+                    } elseif ( is_string($rightmost['type'] ?? null) && '' !== $rightmost['type'] ) {
+                        $target = 'tags';
+                        $key = strtolower((string) $rightmost['type']);
+                    }
+                }
+                $entry = array(
+                    'order' => $rule['order'],
+                    'sequence' => $sequence++,
+                    'key' => $rule['order'] . ':' . $selectorIndex,
+                    'rule' => array_merge($selector, array('declarations' => $rule['declarations'], 'rule_order' => $rule['order'], 'key' => $rule['order'] . ':' . $selectorIndex)),
+                );
+                if ( 'universal' === $target ) {
+                    $index['universal'][] = $entry;
+                } else {
+                    $index[$target][$key][] = $entry;
+                }
+                ++$index['total'];
+            }
+        }
+        return $index;
     }
 
     private function selectorMatchingSurvivesWrapperCoalescing(DOMElement $element, DOMElement $child): bool
@@ -7072,10 +7124,11 @@ final class HtmlTransformer
             return false;
         }
 
+        $beforeCandidates = $this->authorStyleRuleCandidates($child);
         $matchesBefore = array();
-        foreach ( $this->authorSelectors as $index => $authorSelector ) {
-            $matchesBefore[$index] = $authorSelector['parsed']['supported']
-                && CssSelectorMatcher::matches($child, $authorSelector['parsed'], true)['matches'];
+        foreach ( $beforeCandidates as $selector ) {
+            $matchesBefore[$selector['key']] = $selector['parsed']['supported']
+                && ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $selector['parsed'], true)['matches'];
         }
 
         $childClass = $this->attr($child, 'class');
@@ -7084,12 +7137,18 @@ final class HtmlTransformer
         $parent->insertBefore($child, $element);
         $parent->removeChild($element);
         $child->setAttribute('class', $this->mergeClassNames($this->attr($element, 'class'), $childClass));
+        $this->invalidateSourceSelectorMatchCache();
 
         $survives = true;
-        foreach ( $this->authorSelectors as $index => $authorSelector ) {
-            $matchesAfter = $authorSelector['parsed']['supported']
-                && CssSelectorMatcher::matches($child, $authorSelector['parsed'], true)['matches'];
-            if ( $matchesBefore[$index] !== $matchesAfter ) {
+        $afterCandidates = $this->authorStyleRuleCandidates($child);
+        $candidates = array();
+        foreach ( array_merge($beforeCandidates, $afterCandidates) as $selector ) {
+            $candidates[$selector['key']] = $selector;
+        }
+        foreach ( $candidates as $key => $selector ) {
+            $matchesAfter = $selector['parsed']['supported']
+                && ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $selector['parsed'], true)['matches'];
+            if ( ($matchesBefore[$key] ?? false) !== $matchesAfter ) {
                 $survives = false;
                 break;
             }
@@ -7103,6 +7162,7 @@ final class HtmlTransformer
         } else {
             $child->setAttribute('class', $childClass);
         }
+        $this->invalidateSourceSelectorMatchCache();
 
         return $survives;
     }
@@ -7384,7 +7444,7 @@ final class HtmlTransformer
     private function authoredDisplay(DOMElement $element): string
     {
         $display = '';
-        foreach ( $this->staticStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
             if ( isset($rule['declarations']['display']) && $this->matchesCssSelector($element, $rule['selector']) ) {
                 $display = (string) $rule['declarations']['display'];
             }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -33,6 +33,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
@@ -558,6 +559,8 @@ final class HtmlTransformer
     /** @var array<string, array<string, mixed>> */
     private array $parsedCssSelectors = array();
 
+    private ?CssSelectorMatchCache $authorSelectorMatchCache = null;
+
     /** @var list<array{selector:string,parsed:array<string,mixed>}> */
     private array $authorSelectors = array();
 
@@ -680,6 +683,7 @@ final class HtmlTransformer
 		$this->authorStyleSourceClasses = array();
         $this->authorSourceSelectorMatches = array();
         $this->parsedCssSelectors = array();
+        $this->authorSelectorMatchCache = null;
         $this->authorSelectors = array();
         $this->authorMarkerSeed = '';
         $this->authorMarkerCounter = 0;
@@ -692,13 +696,15 @@ final class HtmlTransformer
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $staticCss = (string) ($options['static_css'] ?? '');
         $styleAnalysisKey = $this->styleAnalysisKey($html, $staticCss);
-        if ( $styleAnalysisKey === ($this->analysisCache->style['key'] ?? null) ) {
-            $this->staticStyleRules = $this->analysisCache->style['static'];
-            $this->conditionalStyleRules = $this->analysisCache->style['conditional'];
-            $this->navigationStateStyleRules = $this->analysisCache->style['navigation_state'];
-            $this->imageShapeStyleRules = $this->analysisCache->style['image_shape'];
-            $this->staticPseudoElementStyleRules = $this->analysisCache->style['pseudo'];
-            $this->cssCustomProperties = $this->analysisCache->style['custom_properties'];
+        if ( isset($this->analysisCache->styles[$styleAnalysisKey]) ) {
+            ++$this->analysisCache->styleHits;
+            $styleAnalysis = $this->analysisCache->styles[$styleAnalysisKey];
+            $this->staticStyleRules = $styleAnalysis['static'];
+            $this->conditionalStyleRules = $styleAnalysis['conditional'];
+            $this->navigationStateStyleRules = $styleAnalysis['navigation_state'];
+            $this->imageShapeStyleRules = $styleAnalysis['image_shape'];
+            $this->staticPseudoElementStyleRules = $styleAnalysis['pseudo'];
+            $this->cssCustomProperties = $styleAnalysis['custom_properties'];
         } else {
             ++$this->analysisCache->styleBuilds;
             $this->staticStyleRules = $this->staticStyleRules($html, $staticCss);
@@ -707,15 +713,14 @@ final class HtmlTransformer
             $this->imageShapeStyleRules = $this->imageShapeStyleRules($html, $staticCss);
             $this->staticPseudoElementStyleRules = $this->staticPseudoElementStyleRules($html, $staticCss);
             $this->cssCustomProperties = $this->cssCustomProperties($html, $staticCss);
-            $this->analysisCache->style = array(
-                'key' => $styleAnalysisKey,
+            $this->analysisCache->rememberStyle($styleAnalysisKey, array(
                 'static' => $this->staticStyleRules,
                 'conditional' => $this->conditionalStyleRules,
                 'navigation_state' => $this->navigationStateStyleRules,
                 'image_shape' => $this->imageShapeStyleRules,
                 'pseudo' => $this->staticPseudoElementStyleRules,
                 'custom_properties' => $this->cssCustomProperties,
-            );
+            ));
         }
         $this->resetPresentationResolutionCache();
         $this->runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
@@ -2571,6 +2576,7 @@ final class HtmlTransformer
         }
 
         $this->authorStyleSourceBody = $sourceBody;
+        $this->authorSelectorMatchCache = new CssSelectorMatchCache();
 		for ( $ancestor = $sourceBody; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
 			$this->recordAuthorSelectorSignals($ancestor);
 		}
@@ -2592,9 +2598,11 @@ final class HtmlTransformer
         }
 
 		$authorAnalysisKey = hash('sha256', $this->combinedAuthorCss);
-        if ( $authorAnalysisKey === ($this->analysisCache->authorSelectors['key'] ?? null) ) {
-            $sourceTagSelectorNames = $this->analysisCache->authorSelectors['source_tags'];
-            $authorSelectors = $this->analysisCache->authorSelectors['selectors'];
+        if ( isset($this->analysisCache->authorSelectorAnalyses[$authorAnalysisKey]) ) {
+            ++$this->analysisCache->authorSelectorHits;
+            $authorAnalysis = $this->analysisCache->authorSelectorAnalyses[$authorAnalysisKey];
+            $sourceTagSelectorNames = $authorAnalysis['source_tags'];
+            $authorSelectors = $authorAnalysis['selectors'];
         } else {
 			++$this->analysisCache->authorSelectorBuilds;
 			$sourceTagSelectorNames = array();
@@ -2612,11 +2620,10 @@ final class HtmlTransformer
 				}
 				return $prelude;
 			});
-            $this->analysisCache->authorSelectors = array(
-                'key' => $authorAnalysisKey,
+            $this->analysisCache->rememberAuthorSelectors($authorAnalysisKey, array(
                 'source_tags' => $sourceTagSelectorNames,
                 'selectors' => $authorSelectors,
-            );
+            ));
         }
         foreach ( array_keys($sourceTagSelectorNames) as $tagName ) {
             $this->sourceTagMarkers[ $tagName ] = $this->allocateAuthorMarker('source-' . $tagName);
@@ -2627,6 +2634,10 @@ final class HtmlTransformer
 		$this->discoverAuthorRootChildPaths($authorSelectors);
 		$this->discoverAuthorTablePaths($authorSelectors);
         $this->sourceBodyProjectionClasses = $this->referencedSourceBodyClasses($sourceBody);
+        $this->analysisCache->authorSelectorClassTokenBuilds += $this->authorSelectorMatchCache->classTokenBuilds;
+        $this->analysisCache->authorSelectorClassTokenHits += $this->authorSelectorMatchCache->classTokenHits;
+        $this->analysisCache->authorSelectorAttributeReads += $this->authorSelectorMatchCache->attributeReads;
+        $this->authorSelectorMatchCache = null;
     }
 
     /** @return list<string> */
@@ -3199,14 +3210,16 @@ final class HtmlTransformer
     private function matchingAuthorSourceElements(string $selector, array $parsed): array
     {
         if ( array_key_exists($selector, $this->authorSourceSelectorMatches) ) {
+            ++$this->analysisCache->authorSelectorMatchResultHits;
             return $this->authorSourceSelectorMatches[$selector];
         }
+		++$this->analysisCache->authorSelectorMatchResultBuilds;
 		if ( ! $this->authorSelectorCanMatch($parsed) ) {
 			return $this->authorSourceSelectorMatches[$selector] = array();
 		}
         $matches = array();
         foreach ( $this->authorSelectorCandidates($parsed) as $element ) {
-            if ( CssSelectorMatcher::matches($element, $parsed, true)['matches'] ) {
+            if ( CssSelectorMatcher::matches($element, $parsed, true, $this->authorSelectorMatchCache)['matches'] ) {
                 $matches[] = $element;
             }
         }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -799,6 +799,9 @@ final class HtmlTransformer
         $this->hydrateDuplicateNavigationSubmenus($body);
         $this->materializeDeclarativeCounters($body, (string) ($options['declarative_state_html'] ?? ''));
         $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
+        // Author-selector preparation marks source nodes for later projection.
+        // General style matching begins only after those source mutations settle.
+        $this->invalidateSourceSelectorMatchCache();
         $this->collectEditorHiddenStateFindings($body);
 
         $fallbacks   = array();
@@ -870,6 +873,7 @@ final class HtmlTransformer
             );
         }
 
+        $this->recordSourceSelectorMatchWork();
         $metrics = $this->metrics($html, $blocks, $serializedBlocks, $fallbacks, $diagnostics, $startedAt);
         $nativeTargetBlocks = $this->runtime->availableCoreBlockNames();
         $sourceReports = array(
@@ -4024,6 +4028,9 @@ final class HtmlTransformer
      */
     private function convertElement(DOMElement $element, array &$fallbacks, bool $captureUnsupported = false): ?array
     {
+        // Conversion helpers may rewrite source markup. Do not reuse selector
+        // results or cached inputs across independently converted elements.
+        $this->invalidateSourceSelectorMatchCache();
         $tagName = strtolower($element->tagName);
 
         // A direct phrasing child participates in its parent's flex or grid

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -19,7 +19,7 @@ final class HtmlTransformerAnalysisCache
 
     public int $styleHits = 0;
 
-    /** @var array<string, array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>}> */
+    /** @var array<string, array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>}>} */
     public array $authorSelectorAnalyses = array();
 
     public int $authorSelectorBuilds = 0;
@@ -35,6 +35,8 @@ final class HtmlTransformerAnalysisCache
     public int $authorSelectorMatchResultBuilds = 0;
 
     public int $authorSelectorMatchResultHits = 0;
+
+    public int $authorStyleRuleBuilds = 0;
 
     public int $sourceSelectorMatchExecutions = 0;
 
@@ -59,7 +61,7 @@ final class HtmlTransformerAnalysisCache
         $this->styles[$key] = $analysis;
     }
 
-    /** @param array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>} $analysis */
+    /** @param array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} $analysis */
     public function rememberAuthorSelectors(string $key, array $analysis): void
     {
         if ( count($this->authorSelectorAnalyses) >= self::MAX_ENTRIES ) {

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -8,13 +8,49 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
  */
 final class HtmlTransformerAnalysisCache
 {
-    /** @var array{key: string, static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array}|null */
-    public ?array $style = null;
+    // Full parsed CSS analyses can be large; eight covers shared site styles
+    // without retaining an unbounded corpus of route-specific stylesheets.
+    private const MAX_ENTRIES = 8;
+
+    /** @var array<string, array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array}> */
+    public array $styles = array();
 
     public int $styleBuilds = 0;
 
-    /** @var array{key: string, source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>}|null */
-    public ?array $authorSelectors = null;
+    public int $styleHits = 0;
+
+    /** @var array<string, array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>}> */
+    public array $authorSelectorAnalyses = array();
 
     public int $authorSelectorBuilds = 0;
+
+    public int $authorSelectorHits = 0;
+
+    public int $authorSelectorClassTokenBuilds = 0;
+
+    public int $authorSelectorClassTokenHits = 0;
+
+    public int $authorSelectorAttributeReads = 0;
+
+    public int $authorSelectorMatchResultBuilds = 0;
+
+    public int $authorSelectorMatchResultHits = 0;
+
+    /** @param array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array} $analysis */
+    public function rememberStyle(string $key, array $analysis): void
+    {
+        if ( count($this->styles) >= self::MAX_ENTRIES ) {
+            array_shift($this->styles);
+        }
+        $this->styles[$key] = $analysis;
+    }
+
+    /** @param array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>} $analysis */
+    public function rememberAuthorSelectors(string $key, array $analysis): void
+    {
+        if ( count($this->authorSelectorAnalyses) >= self::MAX_ENTRIES ) {
+            array_shift($this->authorSelectorAnalyses);
+        }
+        $this->authorSelectorAnalyses[$key] = $analysis;
+    }
 }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -36,6 +36,20 @@ final class HtmlTransformerAnalysisCache
 
     public int $authorSelectorMatchResultHits = 0;
 
+    public int $sourceSelectorMatchExecutions = 0;
+
+    public int $sourceSelectorMatchHits = 0;
+
+    public int $sourceSelectorClassTokenBuilds = 0;
+
+    public int $sourceSelectorClassTokenHits = 0;
+
+    public int $sourceSelectorAttributeReads = 0;
+
+    public int $sourceStyleCandidateRuleChecks = 0;
+
+    public int $sourceStyleCandidateRulesSkipped = 0;
+
     /** @param array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array} $analysis */
     public function rememberStyle(string $key, array $analysis): void
     {

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -10,6 +10,8 @@ final class CssSelectorMatchCache
 {
     private const MAX_MATCHES = 4096;
 
+    private const MAX_CANDIDATE_RULES = 4096;
+
     /** @var array<string, list<string>> */
     private array $classTokens = array();
 
@@ -35,6 +37,8 @@ final class CssSelectorMatchCache
     public int $candidateRuleChecks = 0;
 
     public int $candidateRulesSkipped = 0;
+
+    public int $candidateRulesRetained = 0;
 
     /** @return list<string> */
     public function classTokens(DOMElement $element): array
@@ -108,6 +112,15 @@ final class CssSelectorMatchCache
         $this->candidateRuleChecks += count($rules);
         $this->candidateRulesSkipped += $index['total'] - count($rules);
 
+        $ruleCount = count($rules);
+        if ( $ruleCount > self::MAX_CANDIDATE_RULES ) {
+            return $rules;
+        }
+        if ( $this->candidateRulesRetained + $ruleCount > self::MAX_CANDIDATE_RULES ) {
+            $this->ruleCandidates = array();
+            $this->candidateRulesRetained = 0;
+        }
+        $this->candidateRulesRetained += $ruleCount;
         return $this->ruleCandidates[$key] = $rules;
     }
 
@@ -118,6 +131,7 @@ final class CssSelectorMatchCache
         $this->attributes = array();
         $this->matches = array();
         $this->ruleCandidates = array();
+        $this->candidateRulesRetained = 0;
     }
 
     private function elementKey(DOMElement $element): string

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+use DOMElement;
+
+/** Caches immutable-DOM selector inputs for one author-selector discovery pass. */
+final class CssSelectorMatchCache
+{
+    /** @var array<string, list<string>> */
+    private array $classTokens = array();
+
+    /** @var array<string, array<string, string|null>> */
+    private array $attributes = array();
+
+    public int $classTokenBuilds = 0;
+
+    public int $classTokenHits = 0;
+
+    public int $attributeReads = 0;
+
+    /** @return list<string> */
+    public function classTokens(DOMElement $element): array
+    {
+        $key = $this->elementKey($element);
+        if ( array_key_exists($key, $this->classTokens) ) {
+            ++$this->classTokenHits;
+            return $this->classTokens[$key];
+        }
+
+        ++$this->classTokenBuilds;
+        return $this->classTokens[$key] = preg_split('/[\x09\x0A\x0C\x0D\x20]+/', trim($this->attribute($element, 'class') ?? '')) ?: array();
+    }
+
+    public function attribute(DOMElement $element, string $name): ?string
+    {
+        $key = $this->elementKey($element);
+        if ( array_key_exists($name, $this->attributes[$key] ?? array()) ) {
+            return $this->attributes[$key][$name];
+        }
+
+        ++$this->attributeReads;
+        return $this->attributes[$key][$name] = $element->hasAttribute($name) ? $element->getAttribute($name) : null;
+    }
+
+    private function elementKey(DOMElement $element): string
+    {
+        return (string) spl_object_id($element);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -8,17 +8,33 @@ use DOMElement;
 /** Caches immutable-DOM selector inputs for one author-selector discovery pass. */
 final class CssSelectorMatchCache
 {
+    private const MAX_MATCHES = 4096;
+
     /** @var array<string, list<string>> */
     private array $classTokens = array();
 
     /** @var array<string, array<string, string|null>> */
     private array $attributes = array();
 
+    /** @var array<string, array{supported: bool, matches: bool}> */
+    private array $matches = array();
+
+    /** @var array<string, list<array<string, mixed>>> */
+    private array $ruleCandidates = array();
+
     public int $classTokenBuilds = 0;
 
     public int $classTokenHits = 0;
 
     public int $attributeReads = 0;
+
+    public int $matchExecutions = 0;
+
+    public int $matchHits = 0;
+
+    public int $candidateRuleChecks = 0;
+
+    public int $candidateRulesSkipped = 0;
 
     /** @return list<string> */
     public function classTokens(DOMElement $element): array
@@ -42,6 +58,66 @@ final class CssSelectorMatchCache
 
         ++$this->attributeReads;
         return $this->attributes[$key][$name] = $element->hasAttribute($name) ? $element->getAttribute($name) : null;
+    }
+
+    /** @param array<string, mixed> $selector @return array{supported: bool, matches: bool} */
+    public function matches(DOMElement $element, string $selectorText, array $selector, bool $accountForPseudoStateSuffix = false): array
+    {
+        $key = $this->elementKey($element) . "\0" . $selectorText . "\0" . ($accountForPseudoStateSuffix ? '1' : '0');
+        if ( isset($this->matches[$key]) ) {
+            ++$this->matchHits;
+            return $this->matches[$key];
+        }
+
+        if ( count($this->matches) >= self::MAX_MATCHES ) {
+            // Keep input tokens for this immutable revision, but bound selector
+            // result retention when a single element sees a huge stylesheet.
+            $this->matches = array();
+        }
+        ++$this->matchExecutions;
+        return $this->matches[$key] = CssSelectorMatcher::matches($element, $selector, $accountForPseudoStateSuffix, $this);
+    }
+
+    /**
+     * @param array{universal: list<array{order: int, rule: array<string, mixed>}>, ids: array<string, list<array{order: int, rule: array<string, mixed>}>>, classes: array<string, list<array{order: int, rule: array<string, mixed>}>>, tags: array<string, list<array{order: int, rule: array<string, mixed>}>>, total: int} $index
+     * @return list<array<string, mixed>>
+     */
+    public function styleRuleCandidates(DOMElement $element, string $collection, array $index): array
+    {
+        $key = $collection . "\0" . $this->elementKey($element);
+        if ( isset($this->ruleCandidates[$key]) ) {
+            return $this->ruleCandidates[$key];
+        }
+
+        $candidates = $index['universal'];
+        $id = $this->attribute($element, 'id');
+        if ( null !== $id ) {
+            $candidates = array_merge($candidates, $index['ids'][$id] ?? array());
+        }
+        foreach ( $this->classTokens($element) as $class ) {
+            $candidates = array_merge($candidates, $index['classes'][$class] ?? array());
+        }
+        $candidates = array_merge($candidates, $index['tags'][strtolower($element->tagName)] ?? array());
+
+        $ordered = array();
+        foreach ( $candidates as $candidate ) {
+            $ordered[$candidate['order']] = $candidate['rule'];
+        }
+        ksort($ordered, SORT_NUMERIC);
+        $rules = array_values($ordered);
+        $this->candidateRuleChecks += count($rules);
+        $this->candidateRulesSkipped += $index['total'] - count($rules);
+
+        return $this->ruleCandidates[$key] = $rules;
+    }
+
+    /** Clear results and selector inputs after a source-DOM mutation. */
+    public function clear(): void
+    {
+        $this->classTokens = array();
+        $this->attributes = array();
+        $this->matches = array();
+        $this->ruleCandidates = array();
     }
 
     private function elementKey(DOMElement $element): string

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -101,10 +101,10 @@ final class CssSelectorMatchCache
 
         $ordered = array();
         foreach ( $candidates as $candidate ) {
-            $ordered[$candidate['order']] = $candidate['rule'];
+            $ordered[(string) ($candidate['key'] ?? $candidate['order'])] = $candidate;
         }
-        ksort($ordered, SORT_NUMERIC);
-        $rules = array_values($ordered);
+        uasort($ordered, static fn (array $left, array $right): int => $left['order'] <=> $right['order'] ?: (($left['sequence'] ?? $left['order']) <=> ($right['sequence'] ?? $right['order'])));
+        $rules = array_column($ordered, 'rule');
         $this->candidateRuleChecks += count($rules);
         $this->candidateRulesSkipped += $index['total'] - count($rules);
 

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatcher.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatcher.php
@@ -78,7 +78,7 @@ final class CssSelectorMatcher
      * @param array<string, mixed> $selector Result of parse().
      * @return array{supported: bool, matches: bool}
      */
-    public static function matches(DOMElement $element, array $selector, bool $accountForPseudoStateSuffix = false): array
+    public static function matches(DOMElement $element, array $selector, bool $accountForPseudoStateSuffix = false, ?CssSelectorMatchCache $cache = null): array
     {
         if ( ! ($selector['supported'] ?? false) ) {
             return array( 'supported' => false, 'matches' => false );
@@ -92,7 +92,7 @@ final class CssSelectorMatcher
 
         return array(
             'supported' => true,
-            'matches' => self::matchesAt($element, $selector['compounds'], $selector['combinators'], count($selector['compounds']) - 1),
+            'matches' => self::matchesAt($element, $selector['compounds'], $selector['combinators'], count($selector['compounds']) - 1, $cache),
         );
     }
 
@@ -397,9 +397,9 @@ final class CssSelectorMatcher
     }
 
     /** @param list<array<string, mixed>> $compounds @param list<string> $combinators */
-    private static function matchesAt(DOMElement $element, array $compounds, array $combinators, int $index): bool
+    private static function matchesAt(DOMElement $element, array $compounds, array $combinators, int $index, ?CssSelectorMatchCache $cache): bool
     {
-        if ( ! self::matchesCompound($element, $compounds[ $index ]) ) {
+        if ( ! self::matchesCompound($element, $compounds[ $index ], $cache) ) {
             return false;
         }
         if ( 0 === $index ) {
@@ -408,15 +408,15 @@ final class CssSelectorMatcher
 
         $combinator = $combinators[ $index - 1 ];
         if ( '>' === $combinator ) {
-            return $element->parentNode instanceof DOMElement && self::matchesAt($element->parentNode, $compounds, $combinators, $index - 1);
+            return $element->parentNode instanceof DOMElement && self::matchesAt($element->parentNode, $compounds, $combinators, $index - 1, $cache);
         }
         if ( '+' === $combinator ) {
             $previous = self::previousElementSibling($element);
-            return null !== $previous && self::matchesAt($previous, $compounds, $combinators, $index - 1);
+            return null !== $previous && self::matchesAt($previous, $compounds, $combinators, $index - 1, $cache);
         }
         if ( '~' === $combinator ) {
             for ( $previous = self::previousElementSibling($element); null !== $previous; $previous = self::previousElementSibling($previous) ) {
-                if ( self::matchesAt($previous, $compounds, $combinators, $index - 1) ) {
+                if ( self::matchesAt($previous, $compounds, $combinators, $index - 1, $cache) ) {
                     return true;
                 }
             }
@@ -424,7 +424,7 @@ final class CssSelectorMatcher
         }
 
         for ( $parent = $element->parentNode; $parent instanceof DOMElement; $parent = $parent->parentNode ) {
-            if ( self::matchesAt($parent, $compounds, $combinators, $index - 1) ) {
+            if ( self::matchesAt($parent, $compounds, $combinators, $index - 1, $cache) ) {
                 return true;
             }
         }
@@ -432,29 +432,30 @@ final class CssSelectorMatcher
     }
 
     /** @param array<string, mixed> $compound */
-    private static function matchesCompound(DOMElement $element, array $compound): bool
+    private static function matchesCompound(DOMElement $element, array $compound, ?CssSelectorMatchCache $cache): bool
     {
         if ( null !== $compound['type'] && 0 !== strcasecmp($element->tagName, $compound['type']) ) {
             return false;
         }
         foreach ( $compound['ids'] as $id ) {
-            if ( $element->getAttribute('id') !== $id ) {
+            $actualId = null !== $cache ? ($cache->attribute($element, 'id') ?? '') : $element->getAttribute('id');
+            if ( $actualId !== $id ) {
                 return false;
             }
         }
-        $classes = preg_split('/[\x09\x0A\x0C\x0D\x20]+/', trim($element->getAttribute('class'))) ?: array();
+        $classes = $cache?->classTokens($element) ?? (preg_split('/[\x09\x0A\x0C\x0D\x20]+/', trim($element->getAttribute('class'))) ?: array());
         foreach ( $compound['classes'] as $class ) {
             if ( ! in_array($class, $classes, true) ) {
                 return false;
             }
         }
         foreach ( $compound['attributes'] as $attribute ) {
-            if ( ! self::matchesAttribute($element, $attribute) ) {
+            if ( ! self::matchesAttribute($element, $attribute, $cache) ) {
                 return false;
             }
         }
         foreach ( $compound['not'] as $negated ) {
-            if ( self::matchesCompound($element, $negated) ) {
+            if ( self::matchesCompound($element, $negated, $cache) ) {
                 return false;
             }
         }
@@ -488,16 +489,22 @@ final class CssSelectorMatcher
     }
 
     /** @param array{name: string, operator: string|null, value: string|null, flag: string|null} $attribute */
-    private static function matchesAttribute(DOMElement $element, array $attribute): bool
+    private static function matchesAttribute(DOMElement $element, array $attribute, ?CssSelectorMatchCache $cache): bool
     {
-        if ( ! $element->hasAttribute($attribute['name']) ) {
+        if ( null !== $cache ) {
+            $actual = $cache->attribute($element, $attribute['name']);
+            if ( null === $actual ) {
+                return false;
+            }
+        } elseif ( ! $element->hasAttribute($attribute['name']) ) {
             return false;
+        } else {
+            $actual = $element->getAttribute($attribute['name']);
         }
         if ( null === $attribute['operator'] ) {
             return true;
         }
 
-        $actual = $element->getAttribute($attribute['name']);
         $expected = (string) $attribute['value'];
         if ( 'i' === $attribute['flag'] ) {
             $actual = strtolower($actual);

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -2616,7 +2616,8 @@ trait StyleResolutionTrait
         $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'total' => count($rules));
         foreach ( $rules as $order => $rule ) {
             $parsed = $this->parsedCssSelector((string) ($rule['selector'] ?? ''));
-            $rightmost = $parsed['compounds'][array_key_last($parsed['compounds'] ?? array())] ?? null;
+            $compounds = $parsed['compounds'] ?? array();
+            $rightmost = array() === $compounds ? null : $compounds[array_key_last($compounds)];
             $target = 'universal';
             $key = '';
             if ( $parsed['supported'] && null === ($parsed['pseudo_state_suffix_span'] ?? null) && is_array($rightmost) ) {

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -62,6 +62,12 @@ trait StyleResolutionTrait
 
     private ?GeometryCarrierClassAllocator $geometryCarrierClassAllocator = null;
 
+    /** Source-selector cache remains valid only between source-DOM mutations. */
+    private ?CssSelectorMatchCache $sourceSelectorMatchCache = null;
+
+    /** @var array<string, array<string, mixed>> */
+    private array $styleRuleCandidateIndexes = array();
+
     /**
      * Author-declared values for the properties an element's inline style could
      * be overriding, keyed by element plus the queried property set. Resolving
@@ -182,6 +188,8 @@ trait StyleResolutionTrait
         $this->generatedGeometryRules = array();
         $this->geometryCarrierClassAllocator = null;
         $this->authorDeclaredPropertyValuesCache = array();
+        $this->sourceSelectorMatchCache = new CssSelectorMatchCache();
+        $this->styleRuleCandidateIndexes = array();
     }
 
     private function styleAttributeMapper(): StyleAttributeMapper
@@ -290,7 +298,7 @@ trait StyleResolutionTrait
         }
 
         $conditionalFamilies = array();
-        foreach ($this->conditionalStyleRules as $rule) {
+        foreach ($this->styleRuleCandidates($element, 'conditional') as $rule) {
             if (! $this->matchesCssSelector($element, $rule['selector'])) {
                 continue;
             }
@@ -380,7 +388,7 @@ trait StyleResolutionTrait
 
     private function hasConditionalStyleFamily(DOMElement $element, string $family): bool
     {
-        foreach ($this->conditionalStyleRules as $rule) {
+        foreach ($this->styleRuleCandidates($element, 'conditional') as $rule) {
             if (! $this->matchesCssSelector($element, $rule['selector'])) {
                 continue;
             }
@@ -577,7 +585,7 @@ trait StyleResolutionTrait
             return true;
         }
 
-        foreach ( array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static-conditional') as $rule ) {
             if ( ! $this->matchesCssSelector($element, $rule['selector']) ) {
                 continue;
             }
@@ -605,7 +613,7 @@ trait StyleResolutionTrait
             return false;
         }
 
-        foreach ( array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static-conditional') as $rule ) {
             if ( ! $this->matchesCssSelector($element, $rule['selector']) ) {
                 continue;
             }
@@ -771,7 +779,7 @@ trait StyleResolutionTrait
 
         $wanted = array_fill_keys($properties, true);
         $declared = array();
-        foreach ( array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static-conditional') as $rule ) {
             if ( ! $this->matchesCssSelector($element, $rule['selector']) ) {
                 continue;
             }
@@ -967,7 +975,7 @@ trait StyleResolutionTrait
             }
         }
 
-        foreach ( $this->conditionalStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($image, 'conditional') as $rule ) {
             if ( ! $this->matchesCssSelector($image, $rule['selector']) ) {
                 continue;
             }
@@ -1051,7 +1059,7 @@ trait StyleResolutionTrait
     private function inlineCustomPropertiesConsumedByAuthorStyles(DOMElement $element): array
     {
         $consumed = array();
-        foreach (array_merge($this->staticStyleRules, $this->conditionalStyleRules, $this->staticPseudoElementStyleRules) as $rule) {
+        foreach ($this->styleRuleCandidates($element, 'static-conditional-pseudo') as $rule) {
             if (! $this->matchesCssSelector($element, $rule['selector'])) {
                 continue;
             }
@@ -1179,7 +1187,7 @@ trait StyleResolutionTrait
     private function structuralPresentationDeclarations(DOMElement $element): array
     {
         $declarations = array();
-        foreach ( $this->staticStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
             if ( $this->matchesCssSelector($element, $rule['selector']) ) {
                 $declarations = $this->mergeCssDeclarationMaps($declarations, $rule['declarations']);
             }
@@ -1199,7 +1207,7 @@ trait StyleResolutionTrait
     {
         $cascade = array();
         $sequence = 0;
-        foreach ($this->staticStyleRules as $rule) {
+        foreach ($this->styleRuleCandidates($element, 'static') as $rule) {
             if (! $this->matchesCssSelector($element, $rule['selector'])) {
                 continue;
             }
@@ -1685,7 +1693,7 @@ trait StyleResolutionTrait
         }
 
         $declarations = array();
-        foreach ( $this->staticStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
             if ( $this->matchesCssSelector($element, $rule['selector']) ) {
                 $declarations = $this->mergeCssDeclarationMaps($declarations, $rule['declarations']);
             }
@@ -1714,7 +1722,7 @@ trait StyleResolutionTrait
     {
         $cascade = array();
         $sequence = 0;
-        foreach ( $this->staticStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
             if ( ! $this->matchesCssSelector($element, $rule['selector']) ) {
                 continue;
             }
@@ -1806,7 +1814,7 @@ trait StyleResolutionTrait
     {
         $cascade = array();
         $sequence = 0;
-        foreach ( $this->staticStyleRules as $rule ) {
+        foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
             if ( ! $this->matchesCssSelector($element, $rule['selector']) ) {
                 continue;
             }
@@ -1934,7 +1942,7 @@ trait StyleResolutionTrait
             return false;
         }
 
-        foreach (array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule) {
+        foreach ($this->styleRuleCandidates($element, 'static-conditional') as $rule) {
             if (! $this->matchesCssSelector($element, $rule['selector'])) {
                 continue;
             }
@@ -2566,8 +2574,71 @@ trait StyleResolutionTrait
 
     private function matchesCssSelector(DOMElement $element, string $selector): bool
     {
-        $match = CssSelectorMatcher::matches($element, $this->parsedCssSelector($selector));
+        $match = ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $selector, $this->parsedCssSelector($selector));
         return $match['supported'] && $match['matches'];
+    }
+
+    private function invalidateSourceSelectorMatchCache(): void
+    {
+        $this->sourceSelectorMatchCache?->clear();
+    }
+
+    private function recordSourceSelectorMatchWork(): void
+    {
+        if ( ! $this->sourceSelectorMatchCache instanceof CssSelectorMatchCache ) {
+            return;
+        }
+        $this->analysisCache->sourceSelectorMatchExecutions += $this->sourceSelectorMatchCache->matchExecutions;
+        $this->analysisCache->sourceSelectorMatchHits += $this->sourceSelectorMatchCache->matchHits;
+        $this->analysisCache->sourceSelectorClassTokenBuilds += $this->sourceSelectorMatchCache->classTokenBuilds;
+        $this->analysisCache->sourceSelectorClassTokenHits += $this->sourceSelectorMatchCache->classTokenHits;
+        $this->analysisCache->sourceSelectorAttributeReads += $this->sourceSelectorMatchCache->attributeReads;
+        $this->analysisCache->sourceStyleCandidateRuleChecks += $this->sourceSelectorMatchCache->candidateRuleChecks;
+        $this->analysisCache->sourceStyleCandidateRulesSkipped += $this->sourceSelectorMatchCache->candidateRulesSkipped;
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function styleRuleCandidates(DOMElement $element, string $collection): array
+    {
+        $index = $this->styleRuleCandidateIndexes[$collection] ??= $this->styleRuleCandidateIndex($collection);
+        return ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, $collection, $index);
+    }
+
+    /** @return array{universal: list<array{order: int, rule: array<string, mixed>}>, ids: array<string, list<array{order: int, rule: array<string, mixed>}>>, classes: array<string, list<array{order: int, rule: array<string, mixed>}>>, tags: array<string, list<array{order: int, rule: array<string, mixed>}>>, total: int} */
+    private function styleRuleCandidateIndex(string $collection): array
+    {
+        $rules = match ($collection) {
+            'static' => $this->staticStyleRules,
+            'conditional' => $this->conditionalStyleRules,
+            'static-conditional' => array_merge($this->staticStyleRules, $this->conditionalStyleRules),
+            'static-conditional-pseudo' => array_merge($this->staticStyleRules, $this->conditionalStyleRules, $this->staticPseudoElementStyleRules),
+        };
+        $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'total' => count($rules));
+        foreach ( $rules as $order => $rule ) {
+            $parsed = $this->parsedCssSelector((string) ($rule['selector'] ?? ''));
+            $rightmost = $parsed['compounds'][array_key_last($parsed['compounds'] ?? array())] ?? null;
+            $target = 'universal';
+            $key = '';
+            if ( $parsed['supported'] && null === ($parsed['pseudo_state_suffix_span'] ?? null) && is_array($rightmost) ) {
+                if ( array() !== ($rightmost['ids'] ?? array()) ) {
+                    $target = 'ids';
+                    $key = (string) $rightmost['ids'][0];
+                } elseif ( array() !== ($rightmost['classes'] ?? array()) ) {
+                    $target = 'classes';
+                    $key = (string) $rightmost['classes'][0];
+                } elseif ( is_string($rightmost['type'] ?? null) && '' !== $rightmost['type'] ) {
+                    $target = 'tags';
+                    $key = strtolower((string) $rightmost['type']);
+                }
+            }
+            $entry = array('order' => (int) $order, 'rule' => $rule);
+            if ( 'universal' === $target ) {
+                $index['universal'][] = $entry;
+            } else {
+                $index[$target][$key][] = $entry;
+            }
+        }
+        return $index;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -66,8 +66,12 @@ trait DomHelpersTrait
 
             $href = LinkUrlSanitizer::sanitize($anchor->getAttribute('href'));
             if ( '' === $href ) {
+                $this->invalidateSourceSelectorMatchCache();
                 $anchor->removeAttribute('href');
                 continue;
+            }
+            if ( $href !== $anchor->getAttribute('href') ) {
+                $this->invalidateSourceSelectorMatchCache();
             }
             $anchor->setAttribute('href', $href);
         }

--- a/php-transformer/tests/unit/css-selector-matcher.php
+++ b/php-transformer/tests/unit/css-selector-matcher.php
@@ -106,6 +106,36 @@ $candidateCache->clear();
 $assert(! $candidateCache->matches($byId('target'), '.final', CssSelectorMatcher::parse('.final'))['matches'], 'clearing the immutable revision cache observes class mutations');
 $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
 $assert(array( '[data-value]', '#target', 'span', ':not(.excluded)' ) === $candidateSelectors, 'clearing the immutable revision cache rebuilds class candidates after mutation');
+$assert(4 === $candidateCache->candidateRulesRetained, 'candidate cache accounts for retained rule references');
+$largeUniversalRules = array();
+for ( $index = 0; $index < 2048; ++$index ) {
+    $largeUniversalRules[] = array( 'order' => $index, 'rule' => array( 'selector' => '*' ) );
+}
+$largeCandidateIndex = array(
+    'universal' => $largeUniversalRules,
+    'ids' => array(),
+    'classes' => array(),
+    'tags' => array(),
+    'total' => count($largeUniversalRules),
+);
+$candidateCache->styleRuleCandidates($byId('one'), 'large', $largeCandidateIndex);
+$candidateCache->styleRuleCandidates($byId('two'), 'large', $largeCandidateIndex);
+$candidateCache->styleRuleCandidates($byId('target'), 'large', $largeCandidateIndex);
+$assert(2048 === $candidateCache->candidateRulesRetained, 'candidate cache evicts prior element lists before retained rule references exceed the bound');
+$oversizedUniversalRules = array();
+for ( $index = 0; $index < 4097; ++$index ) {
+    $oversizedUniversalRules[] = array( 'order' => $index, 'rule' => array( 'selector' => '*' ) );
+}
+$candidateCache->styleRuleCandidates($byId('control'), 'oversized', array(
+    'universal' => $oversizedUniversalRules,
+    'ids' => array(),
+    'classes' => array(),
+    'tags' => array(),
+    'total' => count($oversizedUniversalRules),
+));
+$assert(2048 === $candidateCache->candidateRulesRetained, 'a single oversized candidate list is returned without retention');
+$candidateCache->clear();
+$assert(0 === $candidateCache->candidateRulesRetained, 'clearing the immutable revision cache resets retained candidate accounting');
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "CssSelectorMatcher unit tests: {$failures} failed, {$passes} passed\n");

--- a/php-transformer/tests/unit/css-selector-matcher.php
+++ b/php-transformer/tests/unit/css-selector-matcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
 
 $failures = 0;
 $passes = 0;
@@ -85,6 +86,26 @@ $invalidUtf8 = ".\xff";
 $assert(! CssSelectorMatcher::parse($invalidUtf8)['supported'], 'rejects malformed UTF-8');
 $parsed = CssSelectorMatcher::parse('/*x*/ div > .final:hover');
 $assert($parsed['supported'] && array( 'start' => 12, 'end' => 24 ) === $parsed['rightmost_compound_span'] && array( 'start' => 18, 'end' => 24 ) === $parsed['pseudo_state_suffix_span'], 'preserves original source spans around comments and whitespace');
+
+$candidateCache = new CssSelectorMatchCache();
+$candidateIndex = array(
+    'universal' => array(
+        array( 'order' => 0, 'rule' => array( 'selector' => '[data-value]' ) ),
+        array( 'order' => 4, 'rule' => array( 'selector' => ':not(.excluded)' ) ),
+    ),
+    'ids' => array( 'target' => array( array( 'order' => 1, 'rule' => array( 'selector' => '#target' ) ) ) ),
+    'classes' => array( 'final' => array( array( 'order' => 2, 'rule' => array( 'selector' => '.final' ) ) ) ),
+    'tags' => array( 'span' => array( array( 'order' => 3, 'rule' => array( 'selector' => 'span' ) ) ) ),
+    'total' => 5,
+);
+$candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
+$assert(array( '[data-value]', '#target', '.final', 'span', ':not(.excluded)' ) === $candidateSelectors, 'candidate index merges universal, id, class, and tag rules in source order');
+$assert($candidateCache->matches($byId('target'), '.final', CssSelectorMatcher::parse('.final'))['matches'], 'selector result cache matches the initial class');
+$byId('target')->setAttribute('class', 'changed');
+$candidateCache->clear();
+$assert(! $candidateCache->matches($byId('target'), '.final', CssSelectorMatcher::parse('.final'))['matches'], 'clearing the immutable revision cache observes class mutations');
+$candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
+$assert(array( '[data-value]', '#target', 'span', ':not(.excluded)' ) === $candidateSelectors, 'clearing the immutable revision cache rebuilds class candidates after mutation');
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "CssSelectorMatcher unit tests: {$failures} failed, {$passes} passed\n");

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -74,4 +74,20 @@ $assert(8 === $selectorCache->authorSelectorClassTokenHits, 'Author selector mat
 $assert(6 === $selectorCache->authorSelectorAttributeReads, 'Author selector matching records cached common-attribute reads deterministically.');
 $assert(4 === $selectorCache->authorSelectorMatchResultBuilds && $selectorCache->authorSelectorMatchResultHits >= 12, 'Author selector result lists are built once and reused by later discovery passes.');
 
+$sourceSelectorCache = new HtmlTransformerAnalysisCache();
+$sourceSelectorHtml = '<style>.card{display:grid;color:red}.card.primary{gap:1rem}.card[data-kind="primary"]{padding:1rem}</style><section class="card primary" data-kind="primary"><p>Repeated source selector matching</p></section>';
+(new HtmlTransformer(analysisCache: $sourceSelectorCache))->transform($sourceSelectorHtml);
+$assert(9 === $sourceSelectorCache->sourceSelectorMatchExecutions && 15 === $sourceSelectorCache->sourceSelectorMatchHits, 'Indexed general style resolution executes 9 matcher calls and reuses 15 repeated element-selector results.');
+$assert(8 === $sourceSelectorCache->sourceSelectorClassTokenBuilds && 9 === $sourceSelectorCache->sourceSelectorClassTokenHits && 15 === $sourceSelectorCache->sourceSelectorAttributeReads, 'General style resolution reuses immutable class and common-attribute inputs.');
+
+$candidateCache = new HtmlTransformerAnalysisCache();
+$noiseRules = array();
+for ( $index = 0; $index < 100; ++$index ) {
+    $noiseRules[] = '.noise-' . $index . '{color:#111}';
+}
+$candidateHtml = '<style>' . implode('', array_merge($noiseRules, array( '.target{color:red}', 'article{padding:1px}', '.target{color:blue}' ) )) . '</style><section class="target">Indexed target</section>';
+$candidateResult = (new HtmlTransformer(analysisCache: $candidateCache))->transform($candidateHtml)->toArray();
+$assert('blue' === ($candidateResult['blocks'][0]['attrs']['style']['color']['text'] ?? ''), 'Rightmost class candidates preserve duplicate matching-key cascade order.');
+$assert(4 === $candidateCache->sourceStyleCandidateRuleChecks && 305 === $candidateCache->sourceStyleCandidateRulesSkipped, 'Indexed collection walks check four relevant rule candidates while deterministically skipping 305 irrelevant candidates.');
+
 fwrite(STDOUT, "HTML transformer shared analysis cache passed\n");

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -31,6 +31,7 @@ $options = array('static_css' => $css, 'skip_author_stylesheet_materialization' 
 $pages = array(
     '<main class="card"><h1>First</h1><img src="first.jpg" alt="First"></main>',
     '<main class="card"><h1>Second</h1><img src="second.jpg" alt="Second"></main>',
+    '<main class="card"><h1>Third</h1><img src="third.jpg" alt="Third"></main>',
 );
 $cache = new HtmlTransformerAnalysisCache();
 
@@ -45,5 +46,32 @@ foreach ( $pages as $html ) {
 
 $assert(1 === $cache->styleBuilds, 'Identical static and inline CSS must be analyzed once across fresh page transformers.');
 $assert(1 === $cache->authorSelectorBuilds, 'Identical author selectors must be parsed once across fresh page transformers.');
+$assert(2 === $cache->styleHits, 'Repeated stylesheet inputs must hit the shared analysis cache for every later document.');
+$assert(2 === $cache->authorSelectorHits, 'Repeated author stylesheet inputs must hit the shared selector cache for every later document.');
+
+$alternateCss = '.alternate{color:rebeccapurple}';
+(new HtmlTransformer(analysisCache: $cache))->transform('<main class="alternate">Alternate</main>', array('static_css' => $alternateCss, 'skip_author_stylesheet_materialization' => true));
+(new HtmlTransformer(analysisCache: $cache))->transform('<main class="card">Again</main>', $options);
+$assert(2 === $cache->styleBuilds && 3 === $cache->styleHits, 'A previously analyzed stylesheet must remain reusable after a different document stylesheet.');
+$assert(2 === $cache->authorSelectorBuilds && 3 === $cache->authorSelectorHits, 'A previously parsed author stylesheet must remain reusable after a different document stylesheet.');
+
+for ( $index = 0; $index < 7; ++$index ) {
+    $class = 'eviction-' . $index;
+    (new HtmlTransformer(analysisCache: $cache))->transform('<main class="' . $class . '">Eviction</main>', array('static_css' => '.' . $class . '{color:#' . $index . $index . $index . '}', 'skip_author_stylesheet_materialization' => true));
+}
+$evicted = (new HtmlTransformer(analysisCache: $cache))->transform('<main class="card">Evicted</main>', $options)->toArray();
+$isolated = (new HtmlTransformer())->transform('<main class="card">Evicted</main>', $options)->toArray();
+$assert($withoutDurations($isolated) === $withoutDurations($evicted), 'Rebuilt stylesheet analysis after eviction must preserve isolated transform output.');
+$assert(8 === count($cache->styles) && 8 === count($cache->authorSelectorAnalyses), 'Shared analysis caches retain at most eight stylesheet entries.');
+$assert(10 === $cache->styleBuilds && 3 === $cache->styleHits, 'The oldest stylesheet analysis is evicted after the eight-entry bound is reached.');
+$assert(10 === $cache->authorSelectorBuilds && 3 === $cache->authorSelectorHits, 'The oldest author selector analysis is evicted after the eight-entry bound is reached.');
+
+$selectorCache = new HtmlTransformerAnalysisCache();
+$selectorHtml = '<style>.card{color:red}.card.featured[data-state="ready"]{color:green}.card .title{font-weight:700}.card.featured .title{color:blue}</style><section class="card featured" data-state="ready"><h2 class="title">One</h2></section><section class="card featured" data-state="ready"><h2 class="title">Two</h2></section>';
+(new HtmlTransformer(analysisCache: $selectorCache))->transform($selectorHtml);
+$assert(4 === $selectorCache->authorSelectorClassTokenBuilds, 'Author selector matching tokenizes each immutable source element class list once.');
+$assert(8 === $selectorCache->authorSelectorClassTokenHits, 'Author selector matching reuses class tokens across repeated selector checks.');
+$assert(6 === $selectorCache->authorSelectorAttributeReads, 'Author selector matching records cached common-attribute reads deterministically.');
+$assert(4 === $selectorCache->authorSelectorMatchResultBuilds && $selectorCache->authorSelectorMatchResultHits >= 12, 'Author selector result lists are built once and reused by later discovery passes.');
 
 fwrite(STDOUT, "HTML transformer shared analysis cache passed\n");

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -46,6 +46,7 @@ foreach ( $pages as $html ) {
 
 $assert(1 === $cache->styleBuilds, 'Identical static and inline CSS must be analyzed once across fresh page transformers.');
 $assert(1 === $cache->authorSelectorBuilds, 'Identical author selectors must be parsed once across fresh page transformers.');
+$assert(1 === $cache->authorStyleRuleBuilds, 'Author stylesheet rules and declaration maps must be built once rather than traversed per element.');
 $assert(2 === $cache->styleHits, 'Repeated stylesheet inputs must hit the shared analysis cache for every later document.');
 $assert(2 === $cache->authorSelectorHits, 'Repeated author stylesheet inputs must hit the shared selector cache for every later document.');
 
@@ -78,7 +79,7 @@ $sourceSelectorCache = new HtmlTransformerAnalysisCache();
 $sourceSelectorHtml = '<style>.card{display:grid;color:red}.card.primary{gap:1rem}.card[data-kind="primary"]{padding:1rem}</style><section class="card primary" data-kind="primary"><p>Repeated source selector matching</p></section>';
 (new HtmlTransformer(analysisCache: $sourceSelectorCache))->transform($sourceSelectorHtml);
 $assert(9 === $sourceSelectorCache->sourceSelectorMatchExecutions && 15 === $sourceSelectorCache->sourceSelectorMatchHits, 'Indexed general style resolution executes 9 matcher calls and reuses 15 repeated element-selector results.');
-$assert(8 === $sourceSelectorCache->sourceSelectorClassTokenBuilds && 9 === $sourceSelectorCache->sourceSelectorClassTokenHits && 15 === $sourceSelectorCache->sourceSelectorAttributeReads, 'General style resolution reuses immutable class and common-attribute inputs.');
+$assert(8 === $sourceSelectorCache->sourceSelectorClassTokenBuilds && 11 === $sourceSelectorCache->sourceSelectorClassTokenHits && 15 === $sourceSelectorCache->sourceSelectorAttributeReads, 'General style resolution reuses immutable class and common-attribute inputs.');
 
 $candidateCache = new HtmlTransformerAnalysisCache();
 $noiseRules = array();


### PR DESCRIPTION
## Summary
- reuse immutable stylesheet and author-selector analysis across page transforms
- index candidate style rules by rightmost selector signals instead of scanning every rule for every element
- cache immutable DOM selector inputs and matches within a transform
- bound retained selector and candidate-rule cache state for large documents

Fixes #913.

## Evidence
- the merged stack spent more than 90 minutes compiling a 203 MB Puffin Wix artifact at sustained CPU before producing a theme
- a live process sample showed repeated DOM attribute and regex selector processing
- candidate indexing includes deterministic work-count assertions while all existing parity fixtures remain byte-compatible

## Testing
- `composer validate --strict`
- `composer test`
- 278 PHP transformer parity fixtures
- 73 selector matcher assertions
- clean package-install proof

## AI assistance
- **Model/tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Hot-path investigation, implementation review, bounded-cache hardening, tests, and PR preparation.
- Chris Huber reviewed and remains responsible for the change.