### PR TITLE
Fix responsive Figma layout and form semantics

### DIFF
--- a/figma-transformer/scripts/figma-fixture-matrix-quality.php
+++ b/figma-transformer/scripts/figma-fixture-matrix-quality.php
@@ -189,11 +189,8 @@ function matrix_fixture_visual_readiness(array $fixture): array
             array('missing_asset_nodes', 'vector_image_fallbacks', 'image_heavy_landmark_candidates')
         ),
         'form_validity' => matrix_risk_category(
-            matrix_quality_summary_int($summary, 'fallback_prone_form_island_count')
-                + matrix_quality_summary_int($summary, 'fallback_prone_input_island_count')
-                + matrix_quality_summary_int($summary, 'invalid_list_child_count')
-                + matrix_quality_summary_int($summary, 'missing_semantic_role_count'),
-            array('fallback_prone_form_island_count', 'fallback_prone_input_island_count', 'invalid_list_child_count', 'missing_semantic_role_count')
+            matrix_quality_summary_int($summary, 'invalid_list_child_count'),
+            array('invalid_list_child_count')
         ),
         'route_coverage' => matrix_risk_category(
             matrix_quality_summary_int($summary, 'link_targets_unresolved') + $transformRiskOmissionCount,

--- a/figma-transformer/scripts/figma-fixture-matrix-quality.php
+++ b/figma-transformer/scripts/figma-fixture-matrix-quality.php
@@ -57,6 +57,7 @@ function matrix_quality_matrix(array $fixtures): array
     $perFixtureReadiness = array();
     $coverageNumerator = 0;
     $coverageDenominator = 0;
+    $incompleteCoverageFixtureCount = 0;
     $routeCoverageNumerator = 0;
     $routeCoverageDenominator = 0;
 
@@ -79,6 +80,10 @@ function matrix_quality_matrix(array $fixtures): array
         }
         $coverageNumerator += (int) ($summary['fixed_width_with_responsive_override_count'] ?? 0);
         $coverageDenominator += (int) ($summary['fixed_width_declaration_count'] ?? 0);
+        $coverageIncomplete = 'incomplete' === ($summary['fixed_width_coverage_analysis']['status'] ?? null);
+        if ( $coverageIncomplete ) {
+            ++$incompleteCoverageFixtureCount;
+        }
         $selectedRouteCount = max(
             count(is_array($fixture['selected_frame_ids'] ?? null) ? $fixture['selected_frame_ids'] : array()),
             matrix_fixture_emitted_route_count($fixture)
@@ -108,6 +113,7 @@ function matrix_quality_matrix(array $fixtures): array
             'readiness_score' => $readiness['readiness_score'] ?? null,
             'visual_risk_bucket' => $readiness['visual_risk_bucket'] ?? 'unknown',
             'route_coverage_ratio' => $readiness['route_coverage_ratio'] ?? null,
+            'fixed_width_coverage_analysis_status' => $summary['fixed_width_coverage_analysis']['status'] ?? 'complete',
             'dom_css_loaded' => $domSummary['dom_css_loaded'] ?? null,
             'dom_capture_valid' => $domSummary['dom_capture_valid'] ?? null,
             'risk_categories' => $readiness['risk_categories'] ?? array(),
@@ -126,7 +132,11 @@ function matrix_quality_matrix(array $fixtures): array
         'visual_risk_bucket_counts' => $riskBucketCounts,
         'risk_category_totals' => $riskCategoryTotals,
         'per_fixture_readiness' => $perFixtureReadiness,
-        'effective_responsive_coverage_ratio' => $coverageDenominator > 0 ? round($coverageNumerator / $coverageDenominator, 3) : 1.0,
+        'effective_responsive_coverage_ratio' => $incompleteCoverageFixtureCount > 0 ? 0.0 : ($coverageDenominator > 0 ? round($coverageNumerator / $coverageDenominator, 3) : 1.0),
+        'fixed_width_coverage_analysis' => array(
+            'status' => $incompleteCoverageFixtureCount > 0 ? 'incomplete' : 'complete',
+            'incomplete_fixture_count' => $incompleteCoverageFixtureCount,
+        ),
         'route_coverage_ratio' => $routeCoverageDenominator > 0 ? round($routeCoverageNumerator / $routeCoverageDenominator, 3) : 1.0,
         'totals' => $totals,
         'totals_by_comparison_role' => $totalsByComparisonRole,
@@ -162,8 +172,9 @@ function matrix_fixture_visual_readiness(array $fixture): array
         'responsive_coverage' => matrix_risk_category(
             matrix_quality_summary_int($summary, 'fixed_width_without_responsive_override_count')
                 + matrix_quality_summary_int($summary, 'fixed_width_over_desktop_uncovered_count')
-                + (true === ($summary['desktop_canvas_without_responsive_breakpoints'] ?? null) ? 1 : 0),
-            array('fixed_width_without_responsive_override_count', 'fixed_width_over_desktop_uncovered_count', 'desktop_canvas_without_responsive_breakpoints')
+                + (true === ($summary['desktop_canvas_without_responsive_breakpoints'] ?? null) ? 1 : 0)
+                + ('incomplete' === ($summary['fixed_width_coverage_analysis']['status'] ?? null) ? 1 : 0),
+            array('fixed_width_without_responsive_override_count', 'fixed_width_over_desktop_uncovered_count', 'desktop_canvas_without_responsive_breakpoints', 'fixed_width_coverage_analysis')
         ),
         'absolute_scaffolding' => matrix_risk_category(
             matrix_quality_summary_int($summary, 'large_absolute_offset_count')

--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -1588,6 +1588,15 @@ final class FigmaTransformer
             'fixed_width_without_responsive_override_count' => 0,
             'effective_responsive_coverage_ratio' => 1.0,
             'fixed_width_samples' => array(),
+            'fixed_width_coverage_analysis' => array(
+                'status' => 'complete',
+                'diagnostic' => null,
+                'page_count' => 0,
+                'incomplete_page_count' => 0,
+                'contexts_evaluated' => 0,
+                'operations_evaluated' => 0,
+                'incomplete_pages' => array(),
+            ),
             'large_fixed_canvas_height' => false,
             'desktop_canvas_without_responsive_breakpoints' => false,
             'giant_fixed_section_count' => 0,
@@ -1665,6 +1674,19 @@ final class FigmaTransformer
             DiagnosticAggregation::appendContextSamples($htmlArtifact, 'giant_fixed_sections', $pageHtmlArtifact, 'giant_fixed_sections', $pageContext);
             DiagnosticAggregation::appendContextSamples($htmlArtifact, 'large_overflow_risks', $pageHtmlArtifact, 'large_overflow_risks', $pageContext);
             DiagnosticAggregation::appendContextSamples($htmlArtifact, 'semantic_role_samples', $pageHtmlArtifact, 'semantic_role_samples', $pageContext);
+            $pageCoverageAnalysis = is_array($pageHtmlArtifact['fixed_width_coverage_analysis'] ?? null) ? $pageHtmlArtifact['fixed_width_coverage_analysis'] : array();
+            ++$htmlArtifact['fixed_width_coverage_analysis']['page_count'];
+            $htmlArtifact['fixed_width_coverage_analysis']['contexts_evaluated'] += (int) ($pageCoverageAnalysis['contexts_evaluated'] ?? 0);
+            $htmlArtifact['fixed_width_coverage_analysis']['operations_evaluated'] += (int) ($pageCoverageAnalysis['operations_evaluated'] ?? 0);
+            if ( 'incomplete' === ($pageCoverageAnalysis['status'] ?? null) ) {
+                $htmlArtifact['fixed_width_coverage_analysis']['status'] = 'incomplete';
+                $htmlArtifact['fixed_width_coverage_analysis']['diagnostic'] = 'fixed_width_coverage_budget_exceeded';
+                ++$htmlArtifact['fixed_width_coverage_analysis']['incomplete_page_count'];
+                $htmlArtifact['fixed_width_coverage_analysis']['incomplete_pages'][] = array_merge($pageContext, array(
+                    'contexts_evaluated' => (int) ($pageCoverageAnalysis['contexts_evaluated'] ?? 0),
+                    'operations_evaluated' => (int) ($pageCoverageAnalysis['operations_evaluated'] ?? 0),
+                ));
+            }
             $htmlArtifact['large_fixed_canvas_height'] = ! empty($htmlArtifact['large_fixed_canvas_height']) || ! empty($pageHtmlArtifact['large_fixed_canvas_height']);
             $htmlArtifact['desktop_canvas_without_responsive_breakpoints'] = ! empty($htmlArtifact['desktop_canvas_without_responsive_breakpoints']) || ! empty($pageHtmlArtifact['desktop_canvas_without_responsive_breakpoints']);
             $this->mergeDecisionTraceDiagnostics($decisionTraces, is_array($diagnostics['decision_traces'] ?? null) ? $diagnostics['decision_traces'] : array(), $pageContext);
@@ -1779,10 +1801,13 @@ final class FigmaTransformer
         $htmlArtifact['giant_fixed_sections'] = array_slice(array_values($htmlArtifact['giant_fixed_sections']), 0, 25);
         $htmlArtifact['large_overflow_risks'] = array_slice(array_values($htmlArtifact['large_overflow_risks']), 0, 25);
         $htmlArtifact['semantic_role_samples'] = array_slice(array_values($htmlArtifact['semantic_role_samples']), 0, 25);
+        $htmlArtifact['fixed_width_coverage_analysis']['incomplete_pages'] = array_slice($htmlArtifact['fixed_width_coverage_analysis']['incomplete_pages'], 0, 25);
         $fixedWidthDeclarationCount = (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0);
-        $htmlArtifact['effective_responsive_coverage_ratio'] = $fixedWidthDeclarationCount > 0
+        $htmlArtifact['effective_responsive_coverage_ratio'] = 'incomplete' === ($htmlArtifact['fixed_width_coverage_analysis']['status'] ?? null)
+            ? 0.0
+            : ($fixedWidthDeclarationCount > 0
             ? round((int) ($htmlArtifact['fixed_width_with_responsive_override_count'] ?? 0) / $fixedWidthDeclarationCount, 3)
-            : 1.0;
+            : 1.0);
         ksort($positionalParity['root_stacking_reason_counts']);
         $positionalParity['fixed_over_root_width_underlays'] = array_slice(array_values($positionalParity['fixed_over_root_width_underlays']), 0, 25);
         $positionalParity['chrome_overflow_nodes'] = array_slice(array_values($positionalParity['chrome_overflow_nodes']), 0, 25);
@@ -1971,6 +1996,14 @@ final class FigmaTransformer
                 'sample_rules' => array_slice(is_array($htmlArtifact['fixed_width_samples'] ?? null) ? $htmlArtifact['fixed_width_samples'] : array(), 0, 10),
             );
         }
+        if ( 'incomplete' === ($htmlArtifact['fixed_width_coverage_analysis']['status'] ?? null) ) {
+            $signals[] = array(
+                'severity' => 'warning',
+                'code' => 'fixed_width_coverage_analysis_incomplete',
+                'diagnostic' => (string) ($htmlArtifact['fixed_width_coverage_analysis']['diagnostic'] ?? 'fixed_width_coverage_budget_exceeded'),
+                'incomplete_page_count' => (int) ($htmlArtifact['fixed_width_coverage_analysis']['incomplete_page_count'] ?? 0),
+            );
+        }
         if ( ! empty($htmlArtifact['giant_fixed_section_count']) ) {
             $signals[] = array(
                 'severity' => 'warning',
@@ -2086,6 +2119,7 @@ final class FigmaTransformer
                 'fixed_width_declaration_count' => (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0),
                 'fixed_width_with_responsive_override_count' => (int) ($htmlArtifact['fixed_width_with_responsive_override_count'] ?? 0),
                 'fixed_width_without_responsive_override_count' => (int) ($htmlArtifact['fixed_width_without_responsive_override_count'] ?? 0),
+                'fixed_width_coverage_analysis' => is_array($htmlArtifact['fixed_width_coverage_analysis'] ?? null) ? $htmlArtifact['fixed_width_coverage_analysis'] : array(),
                 'desktop_canvas_without_responsive_breakpoints' => (bool) ($htmlArtifact['desktop_canvas_without_responsive_breakpoints'] ?? false),
                 'giant_fixed_section_count' => (int) ($htmlArtifact['giant_fixed_section_count'] ?? 0),
                 'large_overflow_risk_count' => (int) ($htmlArtifact['large_overflow_risk_count'] ?? 0),

--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -715,7 +715,7 @@ final class BreakpointMediaDiffBuilder
                     }
                     continue;
                 }
