### PR TITLE
Enforce bounded editability policy

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -7,6 +7,7 @@ use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\ReferenceAnalyzer;
 use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionReportProjection;
 use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Contract\CoreHtmlFallbackEvidence;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
@@ -287,6 +288,16 @@ final class ArtifactCompiler
             );
         }
         $sourceReports['editability_report'] = (new EditabilityReport())->fromDocuments($editabilityDocuments);
+        $sourceReports['editability_policy'] = (new EditabilityPolicy())->evaluate($sourceReports['editability_report']);
+        foreach ($sourceReports['editability_policy']['failures'] as $failure) {
+            $diagnostics[] = $this->diagnostic('editability_policy_failed', 'error', (string) $failure['message'], array(
+                'policy_schema' => EditabilityPolicy::SCHEMA,
+                'metric' => $failure['metric'],
+                'actual' => $failure['actual'],
+                'maximum' => $failure['maximum'],
+                'source_path' => $failure['source_path'] ?? '',
+            ));
+        }
         if ( array() !== $allGutenbergGaps ) {
             $sourceReports['gutenberg_gaps'] = $allGutenbergGaps;
         }
@@ -322,8 +333,9 @@ final class ArtifactCompiler
             'transform_duration_ms' => (hrtime(true) - $startedAt) / 1000000,
             'output_bytes'          => strlen($serializedBlocks),
         );
