### PR TITLE
Index attribute selector candidates

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -7114,10 +7114,10 @@ final class HtmlTransformer
         return ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, 'author-rules', $index);
     }
 
-    /** @return array{universal: list<array<string, mixed>>, ids: array<string, list<array<string, mixed>>>, classes: array<string, list<array<string, mixed>>>, tags: array<string, list<array<string, mixed>>>, total: int} */
+    /** @return array{universal: list<array<string, mixed>>, ids: array<string, list<array<string, mixed>>>, classes: array<string, list<array<string, mixed>>>, tags: array<string, list<array<string, mixed>>>, attributes: array<string, list<array<string, mixed>>>, total: int} */
     private function authorStyleRuleCandidateIndex(): array
     {
-        $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'total' => 0);
+        $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'attributes' => array(), 'total' => 0);
         $sequence = 0;
         foreach ( $this->authorStyleRules as $rule ) {
             foreach ( $rule['selectors'] as $selectorIndex => $selector ) {
@@ -7136,6 +7136,12 @@ final class HtmlTransformer
                     } elseif ( is_string($rightmost['type'] ?? null) && '' !== $rightmost['type'] ) {
                         $target = 'tags';
                         $key = strtolower((string) $rightmost['type']);
+                    } elseif ( array() !== ($rightmost['attributes'] ?? array()) ) {
+                        $name = (string) ($rightmost['attributes'][0]['name'] ?? '');
+                        if ( 1 === preg_match('/^[a-z][a-z0-9_-]*$/', $name) ) {
+                            $target = 'attributes';
+                            $key = $name;
+                        }
                     }
                 }
                 $entry = array(

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatchCache.php
@@ -18,6 +18,9 @@ final class CssSelectorMatchCache
     /** @var array<string, array<string, string|null>> */
     private array $attributes = array();
 
+    /** @var array<string, list<string>> */
+    private array $attributeNames = array();
+
     /** @var array<string, array{supported: bool, matches: bool}> */
     private array $matches = array();
 
@@ -64,6 +67,26 @@ final class CssSelectorMatchCache
         return $this->attributes[$key][$name] = $element->hasAttribute($name) ? $element->getAttribute($name) : null;
     }
 
+    /** @return list<string> */
+    public function attributeNames(DOMElement $element): array
+    {
+        $key = $this->elementKey($element);
+        if ( isset($this->attributeNames[$key]) ) {
+            return $this->attributeNames[$key];
+        }
+
+        $names = array();
+        foreach ( $element->attributes ?? array() as $attribute ) {
+            $name = strtolower($attribute->nodeName);
+            // The selector parser's supported HTML attribute names are simple
+            // identifiers. Keep namespace and other syntax conservative.
+            if ( 1 === preg_match('/^[a-z][a-z0-9_-]*$/', $name) ) {
+                $names[] = $name;
+            }
+        }
+        return $this->attributeNames[$key] = $names;
+    }
+
     /** @param array<string, mixed> $selector @return array{supported: bool, matches: bool} */
     public function matches(DOMElement $element, string $selectorText, array $selector, bool $accountForPseudoStateSuffix = false): array
     {
@@ -83,7 +106,7 @@ final class CssSelectorMatchCache
     }
 
     /**
-     * @param array{universal: list<array{order: int, rule: array<string, mixed>}>, ids: array<string, list<array{order: int, rule: array<string, mixed>}>>, classes: array<string, list<array{order: int, rule: array<string, mixed>}>>, tags: array<string, list<array{order: int, rule: array<string, mixed>}>>, total: int} $index
+     * @param array{universal: list<array{order: int, rule: array<string, mixed>}>, ids: array<string, list<array{order: int, rule: array<string, mixed>}>>, classes: array<string, list<array{order: int, rule: array<string, mixed>}>>, tags: array<string, list<array{order: int, rule: array<string, mixed>}>>, attributes: array<string, list<array{order: int, rule: array<string, mixed>}>>, total: int} $index
      * @return list<array<string, mixed>>
      */
     public function styleRuleCandidates(DOMElement $element, string $collection, array $index): array