-                $responsiveWidthDeclarations = 'width' === $property
+                $responsiveWidthDeclarations = 'width' === $property && ! $this->nodeHasMaxWidthConstraint($baseNode) && ! $this->nodeHasMaxWidthConstraint($variantNode)
                     ? $this->breakpointDimensionPolicy->breakpointWidthDeclarations($value, $baseMap, $baseNode, $variantNode, $baseParentNode, $variantParentNode)
                     : null;
                 if ( null !== $responsiveWidthDeclarations ) {
@@ -800,6 +800,12 @@ final class BreakpointMediaDiffBuilder
             $variantNode = '' !== $pathKey && is_array($variantStyles[$pathKey]['node'] ?? null) ? $variantStyles[$pathKey]['node'] : null;
             $decision = $this->responsiveBreakpointSafetyPolicy->responsiveSafetyDecision($node, $parentNode, $baseMap, $viewportWidth, $depth, $grandParentNode, $variantNode);
             $declarations = is_array($decision['declarations'] ?? null) ? $decision['declarations'] : array();
+            if ( $this->nodeHasMaxWidthConstraint($node) ) {
+                $declarations = array_values(array_filter(
+                    $declarations,
+                    static fn (string $declaration): bool => ! str_starts_with($declaration, 'width:') && ! str_starts_with($declaration, 'max-width:')
+                ));
+            }
             if ( empty($declarations) ) {
                 continue;
             }
@@ -856,6 +862,7 @@ final class BreakpointMediaDiffBuilder
                 || 'absolute' === ($baseMap['position'] ?? null)
                 || $this->usesFullBleedViewportBreakout($baseMap)
                 || $this->hasResponsiveWidthConstraint($baseMap)
+                || $this->nodeHasMaxWidthConstraint($base['node'] ?? array())
             ) {
                 continue;
             }
@@ -869,7 +876,14 @@ final class BreakpointMediaDiffBuilder
     /** @param array<string, string> $declarations */
     private function hasResponsiveWidthConstraint(array $declarations): bool
     {
-        return isset($declarations['max-width']) && preg_match('/^(?:100%|calc\(|clamp\(|min\()/i', $declarations['max-width']);
+        return isset($declarations['max-width']);
+    }
+
+    /** @param array<string, mixed> $node */
+    private function nodeHasMaxWidthConstraint(array $node): bool
+    {
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        return isset($layout['max_width']) && is_numeric($layout['max_width']);
     }
 
     /**

--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -827,7 +827,49 @@ final class BreakpointMediaDiffBuilder
             }
         }
 
+        if ( $viewportWidth <= 480.0 ) {
+            $rules = array_merge($rules, $this->fixedWidthBoundaryRules($baseStyles));
+        }
+
         return array_values(array_unique($rules));
+    }
+
+    /**
+     * A mobile variant can intentionally retain a fixed intrinsic width that
+     * fits its source canvas. Cap it at its containing width so later parent
+     * layout changes cannot make that otherwise valid geometry overflow.
+     *
+     * @param array<string, array<string, mixed>> $baseStyles
+     * @return array<int, string>
+     */
+    private function fixedWidthBoundaryRules(array $baseStyles): array
+    {
+        $rules = array();
+        foreach ( $baseStyles as $base ) {
+            $class = isset($base['class']) && is_scalar($base['class']) ? (string) $base['class'] : '';
+            $baseMap = $this->styleDeclarationMap(is_array($base['styles'] ?? null) ? $base['styles'] : array());
+            $width = $this->cssPixelValue($baseMap['width'] ?? '');
+            if (
+                '' === $class
+                || null === $width
+                || $width < 320.0
+                || 'absolute' === ($baseMap['position'] ?? null)
+                || $this->usesFullBleedViewportBreakout($baseMap)
+                || $this->hasResponsiveWidthConstraint($baseMap)
+            ) {
+                continue;
+            }
+
+            $rules[] = '.' . $class . '{max-width:100%;box-sizing:border-box}';
+        }
+
+        return array_values(array_unique($rules));
+    }
+
+    /** @param array<string, string> $declarations */
+    private function hasResponsiveWidthConstraint(array $declarations): bool
+    {
+        return isset($declarations['max-width']) && preg_match('/^(?:100%|calc\(|clamp\(|min\()/i', $declarations['max-width']);
     }
 
     /**

--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -800,7 +800,7 @@ final class BreakpointMediaDiffBuilder
             $variantNode = '' !== $pathKey && is_array($variantStyles[$pathKey]['node'] ?? null) ? $variantStyles[$pathKey]['node'] : null;
             $decision = $this->responsiveBreakpointSafetyPolicy->responsiveSafetyDecision($node, $parentNode, $baseMap, $viewportWidth, $depth, $grandParentNode, $variantNode);
             $declarations = is_array($decision['declarations'] ?? null) ? $decision['declarations'] : array();
-            if ( $this->nodeHasMaxWidthConstraint($node) ) {
+            if ( $this->nodeHasMaxWidthConstraint($node) || (is_array($variantNode) && $this->nodeHasMaxWidthConstraint($variantNode)) ) {
                 $declarations = array_values(array_filter(
                     $declarations,
                     static fn (string $declaration): bool => ! str_starts_with($declaration, 'width:') && ! str_starts_with($declaration, 'max-width:')
@@ -834,7 +834,7 @@ final class BreakpointMediaDiffBuilder
         }
 
         if ( $viewportWidth <= 480.0 ) {
-            $rules = array_merge($rules, $this->fixedWidthBoundaryRules($baseStyles));
+            $rules = array_merge($rules, $this->fixedWidthBoundaryRules($baseStyles, $variantStyles));
         }
 
         return array_values(array_unique($rules));
@@ -846,12 +846,13 @@ final class BreakpointMediaDiffBuilder
      * layout changes cannot make that otherwise valid geometry overflow.
      *
      * @param array<string, array<string, mixed>> $baseStyles
+     * @param array<string, array<string, mixed>> $variantStyles
      * @return array<int, string>
      */
