### PR TITLE
Match core backslash escaping in standalone serialization

### DIFF
--- a/php-transformer/src/WordPress/Runtime.php
+++ b/php-transformer/src/WordPress/Runtime.php
@@ -613,7 +613,7 @@ final class Runtime
      * Serialize block attributes for the comment delimiter the way WordPress
      * core's serialize_block_attributes() does: JSON-encode, then escape the
      * characters that could otherwise break out of the surrounding HTML comment
-     * (`--`, `<`, `>`, `&`) plus escaped quotes. This keeps the delimiter
+     * (`\\`, `--`, `<`, `>`, `&`) plus escaped quotes. This keeps the delimiter
      * comment-safe and WP-canonical even when an attribute value embeds raw HTML
      * (e.g. a core/paragraph `content` carrying an inline `<a>`), so the comment
      * stays a single parseable token. The codebase's unescaped-slash/unicode JSON
@@ -623,13 +623,17 @@ final class Runtime
      */
     private function serializeBlockAttributes(array $attrs): string
     {
-        $encoded = $this->encodeJson($attrs);
-        $encoded = str_replace('--', '\\u002d\\u002d', $encoded);
-        $encoded = preg_replace('/</', '\\u003c', $encoded) ?? $encoded;
-        $encoded = preg_replace('/>/', '\\u003e', $encoded) ?? $encoded;
-        $encoded = preg_replace('/&/', '\\u0026', $encoded) ?? $encoded;
-
-        return preg_replace('/\\\\"/', '\\u0022', $encoded) ?? $encoded;
+        return strtr(
+            $this->encodeJson($attrs),
+            array(
+                '\\\\' => '\\u005c',
+                '--'   => '\\u002d\\u002d',
+                '<'    => '\\u003c',
+                '>'    => '\\u003e',
+                '&'    => '\\u0026',
+                '\\"'  => '\\u0022',
+            )
+        );
     }
 
     /**

--- a/php-transformer/tests/contract/runtime-no-wordpress.php
+++ b/php-transformer/tests/contract/runtime-no-wordpress.php
@@ -63,6 +63,21 @@ $escapedHyphen = chr(92) . 'u002d';
 assertSame(true, str_contains($customPropertyMarkup, 'var(' . $escapedHyphen . $escapedHyphen . 'responsive-font-size,20px)'), 'Fallback serializer should retain escaped CSS custom-property hyphens.');
 assertSame(false, str_contains($customPropertyMarkup, 'var(u002du002dresponsive-font-size,20px)'), 'Fallback serializer should not drop custom-property escape backslashes.');
 
+$attributeSerializationFixtures = json_decode((string) file_get_contents(dirname(__DIR__) . '/fixtures/contract/standalone-block-attribute-serialization.json'), true);
+assertSame('blocks-engine/php-transformer/standalone-block-attribute-serialization/v1', $attributeSerializationFixtures['schema'] ?? null, 'Standalone block attribute serialization fixture should expose its schema.');
+foreach ( $attributeSerializationFixtures['cases'] ?? array() as $case ) {
+    $block = array(
+        'blockName'    => 'blocks-engine/fixture',
+        'attrs'        => $case['attrs'],
+        'innerBlocks'  => array(),
+        'innerHTML'    => '',
+        'innerContent' => array(),
+    );
+    $serialized = $runtime->serializeBlocks(array( $block ));
+    assertSame($case['expected'], $serialized, 'Fallback serializer should match WordPress core attribute escaping for fixture ' . $case['name']);
+    assertSame($case['attrs'], $runtime->parseBlocks($serialized)[0]['attrs'] ?? null, 'Fallback parser should round-trip fixture attributes for ' . $case['name']);
+}
+
 // Dynamic/nested blocks (core/navigation et al.) save() to null inner HTML, so
 // the WordPress-free fallback serializer must emit canonical comment-delimited
 // markup recursively rather than rendering static HTML. A standalone navigation

--- a/php-transformer/tests/fixtures/contract/standalone-block-attribute-serialization.json
+++ b/php-transformer/tests/fixtures/contract/standalone-block-attribute-serialization.json
@@ -1,0 +1,14 @@
+{
+  "schema": "blocks-engine/php-transformer/standalone-block-attribute-serialization/v1",
+  "cases": [
+    {
+      "name": "backslashes-quotes-comment-delimiters-unicode-and-markup",
+      "attrs": {
+        "backslashes": "C:\\Users\\Chris\\blocks-engine",
+        "quoted": "She said \"hello\"",
+        "commentAndMarkup": "<!-- note --><span data-label=\"A&B\">naïve ✓</span>"
+      },
+      "expected": "<!-- wp:blocks-engine/fixture {\"backslashes\":\"C:\\u005cUsers\\u005cChris\\u005cblocks-engine\",\"quoted\":\"She said \\u0022hello\\u0022\",\"commentAndMarkup\":\"\\u003c!\\u002d\\u002d note \\u002d\\u002d\\u003e\\u003cspan data-label=\\u0022A\\u0026B\\u0022\\u003enaïve ✓\\u003c/span\\u003e\"} /-->"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- mirror WordPress core block-attribute substitutions exactly
- add backslash, quote, comment, Unicode, and markup parity fixtures

## Verification
- standalone runtime contract and direct WordPress parity passed
- full `composer test` passed before rebase, including 278 parity fixtures and packaging
- current trunk independently stops in `tests/contract/template-surfaces.php` on the shared Figma front-page assertion

Closes #925.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed this change. Chris Huber directed the work and remains responsible for every line.