### PR TITLE
Move navigation source provenance out of core attributes

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -95,6 +95,7 @@
       "php tests/unit/navigation-brand-cue-carrier.php",
       "php tests/unit/navigation-direct-cluster-parity.php",
       "php tests/unit/navigation-inline-margin-carry.php",
+      "php tests/unit/navigation-source-provenance.php",
       "php tests/unit/navigation-dropped-anchors.php",
       "php tests/unit/button-signal-classifier.php",
       "php tests/unit/button-style-resolver.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1564,8 +1564,8 @@ final class HtmlTransformer
      * A design styles a menu CTA through its anchor — sunny-ember writes
      * `.navlinks a.nav-cta{background;color;padding}`. core/navigation-link puts
      * the authored class on the `<li>` and hard-codes the anchor's own class in
-     * `render_block_core_navigation_link()`, which is why `anchorClassName` is
-     * discarded downstream: no renderer can consume it. The authored selector
+     * `render_block_core_navigation_link()`, so the source anchor class lands on
+     * the navigation item rather than the rendered anchor. The authored selector
      * therefore matches nothing and the pill renders as plain text.
      *
      * The rule is rewritten onto `.wp-block-navigation-item.<class> >
@@ -1601,7 +1601,7 @@ final class HtmlTransformer
             return array();
         }
 
-        $anchorClasses = $this->listNavigationAnchorClasses($serializedBlocks);
+        $anchorClasses = $this->listNavigationAnchorClasses($sourceProvenance);
         if ( array() === $anchorClasses ) {
             return array();
         }
@@ -1973,13 +1973,14 @@ final class HtmlTransformer
     {
         $selectors = array();
         foreach ( $sourceProvenance as $entry ) {
-            if ( 'core/navigation-link' !== ($entry['block_name'] ?? '') || 'a' !== ($entry['tag'] ?? '') ) {
+            if ( ! in_array($entry['block_name'] ?? '', array( 'core/navigation-link', 'core/navigation-submenu' ), true) ) {
                 continue;
             }
-            $attributes = is_array($entry['source_attributes'] ?? null) ? $entry['source_attributes'] : array();
-            $classes = preg_split('/\s+/', trim((string) ($attributes['class'] ?? ''))) ?: array();
-            if ( in_array($class, $classes, true) ) {
-                $selectors[(string) ($entry['selector'] ?? '')] = true;
+            if ( in_array($class, $this->navigationSourceOwnershipClasses($entry, 'anchor'), true) ) {
+                $selector = (string) ($entry['navigation_source_ownership']['anchor']['selector'] ?? $entry['selector'] ?? '');
+                if ( '' !== $selector ) {
+                    $selectors[$selector] = true;
+                }
             }
         }
         if ( array() === $selectors ) {
@@ -2271,27 +2272,20 @@ final class HtmlTransformer
     /**
      * Classes authored on anchors that became navigation-link blocks.
      *
-     * `anchorClassName` is retained in serialized block attributes as source
-     * provenance even though core's renderer cannot apply it to the anchor.
-     * Reading that field distinguishes an anchor-owned class from one authored
-     * on the source `<li>`, whose `className` legitimately belongs on the item.
+     * Source provenance distinguishes an anchor-owned class from one authored on
+     * the source `<li>`, whose `className` legitimately belongs on the item.
      *
      * @return array<string, true>
      */
-    private function listNavigationAnchorClasses(string $serializedBlocks): array
+    private function listNavigationAnchorClasses(array $sourceProvenance): array
     {
-        if ( ! preg_match_all('/<!--\s*wp:navigation-link\s*(\{.*?\})\s*\/-->/s', $serializedBlocks, $matches, PREG_SET_ORDER) ) {
-            return array();
-        }
-
         $classes = array();
-        foreach ( $matches as $match ) {
-            $attrs = json_decode($match[1], true);
-            if ( ! is_array($attrs) ) {
+        foreach ( $sourceProvenance as $entry ) {
+            if ( ! in_array($entry['block_name'] ?? '', array( 'core/navigation-link', 'core/navigation-submenu' ), true) ) {
                 continue;
             }
 
-            foreach ( preg_split('/\s+/', trim((string) ($attrs['anchorClassName'] ?? ''))) ?: array() as $candidate ) {
+            foreach ( $this->navigationSourceOwnershipClasses($entry, 'anchor') as $candidate ) {
                 if ( '' !== $candidate && ! str_starts_with($candidate, 'blocks-engine-') ) {
                     $classes[$candidate] = true;
                 }
@@ -7077,7 +7071,54 @@ final class HtmlTransformer
             'source_bytes'      => strlen($sourceHtml),
             'source_path'       => $this->fallbackProvenance['source'] ?? '',
             'context'           => $this->sourceContext($element),
-        ), $this->sourceConversionMetadata($blockName, $element));
+        ), $this->sourceConversionMetadata($blockName, $element), $this->navigationSourceOwnership($blockName, $element));
+    }
+
+    /** @return array<string, array<string, array<string, string>>> */
+    private function navigationSourceOwnership(string $blockName, DOMElement $element): array
+    {
+        if ( ! in_array($blockName, array( 'core/navigation-link', 'core/navigation-submenu' ), true) ) {
+            return array();
+        }
+
+        $anchor = 'a' === strtolower($element->tagName) ? $element : null;
+        $submenu = null;
+        if ( 'core/navigation-submenu' === $blockName ) {
+            foreach ( $element->childNodes as $child ) {
+                if ( ! $child instanceof DOMElement ) {
+                    continue;
+                }
+                if ( 'a' === strtolower($child->tagName) && ! $anchor instanceof DOMElement ) {
+                    $anchor = $child;
+                }
+                if ( 'a' !== strtolower($child->tagName)
+                    && 0 < $child->getElementsByTagName('a')->length
+                    && ! $submenu instanceof DOMElement
+                ) {
+                    $submenu = $child;
+                }
+            }
+        }
+
+        $ownership = array();
+        foreach ( array( 'anchor' => $anchor, 'submenu' => $submenu ) as $kind => $source ) {
+            if ( ! $source instanceof DOMElement ) {
+                continue;
+            }
+            $ownership[$kind] = array(
+                'selector'   => $this->elementSelector($source),
+                'class_name' => trim($this->attr($source, 'class')),
+            );
+        }
+
+        return array() === $ownership ? array() : array( 'navigation_source_ownership' => $ownership );
+    }
+
+    /** @return list<string> */
+    private function navigationSourceOwnershipClasses(array $entry, string $kind): array
+    {
+        $className = (string) ($entry['navigation_source_ownership'][$kind]['class_name'] ?? '');
+        return array_values(array_filter(preg_split('/\s+/', trim($className)) ?: array()));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -139,8 +139,8 @@ final class NavigationPattern implements PatternRecognizerInterface
      * authors THREE elements — the landmark, the brand, and the menu — each with
      * its own CSS rule. Folding all three into one core/navigation makes the
      * brand a menu item: the landmark's own box rules then compete with the
-     * menu list's rules on a single element, and the brand emits
-     * `anchorClassName`, which core/navigation-link does not register.
+     * menu list's rules on a single element, and would require a source-only
+     * attribute that core/navigation-link does not register.
      *
      * Emit the landmark as a carrier group instead, holding the brand block and
      * a core/navigation built from the link cluster alone. Structural position
@@ -919,13 +919,10 @@ final class NavigationPattern implements PatternRecognizerInterface
             }
         }
 
-        // The anchor/submenu CSS rides on the preserved classNames + companion CSS;
-        // a raw inline `style` string on the navigation-link/submenu inner markup
-        // would diverge from the block save() output, so it is not emitted (#261).
-        return array_filter(array_replace_recursive($itemAttrs, $baseAttrs, array(
-            'anchorClassName'  => $anchorAttrs['className'] ?? '',
-            'submenuClassName' => $submenuAttrs['className'] ?? '',
-        )), static fn ($value): bool => '' !== $value);
+        // Source ownership is retained in the transformer provenance report.
+        // Core does not register either attribute, so serializing them would make
+        // an editor parse/save discard CSS projection input.
+        return array_filter(array_replace_recursive($itemAttrs, $baseAttrs), static fn ($value): bool => '' !== $value);
     }
 
     private function navigationTextColorFromStyle(string $style): string

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2014,12 +2014,17 @@ $nestedNavMenu = ( new HtmlTransformer() )->transform(
 $nestedNavMenuSerialized = (string) ($nestedNavMenu['serialized_blocks'] ?? '');
 $nestedNavMenuParity = $nestedNavMenu['source_reports']['semantic_parity'] ?? array();
 $nestedNavMenuBlock = $nestedNavMenuParity['navigation_menus']['blocks'][0] ?? array();
+$nestedNavMenuSubmenuSource = array_values(array_filter(
+    $nestedNavMenu['source_reports']['html']['source_provenance'] ?? array(),
+    static fn (array $entry): bool => str_contains((string) ($entry['navigation_source_ownership']['submenu']['class_name'] ?? ''), 'nav-links')
+));
 $assert('pass' === ($nestedNavMenu['source_reports']['wp_block_validity']['status'] ?? ''), 'nested nav/menu serializes to valid WordPress navigation blocks');
 $assert(str_contains($nestedNavMenuSerialized, '<!-- wp:navigation-submenu'), 'nested nav/menu emits a canonical navigation-submenu block');
 $assert(! str_contains($nestedNavMenuSerialized, '<nav id="nav-links"'), 'nested nav/menu does not embed a raw nav wrapper inside core/navigation content');
 $assert(! str_contains($nestedNavMenuSerialized, 'style="display:none'), 'nested nav/menu does not freeze hidden raw inline nav styles into serialized block markup');
 $assert(! str_contains($nestedNavMenuSerialized, 'wp-block-navigation nav-links'), 'nested nav/menu strips core wrapper classes while preserving custom nav classes');
-$assert(str_contains($nestedNavMenuSerialized, 'nav-links'), 'nested nav/menu preserves the custom submenu class for styling');
+$assert(str_contains((string) ($nestedNavMenuSubmenuSource[0]['navigation_source_ownership']['submenu']['class_name'] ?? ''), 'nav-links'), 'nested nav/menu preserves custom submenu ownership in the stable source report');
+$assert(! str_contains($nestedNavMenuSerialized, 'anchorClassName') && ! str_contains($nestedNavMenuSerialized, 'submenuClassName'), 'nested nav/menu serializes no unregistered navigation source attributes');
 $assert(4 === ($nestedNavMenuBlock['item_count'] ?? null), 'nested nav/menu preserves parent, submenu, and sibling link items');
 $assert('Latte' === ($nestedNavMenuBlock['items'][2]['label'] ?? ''), 'nested nav/menu preserves submenu item labels');
 

--- a/php-transformer/tests/fixtures/parity/html-nav-cta-vs-plain-links.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-cta-vs-plain-links.json
@@ -18,7 +18,7 @@
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "site-nav" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Services", "url": "/services", "kind": "custom" } },
-    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Book Now", "url": "/book", "kind": "custom", "anchorClassName": "btn btn-primary cta" } }
+    { "path": "blocks.0.innerBlocks.1", "name": "core/navigation-link", "attrs": { "label": "Book Now", "url": "/book", "kind": "custom" } }
   ],
   "expected_fallbacks": [],
   "expect": [

--- a/php-transformer/tests/fixtures/parity/html-nav-dropdown-panel-styling.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-dropdown-panel-styling.json
@@ -17,13 +17,15 @@
   },
   "expected_blocks": [
     { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "primary-nav blocks-engine-list-navigation" } },
-    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-submenu", "attrs": { "label": "Services", "url": "/services", "kind": "custom", "className": "menu-item has-dropdown", "style": { "color": { "background": "#fff" } }, "submenuClassName": "dropdown-panel shadow-lg surface be-inline-geometry-014c224e7fece21c5ce5360da34d3c2e67a3d53488c6a46c3bd81a8fca94ae8e" } }
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-submenu", "attrs": { "label": "Services", "url": "/services", "kind": "custom", "className": "menu-item has-dropdown", "style": { "color": { "background": "#fff" } } } }
   ],
   "expected_fallbacks": [],
   "expect": [
     { "path": "status", "assert": "equals", "value": "success" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 2 },
-    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-submenu {\"className\":\"menu-item has-dropdown\",\"style\":{\"color\":{\"background\":\"#fff\"}},\"label\":\"Services\",\"url\":\"/services\",\"kind\":\"custom\",\"submenuClassName\":\"dropdown-panel shadow-lg surface be-inline-geometry-014c224e7fece21c5ce5360da34d3c2e67a3d53488c6a46c3bd81a8fca94ae8e\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-submenu {\"className\":\"menu-item has-dropdown\",\"style\":{\"color\":{\"background\":\"#fff\"}},\"label\":\"Services\",\"url\":\"/services\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "anchorClassName" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "submenuClassName" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "style=\"background:#fff;box-shadow:0 16px 40px rgba(0,0,0,.18);border-radius:18px\"" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "wp-block-navigation__submenu-container" },
     { "path": "fallbacks", "assert": "count", "count": 0 }

--- a/php-transformer/tests/fixtures/parity/html-nav-menu-flat-list.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-menu-flat-list.json
@@ -20,8 +20,8 @@
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "nav-inner" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/paragraph", "attrs": { "className": "nav-logo blocks-engine-synthetic-paragraph" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/navigation", "attrs": { "className": "nav-menu blocks-engine-list-navigation blocks-engine-native-responsive-navigation" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "index.html", "kind": "custom", "anchorClassName": "nav-link" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.4", "name": "core/navigation-link", "attrs": { "label": "Join Us", "url": "membership.html", "kind": "custom", "anchorClassName": "nav-cta" } }
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "Home", "url": "index.html", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.4", "name": "core/navigation-link", "attrs": { "label": "Join Us", "url": "membership.html", "kind": "custom" } }
   ],
   "expected_fallbacks": [],
   "expect": [

--- a/php-transformer/tests/unit/navigation-brand-cue-carrier.php
+++ b/php-transformer/tests/unit/navigation-brand-cue-carrier.php
@@ -283,9 +283,8 @@ $assert(
 
 // --- sunny-ember: a CTA styled through the ANCHOR, inside the menu list.
 //
-// `render_block_core_navigation_link()` hard-codes the anchor's class, which is
-// why `anchorClassName` is deliberately discarded downstream. The authored class
-// therefore lands on the <li>, and an anchor-scoped rule like
+// `render_block_core_navigation_link()` hard-codes the anchor's class, so the
+// authored class lands on the <li>. An anchor-scoped rule like
 // `.navlinks a.nav-cta{...}` selects nothing — sunny-ember's yellow pill
 // rendered as plain text. A compat rule re-points that authored selector at the
 // element core actually gives the class-bearing item.

--- a/php-transformer/tests/unit/navigation-source-provenance.php
+++ b/php-transformer/tests/unit/navigation-source-provenance.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$result = (new HtmlTransformer())->transform(
+    '<style>.site-nav a.cta{background:#111;color:#fff}.dropdown-panel{box-shadow:0 8px 24px #000}</style>'
+    . '<nav class="site-nav"><ul><li><a class="cta current" href="/home">Home</a></li>'
+    . '<li class="menu-item"><a href="/services">Services</a><ul class="dropdown-panel"><li><a href="/design">Design</a></li></ul></li></ul></nav>',
+    array()
+)->toArray();
+
+$markup = (string) ($result['serialized_blocks'] ?? '');
+$assets = is_array($result['assets'] ?? null) ? $result['assets'] : array();
+$css = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $assets));
+$provenance = $result['source_reports']['html']['source_provenance'] ?? array();
+$submenuOwnership = array_values(array_filter(
+    is_array($provenance) ? $provenance : array(),
+    static fn (array $entry): bool => 'core/navigation-submenu' === ($entry['block_name'] ?? '')
+));
+$anchorOwnership = array_values(array_filter(
+    is_array($provenance) ? $provenance : array(),
+    static fn (array $entry): bool => 'cta current' === ($entry['navigation_source_ownership']['anchor']['class_name'] ?? null)
+));
+
+$assertions = array(
+    array(! str_contains($markup, 'anchorClassName') && ! str_contains($markup, 'submenuClassName'), 'navigation comments contain only registered attributes'),
+    array(str_contains($markup, 'blocks-engine-current-navigation-item'), 'current-item classes survive without source-only attributes'),
+    array(str_contains($css, '.wp-block-navigation-item.cta>.wp-block-navigation-item__content{background:#111;color:#fff}'), 'anchor-owned CTA CSS projects from provenance onto the rendered anchor'),
+    array('dropdown-panel' === ($submenuOwnership[0]['navigation_source_ownership']['submenu']['class_name'] ?? null), 'submenu source ownership is retained in the stable source report'),
+    array('cta current' === ($anchorOwnership[0]['navigation_source_ownership']['anchor']['class_name'] ?? null), 'anchor source ownership is retained in the stable source report'),
+);
+
+$failures = array_map(
+    static fn (array $assertion): string => $assertion[1],
+    array_filter($assertions, static fn (array $assertion): bool => ! $assertion[0])
+);
+if ( array() !== $failures ) {
+    fwrite(STDERR, "Navigation source provenance contract failed:\n" . implode("\n", $failures) . "\n");
+    exit(1);
+}
+
+echo 'Navigation source provenance contract passed: ' . count($assertions) . " assertions\n";


### PR DESCRIPTION
## Summary
- remove unregistered anchor and submenu class attributes from core Navigation blocks
- retain source ownership in stable conversion provenance
- drive CSS projection from provenance rather than reparsed comments

## Verification
- navigation provenance and parity regressions passed
- full `composer test` passed before rebase, including 278 parity fixtures and packaging
- current trunk independently stops in `tests/contract/template-surfaces.php` on the shared Figma front-page assertion

Closes #921.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed this change. Chris Huber directed the work and remains responsible for every line.