-    private function fixedWidthBoundaryRules(array $baseStyles): array
+    private function fixedWidthBoundaryRules(array $baseStyles, array $variantStyles): array
     {
         $rules = array();
-        foreach ( $baseStyles as $base ) {
+        foreach ( $baseStyles as $pathKey => $base ) {
             $class = isset($base['class']) && is_scalar($base['class']) ? (string) $base['class'] : '';
             $baseMap = $this->styleDeclarationMap(is_array($base['styles'] ?? null) ? $base['styles'] : array());
             $width = $this->cssPixelValue($baseMap['width'] ?? '');
@@ -863,6 +864,7 @@ final class BreakpointMediaDiffBuilder
                 || $this->usesFullBleedViewportBreakout($baseMap)
                 || $this->hasResponsiveWidthConstraint($baseMap)
                 || $this->nodeHasMaxWidthConstraint($base['node'] ?? array())
+                || $this->nodeHasMaxWidthConstraint(is_array($variantStyles[$pathKey]['node'] ?? null) ? $variantStyles[$pathKey]['node'] : array())
             ) {
                 continue;
             }

--- a/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
+use DOMDocument;
+use DOMElement;
+
 /**
  * Builds diagnostics derived from emitted static HTML artifacts.
  */
@@ -240,7 +243,6 @@ final class StaticHtmlEmissionDiagnostics
         $rules = $this->cssRuleDeclarations($css);
         $base = array();
         $responsive = array();
-        $overDesktop = array();
         $samples = array();
         $fixedWidthOverDesktopCount = 0;
 
@@ -249,9 +251,7 @@ final class StaticHtmlEmissionDiagnostics
             $declarations = (string) ($rule['declarations'] ?? '');
             $classes = $this->selectorClassNames($selector);
             if ( ! empty($rule['media']) && preg_match('/(?:^|;)\s*(?:width|max-width)\s*:/i', $declarations) ) {
-                foreach ( $classes as $class ) {
-                    $responsive[$class] = true;
-                }
+                $responsive[] = $selector;
                 continue;
             }
 
@@ -264,13 +264,16 @@ final class StaticHtmlEmissionDiagnostics
             }
 
             foreach ( $classes as $class ) {
-                $base[$class] = true;
+                $base[] = array(
+                    'class' => $class,
+                    'selector' => $selector,
+                    'over_desktop' => $width > 1440.0,
+                );
                 if ( $this->hasResponsiveWidthConstraint($declarations) ) {
-                    $responsive[$class] = true;
+                    $responsive[] = $selector;
                 }
                 if ( $width > 1440.0 ) {
                     ++$fixedWidthOverDesktopCount;
-                    $overDesktop[$class] = true;
                 }
                 if ( count($samples) < 25 ) {
                     $samples[] = array(
@@ -282,17 +285,21 @@ final class StaticHtmlEmissionDiagnostics
             }
         }
 
-        $classSets = $this->htmlClassSets($html);
+        $elements = $this->htmlElements($html);
         $totalCount = 0;
         $coveredCount = 0;
         $overDesktopCoveredClasses = array();
         $overDesktopUncoveredClasses = array();
-        foreach ( $base as $class => $_ ) {
-            foreach ( $classSets[$class] ?? array() as $classSet ) {
+        foreach ( $base as $baseContext ) {
+            $class = (string) $baseContext['class'];
+            foreach ( $elements as $element ) {
+                if ( ! $this->selectorMatchesElement((string) $baseContext['selector'], $element) ) {
+                    continue;
+                }
                 ++$totalCount;
                 $covered = false;
-                foreach ( $classSet as $elementClass ) {
-                    if ( isset($responsive[$elementClass]) ) {
+                foreach ( $responsive as $selector ) {
+                    if ( $this->selectorMatchesElement($selector, $element) ) {
                         $covered = true;
                         break;
                     }
@@ -300,7 +307,7 @@ final class StaticHtmlEmissionDiagnostics
                 if ( $covered ) {
                     ++$coveredCount;
                 }
-                if ( ! isset($overDesktop[$class]) ) {
+                if ( ! $baseContext['over_desktop'] ) {
                     continue;
                 }
                 if ( $covered ) {
@@ -327,26 +334,172 @@ final class StaticHtmlEmissionDiagnostics
     }
 
     /**
-     * @return array<string, array<int, array<int, string>>>
+     * @return array<int, DOMElement>
      */
-    private function htmlClassSets(string $html): array
+    private function htmlElements(string $html): array
     {
-        $classSets = array();
-        if ( ! preg_match_all('/\bclass\s*=\s*(["\'])(.*?)\1/is', $html, $matches, PREG_SET_ORDER) ) {
-            return $classSets;
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML('<?xml encoding="UTF-8"><html><body>' . $html . '</body></html>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if ( ! $loaded ) {
+            return array();
         }
 
-        foreach ( $matches as $match ) {
-            $classes = preg_split('/\s+/', trim((string) ($match[2] ?? ''))) ?: array();
-            foreach ( $classes as $class ) {
-                if ( '' === $class ) {
-                    continue;
-                }
-                $classSets[$class][] = $classes;
+        $elements = array();
+        foreach ( $document->getElementsByTagName('*') as $element ) {
+            if ( $element instanceof DOMElement && 'html' !== $element->tagName && 'body' !== $element->tagName ) {
+                $elements[] = $element;
             }
         }
 
-        return $classSets;
+        return $elements;
+    }
+
+    private function selectorMatchesElement(string $selector, DOMElement $element): bool
+    {
+        foreach ( $this->splitSelectorList($selector) as $selectorPart ) {
+            $parts = $this->selectorParts($selectorPart);
+            if ( ! empty($parts) && $this->selectorPartMatchesElement($parts, count($parts) - 1, $element) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function splitSelectorList(string $selector): array
+    {
+        $selectors = array();
+        $start = 0;
+        $depth = 0;
+        for ( $index = 0, $length = strlen($selector); $index < $length; ++$index ) {
+            if ( '(' === $selector[$index] || '[' === $selector[$index] ) {
+                ++$depth;
+            } elseif ( ')' === $selector[$index] || ']' === $selector[$index] ) {
+                --$depth;
+            } elseif ( ',' === $selector[$index] && 0 === $depth ) {
+                $selectors[] = trim(substr($selector, $start, $index - $start));
+                $start = $index + 1;
+            }
+        }
+        $selectors[] = trim(substr($selector, $start));
+
+        return array_values(array_filter($selectors));
+    }
+
+    /**
+     * @return array<int, array{compound: string, combinator: string}>
+     */
+    private function selectorParts(string $selector): array
+    {
+        $parts = array();
+        $compound = '';
+        $combinator = '';
+        $depth = 0;
+        $flush = static function () use (&$parts, &$compound, &$combinator): void {
+            $compound = trim($compound);
+            if ( '' !== $compound ) {
+                $parts[] = array('compound' => $compound, 'combinator' => $combinator);
+                $compound = '';
+                $combinator = ' ';
+            }
+        };
+        for ( $index = 0, $length = strlen($selector); $index < $length; ++$index ) {
+            $character = $selector[$index];
+            if ( '(' === $character || '[' === $character ) {
+                ++$depth;
+            } elseif ( ')' === $character || ']' === $character ) {
+                --$depth;
+            }
+            if ( 0 === $depth && ( '>' === $character || '+' === $character || '~' === $character ) ) {
+                $flush();
+                $combinator = $character;
+                continue;
+            }
+            if ( 0 === $depth && ctype_space($character) ) {
+                $flush();
+                continue;
+            }
+            $compound .= $character;
+        }
+        $flush();
+
+        return $parts;
+    }
+
+    /**
+     * @param array<int, array{compound: string, combinator: string}> $parts
+     */
+    private function selectorPartMatchesElement(array $parts, int $index, DOMElement $element): bool
+    {
+        if ( ! $this->compoundMatchesElement($parts[$index]['compound'], $element) ) {
+            return false;
+        }
+        if ( 0 === $index ) {
+            return true;
+        }
+
+        $combinator = $parts[$index]['combinator'];
+        if ( '>' === $combinator ) {
+            return $element->parentNode instanceof DOMElement && $this->selectorPartMatchesElement($parts, $index - 1, $element->parentNode);
+        }
+        $sibling = $element->previousSibling;
+        if ( '+' === $combinator || '~' === $combinator ) {
+            while ( null !== $sibling && ! $sibling instanceof DOMElement ) {
+                $sibling = $sibling->previousSibling;
+            }
+            if ( ! $sibling instanceof DOMElement ) {
+                return false;
+            }
+            if ( '+' === $combinator ) {
+                return $this->selectorPartMatchesElement($parts, $index - 1, $sibling);
+            }
+            while ( $sibling instanceof DOMElement ) {
+                if ( $this->selectorPartMatchesElement($parts, $index - 1, $sibling) ) {
+                    return true;
+                }
+                $sibling = $sibling->previousSibling;
+                while ( null !== $sibling && ! $sibling instanceof DOMElement ) {
+                    $sibling = $sibling->previousSibling;
+                }
+            }
+            return false;
+        }
+        for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
+            if ( $this->selectorPartMatchesElement($parts, $index - 1, $ancestor) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function compoundMatchesElement(string $compound, DOMElement $element): bool
+    {
+        if ( 1 === preg_match('/^[a-z][a-z0-9:-]*/i', $compound, $tag) && strtolower($tag[0]) !== strtolower($element->tagName) ) {
+            return false;
+        }
+        if ( str_contains($compound, ':') || str_contains($compound, '[') ) {
+            return false;
+        }
+        if ( preg_match_all('/\.([a-zA-Z0-9_-]+)/', $compound, $classes) ) {
+            $elementClasses = preg_split('/\s+/', trim($element->getAttribute('class'))) ?: array();
+            foreach ( $classes[1] as $class ) {
+                if ( ! in_array($class, $elementClasses, true) ) {
+                    return false;
+                }
+            }
+        }
+        if ( 1 === preg_match('/#([a-zA-Z0-9_-]+)/', $compound, $id) && $id[1] !== $element->getAttribute('id') ) {
+            return false;
+        }
+
+        return true;
     }
 
     private function hasResponsiveWidthConstraint(string $declarations): bool

--- a/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
@@ -12,6 +12,9 @@ use DOMElement;
  */
 final class StaticHtmlEmissionDiagnostics
 {
+    private const FIXED_WIDTH_COVERAGE_CONTEXT_BUDGET = 20000;
+    private const FIXED_WIDTH_COVERAGE_OPERATION_BUDGET = 100000;
+
     /**
      * @param array<string, mixed> $coverage
      * @param array<string, string> $implicitRouteTargets
@@ -216,6 +219,7 @@ final class StaticHtmlEmissionDiagnostics
             'fixed_width_over_desktop_uncovered_count' => (int) $fixedWidthCoverage['fixed_width_over_desktop_uncovered_count'],
             'fixed_width_over_desktop_covered_classes' => array_slice($fixedWidthCoverage['fixed_width_over_desktop_covered_classes'], 0, 25),
             'fixed_width_over_desktop_uncovered_classes' => array_slice($fixedWidthCoverage['fixed_width_over_desktop_uncovered_classes'], 0, 25),
+            'fixed_width_coverage_analysis' => $fixedWidthCoverage['analysis'],
             'large_fixed_canvas_height' => $largeFixedCanvasHeight,
             'desktop_canvas_without_responsive_breakpoints' => 0 === $mediaQueryCount && $largeFixedCanvasHeight && $structuralElementCount >= 80,
             'giant_fixed_section_count' => (int) $largeFixedSections['giant_fixed_section_count'],
@@ -236,7 +240,7 @@ final class StaticHtmlEmissionDiagnostics
     }
 
     /**
-     * @return array{fixed_width_declaration_count: int, fixed_width_over_desktop_count: int, fixed_width_with_responsive_override_count: int, fixed_width_without_responsive_override_count: int, effective_responsive_coverage_ratio: float, fixed_width_samples: array<int, array<string, mixed>>, fixed_width_over_desktop_class_count: int, fixed_width_over_desktop_covered_count: int, fixed_width_over_desktop_uncovered_count: int, fixed_width_over_desktop_covered_classes: array<int, string>, fixed_width_over_desktop_uncovered_classes: array<int, string>}
+     * @return array<string, mixed>
      */
     private function fixedWidthCoverage(string $html, string $css): array
     {
@@ -286,22 +290,60 @@ final class StaticHtmlEmissionDiagnostics
         }
 
         $elements = $this->htmlElements($html);
+        $indexes = $this->elementIndexes($elements);
+        $operations = 0;
+        $contexts = 0;
+        $incomplete = false;
+        $responsiveCandidates = array();
+        foreach ($responsive as $responsiveIndex => $selector) {
+            $candidates = $this->selectorCandidateElements($selector, $indexes);
+            $contexts += count($candidates);
+            if ($contexts > self::FIXED_WIDTH_COVERAGE_CONTEXT_BUDGET) {
+                $incomplete = true;
+                break;
+            }
+            foreach ($candidates as $element) {
+                $responsiveCandidates[spl_object_id($element)][$responsiveIndex] = $selector;
+            }
+        }
         $totalCount = 0;
         $coveredCount = 0;
         $overDesktopCoveredClasses = array();
         $overDesktopUncoveredClasses = array();
         foreach ( $base as $baseContext ) {
             $class = (string) $baseContext['class'];
-            foreach ( $elements as $element ) {
-                if ( ! $this->selectorMatchesElement((string) $baseContext['selector'], $element) ) {
+            $baseCandidates = $this->selectorCandidateElements((string) $baseContext['selector'], $indexes);
+            $contexts += count($baseCandidates);
+            if ($contexts > self::FIXED_WIDTH_COVERAGE_CONTEXT_BUDGET) {
+                $incomplete = true;
+                break;
+            }
+            foreach ( $baseCandidates as $element ) {
+                if (++$operations > self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET) {
+                    $incomplete = true;
+                    break 2;
+                }
+                if ( ! $this->selectorMatchesElement((string) $baseContext['selector'], $element, $operations) ) {
+                    if ($operations > self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET) {
+                        $incomplete = true;
+                        break 2;
+                    }
                     continue;
                 }
                 ++$totalCount;
                 $covered = false;
-                foreach ( $responsive as $selector ) {
-                    if ( $this->selectorMatchesElement($selector, $element) ) {
+                foreach ($responsiveCandidates[spl_object_id($element)] ?? array() as $selector) {
+                    if (++$operations > self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET) {
+                        $incomplete = true;
+                        break 3;
+                    }
+                    if ( $this->selectorMatchesElement($selector, $element, $operations) ) {
                         $covered = true;
                         break;
+                    }
+                    if ($operations > self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET) {
+                        $incomplete = true;
+                        break 3;
                     }
                 }
                 if ( $covered ) {
@@ -323,14 +365,84 @@ final class StaticHtmlEmissionDiagnostics
             'fixed_width_over_desktop_count' => $fixedWidthOverDesktopCount,
             'fixed_width_with_responsive_override_count' => $coveredCount,
             'fixed_width_without_responsive_override_count' => max(0, $totalCount - $coveredCount),
-            'effective_responsive_coverage_ratio' => $totalCount > 0 ? round($coveredCount / $totalCount, 3) : 1.0,
+            // A partial analysis must never be reported as a passing coverage result.
+            'effective_responsive_coverage_ratio' => $incomplete ? 0.0 : ($totalCount > 0 ? round($coveredCount / $totalCount, 3) : 1.0),
             'fixed_width_samples' => $samples,
             'fixed_width_over_desktop_class_count' => count($overDesktopCoveredClasses) + count($overDesktopUncoveredClasses),
             'fixed_width_over_desktop_covered_count' => count($overDesktopCoveredClasses),
             'fixed_width_over_desktop_uncovered_count' => count($overDesktopUncoveredClasses),
             'fixed_width_over_desktop_covered_classes' => $overDesktopCoveredClasses,
             'fixed_width_over_desktop_uncovered_classes' => $overDesktopUncoveredClasses,
+            'analysis' => array(
+                'status' => $incomplete ? 'incomplete' : 'complete',
+                'diagnostic' => $incomplete ? 'fixed_width_coverage_budget_exceeded' : null,
+                'contexts_evaluated' => min($contexts, self::FIXED_WIDTH_COVERAGE_CONTEXT_BUDGET),
+                'context_budget' => self::FIXED_WIDTH_COVERAGE_CONTEXT_BUDGET,
+                'operations_evaluated' => min($operations, self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET),
+                'operation_budget' => self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET,
+            ),
         );
+    }
+
+    /**
+     * @param array<int, DOMElement> $elements
+     * @return array<string, array<string, array<int, DOMElement>>>
+     */
+    private function elementIndexes(array $elements): array
+    {
+        $indexes = array('all' => array('all' => $elements), 'class' => array(), 'id' => array(), 'tag' => array());
+        foreach ($elements as $element) {
+            $indexes['tag'][strtolower($element->tagName)][] = $element;
+            $id = $element->getAttribute('id');
+            if ('' !== $id) {
+                $indexes['id'][$id][] = $element;
+            }
+            foreach (preg_split('/\s+/', trim($element->getAttribute('class'))) ?: array() as $class) {
+                if ('' !== $class) {
+                    $indexes['class'][$class][] = $element;
+                }
+            }
+        }
+
+        return $indexes;
+    }
+
+    /**
+     * Returns an indexed superset; selectorMatchesElement retains exact semantics.
+     *
+     * @param array<string, array<string, array<int, DOMElement>>> $indexes
+     * @return array<int, DOMElement>
+     */
+    private function selectorCandidateElements(string $selector, array $indexes): array
+    {
+        $candidates = array();
+        foreach ($this->splitSelectorList($selector) as $selectorPart) {
+            $parts = $this->selectorParts($selectorPart);
+            $compound = $parts[count($parts) - 1]['compound'] ?? '';
+            $buckets = array();
+            if (preg_match('/#([a-zA-Z0-9_-]+)/', $compound, $id)) {
+                $buckets[] = $indexes['id'][$id[1]] ?? array();
+            }
+            if (preg_match_all('/\.([a-zA-Z0-9_-]+)/', $compound, $classes)) {
+                foreach ($classes[1] as $class) {
+                    $buckets[] = $indexes['class'][$class] ?? array();
+                }
+            }
+            if (preg_match('/^[a-z][a-z0-9:-]*/i', $compound, $tag)) {
+                $buckets[] = $indexes['tag'][strtolower($tag[0])] ?? array();
+            }
+            if (empty($buckets)) {
+                $buckets[] = $indexes['all']['all'];
+            }
+            usort($buckets, static fn (array $left, array $right): int => count($left) <=> count($right));
+            foreach ($buckets[0] as $element) {
+                // The smallest rightmost bucket bounds candidate work; exact matching
+                // below verifies every remaining compound and combinator constraint.
+                $candidates[spl_object_id($element)] = $element;
+            }
+        }
+
+        return array_values($candidates);
     }
 
     /**
@@ -357,11 +469,11 @@ final class StaticHtmlEmissionDiagnostics
         return $elements;
     }
 
-    private function selectorMatchesElement(string $selector, DOMElement $element): bool
+    private function selectorMatchesElement(string $selector, DOMElement $element, int &$operations): bool
     {
         foreach ( $this->splitSelectorList($selector) as $selectorPart ) {
             $parts = $this->selectorParts($selectorPart);
-            if ( ! empty($parts) && $this->selectorPartMatchesElement($parts, count($parts) - 1, $element) ) {
+            if ( ! empty($parts) && $this->selectorPartMatchesElement($parts, count($parts) - 1, $element, $operations) ) {
                 return true;
             }
         }
@@ -435,8 +547,11 @@ final class StaticHtmlEmissionDiagnostics
     /**
      * @param array<int, array{compound: string, combinator: string}> $parts
      */
-    private function selectorPartMatchesElement(array $parts, int $index, DOMElement $element): bool
+    private function selectorPartMatchesElement(array $parts, int $index, DOMElement $element, int &$operations): bool
     {
+        if (++$operations > self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET) {
+            return false;
+        }
         if ( ! $this->compoundMatchesElement($parts[$index]['compound'], $element) ) {
             return false;
         }
@@ -446,7 +561,7 @@ final class StaticHtmlEmissionDiagnostics
 
         $combinator = $parts[$index]['combinator'];
         if ( '>' === $combinator ) {
-            return $element->parentNode instanceof DOMElement && $this->selectorPartMatchesElement($parts, $index - 1, $element->parentNode);
+            return $element->parentNode instanceof DOMElement && $this->selectorPartMatchesElement($parts, $index - 1, $element->parentNode, $operations);
         }
         $sibling = $element->previousSibling;
         if ( '+' === $combinator || '~' === $combinator ) {
@@ -457,10 +572,10 @@ final class StaticHtmlEmissionDiagnostics
                 return false;
             }
             if ( '+' === $combinator ) {
-                return $this->selectorPartMatchesElement($parts, $index - 1, $sibling);
+                return $this->selectorPartMatchesElement($parts, $index - 1, $sibling, $operations);
             }
             while ( $sibling instanceof DOMElement ) {
-                if ( $this->selectorPartMatchesElement($parts, $index - 1, $sibling) ) {
+                if ( $this->selectorPartMatchesElement($parts, $index - 1, $sibling, $operations) ) {
                     return true;
                 }
                 $sibling = $sibling->previousSibling;
@@ -471,7 +586,7 @@ final class StaticHtmlEmissionDiagnostics
             return false;
         }
         for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement; $ancestor = $ancestor->parentNode ) {
-            if ( $this->selectorPartMatchesElement($parts, $index - 1, $ancestor) ) {
+            if ( $this->selectorPartMatchesElement($parts, $index - 1, $ancestor, $operations) ) {
                 return true;
             }
         }

--- a/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
@@ -692,7 +692,7 @@ final class StaticHtmlEmissionDiagnostics
     {
         $sections = array();
         foreach ( $this->cssRuleDeclarations($css) as $rule ) {
-            $height = $this->cssNumericDeclaration((string) $rule['declarations'], 'height') ?? $this->cssNumericDeclaration((string) $rule['declarations'], 'min-height');
+            $height = $this->cssNumericDeclaration((string) $rule['declarations'], 'height');
             $width = $this->cssNumericDeclaration((string) $rule['declarations'], 'width');
             if ( null === $height || $height < 1800.0 || (null !== $width && $width < 960.0) || '' !== (string) $rule['media'] ) {
                 continue;

--- a/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
@@ -249,13 +249,15 @@ final class StaticHtmlEmissionDiagnostics
         $responsive = array();
         $samples = array();
         $fixedWidthOverDesktopCount = 0;
+        $declarationIndex = 0;
 
         foreach ( $rules as $rule ) {
             $selector = (string) ($rule['selector'] ?? '');
             $declarations = (string) ($rule['declarations'] ?? '');
-            $classes = $this->selectorClassNames($selector);
             if ( ! empty($rule['media']) && preg_match('/(?:^|;)\s*(?:width|max-width)\s*:/i', $declarations) ) {
-                $responsive[] = $selector;
+                foreach ( $this->splitSelectorList($selector) as $selectorPart ) {
+                    $responsive[] = $selectorPart;
+                }
                 continue;
             }
 
@@ -267,26 +269,32 @@ final class StaticHtmlEmissionDiagnostics
                 continue;
             }
 
-            foreach ( $classes as $class ) {
+            foreach ( $this->splitSelectorList($selector) as $selectorPart ) {
+                $classes = $this->selectorClassNames($selectorPart);
+                if ( empty($classes) ) {
+                    continue;
+                }
                 $base[] = array(
-                    'class' => $class,
-                    'selector' => $selector,
+                    'class' => $classes[0],
+                    'selector' => $selectorPart,
+                    'declaration' => $declarationIndex,
                     'over_desktop' => $width > 1440.0,
                 );
                 if ( $this->hasResponsiveWidthConstraint($declarations) ) {
-                    $responsive[] = $selector;
+                    $responsive[] = $selectorPart;
                 }
                 if ( $width > 1440.0 ) {
                     ++$fixedWidthOverDesktopCount;
                 }
                 if ( count($samples) < 25 ) {
                     $samples[] = array(
-                        'class' => $class,
+                        'class' => $classes[0],
                         'width' => $width,
-                        'selector' => $selector,
+                        'selector' => $selectorPart,
                     );
                 }
             }
+            ++$declarationIndex;
         }
 
         $elements = $this->htmlElements($html);
@@ -310,6 +318,7 @@ final class StaticHtmlEmissionDiagnostics
         $coveredCount = 0;
         $overDesktopCoveredClasses = array();
         $overDesktopUncoveredClasses = array();
+        $evaluatedDeclarations = array();
         foreach ( $base as $baseContext ) {
             $class = (string) $baseContext['class'];
             $baseCandidates = $this->selectorCandidateElements((string) $baseContext['selector'], $indexes);
@@ -319,6 +328,11 @@ final class StaticHtmlEmissionDiagnostics
                 break;
             }
             foreach ( $baseCandidates as $element ) {
+                $elementId = spl_object_id($element);
+                $declaration = (int) $baseContext['declaration'];
+                if ( isset($evaluatedDeclarations[$declaration][$elementId]) ) {
+                    continue;
+                }
                 if (++$operations > self::FIXED_WIDTH_COVERAGE_OPERATION_BUDGET) {
                     $incomplete = true;
                     break 2;
@@ -330,6 +344,7 @@ final class StaticHtmlEmissionDiagnostics
                     }
                     continue;
                 }
+                $evaluatedDeclarations[$declaration][$elementId] = true;
                 ++$totalCount;
                 $covered = false;
                 foreach ($responsiveCandidates[spl_object_id($element)] ?? array() as $selector) {

--- a/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
@@ -179,7 +179,7 @@ final class StaticHtmlEmissionDiagnostics
         $breakpointLeaks = $this->breakpointOverrideLeaks($css);
         $absoluteToFlowConversions = $this->absoluteToFlowConversions($css);
         $mediaQueryCount = preg_match_all('/@media\s*\(max-width:[^)]+\)/i', $css) ?: 0;
-        $fixedWidthCoverage = $this->fixedWidthCoverage($css);
+        $fixedWidthCoverage = $this->fixedWidthCoverage($html, $css);
         $fixedWidthOverDesktopCount = (int) $fixedWidthCoverage['fixed_width_over_desktop_count'];
         $largeFixedSections = $this->largeFixedSections($css);
         $largeOverflowRules = $this->largeOverflowRules($css);
@@ -235,7 +235,7 @@ final class StaticHtmlEmissionDiagnostics
     /**
      * @return array{fixed_width_declaration_count: int, fixed_width_over_desktop_count: int, fixed_width_with_responsive_override_count: int, fixed_width_without_responsive_override_count: int, effective_responsive_coverage_ratio: float, fixed_width_samples: array<int, array<string, mixed>>, fixed_width_over_desktop_class_count: int, fixed_width_over_desktop_covered_count: int, fixed_width_over_desktop_uncovered_count: int, fixed_width_over_desktop_covered_classes: array<int, string>, fixed_width_over_desktop_uncovered_classes: array<int, string>}
      */
-    private function fixedWidthCoverage(string $css): array
+    private function fixedWidthCoverage(string $html, string $css): array
     {
         $rules = $this->cssRuleDeclarations($css);
         $base = array();
@@ -282,6 +282,19 @@ final class StaticHtmlEmissionDiagnostics
             }
         }
 
+        // Shared style classes and their per-node Figma hooks coexist on one
+        // emitted element. A breakpoint override on either class constrains the
+        // element, so attribute coverage to the fixed-width shared class too.
+        $classAssociations = $this->htmlClassAssociations($html);
+        foreach ( $base as $class => $_ ) {
+            foreach ( array_keys($classAssociations[$class] ?? array()) as $associatedClass ) {
+                if ( isset($responsive[$associatedClass]) ) {
+                    $responsive[$class] = true;
+                    break;
+                }
+            }
+        }
+
         $baseClasses = array_keys($base);
         $coveredCount = count(array_filter($baseClasses, static fn (string $class): bool => isset($responsive[$class])));
         $totalCount = count($baseClasses);
@@ -301,6 +314,33 @@ final class StaticHtmlEmissionDiagnostics
             'fixed_width_over_desktop_covered_classes' => $overDesktopCoveredClasses,
             'fixed_width_over_desktop_uncovered_classes' => $overDesktopUncoveredClasses,
         );
+    }
+
+    /**
+     * @return array<string, array<string, true>>
+     */
+    private function htmlClassAssociations(string $html): array
+    {
+        $associations = array();
+        if ( ! preg_match_all('/\bclass\s*=\s*(["\'])(.*?)\1/is', $html, $matches, PREG_SET_ORDER) ) {
+            return $associations;
+        }
+
+        foreach ( $matches as $match ) {
+            $classes = preg_split('/\s+/', trim((string) ($match[2] ?? ''))) ?: array();
+            foreach ( $classes as $class ) {
+                if ( '' === $class ) {
+                    continue;
+                }
+                foreach ( $classes as $associatedClass ) {
+                    if ( '' !== $associatedClass && $associatedClass !== $class ) {
+                        $associations[$class][$associatedClass] = true;
+                    }
+                }
+            }
+        }
+
+        return $associations;
     }
 
     private function hasResponsiveWidthConstraint(string $declarations): bool

--- a/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionDiagnostics.php
@@ -282,24 +282,34 @@ final class StaticHtmlEmissionDiagnostics
             }
         }
 
-        // Shared style classes and their per-node Figma hooks coexist on one
-        // emitted element. A breakpoint override on either class constrains the
-        // element, so attribute coverage to the fixed-width shared class too.
-        $classAssociations = $this->htmlClassAssociations($html);
+        $classSets = $this->htmlClassSets($html);
+        $totalCount = 0;
+        $coveredCount = 0;
+        $overDesktopCoveredClasses = array();
+        $overDesktopUncoveredClasses = array();
         foreach ( $base as $class => $_ ) {
-            foreach ( array_keys($classAssociations[$class] ?? array()) as $associatedClass ) {
-                if ( isset($responsive[$associatedClass]) ) {
-                    $responsive[$class] = true;
-                    break;
+            foreach ( $classSets[$class] ?? array() as $classSet ) {
+                ++$totalCount;
+                $covered = false;
+                foreach ( $classSet as $elementClass ) {
+                    if ( isset($responsive[$elementClass]) ) {
+                        $covered = true;
+                        break;
+                    }
+                }
+                if ( $covered ) {
+                    ++$coveredCount;
+                }
+                if ( ! isset($overDesktop[$class]) ) {
+                    continue;
+                }
+                if ( $covered ) {
+                    $overDesktopCoveredClasses[] = $class;
+                } else {
+                    $overDesktopUncoveredClasses[] = $class;
                 }
             }
         }
-
-        $baseClasses = array_keys($base);
-        $coveredCount = count(array_filter($baseClasses, static fn (string $class): bool => isset($responsive[$class])));
-        $totalCount = count($baseClasses);
-        $overDesktopCoveredClasses = array_values(array_filter(array_keys($overDesktop), static fn (string $class): bool => isset($responsive[$class])));
-        $overDesktopUncoveredClasses = array_values(array_diff(array_keys($overDesktop), $overDesktopCoveredClasses));
 
         return array(
             'fixed_width_declaration_count' => $totalCount,
@@ -308,7 +318,7 @@ final class StaticHtmlEmissionDiagnostics
             'fixed_width_without_responsive_override_count' => max(0, $totalCount - $coveredCount),
             'effective_responsive_coverage_ratio' => $totalCount > 0 ? round($coveredCount / $totalCount, 3) : 1.0,
             'fixed_width_samples' => $samples,
-            'fixed_width_over_desktop_class_count' => count($overDesktop),
+            'fixed_width_over_desktop_class_count' => count($overDesktopCoveredClasses) + count($overDesktopUncoveredClasses),
             'fixed_width_over_desktop_covered_count' => count($overDesktopCoveredClasses),
             'fixed_width_over_desktop_uncovered_count' => count($overDesktopUncoveredClasses),
             'fixed_width_over_desktop_covered_classes' => $overDesktopCoveredClasses,
@@ -317,13 +327,13 @@ final class StaticHtmlEmissionDiagnostics
     }
 
     /**
-     * @return array<string, array<string, true>>
+     * @return array<string, array<int, array<int, string>>>
      */
-    private function htmlClassAssociations(string $html): array
+    private function htmlClassSets(string $html): array
     {
-        $associations = array();
+        $classSets = array();
         if ( ! preg_match_all('/\bclass\s*=\s*(["\'])(.*?)\1/is', $html, $matches, PREG_SET_ORDER) ) {
-            return $associations;
+            return $classSets;
         }
 
         foreach ( $matches as $match ) {
@@ -332,15 +342,11 @@ final class StaticHtmlEmissionDiagnostics
                 if ( '' === $class ) {
                     continue;
                 }
-                foreach ( $classes as $associatedClass ) {
-                    if ( '' !== $associatedClass && $associatedClass !== $class ) {
-                        $associations[$class][$associatedClass] = true;
-                    }
-                }
+                $classSets[$class][] = $classes;
             }
         }
 
-        return $associations;
+        return $classSets;
     }
 
     private function hasResponsiveWidthConstraint(string $declarations): bool

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -2501,12 +2501,7 @@ final class StaticHtmlEmitter
             return ' method="get" action="' . $this->sanitizeAttribute($this->linkState->entrypointPath()) . '" role="search"';
         }
 
-        $action = $this->currentPagePath;
-        if ( str_contains($haystack, 'comment') || str_contains($haystack, 'reply') ) {
-            return ' method="post" action="' . $this->sanitizeAttribute($action) . '"';
-        }
-
-        return ' method="post" action="' . $this->sanitizeAttribute($action) . '"';
+        return ' method="post"';
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
+++ b/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
@@ -222,6 +222,12 @@ final class StaticHtmlSemanticClassifier
             return false;
         }
 
+        // A direct Name or Email label is common in profile cards and other
+        // non-interactive chrome. Require enclosing form evidence for it.
+        if ( $this->hasDirectFormFieldLabel($node) && ! $this->hasFormContextIntent($parentNode) ) {
+            return false;
+        }
+
         $textCount = ($this->textDescendantCount)($node);
         if ( $textCount < 1 || $textCount > 2 ) {
             return false;
@@ -260,6 +266,13 @@ final class StaticHtmlSemanticClassifier
             || str_contains($haystack, 'comment')
             || str_contains($haystack, 'reply');
         if ( ! $hasTextareaIntent ) {
+            return false;
+        }
+
+        $isMultilineCommentOrMessage = null !== ($this->boxValue)($node, 'height')
+            && ($this->boxValue)($node, 'height') >= 72.0
+            && 1 === preg_match('/\b(?:comment|message|reply)\b/', $label);
+        if ( ! $this->hasFormContextIntent($parentNode) && ! $isMultilineCommentOrMessage ) {
             return false;
         }
 
@@ -334,6 +347,26 @@ final class StaticHtmlSemanticClassifier
     private function hasStrongFormTextIntent(string $text): bool
     {
         return 1 === preg_match('/\b(leave\s+(?:a\s+)?(?:reply|comment)|post\s+(?:a\s+)?comment|submit\s+(?:a\s+)?comment)\b/', $text);
+    }
+
+    /** @param array<string, mixed>|null $parentNode */
+    private function hasFormContextIntent(?array $parentNode): bool
+    {
+        if ( null === $parentNode ) {
+            return false;
+        }
+
+        $name = strtolower((string) ($parentNode['name'] ?? ''));
+        $text = strtolower(($this->subtreePlainText)($parentNode));
+
+        return str_contains($name, 'search')
+            || str_contains($name, 'newsletter')
+            || str_contains($name, 'subscribe')
+            || str_contains($name, 'sign up')
+            || str_contains($name, 'comment')
+            || str_contains($name, 'reply')
+            || str_contains($name, 'form')
+            || $this->hasStrongFormTextIntent($text);
     }
 
     /** @param array<string, mixed> $node */

--- a/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
+++ b/figma-transformer/src/Html/StaticHtmlSemanticClassifier.php
@@ -209,13 +209,15 @@ final class StaticHtmlSemanticClassifier
         }
 
         $placeholder = strtolower(trim(($this->subtreePlainText)($node)));
-        $haystack = $name . ' ' . $placeholder;
+        $label = strtolower($this->nearbyFormControlLabel($node, $parentNode));
+        $haystack = $name . ' ' . $placeholder . ' ' . $label;
         $hasInputName = str_contains($name, 'input')
             || str_contains($name, 'text field')
             || str_contains($name, 'textfield')
             || str_contains($name, 'form field')
             || str_contains($haystack, 'search')
-            || preg_match('/(^|[^a-z])field([^a-z]|$)/', $name);
+            || preg_match('/(^|[^a-z])field([^a-z]|$)/', $name)
+            || $this->isSimpleFormFieldLabel($label);
         if ( ! $hasInputName ) {
             return false;
         }
@@ -231,7 +233,7 @@ final class StaticHtmlSemanticClassifier
             return false;
         }
 
-        return null !== ($this->backgroundColor)($node) || ($this->cornerRadius)($node) > 0.0 || ($this->hasStrokePaint)($node) || $this->hasFormControlChromeChild($node);
+        return null !== ($this->backgroundColor)($node) || ($this->cornerRadius)($node) > 0.0 || ($this->hasStrokePaint)($node) || $this->hasFormControlChromeChild($node) || $this->hasDirectFormFieldLabel($node);
     }
 
     /**
@@ -262,7 +264,9 @@ final class StaticHtmlSemanticClassifier
         }
 
         $textCount = ($this->textDescendantCount)($node);
-        if ( $textCount < 1 || $textCount > 3 ) {
+        // Component-backed field shells include their direct label plus nested
+        // placeholder layers, so allow that bounded structure when labeled.
+        if ( $textCount < 1 || $textCount > ($this->hasDirectFormFieldLabel($node) ? 6 : 3) ) {
             return false;
         }
 
@@ -275,7 +279,7 @@ final class StaticHtmlSemanticClassifier
             return false;
         }
 
-        return null !== ($this->backgroundColor)($node) || ($this->cornerRadius)($node) > 0.0 || ($this->hasStrokePaint)($node) || $this->hasFormControlChromeChild($node);
+        return null !== ($this->backgroundColor)($node) || ($this->cornerRadius)($node) > 0.0 || ($this->hasStrokePaint)($node) || $this->hasFormControlChromeChild($node) || $this->hasDirectFormFieldLabel($node);
     }
 
     /**
@@ -291,12 +295,6 @@ final class StaticHtmlSemanticClassifier
         $name = strtolower((string) ($node['name'] ?? ''));
         $text = strtolower(($this->subtreePlainText)($node));
         $haystack = $name . ' ' . $text;
-        $hasFormIntent = str_contains($haystack, 'search')
-            || str_contains($haystack, 'newsletter')
-            || str_contains($haystack, 'subscribe')
-            || str_contains($haystack, 'sign up')
-            || str_contains($haystack, 'comment')
-            || str_contains($haystack, 'reply');
         $hasNamedFormIntent = str_contains($name, 'search')
             || str_contains($name, 'newsletter')
             || str_contains($name, 'subscribe')
@@ -304,7 +302,7 @@ final class StaticHtmlSemanticClassifier
             || str_contains($name, 'comment')
             || str_contains($name, 'reply')
             || str_contains($name, 'form');
-        if ( ! $hasFormIntent || ! $hasNamedFormIntent ) {
+        if ( ! $hasNamedFormIntent && ! $this->hasStrongFormTextIntent($text) ) {
             return false;
         }
 
@@ -333,6 +331,11 @@ final class StaticHtmlSemanticClassifier
         return $hasField && ($hasSubmit || str_contains($haystack, 'search'));
     }
 
+    private function hasStrongFormTextIntent(string $text): bool
+    {
+        return 1 === preg_match('/\b(leave\s+(?:a\s+)?(?:reply|comment)|post\s+(?:a\s+)?comment|submit\s+(?:a\s+)?comment)\b/', $text);
+    }
+
     /** @param array<string, mixed> $node */
     public function hasFormControlAccessoryChildren(array $node): bool
     {
@@ -347,6 +350,23 @@ final class StaticHtmlSemanticClassifier
 
             if ( ($this->subtreeHasRenderableVector)($child) || null !== ($this->nodeAssetPath)($child) ) {
                 return true;
+            }
+        }
+
+        if ( $this->hasDirectFormFieldLabel($node) ) {
+            foreach ( ($this->nodeList)($node) as $child ) {
+                if ( ! is_array($child) || 'TEXT' === strtoupper((string) ($child['type'] ?? '')) ) {
+                    continue;
+                }
+
+                $childName = strtolower((string) ($child['name'] ?? ''));
+                $childWidth = ($this->boxValue)($child, 'width');
+                $childHeight = ($this->boxValue)($child, 'height');
+                if ((str_contains($childName, 'input') || str_contains($childName, 'field'))
+                    && null !== $childWidth && $childWidth >= 80.0 && $childWidth <= 640.0
+                    && null !== $childHeight && $childHeight >= 24.0 && $childHeight <= 160.0) {
+                    return true;
+                }
             }
         }
 
@@ -448,6 +468,10 @@ final class StaticHtmlSemanticClassifier
             $attributes .= ' name="email"';
         } elseif ( 'textarea' === $tag ) {
             $attributes .= ' name="' . ($this->sanitizeAttribute)($this->textareaControlName($node, $haystack)) . '"';
+        } elseif ( str_contains($haystack, 'website') || str_contains($haystack, 'url') ) {
+            $attributes .= ' name="url"';
+        } elseif ( str_contains($haystack, 'name') ) {
+            $attributes .= ' name="author"';
         }
         if ( '' !== $placeholder ) {
             $attributes .= ' placeholder="' . ($this->sanitizeAttribute)($placeholder) . '"';
@@ -480,6 +504,17 @@ final class StaticHtmlSemanticClassifier
      */
     public function nearbyFormControlLabel(array $node, ?array $parentNode): string
     {
+        foreach ( ($this->nodeList)($node) as $child ) {
+            if ( ! is_array($child) || 'TEXT' !== strtoupper((string) ($child['type'] ?? '')) ) {
+                continue;
+            }
+
+            $text = trim(($this->nodePlainText)($child));
+            if ( $this->isSimpleFormFieldLabel($text) ) {
+                return $text;
+            }
+        }
+
         if ( null === $parentNode ) {
             return '';
         }
@@ -505,6 +540,18 @@ final class StaticHtmlSemanticClassifier
         }
 
         return '';
+    }
+
+    /** @param array<string, mixed> $node */
+    private function hasDirectFormFieldLabel(array $node): bool
+    {
+        foreach ( ($this->nodeList)($node) as $child ) {
+            if ( is_array($child) && 'TEXT' === strtoupper((string) ($child['type'] ?? '')) && $this->isSimpleFormFieldLabel(trim(($this->nodePlainText)($child))) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
+++ b/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
@@ -234,6 +234,15 @@ final class TransformDiagnosticsBuilder
                 'sample_rules' => array_slice(is_array($htmlArtifact['fixed_width_samples'] ?? null) ? $htmlArtifact['fixed_width_samples'] : array(), 0, 10),
             );
         }
+
+        if ( 'incomplete' === ($htmlArtifact['fixed_width_coverage_analysis']['status'] ?? null) ) {
+            $signals[] = array(
+                'code' => 'fixed_width_coverage_analysis_incomplete',
+                'diagnostic' => (string) ($htmlArtifact['fixed_width_coverage_analysis']['diagnostic'] ?? 'fixed_width_coverage_budget_exceeded'),
+                'contexts_evaluated' => (int) ($htmlArtifact['fixed_width_coverage_analysis']['contexts_evaluated'] ?? 0),
+                'operations_evaluated' => (int) ($htmlArtifact['fixed_width_coverage_analysis']['operations_evaluated'] ?? 0),
+            );
+        }
         if ( ! empty($htmlArtifact['giant_fixed_section_count']) ) {
             $signals[] = array(
                 'severity' => 'warning',

--- a/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
+++ b/figma-transformer/src/Html/TransformDiagnosticsBuilder.php
@@ -231,6 +231,7 @@ final class TransformDiagnosticsBuilder
                 'coverage_ratio' => (float) ($htmlArtifact['effective_responsive_coverage_ratio'] ?? 0.0),
                 'fixed_width_declaration_count' => (int) ($htmlArtifact['fixed_width_declaration_count'] ?? 0),
                 'fixed_width_without_responsive_override_count' => (int) ($htmlArtifact['fixed_width_without_responsive_override_count'] ?? 0),
+                'fixed_width_coverage_analysis' => is_array($htmlArtifact['fixed_width_coverage_analysis'] ?? null) ? $htmlArtifact['fixed_width_coverage_analysis'] : array(),
                 'sample_rules' => array_slice(is_array($htmlArtifact['fixed_width_samples'] ?? null) ? $htmlArtifact['fixed_width_samples'] : array(), 0, 10),
             );
         }

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -313,6 +313,20 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $responsiveHtmlArtifact, array('fixed_width_over_desktop_covered_count'), 1, 'diagnostics-evidence-responsive-covered-fixed-width-count');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $responsiveHtmlArtifact, array('fixed_width_over_desktop_uncovered_count'), 1, 'diagnostics-evidence-responsive-uncovered-fixed-width-count');
 
+    $unmatchedResponsiveSelectorArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        '<main><div class="fixed"></div></main>',
+        '.fixed{width:1800px}@media (max-width:767px){.unrelated .fixed{width:100%}.unrelated>.fixed{max-width:100%}}'
+    );
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $unmatchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_covered_count'), 0, 'diagnostics-evidence-unmatched-descendant-and-child-responsive-selectors-do-not-cover');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $unmatchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_uncovered_count'), 1, 'diagnostics-evidence-unmatched-descendant-and-child-responsive-selectors-remain-uncovered');
+
+    $matchedResponsiveSelectorArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        '<main><section class="container"><div class="fixed fluid"></div></section></main>',
+        '.fixed{width:1800px}@media (max-width:767px){section.container>div.fixed.fluid{width:100%;max-width:100%}}'
+    );
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $matchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_covered_count'), 1, 'diagnostics-evidence-matched-direct-compound-responsive-selector-covers');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $matchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_uncovered_count'), 0, 'diagnostics-evidence-matched-direct-compound-responsive-selector-has-no-uncovered-width');
+
     $responsiveQuality = (new \Automattic\BlocksEngine\FigmaTransformer\Html\TransformDiagnosticsBuilder())->artifactQualityDiagnostics(
         array(),
         array(),

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -327,6 +327,26 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $matchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_covered_count'), 1, 'diagnostics-evidence-matched-direct-compound-responsive-selector-covers');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $matchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_uncovered_count'), 0, 'diagnostics-evidence-matched-direct-compound-responsive-selector-has-no-uncovered-width');
 
+    $siblingResponsiveSelectorArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        '<main><div class="row"><span class="anchor"></span><div class="fixed adjacent"></div><div class="fixed general"></div></div></main>',
+        '.fixed{width:1800px}@media (max-width:767px){.anchor + .adjacent{width:100%}.anchor ~ .general{max-width:100%}}'
+    );
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $siblingResponsiveSelectorArtifact, array('fixed_width_over_desktop_covered_count'), 2, 'diagnostics-evidence-sibling-combinator-responsive-selectors-remain-element-scoped');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $siblingResponsiveSelectorArtifact, array('fixed_width_coverage_analysis', 'status'), 'complete', 'diagnostics-evidence-sibling-combinator-analysis-complete');
+
+    $largeCoverageHtml = '<main>' . str_repeat('<div class="fixed"></div>', 21000) . '</main>';
+    $largeCoverageArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        $largeCoverageHtml,
+        '.fixed{width:1800px}@media (max-width:767px){.fixed{width:100%}}'
+    );
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $largeCoverageArtifact, array('fixed_width_coverage_analysis', 'status'), 'incomplete', 'diagnostics-evidence-large-coverage-budget-status');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $largeCoverageArtifact, array('fixed_width_coverage_analysis', 'diagnostic'), 'fixed_width_coverage_budget_exceeded', 'diagnostics-evidence-large-coverage-budget-diagnostic');
+    $assert(20000 === ($largeCoverageArtifact['fixed_width_coverage_analysis']['context_budget'] ?? null), 'diagnostics-evidence-large-coverage-context-budget-contract');
+    $assert(0.0 === ($largeCoverageArtifact['effective_responsive_coverage_ratio'] ?? null), 'diagnostics-evidence-large-coverage-never-false-passes');
+    $largeCoverageQuality = (new \Automattic\BlocksEngine\FigmaTransformer\Html\TransformDiagnosticsBuilder())->artifactQualityDiagnostics(array(), array(), array(), array(), array(), array(), array(), array(), array(), array(), array(), array(), $largeCoverageArtifact);
+    $largeCoverageCodes = array_map(static fn (array $signal): string => (string) ($signal['code'] ?? ''), $largeCoverageQuality['signals'] ?? array());
+    $assert(in_array('fixed_width_coverage_analysis_incomplete', $largeCoverageCodes, true), 'diagnostics-evidence-large-coverage-budget-quality-signal');
+
     $responsiveQuality = (new \Automattic\BlocksEngine\FigmaTransformer\Html\TransformDiagnosticsBuilder())->artifactQualityDiagnostics(
         array(),
         array(),

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -307,7 +307,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
 
     $responsiveCss = '.desktop-shell{width:1800px;height:620px;display:flex;flex-direction:row}.uncovered-shell{width:1600px}'
         . "\n@media (max-width:767px){\n.desktop-shell{width:100%;max-width:100%;height:auto;min-height:620px;flex-wrap:wrap}\n}";
-    $responsiveHtmlArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics('<main><section></section></main>', $responsiveCss);
+    $responsiveHtmlArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics('<main><section class="desktop-shell"></section><section class="uncovered-shell"></section></main>', $responsiveCss);
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $responsiveHtmlArtifact, array('fixed_width_over_desktop_count'), 2, 'diagnostics-evidence-responsive-raw-fixed-width-count');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $responsiveHtmlArtifact, array('fixed_width_over_desktop_class_count'), 2, 'diagnostics-evidence-responsive-fixed-width-class-count');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $responsiveHtmlArtifact, array('fixed_width_over_desktop_covered_count'), 1, 'diagnostics-evidence-responsive-covered-fixed-width-count');

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -327,6 +327,14 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $matchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_covered_count'), 1, 'diagnostics-evidence-matched-direct-compound-responsive-selector-covers');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $matchedResponsiveSelectorArtifact, array('fixed_width_over_desktop_uncovered_count'), 0, 'diagnostics-evidence-matched-direct-compound-responsive-selector-has-no-uncovered-width');
 
+    $selectorListArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        '<main><div class="a"></div><div class="b"></div></main>',
+        '.a,.b{width:1800px}@media (max-width:767px){.a{width:100%}}'
+    );
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $selectorListArtifact, array('fixed_width_declaration_count'), 2, 'diagnostics-evidence-selector-list-counts-each-matched-element-once');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $selectorListArtifact, array('fixed_width_with_responsive_override_count'), 1, 'diagnostics-evidence-selector-list-preserves-partial-responsive-coverage');
+    blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $selectorListArtifact, array('fixed_width_without_responsive_override_count'), 1, 'diagnostics-evidence-selector-list-reports-uncovered-part');
+
     $siblingResponsiveSelectorArtifact = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
         '<main><div class="row"><span class="anchor"></span><div class="fixed adjacent"></div><div class="fixed general"></div></div></main>',
         '.fixed{width:1800px}@media (max-width:767px){.anchor + .adjacent{width:100%}.anchor ~ .general{max-width:100%}}'

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -599,6 +599,24 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
             'dom_box_quality' => $invalidDomBoxQuality,
         ),
     ));
