### PR TITLE
Preserve pure-text box chrome on one native block

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -8188,19 +8188,13 @@ final class HtmlTransformer
             return null;
         }
 
-        // A pure-text styled wrapper whose CSS carries no block-level box chrome
-        // round-trips as a single styled `core/paragraph` carrying the wrapper
-        // class. The `core/group` + default inner paragraph form neither inherits
-        // the wrapper's typographic scale onto that inner paragraph nor suppresses
-        // default block spacing, so an eyebrow like `<div class="label">The Shop
-        // </div>` renders at the wrong size and pushes every following block down.
-        //
-        // Only real box chrome — padding, border, or explicit sizing — disqualifies
-        // the collapse, because a paragraph cannot reproduce that geometry. Flex
-        // layout (`display`/`gap`) does not: a childless text leaf has no flex
-        // items, so its `display:inline-flex;gap` only positions a `::before`
-        // decoration, which the wrapper class still applies to the paragraph. Real
-        // flex containers hold child elements and are already excluded above by the
+        // A childless styled text wrapper round-trips as a single styled
+        // `core/paragraph` carrying the wrapper class and presentation supports.
+        // Keeping its box chrome on that same element preserves the source paint
+        // structure; a core/group plus inner paragraph produces a separate text
+        // paint layer that can differ around rounded borders. Unsupported geometry
+        // remains on the generated CSS carrier attached to the paragraph. Real flex
+        // containers hold child elements and are already excluded above by the
         // `childElementCount === 0` guard (e.g. `.tier-price` wrapping a `<span>`).
         //
         // Descendant paragraph rules the source used a non-`p` tag to escape (e.g.
@@ -8208,7 +8202,7 @@ final class HtmlTransformer
         // authored as `<div class="label">` avoided it) do not capture the collapsed
         // paragraph: author `p` type selectors are projected through the source-`p`
         // tag marker, which only elements that were `<p>` in the source carry.