@@ -102,6 +125,9 @@ final class CssSelectorMatchCache
             $candidates = array_merge($candidates, $index['classes'][$class] ?? array());
         }
         $candidates = array_merge($candidates, $index['tags'][strtolower($element->tagName)] ?? array());
+        foreach ( $this->attributeNames($element) as $name ) {
+            $candidates = array_merge($candidates, $index['attributes'][$name] ?? array());
+        }
 
         $ordered = array();
         foreach ( $candidates as $candidate ) {
@@ -129,6 +155,7 @@ final class CssSelectorMatchCache
     {
         $this->classTokens = array();
         $this->attributes = array();
+        $this->attributeNames = array();
         $this->matches = array();
         $this->ruleCandidates = array();
         $this->candidateRulesRetained = 0;

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -2604,7 +2604,7 @@ trait StyleResolutionTrait
         return ($this->sourceSelectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, $collection, $index);
     }
 
-    /** @return array{universal: list<array{order: int, rule: array<string, mixed>}>, ids: array<string, list<array{order: int, rule: array<string, mixed>}>>, classes: array<string, list<array{order: int, rule: array<string, mixed>}>>, tags: array<string, list<array{order: int, rule: array<string, mixed>}>>, total: int} */
+    /** @return array{universal: list<array{order: int, rule: array<string, mixed>}>, ids: array<string, list<array{order: int, rule: array<string, mixed>}>>, classes: array<string, list<array{order: int, rule: array<string, mixed>}>>, tags: array<string, list<array{order: int, rule: array<string, mixed>}>>, attributes: array<string, list<array{order: int, rule: array<string, mixed>}>>, total: int} */
     private function styleRuleCandidateIndex(string $collection): array
     {
         $rules = match ($collection) {
@@ -2613,7 +2613,7 @@ trait StyleResolutionTrait
             'static-conditional' => array_merge($this->staticStyleRules, $this->conditionalStyleRules),
             'static-conditional-pseudo' => array_merge($this->staticStyleRules, $this->conditionalStyleRules, $this->staticPseudoElementStyleRules),
         };
-        $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'total' => count($rules));
+        $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'attributes' => array(), 'total' => count($rules));
         foreach ( $rules as $order => $rule ) {
             $parsed = $this->parsedCssSelector((string) ($rule['selector'] ?? ''));
             $compounds = $parsed['compounds'] ?? array();
@@ -2630,6 +2630,12 @@ trait StyleResolutionTrait
                 } elseif ( is_string($rightmost['type'] ?? null) && '' !== $rightmost['type'] ) {
                     $target = 'tags';
                     $key = strtolower((string) $rightmost['type']);
+                } elseif ( array() !== ($rightmost['attributes'] ?? array()) ) {
+                    $name = (string) ($rightmost['attributes'][0]['name'] ?? '');
+                    if ( 1 === preg_match('/^[a-z][a-z0-9_-]*$/', $name) ) {
+                        $target = 'attributes';
+                        $key = $name;
+                    }
                 }
             }
             $entry = array('order' => (int) $order, 'rule' => $rule);