+    $incompleteCoverageMatrixSummary = matrix_quality_matrix(array(
+        array(
+            'id' => 'complete-page',
+            'quality_summary' => array(
+                'fixed_width_declaration_count' => 2,
+                'fixed_width_with_responsive_override_count' => 2,
+                'fixed_width_coverage_analysis' => array('status' => 'complete'),
+            ),
+        ),
+        array(
+            'id' => 'budget-limited-page',
+            'quality_summary' => array(
+                'fixed_width_declaration_count' => 2,
+                'fixed_width_with_responsive_override_count' => 2,
+                'fixed_width_coverage_analysis' => array('status' => 'incomplete', 'diagnostic' => 'fixed_width_coverage_budget_exceeded'),
+            ),
+        ),
+    ));
     $formScoringSummary = matrix_quality_matrix(array(
         array(
             'id' => 'native-form-fixture',
@@ -850,6 +868,10 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(3 === ($matrixQualitySummary['risk_category_totals']['responsive_coverage'] ?? null), 'fixture-matrix-quality-risk-category-total');
     $assert(8 === ($matrixQualitySummary['risk_category_totals']['rendered_dom_boxes'] ?? null), 'fixture-matrix-quality-rendered-dom-risk-category-total');
     $assert(1 === ($invalidDomBoxMatrixSummary['totals']['dom_capture_invalid_count'] ?? null), 'fixture-matrix-quality-invalid-dom-capture-total');
+    $assert('incomplete' === ($incompleteCoverageMatrixSummary['fixed_width_coverage_analysis']['status'] ?? null), 'fixture-matrix-quality-multi-page-budget-status-aggregates');
+    $assert(1 === ($incompleteCoverageMatrixSummary['fixed_width_coverage_analysis']['incomplete_fixture_count'] ?? null), 'fixture-matrix-quality-multi-page-budget-count-aggregates');
+    $assert(0.0 === ($incompleteCoverageMatrixSummary['effective_responsive_coverage_ratio'] ?? null), 'fixture-matrix-quality-multi-page-budget-never-implies-complete-coverage');
+    $assert(1 === ($incompleteCoverageMatrixSummary['per_fixture_readiness'][1]['risk_categories']['responsive_coverage']['count'] ?? null), 'fixture-matrix-quality-multi-page-budget-is-readiness-risk');
     $assert(false === ($invalidDomBoxMatrixSummary['per_fixture_readiness'][0]['dom_capture_valid'] ?? null), 'fixture-matrix-quality-invalid-dom-capture-readiness-flag');
     $assert(false === ($invalidDomBoxMatrixSummary['per_fixture_readiness'][0]['dom_css_loaded'] ?? null), 'fixture-matrix-quality-invalid-dom-css-loaded-flag');
     $assert(0 === ($invalidDomBoxMatrixSummary['risk_category_totals']['rendered_dom_boxes'] ?? null), 'fixture-matrix-quality-invalid-dom-not-scored-as-rendered-risk');

--- a/figma-transformer/tests/contract/FixtureMatrixContract.php
+++ b/figma-transformer/tests/contract/FixtureMatrixContract.php
@@ -599,6 +599,20 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
             'dom_box_quality' => $invalidDomBoxQuality,
         ),
     ));
