### PR TITLE
Fix duplicate Figma template surfaces

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -747,16 +747,19 @@ final class FigmaTransformer
             if ( '' !== $html ) {
                 $sourceFrameIdentity = is_array($page['source_frame_identity'] ?? null) ? $page['source_frame_identity'] : array();
                 $canonicalTemplatePath = $this->canonicalTemplatePath($pageType);
-                $files[] = array(
-                    'path'                    => $path,
-                    'role'                    => true === ($page['entrypoint'] ?? false) ? 'entrypoint' : 'document',
-                    'mime_type'               => 'text/html',
-                    'content'                 => $html,
-                    'page_type'               => $pageType,
-                    'template_slug'           => $this->canonicalTemplateSlug($pageType) ?: (string) ($page['slug'] ?? ''),
-                    'canonical_template_path' => '' !== $canonicalTemplatePath ? $canonicalTemplatePath : null,
-                    'source_frame_identity'   => $sourceFrameIdentity,
-                );
+                $templateAliasReplacesSource = $emitTemplateAliases && '' !== $canonicalTemplatePath && $canonicalTemplatePath !== $path;
+                if ( ! $templateAliasReplacesSource ) {
+                    $files[] = array(
+                        'path'                    => $path,
+                        'role'                    => true === ($page['entrypoint'] ?? false) ? 'entrypoint' : 'document',
+                        'mime_type'               => 'text/html',
+                        'content'                 => $html,
+                        'page_type'               => $pageType,
+                        'template_slug'           => $this->canonicalTemplateSlug($pageType) ?: (string) ($page['slug'] ?? ''),
+                        'canonical_template_path' => '' !== $canonicalTemplatePath ? $canonicalTemplatePath : null,
+                        'source_frame_identity'   => $sourceFrameIdentity,
+                    );
+                }
                 if ( in_array($pageType, array('single', 'archive', '404'), true) && (! $emitTemplateAliases || $canonicalTemplatePath === $path) ) {
                     $files[array_key_last($files)]['metadata'] = array(
                         'template_surface' => array(
@@ -770,7 +773,7 @@ final class FigmaTransformer
                     );
                 }
 
-                if ( $emitTemplateAliases && '' !== $canonicalTemplatePath && $canonicalTemplatePath !== $path ) {
+                if ( $templateAliasReplacesSource ) {
                     $files[] = array(
                         'path'                    => $canonicalTemplatePath,
                         'role'                    => 'template-alias',

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -82,7 +82,8 @@ function blocks_engine_figma_transformer_run_site_generation_quality_contract(ca
         static fn (array $file): string => (string) ($file['path'] ?? ''),
         array_filter($templateArtifactResult['files'] ?? array(), static fn (array $file): bool => 'text/html' === ($file['mime_type'] ?? null))
     ));
-    $assert(array_values(array_intersect(array('index.html', 'single.html', 'archive.html', '404.html'), $templatePaths)) === array('index.html', 'single.html', 'archive.html', '404.html'), 'multi-template-artifact-emits-canonical-html-paths');
+    $canonicalTemplatePaths = array('index.html', 'single.html', 'archive.html', '404.html');
+    $assert(count($canonicalTemplatePaths) === count($templatePaths) && array() === array_values(array_diff($templatePaths, $canonicalTemplatePaths)), 'multi-template-artifact-emits-only-canonical-template-html-paths');
     $singleTemplateHtml = $fileContent($templateArtifactResult, 'single.html');
     $assert(str_contains($singleTemplateHtml, 'data-template-type="single"') && str_contains($singleTemplateHtml, 'data-template-slug="single"'), 'single-template-root-carries-template-metadata');
     $assert(str_contains($singleTemplateHtml, 'data-template-area="header"') && str_contains($singleTemplateHtml, 'data-template-area="content"') && str_contains($singleTemplateHtml, 'data-template-area="comments"') && str_contains($singleTemplateHtml, 'data-template-area="footer"'), 'single-template-carries-semantic-area-metadata');


### PR DESCRIPTION
## Summary

- replace noncanonical Figma template-source artifacts with their canonical aliases
- prevent generic template-surface inference from seeing conflicting duplicate declarations
- require multi-template Figma output to contain only canonical HTML paths

Fixes #948. Follow-up to #938.

## Verification

- `cd php-transformer && php tests/contract/template-surfaces.php`
- `cd php-transformer && php tests/contract/run.php`
- PHP syntax checks and `git diff --check`

The full Figma contract currently reports four pre-existing assertions unrelated to template paths; the new canonical-path assertion itself passes.

## AI assistance

GPT-5.6 Sol in OpenCode reproduced the merged trunk failure, diagnosed the duplicate producer output, implemented the fix, and ran focused tests. Chris Huber reviewed and is responsible for every line.