### PR TITLE
Remove duplicate transformer branches and pattern helpers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4547,15 +4547,6 @@ final class HtmlTransformer
             );
         }
 
-        if ( 'address' === $tagName ) {
-            $content = $this->innerHtml($element);
-            if ( '' === trim($this->runtime->stripAllTags($content)) ) {
-                return null;
-            }
-
-            return $this->createBlock('core/paragraph', array_merge($this->presentationAttributes($element), array( 'content' => $content )), array(), $element);
-        }
-
         if ( 'figure' === $tagName ) {
             $gallery = $this->mediaGalleryBlockFromElement($element);
             if ( null !== $gallery ) {

--- a/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
@@ -7,6 +7,8 @@ use DOMElement;
 
 final class AccordionPattern implements PatternRecognizerInterface
 {
+    use PatternDomHelpersTrait;
+
     /**
      * @return array<string, mixed>|null
      */
@@ -54,7 +56,7 @@ final class AccordionPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $titleHtml = $this->titleHtml($title, $innerHtml);
+        $titleHtml = $this->disclosureLabelHtml($title, $innerHtml);
         if ( '' === trim(strip_tags($titleHtml)) ) {
             return null;
         }
@@ -80,13 +82,13 @@ final class AccordionPattern implements PatternRecognizerInterface
     private function hasAccordionSignal(DOMElement $element): bool
     {
         $tagName = strtolower($element->tagName);
-        $class = strtolower($this->attr($element, 'class'));
-        $role = strtolower($this->attr($element, 'role'));
+        $class = strtolower($this->trimmedAttribute($element, 'class'));
+        $role = strtolower($this->trimmedAttribute($element, 'role'));
 
         return str_contains($class, 'accordion')
             || str_contains($class, 'faq')
             || 'accordion' === $role
-            || in_array($tagName, array( 'section', 'div', 'ul', 'ol' ), true) && str_contains(strtolower($this->attr($element, 'aria-label')), 'faq');
+            || in_array($tagName, array( 'section', 'div', 'ul', 'ol' ), true) && str_contains(strtolower($this->trimmedAttribute($element, 'aria-label')), 'faq');
     }
 
     private function isAccordionItemElement(DOMElement $element): bool
@@ -95,7 +97,7 @@ final class AccordionPattern implements PatternRecognizerInterface
             return true;
         }
 
-        $class = strtolower($this->attr($element, 'class'));
+        $class = strtolower($this->trimmedAttribute($element, 'class'));
         return str_contains($class, 'item')
             || str_contains($class, 'accordion')
             || str_contains($class, 'faq')
@@ -110,7 +112,7 @@ final class AccordionPattern implements PatternRecognizerInterface
                 return $child;
             }
 
-            $class = strtolower($this->attr($child, 'class'));
+            $class = strtolower($this->trimmedAttribute($child, 'class'));
             if ( str_contains($class, 'title') || str_contains($class, 'heading') || str_contains($class, 'question') || str_contains($class, 'trigger') ) {
                 return $child;
             }
@@ -121,7 +123,7 @@ final class AccordionPattern implements PatternRecognizerInterface
 
     private function panelElement(DOMElement $item, DOMElement $title): ?DOMElement
     {
-        $controlledId = trim($this->attr($title, 'aria-controls'));
+        $controlledId = $this->trimmedAttribute($title, 'aria-controls');
         if ( '' !== $controlledId ) {
             foreach ( $item->getElementsByTagName('*') as $candidate ) {
                 if ( $candidate instanceof DOMElement && $candidate->getAttribute('id') === $controlledId ) {
@@ -135,23 +137,14 @@ final class AccordionPattern implements PatternRecognizerInterface
                 continue;
             }
 
-            $class = strtolower($this->attr($child, 'class'));
-            $role = strtolower($this->attr($child, 'role'));
+            $class = strtolower($this->trimmedAttribute($child, 'class'));
+            $role = strtolower($this->trimmedAttribute($child, 'role'));
             if ( 'region' === $role || str_contains($class, 'panel') || str_contains($class, 'content') || str_contains($class, 'body') || str_contains($class, 'answer') ) {
                 return $child;
             }
         }
 
         return null;
-    }
-
-    private function titleHtml(DOMElement $title, callable $innerHtml): string
-    {
-        $html = $innerHtml($title);
-        $html = preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html;
-        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>.*?<\/\1>/is', '', $html) ?? $html;
-
-        return trim($html);
     }
 
     private function headingLevel(DOMElement $title): int
@@ -161,12 +154,12 @@ final class AccordionPattern implements PatternRecognizerInterface
 
     private function isOpen(DOMElement $item, DOMElement $title, ?DOMElement $panel): bool
     {
-        if ( $item->hasAttribute('open') || 'true' === strtolower($this->attr($title, 'aria-expanded')) ) {
+        if ( $item->hasAttribute('open') || 'true' === strtolower($this->trimmedAttribute($title, 'aria-expanded')) ) {
             return true;
         }
 
         foreach ( array_filter(array( $item, $title, $panel )) as $element ) {
-            if ( $element instanceof DOMElement && preg_match('/(?:^|\s)(?:active|open|is-active|is-open|expanded)(?:\s|$)/i', $this->attr($element, 'class')) ) {
+            if ( $element instanceof DOMElement && preg_match('/(?:^|\s)(?:active|open|is-active|is-open|expanded)(?:\s|$)/i', $this->trimmedAttribute($element, 'class')) ) {
                 return true;
             }
         }
@@ -174,42 +167,4 @@ final class AccordionPattern implements PatternRecognizerInterface
         return false;
     }
 
-    private function hasRuntimeHeavyDescendant(DOMElement $element): bool
-    {
-        foreach ( $element->getElementsByTagName('*') as $candidate ) {
-            if ( ! $candidate instanceof DOMElement ) {
-                continue;
-            }
-
-            if ( in_array(strtolower($candidate->tagName), array( 'script', 'canvas', 'template', 'iframe', 'form' ), true) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @return array<int, DOMElement>
-     */
-    private function directChildElements(DOMElement $element): array
-    {
-        $children = array();
-        foreach ( $element->childNodes as $child ) {
-            if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') ) {
-                return array();
-            }
-
-            if ( $child instanceof DOMElement ) {
-                $children[] = $child;
-            }
-        }
-
-        return $children;
-    }
-
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? trim($element->getAttribute($name)) : '';
-    }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 
 /**
  * Recognizes column / split-layout / documentation-sidebar containers and
@@ -107,7 +108,7 @@ final class ColumnsPattern
 
     private function isColumnWrapperElement(DOMElement $element): bool
     {
-        return in_array(strtolower($element->tagName), array( 'article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section' ), true);
+        return ShellLandmarkPolicy::isColumnsWrapperTag($element->tagName);
     }
 
     private function looksLikeColumnsContainer(DOMElement $element, string $resolvedStyle): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -7,6 +7,8 @@ use DOMElement;
 
 final class DetailsPattern
 {
+    use PatternDomHelpersTrait;
+
     /**
      * @param array<int, array<string, mixed>> $fallbacks
      * @param callable(DOMElement, array<int, array<string, mixed>>&, array<int, string>): array<int, array<string, mixed>> $convertChildrenWithoutTags
@@ -63,7 +65,7 @@ final class DetailsPattern
 
         $toggle = $toggles[0];
 
-        $summaryHtml = $this->toggleLabelHtml($toggle, $innerHtml);
+        $summaryHtml = $this->disclosureLabelHtml($toggle, $innerHtml);
         if ( '' === trim(strip_tags($summaryHtml)) ) {
             return null;
         }
@@ -119,7 +121,7 @@ final class DetailsPattern
         }
 
         $tagName = strtolower($element->tagName);
-        $role = strtolower($this->attr($element, 'role'));
+        $role = strtolower($this->trimmedAttribute($element, 'role'));
 
         return 'button' === $tagName || 'summary' === $tagName || 'button' === $role
             || ( 'a' === $tagName && 'button' === $role );
@@ -131,7 +133,7 @@ final class DetailsPattern
      */
     private function disclosurePanel(DOMElement $element, DOMElement $toggle, DOMElement $header): ?DOMElement
     {
-        $controlledId = trim($this->attr($toggle, 'aria-controls'));
+        $controlledId = $this->trimmedAttribute($toggle, 'aria-controls');
         if ( '' !== $controlledId ) {
             foreach ( $element->getElementsByTagName('*') as $candidate ) {
                 if ( ! $candidate instanceof DOMElement || $candidate->getAttribute('id') !== $controlledId ) {
@@ -171,29 +173,9 @@ final class DetailsPattern
         return null;
     }
 
-    private function toggleLabelHtml(DOMElement $toggle, callable $innerHtml): string
-    {
-        $html = $innerHtml($toggle);
-        $html = preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html;
-        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>.*?<\/\1>/is', '', $html) ?? $html;
-
-        return trim($html);
-    }
-
     private function isNavigationLandmark(DOMElement $element): bool
     {
-        return 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->attr($element, 'role'));
-    }
-
-    private function hasRuntimeHeavyDescendant(DOMElement $element): bool
-    {
-        foreach ( $element->getElementsByTagName('*') as $candidate ) {
-            if ( $candidate instanceof DOMElement && in_array(strtolower($candidate->tagName), array( 'script', 'canvas', 'template', 'iframe', 'form' ), true) ) {
-                return true;
-            }
-        }
-
-        return false;
+        return 'nav' === strtolower($element->tagName) || 'navigation' === strtolower($this->trimmedAttribute($element, 'role'));
     }
 
     private function containsNode(DOMElement $ancestor, DOMElement $node): bool
@@ -207,19 +189,4 @@ final class DetailsPattern
         return false;
     }
 
-    private function attr(DOMElement $element, string $name): string
-    {
-        return $element->hasAttribute($name) ? trim($element->getAttribute($name)) : '';
-    }
-
-    private function firstChildElement(DOMElement $element, string $tagName): ?DOMElement
-    {
-        foreach ( $element->childNodes as $child ) {
-            if ( $child instanceof DOMElement && strtolower($child->tagName) === $tagName ) {
-                return $child;
-            }
-        }
-
-        return null;
-    }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternDomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternDomHelpersTrait.php
@@ -38,4 +38,48 @@ trait PatternDomHelpersTrait
 
         return false;
     }
+
+    private function trimmedAttribute(DOMElement $element, string $name): string
+    {
+        return $element->hasAttribute($name) ? trim($element->getAttribute($name)) : '';
+    }
+
+    private function disclosureLabelHtml(DOMElement $element, callable $innerHtml): string
+    {
+        $html = $innerHtml($element);
+        $html = preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html;
+        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>.*?<\/\1>/is', '', $html) ?? $html;
+
+        return trim($html);
+    }
+
+    private function hasRuntimeHeavyDescendant(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( $candidate instanceof DOMElement && in_array(strtolower($candidate->tagName), array( 'script', 'canvas', 'template', 'iframe', 'form' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    private function directChildElements(DOMElement $element): array
+    {
+        $children = array();
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' !== trim($child->textContent ?? '') ) {
+                return array();
+            }
+
+            if ( $child instanceof DOMElement ) {
+                $children[] = $child;
+            }
+        }
+
+        return $children;
+    }
 }

--- a/php-transformer/src/HtmlToBlocks/ShellLandmarkPolicy.php
+++ b/php-transformer/src/HtmlToBlocks/ShellLandmarkPolicy.php
@@ -47,6 +47,11 @@ final class ShellLandmarkPolicy
         return in_array(strtolower($tagName), self::WRAPPER_PRESERVING_TAGS, true);
     }
 
+    public static function isColumnsWrapperTag(string $tagName): bool
+    {
+        return in_array(strtolower($tagName), self::WRAPPER_PRESERVING_TAGS, true);
+    }
+
     public static function isInlineTokenContainerTag(string $tagName): bool
     {
         return in_array(strtolower($tagName), self::INLINE_TOKEN_CONTAINER_TAGS, true);

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -489,6 +489,9 @@ $assert('core/accordion-panel' === ($accordionItems[0]['innerBlocks'][1]['blockN
 $assert('Assessment and treatment planning.' === ($accordionItems[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? null), 'accordion conversion preserves panel text');
 $assert(str_contains((string) ($accordionResult['serialized_blocks'] ?? ''), '<!-- wp:accordion '), 'accordion conversion serializes native accordion block comments');
 
+$decorativeAccordionResult = ( new HtmlTransformer() )->transform('<section class="faq"><div class="faq-item"><button aria-controls="answer-a"><svg aria-hidden="true"></svg><span aria-hidden="true">Question:</span> What is covered?</button><div id="answer-a"><p>Assessment and treatment planning.</p></div></div><div class="faq-item"><button aria-controls="answer-b">How long is a visit?</button><div id="answer-b"><p>Most visits take 45 minutes.</p></div></div></section>')->toArray();
+$assert('What is covered?' === ($decorativeAccordionResult['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['title'] ?? null), 'accordion labels omit decorative SVG and hidden text');
+
 $complexAccordionResult = ( new HtmlTransformer() )->transform('<section class="faq"><div class="faq-item"><button aria-controls="a">Question A</button><div id="a"><script src="accordion.js"></script><p>Answer A</p></div></div><div class="faq-item"><button aria-controls="b">Question B</button><div id="b"><p>Answer B</p></div></div></section>')->toArray();
 $assert('core/accordion' !== (($complexAccordionResult['blocks'][0] ?? array())['blockName'] ?? null), 'runtime-heavy accordion markup is not forced into native accordion');
 
@@ -527,6 +530,9 @@ $assert('core/details' === ($disclosureBlock['blockName'] ?? null), 'a single ar
 $assert('What is your refund policy?' === ($disclosureBlock['attrs']['summary'] ?? null), 'disclosure toggle text maps to the details summary');
 $assert('Full refund within 30 days.' === ($disclosureBlock['innerBlocks'][0]['attrs']['content'] ?? null), 'disclosure panel content is preserved inside core/details');
 $assert(str_contains((string) ($disclosureResult['serialized_blocks'] ?? ''), '<!-- wp:details'), 'disclosure conversion serializes a native details block comment');
+
+$decorativeDisclosureResult = ( new HtmlTransformer() )->transform('<div><button aria-expanded="false" aria-controls="answer-2"><svg aria-hidden="true"></svg><span aria-hidden="true">Question:</span> What is your refund policy?</button><div id="answer-2"><p>Full refund within 30 days.</p></div></div>')->toArray();
+$assert('What is your refund policy?' === ($decorativeDisclosureResult['blocks'][0]['attrs']['summary'] ?? null), 'disclosure labels omit decorative SVG and hidden text');
 
 // A heading-wrapped toggle (button nested inside the header) is recognized by
 // the same structural signal.

--- a/php-transformer/tests/unit/shell-landmark-policy.php
+++ b/php-transformer/tests/unit/shell-landmark-policy.php
@@ -33,6 +33,9 @@ $assert('main' === ShellLandmarkPolicy::landmarkKind('main'), 'main maps to main
 $assert(ShellLandmarkPolicy::isSemanticGroupTag('main'), 'main can remain a semantic core/group tag');
 $assert(ShellLandmarkPolicy::isWrapperPreservingTag('main'), 'main wrapper can preserve source style/structure');
 $assert(ShellLandmarkPolicy::isInlineContentWrapperTag('footer'), 'footer can still be content-local phrasing wrapper');
+$assert(ShellLandmarkPolicy::isColumnsWrapperTag('section'), 'section remains an eligible Columns wrapper');
+$assert(! ShellLandmarkPolicy::isColumnsWrapperTag('body'), 'body remains ineligible as a Columns wrapper');
+$assert(! ShellLandmarkPolicy::isColumnsWrapperTag('center'), 'center remains ineligible as a Columns wrapper');
 
 $assert('header' === ShellLandmarkPolicy::templatePartArea('parts/header.html', ''), 'header template part area comes from path');
 $assert('footer' === ShellLandmarkPolicy::templatePartArea('parts/site-shell.html', 'template-part footer'), 'footer template part area comes from role');


### PR DESCRIPTION
## Summary
- remove unreachable address dispatch
- share disclosure DOM and label helpers
- centralize the exact Columns wrapper policy without broadening recognition

## Verification
- focused policy and pattern tests passed
- full `composer test` passed before rebase, including 278 parity fixtures and packaging
- current trunk independently stops in `tests/contract/template-surfaces.php` on the shared Figma front-page assertion

Closes #920.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed this change. Chris Huber directed the work and remains responsible for every line.