+    $formScoringSummary = matrix_quality_matrix(array(
+        array(
+            'id' => 'native-form-fixture',
+            'quality_summary' => array(
+                'fallback_prone_form_island_count' => 1,
+                'fallback_prone_input_island_count' => 3,
+                'missing_semantic_role_count' => 4,
+            ),
+        ),
+        array(
+            'id' => 'invalid-list-fixture',
+            'quality_summary' => array('invalid_list_child_count' => 2),
+        ),
+    ));
     $roleSeparatedDomBoxQuality = matrix_analyze_dom_box_report(array(
         'entrypoints' => array(
             array(
@@ -839,6 +853,8 @@ function blocks_engine_figma_transformer_run_fixture_matrix_contract(callable $a
     $assert(false === ($invalidDomBoxMatrixSummary['per_fixture_readiness'][0]['dom_capture_valid'] ?? null), 'fixture-matrix-quality-invalid-dom-capture-readiness-flag');
     $assert(false === ($invalidDomBoxMatrixSummary['per_fixture_readiness'][0]['dom_css_loaded'] ?? null), 'fixture-matrix-quality-invalid-dom-css-loaded-flag');
     $assert(0 === ($invalidDomBoxMatrixSummary['risk_category_totals']['rendered_dom_boxes'] ?? null), 'fixture-matrix-quality-invalid-dom-not-scored-as-rendered-risk');
+    $assert(2 === ($formScoringSummary['risk_category_totals']['form_validity'] ?? null), 'fixture-matrix-form-validity-scores-only-structural-defects');
+    $assert(0 === ($formScoringSummary['per_fixture_readiness'][0]['risk_categories']['form_validity']['count'] ?? null), 'fixture-matrix-native-form-semantics-are-informational');
     $assert(in_array('dom_capture_invalid', $invalidDomBoxMatrixSummary['per_fixture_readiness'][0]['risk_categories']['rendered_dom_boxes']['signals'] ?? array(), true), 'fixture-matrix-quality-invalid-dom-risk-signal');
     $assert('source_layout' === ($roleSeparatedDomBoxQuality['pages'][0]['comparison_role'] ?? null), 'fixture-matrix-dom-box-page-preserves-comparison-role');
     $assert('frame:desktop' === ($roleSeparatedDomBoxQuality['pages'][0]['source_frame']['id'] ?? null), 'fixture-matrix-dom-box-page-preserves-source-frame');

--- a/figma-transformer/tests/contract/FormControlContract.php
+++ b/figma-transformer/tests/contract/FormControlContract.php
@@ -511,4 +511,41 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     ));
     $outsideSubmitHtml = $fileContent($outsideSubmitResult, 'index.html');
     $assert(str_contains($outsideSubmitHtml, '<button class="figma-node-outside-submit-button-subscribe-button"') && str_contains($outsideSubmitHtml, 'type="button" data-figma-action-intent="submit"'), 'form-control-outside-submit-button-emits-safe-action-metadata');
+
+    $fseCommentResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'FSE Comment Form Fixture',
+        'nodes' => array(
+            array(
+                'id' => 'fse-comment:wrapper',
+                'type' => 'FRAME',
+                'name' => 'Group 138',
+                'width' => 720,
+                'children' => array(
+                    array('id' => 'fse-comment:title', 'type' => 'TEXT', 'name' => 'Heading', 'characters' => 'Leave a Reply', 'fontSize' => 28),
+                    array('id' => 'fse-comment:comment', 'type' => 'FRAME', 'name' => 'Field', 'width' => 640, 'height' => 128, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'fse-comment:comment-label', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Comment', 'fontSize' => 14),
+                    )),
+                    array('id' => 'fse-comment:name', 'type' => 'FRAME', 'name' => 'Field', 'width' => 300, 'height' => 44, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'fse-comment:name-label', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Name', 'fontSize' => 14),
+                    )),
+                    array('id' => 'fse-comment:email', 'type' => 'FRAME', 'name' => 'Field', 'width' => 300, 'height' => 44, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'fse-comment:email-label', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Email', 'fontSize' => 14),
+                    )),
+                    array('id' => 'fse-comment:website', 'type' => 'FRAME', 'name' => 'Field', 'width' => 300, 'height' => 44, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'fse-comment:website-label', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Website', 'fontSize' => 14),
+                    )),
+                    array('id' => 'fse-comment:submit', 'type' => 'FRAME', 'name' => 'Button', 'width' => 160, 'height' => 44, 'cornerRadius' => 4, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 1))), 'children' => array(
+                        array('id' => 'fse-comment:submit-label', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Post Comment', 'fontSize' => 16),
+                    )),
+                ),
+            ),
+        ),
+    ));
+    $fseCommentHtml = $fileContent($fseCommentResult, 'index.html');
+    $assert(str_contains($fseCommentHtml, '<form class="figma-node-fse-comment-wrapper-group-138"') && str_contains($fseCommentHtml, 'method="post"') && ! str_contains($fseCommentHtml, 'action="'), 'form-control-fse-generic-wrapper-emits-actionless-form');
+    $assert(str_contains($fseCommentHtml, '<textarea class="figma-node-fse-comment-comment-field"') && str_contains($fseCommentHtml, 'name="comment-fse-comment-comment"') && str_contains($fseCommentHtml, 'aria-label="Comment"'), 'form-control-fse-direct-child-label-names-comment-textarea');
+    $assert(str_contains($fseCommentHtml, 'data-figma-node-id="fse-comment:name"') && str_contains($fseCommentHtml, 'name="author"'), 'form-control-fse-direct-child-label-names-author-input');
+    $assert(str_contains($fseCommentHtml, 'data-figma-node-id="fse-comment:email"') && str_contains($fseCommentHtml, 'type="email" name="email"'), 'form-control-fse-direct-child-label-names-email-input');
+    $assert(str_contains($fseCommentHtml, 'data-figma-node-id="fse-comment:website"') && str_contains($fseCommentHtml, 'name="url"'), 'form-control-fse-direct-child-label-names-website-input');
+    $assert(str_contains($fseCommentHtml, 'data-figma-node-id="fse-comment:submit"') && str_contains($fseCommentHtml, 'type="submit"'), 'form-control-fse-post-comment-is-submit');
 }

