### PR TITLE
Preserve fallback diagnostics across pattern recursion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -126,6 +126,28 @@ final class FallbackEmitter
     }
 
     /**
+     * @return array{runtime_island_origins: array<int, array{document: int, path: string}>, generated_block_names: array<string, string>, generated_block_identities: array<string, string>}
+     */
+    public function mutableState(): array
+    {
+        return array(
+            'runtime_island_origins'     => $this->runtimeIslandOrigins,
+            'generated_block_names'      => $this->generatedBlockNames,
+            'generated_block_identities' => $this->generatedBlockIdentities,
+        );
+    }
+
+    /**
+     * @param array{runtime_island_origins: array<int, array{document: int, path: string}>, generated_block_names: array<string, string>, generated_block_identities: array<string, string>} $state
+     */
+    public function restoreMutableState(array $state): void
+    {
+        $this->runtimeIslandOrigins     = $state['runtime_island_origins'];
+        $this->generatedBlockNames      = $state['generated_block_names'];
+        $this->generatedBlockIdentities = $state['generated_block_identities'];
+    }
+
+    /**
      * Producer link of the classify -> route -> generate chain (issue #497).
      *
      * At a `core/html` fallback decision (a subtree that mapped to nothing

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -29,6 +29,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationUnder
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ParameterTablePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternResult;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
@@ -4165,42 +4166,74 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
             fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement),
             $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
-            fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
-            fn (DOMElement $sourceElement, array $excludedTags): array => $this->convertPatternChildrenWithoutTags($sourceElement, $excludedTags),
+            fn (DOMElement $sourceElement): PatternResult => $this->convertPatternChildren($sourceElement),
+            fn (DOMElement $sourceElement, array $excludedTags): PatternResult => $this->convertPatternChildrenWithoutTags($sourceElement, $excludedTags),
             fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
             fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement)),
-            fn (DOMElement $sourceElement): ?array => $this->convertPatternElement($sourceElement),
+            fn (DOMElement $sourceElement): PatternResult => $this->convertPatternElement($sourceElement),
             fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement)
+            fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement),
+            fn (): \Closure => $this->patternMutationRollback()
         );
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * Capture every mutable transformer property before registry recursion. The
+     * recursive converter is deliberately allowed to use the normal pipeline;
+     * rejecting its candidate restores generated output, findings, provenance,
+     * markers, and style state as though that conversion never happened.
      */
