### PR TITLE
Respect template surface declaration authority

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -833,6 +833,8 @@ final class WordPressSitePlan
         foreach ($documents as $document) if (is_array($document['template_surface'] ?? null)) $groups[$document['template_surface']['role'] . "\0" . $document['template_surface']['slug']][] = $document;
         $surfaces = array();
         foreach ($groups as $key => $candidates) {
+            $metadataCandidates = array_values(array_filter($candidates, static fn(array $candidate): bool => 'artifact_metadata' === ($candidate['template_surface']['declaration_provenance']['kind'] ?? null)));
+            if (array() !== $metadataCandidates) $candidates = $metadataCandidates;
             usort($candidates, static fn(array $a, array $b): int => strcmp((string) $a['source_path'], (string) $b['source_path']));
             $hashes = array_unique(array_map(static fn(array $document): string => hash('sha256', (string) ($document['block_markup'] ?? '')), $candidates));
             if (count($hashes) > 1) throw new ValidationException('Declared template surface variants have different block markup.', array('source_path' => (string) $candidates[0]['source_path'], 'document_kind' => 'template_surface', 'declaration_kind' => 'template_surface', 'reason' => 'template_surface_ambiguous', 'fields' => array('surface' => str_replace("\0", ':', $key), 'candidate_count' => count($candidates))));


### PR DESCRIPTION
## Summary

- prefer explicit artifact-metadata template declarations over declarations inferred from HTML for the same logical surface
- preserve all declared documents as non-page content while avoiding false variant ambiguity from canonical aliases
- restore the template-surface contract and PHP Transformer CI on current trunk

## Verification

- `cd figma-transformer && composer test`
- `cd php-transformer && composer test`
- 278 PHP transformer parity fixtures
- package install proof

Fixes #950

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the trunk regression, evaluated the producer compatibility boundary, implemented the declaration-authority fix, and ran both transformer suites. Chris Huber directed the work and remains responsible for every line.