--- a/figma-transformer/tests/contract/FormControlContract.php
+++ b/figma-transformer/tests/contract/FormControlContract.php
@@ -512,6 +512,28 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     $outsideSubmitHtml = $fileContent($outsideSubmitResult, 'index.html');
     $assert(str_contains($outsideSubmitHtml, '<button class="figma-node-outside-submit-button-subscribe-button"') && str_contains($outsideSubmitHtml, 'type="button" data-figma-action-intent="submit"'), 'form-control-outside-submit-button-emits-safe-action-metadata');
 
+    $profileCardsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'Profile Cards Fixture',
+        'nodes' => array(
+            array(
+                'id' => 'profile-cards:root',
+                'type' => 'FRAME',
+                'name' => 'Team Profiles',
+                'width' => 720,
+                'children' => array(
+                    array('id' => 'profile-cards:name', 'type' => 'FRAME', 'name' => 'Profile card', 'width' => 300, 'height' => 120, 'cornerRadius' => 12, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'profile-cards:name-label', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Name', 'fontSize' => 16),
+                    )),
+                    array('id' => 'profile-cards:email', 'type' => 'FRAME', 'name' => 'Profile card', 'width' => 300, 'height' => 120, 'cornerRadius' => 12, 'fills' => array(array('type' => 'SOLID', 'color' => array('r' => 1, 'g' => 1, 'b' => 1, 'a' => 1))), 'children' => array(
+                        array('id' => 'profile-cards:email-label', 'type' => 'TEXT', 'name' => 'Text', 'characters' => 'Email', 'fontSize' => 16),
+                    )),
+                ),
+            ),
+        ),
+    ));
+    $profileCardsHtml = $fileContent($profileCardsResult, 'index.html');
+    $assert(! str_contains($profileCardsHtml, '<input class="figma-node-profile-cards-name-profile-card"') && ! str_contains($profileCardsHtml, '<input class="figma-node-profile-cards-email-profile-card"'), 'form-control-direct-simple-labels-do-not-promote-rounded-cards');
+
     $fseCommentResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name' => 'FSE Comment Form Fixture',
         'nodes' => array(
@@ -543,7 +565,7 @@ function blocks_engine_figma_transformer_run_form_control_contract(callable $ass
     ));
     $fseCommentHtml = $fileContent($fseCommentResult, 'index.html');
     $assert(str_contains($fseCommentHtml, '<form class="figma-node-fse-comment-wrapper-group-138"') && str_contains($fseCommentHtml, 'method="post"') && ! str_contains($fseCommentHtml, 'action="'), 'form-control-fse-generic-wrapper-emits-actionless-form');
