### PR TITLE
Register generated custom blocks in Gutenberg

### DIFF
--- a/php-transformer/src/HtmlToBlocks/CustomBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/CustomBlockGenerator.php
@@ -49,6 +49,7 @@ final class CustomBlockGenerator
             'name'       => $blockName,
             'title'      => $title,
             'category'   => self::CATEGORY,
+            'editorScript' => 'file:./index.js',
             'attributes' => array(
                 // The captured, sanitized subtree markup. Editable, so the block
                 // is a real content unit rather than frozen raw HTML.
@@ -71,6 +72,37 @@ final class CustomBlockGenerator
     public function render(string $content): string
     {
         return $content;
+    }
+
+    /** @return array<string, string> */
+    public function assets(string $blockName): array
+    {
+        $script = <<<'JS'
+( function( blocks, blockEditor, components, element ) {
+    var createElement = element.createElement;
+    function edit( props ) {
+        var content = props.attributes.content || '';
+        return createElement(
+            'div',
+            blockEditor.useBlockProps(),
+            createElement( element.RawHTML, null, content ),
+            createElement( components.TextareaControl, {
+                label: 'HTML',
+                value: content,
+                onChange: function( value ) { props.setAttributes( { content: value } ); }
+            } )
+        );
+    }
+    blocks.registerBlockType( '__BLOCK_NAME__', {
+        attributes: { content: { type: 'string', default: '' } },
+        supports: { html: false },
+        edit: edit,
+        save: function() { return null; }
+    } );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.components, window.wp.element );
+JS;
+
+        return array( 'index.js' => str_replace('__BLOCK_NAME__', $blockName, $script) );
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -170,10 +170,15 @@ final class FallbackEmitter
         } else {
             $localName = $this->generatedBlockLocalName($result->signals(), $identity);
             $this->generatedBlockNames[$identity] = $localName;
+            $blockName = $namespace . '/' . $localName;
             $generatedBlocks[] = array(
                 'name'       => $localName,
-                'block_json' => $this->blockGenerator->blockJson($namespace . '/' . $localName, $this->generatedBlockTitle($result->signals())),
+                'block_json' => $this->blockGenerator->blockJson($blockName, $this->generatedBlockTitle($result->signals())),
                 'render'     => $this->blockGenerator->render($content),
+                'assets'     => $this->blockGenerator->assets($blockName),
+                'script_dependencies' => array(
+                    'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element' ),
+                ),
                 // Diagnostic-only; stripped before the payload reaches SSI.
                 'signature'  => $signature,
             );

--- a/php-transformer/tests/unit/custom-block-generator.php
+++ b/php-transformer/tests/unit/custom-block-generator.php
@@ -37,12 +37,15 @@ $blockJson = $generator->blockJson('ssi-acme/collection-1234abcd', 'Custom Colle
 $assert(($blockJson['apiVersion'] ?? null) === 3, '1: block.json declares apiVersion 3');
 $assert(($blockJson['name'] ?? null) === 'ssi-acme/collection-1234abcd', '1: block.json carries the fully-qualified name');
 $assert(($blockJson['render'] ?? null) === 'file:./render.php', '1: block.json points render at render.php');
+$assert(($blockJson['editorScript'] ?? null) === 'file:./index.js', '1: block.json declares the generated editor script');
 $assert(isset($blockJson['attributes']['content']['type']) && 'string' === $blockJson['attributes']['content']['type'], '1: content attribute is a string');
 $assert(($blockJson['supports']['html'] ?? null) === false, '1: generated block disables raw-HTML support');
 
 $render = $generator->render('<p>hello</p>');
 $assert('<p>hello</p>' === $render, '2: render is the supplied sanitized static HTML');
 $assert(! str_contains($render, '<?'), '2: render contains no server code');
+$editorScript = $generator->assets('ssi-acme/collection-1234abcd')['index.js'] ?? '';
+$assert(str_contains($editorScript, "registerBlockType( 'ssi-acme/collection-1234abcd'") && str_contains($editorScript, 'TextareaControl'), '2: editor asset registers the exact block with editable source content');
 
 $refAttrs = $generator->referenceAttributes('<p>hello</p>');
 $assert($refAttrs === array('content' => '<p>hello</p>'), '3: reference carries per-instance content only');
@@ -66,6 +69,7 @@ $assert('' === ($result['blocks'][0]['innerHTML'] ?? 'x'), '4: reference is self
 $assert(count($result['fallbacks']) === 0, '4: no core/html fallback emitted for the generated subtree');
 $assert(count($generated) === 1, '4: one generated block type recorded');
 $assert(($generated[0]['render'] ?? null) === ($result['blocks'][0]['attrs']['content'] ?? null), '4: generated type carries the reference sanitized content as static render');
+$assert(isset($generated[0]['assets']['index.js']) && array('wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element') === ($generated[0]['script_dependencies']['index.js'] ?? null), '4: generated definition carries its editor asset and WordPress dependencies');
 
 // ---------------------------------------------------------------------------
 // 5. Dedup: identical sanitized content -> one type, two references.


### PR DESCRIPTION
## Summary
- add a generic editor script to generated custom block metadata
- render sanitized captured markup in Gutenberg while exposing the content attribute through an editable textarea
- carry explicit WordPress script dependencies through the companion payload
- verify exact generated block registration and asset packaging

Fixes #934.

## Evidence
- `composer test`
- 278 parity fixtures pass
- 36 custom-block generator assertions pass
- Triggered by 28-route artifact acceptance where PHP registered three generated gallery blocks but Gutenberg registered none.

## AI assistance
- **Model/tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** tracing server/client registration, implementing the generic editor asset, and running deterministic package verification.
- Chris Huber reviewed and remains responsible for the change.