### PR TITLE
Reuse shared CSS analysis in form layout graphs

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -79,6 +79,7 @@
       "php tests/unit/media-text-pattern.php",
       "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",
+      "php tests/unit/css-rule-analyzer.php",
       "php tests/unit/css-selector-matcher.php",
       "php tests/unit/author-selector-semantics.php",
       "php tests/unit/engine-support-css-asset.php",

--- a/php-transformer/src/HtmlToBlocks/Style/CssCascade.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssCascade.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/** Shared author-origin importance, specificity, and source-order cascade. */
+final class CssCascade
+{
+    /** @param array<string, mixed> $candidate @param array<string, mixed> $current */
+    public static function wins(array $candidate, array $current): bool
+    {
+        return (int) $candidate['important'] > (int) $current['important']
+            || ((bool) $candidate['important'] === $current['important']
+                && ($candidate['specificity'] > $current['specificity']
+                    || ($candidate['specificity'] === $current['specificity'] && $candidate['order'] >= $current['order'])));
+    }
+
+    /** @param array<string, array<string, mixed>> $facts @param array<string, mixed> $candidate */
+    public static function apply(array &$facts, string $property, array $candidate): bool
+    {
+        $current = $facts[$property] ?? null;
+        if ( ! is_array($current) || self::wins($candidate, $current) ) {
+            $facts[$property] = $candidate;
+            return true;
+        }
+        return false;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/CssRuleAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssRuleAnalyzer.php
@@ -1,0 +1,282 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/**
+ * Bounded, source-preserving CSS rule analysis for consumers that need declared
+ * cascade facts without implementing a second stylesheet parser.
+ */
+final class CssRuleAnalyzer
+{
+    /**
+     * @param list<array<string, mixed>> $stylesheets
+     * @param list<string> $properties
+     * @return array{rules: list<array<string, mixed>>, diagnostics: list<string>, truncated: bool}
+     */
+    public function analyze(array $stylesheets, string $inlineCss, array $properties, int $maxCssBytes, int $maxRules, int $maxSelectors, int $maxConditionDepth): array
+    {
+        $result = array( 'rules' => array(), 'diagnostics' => array(), 'truncated' => false );
+        $order = 0;
+
+        foreach ( $stylesheets as $sheet ) {
+            $this->analyzeStylesheet(
+                (string) ( $sheet['content'] ?? '' ),
+                (string) ( $sheet['source_path'] ?? $sheet['path'] ?? '' ),
+                (string) ( $sheet['source_hash'] ?? '' ),
+                $this->linkCondition($sheet),
+                $properties,
+                $maxCssBytes,
+                $maxRules,
+                $maxSelectors,
+                $maxConditionDepth,
+                $result,
+                $order
+            );
+        }
+
+        if ( array() === $stylesheets && '' !== trim($inlineCss) ) {
+            $this->analyzeStylesheet($inlineCss, 'inline-style', hash('sha256', $inlineCss), null, $properties, $maxCssBytes, $maxRules, $maxSelectors, $maxConditionDepth, $result, $order);
+        }
+
+        $result['diagnostics'] = array_values(array_unique($result['diagnostics']));
+        return $result;
+    }
+
+    /** @param array<string, mixed> $sheet */
+    private function linkCondition(array $sheet): ?array
+    {
+        $media = trim((string) ($sheet['media'] ?? ''));
+        return '' === $media ? null : array( 'kind' => 'media', 'query' => $media );
+    }
+
+    /**
+     * @param list<string> $properties
+     * @param array{rules: list<array<string, mixed>>, diagnostics: list<string>, truncated: bool} $result
+     */
+    private function analyzeStylesheet(string $css, string $path, string $hash, ?array $condition, array $properties, int $maxCssBytes, int $maxRules, int $maxSelectors, int $maxConditionDepth, array &$result, int &$order, int $conditionDepth = 0): void
+    {
+        if ( strlen($css) > $maxCssBytes ) {
+            $css = substr($css, 0, $maxCssBytes);
+            $result['truncated'] = true;
+            $result['diagnostics'][] = 'css_bytes_truncated:' . $path;
+        }
+        for ( $offset = 0, $length = strlen($css); $offset < $length; ) {
+            $boundary = $this->nextRuleBoundary($css, $offset);
+            if ( null === $boundary ) {
+                if ( '' !== trim(substr($css, $offset)) ) {
+                    $result['diagnostics'][] = 'malformed_stylesheet:' . $path;
+                }
+                return;
+            }
+
+            if ( ';' === $css[ $boundary ] ) {
+                $offset = $boundary + 1;
+                continue;
+            }
+
+            $end = $this->matchingBrace($css, $boundary);
+            if ( null === $end ) {
+                $result['diagnostics'][] = 'malformed_stylesheet:' . $path;
+                return;
+            }
+
+            $prelude = trim(substr($css, $offset, $boundary - $offset));
+            $body = substr($css, $boundary + 1, $end - $boundary - 1);
+            $atRule = $this->atRule($prelude);
+            if ( null !== $atRule ) {
+                if ( in_array($atRule['name'], array( 'media', 'container', 'supports' ), true) ) {
+                    if ( $conditionDepth >= $maxConditionDepth ) {
+                        $result['truncated'] = true;
+                        $result['diagnostics'][] = 'condition_depth_limit';
+                        return;
+                    }
+                    $this->analyzeStylesheet($body, $path, $hash, $this->combineCondition($condition, array( 'kind' => $atRule['name'], 'query' => $atRule['query'] )), $properties, $maxCssBytes, $maxRules, $maxSelectors, $maxConditionDepth, $result, $order, $conditionDepth + 1);
+                }
+                $offset = $end + 1;
+                continue;
+            }
+
+            $selectors = CssStylesheetTransformer::splitSelectorList($prelude);
+            if ( null === $selectors ) {
+                $result['diagnostics'][] = 'malformed_stylesheet:' . $path;
+                return;
+            }
+            $declarations = $this->declarations($body, $properties);
+            foreach ( $selectors as $selector ) {
+                $selector = trim($this->normalizeSelectorComments($selector));
+                if ( '' === $selector ) {
+                    continue;
+                }
+                if ( count($result['rules']) >= $maxRules || $this->selectorCount($result['rules']) >= $maxSelectors ) {
+                    $result['truncated'] = true;
+                    $result['diagnostics'][] = 'css_rule_or_selector_limit';
+                    return;
+                }
+                if ( array() !== $declarations ) {
+                    $parsed = CssSelectorMatcher::parse($selector);
+                    $result['rules'][] = array(
+                        'selector' => $selector,
+                        'parsed_selector' => $parsed,
+                        'declarations' => $declarations,
+                        'condition' => $condition,
+                        'path' => $path,
+                        'hash' => $hash,
+                        'order' => $order++,
+                        'specificity' => CssSelectorMatcher::specificity($parsed),
+                    );
+                }
+            }
+            $offset = $end + 1;
+        }
+    }
+
+    /** @param list<array<string, mixed>> $rules */
+    private function selectorCount(array $rules): int
+    {
+        return count($rules);
+    }
+
+    /** @return list<array{name: string, value: string}> */
+    public static function declarations(string $body, array $properties): array
+    {
+        $declarations = array();
+        $start = 0;
+        $state = CssSyntaxScanner::state();
+        $length = strlen($body);
+        for ( $offset = 0; $offset <= $length; ++$offset ) {
+            $boundary = $offset === $length || ( ';' === $body[ $offset ] && CssSyntaxScanner::isTopLevel($state) );
+            if ( $boundary ) {
+                $declaration = trim(substr($body, $start, $offset - $start));
+                $start = $offset + 1;
+                $colon = self::topLevelColon($declaration);
+                if ( null !== $colon ) {
+                    $name = strtolower(trim(substr($declaration, 0, $colon)));
+                    $value = trim(substr($declaration, $colon + 1));
+                    if ( in_array($name, $properties, true) && '' !== $value ) {
+                        $declarations[] = array( 'name' => $name, 'value' => preg_replace('/\s+/', ' ', $value) ?? $value );
+                    }
+                }
+                continue;
+            }
+            $next = CssSyntaxScanner::consume($body, $offset, $state);
+            if ( null === $next ) {
+                return array();
+            }
+            $offset = $next - 1;
+        }
+        return CssSyntaxScanner::isComplete($state) ? $declarations : array();
+    }
+
+    private static function topLevelColon(string $value): ?int
+    {
+        $state = CssSyntaxScanner::state();
+        for ( $offset = 0, $length = strlen($value); $offset < $length; ) {
+            $topLevel = CssSyntaxScanner::isTopLevel($state);
+            $next = CssSyntaxScanner::consume($value, $offset, $state);
+            if ( null === $next ) {
+                return null;
+            }
+            if ( ':' === $value[ $offset ] && $topLevel ) {
+                return $offset;
+            }
+            $offset = $next;
+        }
+        return null;
+    }
+
+    /** @return array{name: string, query: string}|null */
+    private function atRule(string $prelude): ?array
+    {
+        $prelude = $this->normalizeAtRuleComments($prelude);
+        if ( ! preg_match('/^@(media|container|supports)\s+(.+)$/i', $prelude, $match) ) {
+            return null;
+        }
+        return array( 'name' => strtolower($match[1]), 'query' => trim($match[2]) );
+    }
+
+    private function combineCondition(?array $left, array $right): array
+    {
+        if ( null === $left ) {
+            return $right;
+        }
+        return array( 'kind' => 'all', 'conditions' => 'all' === ($left['kind'] ?? null) ? array_merge($left['conditions'], array($right)) : array($left, $right) );
+    }
+
+    private function nextRuleBoundary(string $css, int $offset): ?int
+    {
+        $state = CssSyntaxScanner::state();
+        for ( $length = strlen($css); $offset < $length; ) {
+            $topLevel = CssSyntaxScanner::isTopLevel($state);
+            $next = CssSyntaxScanner::consume($css, $offset, $state);
+            if ( null === $next ) {
+                return null;
+            }
+            if ( $topLevel && $next === $offset + 1 && ( '{' === $css[ $offset ] || ';' === $css[ $offset ] ) ) {
+                return $offset;
+            }
+            $offset = $next;
+        }
+        return null;
+    }
+
+    /**
+     * CSS comments disappear from selectors, but adjacent identifier-like tokens
+     * need a separator to avoid changing a descendant selector into one token.
+     */
+    private function normalizeSelectorComments(string $selector): string
+    {
+        $output = '';
+        $state = CssSyntaxScanner::state();
+        for ( $offset = 0, $length = strlen($selector); $offset < $length; ) {
+            $insideComment = $state['comment'];
+            $startsComment = ! $insideComment && '' === $state['quote'] && '/*' === substr($selector, $offset, 2);
+            $next = CssSyntaxScanner::consume($selector, $offset, $state);
+            if ( null === $next ) {
+                return $selector;
+            }
+            if ( $startsComment ) {
+                $commentEnd = strpos($selector, '*/', $offset + 2);
+                $before = $output === '' ? '' : substr($output, -1);
+                $after = false === $commentEnd ? '' : ($selector[ $commentEnd + 2 ] ?? '');
+                if ( self::identifierLike($before) && self::identifierLike($after) ) {
+                    $output .= ' ';
+                }
+            } elseif ( ! $insideComment ) {
+                $output .= substr($selector, $offset, $next - $offset);
+            }
+            $offset = $next;
+        }
+        return $output;
+    }
+
+    private function normalizeAtRuleComments(string $prelude): string
+    {
+        return preg_replace('~/\*.*?\*/~s', ' ', $prelude) ?? $prelude;
+    }
+
+    private static function identifierLike(string $character): bool
+    {
+        return '' !== $character && (ctype_alnum($character) || '_' === $character || '-' === $character || '\\' === $character);
+    }
+
+    private function matchingBrace(string $css, int $openingBrace): ?int
+    {
+        $state = CssSyntaxScanner::state();
+        $depth = 0;
+        for ( $offset = $openingBrace, $length = strlen($css); $offset < $length; ) {
+            $topLevel = CssSyntaxScanner::isTopLevel($state);
+            $next = CssSyntaxScanner::consume($css, $offset, $state);
+            if ( null === $next ) {
+                return null;
+            }
+            if ( $topLevel && $next === $offset + 1 && '{' === $css[ $offset ] ) {
+                ++$depth;
+            } elseif ( $topLevel && $next === $offset + 1 && '}' === $css[ $offset ] && 0 === --$depth ) {
+                return $offset;
+            }
+            $offset = $next;
+        }
+        return null;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatcher.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssSelectorMatcher.php
@@ -71,6 +71,39 @@ final class CssSelectorMatcher
         );
     }
 
+    /** @param array<string, mixed> $selector */
+    public static function specificity(array $selector): int
+    {
+        if ( ! ($selector['supported'] ?? false) ) {
+            return 0;
+        }
+
+        $specificity = 0;
+        foreach ( $selector['compounds'] as $compound ) {
+            $specificity += 100 * count($compound['ids']);
+            $specificity += 10 * (count($compound['classes']) + count($compound['attributes']) + (null !== $compound['nth_child'] ? 1 : 0) + (int) $compound['first_child'] + (int) $compound['last_child']);
+            $specificity += null === $compound['type'] ? 0 : 1;
+            foreach ( $compound['not'] as $negated ) {
+                $specificity += self::compoundSpecificity($negated);
+            }
+        }
+        if ( null !== $selector['pseudo_state_suffix_span'] ) {
+            $specificity += 10;
+        }
+        return $specificity;
+    }
+
+    /** @param array<string, mixed> $compound */
+    private static function compoundSpecificity(array $compound): int
+    {
+        $specificity = 100 * count($compound['ids']) + 10 * (count($compound['classes']) + count($compound['attributes']) + (null !== $compound['nth_child'] ? 1 : 0) + (int) $compound['first_child'] + (int) $compound['last_child']);
+        $specificity += null === $compound['type'] ? 0 : 1;
+        foreach ( $compound['not'] as $negated ) {
+            $specificity += self::compoundSpecificity($negated);
+        }
+        return $specificity;
+    }
+
     /**
      * Match from the rightmost compound. Only hover, focus, active, and visited
      * are detachable dynamic suffixes; callers must explicitly account for them.

--- a/php-transformer/src/HtmlToBlocks/Style/FormLayoutGraphBuilder.php
+++ b/php-transformer/src/HtmlToBlocks/Style/FormLayoutGraphBuilder.php
@@ -18,66 +18,343 @@ final class FormLayoutGraphBuilder
     private const MAX_CONDITION_DEPTH = 8;
     private const MAX_VARIANTS = 256;
     private const MAX_PROVENANCE = 16;
-    private const PROPERTIES = array('display', 'grid-template-columns', 'grid-template-rows', 'gap', 'row-gap', 'column-gap', 'grid-column', 'grid-row', 'grid-area', 'flex-direction', 'flex-wrap', 'align-items', 'align-content', 'justify-content', 'align-self', 'justify-self', 'order', 'flex', 'flex-grow', 'flex-shrink', 'flex-basis');
-    private const LAYOUT_KEYS = array('display', 'columns', 'rows', 'gap', 'row_gap', 'column_gap', 'column', 'row', 'area', 'direction', 'wrap', 'align_items', 'align_content', 'justify_content', 'align_self', 'justify_self', 'order', 'flex', 'flex_grow', 'flex_shrink', 'flex_basis');
+    private const PROPERTIES = array( 'display', 'grid-template-columns', 'grid-template-rows', 'gap', 'row-gap', 'column-gap', 'grid-column', 'grid-row', 'grid-area', 'flex-direction', 'flex-wrap', 'align-items', 'align-content', 'justify-content', 'align-self', 'justify-self', 'order', 'flex', 'flex-grow', 'flex-shrink', 'flex-basis' );
+    private const LAYOUT_KEYS = array( 'display', 'columns', 'rows', 'gap', 'row_gap', 'column_gap', 'column', 'row', 'area', 'direction', 'wrap', 'align_items', 'align_content', 'justify_content', 'align_self', 'justify_self', 'order', 'flex', 'flex_grow', 'flex_shrink', 'flex_basis' );
+
     private array $diagnostics = array();
     private bool $truncated = false;
-    private int $selectorCount = 0;
 
-    /** @param list<array<string,mixed>> $stylesheets @return array<string,mixed> */
+    /** @param list<array<string, mixed>> $stylesheets @return array<string, mixed> */
     public function build(DOMElement $form, array $stylesheets, string $inlineCss = ''): array
     {
-        $this->diagnostics = array(); $this->truncated = false; $this->selectorCount = 0;
-        $rules = $this->rules($stylesheets, $inlineCss);
-        $controls = array(); $relevant = array();
-        foreach ($this->controls($form) as $index => $control) { $controls[$control->getNodePath()] = $index; for ($node = $control->parentNode; $node instanceof DOMElement && $node !== $form; $node = $node->parentNode) $relevant[$node->getNodePath()] = true; }
-        $entries = array(); $wrapper = 0; $this->collect($form, null, 0, 0, $controls, $relevant, $entries, $wrapper);
-        $nodes = array(); $variants = array();
-        foreach ($entries as $entry) {
-            $matched = $this->matched($entry['element'], $rules);
+        $this->diagnostics = array();
+        $this->truncated = false;
+        $analysis = (new CssRuleAnalyzer())->analyze($stylesheets, $inlineCss, self::PROPERTIES, self::MAX_CSS_BYTES, self::MAX_RULES, self::MAX_SELECTORS, self::MAX_CONDITION_DEPTH);
+        $this->diagnostics = $analysis['diagnostics'];
+        $this->truncated = $analysis['truncated'];
+
+        $controls = array();
+        $relevant = array();
+        foreach ( $this->controls($form) as $index => $control ) {
+            $controls[$control->getNodePath()] = $index;
+            for ( $node = $control->parentNode; $node instanceof DOMElement && $node !== $form; $node = $node->parentNode ) {
+                $relevant[$node->getNodePath()] = true;
+            }
+        }
+
+        $entries = array();
+        $wrapper = 0;
+        $this->collect($form, null, 0, 0, $controls, $relevant, $entries, $wrapper);
+        $nodes = array();
+        $variants = array();
+        foreach ( $entries as $entry ) {
+            $matched = $this->matched($entry['element'], $analysis['rules']);
             $layout = $this->layout($matched['base']);
             $conditional = $this->effectiveConditional($matched['conditional'], $matched['base']);
-            if (array() === $layout && array() === $conditional) continue;
-            $nodes[$entry['id']] = array_filter(array('id' => $entry['id'], 'kind' => $entry['kind'], 'parent' => $entry['parent'], 'order' => $entry['order'], 'source' => $this->source($entry['element']), 'layout' => $layout, 'provenance' => $this->provenance($matched['base'], null)), static fn(mixed $value): bool => null !== $value);
-            foreach ($conditional as $encoded => $facts) { if (count($variants) >= self::MAX_VARIANTS) { $this->truncated = true; $this->diagnostics[] = 'variant_limit'; break; } $condition = json_decode($encoded, true); $patch = $this->layout($facts); if (array() !== $patch) $variants[] = array('node' => $entry['id'], 'condition' => $condition, 'layout_patch' => $patch, 'precedence' => $this->precedence($facts), 'provenance' => $this->provenance($facts, $condition)); }
+            if ( array() === $layout && array() === $conditional ) {
+                continue;
+            }
+
+            $nodes[$entry['id']] = $this->node($entry, $layout, $this->provenance($matched['base'], null));
+            foreach ( $conditional as $encoded => $facts ) {
+                if ( count($variants) >= self::MAX_VARIANTS ) {
+                    $this->truncated = true;
+                    $this->diagnostics[] = 'variant_limit';
+                    break;
+                }
+                $condition = json_decode($encoded, true);
+                $patch = $this->layout($facts);
+                if ( array() !== $patch ) {
+                    $variants[] = array( 'node' => $entry['id'], 'condition' => $condition, 'layout_patch' => $patch, 'precedence' => $this->precedence($facts), 'provenance' => $this->provenance($facts, $condition) );
+                }
+            }
         }
-        // Layout-bearing descendants retain their structural ancestry even when the ancestor has no layout declaration.
-        foreach ($entries as $entry) if (!isset($nodes[$entry['id']])) foreach (array_keys($nodes) as $nodeId) if ($this->hasAncestor($entries, $nodeId, $entry['id'])) $nodes[$entry['id']] = array_filter(array('id' => $entry['id'], 'kind' => $entry['kind'], 'parent' => $entry['parent'], 'order' => $entry['order'], 'source' => $this->source($entry['element']), 'layout' => array(), 'provenance' => array()), static fn(mixed $value): bool => null !== $value);
-        $graph = array('schema' => 'generic/computed-layout-graph/v1', 'basis' => 'source_css_cascade', 'truncated' => $this->truncated, 'limits' => array('nodes' => self::MAX_NODES, 'depth' => self::MAX_DEPTH, 'rules_per_node' => self::MAX_RULES_PER_NODE), 'nodes' => array_values(array_filter($entries, static fn(array $entry): bool => isset($nodes[$entry['id']]))), 'variants' => $variants, 'diagnostics' => array_values(array_unique($this->diagnostics)));
-        $graph['nodes'] = array_map(static fn(array $entry): array => $nodes[$entry['id']], $graph['nodes']);
+
+        // Layout-bearing descendants retain structural ancestry even when the ancestor has no layout declaration.
+        foreach ( $entries as $entry ) {
+            if ( isset($nodes[$entry['id']]) ) {
+                continue;
+            }
+            foreach ( array_keys($nodes) as $nodeId ) {
+                if ( $this->hasAncestor($entries, $nodeId, $entry['id']) ) {
+                    $nodes[$entry['id']] = $this->node($entry, array(), array());
+                    break;
+                }
+            }
+        }
+
+        $graph = array(
+            'schema' => 'generic/computed-layout-graph/v1',
+            'basis' => 'source_css_cascade',
+            'truncated' => $this->truncated,
+            'limits' => array( 'nodes' => self::MAX_NODES, 'depth' => self::MAX_DEPTH, 'rules_per_node' => self::MAX_RULES_PER_NODE ),
+            'nodes' => array_values(array_filter($entries, static fn (array $entry): bool => isset($nodes[$entry['id']]))),
+            'variants' => $variants,
+            'diagnostics' => array_values(array_unique($this->diagnostics)),
+        );
+        $graph['nodes'] = array_map(static fn (array $entry): array => $nodes[$entry['id']], $graph['nodes']);
         self::assertValid($graph);
         return $graph;
     }
 
-    /** @param array<string,mixed> $graph */
+    /** @param array<string, mixed> $entry @param array<string, string> $layout @param list<array<string, mixed>> $provenance */
+    private function node(array $entry, array $layout, array $provenance): array
+    {
+        return array_filter(array( 'id' => $entry['id'], 'kind' => $entry['kind'], 'parent' => $entry['parent'], 'order' => $entry['order'], 'source' => $this->source($entry['element']), 'layout' => $layout, 'provenance' => $provenance ), static fn (mixed $value): bool => null !== $value);
+    }
+
+    /** @param array<string, mixed> $graph */
     public static function assertValid(array $graph): void
     {
-        if ('generic/computed-layout-graph/v1' !== ($graph['schema'] ?? null) || 'source_css_cascade' !== ($graph['basis'] ?? null) || !is_bool($graph['truncated'] ?? null) || !is_array($graph['limits'] ?? null) || self::MAX_NODES !== ($graph['limits']['nodes'] ?? null) || self::MAX_DEPTH !== ($graph['limits']['depth'] ?? null) || self::MAX_RULES_PER_NODE !== ($graph['limits']['rules_per_node'] ?? null) || !is_array($graph['nodes'] ?? null) || !is_array($graph['variants'] ?? null) || !is_array($graph['diagnostics'] ?? null)) throw new InvalidArgumentException('Form layout graph envelope is invalid.');
-        if (count($graph['nodes']) > self::MAX_NODES) throw new InvalidArgumentException('Form layout graph exceeds its node limit.');
-        $ids = array(); foreach ($graph['nodes'] as $node) { if (!is_array($node) || !is_string($node['id'] ?? null) || isset($ids[$node['id']]) || !in_array($node['kind'] ?? null, array('container', 'control'), true) || !is_int($node['order'] ?? null) || !is_array($node['source'] ?? null) || !is_string($node['source']['tag'] ?? null) || !is_array($node['source']['classes'] ?? null) || !is_array($node['layout'] ?? null) || !is_array($node['provenance'] ?? null)) throw new InvalidArgumentException('Form layout graph node is invalid.'); $ids[$node['id']] = true; }
-        foreach ($graph['nodes'] as $node) { if (null !== ($node['parent'] ?? null) && !isset($ids[$node['parent']])) throw new InvalidArgumentException('Form layout graph has a dangling parent.'); for ($parent = $node['parent'] ?? null, $seen = array($node['id'] => true); null !== $parent; ) { if (isset($seen[$parent])) throw new InvalidArgumentException('Form layout graph has a parent cycle.'); $seen[$parent] = true; foreach ($graph['nodes'] as $candidate) if ($candidate['id'] === $parent) { $parent = $candidate['parent'] ?? null; continue 2; } break; } self::assertFacts($node['layout'], $node['provenance'], null); }
-        if (count($graph['variants']) > self::MAX_VARIANTS) throw new InvalidArgumentException('Form layout graph exceeds its variant limit.'); foreach ($graph['variants'] as $variant) { if (!is_array($variant) || !isset($ids[$variant['node'] ?? '']) || !is_array($variant['condition'] ?? null) || !self::validCondition($variant['condition']) || !is_array($variant['layout_patch'] ?? null) || !is_array($variant['precedence'] ?? null) || !is_array($variant['provenance'] ?? null)) throw new InvalidArgumentException('Form layout graph variant is invalid.'); foreach ($variant['precedence'] as $property => $precedence) if (!is_string($property) || !in_array($property, self::PROPERTIES, true) || !isset($variant['layout_patch'][self::layoutKey($property)]) || !is_array($precedence) || !is_int($precedence['source_order'] ?? null) || !is_int($precedence['specificity'] ?? null) || !is_bool($precedence['important'] ?? null)) throw new InvalidArgumentException('Form layout graph variant precedence is invalid.'); self::assertFacts($variant['layout_patch'], $variant['provenance'], $variant['condition']); }
+        if ( 'generic/computed-layout-graph/v1' !== ($graph['schema'] ?? null) || 'source_css_cascade' !== ($graph['basis'] ?? null) || ! is_bool($graph['truncated'] ?? null) || ! is_array($graph['limits'] ?? null) || self::MAX_NODES !== ($graph['limits']['nodes'] ?? null) || self::MAX_DEPTH !== ($graph['limits']['depth'] ?? null) || self::MAX_RULES_PER_NODE !== ($graph['limits']['rules_per_node'] ?? null) || ! is_array($graph['nodes'] ?? null) || ! is_array($graph['variants'] ?? null) || ! is_array($graph['diagnostics'] ?? null) ) {
+            throw new InvalidArgumentException('Form layout graph envelope is invalid.');
+        }
+        if ( count($graph['nodes']) > self::MAX_NODES ) {
+            throw new InvalidArgumentException('Form layout graph exceeds its node limit.');
+        }
+        $ids = array();
+        foreach ( $graph['nodes'] as $node ) {
+            if ( ! is_array($node) || ! is_string($node['id'] ?? null) || isset($ids[$node['id']]) || ! in_array($node['kind'] ?? null, array( 'container', 'control' ), true) || ! is_int($node['order'] ?? null) || ! is_array($node['source'] ?? null) || ! is_string($node['source']['tag'] ?? null) || ! is_array($node['source']['classes'] ?? null) || ! is_array($node['layout'] ?? null) || ! is_array($node['provenance'] ?? null) ) {
+                throw new InvalidArgumentException('Form layout graph node is invalid.');
+            }
+            $ids[$node['id']] = true;
+        }
+        foreach ( $graph['nodes'] as $node ) {
+            if ( null !== ($node['parent'] ?? null) && ! isset($ids[$node['parent']]) ) {
+                throw new InvalidArgumentException('Form layout graph has a dangling parent.');
+            }
+            for ( $parent = $node['parent'] ?? null, $seen = array( $node['id'] => true ); null !== $parent; ) {
+                if ( isset($seen[$parent]) ) {
+                    throw new InvalidArgumentException('Form layout graph has a parent cycle.');
+                }
+                $seen[$parent] = true;
+                foreach ( $graph['nodes'] as $candidate ) {
+                    if ( $candidate['id'] === $parent ) {
+                        $parent = $candidate['parent'] ?? null;
+                        continue 2;
+                    }
+                }
+                break;
+            }
+            self::assertFacts($node['layout'], $node['provenance'], null);
+        }
+        if ( count($graph['variants']) > self::MAX_VARIANTS ) {
+            throw new InvalidArgumentException('Form layout graph exceeds its variant limit.');
+        }
+        foreach ( $graph['variants'] as $variant ) {
+            if ( ! is_array($variant) || ! isset($ids[$variant['node'] ?? '']) || ! is_array($variant['condition'] ?? null) || ! self::validCondition($variant['condition']) || ! is_array($variant['layout_patch'] ?? null) || ! is_array($variant['precedence'] ?? null) || ! is_array($variant['provenance'] ?? null) ) {
+                throw new InvalidArgumentException('Form layout graph variant is invalid.');
+            }
+            foreach ( $variant['precedence'] as $property => $precedence ) {
+                if ( ! is_string($property) || ! in_array($property, self::PROPERTIES, true) || ! isset($variant['layout_patch'][self::layoutKey($property)]) || ! is_array($precedence) || ! is_int($precedence['source_order'] ?? null) || ! is_int($precedence['specificity'] ?? null) || ! is_bool($precedence['important'] ?? null) ) {
+                    throw new InvalidArgumentException('Form layout graph variant precedence is invalid.');
+                }
+            }
+            self::assertFacts($variant['layout_patch'], $variant['provenance'], $variant['condition']);
+        }
     }
-    private static function assertFacts(array $layout, array $provenance, ?array $condition): void { foreach ($layout as $key => $value) if (!is_string($key) || !in_array($key, self::LAYOUT_KEYS, true) || !is_string($value) || '' === trim($value)) throw new InvalidArgumentException('Form layout graph value is invalid.'); if (count($provenance) > self::MAX_PROVENANCE) throw new InvalidArgumentException('Form layout graph provenance exceeds its limit.'); foreach ($provenance as $fact) if (!is_array($fact) || !is_string($fact['source_path'] ?? null) || !preg_match('~^(?!.*(?:^|/)\.\.(?:/|$))[A-Za-z0-9._/-]+$~', $fact['source_path']) || !preg_match('/^[a-f0-9]{64}$/', $fact['source_sha256'] ?? '') || !is_string($fact['selector'] ?? null) || '' === trim($fact['selector']) || strlen($fact['selector']) > 1024 || !is_array($fact['properties'] ?? null) || array() === $fact['properties'] || count($fact['properties']) > count(self::PROPERTIES) || array_filter($fact['properties'], static fn(mixed $property): bool => !is_string($property) || !in_array($property, self::PROPERTIES, true) || !isset($layout[self::layoutKey($property)])) || ($condition !== null && $fact['condition'] !== $condition) || ($condition === null && ($fact['condition'] ?? null) !== null)) throw new InvalidArgumentException('Form layout graph provenance is invalid.'); }
-    private static function validCondition(array $condition, int $depth = 0): bool { if ($depth > self::MAX_CONDITION_DEPTH) return false; if ('all' === ($condition['kind'] ?? null)) return is_array($condition['conditions'] ?? null) && array() !== $condition['conditions'] && count($condition['conditions']) <= self::MAX_CONDITION_DEPTH && array_reduce($condition['conditions'], static fn(bool $ok, mixed $item): bool => $ok && is_array($item) && self::validCondition($item, $depth + 1), true); return in_array($condition['kind'] ?? null, array('media', 'container', 'supports'), true) && is_string($condition['query'] ?? null) && '' !== trim($condition['query']) && strlen($condition['query']) <= 1024; }
 
-    /** @param array<string,int> $controls @param array<string,bool> $relevant @param list<array<string,mixed>> $entries */
-    private function collect(DOMElement $element, ?string $parent, int $order, int $depth, array $controls, array $relevant, array &$entries, int &$wrapper): void { $path = $element->getNodePath(); $root = 'form' === strtolower($element->tagName) && null === $parent; if (!$root && !isset($controls[$path]) && !isset($relevant[$path])) return; if ($depth > self::MAX_DEPTH || count($entries) >= self::MAX_NODES) { $this->truncated = true; $this->diagnostics[] = 'node_or_depth_limit'; return; } $id = $root ? 'form' : (isset($controls[$path]) ? 'control-' . $controls[$path] : 'wrapper-' . $wrapper++); $entries[] = array('id' => $id, 'kind' => isset($controls[$path]) ? 'control' : 'container', 'parent' => $parent, 'order' => $order, 'element' => $element); $childOrder = 0; foreach ($element->childNodes as $child) if ($child instanceof DOMElement) { $before = count($entries); $this->collect($child, $id, $childOrder, $depth + 1, $controls, $relevant, $entries, $wrapper); if (count($entries) > $before) ++$childOrder; } }
-    private function hasAncestor(array $entries, string $node, string $ancestor): bool { foreach ($entries as $entry) if ($entry['id'] === $node) { for ($parent = $entry['parent']; null !== $parent; ) { if ($parent === $ancestor) return true; foreach ($entries as $candidate) if ($candidate['id'] === $parent) { $parent = $candidate['parent']; continue 2; } return false; } } return false; }
-    /** @return list<DOMElement> */ private function controls(DOMElement $form): array { $result = array(); foreach ($form->getElementsByTagName('*') as $element) if (in_array(strtolower($element->tagName), array('input', 'select', 'textarea', 'button'), true)) $result[] = $element; return $result; }
-    /** @param list<array<string,mixed>> $sheets @return list<array<string,mixed>> */ private function rules(array $sheets, string $inlineCss): array { $rules = array(); $order = 0; foreach ($sheets as $sheet) $this->parse((string) ($sheet['content'] ?? ''), (string) ($sheet['source_path'] ?? $sheet['path'] ?? ''), (string) ($sheet['source_hash'] ?? ''), $this->linkCondition($sheet), $rules, $order); if (array() === $sheets && '' !== trim($inlineCss)) $this->parse($inlineCss, 'inline-style', hash('sha256', $inlineCss), null, $rules, $order); return $rules; }
-    private function linkCondition(array $sheet): ?array { $media = trim((string) ($sheet['media'] ?? '')); return '' === $media ? null : array('kind' => 'media', 'query' => $media); }
-    /** @param list<array<string,mixed>> $rules */ private function parse(string $css, string $path, string $hash, ?array $condition, array &$rules, int &$order, int $conditionDepth = 0): void { if (strlen($css) > self::MAX_CSS_BYTES) { $css = substr($css, 0, self::MAX_CSS_BYTES); $this->truncated = true; $this->diagnostics[] = 'css_bytes_truncated:' . $path; } $css = preg_replace('~/\*.*?\*/~s', '', $css) ?? $css; for ($offset = 0, $length = strlen($css); $offset < $length;) { while ($offset < $length && ctype_space($css[$offset])) ++$offset; $start = $offset; $quote = ''; $paren = 0; while ($offset < $length) { $c = $css[$offset]; if ('' !== $quote) { if ($c === $quote && '\\' !== ($css[$offset - 1] ?? '')) $quote = ''; } elseif ('"' === $c || "'" === $c) $quote = $c; elseif ('(' === $c) ++$paren; elseif (')' === $c) --$paren; elseif ('{' === $c && 0 === $paren) break; ++$offset; } if ($offset >= $length) break; $prelude = trim(substr($css, $start, $offset++ - $start)); $bodyStart = $offset; for ($depth = 1, $quote = ''; $offset < $length && $depth > 0; ++$offset) { $c = $css[$offset]; if ('' !== $quote) { if ($c === $quote && '\\' !== ($css[$offset - 1] ?? '')) $quote = ''; } elseif ('"' === $c || "'" === $c) $quote = $c; elseif ('{' === $c) ++$depth; elseif ('}' === $c) --$depth; } if (0 !== $depth) { $this->diagnostics[] = 'malformed_stylesheet:' . $path; return; } $body = substr($css, $bodyStart, $offset - $bodyStart - 1); if (preg_match('/^@(media|container|supports)\s+(.+)$/i', $prelude, $match)) { if ($conditionDepth >= self::MAX_CONDITION_DEPTH) { $this->truncated = true; $this->diagnostics[] = 'condition_depth_limit'; return; } $next = $this->combineCondition($condition, array('kind' => strtolower($match[1]), 'query' => trim($match[2]))); if (!self::validCondition($next)) { $this->truncated = true; $this->diagnostics[] = 'invalid_condition'; return; } $this->parse($body, $path, $hash, $next, $rules, $order, $conditionDepth + 1); continue; } if (str_starts_with($prelude, '@')) continue; foreach ($this->selectors($prelude) as $selector) { if (count($rules) >= self::MAX_RULES || $this->selectorCount >= self::MAX_SELECTORS) { $this->truncated = true; $this->diagnostics[] = 'css_rule_or_selector_limit'; return; } $rules[] = array('selector' => $selector, 'declarations' => $this->declarations($body), 'condition' => $condition, 'path' => $path, 'hash' => $hash, 'order' => $order++, 'specificity' => $this->specificity($selector)); ++$this->selectorCount; } } }
-    private function combineCondition(?array $left, array $right): array { if (null === $left) return $right; return array('kind' => 'all', 'conditions' => ('all' === ($left['kind'] ?? null) ? array_merge($left['conditions'], array($right)) : array($left, $right))); }
-    /** @return list<string> */ private function selectors(string $prelude): array { $result = array(); $start = 0; $depth = 0; for ($i = 0, $length = strlen($prelude); $i < $length; ++$i) { if (in_array($prelude[$i], array('(', '['), true)) ++$depth; elseif (in_array($prelude[$i], array(')', ']'), true)) --$depth; elseif (',' === $prelude[$i] && 0 === $depth) { $result[] = trim(substr($prelude, $start, $i - $start)); $start = $i + 1; } } $result[] = trim(substr($prelude, $start)); return array_values(array_filter($result)); }
-    /** @return list<array{name:string,value:string}> */ private function declarations(string $body): array { $result = array(); foreach (explode(';', $body) as $declaration) if (str_contains($declaration, ':')) { [$name, $value] = array_map('trim', explode(':', $declaration, 2)); if (in_array(strtolower($name), self::PROPERTIES, true) && '' !== $value) $result[] = array('name' => strtolower($name), 'value' => preg_replace('/\s+/', ' ', $value) ?? $value); } return $result; }
-    private function specificity(string $selector): int { return 100 * preg_match_all('/#[A-Za-z0-9_-]+/', $selector) + 10 * preg_match_all('/\.[A-Za-z0-9_-]+|\[[^]]+\]|:[A-Za-z-]+/', $selector) + preg_match_all('/(?<![#.:-])[A-Za-z][A-Za-z0-9_-]*/', $selector); }
-    /** @return array{base:array<string,array<string,mixed>>,conditional:array<string,array<string,array<string,mixed>>>} */ private function matched(DOMElement $element, array $rules): array { if ($element->hasAttribute('style')) $rules[] = array('inline' => true, 'selector' => '[style]', 'declarations' => $this->declarations($element->getAttribute('style')), 'condition' => null, 'path' => 'inline-style', 'hash' => hash('sha256', $element->getAttribute('style')), 'order' => PHP_INT_MAX, 'specificity' => 10000); $base = array(); $conditional = array(); $matched = 0; foreach ($rules as $rule) { $match = !empty($rule['inline']) ? array('supported' => true, 'matches' => true) : CssSelectorMatcher::matches($element, CssSelectorMatcher::parse($rule['selector'])); if (!$match['supported']) { $this->diagnostics[] = 'unsupported_selector:' . $rule['selector']; continue; } if (!$match['matches']) continue; if ($matched++ >= self::MAX_RULES_PER_NODE) { $this->truncated = true; $this->diagnostics[] = 'rules_per_node_limit'; break; } foreach ($rule['declarations'] as $declaration) { $important = 1 === preg_match('/\s*!important\s*$/i', $declaration['value']); $value = preg_replace('/\s*!important\s*$/i', '', $declaration['value']) ?? $declaration['value']; $key = null === $rule['condition'] ? null : json_encode($rule['condition']); if (null === $key) $target =& $base; else { $conditional[$key] ??= array(); $target =& $conditional[$key]; } $current = $target[$declaration['name']] ?? null; if (is_array($current) && $current['value'] !== $value) $this->diagnostics[] = 'cascade_conflict:' . $declaration['name']; if (!is_array($current) || (int) $important > (int) $current['important'] || ((bool) $important === $current['important'] && ($rule['specificity'] > $current['specificity'] || ($rule['specificity'] === $current['specificity'] && $rule['order'] >= $current['order'])))) $target[$declaration['name']] = array('value' => $value, 'path' => $rule['path'], 'hash' => $rule['hash'], 'selector' => $rule['selector'], 'order' => $rule['order'], 'specificity' => $rule['specificity'], 'important' => $important); unset($target); } } return array('base' => $base, 'conditional' => $conditional); }
-    /** @return array<string,string> */ private function layout(array $facts): array { $map = array('grid-template-columns' => 'columns', 'grid-template-rows' => 'rows', 'row-gap' => 'row_gap', 'column-gap' => 'column_gap', 'grid-column' => 'column', 'grid-row' => 'row', 'grid-area' => 'area', 'flex-direction' => 'direction', 'flex-wrap' => 'wrap', 'align-items' => 'align_items', 'align-content' => 'align_content', 'justify-content' => 'justify_content', 'align-self' => 'align_self', 'justify-self' => 'justify_self', 'flex-grow' => 'flex_grow', 'flex-shrink' => 'flex_shrink', 'flex-basis' => 'flex_basis'); $result = array(); foreach ($facts as $property => $fact) $result[$map[$property] ?? $property] = $fact['value']; ksort($result); return $result; }
-    private static function layoutKey(string $property): string { return array('grid-template-columns' => 'columns', 'grid-template-rows' => 'rows', 'row-gap' => 'row_gap', 'column-gap' => 'column_gap', 'grid-column' => 'column', 'grid-row' => 'row', 'grid-area' => 'area', 'flex-direction' => 'direction', 'flex-wrap' => 'wrap', 'align-items' => 'align_items', 'align-content' => 'align_content', 'justify-content' => 'justify_content', 'align-self' => 'align_self', 'justify-self' => 'justify_self', 'flex-grow' => 'flex_grow', 'flex-shrink' => 'flex_shrink', 'flex-basis' => 'flex_basis')[$property] ?? $property; }
-    /** @return array<string,array<string,array<string,mixed>>> */ private function effectiveConditional(array $conditional, array $base): array { foreach ($conditional as $condition => &$facts) foreach ($facts as $property => $fact) if (isset($base[$property]) && !$this->wins($fact, $base[$property])) unset($facts[$property]); unset($facts); foreach ($conditional as $condition => $facts) if (array() === $facts) unset($conditional[$condition]); return $conditional; }
-    private function wins(array $candidate, array $current): bool { return (int) $candidate['important'] > (int) $current['important'] || ((bool) $candidate['important'] === $current['important'] && ($candidate['specificity'] > $current['specificity'] || ($candidate['specificity'] === $current['specificity'] && $candidate['order'] >= $current['order']))); }
-    /** @return array<string,array<string,int|bool>> */ private function precedence(array $facts): array { $result = array(); foreach ($facts as $property => $fact) $result[$property] = array('source_order' => $fact['order'], 'specificity' => $fact['specificity'], 'important' => $fact['important']); ksort($result); return $result; }
-    /** @return list<array<string,mixed>> */ private function provenance(array $facts, ?array $condition): array { $grouped = array(); foreach ($facts as $property => $fact) { $key = $fact['path'] . "\n" . $fact['selector']; $grouped[$key] ??= array('source_path' => $fact['path'], 'source_sha256' => $fact['hash'], 'selector' => $fact['selector'], 'condition' => $condition, 'properties' => array()); $grouped[$key]['properties'][] = $property; } foreach ($grouped as &$item) sort($item['properties'], SORT_STRING); return array_values($grouped); }
-    /** @return array<string,mixed> */ private function source(DOMElement $element): array { $classes = array_values(array_filter(preg_split('/\s+/', trim($element->getAttribute('class'))) ?: array(), static fn(string $class): bool => 1 === preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $class))); return array('tag' => strtolower($element->tagName), 'id' => 1 === preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $element->getAttribute('id')) ? $element->getAttribute('id') : null, 'classes' => array_slice($classes, 0, 8)); }
+    private static function assertFacts(array $layout, array $provenance, ?array $condition): void
+    {
+        foreach ( $layout as $key => $value ) {
+            if ( ! is_string($key) || ! in_array($key, self::LAYOUT_KEYS, true) || ! is_string($value) || '' === trim($value) ) {
+                throw new InvalidArgumentException('Form layout graph value is invalid.');
+            }
+        }
+        if ( count($provenance) > self::MAX_PROVENANCE ) {
+            throw new InvalidArgumentException('Form layout graph provenance exceeds its limit.');
+        }
+        foreach ( $provenance as $fact ) {
+            if ( ! is_array($fact) || ! is_string($fact['source_path'] ?? null) || ! preg_match('~^(?!.*(?:^|/)\.\.(?:/|$))[A-Za-z0-9._/-]+$~', $fact['source_path']) || ! preg_match('/^[a-f0-9]{64}$/', $fact['source_sha256'] ?? '') || ! is_string($fact['selector'] ?? null) || '' === trim($fact['selector']) || strlen($fact['selector']) > 1024 || ! is_array($fact['properties'] ?? null) || array() === $fact['properties'] || count($fact['properties']) > count(self::PROPERTIES) || array_filter($fact['properties'], static fn (mixed $property): bool => ! is_string($property) || ! in_array($property, self::PROPERTIES, true) || ! isset($layout[self::layoutKey($property)])) || ($condition !== null && $fact['condition'] !== $condition) || ($condition === null && ($fact['condition'] ?? null) !== null) ) {
+                throw new InvalidArgumentException('Form layout graph provenance is invalid.');
+            }
+        }
+    }
+
+    private static function validCondition(array $condition, int $depth = 0): bool
+    {
+        if ( $depth > self::MAX_CONDITION_DEPTH ) {
+            return false;
+        }
+        if ( 'all' === ($condition['kind'] ?? null) ) {
+            return is_array($condition['conditions'] ?? null) && array() !== $condition['conditions'] && count($condition['conditions']) <= self::MAX_CONDITION_DEPTH && array_reduce($condition['conditions'], static fn (bool $ok, mixed $item): bool => $ok && is_array($item) && self::validCondition($item, $depth + 1), true);
+        }
+        return in_array($condition['kind'] ?? null, array( 'media', 'container', 'supports' ), true) && is_string($condition['query'] ?? null) && '' !== trim($condition['query']) && strlen($condition['query']) <= 1024;
+    }
+
+    /** @param array<string, int> $controls @param array<string, bool> $relevant @param list<array<string, mixed>> $entries */
+    private function collect(DOMElement $element, ?string $parent, int $order, int $depth, array $controls, array $relevant, array &$entries, int &$wrapper): void
+    {
+        $path = $element->getNodePath();
+        $root = 'form' === strtolower($element->tagName) && null === $parent;
+        if ( ! $root && ! isset($controls[$path]) && ! isset($relevant[$path]) ) {
+            return;
+        }
+        if ( $depth > self::MAX_DEPTH || count($entries) >= self::MAX_NODES ) {
+            $this->truncated = true;
+            $this->diagnostics[] = 'node_or_depth_limit';
+            return;
+        }
+        $id = $root ? 'form' : (isset($controls[$path]) ? 'control-' . $controls[$path] : 'wrapper-' . $wrapper++);
+        $entries[] = array( 'id' => $id, 'kind' => isset($controls[$path]) ? 'control' : 'container', 'parent' => $parent, 'order' => $order, 'element' => $element );
+        $childOrder = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( ! $child instanceof DOMElement ) {
+                continue;
+            }
+            $before = count($entries);
+            $this->collect($child, $id, $childOrder, $depth + 1, $controls, $relevant, $entries, $wrapper);
+            if ( count($entries) > $before ) {
+                ++$childOrder;
+            }
+        }
+    }
+
+    /** @param list<array<string, mixed>> $entries */
+    private function hasAncestor(array $entries, string $node, string $ancestor): bool
+    {
+        foreach ( $entries as $entry ) {
+            if ( $entry['id'] !== $node ) {
+                continue;
+            }
+            for ( $parent = $entry['parent']; null !== $parent; ) {
+                if ( $parent === $ancestor ) {
+                    return true;
+                }
+                foreach ( $entries as $candidate ) {
+                    if ( $candidate['id'] === $parent ) {
+                        $parent = $candidate['parent'];
+                        continue 2;
+                    }
+                }
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /** @return list<DOMElement> */
+    private function controls(DOMElement $form): array
+    {
+        $result = array();
+        foreach ( $form->getElementsByTagName('*') as $element ) {
+            if ( in_array(strtolower($element->tagName), array( 'input', 'select', 'textarea', 'button' ), true) ) {
+                $result[] = $element;
+            }
+        }
+        return $result;
+    }
+
+    /** @param list<array<string, mixed>> $rules @return array{base: array<string, array<string, mixed>>, conditional: array<string, array<string, array<string, mixed>>>} */
+    private function matched(DOMElement $element, array $rules): array
+    {
+        if ( $element->hasAttribute('style') ) {
+            $inline = $element->getAttribute('style');
+            $rules[] = array( 'inline' => true, 'selector' => '[style]', 'declarations' => CssRuleAnalyzer::declarations($inline, self::PROPERTIES), 'condition' => null, 'path' => 'inline-style', 'hash' => hash('sha256', $inline), 'order' => PHP_INT_MAX, 'specificity' => 10000 );
+        }
+        $base = array();
+        $conditional = array();
+        $matched = 0;
+        foreach ( $rules as $rule ) {
+            $match = ! empty($rule['inline']) ? array( 'supported' => true, 'matches' => true ) : CssSelectorMatcher::matches($element, $rule['parsed_selector']);
+            if ( ! $match['supported'] ) {
+                $this->diagnostics[] = 'unsupported_selector:' . $rule['selector'];
+                continue;
+            }
+            if ( ! $match['matches'] ) {
+                continue;
+            }
+            if ( $matched++ >= self::MAX_RULES_PER_NODE ) {
+                $this->truncated = true;
+                $this->diagnostics[] = 'rules_per_node_limit';
+                break;
+            }
+            foreach ( $rule['declarations'] as $declaration ) {
+                $important = 1 === preg_match('/\s*!important\s*$/i', $declaration['value']);
+                $value = preg_replace('/\s*!important\s*$/i', '', $declaration['value']) ?? $declaration['value'];
+                $fact = array( 'value' => $value, 'path' => $rule['path'], 'hash' => $rule['hash'], 'selector' => $rule['selector'], 'order' => $rule['order'], 'specificity' => $rule['specificity'], 'important' => $important );
+                $key = null === $rule['condition'] ? null : json_encode($rule['condition']);
+                if ( null === $key ) {
+                    $target =& $base;
+                } else {
+                    $conditional[$key] ??= array();
+                    $target =& $conditional[$key];
+                }
+                $current = $target[$declaration['name']] ?? null;
+                if ( is_array($current) && $current['value'] !== $value ) {
+                    $this->diagnostics[] = 'cascade_conflict:' . $declaration['name'];
+                }
+                CssCascade::apply($target, $declaration['name'], $fact);
+                unset($target);
+            }
+        }
+        return array( 'base' => $base, 'conditional' => $conditional );
+    }
+
+    /** @return array<string, string> */
+    private function layout(array $facts): array
+    {
+        $result = array();
+        foreach ( $facts as $property => $fact ) {
+            $result[self::layoutKey($property)] = $fact['value'];
+        }
+        ksort($result);
+        return $result;
+    }
+
+    private static function layoutKey(string $property): string
+    {
+        return array( 'grid-template-columns' => 'columns', 'grid-template-rows' => 'rows', 'row-gap' => 'row_gap', 'column-gap' => 'column_gap', 'grid-column' => 'column', 'grid-row' => 'row', 'grid-area' => 'area', 'flex-direction' => 'direction', 'flex-wrap' => 'wrap', 'align-items' => 'align_items', 'align-content' => 'align_content', 'justify-content' => 'justify_content', 'align-self' => 'align_self', 'justify-self' => 'justify_self', 'flex-grow' => 'flex_grow', 'flex-shrink' => 'flex_shrink', 'flex-basis' => 'flex_basis' )[$property] ?? $property;
+    }
+
+    /** @return array<string, array<string, array<string, mixed>>> */
+    private function effectiveConditional(array $conditional, array $base): array
+    {
+        foreach ( $conditional as $condition => &$facts ) {
+            foreach ( $facts as $property => $fact ) {
+                if ( isset($base[$property]) && ! CssCascade::wins($fact, $base[$property]) ) {
+                    unset($facts[$property]);
+                }
+            }
+            if ( array() === $facts ) {
+                unset($conditional[$condition]);
+            }
+        }
+        unset($facts);
+        return $conditional;
+    }
+
+    /** @return array<string, array<string, int|bool>> */
+    private function precedence(array $facts): array
+    {
+        $result = array();
+        foreach ( $facts as $property => $fact ) {
+            $result[$property] = array( 'source_order' => $fact['order'], 'specificity' => $fact['specificity'], 'important' => $fact['important'] );
+        }
+        ksort($result);
+        return $result;
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function provenance(array $facts, ?array $condition): array
+    {
+        $grouped = array();
+        foreach ( $facts as $property => $fact ) {
+            $key = $fact['path'] . "\n" . $fact['selector'];
+            $grouped[$key] ??= array( 'source_path' => $fact['path'], 'source_sha256' => $fact['hash'], 'selector' => $fact['selector'], 'condition' => $condition, 'properties' => array() );
+            $grouped[$key]['properties'][] = $property;
+        }
+        foreach ( $grouped as &$item ) {
+            sort($item['properties'], SORT_STRING);
+        }
+        unset($item);
+        return array_values($grouped);
+    }
+
+    /** @return array<string, mixed> */
+    private function source(DOMElement $element): array
+    {
+        $classes = array_values(array_filter(preg_split('/\s+/', trim($element->getAttribute('class'))) ?: array(), static fn (string $class): bool => 1 === preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $class)));
+        return array( 'tag' => strtolower($element->tagName), 'id' => 1 === preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $element->getAttribute('id')) ? $element->getAttribute('id') : null, 'classes' => array_slice($classes, 0, 8) );
+    }
 }

--- a/php-transformer/tests/unit/css-rule-analyzer.php
+++ b/php-transformer/tests/unit/css-rule-analyzer.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssCascade;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssRuleAnalyzer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, "FAIL: {$message}\n");
+};
+
+$analysis = (new CssRuleAnalyzer())->analyze(
+    array(
+        array(
+            'content' => '@media (max-width: 40rem) { @supports (display: grid) { .field, [data-label="a,b"] { display:flex; gap:var(--gap, "a;b") } } } .field { display:grid !important; display:block }',
+            'source_path' => 'form.css',
+            'source_hash' => hash('sha256', 'form.css'),
+        ),
+    ),
+    '',
+    array( 'display', 'gap' ),
+    1024,
+    16,
+    16,
+    4
+);
+
+$rules = $analysis['rules'];
+$conditional = $rules[0] ?? array();
+$quotedSelector = $rules[1] ?? array();
+$base = $rules[2] ?? array();
+$assert(3 === count($rules), 'analyzes nested at-rules and selector lists into shared rules');
+$assert('all' === ($conditional['condition']['kind'] ?? null) && 'media' === ($conditional['condition']['conditions'][0]['kind'] ?? null) && 'supports' === ($conditional['condition']['conditions'][1]['kind'] ?? null), 'retains nested at-rule conditions');
+$assert('[data-label="a,b"]' === ($quotedSelector['selector'] ?? null) && 'var(--gap, "a;b")' === ($quotedSelector['declarations'][1]['value'] ?? null), 'quoted commas and semicolons remain inside selector and declaration values');
+$assert(2 === count($base['declarations'] ?? array()), 'preserves duplicate declaration order for cascade resolution');
+
+$dom = new DOMDocument();
+libxml_use_internal_errors(true);
+$dom->loadHTML('<!doctype html><div class="field" data-label="a,b"></div>');
+libxml_clear_errors();
+$element = $dom->getElementsByTagName('div')->item(0);
+$facts = array();
+foreach ( array($base, $conditional) as $rule ) {
+    $match = CssSelectorMatcher::matches($element, $rule['parsed_selector']);
+    $assert($match['supported'] && $match['matches'], 'analyzed rules use the shared selector matcher');
+    foreach ( $rule['declarations'] as $declaration ) {
+        $important = 1 === preg_match('/\s*!important\s*$/i', $declaration['value']);
+        $fact = array( 'value' => preg_replace('/\s*!important\s*$/i', '', $declaration['value']), 'important' => $important, 'specificity' => $rule['specificity'], 'order' => $rule['order'] );
+        CssCascade::apply($facts, $declaration['name'], $fact);
+    }
+}
+$assert('grid' === ($facts['display']['value'] ?? null) && true === ($facts['display']['important'] ?? null), 'shared cascade gives !important precedence over later normal declarations');
+$assert('var(--gap, "a;b")' === ($facts['gap']['value'] ?? null), 'shared cascade retains quoted declaration delimiters');
+
+$commentAnalysis = (new CssRuleAnalyzer())->analyze(
+    array( array( 'content' => '.field/**/input { align-self:flex-start }', 'source_path' => 'comments.css', 'source_hash' => hash('sha256', 'comments.css') ) ),
+    '',
+    array( 'align-self' ),
+    1024,
+    16,
+    16,
+    4
+);
+$commentRule = $commentAnalysis['rules'][0] ?? array();
+$commentDom = new DOMDocument();
+$commentDom->loadHTML('<!doctype html><div class="field"><input></div>');
+$commentInput = $commentDom->getElementsByTagName('input')->item(0);
+$commentMatch = CssSelectorMatcher::matches($commentInput, $commentRule['parsed_selector'] ?? array());
+$assert('.field input' === ($commentRule['selector'] ?? null) && $commentMatch['supported'] && $commentMatch['matches'], 'comments separating identifier-like selector tokens retain descendant boundaries');
+
+$commentGraph = (new HtmlTransformer())->transform('<form><div class="field"><input name="email"></div><button type="submit">Send</button></form>', array( 'static_css' => '.field/**/input { align-self:flex-start }' ))->toArray()['fallbacks'][0]['layout_graph'] ?? array();
+$commentGraphNodes = array_column($commentGraph['nodes'] ?? array(), null, 'id');
+$assert('flex-start' === ($commentGraphNodes['control-0']['layout']['align_self'] ?? null), 'form layout graphs retain CSS comment selector boundaries');
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "CssRuleAnalyzer unit tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+fwrite(STDOUT, "CssRuleAnalyzer unit tests: {$passes} passed\n");


### PR DESCRIPTION
## Summary
- extract bounded shared CSS rule and cascade primitives
- make FormLayoutGraphBuilder consume shared selector and winner semantics
- preserve token whitespace around comments and add semantic regressions

## Verification
- focused CSS analyzer and form graph tests passed
- full `composer test` passed before rebase, including 278 parity fixtures and packaging
- current trunk independently stops in `tests/contract/template-surfaces.php` on the shared Figma front-page assertion

Closes #922.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed this change. Chris Huber directed the work and remains responsible for every line.