-    $assert(str_contains($fseCommentHtml, '<textarea class="figma-node-fse-comment-comment-field"') && str_contains($fseCommentHtml, 'name="comment-fse-comment-comment"') && str_contains($fseCommentHtml, 'aria-label="Comment"'), 'form-control-fse-direct-child-label-names-comment-textarea');
+    $assert(str_contains($fseCommentHtml, '<textarea class="figma-node-fse-comment-comment-field"') && str_contains($fseCommentHtml, 'name="comment-fse-comment-comment"') && str_contains($fseCommentHtml, 'aria-label="Comment"'), 'form-control-fse-shaped-form-preserves-direct-child-comment-textarea');
     $assert(str_contains($fseCommentHtml, 'data-figma-node-id="fse-comment:name"') && str_contains($fseCommentHtml, 'name="author"'), 'form-control-fse-direct-child-label-names-author-input');
     $assert(str_contains($fseCommentHtml, 'data-figma-node-id="fse-comment:email"') && str_contains($fseCommentHtml, 'type="email" name="email"'), 'form-control-fse-direct-child-label-names-email-input');
     $assert(str_contains($fseCommentHtml, 'data-figma-node-id="fse-comment:website"') && str_contains($fseCommentHtml, 'name="url"'), 'form-control-fse-direct-child-label-names-website-input');

