### PR TITLE
fix: bound standalone block parser

### DIFF
--- a/php-transformer/src/WordPress/Runtime.php
+++ b/php-transformer/src/WordPress/Runtime.php
@@ -329,7 +329,7 @@ final class Runtime
         $this->addDiagnostic('wordpress_parse_blocks_unavailable', 'parse_blocks() is unavailable; using the PHP transformer serialized-block fallback.');
 
         $blocks = $this->parseSerializedBlocks($content);
-        if ( array() !== $blocks ) {
+        if ( null !== $blocks && ( array() !== $blocks || '' === trim($content) ) ) {
             return $blocks;
         }
 
@@ -717,30 +717,53 @@ final class Runtime
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * Parse only the canonical comment delimiters this transformer emits. This
+     * is deliberately not a replacement for WP_Block_Parser: WordPress returns
+     * a best-effort tree for malformed input, while this fallback preserves any
+     * malformed or unsupported document as one freeform block.
+     *
+     * @return array<int, array<string, mixed>>|null Null when the document is outside this bounded contract.
      */
-    private function parseSerializedBlocks(string $content): array
+    private function parseSerializedBlocks(string $content): ?array
     {
-        if ( ! preg_match_all('/<!--\s*(\/)?wp:([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)(?:\s+(\{.*?\}))?\s*(\/)?\s*-->/s', $content, $matches, PREG_OFFSET_CAPTURE) ) {
-            return array();
-        }
-
         $blocks = array();
         $stack  = array();
         $cursor = 0;
+        $search = 0;
+        $found  = false;
 
-        foreach ( $matches[0] as $index => $match ) {
-            $raw     = $match[0];
-            $offset  = $match[1];
+        while ( false !== ( $offset = strpos($content, '<!--', $search) ) ) {
+            $end = strpos($content, '-->', $offset + 4);
+            if ( false === $end ) {
+                if ( preg_match('/^<!--\s*\/?wp:/', substr($content, $offset)) ) {
+                    return null;
+                }
+                $this->appendStandaloneFreeform($blocks, $content, $cursor);
+                return $blocks;
+            }
+
+            $raw       = substr($content, $offset, $end + 3 - $offset);
+            $delimiter = $this->parseStandaloneBlockDelimiter($raw);
+            if ( false === $delimiter ) {
+                return null;
+            }
+            if ( null === $delimiter ) {
+                $search = $end + 3;
+                continue;
+            }
+
+            $found   = true;
             $between = substr($content, $cursor, $offset - $cursor);
-            if ( '' !== $between && array() !== $stack ) {
+            if ( '' !== $between && array() === $stack ) {
+                $this->appendStandaloneFreeform($blocks, $between);
+            } elseif ( '' !== $between ) {
                 $stack[array_key_last($stack)]['innerContent'][] = $between;
             }
 
-            $isClose = '' !== ($matches[1][$index][0] ?? '');
-            $name    = $matches[2][$index][0];
-            $attrs   = $this->decodeBlockAttrs($matches[3][$index][0] ?? '');
-            $isVoid  = '' !== ($matches[4][$index][0] ?? '');
+            $isClose = $delimiter['close'];
+            $name    = $delimiter['name'];
+            $attrs   = $delimiter['attrs'];
+            $isVoid  = $delimiter['void'];
 
             if ( $isClose ) {
                 $frame = array_pop($stack);
@@ -761,28 +784,74 @@ final class Runtime
                 );
             }
 
-            $cursor = $offset + strlen($raw);
+            $cursor = $end + 3;
+            $search = $cursor;
         }
 
-        if ( array() !== $stack ) {
-            return array();
+        if ( ! $found || array() !== $stack ) {
+            return null;
         }
 
+        $this->appendStandaloneFreeform($blocks, substr($content, $cursor));
         return $blocks;
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array{close: bool, name: string, attrs: array<string, mixed>, void: bool}|false|null
      */
-    private function decodeBlockAttrs(string $json): array
+    private function parseStandaloneBlockDelimiter(string $comment): array|false|null
     {
-        if ( '' === trim($json) ) {
-            return array();
+        if ( ! preg_match('/^<!--\s+.*(?:\s+|\/)-->$/s', $comment) ) {
+            return false;
         }
 
-        $attrs = json_decode($json, true);
+        $body = trim(substr($comment, 4, -3));
+        if ( ! str_starts_with($body, 'wp:') && ! str_starts_with($body, '/wp:') ) {
+            return null;
+        }
 
-        return is_array($attrs) ? $attrs : array();
+        if ( preg_match('/^\/wp:([a-z][a-z0-9_-]*(?:\/[a-z][a-z0-9_-]*)?)$/', $body, $match) ) {
+            return array( 'close' => true, 'name' => $match[1], 'attrs' => array(), 'void' => false );
+        }
+
+        if ( ! preg_match('/^wp:([a-z][a-z0-9_-]*(?:\/[a-z][a-z0-9_-]*)?)(?:\s+(.+?))?$/s', $body, $match) ) {
+            return false;
+        }
+
+        $payload = trim($match[2] ?? '');
+        $isVoid  = str_ends_with($payload, '/');
+        if ( $isVoid ) {
+            $payload = trim(substr($payload, 0, -1));
+        }
+
+        if ( '' === $payload ) {
+            return array( 'close' => false, 'name' => $match[1], 'attrs' => array(), 'void' => $isVoid );
+        }
+
+        if ( ! str_starts_with($payload, '{') || ! str_ends_with($payload, '}') ) {
+            return false;
+        }
+
+        $attrs = json_decode($payload, true);
+        if ( ! is_array($attrs) ) {
+            return false;
+        }
+
+        return array( 'close' => false, 'name' => $match[1], 'attrs' => $attrs, 'void' => $isVoid );
+    }
+
+    /** @param array<int, array<string, mixed>> $blocks */
+    private function appendStandaloneFreeform(array &$blocks, string $html): void
+    {
+        if ( '' !== $html ) {
+            $blocks[] = array(
+                'blockName'    => null,
+                'attrs'        => array(),
+                'innerBlocks'  => array(),
+                'innerHTML'    => $html,
+                'innerContent' => array( $html ),
+            );
+        }
     }
 
     /**

--- a/php-transformer/tests/contract/runtime-no-wordpress.php
+++ b/php-transformer/tests/contract/runtime-no-wordpress.php
@@ -23,6 +23,21 @@ $blocks = $runtime->parseBlocks('<!-- wp:paragraph {"content":"Hello"} --><p>Hel
 assertSame('core/paragraph', $blocks[0]['blockName'] ?? null, 'Fallback parser should parse serialized block comments.');
 assertSame('wordpress_parse_blocks_unavailable', $runtime->diagnostics()[0]['code'] ?? null, 'Fallback parser should expose a diagnostic.');
 
+$parserFixtures = json_decode((string) file_get_contents(dirname(__DIR__) . '/fixtures/contract/standalone-block-parser.json'), true);
+assertSame('blocks-engine/php-transformer/standalone-block-parser/v1', $parserFixtures['schema'] ?? null, 'Standalone parser fixture should expose its schema.');
+foreach ( $parserFixtures['cases'] ?? array() as $case ) {
+    $parsed = $runtime->parseBlocks($case['markup']);
+    if ( 'freeform' === ($case['expectation'] ?? null) ) {
+        assertSame(true, array_key_exists('blockName', $parsed[0] ?? array()) && null === $parsed[0]['blockName'], 'Standalone parser should preserve malformed input as freeform for ' . $case['name']);
+        assertSame($case['markup'], $parsed[0]['innerHTML'] ?? null, 'Standalone parser should preserve malformed input byte-for-byte for ' . $case['name']);
+        continue;
+    }
+    assertSame($case['top_level_block'], $parsed[array_key_exists('freeform_segments', $case) ? 1 : 0]['blockName'] ?? null, 'Standalone parser should parse bounded fixture ' . $case['name']);
+    if ( isset($case['nested_block']) ) assertSame($case['nested_block'], $parsed[0]['innerBlocks'][0]['blockName'] ?? null, 'Standalone parser should retain nested blocks for ' . $case['name']);
+    if ( isset($case['attribute']) ) assertSame($case['attribute'], $parsed[0]['attrs']['content'] ?? null, 'Standalone parser should decode escaped delimiter text for ' . $case['name']);
+    if ( isset($case['freeform_segments']) ) assertSame($case['freeform_segments'], array($parsed[0]['innerHTML'] ?? null, $parsed[2]['innerHTML'] ?? null), 'Standalone parser should preserve freeform interleaving for ' . $case['name']);
+}
+
 $serialized = $runtime->serializeBlocks($blocks);
 assertSame('<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->', $serialized, 'Standalone canonicalization should omit Paragraph rich-text content from block comments.');
 assertSame('wordpress_serialize_blocks_unavailable', $runtime->diagnostics()[0]['code'] ?? null, 'Fallback serializer should expose a diagnostic.');

--- a/php-transformer/tests/fixtures/contract/standalone-block-parser.json
+++ b/php-transformer/tests/fixtures/contract/standalone-block-parser.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/standalone-block-parser/v1",
+  "contract": "Parses only complete canonical block delimiters emitted by this transformer. WordPress parse_blocks() remains authoritative and performs best-effort recovery for malformed input.",
+  "cases": [
+    {
+      "name": "nested attributes",
+      "markup": "<!-- wp:group {\"layout\":{\"type\":\"constrained\"},\"style\":{\"spacing\":{\"padding\":{\"top\":\"2rem\"}}}} --><div><!-- wp:paragraph {\"dropCap\":true} --><p>Text</p><!-- /wp:paragraph --></div><!-- /wp:group -->",
+      "expectation": "parsed",
+      "top_level_block": "core/group",
+      "nested_block": "core/paragraph"
+    },
+    {
+      "name": "escaped delimiter text",
+      "markup": "<!-- wp:paragraph {\"content\":\"before \\u002d\\u002d\\u003e after\"} --><p>Text</p><!-- /wp:paragraph -->",
+      "expectation": "parsed",
+      "top_level_block": "core/paragraph",
+      "attribute": "before --> after"
+    },
+    {
+      "name": "freeform interleaving",
+      "markup": "before<!-- wp:separator /-->after",
+      "expectation": "parsed",
+      "top_level_block": "core/separator",
+      "freeform_segments": ["before", "after"]
+    },
+    {
+      "name": "custom namespace",
+      "markup": "<!-- wp:acme/card {\"featured\":true} /-->",
+      "expectation": "parsed",
+      "top_level_block": "acme/card"
+    },
+    {
+      "name": "malformed recovery is intentionally not core-equivalent",
+      "markup": "<!-- wp:group --><div><!-- wp:paragraph --><p>Text</p><!-- /wp:group -->",
+      "expectation": "freeform",
+      "wordpress_behavior": "best-effort recovery",
+      "standalone_behavior": "preserve the complete document as freeform"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the standalone serialized-block regex with a canonical-delimiter-only scanner
- preserve malformed or unsupported documents as freeform instead of claiming WordPress recovery semantics
- add bounded parser fixtures for nested attributes, escaped delimiter text, freeform interleaving, custom namespaces, and malformed recovery

Closes #959

## Verification
- `php tests/contract/runtime-no-wordpress.php`
- `php -l src/WordPress/Runtime.php`
- live WordPress `parse_blocks()` check: malformed fixture recovers a `core/group` containing `core/paragraph`; the standalone fallback deliberately preserves that complete malformed document as freeform
- `composer test` reaches 90 passing assertions, then fails at the unrelated existing `author-selector-semantics` assertion: `multiple retained custom properties move to generated carrier CSS while supported styles retain a valid core block round trip`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to inspect WordPress parser behavior, implement the bounded fallback, and run verification. Chris is responsible for every line.