### PR TITLE
Recognize reusable source components

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -106,6 +106,7 @@
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",
       "php tests/unit/html-transformer-shared-analysis-cache.php",
+      "php tests/unit/reusable-component-recognition.php",
       "php tests/unit/compile-fragment-author-stylesheet.php"
     ],
     "test:parity": "php tests/parity/run.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -44,6 +44,8 @@ final class ArtifactCompiler
 
     private ?HtmlTransformerAnalysisCache $htmlTransformerAnalysisCache = null;
 
+    private string $generatedAssetRoot = '';
+
     /** @var array<string, array<string, mixed>> */
     private array $filesByPath = array();
 
@@ -190,6 +192,7 @@ final class ArtifactCompiler
         }
 
         $entryPath = is_array($entry) ? (string) $entry['path'] : '';
+        $this->generatedAssetRoot = '.' === dirname($entryPath) ? '' : trim(dirname($entryPath), '/');
         $html = is_array($entry) ? (string) $entry['content'] : '';
         $components = $this->detectComponents($normalized['files'], $entryPath, $documents['components']);
         $blockTypes = $this->detectBlockTypes($normalized['files'], $diagnostics);
@@ -230,6 +233,7 @@ final class ArtifactCompiler
         if ( null !== $wordpressCompatAsset ) {
             $assets[] = $wordpressCompatAsset;
         }
