### PR TITLE
Materialize passive exported SVG artwork

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -825,7 +825,7 @@ trait SvgMaterializationTrait
         ));
         $allowedAttributes = array_flip(array(
             'aria-hidden', 'aria-label', 'class', 'clip-path', 'clip-rule', 'cx', 'cy', 'd',
-            'dominant-baseline', 'dx', 'dy', 'fill', 'fill-opacity', 'fill-rule', 'font-family',
+            'dominant-baseline', 'dx', 'dy', 'enable-background', 'fill', 'fill-opacity', 'fill-rule', 'font-family',
             'filter', 'font-size', 'font-style', 'font-weight', 'gradienttransform', 'gradientunits',
             'height', 'id', 'letter-spacing', 'marker-end', 'marker-mid', 'marker-start',
             'markerheight', 'markerunits', 'markerwidth', 'mask', 'offset', 'opacity', 'orient',
@@ -834,8 +834,8 @@ trait SvgMaterializationTrait
             'spreadmethod', 'stop-color', 'stop-opacity', 'stroke', 'stroke-dasharray',
             'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit',
             'stroke-opacity', 'stroke-width', 'stddeviation', 'style', 'text-anchor', 'transform',
-            'vector-effect', 'viewbox', 'width', 'x', 'x1', 'x2', 'xlink:href', 'xmlns', 'y', 'y1', 'y2',
-            'in', 'title',
+            'vector-effect', 'version', 'viewbox', 'width', 'x', 'x1', 'x2', 'xlink:href', 'xml:space',
+            'xmlns', 'xmlns:xlink', 'y', 'y1', 'y2', 'in', 'title',
         ));
 
         foreach ( $element->getElementsByTagName('*') as $child ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -831,6 +831,12 @@ $assert(str_contains($inlineSvgMarkup, 'alt="Album art"'), 'passive meaningful i
 $inlineSvgCss = implode("\n", array_map(static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '', $inlineSvgArtwork['assets'] ?? array()));
 $assert(str_contains($inlineSvgMarkup, 'be-inline-geometry-') && ! str_contains($inlineSvgMarkup, 'line-height:0') && str_contains($inlineSvgCss, '>img{display:inline;vertical-align:baseline}'), 'default-inline SVG core/image restores the source baseline over WordPress image alignment');
 
+$exportedSvgArtwork = ( new HtmlTransformer() )->transform(
+    '<main><svg version="1.1" class="quote-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 25.666 20.188" enable-background="new 0 0 25.666 20.188" xml:space="preserve"><g><path d="M9.33,9.33H4.814V0h9.33V9.33z"></path></g></svg></main>'
+)->toArray();
+$exportedSvgMarkup = (string) ($exportedSvgArtwork['serialized_blocks'] ?? '');
+$assert('core/image' === ($exportedSvgArtwork['blocks'][0]['blockName'] ?? '') && ! str_contains($exportedSvgMarkup, '<!-- wp:html'), 'passive exported SVG metadata remains native core/image artwork');
+
 $positionedFillSvg = ( new HtmlTransformer() )->transform(
     '<style>.hero-media{position:relative;width:1280px;height:760px}@media(max-width:700px){.hero-media{width:320px;height:240px}}</style><main><div class="hero-media"><svg class="hero-art" width="100%" height="100%" style="object-fit:cover" viewBox="0 0 1280 728.88"><rect width="1280" height="728.88" fill="#111"/></svg></div></main>'
 )->toArray();


### PR DESCRIPTION
## Summary

- recognize standard SVG root metadata (`version`, `enable-background`, `xml:space`, and `xmlns:xlink`) as passive
- materialize otherwise-safe exported SVG artwork as native `core/image` blocks
- cover the real exported quote-icon shape with a transformer contract test

## Evidence

- `composer test` passes, including 278 PHP transformer parity fixtures and package installation proof
- the persisted Taste & Travel Italy Product document drops from 104 `core/html` blocks to zero
- 104 repeated icon occurrences deduplicate to two unique materialized SVG asset paths
- Home remains at two unrelated layout-table fallbacks; current trunk converts Contact without fallback

Related to #868 and Automattic/studio#3952.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the site-plan materialization path, reproduced the fallback against current trunk, implemented the allowlist and regression test, and ran the verification suite. Chris Huber reviewed and remains responsible for the change.