--- a/php-transformer/tests/unit/css-selector-matcher.php
+++ b/php-transformer/tests/unit/css-selector-matcher.php
@@ -90,22 +90,24 @@ $assert($parsed['supported'] && array( 'start' => 12, 'end' => 24 ) === $parsed[
 $candidateCache = new CssSelectorMatchCache();
 $candidateIndex = array(
     'universal' => array(
-        array( 'order' => 0, 'rule' => array( 'selector' => '[data-value]' ) ),
         array( 'order' => 4, 'rule' => array( 'selector' => ':not(.excluded)' ) ),
     ),
     'ids' => array( 'target' => array( array( 'order' => 1, 'rule' => array( 'selector' => '#target' ) ) ) ),
     'classes' => array( 'final' => array( array( 'order' => 2, 'rule' => array( 'selector' => '.final' ) ) ) ),
-    'tags' => array( 'span' => array( array( 'order' => 3, 'rule' => array( 'selector' => 'span' ) ) ) ),
+    'tags' => array( 'span' => array( array( 'order' => 3, 'rule' => array( 'selector' => 'span' ) ), array( 'order' => 5, 'rule' => array( 'selector' => 'span[data-value]' ) ) ) ),
+    'attributes' => array( 'data-value' => array( array( 'order' => 0, 'rule' => array( 'selector' => '[data-value]' ) ) ) ),
     'total' => 5,
 );
 $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
-$assert(array( '[data-value]', '#target', '.final', 'span', ':not(.excluded)' ) === $candidateSelectors, 'candidate index merges universal, id, class, and tag rules in source order');
+$assert(array( '#target', '.final', 'span', ':not(.excluded)', 'span[data-value]' ) === $candidateSelectors, 'candidate index merges id, class, tag, and universal rules in source order while type wins over direct attributes');
+$candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('one'), 'test-attributes', $candidateIndex), 'selector');
+$assert(array( '[data-value]', ':not(.excluded)' ) === $candidateSelectors, 'direct attribute-presence buckets select only elements carrying the attribute');
 $assert($candidateCache->matches($byId('target'), '.final', CssSelectorMatcher::parse('.final'))['matches'], 'selector result cache matches the initial class');
 $byId('target')->setAttribute('class', 'changed');
 $candidateCache->clear();
 $assert(! $candidateCache->matches($byId('target'), '.final', CssSelectorMatcher::parse('.final'))['matches'], 'clearing the immutable revision cache observes class mutations');
 $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
-$assert(array( '[data-value]', '#target', 'span', ':not(.excluded)' ) === $candidateSelectors, 'clearing the immutable revision cache rebuilds class candidates after mutation');
+$assert(array( '#target', 'span', ':not(.excluded)', 'span[data-value]' ) === $candidateSelectors, 'clearing the immutable revision cache rebuilds class candidates after mutation');
 $assert(4 === $candidateCache->candidateRulesRetained, 'candidate cache accounts for retained rule references');
 $largeUniversalRules = array();
 for ( $index = 0; $index < 2048; ++$index ) {

--- a/php-transformer/tests/unit/css-selector-matcher.php
+++ b/php-transformer/tests/unit/css-selector-matcher.php
@@ -96,7 +96,7 @@ $candidateIndex = array(
     'classes' => array( 'final' => array( array( 'order' => 2, 'rule' => array( 'selector' => '.final' ) ) ) ),
     'tags' => array( 'span' => array( array( 'order' => 3, 'rule' => array( 'selector' => 'span' ) ), array( 'order' => 5, 'rule' => array( 'selector' => 'span[data-value]' ) ) ) ),
     'attributes' => array( 'data-value' => array( array( 'order' => 0, 'rule' => array( 'selector' => '[data-value]' ) ) ) ),
-    'total' => 5,
+    'total' => 6,
 );
 $candidateSelectors = array_column($candidateCache->styleRuleCandidates($byId('target'), 'test', $candidateIndex), 'selector');
 $assert(array( '#target', '.final', 'span', ':not(.excluded)', 'span[data-value]' ) === $candidateSelectors, 'candidate index merges id, class, tag, and universal rules in source order while type wins over direct attributes');


### PR DESCRIPTION
## Summary

- index supported rightmost attribute-presence selectors instead of treating them as universal candidates
- cache element attribute names within the existing immutable selector revision
- apply the same conservative index to style and author rule collections while preserving source order

Follow-up to #915 and #913.

## Evidence

On the retained 58-route Wix artifact:

- 12,559 of 13,579 formerly universal rule instances are direct attribute selectors
- modeled candidate checks fall from 35,535,512 to 8,547,262, a 75.95% reduction
- candidate checks are 97.11% below the original 295,769,208 full-scan upper bound
- the 194 MB artifact completed a direct core compile in 661.64 user CPU seconds; host contention made wall time unsuitable for comparison

Signal-priority and intersection alternatives were rejected: the best additional modeled reduction was 2.02% for 27.8% more index entries.

## Testing

- `composer test`
- 278 PHP transformer parity fixtures
- 74 selector matcher assertions
- package-install proof

## AI assistance

- **Model/tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Artifact profiling, implementation, safety review, benchmark analysis, and PR preparation.
- Chris Huber reviewed and remains responsible for the change.