-    private function convertPatternChildren(DOMElement $element): array
+    private function patternMutationRollback(): \Closure
     {
-        $fallbacks = array();
-        return $this->convertChildren($element, $fallbacks, true);
+        $state = array();
+        $reflection = new \ReflectionObject($this);
+        foreach ( $reflection->getProperties() as $property ) {
+            if ( $property->isStatic() || $property->isReadOnly() || ! $property->isInitialized($this) ) {
+                continue;
+            }
+
+            $value = $property->getValue($this);
+            if ( $value instanceof DOMNode ) {
+                continue;
+            }
+            $state[$property->getName()] = is_object($value) ? clone $value : $value;
+        }
+        $fallbackEmitterState = $this->fallbackEmitter->mutableState();
+
+        return function () use ($state, $fallbackEmitterState): void {
+            foreach ( $state as $name => $value ) {
+                $this->{$name} = $value;
+            }
+            $this->fallbackEmitter->restoreMutableState($fallbackEmitterState);
+        };
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return PatternResult
      */
-    private function convertPatternElement(DOMElement $element): ?array
+    private function convertPatternChildren(DOMElement $element): PatternResult
     {
         $fallbacks = array();
-        return $this->convertElement($element, $fallbacks, true);
+        return new PatternResult(null, $this->convertChildren($element, $fallbacks, true), $fallbacks);
+    }
+
+    /**
+     * @return PatternResult
+     */
+    private function convertPatternElement(DOMElement $element): PatternResult
+    {
+        $fallbacks = array();
+        return new PatternResult($this->convertElement($element, $fallbacks, true), array(), $fallbacks);
     }
 
     /**
      * @param array<int, string> $excludedTags
-     * @return array<int, array<string, mixed>>
+     * @return PatternResult
      */
-    private function convertPatternChildrenWithoutTags(DOMElement $element, array $excludedTags): array
+    private function convertPatternChildrenWithoutTags(DOMElement $element, array $excludedTags): PatternResult
     {
         $fallbacks = array();
-        return $this->convertChildrenWithoutTags($element, $fallbacks, $excludedTags);
+        return new PatternResult(null, $this->convertChildrenWithoutTags($element, $fallbacks, $excludedTags), $fallbacks);
     }
 
     /**
@@ -4449,9 +4482,10 @@ final class HtmlTransformer
         }
 
         if ( 'ul' === $tagName || 'ol' === $tagName ) {
-            $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
-            if ( null !== $navigation ) {
-                return $this->rememberAccordionDisclosureRoot($navigation, $element);
+            $navigationResult = $this->patternRecognizers->firstMatch($element, $this->patternContext());
+            if ( null !== $navigationResult ) {
+                PatternResult::mergeFallbacksInto($fallbacks, $navigationResult->fallbacks());
+                return $this->rememberAccordionDisclosureRoot($navigationResult->block() ?? array(), $element);
             }
 
             if ( $this->isStructuredCardList($element) ) {
@@ -4841,9 +4875,10 @@ final class HtmlTransformer
         }
 
         if ( 'nav' === $tagName ) {
-            $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext(false));
-            if ( null !== $navigation ) {
-                return $this->rememberAccordionDisclosureRoot($navigation, $element);
+            $navigationResult = $this->patternRecognizers->firstMatch($element, $this->patternContext(false));
+            if ( null !== $navigationResult ) {
+                PatternResult::mergeFallbacksInto($fallbacks, $navigationResult->fallbacks());
+                return $this->rememberAccordionDisclosureRoot($navigationResult->block() ?? array(), $element);
             }
 
             $inlineNavigation = $this->inlineNavigationGroupBlockFromElement($element);
@@ -4952,9 +4987,10 @@ final class HtmlTransformer
             }
 
             if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
-                $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
-                if ( null !== $navigation ) {
-                    return $this->rememberAccordionDisclosureRoot($navigation, $element);
+                $navigationResult = $this->patternRecognizers->firstMatch($element, $this->patternContext());
+                if ( null !== $navigationResult ) {
+                    PatternResult::mergeFallbacksInto($fallbacks, $navigationResult->fallbacks());
+                    return $this->rememberAccordionDisclosureRoot($navigationResult->block() ?? array(), $element);
                 }
             }
 
@@ -4966,7 +5002,7 @@ final class HtmlTransformer
 
                 $disclosure = $this->detailsPattern->matchDisclosure(
                     $element,
-                    fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
+                    fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement)->blocks(),
                     fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
                     fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
                     fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)

--- a/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
@@ -59,7 +59,8 @@ final class AccordionPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $panelBlocks = $panel instanceof DOMElement ? $convertChildren($panel) : $convertChildrenWithoutTags($item, array( 'summary' ));
+        $panelResult = $panel instanceof DOMElement ? $convertChildren($panel) : $convertChildrenWithoutTags($item, array( 'summary' ));
+        $panelBlocks = $panelResult->blocks();
         if ( array() === $panelBlocks ) {
             return null;
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -268,7 +268,7 @@ final class NavigationPattern implements PatternRecognizerInterface
 
         // An anchor that only converts to an HTML fallback would trade a menu
         // item for raw markup; keep today's shape rather than lose the block.
-        $brand = $convertElement($anchor);
+        $brand = $convertElement($anchor)->block();
         $brandName = is_array($brand) ? (string) ($brand['blockName'] ?? '') : '';
         if ( '' === $brandName || 'core/html' === $brandName ) {
             return null;
@@ -344,7 +344,7 @@ final class NavigationPattern implements PatternRecognizerInterface
 
         $extraBlocks = array();
         foreach ( $extras as $extra ) {
-            $extraBlock = $convertElement($extra);
+            $extraBlock = $convertElement($extra)->block();
             $extraName = is_array($extraBlock) ? (string) ($extraBlock['blockName'] ?? '') : '';
             if ( '' === $extraName || 'core/html' === $extraName ) {
                 return null;

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -12,13 +12,14 @@ final class PatternContext
      * @param callable(DOMElement): string $innerHtml
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @param callable(DOMElement): bool|null $isRuntimeDomTarget
-     * @param callable(DOMElement): array<int, array<string, mixed>>|null $convertChildren
-     * @param callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null $convertChildrenWithoutTags
+     * @param callable(DOMElement): PatternResult|null $convertChildren
+     * @param callable(DOMElement, array<int, string>): PatternResult|null $convertChildrenWithoutTags
      * @param callable(DOMElement, DOMElement): string|null $navigationUnderlineColor
      * @param callable(DOMElement): string|null $resolvedStyle
-     * @param callable(DOMElement): array<string, mixed>|null $convertElement
+     * @param callable(DOMElement): PatternResult|null $convertElement
      * @param callable(DOMElement): list<string>|null $navigationColorInteractionStates
      * @param callable(DOMElement): string|null $navigationOverlayMenu
+     * @param callable(): callable|null $beginMutationScope
      */
     public function __construct(
         private readonly mixed $presentationAttributes,
@@ -31,9 +32,13 @@ final class PatternContext
         private readonly mixed $resolvedStyle = null,
         private readonly mixed $convertElement = null,
         private readonly mixed $navigationColorInteractionStates = null,
-        private readonly mixed $navigationOverlayMenu = null
+        private readonly mixed $navigationOverlayMenu = null,
+        private readonly mixed $beginMutationScope = null
     ) {
     }
+
+    /** @var array<int, array<string, mixed>> */
+    private array $fallbacks = array();
 
     /**
      * @return callable(DOMElement): array<string, mixed>
@@ -68,11 +73,20 @@ final class PatternContext
     }
 
     /**
-     * @return callable(DOMElement): array<int, array<string, mixed>>|null
+     * @return callable(DOMElement): PatternResult|null
      */
     public function convertChildrenCallback(): ?callable
     {
-        return is_callable($this->convertChildren) ? $this->convertChildren : null;
+        if ( ! is_callable($this->convertChildren) ) {
+            return null;
+        }
+
+        return function (DOMElement $element): PatternResult {
+            $this->beginMutationScope();
+            $result = ($this->convertChildren)($element);
+            $this->record($result);
+            return $result;
+        };
     }
 
     /**
@@ -81,19 +95,37 @@ final class PatternContext
      * element's own conversion rather than its children's, so the sibling is
      * emitted exactly as it would be anywhere else in the document.
      *
-     * @return callable(DOMElement): array<string, mixed>|null
+     * @return callable(DOMElement): PatternResult|null
      */
     public function convertElementCallback(): ?callable
     {
-        return is_callable($this->convertElement) ? $this->convertElement : null;
+        if ( ! is_callable($this->convertElement) ) {
+            return null;
+        }
+
+        return function (DOMElement $element): PatternResult {
+            $this->beginMutationScope();
+            $result = ($this->convertElement)($element);
+            $this->record($result);
+            return $result;
+        };
     }
 
     /**
-     * @return callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null
+     * @return callable(DOMElement, array<int, string>): PatternResult|null
      */
     public function convertChildrenWithoutTagsCallback(): ?callable
     {
-        return is_callable($this->convertChildrenWithoutTags) ? $this->convertChildrenWithoutTags : null;
+        if ( ! is_callable($this->convertChildrenWithoutTags) ) {
+            return null;
+        }
+
+        return function (DOMElement $element, array $excludedTags): PatternResult {
+            $this->beginMutationScope();
+            $result = ($this->convertChildrenWithoutTags)($element, $excludedTags);
+            $this->record($result);
+            return $result;
+        };
     }
 
     /**
@@ -126,5 +158,60 @@ final class PatternContext
     public function navigationOverlayMenuCallback(): ?callable
     {
         return is_callable($this->navigationOverlayMenu) ? $this->navigationOverlayMenu : null;
+    }
+
+    public function matchScope(): self
+    {
+        return new self(
+            $this->presentationAttributes,
+            $this->innerHtml,
+            $this->createBlock,
+            $this->isRuntimeDomTarget,
+            $this->convertChildren,
+            $this->convertChildrenWithoutTags,
+            $this->navigationUnderlineColor,
+            $this->resolvedStyle,
+            $this->convertElement,
+            $this->navigationColorInteractionStates,
+            $this->navigationOverlayMenu,
+            $this->beginMutationScope
+        );
+    }
+
+    public function commitMutations(): void
+    {
+        $this->rollbackMutations = null;
+    }
+
+    public function discardMutations(): void
+    {
+        if ( null !== $this->rollbackMutations ) {
+            ($this->rollbackMutations)();
+            $this->rollbackMutations = null;
+        }
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function fallbacks(): array
+    {
+        return $this->fallbacks;
+    }
+
+    private function record(PatternResult $result): void
+    {
+        PatternResult::mergeFallbacksInto($this->fallbacks, $result->fallbacks());
+    }
+
+    /** @var callable|null */
+    private mixed $rollbackMutations = null;
+
+    private function beginMutationScope(): void
+    {
+        if ( null !== $this->rollbackMutations || ! is_callable($this->beginMutationScope) ) {
+            return;
+        }
+
+        $rollback = ($this->beginMutationScope)();
+        $this->rollbackMutations = is_callable($rollback) ? $rollback : null;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
@@ -15,15 +15,23 @@ final class PatternRecognizerRegistry
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return PatternResult|null
      */
-    public function firstMatch(DOMElement $element, PatternContext $context): ?array
+    public function firstMatch(DOMElement $element, PatternContext $context): ?PatternResult
     {
         foreach ( $this->recognizers as $recognizer ) {
-            $block = $recognizer->match($element, $context);
-            if ( null !== $block ) {
-                return $block;
+            $scope = $context->matchScope();
+            try {
+                $block = $recognizer->match($element, $scope);
+            } catch ( \Throwable $exception ) {
+                $scope->discardMutations();
+                throw $exception;
             }
+            if ( null !== $block ) {
+                $scope->commitMutations();
+                return new PatternResult($block, array(), $scope->fallbacks(), array($element->getNodePath() ?: ''));
+            }
+            $scope->discardMutations();
         }
 
         return null;

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternResult.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternResult.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+/**
+ * The output of a recursive pattern conversion or a matched registry pattern.
+ * Findings stay with the candidate until the registry accepts its block.
+ */
+final class PatternResult
+{
+    /**
+     * @param array<string, mixed>|null $block
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @param list<string> $consumedSourceNodes
+     * @param array<string, mixed> $provenance
+     */
+    public function __construct(
+        private readonly ?array $block = null,
+        private readonly array $blocks = array(),
+        private readonly array $fallbacks = array(),
+        private readonly array $consumedSourceNodes = array(),
+        private readonly array $provenance = array()
+    ) {
+    }
+
+    /** @return array<string, mixed>|null */
+    public function block(): ?array
+    {
+        return $this->block;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function blocks(): array
+    {
+        return $this->blocks;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function fallbacks(): array
+    {
+        return $this->fallbacks;
+    }
+
+    /** @return list<string> */
+    public function consumedSourceNodes(): array
+    {
+        return $this->consumedSourceNodes;
+    }
+
+    /** @return array<string, mixed> */
+    public function provenance(): array
+    {
+        return $this->provenance;
+    }
+
+    /**
+     * Keep first-seen finding order while avoiding duplicate findings when a
+     * pattern combines multiple recursive conversions.
+     *
+     * @param array<int, array<string, mixed>> $fallbacks
+     */
+    public static function mergeFallbacksInto(array &$fallbacks, array $additional): void
+    {
+        $seen = array();
+        foreach ( $fallbacks as $fallback ) {
+            $seen[serialize($fallback)] = true;
+        }
+
+        foreach ( $additional as $fallback ) {
+            $key = serialize($fallback);
+            if ( isset($seen[$key]) ) {
+                continue;
+            }
+            $fallbacks[] = $fallback;
+            $seen[$key] = true;
+        }
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -491,7 +491,7 @@ trait NavigationToggleSuppressionTrait
     {
         $navigation = $this->patternRecognizers->firstMatch($element, $this->probePatternContext());
 
-        return null !== $navigation && 'core/navigation' === ($navigation['blockName'] ?? '');
+        return null !== $navigation && 'core/navigation' === ($navigation->block()['blockName'] ?? '');
     }
 
     private function elementWithId(DOMElement $context, string $id): ?DOMElement

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -17,6 +17,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolic
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerInterface;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternResult;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationView;
@@ -364,7 +365,54 @@ $registryContext = new PatternContext(
     static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $innerBlocks)
 );
 $assert($registryElement instanceof DOMElement, 'pattern registry fixture element parses');
-$assert('core/group' === ($registry->firstMatch($registryElement, $registryContext)['blockName'] ?? null), 'pattern registry returns the first recognizer match');
+$assert('core/group' === ($registry->firstMatch($registryElement, $registryContext)?->block()['blockName'] ?? null), 'pattern registry returns the first recognizer match');
+
+$candidateState = array(
+    'generated_assets' => array(),
+    'provenance' => array(),
+    'responsive_findings' => array(),
+    'markers' => array(),
+);
+$rejectedRegistry = new PatternRecognizerRegistry(array(
+    new class implements PatternRecognizerInterface {
+        public function match(DOMElement $element, PatternContext $context): ?array
+        {
+            $convertChildren = $context->convertChildrenCallback();
+            if ( null !== $convertChildren ) {
+                $convertChildren($element);
+            }
+
+            return null;
+        }
+    },
+));
+$rejectedContext = new PatternContext(
+    static fn (DOMElement $element): array => array(),
+    static fn (DOMElement $element): string => '',
+    static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $innerBlocks),
+    null,
+    static function (DOMElement $element) use (&$candidateState): PatternResult {
+        $candidateState['generated_assets'][] = 'candidate.svg';
+        $candidateState['provenance'][] = 'candidate';
+        $candidateState['responsive_findings'][] = 'candidate';
+        $candidateState['markers'][] = 'candidate';
+        return new PatternResult(null, array(), array(array('diagnostic_code' => 'candidate_fallback')));
+    },
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    static function () use (&$candidateState): Closure {
+        $snapshot = $candidateState;
+        return static function () use (&$candidateState, $snapshot): void {
+            $candidateState = $snapshot;
+        };
+    }
+);
+$assert(null === $rejectedRegistry->firstMatch($registryElement, $rejectedContext), 'rejected registry candidate does not match');
+$assert(array('generated_assets' => array(), 'provenance' => array(), 'responsive_findings' => array(), 'markers' => array()) === $candidateState, 'rejected registry recursion rolls back generated assets, provenance, responsive findings, and markers');
 
 $tableElement = static function (string $html): DOMElement {
     $document = new DOMDocument();
@@ -488,6 +536,11 @@ $assert('What is covered?' === ($accordionItems[0]['innerBlocks'][0]['attrs']['t
 $assert('core/accordion-panel' === ($accordionItems[0]['innerBlocks'][1]['blockName'] ?? null), 'accordion conversion emits core accordion panels');
 $assert('Assessment and treatment planning.' === ($accordionItems[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? null), 'accordion conversion preserves panel text');
 $assert(str_contains((string) ($accordionResult['serialized_blocks'] ?? ''), '<!-- wp:accordion '), 'accordion conversion serializes native accordion block comments');
+
+$accordionFallbackResult = ( new HtmlTransformer() )->transform('<section class="faq"><div class="faq-item"><button aria-controls="answer-a">Question A</button><div id="answer-a"><unsupported-widget></unsupported-widget><p>Answer A</p></div></div><div class="faq-item"><button aria-controls="answer-b">Question B</button><div id="answer-b"><p>Answer B</p></div></div></section>')->toArray();
+$accordionFallback = current(array_filter($accordionFallbackResult['fallbacks'] ?? array(), static fn (array $fallback): bool => 'unsupported-widget' === ($fallback['tag'] ?? '')));
+$assert('core/accordion' === (($accordionFallbackResult['blocks'][0] ?? array())['blockName'] ?? null), 'accordion conversion remains native when a panel also preserves unsupported content');
+$assert('html_unsupported_element' === ($accordionFallback['diagnostic_code'] ?? ''), 'accordion recursive conversion returns unsupported child fallback findings');
 
 $complexAccordionResult = ( new HtmlTransformer() )->transform('<section class="faq"><div class="faq-item"><button aria-controls="a">Question A</button><div id="a"><script src="accordion.js"></script><p>Answer A</p></div></div><div class="faq-item"><button aria-controls="b">Question B</button><div id="b"><p>Answer B</p></div></div></section>')->toArray();
 $assert('core/accordion' !== (($complexAccordionResult['blocks'][0] ?? array())['blockName'] ?? null), 'runtime-heavy accordion markup is not forced into native accordion');


### PR DESCRIPTION
## Summary
- add structured pattern results with explicit fallback propagation
- make rejected recognizer attempts transactional and side-effect free
- keep probe contexts mutation-free

## Verification
- focused contract regression passed
- full `composer test` passed before rebase, including 278 parity fixtures and packaging
- current trunk independently stops in `tests/contract/template-surfaces.php` on the shared Figma front-page assertion

Closes #919.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed this change. Chris Huber directed the work and remains responsible for every line.