+        $assets = $this->deduplicateVisualAssets($assets);
         $diagnostics = array_merge($diagnostics, $allDiagnostics);
         $serializedBlocks = $entryBlocks['serialized_blocks'];
         if ( '' === $serializedBlocks && ! empty($documents['documents'][0]['block_markup']) ) {
@@ -237,6 +241,7 @@ final class ArtifactCompiler
         }
         $sourceReports = array(
             'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::merge($coreHtmlFallbackEvidence),
+            'reusable_components' => $this->reusableComponentEvidence($entryPath, $entryBlocks['reusable_components'], $compiledHtmlDocuments, $generatedAssets),
             'artifact' => array(
                 'schema'          => self::INPUT_SCHEMA,
                 'original_schema' => is_string($artifact['schema'] ?? null) ? $artifact['schema'] : '',
@@ -449,7 +454,7 @@ final class ArtifactCompiler
                 if ( 'css' === ($asset['kind'] ?? null) ) {
                     $asset['compilation'] ??= $ownership;
                 }
-                $payload = is_string($asset['content_base64'] ?? null) ? $asset['content_base64'] : (string) ($asset['content'] ?? '');
+                $payload = is_string($asset['visual_payload'] ?? null) ? $asset['visual_payload'] : (is_string($asset['content_base64'] ?? null) ? $asset['content_base64'] : (string) ($asset['content'] ?? ''));
                 $identity = hash('sha256', (string) ($asset['path'] ?? '') . "\0" . $payload);
                 if ( ! isset($assetIndexes[$identity]) ) {
                     $assetIndexes[$identity] = count($assets);
@@ -457,6 +462,22 @@ final class ArtifactCompiler
                     continue;
                 }
                 $index = $assetIndexes[$identity];
+                if (is_string($asset['visual_payload'] ?? null)) {
+                    $assets[$index]['content'] = $asset['visual_payload'];
+                    $assets[$index]['bytes'] = strlen($asset['visual_payload']);
+                    $assets[$index]['hash'] = hash('sha256', $asset['visual_payload']);
+                    $assets[$index]['source_hash'] = $assets[$index]['hash'];
+                    $assets[$index]['visual_payload'] = $asset['visual_payload'];
+                }
+                $occurrences = is_array($assets[$index]['component_occurrences'] ?? null) ? $assets[$index]['component_occurrences'] : array();
+                foreach (is_array($asset['component_occurrences'] ?? null) ? $asset['component_occurrences'] : array() as $occurrence) {
+                    if (count($occurrences) < 8 && !in_array($occurrence, $occurrences, true)) $occurrences[] = $occurrence;
+                }
+                if (array() !== $occurrences) $assets[$index]['component_occurrences'] = $occurrences;
+                $counts = is_array($assets[$index]['component_occurrence_counts'] ?? null) ? $assets[$index]['component_occurrence_counts'] : array();
+                foreach (is_array($asset['component_occurrence_counts'] ?? null) ? $asset['component_occurrence_counts'] : array() as $fingerprint => $count) if (is_string($fingerprint) && is_int($count)) $counts[$fingerprint] = (int) ($counts[$fingerprint] ?? 0) + $count;
+                if (array() !== $counts) $assets[$index]['component_occurrence_counts'] = $counts;
+                $assets[$index]['component_occurrences_omitted'] = max(0, array_sum($counts) - count($occurrences));
                 if ( 'css' !== ($asset['kind'] ?? null) ) {
                     continue;
                 }
@@ -473,15 +494,92 @@ final class ArtifactCompiler
         foreach ( $compiledHtmlDocuments as $sourcePath => $compiledHtmlDocument ) {
             $file = $filesByPath[$sourcePath] ?? array('path' => $sourcePath, 'kind' => 'html');
             $append(
-                array_values(array_filter(
-                    is_array($compiledHtmlDocument['assets'] ?? null) ? $compiledHtmlDocument['assets'] : array(),
-                    static fn (array $asset): bool => 'css' === ($asset['kind'] ?? null)
-                )),
+                is_array($compiledHtmlDocument['assets'] ?? null) ? $compiledHtmlDocument['assets'] : array(),
                 $this->fileOwnership($file)
             );
         }
 
         return $assets;
+    }
+
+    /** @param array<int, array<string, mixed>> $assets @return array<int, array<string, mixed>> */
+    private function deduplicateVisualAssets(array $assets): array
+    {
+        $deduplicated = array();
+        $indexes = array();
+        foreach ($assets as $asset) {
+            $payload = is_string($asset['visual_payload'] ?? null) ? $asset['visual_payload'] : null;
+            $canonicalPayload = $payload ?? (string) ($asset['content'] ?? '');
+            if ('inline-svg' === ($asset['source'] ?? null)) {
+                // The content-addressed filename is already the visual payload
+                // identity. Some later projections retain only the public asset
+                // fields, so use that stable path at this final boundary too.
+                $payload = '';
+            }
+            if (null === $payload) {
+                $deduplicated[] = $asset;
+                continue;
+            }
+            $identity = hash('sha256', (string) ($asset['path'] ?? '') . "\0" . $payload);
+            if (!isset($indexes[$identity])) {
+                $indexes[$identity] = count($deduplicated);
+                $deduplicated[] = $asset;
+                continue;
+            }
+            $index = $indexes[$identity];
+            $deduplicated[$index]['content'] = $canonicalPayload;
+            $deduplicated[$index]['bytes'] = strlen($canonicalPayload);
+            $deduplicated[$index]['hash'] = hash('sha256', $canonicalPayload);
+            $deduplicated[$index]['source_hash'] = $deduplicated[$index]['hash'];
+            $rows = is_array($deduplicated[$index]['component_occurrences'] ?? null) ? $deduplicated[$index]['component_occurrences'] : array();
+            $incomingRows = is_array($asset['component_occurrences'] ?? null) ? $asset['component_occurrences'] : array();
+            $alreadyIncluded = array() !== $incomingRows;
+            foreach ($incomingRows as $row) {
+                if (!in_array($row, $rows, true)) $alreadyIncluded = false;
+                if (count($rows) < 8 && !in_array($row, $rows, true)) $rows[] = $row;
+            }
+            $deduplicated[$index]['component_occurrences'] = $rows;
+            if (!$alreadyIncluded) foreach (is_array($asset['component_occurrence_counts'] ?? null) ? $asset['component_occurrence_counts'] : array() as $fingerprint => $count) if (is_string($fingerprint) && is_int($count)) $deduplicated[$index]['component_occurrence_counts'][$fingerprint] = (int) ($deduplicated[$index]['component_occurrence_counts'][$fingerprint] ?? 0) + $count;
+            $deduplicated[$index]['component_occurrences_omitted'] = max(0, array_sum(is_array($deduplicated[$index]['component_occurrence_counts'] ?? null) ? $deduplicated[$index]['component_occurrence_counts'] : array()) - count($rows));
+        }
+        return $deduplicated;
+    }
+
+    /** @param array<string, mixed> $entryEvidence @param array<string, array<string, mixed>> $documents @param array<int, array<string, mixed>> $assets */
+    private function reusableComponentEvidence(string $entryPath, array $entryEvidence, array $documents, array $assets): array
+    {
+        $candidates = array();
+        $append = static function (string $sourcePath, array $evidence) use (&$candidates): void {
+            foreach (is_array($evidence['candidates'] ?? null) ? $evidence['candidates'] : array() as $candidate) {
+                if (is_array($candidate) && is_string($candidate['fingerprint'] ?? null) && is_string($candidate['path'] ?? null) && is_string($candidate['tag'] ?? null)) $candidates[$candidate['fingerprint']][] = array('source_path' => $sourcePath, 'path' => $candidate['path'], 'tag' => $candidate['tag']);
+            }
+        };
+        $append($entryPath, $entryEvidence);
+        foreach ($documents as $sourcePath => $document) $append((string) $sourcePath, is_array($document['reusable_components'] ?? null) ? $document['reusable_components'] : array());
+        $mapped = array();
+        foreach ($assets as $asset) foreach (is_array($asset['component_occurrence_counts'] ?? null) ? $asset['component_occurrence_counts'] : array() as $fingerprint => $count) if (is_string($fingerprint) && is_int($count)) $mapped[$fingerprint] = (int) ($mapped[$fingerprint] ?? 0) + $count;
+        $components = array();
+        foreach ($candidates as $fingerprint => $occurrences) {
+            if (count($occurrences) < 2) continue;
+            $tag = $occurrences[0]['tag'];
+            $mappedCount = (int) ($mapped[$fingerprint] ?? 0);
+            $retained = min(count($occurrences), 8);
+            $omitted = count($occurrences) - $retained;
+            $components[] = array('fingerprint' => $fingerprint, 'tag' => $tag, 'occurrence_count' => count($occurrences), 'mapping' => 'svg' === $tag && $mappedCount === count($occurrences) ? 'shared_core_image_asset' : ('svg' === $tag ? 'capability_gap:svg_instances_not_all_core_image_assets' : 'capability_gap:no_safe_reusable_block_mapping'), 'mapped_asset_occurrence_count' => $mappedCount, 'occurrence_limit' => 8, 'retained_occurrence_count' => $retained, 'omitted_occurrence_count' => $omitted, 'truncated' => 0 < $omitted, 'truncation_reason' => 0 < $omitted ? 'max_occurrences' : '', 'incomplete' => 0 < $omitted, 'occurrences' => array_slice($occurrences, 0, 8));
+        }
+        usort($components, static fn(array $a, array $b): int => $b['occurrence_count'] <=> $a['occurrence_count'] ?: strcmp($a['fingerprint'], $b['fingerprint']));
+        $documentScans = array();
+        $scan = static function (string $sourcePath, array $evidence) use (&$documentScans): void { $documentScans[] = array('source_path' => $sourcePath, 'scanned_node_count' => (int) ($evidence['scanned_node_count'] ?? 0), 'candidate_count' => (int) ($evidence['candidate_count'] ?? 0), 'omitted_candidate_count' => (int) ($evidence['omitted_candidate_count'] ?? 0), 'truncated' => array_values(is_array($evidence['truncated'] ?? null) ? $evidence['truncated'] : array())); };
+        $scan($entryPath, $entryEvidence);
+        foreach ($documents as $sourcePath => $document) $scan((string) $sourcePath, is_array($document['reusable_components'] ?? null) ? $document['reusable_components'] : array());
+        $truncated = array_values(array_unique(array_merge(...array_map(static fn(array $scan): array => $scan['truncated'], $documentScans))));
+        $componentOmitted = max(0, count($components) - 32);
+        $documentOmitted = max(0, count($documentScans) - 64);
+        if (0 < $componentOmitted) $truncated[] = 'max_components';
+        if (0 < $documentOmitted) $truncated[] = 'max_documents';
+        if (array_filter($components, static fn(array $component): bool => !empty($component['incomplete']))) $truncated[] = 'max_occurrences';
+        $truncated = array_values(array_unique($truncated));
+        return array('schema' => 'blocks-engine/reusable-component-recognition/v1', 'limits' => array('max_components' => 32, 'max_documents' => 64), 'retained_component_count' => min(count($components), 32), 'omitted_component_count' => $componentOmitted, 'components' => array_slice($components, 0, 32), 'scanned_node_count' => array_sum(array_column($documentScans, 'scanned_node_count')), 'candidate_count' => array_sum(array_column($documentScans, 'candidate_count')), 'omitted_candidate_count' => array_sum(array_column($documentScans, 'omitted_candidate_count')), 'retained_document_count' => min(count($documentScans), 64), 'omitted_document_count' => $documentOmitted, 'truncated' => $truncated, 'incomplete' => array() !== $truncated, 'documents' => array_slice($documentScans, 0, 64));
     }
 
     /**
@@ -915,6 +1013,7 @@ final class ArtifactCompiler
             'author_stylesheet_projections' => $result['author_stylesheet_projections'],
             'shell_artifacts' => $result['shell_artifacts'],
             'core_html_fallback_evidence' => $result['core_html_fallback_evidence'],
+            'reusable_components' => $result['reusable_components'],
         );
     }
 
@@ -939,6 +1038,7 @@ final class ArtifactCompiler
                 'author_stylesheet_projections' => array(),
                 'shell_artifacts' => array(),
                 'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::fromBlocks(array(), array(), array()),
+                'reusable_components' => array(),
             );
         }
 
@@ -957,6 +1057,7 @@ final class ArtifactCompiler
                 'author_stylesheet_projections' => array(),
                 'shell_artifacts' => array(),
                 'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::fromBlocks(array(), array(), array()),
+                'reusable_components' => array(),
             );
         }
 
@@ -972,6 +1073,7 @@ final class ArtifactCompiler
             'runtime_dom_selectors'     => $this->runtimeDomSelectors($html, $sourcePath, $files),
             'runtime_canvas_selectors'  => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
             'generated_block_namespace' => $generatedBlockNamespace,
+            'generated_asset_root'       => $this->generatedAssetRoot,
             'extract_global_shell'       => $extractGlobalShell,
         ))->toArray();
 
@@ -981,6 +1083,7 @@ final class ArtifactCompiler
             'diagnostics'       => is_array($result['diagnostics'] ?? null) ? $result['diagnostics'] : array(),
             'fallbacks'         => is_array($result['fallbacks'] ?? null) ? $result['fallbacks'] : array(),
             'core_html_fallback_evidence' => is_array($result['source_reports']['html']['core_html_fallback_evidence'] ?? null) ? $result['source_reports']['html']['core_html_fallback_evidence'] : CoreHtmlFallbackEvidence::fromBlocks(array(), array(), array()),
+            'reusable_components' => is_array($result['source_reports']['html']['reusable_components'] ?? null) ? $result['source_reports']['html']['reusable_components'] : array(),
             'assets'            => is_array($result['assets'] ?? null) ? $result['assets'] : array(),
             'runtime_islands'   => $this->runtimeIslandsWithMaterializedInlineScripts(
                 is_array($result['source_reports']['runtime_islands'] ?? null) ? $result['source_reports']['runtime_islands'] : array(),
@@ -2977,7 +3080,7 @@ final class ArtifactCompiler
         $assetPayloadsByPath = array();
         foreach ( $assets as $asset ) {
             $path = (string) ($asset['path'] ?? '');
-            $payload = is_string($asset['content_base64'] ?? null) ? $asset['content_base64'] : (string) ($asset['content'] ?? '');
+            $payload = is_string($asset['visual_payload'] ?? null) ? $asset['visual_payload'] : (is_string($asset['content_base64'] ?? null) ? $asset['content_base64'] : (string) ($asset['content'] ?? ''));
             $assetPayloadsByPath[$path][hash('sha256', $payload)] = true;
         }
         foreach ( $artifact['files'] as $file ) {
@@ -2998,7 +3101,7 @@ final class ArtifactCompiler
                         $generatedAsset['compilation'] = array('scope' => 'page', 'id' => $path);
                     }
                     $generatedAssetPath = (string) ($generatedAsset['path'] ?? '');
-                    $payload = is_string($generatedAsset['content_base64'] ?? null) ? $generatedAsset['content_base64'] : (string) ($generatedAsset['content'] ?? '');
+                    $payload = is_string($generatedAsset['visual_payload'] ?? null) ? $generatedAsset['visual_payload'] : (is_string($generatedAsset['content_base64'] ?? null) ? $generatedAsset['content_base64'] : (string) ($generatedAsset['content'] ?? ''));
                     $payloadHash = hash('sha256', $payload);
                     if ( isset($assetPayloadsByPath[$generatedAssetPath][$payloadHash]) ) {
                         continue;

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -215,6 +215,11 @@ final class HtmlTransformer
 
     private readonly ContentRoundTripReporter $contentRoundTripReporter;
 
+    private readonly ReusableComponentRecognizer $reusableComponentRecognizer;
+
+    /** @var array<string, string> */
+    private array $reusableComponentFingerprints = array();
+
     /**
      * Text the transformer SYNTHESIZES from form controls (label + value/
      * placeholder/required state) rather than extracting from visible source.
@@ -332,6 +337,8 @@ final class HtmlTransformer
      * fall back to a generic namespace.
      */
     private string $generatedBlockNamespace = 'custom';
+
+    private string $generatedAssetRoot = '';
 
     /**
      * @var array<int, array<string, mixed>>
@@ -621,6 +628,7 @@ final class HtmlTransformer
         $this->diagnosticsCollector = new DiagnosticsCollector();
         $this->semanticParityReporter = new SemanticParityReporter($this->runtime);
         $this->contentRoundTripReporter = new ContentRoundTripReporter();
+        $this->reusableComponentRecognizer = new ReusableComponentRecognizer();
         $this->fallbackEmitter = new FallbackEmitter(
             $this->runtime,
             fn (DOMElement $element): array => $this->sourceContext($element)
@@ -653,11 +661,13 @@ final class HtmlTransformer
         $this->responsiveImageFallbacks = array();
         $this->responsiveImageFallbackSelectors = array();
         $this->generatedBlockNamespace = $this->generatedBlockNamespaceFromOptions($options);
+        $this->generatedAssetRoot = trim((string) ($options['generated_asset_root'] ?? ''), '/');
         $this->preserveShellLandmarks = !empty($options['extract_global_shell']);
         $this->fallbackEmitter->resetGeneratedBlocks();
         $this->runtimeScriptMetadata = $this->runtimeScriptMetadataFromOptions($options);
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->generatedAssets = array();
+        $this->reusableComponentFingerprints = array();
         $this->nativeSearchTriggerCssRules = array();
         $this->nativeButtonStyleRules = array();
         $this->syntheticHeaderAnchorStyleRules = array();
@@ -811,6 +821,10 @@ final class HtmlTransformer
         // General style matching begins only after those source mutations settle.
         $this->invalidateSourceSelectorMatchCache();
         $this->collectEditorHiddenStateFindings($body);
+        $reusableComponentRecognition = $this->reusableComponentRecognizer->recognize($body);
+        foreach ($reusableComponentRecognition['candidates'] as $candidate) {
+            if (is_array($candidate) && is_string($candidate['path'] ?? null) && is_string($candidate['fingerprint'] ?? null)) $this->reusableComponentFingerprints[$candidate['path']] = $candidate['fingerprint'];
+        }
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
@@ -823,6 +837,7 @@ final class HtmlTransformer
         $this->appendProductGridFallbacks($body, $fallbacks, $blocks);
         $this->appendCommerceControlsFallbacks($body, $fallbacks);
         $this->finalizeFallbackBindings($fallbacks, $blocks);
+        $reusableComponentRecognition = $this->finalizeReusableComponentRecognition($reusableComponentRecognition);
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $authorStylesheetProjections = $this->authorStylesheetProjections();
@@ -916,6 +931,7 @@ final class HtmlTransformer
                 'source_provenance'    => $sourceProvenance,
                 'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::fromBlocks($blocks, $fallbacks, $sourceProvenance),
                 'structure_signals'    => $this->structureProvenance,
+                'reusable_components' => $reusableComponentRecognition,
                 'script_metadata'      => $this->scriptMetadata,
                 'runtime_islands'      => $this->runtimeIslands,
             ),
@@ -1044,6 +1060,31 @@ final class HtmlTransformer
             'transform_duration_ms' => (hrtime(true) - $startedAt) / 1000000,
             'output_bytes'          => strlen($output),
         );
+    }
+
+    private function reusableComponentFingerprintFor(DOMElement $element): ?string
+    {
+        return $this->reusableComponentFingerprints[$element->getNodePath()] ?? null;
+    }
+
+    /** @param array<string, mixed> $recognition @return array<string, mixed> */
+    private function finalizeReusableComponentRecognition(array $recognition): array
+    {
+        $assetOccurrences = array();
+        foreach ($this->generatedAssets as $asset) {
+            if (!is_array($asset) || 'inline-svg' !== ($asset['source'] ?? null)) continue;
+            foreach (is_array($asset['component_occurrence_counts'] ?? null) ? $asset['component_occurrence_counts'] : array() as $fingerprint => $count) if (is_string($fingerprint) && is_int($count)) $assetOccurrences[$fingerprint] = (int) ($assetOccurrences[$fingerprint] ?? 0) + $count;
+        }
+        foreach ($recognition['components'] as &$component) {
+            if (!is_array($component) || 'svg' !== ($component['tag'] ?? null)) continue;
+            $mapped = (int) ($assetOccurrences[$component['fingerprint']] ?? 0);
+            $component['mapping'] = $mapped === ($component['occurrence_count'] ?? 0) && 0 < $mapped
+                ? 'shared_core_image_asset'
+                : 'capability_gap:svg_instances_not_all_core_image_assets';
+            $component['mapped_asset_occurrence_count'] = $mapped;
+        }
+        unset($component);
+        return $recognition;
     }
 
     /**
@@ -7762,7 +7803,9 @@ final class HtmlTransformer
 
     private function isGeneratedInlineSvgSource(string $source): bool
     {
-        return isset($this->generatedAssets[$source]) && 'inline-svg' === ($this->generatedAssets[$source]['source'] ?? '');
+        if (isset($this->generatedAssets[$source]) && 'inline-svg' === ($this->generatedAssets[$source]['source'] ?? '')) return true;
+        foreach ($this->generatedAssets as $asset) if (is_array($asset) && 'inline-svg' === ($asset['source'] ?? '') && $source === ($asset['source_url'] ?? null)) return true;
+        return false;
     }
 
     private function stripDecorativeSvgFromRichText(string $content): string

--- a/php-transformer/src/HtmlToBlocks/ReusableComponentRecognizer.php
+++ b/php-transformer/src/HtmlToBlocks/ReusableComponentRecognizer.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+use Automattic\BlocksEngine\PhpTransformer\WordPress\GeneratedGutenbergClassPolicy;
+use DOMElement;
+use DOMNode;
+
+final class ReusableComponentRecognizer
+{
+    private const MAX_CANDIDATES = 256;
+    private const MAX_COMPONENTS = 32;
+    private const MAX_OCCURRENCES = 8;
+    private const MAX_NEAR_MATCHES = 16;
+    private const MAX_NODES = 2048;
+    private const MAX_DEPTH = 32;
+    private const MAX_SIGNATURE_BYTES = 8192;
+    private const MAX_SIGNATURE_WORK = 32768;
+
+    /** @var array<string, true> */
+    private const CANDIDATE_TAGS = array('article' => true, 'aside' => true, 'div' => true, 'figure' => true, 'footer' => true, 'form' => true, 'header' => true, 'li' => true, 'main' => true, 'nav' => true, 'ol' => true, 'section' => true, 'svg' => true, 'ul' => true);
+
+    /** @return array<string, mixed> */
+    public function recognize(DOMElement $root): array
+    {
+        $state = array('nodes' => 0, 'signature_work' => 0, 'omitted_candidates' => 0, 'truncated' => array());
+        $candidates = array();
+        $this->collect($root, 0, $candidates, $state);
+        $exact = array();
+        $shape = array();
+        foreach ($candidates as $candidate) {
+            $exact[$candidate['fingerprint']][] = $candidate;
+            $shape[$candidate['shape_fingerprint']][] = $candidate;
+        }
+        $components = array();
+        foreach ($exact as $fingerprint => $occurrences) {
+            if (count($occurrences) < 2) continue;
+            $components[] = $this->component($fingerprint, $occurrences);
+        }
+        usort($components, static fn(array $a, array $b): int => $b['occurrence_count'] <=> $a['occurrence_count'] ?: strcmp($a['fingerprint'], $b['fingerprint']));
+        $nearMatches = array();
+        foreach ($shape as $shapeFingerprint => $occurrences) {
+            $variants = array_values(array_unique(array_column($occurrences, 'fingerprint')));
+            if (count($variants) < 2) continue;
+            sort($variants, SORT_STRING);
+            $nearMatches[] = array('shape_fingerprint' => $shapeFingerprint, 'occurrence_count' => count($occurrences), 'rejected_reason' => 'style_or_semantic_attribute_variation', 'fingerprints' => array_slice($variants, 0, self::MAX_OCCURRENCES));
+        }
+        usort($nearMatches, static fn(array $a, array $b): int => $b['occurrence_count'] <=> $a['occurrence_count'] ?: strcmp($a['shape_fingerprint'], $b['shape_fingerprint']));
+        $componentOmitted = max(0, count($components) - self::MAX_COMPONENTS);
+        $nearMatchOmitted = max(0, count($nearMatches) - self::MAX_NEAR_MATCHES);
+        if (0 < $componentOmitted) $state['truncated'][] = 'max_components';
+        if (0 < $nearMatchOmitted) $state['truncated'][] = 'max_near_matches';
+        if (array_filter($components, static fn(array $component): bool => !empty($component['incomplete']))) $state['truncated'][] = 'max_occurrences';
+        $truncated = array_values(array_unique($state['truncated']));
+        return array('schema' => 'blocks-engine/reusable-component-recognition/v1', 'scanned_node_count' => $state['nodes'], 'candidate_count' => count($candidates), 'omitted_candidate_count' => $state['omitted_candidates'], 'retained_component_count' => min(count($components), self::MAX_COMPONENTS), 'omitted_component_count' => $componentOmitted, 'components' => array_slice($components, 0, self::MAX_COMPONENTS), 'near_match_limit' => self::MAX_NEAR_MATCHES, 'retained_near_match_count' => min(count($nearMatches), self::MAX_NEAR_MATCHES), 'omitted_near_match_count' => $nearMatchOmitted, 'near_match_truncation_reason' => 0 < $nearMatchOmitted ? 'max_near_matches' : '', 'near_matches' => array_slice($nearMatches, 0, self::MAX_NEAR_MATCHES), 'candidates' => $candidates, 'limits' => array('max_candidates' => self::MAX_CANDIDATES, 'max_components' => self::MAX_COMPONENTS, 'max_near_matches' => self::MAX_NEAR_MATCHES, 'max_nodes' => self::MAX_NODES, 'max_depth' => self::MAX_DEPTH, 'max_signature_bytes' => self::MAX_SIGNATURE_BYTES, 'max_signature_work' => self::MAX_SIGNATURE_WORK), 'truncated' => $truncated, 'incomplete' => array() !== $truncated);
+    }
+
+    /** @param list<array<string, string>> $occurrences @return array<string, mixed> */
+    private function component(string $fingerprint, array $occurrences): array
+    {
+        $first = $occurrences[0];
+        $retained = min(count($occurrences), self::MAX_OCCURRENCES);
+        $omitted = count($occurrences) - $retained;
+        return array('fingerprint' => $fingerprint, 'tag' => $first['tag'], 'occurrence_count' => count($occurrences), 'mapping' => 'svg' === $first['tag'] ? 'pending_core_image_asset_verification' : 'capability_gap:no_safe_reusable_block_mapping', 'occurrence_limit' => self::MAX_OCCURRENCES, 'retained_occurrence_count' => $retained, 'omitted_occurrence_count' => $omitted, 'truncated' => 0 < $omitted, 'truncation_reason' => 0 < $omitted ? 'max_occurrences' : '', 'incomplete' => 0 < $omitted, 'occurrences' => array_slice(array_map(static fn(array $row): array => array('path' => $row['path'], 'tag' => $row['tag']), $occurrences), 0, self::MAX_OCCURRENCES));
+    }
+
+    /** @param list<array<string, string>> $candidates @param array<string, mixed> $state */
+    private function collect(DOMElement $element, int $depth, array &$candidates, array &$state): void
+    {
+        if ($depth >= self::MAX_DEPTH) {
+            $state['truncated'][] = 'max_depth';
+            return;
+        }
+        foreach ($element->childNodes as $child) {
+            if (!$child instanceof DOMElement) continue;
+            if (++$state['nodes'] > self::MAX_NODES) {
+                $state['truncated'][] = 'max_nodes';
+                return;
+            }
+            if (isset(self::CANDIDATE_TAGS[strtolower($child->tagName)]) && $this->isSubtreeCandidate($child)) {
+                if (count($candidates) >= self::MAX_CANDIDATES) {
+                    ++$state['omitted_candidates'];
+                    $state['truncated'][] = 'max_candidates';
+                    $this->collect($child, $depth + 1, $candidates, $state);
+                    continue;
+                }
+                $exact = $this->signature($child, false, $state);
+                $shape = null === $exact ? null : $this->signature($child, true, $state);
+                if (null !== $exact && null !== $shape) $candidates[] = array('tag' => strtolower($child->tagName), 'path' => $child->getNodePath(), 'fingerprint' => hash('sha256', $exact), 'shape_fingerprint' => hash('sha256', $shape));
+                else ++$state['omitted_candidates'];
+            }
+            $this->collect($child, $depth + 1, $candidates, $state);
+        }
+    }
+
+    private function isSubtreeCandidate(DOMElement $element): bool
+    {
+        if ('svg' === strtolower($element->tagName)) return true;
+        foreach ($element->childNodes as $child) if ($child instanceof DOMElement) return true;
+        return false;
+    }
+
+    /** @param array<string, mixed> $state */
+    private function signature(DOMNode $node, bool $shapeOnly, array &$state): ?string
+    {
+        if (++$state['signature_work'] > self::MAX_SIGNATURE_WORK) {
+            $state['truncated'][] = 'max_signature_work';
+            return null;
+        }
+        if (XML_TEXT_NODE === $node->nodeType) return '' === trim((string) $node->textContent) ? '' : '#text';
+        if (!$node instanceof DOMElement) return '';
+        $attributes = array();
+        foreach ($node->attributes as $attribute) {
+            $name = strtolower($attribute->name);
+            $value = $this->normalizedAttributeValue($name, $attribute->value);
+            if (null === $value) continue;
+            $attributes[] = $shapeOnly ? $name : ($this->isContentSlot($name) ? $name . '=#slot' : $name . '=' . $value);
+        }
+        sort($attributes, SORT_STRING);
+        $signature = '<' . strtolower($node->tagName) . ' ' . implode(' ', $attributes) . '>';
+        foreach ($node->childNodes as $child) {
+            $childSignature = $this->signature($child, $shapeOnly, $state);
+            if (null === $childSignature) return null;
+            $signature .= $childSignature;
+            if (strlen($signature) > self::MAX_SIGNATURE_BYTES) {
+                $state['truncated'][] = 'max_signature_bytes';
+                return null;
+            }
+        }
+        return $signature . '</' . strtolower($node->tagName) . '>';
+    }
+
+    private function isContentSlot(string $name): bool
+    {
+        return in_array($name, array('action', 'alt', 'content', 'href', 'placeholder', 'src', 'title', 'value'), true) || str_starts_with($name, 'aria-');
+    }
+
+    private function normalizedAttributeValue(string $name, string $value): ?string
+    {
+        if ('class' !== $name) return trim($value);
+        $classes = array();
+        foreach (preg_split('/\s+/', trim($value)) ?: array() as $class) {
+            // These names are emitted by WordPress core, unlike CSS-module-like
+            // source classes whose styling provenance cannot be proven here.
+            if (!GeneratedGutenbergClassPolicy::isGeneratedClassName($class)) $classes[] = $class;
+        }
+        sort($classes, SORT_STRING);
+        return array() === $classes ? null : implode(' ', array_unique($classes));
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -78,27 +78,61 @@ trait SvgMaterializationTrait
         }
 
         $html = $this->ensureSvgImageNamespace($this->minifyInlineSvgForImage($html));
-        $path = $this->materializedInlineSvgPath($element, $html);
-        $this->generatedAssets[$path] = array(
+        $assetHtml = $html;
+        $visualPayload = $this->svgImageAssetIdentity($html);
+        $path = $this->materializedInlineSvgPath($element, $visualPayload);
+        $url = $this->sourceRelativeMaterializedSvgPath($path);
+        $occurrence = array_filter(array(
+            'source_path' => $this->transformSourcePath(),
+            'selector' => $this->elementSelector($element),
+            'fingerprint' => $this->reusableComponentFingerprintFor($element),
+        ), static fn (mixed $value): bool => is_string($value) && '' !== $value);
+        $asset = array(
             'source'      => 'inline-svg',
             'source_path' => $this->transformSourcePath(),
             'selector'    => $this->elementSelector($element),
             'path'        => $path,
             'target_path' => $path,
+            'source_url'  => $url,
             'kind'        => 'svg',
             'role'        => 'image',
             'mime_type'   => 'image/svg+xml',
             'media_type'  => 'image/svg+xml',
-            'content'     => $html . "\n",
-            'bytes'       => strlen($html) + 1,
+            'content'     => $assetHtml . "\n",
+            'bytes'       => strlen($assetHtml) + 1,
             'encoding'    => 'utf-8',
             'binary'      => false,
             'source_role' => 'importer_owned',
             'keep_source' => false,
-            'hash'        => hash('sha256', $html),
-            'source_hash' => hash('sha256', $html),
+            'hash'        => hash('sha256', $assetHtml),
+            'source_hash' => hash('sha256', $assetHtml),
             'pipeline_sanitized' => true,
+            'visual_payload' => $visualPayload . "\n",
         );
+        if (array() !== $occurrence) $asset['component_occurrences'] = array($occurrence);
+        if (isset($this->generatedAssets[$path])) {
+            $existing = $this->generatedAssets[$path];
+            // A shared path represents visual identity. Once more than one
+            // instance uses it, discard instance accessibility metadata from
+            // the payload; core/image owns that metadata per block via alt.
+            $existing['content'] = (string) ($existing['visual_payload'] ?? $visualPayload . "\n");
+            $existing['bytes'] = strlen($existing['content']);
+            $existing['hash'] = hash('sha256', $existing['content']);
+            $existing['source_hash'] = $existing['hash'];
+            $occurrences = is_array($existing['component_occurrences'] ?? null) ? $existing['component_occurrences'] : array();
+            $counts = is_array($existing['component_occurrence_counts'] ?? null) ? $existing['component_occurrence_counts'] : array();
+            if (is_string($occurrence['fingerprint'] ?? null)) $counts[$occurrence['fingerprint']] = (int) ($counts[$occurrence['fingerprint']] ?? 0) + 1;
+            if (count($occurrences) < 8 && !in_array($occurrence, $occurrences, true)) $occurrences[] = $occurrence;
+            elseif (!in_array($occurrence, $occurrences, true)) $existing['component_occurrences_omitted'] = (int) ($existing['component_occurrences_omitted'] ?? 0) + 1;
+            $existing['component_occurrences'] = $occurrences;
+            $existing['component_occurrence_counts'] = $counts;
+            $existing['selector'] = $occurrences[0]['selector'] ?? $existing['selector'];
+            $this->generatedAssets[$path] = $existing;
+        } else {
+            if (is_string($occurrence['fingerprint'] ?? null)) $asset['component_occurrence_counts'] = array($occurrence['fingerprint'] => 1);
+            $asset['component_occurrences_omitted'] = 0;
+            $this->generatedAssets[$path] = $asset;
+        }
 
         $dimensions = $this->cssOwnsMediaBox($element) ? array() : $this->svgImageDimensions($element, $html);
         $presentation = $this->presentationDeclarations($element);
@@ -133,7 +167,7 @@ trait SvgMaterializationTrait
             $fillClass = ($this->geometryCarrierClassAllocator ??= new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
             $this->generatedGeometryRules[$fillClass] = '.' . $fillClass . $figureRule . '.wp-block-image.' . $fillClass . $imgRule;
             $attrs = array(
-                'url'       => $path,
+                'url'       => $url,
                 'alt'       => $this->svgImageAlt($element),
                 'className'  => $this->mergePresentationClassNames($this->attr($element, 'class'), $fillClass),
                 'style'      => array(
@@ -161,7 +195,7 @@ trait SvgMaterializationTrait
             $this->generatedGeometryRules[$geometryClass] = '.' . $geometryClass . $rule;
         }
         $attrs = array_filter(array_merge(array(
-            'url'          => $path,
+            'url'          => $url,
             'alt'          => $this->svgImageAlt($element),
             'className'    => $this->mergePresentationClassNames($this->attr($element, 'class'), $geometryClass),
             'style'        => $preserveInlineGeometry ? null : array(
@@ -339,6 +373,16 @@ trait SvgMaterializationTrait
         return trim($html);
     }
 
+    private function svgImageAssetIdentity(string $html): string
+    {
+        // core/image owns the accessible name through its per-instance alt
+        // attribute. Accessibility metadata therefore does not participate in
+        // visual asset identity, while the first materialized payload retains
+        // its original metadata for compatibility with direct SVG consumers.
+        $html = preg_replace('/\s(?:aria-[a-z-]+|title)\s*=\s*(["\']).*?\1/i', '', $html) ?? $html;
+        return preg_replace('/<(?:title|desc)\b[^>]*>.*?<\/(?:title|desc)>/is', '', $html) ?? $html;
+    }
+
     private function ensureSvgImageNamespace(string $html): string
     {
         if ( preg_match('/<svg\b[^>]*\sxmlns\s*=/i', $html) ) {
@@ -462,21 +506,23 @@ trait SvgMaterializationTrait
 
     private function materializedInlineSvgPath(DOMElement $element, string $html): string
     {
-        $sourcePath = $this->transformSourcePath();
-        $sourceDir = '' !== $sourcePath ? dirname($sourcePath) : '';
-        if ( '.' === $sourceDir ) {
-            $sourceDir = '';
-        }
+        unset($element);
+        // The asset is the sanitized vector payload, not its generated source
+        // selector. A content address lets every compatible instance share one
+        // core/image asset while retaining its own alt text and presentation.
+        $filename = 'inline-svg-' . substr(hash('sha256', $html), 0, 16) . '.svg';
+        return ('' !== $this->generatedAssetRoot ? $this->generatedAssetRoot . '/' : '') . 'assets/materialized-svg/' . $filename;
+    }
 
-        $label = strtolower(trim($this->attr($element, 'id') . ' ' . $this->attr($element, 'class') . ' ' . $this->attr($element, 'aria-label')));
-        $label = trim(preg_replace('/[^a-z0-9]+/', '-', $label) ?? '', '-');
-        if ( '' === $label ) {
-            $label = 'inline-svg';
+    private function sourceRelativeMaterializedSvgPath(string $path): string
+    {
+        $from = array_values(array_filter(explode('/', trim(dirname($this->transformSourcePath()), '/')), static fn(string $segment): bool => '' !== $segment && '.' !== $segment));
+        $to = array_values(array_filter(explode('/', trim($path, '/')), static fn(string $segment): bool => '' !== $segment && '.' !== $segment));
+        while (array() !== $from && array() !== $to && $from[0] === $to[0]) {
+            array_shift($from);
+            array_shift($to);
         }
-        $filename = substr($label, 0, 48) . '-' . substr(hash('sha256', $html), 0, 16) . '.svg';
-        $path = ( '' !== $sourceDir ? trim($sourceDir, '/') . '/' : '' ) . 'assets/materialized-svg/' . $filename;
-
-        return preg_replace('#/+#', '/', $path) ?? $path;
+        return str_repeat('../', count($from)) . implode('/', $to);
     }
 
     private function transformSourcePath(): string
@@ -789,7 +835,7 @@ trait SvgMaterializationTrait
             'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit',
             'stroke-opacity', 'stroke-width', 'stddeviation', 'style', 'text-anchor', 'transform',
             'vector-effect', 'viewbox', 'width', 'x', 'x1', 'x2', 'xlink:href', 'xmlns', 'y', 'y1', 'y2',
-            'in',
+            'in', 'title',
         ));
 
         foreach ( $element->getElementsByTagName('*') as $child ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -840,7 +840,7 @@ $artifactInlineSvg = ( new ArtifactCompiler() )->compile(
     )
 )->toArray();
 $artifactInlineSvgMarkup = (string) ($artifactInlineSvg['serialized_blocks'] ?? '');
-$assert(str_contains($artifactInlineSvgMarkup, '<!-- wp:paragraph') && str_contains($artifactInlineSvgMarkup, 'website/assets/materialized-svg/'), 'source-relative materialized SVG remains a native RichText image object');
+$assert(str_contains($artifactInlineSvgMarkup, '<!-- wp:paragraph') && str_contains($artifactInlineSvgMarkup, 'assets/materialized-svg/'), 'source-relative materialized SVG remains a native RichText image object');
 $assert(! str_contains($artifactInlineSvgMarkup, '<!-- wp:html'), 'source-relative materialized SVG does not fall back to core/html');
 
 $largeCssSizedInlineSvgArtwork = ( new HtmlTransformer() )->transform(

--- a/php-transformer/tests/unit/reusable-component-recognition.php
+++ b/php-transformer/tests/unit/reusable-component-recognition.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$assert = static function (bool $condition, string $message): void {
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+};
+$recognition = static function (string $html): array {
+    return (new HtmlTransformer())->transform($html)->toArray()['source_reports']['html']['reusable_components'] ?? array();
+};
+
+$exact = $recognition('<main><span class="icon"><svg class="wp-container-1"><path d="M0 0h1v1z"/></svg></span><span class="icon"><svg class="wp-container-2"><path d="M0 0h1v1z"/></svg></span></main>');
+$assert(1 === count($exact['components'] ?? array()), 'Proven WordPress-generated classes normalize for exact semantic repeats.');
+$assert('shared_core_image_asset' === ($exact['components'][0]['mapping'] ?? ''), 'Repeated vectors report the emitted shared core/image asset mapping.');
+
+$authoredClasses = $recognition('<main><section class="css-brand"><p>One</p></section><section class="css-other"><p>Two</p></section></main>');
+$assert(array() === ($authoredClasses['components'] ?? array()), 'Authored css-* classes remain a styling boundary without generator proof.');
+
+$slots = $recognition('<main><section class="card"><a href="/one" aria-label="One"><img src="one.svg" alt="One">First</a></section><section class="card"><a href="/two" aria-label="Two"><img src="two.svg" alt="Two">Second</a></section></main>');
+$assert(1 === count($slots['components'] ?? array()) && 2 === ($slots['components'][0]['occurrence_count'] ?? 0), 'Content, links, and accessibility values are content slots while their semantic attributes remain boundaries.');
+
+$styles = $recognition('<main><section class="card" style="color:red"><p>One</p></section><section class="card" style="color:blue"><p>Two</p></section></main>');
+$assert(array() === ($styles['components'] ?? array()) && 1 === count($styles['near_matches'] ?? array()), 'Style variation is rejected as a reusable mapping and emitted as bounded near-match evidence.');
+
+$falsePositive = $recognition('<main><section class="card"><a href="/one">One</a></section><section class="card"><button type="button">Two</button></section></main>');
+$assert(array() === ($falsePositive['components'] ?? array()) && array() === ($falsePositive['near_matches'] ?? array()), 'Different semantic controls never share a component fingerprint.');
+
+$svgResult = (new HtmlTransformer())->transform('<main><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span></main>')->toArray();
+$svgAssets = array_values(array_filter($svgResult['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? '')));
+$assert(1 === count($svgAssets), 'Repeated passive SVG payloads emit one shared generated asset.');
+
+$ariaResult = (new HtmlTransformer())->transform('<main><span class="icon"><svg aria-label="One"><path d="M0 0h1v1z"/></svg></span><span class="icon"><svg aria-label="Two"><path d="M0 0h1v1z"/></svg></span></main>')->toArray();
+$ariaAssets = array_values(array_filter($ariaResult['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? '')));
+$assert(1 === count($ariaAssets) && 'One' === ($ariaResult['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['alt'] ?? '') && 'Two' === ($ariaResult['blocks'][0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['alt'] ?? ''), 'Accessibility variants share the visual asset while preserving per-instance accessible names.');
+
+$site = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span></main>', 'about.html' => '<main><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span></main>')))->toArray();
+$siteComponents = $site['source_reports']['reusable_components']['components'] ?? array();
+$siteAssets = array_values(array_filter($site['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? '')));
+$siteVector = array_values(array_filter($siteComponents, static fn(array $component): bool => 'shared_core_image_asset' === ($component['mapping'] ?? '')));
+$assert(1 === count($siteVector) && 2 === ($siteVector[0]['occurrence_count'] ?? 0) && 2 === count($siteAssets[0]['component_occurrences'] ?? array()), 'Cross-document vector repeats aggregate evidence, emit one asset, and retain both selectors.');
+
+$nested = (new HtmlTransformer())->transform('<main><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span></main>', array('source' => 'nested/about.html'))->toArray();
+$nestedAsset = array_values(array_filter($nested['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? '')))[0] ?? array();
+$assert('assets/materialized-svg/inline-svg-5b3525e620052139.svg' === ($nestedAsset['path'] ?? '') && str_contains((string) ($nested['serialized_blocks'] ?? ''), 'src="../assets/materialized-svg/inline-svg-5b3525e620052139.svg"'), 'Nested documents use a global generated asset identity and source-relative block URL.');
+
+$deepNested = (new HtmlTransformer())->transform('<main><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span></main>', array('source' => 'one/two/about.html'))->toArray();
+$assert(str_contains((string) ($deepNested['serialized_blocks'] ?? ''), 'src="../../assets/materialized-svg/inline-svg-5b3525e620052139.svg"'), 'Multi-level nested documents calculate source-relative SVG URLs segment by segment.');
+
+$artifactNested = (new HtmlTransformer())->transform('<main><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span></main>', array('source' => 'website/nested/about.html', 'generated_asset_root' => 'website'))->toArray();
+$artifactDeepNested = (new HtmlTransformer())->transform('<main><span class="icon"><svg><path d="M0 0h1v1z"/></svg></span></main>', array('source' => 'website/one/two/about.html', 'generated_asset_root' => 'website'))->toArray();
+$assert(str_contains((string) ($artifactNested['serialized_blocks'] ?? ''), 'src="../assets/materialized-svg/inline-svg-5b3525e620052139.svg"') && str_contains((string) ($artifactDeepNested['serialized_blocks'] ?? ''), 'src="../../assets/materialized-svg/inline-svg-5b3525e620052139.svg"'), 'Artifact-root documents calculate relative SVG URLs from each nested source directory.');
+
+$nine = (new HtmlTransformer())->transform('<main>' . str_repeat('<span class="icon"><svg><path d="M0 0h1v1z"/></svg></span>', 9) . '</main>')->toArray();
+$nineAsset = array_values(array_filter($nine['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? '')))[0] ?? array();
+$nineComponent = array_values(array_filter($nine['source_reports']['html']['reusable_components']['components'] ?? array(), static fn(array $component): bool => 'shared_core_image_asset' === ($component['mapping'] ?? '')))[0] ?? array();
+$assert(9 === ($nineComponent['mapped_asset_occurrence_count'] ?? 0) && 8 === ($nineComponent['retained_occurrence_count'] ?? 0) && 1 === ($nineComponent['omitted_occurrence_count'] ?? 0) && true === ($nineComponent['incomplete'] ?? false) && 8 === count($nineAsset['component_occurrences'] ?? array()) && 1 === ($nineAsset['component_occurrences_omitted'] ?? 0), 'Mapped occurrence counts remain complete after bounded document provenance samples truncate.');
+
+$eight = (new HtmlTransformer())->transform('<main>' . str_repeat('<span class="icon"><svg><path d="M0 0h1v1z"/></svg></span>', 8) . '</main>')->toArray();
+$eightAsset = array_values(array_filter($eight['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? '')))[0] ?? array();
+$assert(8 === count($eightAsset['component_occurrences'] ?? array()) && 0 === ($eightAsset['component_occurrences_omitted'] ?? -1), 'Eight retained SVG provenance rows report zero omissions.');
+
+$nineSite = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main>' . str_repeat('<span class="icon"><svg><path d="M0 0h1v1z"/></svg></span>', 9) . '</main>')))->toArray()['source_reports']['reusable_components']['components'] ?? array();
+$nineSiteVector = array_values(array_filter($nineSite, static fn(array $component): bool => 'shared_core_image_asset' === ($component['mapping'] ?? '')))[0] ?? array();
+$assert(9 === ($nineSiteVector['occurrence_count'] ?? 0) && 8 === ($nineSiteVector['retained_occurrence_count'] ?? 0) && 1 === ($nineSiteVector['omitted_occurrence_count'] ?? 0) && true === ($nineSiteVector['incomplete'] ?? false), 'Cross-document component evidence reports bounded occurrence samples as incomplete.');
+
+$nearMatchHtml = static function (int $count): string {
+    $html = '<main>';
+    for ($index = 0; $index < $count; ++$index) $html .= '<section data-shape-' . $index . '="one" style="color:red"><p>One</p></section><section data-shape-' . $index . '="two" style="color:blue"><p>Two</p></section>';
+    return $html . '</main>';
+};
+$sixteenNearMatches = $recognition($nearMatchHtml(16));
+$seventeenNearMatches = $recognition($nearMatchHtml(17));
+$assert(16 === ($sixteenNearMatches['retained_near_match_count'] ?? 0) && 0 === ($sixteenNearMatches['omitted_near_match_count'] ?? -1) && false === ($sixteenNearMatches['incomplete'] ?? true), 'Sixteen near matches remain complete at the report boundary.');
+$assert(16 === ($seventeenNearMatches['retained_near_match_count'] ?? 0) && 1 === ($seventeenNearMatches['omitted_near_match_count'] ?? 0) && 'max_near_matches' === ($seventeenNearMatches['near_match_truncation_reason'] ?? '') && true === ($seventeenNearMatches['incomplete'] ?? false) && in_array('max_near_matches', $seventeenNearMatches['truncated'] ?? array(), true), 'Seventeen near matches report explicit bounded truncation.');
+
+$ariaSite = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><span class="icon"><svg aria-label="One" title="One"><path d="M0 0h1v1z"/></svg></span></main>', 'about.html' => '<main><span class="icon"><svg aria-label="Two" title="Two"><path d="M0 0h1v1z"/></svg></span></main>')))->toArray();
+$ariaSiteAssets = array_values(array_filter($ariaSite['assets'] ?? array(), static fn(array $asset): bool => 'inline-svg' === ($asset['source'] ?? '')));
+$assert(1 === count($ariaSiteAssets) && !str_contains((string) ($ariaSiteAssets[0]['content'] ?? ''), 'aria-label') && !str_contains((string) ($ariaSiteAssets[0]['content'] ?? ''), '<title>'), 'Cross-document accessibility variants share one canonical visual SVG payload and path.');
+
+$deep = '<main>' . str_repeat('<section>', 40) . 'x' . str_repeat('</section>', 40) . '</main>';
+$limited = $recognition($deep);
+$assert(in_array('max_depth', $limited['truncated'] ?? array(), true), 'Recognition reports depth budget truncation rather than unbounded traversal.');
+
+$wide = '<main>' . str_repeat('<section><p>x</p></section>', 300) . '</main>';
+$wideLimited = $recognition($wide);
+$assert(in_array('max_candidates', $wideLimited['truncated'] ?? array(), true), 'Recognition reports candidate budget truncation for wide repeated input.');
+
+$incompleteSite = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main>Entry</main>', 'about.html' => $wide)))->toArray()['source_reports']['reusable_components'] ?? array();
+$assert(true === ($incompleteSite['incomplete'] ?? false) && in_array('max_candidates', $incompleteSite['truncated'] ?? array(), true) && 0 < ($incompleteSite['omitted_candidate_count'] ?? 0), 'Site-level evidence remains explicitly incomplete when a document reaches its candidate budget.');
+
+$componentMarkup = '<main>';
+for ($index = 0; $index < 33; ++$index) $componentMarkup .= '<section class="component-' . $index . '"><p>One</p></section><section class="component-' . $index . '"><p>Two</p></section>';
+$componentMarkup .= '</main>';
+$componentBound = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => $componentMarkup)))->toArray()['source_reports']['reusable_components'] ?? array();
+$assert(32 === ($componentBound['retained_component_count'] ?? 0) && 0 < ($componentBound['omitted_component_count'] ?? 0) && in_array('max_components', $componentBound['truncated'] ?? array(), true) && true === ($componentBound['incomplete'] ?? false), 'Site reports expose component cap omissions and incomplete evidence.');
+
+$documentFiles = array('index.html' => '<main>Entry</main>');
+for ($index = 0; $index < 64; ++$index) $documentFiles['document-' . $index . '.html'] = '<main>Document</main>';
+$documentBound = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => $documentFiles))->toArray()['source_reports']['reusable_components'] ?? array();
+$assert(64 === ($documentBound['retained_document_count'] ?? 0) && 1 === ($documentBound['omitted_document_count'] ?? 0) && in_array('max_documents', $documentBound['truncated'] ?? array(), true) && true === ($documentBound['incomplete'] ?? false), 'Site reports expose document cap omissions and incomplete evidence.');
+
+$largeAttribute = $recognition('<main><section data-payload="' . str_repeat('x', 9000) . '"><p>x</p></section></main>');
+$assert(in_array('max_signature_bytes', $largeAttribute['truncated'] ?? array(), true), 'Recognition reports signature-byte truncation for oversized attributes.');
+
+fwrite(STDOUT, "reusable component recognition passed\n");


### PR DESCRIPTION
## Summary

- add bounded structural fingerprinting for repeated semantic subtrees
- map repeated SVG instances to one content-addressed `core/image` asset while preserving per-block accessibility and presentation
- aggregate truthful cross-document component evidence with explicit candidate, occurrence, component, document, and near-match bounds
- retain bounded source occurrence provenance and report non-vector repeats as capability gaps

## Verification

- `cd php-transformer && composer test`
- 278 parity fixtures
- exact/content-slot/style/accessibility false-positive boundaries
- nested-document URL and cross-document asset deduplication coverage
- 8/9 occurrence, 16/17 near-match, component/document, and workload-boundary coverage

Fixes #930
Related to #868

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode measured repeated artifact structures, implemented reusable-component recognition and SVG mapping, generated tests, and performed iterative code review. Chris Huber directed the work and remains responsible for every line.