### PR TITLE
Add bounded WordPress site plan view

### DIFF
--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -37,13 +37,14 @@ PHP Transformer does not own product workflows such as importer admin screens, u
 
 Consumers should treat these classes and interface as the public entrypoints for the current package:
 
-- `Contract\TransformerResult` - stable result envelope. Use `toArray()` when passing results across process, HTTP, fixture, or compatibility boundaries.
+- `Contract\TransformerResult` - stable result envelope. Use `toArray()` for complete compatibility boundaries or `toWordPressSitePlanView()` for bounded WordPress materialization handoffs.
 - `HtmlToBlocks\HtmlTransformer` - converts supported HTML elements into WordPress block arrays and serialized block markup. Unsupported top-level HTML is reported in `fallbacks`.
 - `FormatBridge\FormatBridge` - normalizes and converts declared `html`, `markdown`, and serialized `blocks` content through `convertResult()`. Markdown support is optional: the adapter registers only when `league/commonmark` + `league/html-to-markdown` are loadable (vendored copies may omit them and `FormatBridge/MarkdownAdapter.php` entirely), otherwise markdown conversion fails cleanly as `unsupported_source_format` and `supportedFormats()` omits `markdown`.
 - `FormatBridge\FormatAdapterInterface` - adapter contract for adding formats to `FormatBridge` when a consumer genuinely needs a package-level extension point.
 - `ArtifactCompiler\ArtifactCompiler` - normalizes generated website artifact bundles into the shared result envelope, including block markup, source reports, assets, components, documents, and block type artifacts.
 - `StaticSite\MaterializationView` - validates a `TransformerResult` object or canonical result array and returns a stable product-neutral array view for importer planning.
 - `WordPressSitePlan\WordPressSitePlan` - projects an artifact result to the self-contained v2 block-theme plan.
+- `WordPressSitePlan\WordPressSitePlanView` - exposes the self-contained WordPress site plan and required ancillary materialization contracts without duplicating legacy compiler projections.
 - `WordPressSitePlan\WordPressSitePlanResolver` - resolves that plan's declared asset tokens with an explicit runtime `theme_uri`.
 - `WordPress\Runtime` - adapter for WordPress functions used by the transformer when running inside or outside WordPress.
 