-        // Failed compilations have no materializable source identity and no site plan.
-        if ( 'failed' !== $this->statusFromDiagnostics($diagnostics) ) {
+        // Editability failures retain a failed-quality plan as review evidence;
+        // all other failures have no materializable source identity or site plan.
+        if ( 'failed' !== $this->statusFromDiagnostics($diagnostics) || 'failed' === ($sourceReports['editability_policy']['status'] ?? null) ) {
             $sourceReports['conversion_report'] = ConversionReportProjection::fromResultParts('artifact', $entryBlocks['blocks'], $allFallbacks, $sourceReports, $assets, $provenance, $metrics);
             try {
                 $sourceReports['wordpress_site_plan'] = ( new WordPressSitePlan() )->fromResult(array(

--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -35,6 +35,7 @@ final class ConversionReportProjection
             'navigation_candidates' => self::navigationCandidates($blocks, $sourceReports),
             'semantic_parity'       => self::semanticParity($sourceReports),
             'editability_report'    => is_array($sourceReports['editability_report'] ?? null) ? $sourceReports['editability_report'] : array(),
+            'editability_policy'    => is_array($sourceReports['editability_policy'] ?? null) ? $sourceReports['editability_policy'] : array(),
             'runtime_dependency_parity' => self::runtimeDependencyParity($sourceReports),
             'runtime_islands'      => self::runtimeIslands($sourceReports),
             'interaction_candidates' => self::interactionCandidates($sourceReports),

--- a/php-transformer/src/Contract/EditabilityPolicy.php
+++ b/php-transformer/src/Contract/EditabilityPolicy.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\Contract;
+
+/** Enforces bounded, source-agnostic editability limits on a measured report. */
+final class EditabilityPolicy
+{
+    public const SCHEMA = 'blocks-engine/php-transformer/editability-policy/v1';
+    public const MAX_REPORTED_FAILURES = 100;
+
+    /**
+     * These limits reject block trees that are impractical in List View while
+     * allowing ordinary documents and leaving visual-parity scoring separate.
+     */
+    public const THRESHOLDS = array(
+        'empty_wrapper_count' => 10,
+        'structural_rich_text_attribute_count' => 0,
+        'max_nesting_depth' => 20,
+        'wrapper_to_content_ratio' => 4.0,
+    );
+
+    /** @param array<string,mixed> $report @return array<string,mixed> */
+    public function evaluate(array $report): array
+    {
+        $failures = array();
+        if (is_array($report['documents'] ?? null)) {
+            foreach ($report['documents'] as $document) {
+                if (!is_array($document)) continue;
+                $failures = array_merge($failures, $this->failures(
+                    is_array($document['metrics'] ?? null) ? $document['metrics'] : array(),
+                    is_string($document['source_path'] ?? null) ? $document['source_path'] : ''
+                ));
+            }
+        } else {
+            $scope = is_array($report['scope'] ?? null) ? $report['scope'] : array();
+            $failures = $this->failures(
+                is_array($report['metrics'] ?? null) ? $report['metrics'] : array(),
+                is_string($scope['source_path'] ?? null) ? $scope['source_path'] : ''
+            );
+        }
+
+        $failureCount = count($failures);
+        return array(
+            'schema' => self::SCHEMA,
+            'enforcement' => 'required',
+            'status' => 0 === $failureCount ? 'passed' : 'failed',
+            'thresholds' => self::THRESHOLDS,
+            'failures' => array_slice($failures, 0, self::MAX_REPORTED_FAILURES),
+            'failure_totals' => array(
+                'observed' => $failureCount,
+                'reported' => min($failureCount, self::MAX_REPORTED_FAILURES),
+                'omitted' => max(0, $failureCount - self::MAX_REPORTED_FAILURES),
+                'truncated' => $failureCount > self::MAX_REPORTED_FAILURES,
+            ),
+        );
+    }
+
+    /** @param array<string,mixed> $metrics @return array<int,array<string,mixed>> */
+    private function failures(array $metrics, string $sourcePath): array
+    {
+        $failures = array();
+        foreach (self::THRESHOLDS as $metric => $maximum) {
+            $actual = $metrics[$metric] ?? 0;
+            if ($actual <= $maximum) continue;
+            $failure = array(
+                'metric' => $metric,
+                'actual' => $actual,
+                'maximum' => $maximum,
+                'message' => sprintf('%s is %s; meaningful editability allows at most %s.', $metric, $actual, $maximum),
+            );
+            if ('' !== $sourcePath) $failure['source_path'] = $sourcePath;
+            $failures[] = $failure;
+        }
+        return $failures;
+    }
+}

--- a/php-transformer/src/Contract/EditabilityReport.php
+++ b/php-transformer/src/Contract/EditabilityReport.php
@@ -6,14 +6,8 @@ namespace Automattic\BlocksEngine\PhpTransformer\Contract;
 /** Measures bounded editability risks independently of visual-parity evidence. */
 final class EditabilityReport
 {
-    public const SCHEMA = 'blocks-engine/php-transformer/editability-report/v2';
+    public const SCHEMA = 'blocks-engine/php-transformer/editability-report/v3';
     private const MAX_REPORTED_SIGNALS = 100;
-    private const THRESHOLDS = array(
-        'empty_wrapper_count' => 10,
-        'structural_rich_text_attribute_count' => 0,
-        'max_nesting_depth' => 20,
-        'wrapper_to_content_ratio' => 4.0,
-    );
     private const INLINE_RICH_TEXT_TAGS = array('a', 'abbr', 'b', 'br', 'cite', 'code', 'del', 'em', 'i', 'img', 'ins', 'kbd', 'mark', 's', 'small', 'span', 'strong', 'sub', 'sup', 'time', 'u');
     private const RICH_TEXT_ATTRIBUTES = array(
         'core/heading' => array('content'),
@@ -49,7 +43,7 @@ final class EditabilityReport
             : round($metrics['wrapper_block_count'] / $metrics['content_block_count'], 4);
 
         $signalCount = count($signals);
-        return $this->withEnforcement(array(
+        return array(
             'schema' => self::SCHEMA,
             'scope' => array_filter(array('source_path' => $sourcePath), static fn(string $value): bool => '' !== $value),
             'metrics' => $metrics,
@@ -61,7 +55,7 @@ final class EditabilityReport
                 'omitted' => max(0, $signalCount - self::MAX_REPORTED_SIGNALS),
                 'truncated' => $signalCount > self::MAX_REPORTED_SIGNALS,
             ),
-        ));
+        );
     }
 
     /** @param array<string,array<string,mixed>> $documents @return array<string,mixed> */
@@ -106,7 +100,7 @@ final class EditabilityReport
             : round($totals['wrapper_block_count'] / $totals['content_block_count'], 4);
         ksort($blockTypes, SORT_STRING);
 
-        return $this->withEnforcement(array(
+        return array(
             'schema' => self::SCHEMA,
             'metrics' => $totals,
             'block_types' => $blockTypes,
@@ -118,22 +112,7 @@ final class EditabilityReport
                 'omitted' => max(0, $signalCount - self::MAX_REPORTED_SIGNALS),
                 'truncated' => $signalCount > self::MAX_REPORTED_SIGNALS,
             ),
-        ));
-    }
-
-    /** @param array<string,mixed> $report @return array<string,mixed> */
-    private function withEnforcement(array $report): array
-    {
-        $failures = array();
-        foreach (self::THRESHOLDS as $metric => $maximum) {
-            $actual = $report['metrics'][$metric] ?? 0;
-            if ($actual > $maximum) $failures[] = array('metric' => $metric, 'actual' => $actual, 'maximum' => $maximum, 'message' => sprintf('%s is %s; meaningful editability allows at most %s.', $metric, $actual, $maximum));
-        }
-        $report['status'] = array() === $failures ? 'passed' : 'failed';
-        $report['enforcement'] = 'thresholds_v1';
-        $report['thresholds'] = self::THRESHOLDS;
-        $report['threshold_failures'] = $failures;
-        return $report;
+        );
     }
 
     /** @param array<string,mixed> $report @param array<int,array<string,mixed>> $templates @return array<string,mixed> */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -7349,6 +7349,12 @@ final class HtmlTransformer
             if ( XML_TEXT_NODE === $node->nodeType && '' === trim($node->textContent ?? '') ) {
                 continue;
             }
+            // Source comments carry no rendered, selector, or runtime boundary.
+            // Treating them as transparent lets generated exports shed an otherwise
+            // inert authoring wrapper without interpreting product-specific markup.
+            if ( XML_COMMENT_NODE === $node->nodeType ) {
+                continue;
+            }
             if ( ! $node instanceof DOMElement || $child instanceof DOMElement ) {
                 return null;
             }

--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeDeclarations;
 use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
@@ -34,6 +35,10 @@ final class WordPressSitePlan
     {
         $data = $result instanceof TransformerResult ? $result->toArray() : $result;
         TransformerResult::assertCanonicalEnvelope($data);
+        $editabilityPolicy = $data['source_reports']['editability_policy'] ?? null;
+        if (!is_array($editabilityPolicy) || EditabilityPolicy::SCHEMA !== ($editabilityPolicy['schema'] ?? null) || 'required' !== ($editabilityPolicy['enforcement'] ?? null) || !in_array($editabilityPolicy['status'] ?? null, array('passed', 'failed'), true)) {
+            throw new InvalidArgumentException('WordPress site plan requires a versioned editability policy.');
+        }
         $compiled = $data['source_reports']['compiled_site'] ?? null;
         $materialization = $data['source_reports']['materialization_plan'] ?? null;
         if ( ! is_array($compiled) || ! is_array($materialization) ) {
@@ -104,7 +109,7 @@ final class WordPressSitePlan
             'visual_repair' => $compiled['visual_repair'] ?? array(),
             'runtime_declarations' => $runtimeDeclarations,
             'diagnostics' => array_merge($data['diagnostics'], $shells['diagnostics'], $scriptLoading['diagnostics']),
-            'quality' => array('status' => $data['status'], 'pass' => 'failed' !== $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks'], 'core_html_fallback_evidence' => $data['source_reports']['conversion_report']['core_html_fallback_evidence'] ?? array()),
+            'quality' => array('status' => $data['status'], 'pass' => 'failed' !== $data['status'], 'metrics' => array_diff_key($data['metrics'], array('transform_duration_ms' => true)), 'fallbacks' => $data['fallbacks'], 'core_html_fallback_evidence' => $data['source_reports']['conversion_report']['core_html_fallback_evidence'] ?? array(), 'editability_policy' => $editabilityPolicy ?? array()),
             'reporting' => $this->reporting($pages, $data, array_merge($shells['diagnostics'], $scriptLoading['diagnostics']), $surfaces),
         );
         self::assertValid($plan);
@@ -276,7 +281,8 @@ final class WordPressSitePlan
         if ( ! is_string($plan['theme']['stylesheet'] ?? null) || ! is_string($plan['theme']['theme_json'] ?? null) || (null !== ($plan['theme']['bootstrap'] ?? null) && ! is_string($plan['theme']['bootstrap'])) ) {
             throw new InvalidArgumentException('WordPress site plan theme is structurally invalid.');
         }
-        if ( !in_array($plan['quality']['status'] ?? null, array('success', 'success_with_warnings', 'failed'), true) || !is_bool($plan['quality']['pass'] ?? null) || ('failed' !== $plan['quality']['status']) !== $plan['quality']['pass'] || ! is_array($plan['quality']['metrics'] ?? null) || ! is_array($plan['quality']['fallbacks'] ?? null) || !is_array($plan['quality']['core_html_fallback_evidence'] ?? null) ) {
+        $policyStatus = 'failed' === ($plan['quality']['status'] ?? null) ? 'failed' : 'passed';
+        if ( !in_array($plan['quality']['status'] ?? null, array('success', 'success_with_warnings', 'failed'), true) || !is_bool($plan['quality']['pass'] ?? null) || ('failed' !== $plan['quality']['status']) !== $plan['quality']['pass'] || ! is_array($plan['quality']['metrics'] ?? null) || ! is_array($plan['quality']['fallbacks'] ?? null) || !is_array($plan['quality']['core_html_fallback_evidence'] ?? null) || EditabilityPolicy::SCHEMA !== ($plan['quality']['editability_policy']['schema'] ?? null) || 'required' !== ($plan['quality']['editability_policy']['enforcement'] ?? null) || $policyStatus !== ($plan['quality']['editability_policy']['status'] ?? null) ) {
             throw new InvalidArgumentException('WordPress site plan quality is structurally invalid.');
         }
     }

--- a/php-transformer/tests/contract/wordpress-site-plan.php
+++ b/php-transformer/tests/contract/wordpress-site-plan.php
@@ -74,6 +74,12 @@ $assert(count($plan['reference_tokens']) === count($plan['assets']), 'Every asse
 $assert(true === ($plan['reference_semantics']['dynamic_client_assets']['materializer_may_reject'] ?? null), 'Plan exposes dynamic client asset capability limits.');
 $assert($plan === ($second['source_reports']['wordpress_site_plan'] ?? null), 'Canonical WordPress site plans are deterministic.');
 $assert(true === ($plan['quality']['pass'] ?? null) && ($plan['quality']['pass'] ?? null) === ('failed' !== ($plan['quality']['status'] ?? null)), 'Quality exposes one canonical pass predicate consistent with status.');
+$pathologicalGroups = array(); for ($i = 0; $i < 22; $i++) $pathologicalGroups[] = '<div style="padding:1px">';
+$pathologicalGroups[] = '<p>Editable copy</p>';
+for ($i = 0; $i < 22; $i++) $pathologicalGroups[] = '</div>';
+$pathological = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => implode('', $pathologicalGroups))))->toArray();
+$pathologicalPolicy = $pathological['source_reports']['editability_policy'] ?? array();
+$assert('failed' === ($pathological['status'] ?? null) && 'failed' === ($pathologicalPolicy['status'] ?? null) && 'required' === ($pathologicalPolicy['enforcement'] ?? null) && 'index.html' === ($pathologicalPolicy['failures'][0]['source_path'] ?? null) && 'failed' === ($pathological['source_reports']['wordpress_site_plan']['quality']['status'] ?? null) && false === ($pathological['source_reports']['wordpress_site_plan']['quality']['pass'] ?? null) && 'editability_policy_failed' === ($pathological['diagnostics'][0]['code'] ?? null) && 'index.html' === ($pathological['diagnostics'][0]['context']['source_path'] ?? null), 'Pathological nesting fails the required editability gate with source attribution and emits only failed-quality site-plan evidence.');
 $fallbackPlan = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array('index.html' => '<main><svg><script>secretToken()</script><path onclick="secretHandler()" d="M0 0"></path></svg></main>')))->toArray()['source_reports']['wordpress_site_plan'] ?? array();
 $fallbackPlanEvidence = $fallbackPlan['quality']['core_html_fallback_evidence'] ?? array();
 $fallbackPlanEmission = $fallbackPlanEvidence['emissions'][0] ?? array();

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -537,6 +537,10 @@ $neutralSameSourceGroupChain = $transform('<div class="outer"><div class="middle
 $neutralSameSourceGroupChainMarkup = (string) ($neutralSameSourceGroupChain['serialized_blocks'] ?? '');
 $assert(1 === substr_count($neutralSameSourceGroupChainMarkup, '<!-- wp:group') && str_contains($neutralSameSourceGroupChainMarkup, 'outer middle content'), 'neutral same-source Group chains coalesce to their source-provenance leaf');
 
+$commentAnnotatedGroupChain = $transform('<div class="outer"><!-- export annotation --><div class="content"><p>Copy</p></div></div>');
+$commentAnnotatedGroupChainMarkup = (string) ($commentAnnotatedGroupChain['serialized_blocks'] ?? '');
+$assert(1 === substr_count($commentAnnotatedGroupChainMarkup, '<!-- wp:group') && str_contains($commentAnnotatedGroupChainMarkup, 'outer content'), 'comment-annotated neutral Group wrappers coalesce because comments are semantically transparent');
+
 $sameSourceGroupChainSelectorEdge = $transform('<style>.outer > .middle{color:red}</style><div class="outer"><div class="middle"><div class="content"><p>Copy</p></div></div></div>');
 $assert(2 === substr_count((string) ($sameSourceGroupChainSelectorEdge['serialized_blocks'] ?? ''), '<!-- wp:group'), 'same-source Group chains retain the outer boundary when an author selector matches a removed chain node');
 

--- a/php-transformer/tests/unit/editability-report.php
+++ b/php-transformer/tests/unit/editability-report.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityPolicy;
 
 $blocks = array(array(
     'blockName' => 'core/group',
@@ -18,7 +19,8 @@ $blocks = array(array(
 
 $report = (new EditabilityReport())->fromBlocks($blocks, 'website/index.html', str_repeat('x', 120));
 $metrics = $report['metrics'];
-if (EditabilityReport::SCHEMA !== $report['schema'] || 'thresholds_v1' !== $report['enforcement'] || 'passed' !== $report['status']) throw new RuntimeException('Editability reports must apply versioned meaningful-editability thresholds independently of parity.');
+if ('blocks-engine/php-transformer/editability-report/v3' !== EditabilityReport::SCHEMA || EditabilityReport::SCHEMA !== $report['schema'] || isset($report['enforcement'], $report['status'])) throw new RuntimeException('The factual-only editability report uses a new schema version rather than changing the v2 contract.');
+if ('passed' !== (new EditabilityPolicy())->evaluate($report)['status']) throw new RuntimeException('The versioned editability policy must accept ordinary editable output independently of parity.');
 if (4 !== $metrics['block_count'] || 2 !== $metrics['wrapper_block_count'] || 1 !== $metrics['empty_wrapper_count'] || 2 !== $metrics['max_nesting_depth']) throw new RuntimeException('Editability report must measure block-tree complexity deterministically.');
 if (1 !== $metrics['html_bearing_table_cell_count'] || 1 !== $metrics['source_marker_class_count'] || 1 !== $metrics['generated_geometry_class_count'] || 120 !== $metrics['serialized_bytes']) throw new RuntimeException('Editability report must expose opaque HTML and generated-class signals.');
 if (1 !== $metrics['html_bearing_attribute_count']) throw new RuntimeException('Supported RichText inline markup must not be classified as opaque structural HTML.');
@@ -34,15 +36,30 @@ $emptyGroups = array_fill(0, 101, array('blockName' => 'core/group', 'attrs' => 
 $bounded = (new EditabilityReport())->fromDocuments(array('large.html' => array('blocks' => $emptyGroups)));
 if (101 !== $bounded['signal_totals']['observed'] || 100 !== $bounded['signal_totals']['reported'] || 1 !== $bounded['signal_totals']['omitted'] || !$bounded['signal_totals']['truncated'] || 100 !== count($bounded['signals'])) throw new RuntimeException('Editability reports must bound evidence without losing aggregate signal totals.');
 
+$cleanDocumentBlocks = array_merge(array_fill(0, 6, array('blockName' => 'core/group', 'attrs' => array(), 'innerBlocks' => array(), 'innerHTML' => '')), array(
+    array('blockName' => 'core/paragraph', 'attrs' => array('content' => 'One'), 'innerBlocks' => array(), 'innerHTML' => '<p>One</p>'),
+    array('blockName' => 'core/paragraph', 'attrs' => array('content' => 'Two'), 'innerBlocks' => array(), 'innerHTML' => '<p>Two</p>'),
+));
+$multiDocumentReport = (new EditabilityReport())->fromDocuments(array('a.html' => array('blocks' => $cleanDocumentBlocks), 'b.html' => array('blocks' => $cleanDocumentBlocks)));
+$multiDocumentPolicy = (new EditabilityPolicy())->evaluate($multiDocumentReport);
+if ('passed' !== $multiDocumentPolicy['status'] || 10 !== $multiDocumentPolicy['thresholds']['empty_wrapper_count'] || 12 !== ($multiDocumentReport['metrics']['empty_wrapper_count'] ?? null)) throw new RuntimeException('Each clean document passes independently even when aggregate empty wrappers exceed the per-document limit.');
+$pathologicalDocumentPolicy = (new EditabilityPolicy())->evaluate((new EditabilityReport())->fromDocuments(array('clean.html' => array('blocks' => $cleanDocumentBlocks), 'bad.html' => array('blocks' => array_fill(0, 11, array('blockName' => 'core/group', 'attrs' => array(), 'innerBlocks' => array(), 'innerHTML' => ''))))));
+if ('failed' !== $pathologicalDocumentPolicy['status'] || 'bad.html' !== ($pathologicalDocumentPolicy['failures'][0]['source_path'] ?? null) || 'empty_wrapper_count' !== ($pathologicalDocumentPolicy['failures'][0]['metric'] ?? null)) throw new RuntimeException('A pathological document fails with deterministic source-path attribution.');
+$manyFailedDocuments = array();
+for ($i = 0; $i < 101; $i++) $manyFailedDocuments[] = array('source_path' => sprintf('page-%03d.html', $i), 'metrics' => array('empty_wrapper_count' => 11));
+$boundedPolicy = (new EditabilityPolicy())->evaluate(array('documents' => $manyFailedDocuments));
+if ('failed' !== $boundedPolicy['status'] || 101 !== ($boundedPolicy['failure_totals']['observed'] ?? null) || 100 !== ($boundedPolicy['failure_totals']['reported'] ?? null) || 1 !== ($boundedPolicy['failure_totals']['omitted'] ?? null) || true !== ($boundedPolicy['failure_totals']['truncated'] ?? null) || 100 !== count($boundedPolicy['failures']) || 'page-099.html' !== ($boundedPolicy['failures'][99]['source_path'] ?? null)) throw new RuntimeException('Policy failure evidence is bounded with deterministic totals and source ordering.');
+
 $structuralRichText = '<div><h3>Card title</h3><p>Card copy</p></div>';
 $richTextReport = (new EditabilityReport())->fromBlocks(array(array(
     'blockName' => 'core/list-item',
     'attrs' => array('content' => $structuralRichText),
     'innerBlocks' => array(),
     'innerHTML' => '<li>' . $structuralRichText . '</li>',
-)));
+)), 'standalone.html');
 if (1 !== $richTextReport['metrics']['structural_rich_text_attribute_count'] || strlen($structuralRichText) !== $richTextReport['metrics']['structural_rich_text_attribute_bytes']) throw new RuntimeException('Editability reports must quantify structural HTML stored in RichText attributes.');
 if ('structural_rich_text_attribute' !== ($richTextReport['signals'][0]['kind'] ?? null) || 'core/list-item' !== ($richTextReport['signals'][0]['block_name'] ?? null)) throw new RuntimeException('Structural RichText evidence must retain block attribution.');
-if ('failed' !== $richTextReport['status'] || 'structural_rich_text_attribute_count' !== ($richTextReport['threshold_failures'][0]['metric'] ?? null)) throw new RuntimeException('Structural RichText must fail the bounded meaningful-editability threshold with an actionable metric.');
+$richTextPolicy = (new EditabilityPolicy())->evaluate($richTextReport);
+if ('failed' !== $richTextPolicy['status'] || 'required' !== $richTextPolicy['enforcement'] || 'structural_rich_text_attribute_count' !== ($richTextPolicy['failures'][0]['metric'] ?? null) || 'standalone.html' !== ($richTextPolicy['failures'][0]['source_path'] ?? null)) throw new RuntimeException('Standalone reports fail the bounded meaningful-editability policy with source-path attribution.');
 
 fwrite(STDOUT, "editability report contract passed\n");


### PR DESCRIPTION
## Summary
- separate factual editability measurement from versioned policy enforcement
- evaluate source documents independently with bounded, source-attributed failures
- retain failed-quality site plans as review evidence while preventing successful materialization
- treat source comments as transparent when proving neutral same-source Group-chain coalescing

## Policy
- at most 10 empty wrappers per document
- maximum nesting depth of 20
- wrapper-to-content ratio at most 4
- no structural HTML in RichText attributes
- at most 100 reported failures, with observed/reported/omitted totals

## Compatibility
- the unreleased `editability-report/v2` remains the factual measurement contract
- enforcement is separately versioned as `editability-policy/v1`
- visual parity remains independent; failed plans retain deterministic evidence with `quality.pass: false`

## Verification
- `composer --working-dir=php-transformer test`
- 278 parity fixtures
- package-install proof
- `git diff --check`

Related to #868. This is a bounded first slice; semantic inference for distinct responsive authoring trees remains follow-up work.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to analyze the pathological block-tree evidence, implement and refine the policy/cleanup contracts, and run verification. Chris Huber reviewed and remains responsible for the change.