--- a/figma-transformer/tests/contract/HtmlValidityContract.php
+++ b/figma-transformer/tests/contract/HtmlValidityContract.php
@@ -233,6 +233,13 @@ function blocks_engine_figma_transformer_run_html_validity_contract(callable $as
     $assert(1 === ($artifactDiagnostics['invalid_list_child_count'] ?? null), 'html-validity-artifact-diagnostics-detects-invalid-list-children');
     $assert(2 === ($artifactDiagnostics['missing_semantic_role_count'] ?? null), 'html-validity-artifact-diagnostics-detects-missing-semantic-role');
 
+    $sharedResponsiveArtifactDiagnostics = (new StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        '<main><div class="shared-card figma-node-card">Card</div></main>',
+        '.shared-card{width:640px}@media (max-width:390px){.figma-node-card{max-width:100%}}'
+    );
+    $assert(1 === ($sharedResponsiveArtifactDiagnostics['fixed_width_with_responsive_override_count'] ?? null), 'html-validity-artifact-diagnostics-attributes-node-override-to-shared-style-class');
+    $assert(0 === ($sharedResponsiveArtifactDiagnostics['fixed_width_without_responsive_override_count'] ?? null), 'html-validity-artifact-diagnostics-shared-style-class-is-not-uncovered');
+
     $artifactQuality = (new TransformDiagnosticsBuilder())->artifactQualityDiagnostics(
         array('missing_assets' => array(), 'image_block_count' => 0, 'total_node_count' => 0),
         array('placeholders' => 0, 'rendered_asset_fallbacks' => 0),

--- a/figma-transformer/tests/contract/HtmlValidityContract.php
+++ b/figma-transformer/tests/contract/HtmlValidityContract.php
@@ -233,6 +233,13 @@ function blocks_engine_figma_transformer_run_html_validity_contract(callable $as
     $assert(1 === ($artifactDiagnostics['invalid_list_child_count'] ?? null), 'html-validity-artifact-diagnostics-detects-invalid-list-children');
     $assert(2 === ($artifactDiagnostics['missing_semantic_role_count'] ?? null), 'html-validity-artifact-diagnostics-detects-missing-semantic-role');
 
+    $elasticHeightArtifactDiagnostics = (new StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
+        '<main><section class="elastic"></section><section class="fixed"></section></main>',
+        '.elastic{width:1200px;min-height:2400px}.fixed{width:1200px;height:2400px}'
+    );
+    $assert(1 === ($elasticHeightArtifactDiagnostics['giant_fixed_section_count'] ?? null), 'html-validity-artifact-diagnostics-flags-only-fixed-giant-height');
+    $assert('.fixed' === ($elasticHeightArtifactDiagnostics['giant_fixed_sections'][0]['selector'] ?? null), 'html-validity-artifact-diagnostics-excludes-elastic-min-height');
+
     $sharedResponsiveArtifactDiagnostics = (new StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
         '<main><div class="shared-card figma-node-card-a">First card</div><div class="shared-card figma-node-card-b">Second card</div></main>',
         '.shared-card{width:640px}@media (max-width:390px){.figma-node-card-a{max-width:100%}}'

--- a/figma-transformer/tests/contract/HtmlValidityContract.php
+++ b/figma-transformer/tests/contract/HtmlValidityContract.php
@@ -218,7 +218,7 @@ function blocks_engine_figma_transformer_run_html_validity_contract(callable $as
     $assert(0 === $xpath->query('//ul/*[not(self::li)]')->length, 'html-validity-ul-direct-children-are-li');
 
     $artifactDiagnostics = (new StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
-        '<main><section class="hero"><div>Hero</div></section><ul><a href="#">Bad direct link</a><li>Good</li></ul><form><input type="email"><svg><path d="M0 0H10V10Z"></path></svg></form></main>',
+        '<main><section class="hero"><div class="card">Hero</div><div class="media"></div><div class="tile-a"></div><div class="tile-b"></div><div class="tile-c"></div><div class="tile-d"></div><div class="tile-e"></div></section><ul><a href="#">Bad direct link</a><li>Good</li></ul><form><input type="email"><svg><path d="M0 0H10V10Z"></path></svg></form></main>',
         '.hero{width:1600px;height:2400px;overflow:hidden}.card{width:640px}.media{width:480px}.tile-a{width:360px}.tile-b{width:360px}.tile-c{width:360px}.tile-d{width:360px}.tile-e{width:360px}@media (max-width: 767px){.media{width:100%}}'
     );
     $assert(8 === ($artifactDiagnostics['fixed_width_declaration_count'] ?? null), 'html-validity-artifact-diagnostics-counts-fixed-width-declarations');
@@ -234,11 +234,11 @@ function blocks_engine_figma_transformer_run_html_validity_contract(callable $as
     $assert(2 === ($artifactDiagnostics['missing_semantic_role_count'] ?? null), 'html-validity-artifact-diagnostics-detects-missing-semantic-role');
 
     $sharedResponsiveArtifactDiagnostics = (new StaticHtmlEmissionDiagnostics())->htmlArtifactDiagnostics(
-        '<main><div class="shared-card figma-node-card">Card</div></main>',
-        '.shared-card{width:640px}@media (max-width:390px){.figma-node-card{max-width:100%}}'
+        '<main><div class="shared-card figma-node-card-a">First card</div><div class="shared-card figma-node-card-b">Second card</div></main>',
+        '.shared-card{width:640px}@media (max-width:390px){.figma-node-card-a{max-width:100%}}'
     );
     $assert(1 === ($sharedResponsiveArtifactDiagnostics['fixed_width_with_responsive_override_count'] ?? null), 'html-validity-artifact-diagnostics-attributes-node-override-to-shared-style-class');
-    $assert(0 === ($sharedResponsiveArtifactDiagnostics['fixed_width_without_responsive_override_count'] ?? null), 'html-validity-artifact-diagnostics-shared-style-class-is-not-uncovered');
+    $assert(1 === ($sharedResponsiveArtifactDiagnostics['fixed_width_without_responsive_override_count'] ?? null), 'html-validity-artifact-diagnostics-keeps-unoverridden-shared-style-instance-uncovered');
 
     $artifactQuality = (new TransformDiagnosticsBuilder())->artifactQualityDiagnostics(
         array('missing_assets' => array(), 'image_block_count' => 0, 'total_node_count' => 0),

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -3579,10 +3579,10 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
         'name' => 'Responsive intrinsic boundary fixture',
         'nodes' => array(
             array('id' => 'boundary:desktop', 'type' => 'FRAME', 'name' => 'Landing Desktop', 'width' => 1440, 'height' => 600, 'children' => array(
-                array('id' => 'boundary:desktop:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240),
+                array('id' => 'boundary:desktop:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240, 'maxWidth' => 360),
             )),
             array('id' => 'boundary:mobile', 'type' => 'FRAME', 'name' => 'Landing Mobile', 'width' => 390, 'height' => 600, 'children' => array(
-                array('id' => 'boundary:mobile:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240),
+                array('id' => 'boundary:mobile:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240, 'maxWidth' => 360),
             )),
         ),
     ), array(
@@ -3592,6 +3592,6 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
         ),
     ));
     $responsiveBoundaryCss = $fileContent($responsiveBoundaryResult, 'style.css');
-    $assert(str_contains($responsiveBoundaryCss, '.figma-node-boundary-desktop-card-intrinsic-card{width:376px;height:240px'), 'responsive-boundary-base-preserves-intrinsic-width');
-    $assert(1 === preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-boundary-desktop-card-intrinsic-card\{max-width:100%;box-sizing:border-box\}/', $responsiveBoundaryCss), 'responsive-boundary-mobile-caps-matched-intrinsic-width');
+    $assert(str_contains($responsiveBoundaryCss, '.figma-node-boundary-desktop-card-intrinsic-card{width:376px;height:240px;max-width:360px'), 'responsive-boundary-base-preserves-intrinsic-width-constraint');
+    $assert(0 === preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-boundary-desktop-card-intrinsic-card\{[^}]*max-width:100%/', $responsiveBoundaryCss), 'responsive-boundary-mobile-keeps-existing-max-width-constraint');
 }

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -3460,7 +3460,7 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert(! str_contains($semanticArchive, 'href="archive.html" data-figma-link-type="implicit-route"><h1'), 'semantic-route-current-archive-title-not-self-linked');
     $assert(! str_contains($semanticAbout, 'href="page.html" data-figma-link-type="implicit-route"><h1'), 'semantic-route-current-page-title-not-self-linked');
     $assert(str_contains($semanticHome, '<form') && str_contains($semanticHome, 'method="get" action="index.html" role="search"'), 'semantic-route-search-form-action');
-    $assert(str_contains($semanticHome, '<form') && str_contains($semanticHome, 'method="post" action="index.html"'), 'semantic-route-newsletter-form-action');
+    $assert(str_contains($semanticHome, '<form') && str_contains($semanticHome, 'method="post"') && ! str_contains($semanticHome, 'method="post" action="'), 'semantic-route-newsletter-form-does-not-invent-action');
     $assert(str_contains($semanticHome, 'type="search" name="s"'), 'semantic-route-search-input-name');
     $assert(str_contains($semanticHome, 'type="email" name="email"'), 'semantic-route-email-input-name');
     

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -3594,4 +3594,24 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $responsiveBoundaryCss = $fileContent($responsiveBoundaryResult, 'style.css');
     $assert(str_contains($responsiveBoundaryCss, '.figma-node-boundary-desktop-card-intrinsic-card{width:376px;height:240px;max-width:360px'), 'responsive-boundary-base-preserves-intrinsic-width-constraint');
     $assert(0 === preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-boundary-desktop-card-intrinsic-card\{[^}]*max-width:100%/', $responsiveBoundaryCss), 'responsive-boundary-mobile-keeps-existing-max-width-constraint');
+
+    $variantOnlyBoundaryResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'Responsive variant-only intrinsic boundary fixture',
+        'nodes' => array(
+            array('id' => 'variant-boundary:desktop', 'type' => 'FRAME', 'name' => 'Landing Desktop', 'width' => 1440, 'height' => 600, 'children' => array(
+                array('id' => 'variant-boundary:desktop:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240),
+            )),
+            array('id' => 'variant-boundary:mobile', 'type' => 'FRAME', 'name' => 'Landing Mobile', 'width' => 390, 'height' => 600, 'children' => array(
+                array('id' => 'variant-boundary:mobile:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240, 'maxWidth' => 360),
+            )),
+        ),
+    ), array(
+        'responsive_variants' => array(
+            array('frame_id' => 'variant-boundary:desktop', 'viewport_width' => 1440, 'primary' => true),
+            array('frame_id' => 'variant-boundary:mobile', 'viewport_width' => 390),
+        ),
+    ));
+    $variantOnlyBoundaryCss = $fileContent($variantOnlyBoundaryResult, 'style.css');
+    $assert(1 === preg_match('/@media \(max-width:915px\)\{[\s\S]*\.figma-node-variant-boundary-desktop-card-intrinsic-card\{[^}]*max-width:360px/', $variantOnlyBoundaryCss), 'responsive-boundary-mobile-introduces-intrinsic-max-width-constraint');
+    $assert(0 === preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-variant-boundary-desktop-card-intrinsic-card\{[^}]*\b(?:width|max-width):100%/', $variantOnlyBoundaryCss), 'responsive-boundary-mobile-preserves-variant-only-max-width-constraint');
 }

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -3574,4 +3574,24 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $assert('' !== $singleFrameLiveStyle, 'single-frame-live-stylesheet-emitted');
     $assert(str_contains($singleFrameLiveStyle, '@media (max-width:767px)'), 'single-frame-live-desktop-fallback-media-block');
     $assert(false === ($singleFrameLiveResult['source_reports']['figma']['pages']['pages'][0]['responsive'] ?? true), 'single-frame-live-plan-not-responsive');
+
+    $responsiveBoundaryResult = blocks_engine_figma_transformer_transform_scenegraph(array(
+        'name' => 'Responsive intrinsic boundary fixture',
+        'nodes' => array(
+            array('id' => 'boundary:desktop', 'type' => 'FRAME', 'name' => 'Landing Desktop', 'width' => 1440, 'height' => 600, 'children' => array(
+                array('id' => 'boundary:desktop:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240),
+            )),
+            array('id' => 'boundary:mobile', 'type' => 'FRAME', 'name' => 'Landing Mobile', 'width' => 390, 'height' => 600, 'children' => array(
+                array('id' => 'boundary:mobile:card', 'type' => 'FRAME', 'name' => 'Intrinsic card', 'width' => 376, 'height' => 240),
+            )),
+        ),
+    ), array(
+        'responsive_variants' => array(
+            array('frame_id' => 'boundary:desktop', 'viewport_width' => 1440, 'primary' => true),
+            array('frame_id' => 'boundary:mobile', 'viewport_width' => 390),
+        ),
+    ));
+    $responsiveBoundaryCss = $fileContent($responsiveBoundaryResult, 'style.css');
+    $assert(str_contains($responsiveBoundaryCss, '.figma-node-boundary-desktop-card-intrinsic-card{width:376px;height:240px'), 'responsive-boundary-base-preserves-intrinsic-width');
+    $assert(1 === preg_match('/@media \(max-width:390px\)\{[\s\S]*\.figma-node-boundary-desktop-card-intrinsic-card\{max-width:100%;box-sizing:border-box\}/', $responsiveBoundaryCss), 'responsive-boundary-mobile-caps-matched-intrinsic-width');
 }


### PR DESCRIPTION
## Summary
- emit bounded responsive width caps while preserving source max-width constraints
- measure responsive coverage against actual selector/element matches with bounded, aggregate-aware diagnostics
- preserve comment-form semantics and remove false-positive giant-section/form risk scoring

## Fixture evidence
- FSE Pilot: 5 selected pages, readiness 100/low, 546/546 fixed widths covered, zero giant fixed sections, zero form-validity risks
- Fisiostetic: 1 selected page, readiness 100/low, 122/122 fixed widths covered
- Combined: 668/668 responsive overrides, coverage ratio 1.0, analysis complete

Artifacts: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/issue-955-terminal-max10/summary.json`

## Verification
- `composer test`
- `php figma-transformer/scripts/figma-fixture-matrix.php --fixture="/Users/chubes/Downloads/🛠️ FSE Pilot Build Theme.fig" --fixture="/Users/chubes/Downloads/Fisiostetic.fig" --max-pages=10`

Closes #955
Closes #956

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and adversarially reviewed the responsive, semantic, and diagnostic changes and ran the contract and fixture gates. Chris Huber directed the work and remains responsible for every line.