### PR TITLE
Reduce redundant same-source Group chains

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -6966,26 +6966,10 @@ final class HtmlTransformer
             return null;
         }
 
-        $sourceChild = null;
-        foreach ( $element->childNodes as $node ) {
-            if ( XML_TEXT_NODE === $node->nodeType && '' === trim($node->textContent ?? '') ) {
-                continue;
-            }
-            if ( ! $node instanceof DOMElement || null !== $sourceChild ) {
-                return null;
-            }
-            $sourceChild = $node;
-        }
-        if ( ! $sourceChild instanceof DOMElement ) {
-            return null;
-        }
-        if ( $this->hasMotionStructureToken($sourceChild) ) {
-            return null;
-        }
-
         $provenanceId = $childBlock['_source_provenance_id'] ?? null;
-        if ( ! is_int($provenanceId)
-            || hash('sha256', $this->safeFallbackHtml($sourceChild)) !== ($this->sourceProvenance[$provenanceId]['source_digest'] ?? null)
+        $sourceChild = is_int($provenanceId) ? $this->sameSourceGroupChainLeaf($element, (string) ($this->sourceProvenance[$provenanceId]['source_digest'] ?? '')) : null;
+        if ( ! $sourceChild instanceof DOMElement
+            || $this->hasMotionStructureToken($sourceChild)
             || $this->hasBoxAffectingAuthorDeclarations($element)
             || $this->hasContainingBlockDependentAuthorDeclarations($sourceChild)
             || ! $this->selectorMatchingSurvivesWrapperCoalescing($element, $sourceChild)
@@ -6998,6 +6982,60 @@ final class HtmlTransformer
         $childAttrs = array_filter($childAttrs, static fn (mixed $value): bool => ! is_string($value) || '' !== trim($value));
 
         return $this->createBlock('core/group', $childAttrs, $childBlock['innerBlocks'] ?? array(), $sourceChild);
+    }
+
+    private function sameSourceGroupChainLeaf(DOMElement $element, string $sourceDigest): ?DOMElement
+    {
+        if ( '' === $sourceDigest ) {
+            return null;
+        }
+
+        $child = $this->soleElementChild($element);
+        while ( $child instanceof DOMElement && hash('sha256', $this->safeFallbackHtml($child)) !== $sourceDigest ) {
+            if ( ! $this->isNeutralGroupChainWrapper($child) ) {
+                return null;
+            }
+            $child = $this->soleElementChild($child);
+        }
+
+        return $child;
+    }
+
+    private function isNeutralGroupChainWrapper(DOMElement $element): bool
+    {
+        if ( 'div' !== strtolower($element->tagName)
+            || $this->isRuntimeDomTarget($element)
+            || $this->isDirectChildOfStructuralLayout($element)
+            || '' !== trim($this->attr($element, 'id'))
+            || '' !== trim($this->attr($element, 'role'))
+            || '' !== trim($this->attr($element, 'style'))
+            || array() !== $this->interactiveAttributes($element)
+            || array() !== $this->safeDataAttributes($element)
+            || array() !== $this->structureSignals($element, array())
+            || $this->hasMotionStructureToken($element)
+            || $this->hasBoxAffectingAuthorDeclarations($element)
+        ) {
+            return false;
+        }
+
+        $attrs = $this->presentationAttributes($element);
+        return ! array_diff(array_keys($attrs), array( 'className' )) && $this->soleElementChild($element) instanceof DOMElement;
+    }
+
+    private function soleElementChild(DOMElement $element): ?DOMElement
+    {
+        $child = null;
+        foreach ( $element->childNodes as $node ) {
+            if ( XML_TEXT_NODE === $node->nodeType && '' === trim($node->textContent ?? '') ) {
+                continue;
+            }
+            if ( ! $node instanceof DOMElement || $child instanceof DOMElement ) {
+                return null;
+            }
+            $child = $node;
+        }
+
+        return $child;
     }
 
     private function hasMotionStructureToken(DOMElement $element): bool
@@ -7052,18 +7090,32 @@ final class HtmlTransformer
             return false;
         }
 
+        $chain = array();
+        for ( $node = $child; $node instanceof DOMElement; $node = $node->parentNode instanceof DOMElement ? $node->parentNode : null ) {
+            $chain[] = $node;
+            if ( $node === $element ) {
+                break;
+            }
+        }
+        if ( $element !== end($chain) ) {
+            return false;
+        }
+
         $matchesBefore = array();
         foreach ( $this->authorSelectors as $index => $authorSelector ) {
-            $matchesBefore[$index] = $authorSelector['parsed']['supported']
-                && CssSelectorMatcher::matches($child, $authorSelector['parsed'], true)['matches'];
+            $matchesBefore[$index] = $authorSelector['parsed']['supported'] && (bool) array_filter(
+                $chain,
+                static fn (DOMElement $node): bool => CssSelectorMatcher::matches($node, $authorSelector['parsed'], true)['matches']
+            );
         }
 
         $childClass = $this->attr($child, 'class');
+        $chainClasses = array_map(fn (DOMElement $node): string => $this->attr($node, 'class'), $chain);
+        $childParent = $child->parentNode;
         $childNextSibling = $child->nextSibling;
