### PR TITLE
Reject numeric Google Fonts family tokens

### DIFF
--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -609,6 +609,7 @@ final class FontMaterializationPlanBuilder
         return str_contains($family, '(')
             || str_contains($family, ')')
             || str_starts_with($family, '--')
+            || is_numeric($family)
             || in_array(strtolower($family), self::CSS_WIDE_KEYWORDS, true);
     }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3545,6 +3545,11 @@ $legacyFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
 );
 $assert(array('Lora', 'Roboto') === array_map(static fn (array $font): string => (string) $font['family'], $legacyFontPlan['fonts'] ?? array()), 'web-font detection handles legacy css family pipes');
 $assert(array(400, 700) === ($legacyFontPlan['fonts'][1]['weights'] ?? null), 'web-font detection parses legacy comma weight lists');
+$malformedLegacyFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
+    '<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:300|400">',
+    ''
+);
+$assert(array(array('family' => 'Raleway', 'weights' => array(300))) === ($malformedLegacyFontPlan['fonts'] ?? null), 'web-font detection rejects numeric legacy pipe tokens as font families');
 
 // Web-font sources flow through the full materialization plan theme contract.
 $webFontMaterializationPlan = ( new MaterializationPlanBuilder() )->fromCompiledSite(array(


### PR DESCRIPTION
## Summary

Reject numeric-only tokens at the existing invalid font-family boundary. This prevents malformed legacy Google Fonts pipe syntax such as `Raleway:300|400` from treating `400` as a family, coercing it to an integer array key, and fatally passing it to strict string APIs.

Valid legacy multi-family syntax remains unchanged.

Fixes #932.
Related integration: Automattic/studio#3952.

## Testing

- `php tests/contract/run.php`
- Exact regression asserts `Raleway:300|400` produces only Raleway weight 300.
- Existing `Roboto:400,700|Lora` assertions continue to pass.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the failure through the Studio/SSI import, traced the parser and PHP key-coercion path, implemented the focused validation and regression, and ran verification. Chris Huber reviewed and remains responsible for every line.