### PR TITLE
Keep unreleased editability report v2

### DIFF
--- a/php-transformer/src/Contract/EditabilityReport.php
+++ b/php-transformer/src/Contract/EditabilityReport.php
@@ -6,7 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\Contract;
 /** Measures bounded editability risks independently of visual-parity evidence. */
 final class EditabilityReport
 {
-    public const SCHEMA = 'blocks-engine/php-transformer/editability-report/v3';
+    public const SCHEMA = 'blocks-engine/php-transformer/editability-report/v2';
     private const MAX_REPORTED_SIGNALS = 100;
     private const INLINE_RICH_TEXT_TAGS = array('a', 'abbr', 'b', 'br', 'cite', 'code', 'del', 'em', 'i', 'img', 'ins', 'kbd', 'mark', 's', 'small', 'span', 'strong', 'sub', 'sup', 'time', 'u');
     private const RICH_TEXT_ATTRIBUTES = array(

--- a/php-transformer/tests/unit/editability-report.php
+++ b/php-transformer/tests/unit/editability-report.php
@@ -19,7 +19,7 @@ $blocks = array(array(
 
 $report = (new EditabilityReport())->fromBlocks($blocks, 'website/index.html', str_repeat('x', 120));
 $metrics = $report['metrics'];
-if ('blocks-engine/php-transformer/editability-report/v3' !== EditabilityReport::SCHEMA || EditabilityReport::SCHEMA !== $report['schema'] || isset($report['enforcement'], $report['status'])) throw new RuntimeException('The factual-only editability report uses a new schema version rather than changing the v2 contract.');
+if ('blocks-engine/php-transformer/editability-report/v2' !== EditabilityReport::SCHEMA || EditabilityReport::SCHEMA !== $report['schema'] || isset($report['enforcement'], $report['status'])) throw new RuntimeException('The unreleased v2 editability report measures facts while policy enforcement uses its own contract.');
 if ('passed' !== (new EditabilityPolicy())->evaluate($report)['status']) throw new RuntimeException('The versioned editability policy must accept ordinary editable output independently of parity.');
 if (4 !== $metrics['block_count'] || 2 !== $metrics['wrapper_block_count'] || 1 !== $metrics['empty_wrapper_count'] || 2 !== $metrics['max_nesting_depth']) throw new RuntimeException('Editability report must measure block-tree complexity deterministically.');
 if (1 !== $metrics['html_bearing_table_cell_count'] || 1 !== $metrics['source_marker_class_count'] || 1 !== $metrics['generated_geometry_class_count'] || 120 !== $metrics['serialized_bytes']) throw new RuntimeException('Editability report must expose opaque HTML and generated-class signals.');


### PR DESCRIPTION
## Summary
- keep the unreleased editability report on schema v2
- leave enforcement separately versioned as `editability-policy/v1`

`editability-report/v2` existed on trunk for only 84 minutes before #965 opened and was never included in a release tag. A v3 bump therefore added migration noise without protecting a shipped contract.

## Verification
- `composer --working-dir=php-transformer test`
- 278 parity fixtures
- package-install proof
- `git diff --check`

Follow-up to #965.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the schema and release history, applied the two-line correction, and ran verification. Chris Huber reviewed and remains responsible for the change.