@@ -62,6 +63,7 @@ use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationView;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanView;
 
 $htmlResult = (new HtmlTransformer())->transform('<h1>Hello</h1>', array(
     'source' => 'fixture:home-html',
@@ -81,6 +83,7 @@ $artifactResult = (new ArtifactCompiler())->compile(array(
 
 $materialization = (new MaterializationView())->fromResult($artifactResult);
 $plan = (new WordPressSitePlan())->fromResult($artifactResult);
+$planView = (new WordPressSitePlanView())->fromResult($artifactResult);
 $resolvedPlan = (new WordPressSitePlanResolver())->resolve($plan, array(
     'theme_uri' => 'https://example.test/wp-content/themes/generated-site',
 ));
@@ -132,6 +135,8 @@ The result envelope includes generic `metrics` for wrapper reporting: `input_byt
 Visual parity tooling should use the product-neutral report/config contracts in `docs/contracts/visual-parity-report.md`. The report covers source and target render metadata, viewports, optional screenshot paths, DOM candidate matches, computed-style deltas, optional visual diff metrics, severity, selector evidence, and recommendations. Button, menu, card, and form fields are modeled as generic UI facts rather than product-specific entities.
 
 Consumers that need a single importer-facing projection should use `StaticSite\MaterializationView::fromResult()` instead of reprojecting `TransformerResult` manually. The view validates the canonical result envelope and exposes `result_schema`, `status`, `artifact_summary`, `materialization_plan`, `compiled_site`, `assets`, `documents`, `block_markup`, `blocks`, `block_types`, `components`, `diagnostics`, `provenance`, and `conversion_report`. It does not perform WordPress writes or encode product-specific import policy.
+
+WordPress materializers that consume the self-contained `wordpress-site-plan/v2` contract should use `WordPressSitePlan\WordPressSitePlanView::fromResult()`. It preserves the exact canonical plan plus Gutenberg gaps, companion-plugin payload, font materialization metadata, and plan diagnostics while omitting the duplicated compiled-site, generic materialization-plan, root asset, document, and block projections.
 
 `HtmlTransformer` preserves syntax-highlight spans inside `<pre><code>` when they use safe inline tags and bounded attributes, while plain code remains escaped as text. Figure-wrapped testimonials and quote shapes are normalized to core quote or pullquote blocks with attribution from `cite`, `footer`, or `figcaption` content.
 

--- a/php-transformer/src/Contract/TransformerResult.php
+++ b/php-transformer/src/Contract/TransformerResult.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\Contract;
 
 use InvalidArgumentException;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanView;
 
 final class TransformerResult
 {
@@ -68,6 +69,12 @@ final class TransformerResult
         self::assertCanonicalEnvelope($result);
 
         return $result;
+    }
+
+    /** @return array<string,mixed> */
+    public function toWordPressSitePlanView(): array
+    {
+        return ( new WordPressSitePlanView() )->fromResult($this);
     }
 
     /**

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlanView.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlanView.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan;
+
+use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+
+/** Bounded importer-facing projection of a canonical WordPress site plan result. */
+final class WordPressSitePlanView
+{
+    public const SCHEMA = 'blocks-engine/wordpress-site-plan-view/v1';
+
+    /** @return array<string,mixed> */
+    public function fromResult(TransformerResult|array $result): array
+    {
+        $data = $result instanceof TransformerResult ? array(
+            'schema' => TransformerResult::SCHEMA,
+            'status' => $result->status,
+            'components' => $result->components,
+            'block_types' => $result->blockTypes,
+            'source_reports' => $result->sourceReports,
+            'blocks' => $result->blocks,
+            'serialized_blocks' => $result->serializedBlocks,
+            'documents' => $result->documents,
+            'assets' => $result->assets,
+            'diagnostics' => $result->diagnostics,
+            'fallbacks' => $result->fallbacks,
+            'provenance' => $result->provenance,
+            'coverage' => $result->coverage,
+            'context' => $result->context,
+            'metrics' => $result->metrics,
+        ) : $result;
+        TransformerResult::assertCanonicalEnvelope($data);
+        $sourceReports = $data['source_reports'];
+        $materializationPlan = is_array($sourceReports['materialization_plan'] ?? null) ? $sourceReports['materialization_plan'] : array();
+        $theme = is_array($materializationPlan['theme'] ?? null) ? $materializationPlan['theme'] : array();
+
+        return array(
+            'schema' => self::SCHEMA,
+            'result_schema' => $data['schema'],
+            'status' => $data['status'],
+            'wordpress_site_plan' => $this->arrayValue($sourceReports, 'wordpress_site_plan'),
+            'gutenberg_gaps' => $this->arrayValue($sourceReports, 'gutenberg_gaps'),
+            'companion_plugin_payload' => $this->arrayValue($sourceReports, 'companion_plugin_payload'),
+            'font_materialization' => $this->arrayValue($theme, 'font_materialization'),
+            'diagnostics' => $this->arrayValue($sourceReports, 'wordpress_site_plan_diagnostics'),
+        );
+    }
+
+    /** @param array<string,mixed> $data @return array<mixed> */
+    private function arrayValue(array $data, string $key): array
+    {
+        return is_array($data[$key] ?? null) ? $data[$key] : array();
+    }
+}

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -20,6 +20,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecogniz
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationView;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanView;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\VisualParity\TypographyVisualProbe;
 use Automattic\BlocksEngine\PhpTransformer\VisualParity\TypographyVisualProbeComparator;
@@ -2695,6 +2696,13 @@ $simple = $compiler->compile(
 )->toArray();
 TransformerResult::assertCanonicalEnvelope($simple);
 $assert('success' === $simple['status'], 'simple artifact compiles successfully', (string) $simple['status']);
+$simplePlanView = ( new WordPressSitePlanView() )->fromResult($simple);
+$simpleObjectPlanView = $compiler->compile(array('generated_html' => '<main><h1>Bounded handoff</h1></main>'))->toWordPressSitePlanView();
+$assert(WordPressSitePlanView::SCHEMA === ($simplePlanView['schema'] ?? ''), 'WordPress site plan view exposes its own schema');
+$assert(WordPressSitePlanView::SCHEMA === ($simpleObjectPlanView['schema'] ?? ''), 'Transformer result exposes the bounded WordPress site plan view directly');
+$assert(($simple['source_reports']['wordpress_site_plan'] ?? array()) === ($simplePlanView['wordpress_site_plan'] ?? null), 'WordPress site plan view preserves the exact canonical plan');
+$assert(array('schema', 'result_schema', 'status', 'wordpress_site_plan', 'gutenberg_gaps', 'companion_plugin_payload', 'font_materialization', 'diagnostics') === array_keys($simplePlanView), 'WordPress site plan view has a stable bounded shape');
+$assert(!isset($simplePlanView['compiled_site'], $simplePlanView['materialization_plan'], $simplePlanView['assets'], $simplePlanView['documents'], $simplePlanView['blocks']), 'WordPress site plan view omits duplicate legacy and root projections');
 $assert(ArtifactCompiler::INPUT_SCHEMA === ($simple['source_reports']['artifact']['schema'] ?? ''), 'artifact report exposes canonical site artifact schema');
 $assert(ArtifactCompiler::INPUT_SCHEMA === ($simple['source_reports']['artifact']['original_schema'] ?? ''), 'canonical site artifact input schema is accepted and preserved');
 $assert('index.html' === ($simple['source_reports']['artifact']['entry_path'] ?? ''), 'generated HTML becomes an index entry');


### PR DESCRIPTION
## Summary

- add a stable `wordpress-site-plan-view/v1` projection for importer handoffs
- preserve the exact self-contained v2 plan and required ancillary contracts
- leave the complete transformer v1, compiled-site v1, and materialization-plan v1 envelopes unchanged

Fixes #936.

## Puffin evidence

A representative 203 MB, 59-page artifact preserves its 4,221-write canonical plan while aggregate serialized result strings fall:

- bytes: 1,603,628,148 to 537,304,595 (-66.5%)
- strings: 831,847 to 199,444 (-76.0%)
- compile peak memory: unchanged at 1,387,118,592 bytes

This specifically addresses importer transport/storage field width; it does not claim reduced compiler peak memory.

## Verification

- `cd php-transformer && composer test:canonical`
- exact plan equality and stable bounded-shape contract assertions
- direct large-artifact benchmark with unchanged page/write counts

## AI assistance

GPT-5.6 Sol in OpenCode mapped result consumers, designed and implemented the bounded projection, ran contract suites, and benchmarked the representative artifact. Chris Huber reviewed and is responsible for every line.