-        if ( 0 === $this->childElementCount($element) && ! $this->hasBoxChromeWrapperStyling($element) ) {
+        if ( 0 === $this->childElementCount($element) ) {
             return $this->createBlock(
                 'core/paragraph',
                 array_merge($this->presentationAttributes($element), array( 'content' => $content )),
@@ -8235,10 +8229,8 @@ final class HtmlTransformer
     private const BOX_MODEL_WRAPPER_PROPERTIES = array( 'display', 'gap', 'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left', 'border', 'border-color', 'border-radius', 'width', 'height', 'min-width', 'max-width', 'min-height' );
 
     /**
-     * Box-chrome CSS declarations that a `core/paragraph` cannot reproduce, so a
-     * pure-text wrapper carrying any of them must stay a `core/group`. Excludes
-     * flex/grid layout properties, which only matter when the wrapper actually has
-     * child elements to lay out.
+     * Box chrome that requires a paragraph with empty visual inline children to
+     * retain a structural wrapper rather than flattening those children.
      *
      * @var array<int, string>
      */

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -271,15 +271,22 @@ $nativeColumnsResult = ( new HtmlTransformer() )->transform($nativeColumnsHtml, 
 $nativeColumnsBlock = $nativeColumnsResult['blocks'][0] ?? array();
 $assert('core/columns' === ($nativeColumnsBlock['blockName'] ?? ''), '29: explicit native Columns markup remains core Columns', (string) ($nativeColumnsBlock['blockName'] ?? '(none)'));
 
-$labelHtml = '<section class="pricing"><div class="section-head"><div class="tag">Pricing</div><h2>Simple plans</h2></div><article class="pricing-card"><div class="tier-name">Team</div><div class="tier-price"><span class="amount">$29</span>/mo</div><div class="use-case-result">Launch faster</div></article></section>';
+$labelHtml = '<section class="pricing"><div class="section-head"><div class="tag" style="padding:4px 12px;border:1px solid #6b4f2d;border-radius:100px;background:#f2e3c6;width:137px;height:28px">Pricing</div><h2>Simple plans</h2></div><article class="pricing-card"><div class="tier-name">Team</div><div class="tier-price"><span class="amount">$29</span>/mo</div><div class="use-case-result">Launch faster</div></article></section>';
 $labelCss = '.tag{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:100px}.pricing-card{padding:2rem}.tier-name{font-family:monospace;font-size:11px;letter-spacing:.12em;text-transform:uppercase}.tier-price{display:flex;align-items:flex-end;gap:6px}.use-case-result{display:flex;align-items:center;gap:8px;padding:10px 14px;border-radius:6px}';
 $labelResult = ( new HtmlTransformer() )->transform($labelHtml, array('static_css' => $labelCss))->toArray();
 $labelMarkup = (string) ($labelResult['serialized_blocks'] ?? '');
+$labelGeometryCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), is_array($labelResult['assets'] ?? null) ? $labelResult['assets'] : array()));
 
-$assert(str_contains($labelMarkup, '<div class="wp-block-group tag'), '25: box-model section badge stays a group wrapper', $labelMarkup);
+$tag = $labelResult['blocks'][0]['innerBlocks'][0]['innerBlocks'][0] ?? array();
+$tagAttrs = is_array($tag['attrs'] ?? null) ? $tag['attrs'] : array();
+$assert('core/paragraph' === ($tag['blockName'] ?? '') && 0 === count($tag['innerBlocks'] ?? array()), '25: pure-text pill becomes one painted paragraph without a nested paragraph', json_encode($tag));
+$assert(str_starts_with((string) ($tagAttrs['className'] ?? ''), 'tag be-inline-geometry-') && '4px' === ($tagAttrs['style']['spacing']['padding']['top'] ?? '') && '12px' === ($tagAttrs['style']['spacing']['padding']['right'] ?? '') && '#f2e3c6' === ($tagAttrs['style']['color']['background'] ?? ''), '25a: pill retains its class, padding, and background on the paragraph', json_encode($tagAttrs));
+$assert('1px' === ($tagAttrs['style']['border']['width'] ?? '') && 'solid' === ($tagAttrs['style']['border']['style'] ?? '') && '#6b4f2d' === ($tagAttrs['style']['border']['color'] ?? '') && '100px' === ($tagAttrs['style']['border']['radius'] ?? ''), '25aa: pill retains its border and radius on the paragraph', json_encode($tagAttrs));
+$assert(str_contains($labelMarkup, '<p class="has-background has-border-color tag be-inline-geometry-') && str_contains($labelMarkup, 'border-radius:100px') && str_contains($labelGeometryCss, 'width:137px !important') && str_contains($labelGeometryCss, 'height:28px !important') && ! str_contains($labelMarkup, '<div class="wp-block-group tag') && ! preg_match('/<!-- wp:paragraph[^>]*"className":"tag"[^>]*-->\s*<p[^>]*>[^<]*<\/p>\s*<!-- \/wp:paragraph -->/', $labelMarkup), '25b: pill chrome and dimensions are serialized on its sole paragraph instead of a group plus nested paragraph', $labelMarkup . "\n" . $labelGeometryCss);
+$assert('pass' === ($labelResult['source_reports']['wp_block_validity']['status'] ?? ''), '25c: single-paragraph pill serialization is Gutenberg-valid', json_encode($labelResult['source_reports']['wp_block_validity'] ?? array()));
 $assert(str_contains($labelMarkup, '<p class="tier-name">Team</p>'), '26: typography-only card tier label collapses to a styled paragraph so its font scale applies', $labelMarkup);
 $assert(str_contains($labelMarkup, '<div class="wp-block-group tier-price blocks-engine-css-owned-layout'), '27: CSS-owned card price row uses the marked core group wrapper', $labelMarkup);
-$assert(str_contains($labelMarkup, '<div class="wp-block-group use-case-result'), '28: box-model card result row stays a group wrapper', $labelMarkup);
+$assert(str_contains($labelMarkup, '<p class="use-case-result">Launch faster</p>'), '28: pure-text card result row carries its box chrome on one paragraph', $labelMarkup);
 $assert(! preg_match('/<!-- wp:group[^>]*"className":"tier-name"/', $labelMarkup), '29: typography-only tier label does not round-trip as a group wrapping a default paragraph', $labelMarkup);
 
 // A universal reset (`* { margin: 0; padding: 0 }`) sets zero-valued box


### PR DESCRIPTION
## Summary

Compile childless visual-text wrappers with supported box chrome as one styled `core/paragraph` instead of a painted `core/group` containing a synthetic paragraph.

## Root cause

The extra inner block changes Chromium paint chunk structure even when geometry and computed styles are identical. On fractional rounded borders, the solved `15-saas` fixture consistently differs by six one-channel anti-alias pixels.

## What changed

- Carry supported padding, border, radius, background, dimensions, typography, source classes, and selector provenance on one native paragraph block.
- Keep wrappers with child elements, semantic/rich content, empty visual children, or unsupported fallbacks as groups.
- Update the box-chrome regression to require one painted block, no nested paragraph, retained presentation, and valid Gutenberg serialization.

## Verification

- `php tests/unit/block-style-support-conversion.php`
- `php tests/unit/author-selector-semantics.php`
- `php tests/contract/run.php`
- `composer test` including 278 parity fixtures
- Browser probe confirms identical source/target geometry and computed presentation
- Independent review found no defects

Fixes #963

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode analyzed the exact CI screenshots, pixel values, DOM snapshots, and transformer dispatch; delegated the isolated implementation; and ran an independent compatibility review across Gutenberg serialization, selectors, and parity fixtures. Chris Huber remains responsible for every line.