-        $element->removeChild($child);
         $parent->insertBefore($child, $element);
         $parent->removeChild($element);
-        $child->setAttribute('class', $this->mergeClassNames($this->attr($element, 'class'), $childClass));
+        $child->setAttribute('class', $this->mergeClassNames(...$chainClasses));
 
         $survives = true;
         foreach ( $this->authorSelectors as $index => $authorSelector ) {
@@ -7077,7 +7129,9 @@ final class HtmlTransformer
 
         $parent->insertBefore($element, $child);
         $parent->removeChild($child);
-        $element->insertBefore($child, $childNextSibling);
+        if ( $childParent instanceof DOMNode ) {
+            $childParent->insertBefore($child, $childNextSibling);
+        }
         if ( '' === $childClass ) {
             $child->removeAttribute('class');
         } else {

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -519,6 +519,13 @@ $assert(2 === substr_count((string) ($selectorEdgeGroup['serialized_blocks'] ?? 
 $geometryEdgeGroup = $transform('<style>.content{margin:10px}</style><div class="outer"><div class="content"><p>Copy</p></div></div>');
 $assert(2 === substr_count((string) ($geometryEdgeGroup['serialized_blocks'] ?? ''), '<!-- wp:group'), 'single-Group wrappers remain separate when the child geometry depends on its containing block');
 
+$neutralSameSourceGroupChain = $transform('<div class="outer"><div class="middle"><div class="content"><p>Copy</p></div></div></div>');
+$neutralSameSourceGroupChainMarkup = (string) ($neutralSameSourceGroupChain['serialized_blocks'] ?? '');
+$assert(1 === substr_count($neutralSameSourceGroupChainMarkup, '<!-- wp:group') && str_contains($neutralSameSourceGroupChainMarkup, 'outer middle content'), 'neutral same-source Group chains coalesce to their source-provenance leaf');
+
+$sameSourceGroupChainSelectorEdge = $transform('<style>.outer > .middle{color:red}</style><div class="outer"><div class="middle"><div class="content"><p>Copy</p></div></div></div>');
+$assert(2 === substr_count((string) ($sameSourceGroupChainSelectorEdge['serialized_blocks'] ?? ''), '<!-- wp:group'), 'same-source Group chains retain the outer boundary when an author selector matches a removed chain node');
+
 if ( $failures > 0 ) {
     fwrite(STDERR, "Author selector semantics unit tests: {$failures} failed, {$passes} passed\n");
     exit(1);


### PR DESCRIPTION
## Summary
Reduce redundant neutral same-source core/group chains while preserving selector, layout, identity, runtime, motion, and rendering boundaries.

## What changed
- Extended the existing #904 wrapper-coalescing predicate to follow only contiguous, provenance-verified single-child neutral div chains to their final Group source.
- Preserved conservative guards for runtime targets, structural layouts, identity/data/interactive attributes, box geometry, containing-block dependencies, motion tokens, and non-class presentation attributes.
- Expanded selector equivalence checks across every removed chain node before flattening.
- Added focused regressions for a reducible three-level same-source chain and an intermediate-selector boundary that retains the outer Group.
- Runtime change evidence: source relationship is a contiguous source-DOM wrapper chain ending at the emitted Group provenance leaf; change kind is structural Group reduction; verification capability is focused transformer regression; evidence boundary excludes platform-specific class-name rules and does not claim route, editor, or visual-parity validation.

## How to test
1. Run `composer --working-dir=php-transformer test`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Conservative, generic reduction only. Chains are unchanged unless every wrapper is neutral and source provenance, selector matching, and rendering-safety predicates prove equivalence. No platform-specific class-name rules were added.

## Evidence
- Verified command `composer --working-dir=php-transformer test`: status=succeeded; candidate commit `557a6e740dcb1ce4fba1ab70f4bf4d4693415e33`, tree `e18c6bb575cbd8393c951de40f8a0b029718748b`, fingerprint `789175b674eb8b56679765c629a6e989d999beaa55744c26b249b881e25b4da8`; durable gate `gate-1`
- Base unchanged since verification: trunk remains at 6bb196515ac9cec80b6933f0fd038f9371d56cff.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: an immutable candidate was adopted through the recorded Cook workflow and passed the recorded gates.
- Cook deterministic verification: 1 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/blocks-engine/issues/905
- Task objective: Implement issue #905 as the smallest generic conservative reduction of redundant same-source Group chains, with focused regression coverage and no platform-specific class-name rules; inspect #904 and the issue acceptance criteria before editing.
- Verified candidate scope: 2 changed file(s): php-transformer/src/HtmlToBlocks/HtmlTransformer.php, php-transformer/tests/unit/author-selector-semantics.php.
- Verified finalization base: trunk at 6bb196515ac9cec80b6933f0fd038f9371d56cff
- deterministic gate passed: sh -lc composer --working-dir=php-transformer test (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Models:** openai/gpt-5.6-terra, openai/gpt-5.6-sol
- **Used for:** Terra implemented the focused Wave-4 candidate. Sol recovered the interrupted Cook after the provider-model fix, rebased the immutable candidate onto the current verified base, reran the recorded deterministic gate, and completed adoption/finalization through Homeboy.