### PR TITLE
Materialize captured dialogs as editable companion blocks

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -184,9 +184,11 @@ final class ArtifactCompiler
 		$this->wordpressCompatCssCache = array();
         $this->htmlTransformerAnalysisCache = new HtmlTransformerAnalysisCache();
         $normalized = ( new ArtifactNormalizer() )->normalize($artifact);
+        $capturedDialogs = ( new CapturedDialogProjector() )->project($normalized['files']);
+        $normalized['files'] = $capturedDialogs['files'];
         $entry = $this->entryFile($normalized['files'], $normalized['entrypoints']);
         $documents = $this->compileSourceDocuments($normalized);
-        $diagnostics = array_merge($normalized['diagnostics'], $documents['diagnostics'], $this->svgAssetDiagnostics($normalized['files']));
+        $diagnostics = array_merge($normalized['diagnostics'], $capturedDialogs['diagnostics'], $documents['diagnostics'], $this->svgAssetDiagnostics($normalized['files']));
 
         if ( null === $entry && array() === $documents['documents'] ) {
             $diagnostics[] = $this->diagnostic('missing_entry_html', 'error', 'No HTML entry file was available to compile.');
@@ -274,6 +276,12 @@ final class ArtifactCompiler
                 'runtime_declarations' => $normalized['runtime_declarations'],
             ),
         );
+        if (0 < $capturedDialogs['projected_count']) {
+            $sourceReports['captured_interactions'] = array(
+                'schema' => 'blocks-engine/captured-interactions/v1',
+                'projected_dialog_count' => $capturedDialogs['projected_count'],
+            );
+        }
         $sourceReports['compiled_site'] = $this->compiledSiteReport($normalized, $entryPath, $documents['documents'], $assets, $blockTypes, $serializedBlocks, $entryBlocks['shell_artifacts'], $compiledHtmlDocuments);
         $fileMetadata = array_column($normalized['files'], null, 'path');
         $entryFile = $fileMetadata[$entryPath] ?? array();

--- a/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
+++ b/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
@@ -1,0 +1,258 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+
+/** Projects bounded captured-dialog evidence into the matching source document. */
+final class CapturedDialogProjector
+{
+    private const REPORT_SCHEMA = 'data-liberation/captured-interactions/v1';
+    private const RECEIPT_SCHEMA = 'data-liberation/capture-receipt/v1';
+    private const MAX_PAGES = 128;
+    private const MAX_STATES_PER_PAGE = 8;
+    private const MAX_DIALOG_BYTES = 65536;
+
+    /**
+     * @param array<int, array<string, mixed>> $files
+     * @return array{files:array<int, array<string, mixed>>, diagnostics:array<int, array<string, mixed>>, projected_count:int}
+     */
+    public function project(array $files): array
+    {
+        $diagnostics = array();
+        $report = $this->jsonFile($files, 'interaction-states.json');
+        if (null === $report) {
+            return array('files' => $files, 'diagnostics' => array(), 'projected_count' => 0);
+        }
+        if (self::REPORT_SCHEMA !== ($report['schema'] ?? null) || ! is_array($report['pages'] ?? null)) {
+            return array('files' => $files, 'diagnostics' => array($this->diagnostic('captured_interactions_invalid', 'warning', 'The captured interaction report has an unsupported schema or pages shape.')), 'projected_count' => 0);
+        }
+        if (count($report['pages']) > self::MAX_PAGES) {
+            return array('files' => $files, 'diagnostics' => array($this->diagnostic('captured_interactions_limit_exceeded', 'warning', 'The captured interaction report exceeded the page limit.', array('max_pages' => self::MAX_PAGES))), 'projected_count' => 0);
+        }
+
+        $receipt = $this->jsonFile($files, 'capture-receipt.json');
+        if (null === $receipt || self::RECEIPT_SCHEMA !== ($receipt['schema'] ?? null) || ! is_array($receipt['routes'] ?? null)) {
+            return array('files' => $files, 'diagnostics' => array($this->diagnostic('captured_interactions_route_map_missing', 'warning', 'Captured dialogs were not projected because the capture receipt route map is unavailable.')), 'projected_count' => 0);
+        }
+
+        $routes = array();
+        foreach ($receipt['routes'] as $route) {
+            if (! is_array($route) || ! is_string($route['url'] ?? null) || ! is_string($route['path'] ?? null)) {
+                continue;
+            }
+            $routes[$this->normalizedUrl($route['url'])] = $route['path'];
+        }
+        $fileIndexes = array();
+        foreach ($files as $index => $file) {
+            if (is_string($file['path'] ?? null)) {
+                $fileIndexes[$file['path']] = $index;
+            }
+        }
+
+        $projected = 0;
+        foreach ($report['pages'] as $page) {
+            if (! is_array($page) || ! is_string($page['sourceUrl'] ?? null) || ! is_array($page['states'] ?? null)) {
+                $diagnostics[] = $this->diagnostic('captured_interaction_page_invalid', 'warning', 'A captured interaction page was ignored because its source URL or states are invalid.');
+                continue;
+            }
+            if (count($page['states']) > self::MAX_STATES_PER_PAGE) {
+                $diagnostics[] = $this->diagnostic('captured_interaction_state_limit_exceeded', 'warning', 'A captured interaction page exceeded the state limit.', array('source_url' => $page['sourceUrl'], 'max_states' => self::MAX_STATES_PER_PAGE));
+                continue;
+            }
+            $path = $routes[$this->normalizedUrl($page['sourceUrl'])] ?? '';
+            $index = $fileIndexes[$path] ?? null;
+            if (! is_int($index) || ! is_string($files[$index]['content'] ?? null)) {
+                $diagnostics[] = $this->diagnostic('captured_interaction_source_unmatched', 'warning', 'A captured interaction page did not match an artifact HTML document.', array('source_url' => $page['sourceUrl']));
+                continue;
+            }
+
+            $projection = $this->projectPage((string) $files[$index]['content'], $page['states'], $path);
+            $diagnostics = array_merge($diagnostics, $projection['diagnostics']);
+            if (0 < $projection['projected_count']) {
+                $files[$index]['content'] = $projection['html'];
+                $files[$index]['bytes'] = strlen($projection['html']);
+                $projected += $projection['projected_count'];
+            }
+        }
+
+        return array('files' => $files, 'diagnostics' => $diagnostics, 'projected_count' => $projected);
+    }
+
+    /**
+     * @param array<int, mixed> $states
+     * @return array{html:string, diagnostics:array<int, array<string, mixed>>, projected_count:int}
+     */
+    private function projectPage(string $html, array $states, string $sourcePath): array
+    {
+        $previous = libxml_use_internal_errors(true);
+        $document = new DOMDocument('1.0', 'UTF-8');
+        $loaded = $document->loadHTML('<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NONET);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if (! $loaded) {
+            return array('html' => $html, 'diagnostics' => array($this->diagnostic('captured_interaction_source_invalid', 'warning', 'Captured dialogs were not projected because the source HTML could not be parsed.', array('source_path' => $sourcePath))), 'projected_count' => 0);
+        }
+
+        $diagnostics = array();
+        $projected = 0;
+        foreach ($states as $state) {
+            if (! is_array($state) || 'captured' !== ($state['status'] ?? null) || ! is_array($state['trigger'] ?? null) || ! is_array($state['dialog'] ?? null)) {
+                continue;
+            }
+            $dialog = $state['dialog'];
+            $dialogHtml = is_string($dialog['html'] ?? null) ? $dialog['html'] : '';
+            $declaredBytes = is_int($dialog['htmlBytes'] ?? null) ? $dialog['htmlBytes'] : -1;
+            if ('' === $dialogHtml || ! empty($dialog['htmlTruncated']) || strlen($dialogHtml) > self::MAX_DIALOG_BYTES || $declaredBytes !== strlen($dialogHtml)) {
+                $diagnostics[] = $this->diagnostic('captured_dialog_unsafe_or_truncated', 'warning', 'A captured dialog was ignored because its HTML is empty, truncated, or exceeds the byte limit.', array('source_path' => $sourcePath));
+                continue;
+            }
+            $trigger = $this->findTrigger($document, $state['trigger']);
+            if (! $trigger instanceof DOMElement) {
+                $diagnostics[] = $this->diagnostic('captured_dialog_trigger_unmatched', 'warning', 'A captured dialog trigger did not match exactly one source element.', array('source_path' => $sourcePath, 'selector' => (string) ($state['trigger']['selector'] ?? '')));
+                continue;
+            }
+            $fragment = $this->safeDialogFragment($dialogHtml);
+            if (null === $fragment) {
+                $diagnostics[] = $this->diagnostic('captured_dialog_markup_invalid', 'warning', 'A captured dialog was ignored because its markup could not be sanitized.', array('source_path' => $sourcePath));
+                continue;
+            }
+
+            $identity = substr(hash('sha256', $sourcePath . "\n" . ($state['trigger']['selector'] ?? '') . "\n" . $dialogHtml), 0, 16);
+            $triggerId = trim($trigger->getAttribute('id'));
+            if ('' === $triggerId) {
+                $triggerId = 'blocks-engine-dialog-trigger-' . $identity;
+                $trigger->setAttribute('id', $triggerId);
+            }
+            $dialogId = 'blocks-engine-dialog-' . $identity;
+            $dialogElement = $document->createElement('dialog');
+            $dialogElement->setAttribute('id', $dialogId);
+            $dialogElement->setAttribute('data-blocks-engine-captured-dialog', 'true');
+            $dialogElement->setAttribute('data-blocks-engine-trigger', $triggerId);
+            if (is_string($fragment['class']) && '' !== $fragment['class']) $dialogElement->setAttribute('class', $fragment['class']);
+            if (is_string($fragment['aria_label']) && '' !== $fragment['aria_label']) $dialogElement->setAttribute('aria-label', $fragment['aria_label']);
+            if (is_string($fragment['aria_labelledby']) && '' !== $fragment['aria_labelledby']) $dialogElement->setAttribute('aria-labelledby', $fragment['aria_labelledby']);
+            if (is_string($fragment['aria_describedby']) && '' !== $fragment['aria_describedby']) $dialogElement->setAttribute('aria-describedby', $fragment['aria_describedby']);
+            if (! $fragment['has_close_control']) $dialogElement->setAttribute('data-blocks-engine-add-close', 'true');
+            foreach ($fragment['nodes'] as $node) {
+                $dialogElement->appendChild($document->importNode($node, true));
+            }
+            ($document->getElementsByTagName('body')->item(0) ?? $document->documentElement)?->appendChild($dialogElement);
+            ++$projected;
+        }
+
+        $output = $document->saveHTML();
+        $output = is_string($output) ? preg_replace('/^<\?xml encoding="UTF-8">/i', '', $output) : null;
+        return array('html' => is_string($output) ? $output : $html, 'diagnostics' => $diagnostics, 'projected_count' => $projected);
+    }
+
+    /** @param array<string, mixed> $trigger */
+    private function findTrigger(DOMDocument $document, array $trigger): ?DOMElement
+    {
+        $xpath = new DOMXPath($document);
+        $selector = is_string($trigger['selector'] ?? null) ? trim($trigger['selector']) : '';
+        $query = '';
+        if (str_starts_with($selector, '#') && 1 === preg_match('/^#[A-Za-z][A-Za-z0-9_.:-]*$/', $selector)) {
+            $query = '//*[@id=' . $this->xpathLiteral(substr($selector, 1)) . ']';
+        } else {
+            $bindings = is_array($trigger['dataBindings'] ?? null) ? $trigger['dataBindings'] : array();
+            foreach ($bindings as $name => $value) {
+                if (is_string($name) && is_string($value) && 1 === preg_match('/^data-(?:popup|modal|dialog)(?:id|target)?$/i', $name) && '' !== $value) {
+                    $query = '//*[@' . strtolower($name) . '=' . $this->xpathLiteral($value) . ']';
+                    break;
+                }
+            }
+        }
+        if ('' === $query) return null;
+        $matches = $xpath->query($query);
+        if (false === $matches || 1 !== $matches->length) return null;
+        $element = $matches->item(0);
+        if (! $element instanceof DOMElement) return null;
+        $tag = is_string($trigger['tag'] ?? null) ? strtolower($trigger['tag']) : '';
+        return '' === $tag || $tag === strtolower($element->tagName) ? $element : null;
+    }
+
+    /** @return array{nodes:array<int, \DOMNode>, class:string, aria_label:string, aria_labelledby:string, aria_describedby:string, has_close_control:bool}|null */
+    private function safeDialogFragment(string $html): ?array
+    {
+        $previous = libxml_use_internal_errors(true);
+        $document = new DOMDocument('1.0', 'UTF-8');
+        $loaded = $document->loadHTML('<?xml encoding="UTF-8"><div data-dialog-root="true">' . $html . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NONET);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if (! $loaded) return null;
+        $xpath = new DOMXPath($document);
+        foreach (array('script', 'iframe', 'object', 'embed', 'template') as $tag) {
+            $matches = $xpath->query('//' . $tag);
+            if (false === $matches) continue;
+            foreach (iterator_to_array($matches) as $node) $node->parentNode?->removeChild($node);
+        }
+        foreach ($xpath->query('//*') ?: array() as $element) {
+            if (! $element instanceof DOMElement) continue;
+            foreach (iterator_to_array($element->attributes) as $attribute) {
+                $name = strtolower($attribute->name);
+                $value = trim($attribute->value);
+                if (str_starts_with($name, 'on') || 'srcdoc' === $name || ('form' === strtolower($element->tagName) && in_array($name, array('action', 'method'), true)) || (in_array($name, array('href', 'src'), true) && preg_match('/^\s*(?:javascript|data\s*:\s*text\/html)/i', $value))) {
+                    $element->removeAttribute($attribute->name);
+                }
+            }
+        }
+        $wrapper = $xpath->query('//*[@data-dialog-root="true"]')?->item(0);
+        if (! $wrapper instanceof DOMElement) return null;
+        $sourceRoot = null;
+        foreach ($wrapper->childNodes as $node) {
+            if ($node instanceof DOMElement) { $sourceRoot = $node; break; }
+        }
+        $container = $sourceRoot instanceof DOMElement ? $sourceRoot : $wrapper;
+        $hasCloseControl = false;
+        foreach ($container->getElementsByTagName('button') as $button) {
+            $label = strtolower(trim($button->getAttribute('aria-label')));
+            $text = strtolower(trim($button->textContent ?? ''));
+            if (str_contains($label, 'close') || in_array($text, array('close', 'x', '×'), true) || $button->hasAttribute('data-close') || $button->hasAttribute('data-dismiss')) {
+                $button->setAttribute('data-blocks-engine-dialog-close', 'true');
+                $hasCloseControl = true;
+                break;
+            }
+        }
+        return array(
+            'nodes' => iterator_to_array($container->childNodes),
+            'class' => $sourceRoot instanceof DOMElement ? trim($sourceRoot->getAttribute('class')) : '',
+            'aria_label' => $sourceRoot instanceof DOMElement ? trim($sourceRoot->getAttribute('aria-label')) : '',
+            'aria_labelledby' => $sourceRoot instanceof DOMElement ? trim($sourceRoot->getAttribute('aria-labelledby')) : '',
+            'aria_describedby' => $sourceRoot instanceof DOMElement ? trim($sourceRoot->getAttribute('aria-describedby')) : '',
+            'has_close_control' => $hasCloseControl,
+        );
+    }
+
+    /** @param array<int, array<string, mixed>> $files @return array<string, mixed>|null */
+    private function jsonFile(array $files, string $path): ?array
+    {
+        foreach ($files as $file) {
+            if ($path !== ($file['path'] ?? null) || ! is_string($file['content'] ?? null) || strlen($file['content']) > 2 * 1024 * 1024) continue;
+            $decoded = json_decode($file['content'], true);
+            return is_array($decoded) ? $decoded : null;
+        }
+        return null;
+    }
+
+    private function normalizedUrl(string $url): string
+    {
+        return rtrim(trim($url), '/');
+    }
+
+    private function xpathLiteral(string $value): string
+    {
+        if (! str_contains($value, "'")) return "'" . $value . "'";
+        if (! str_contains($value, '"')) return '"' . $value . '"';
+        return 'concat(' . implode(', "\'", ', array_map(static fn(string $part): string => "'" . $part . "'", explode("'", $value))) . ')';
+    }
+
+    /** @param array<string, mixed> $context @return array<string, mixed> */
+    private function diagnostic(string $code, string $severity, string $message, array $context = array()): array
+    {
+        return array_filter(array('code' => $code, 'severity' => $severity, 'message' => $message, 'source' => self::class, 'context' => $context), static fn(mixed $value): bool => array() !== $value);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/CapturedDialogBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/CapturedDialogBlockGenerator.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/** Defines the editable companion block used for captured dialogs. */
+final class CapturedDialogBlockGenerator
+{
+    public const LOCAL_NAME = 'captured-dialog';
+
+    /** @return array<string, mixed> */
+    public function definition(string $blockName): array
+    {
+        $attributes = array(
+            'dialogId' => array('type' => 'string', 'default' => ''),
+            'triggerId' => array('type' => 'string', 'default' => ''),
+            'ariaLabel' => array('type' => 'string', 'default' => ''),
+            'ariaLabelledby' => array('type' => 'string', 'default' => ''),
+            'ariaDescribedby' => array('type' => 'string', 'default' => ''),
+            'className' => array('type' => 'string', 'default' => ''),
+            'addCloseButton' => array('type' => 'boolean', 'default' => false),
+        );
+        $editor = <<<'JS'
+( function( blocks, blockEditor, element ) {
+    var createElement = element.createElement;
+    var InnerBlocks = blockEditor.InnerBlocks;
+    function dialogProps( attrs ) {
+        return { id: attrs.dialogId || undefined, className: attrs.className || undefined, 'aria-label': attrs.ariaLabel || undefined, 'aria-labelledby': attrs.ariaLabelledby || undefined, 'aria-describedby': attrs.ariaDescribedby || undefined, 'data-blocks-engine-trigger': attrs.triggerId || undefined };
+    }
+    blocks.registerBlockType( '__BLOCK_NAME__', {
+        attributes: __ATTRIBUTES__,
+        supports: { html: false, customClassName: false },
+        edit: function( props ) { return createElement( 'div', { className: 'blocks-engine-captured-dialog-editor' }, createElement( 'strong', null, props.attributes.ariaLabel || 'Dialog' ), createElement( InnerBlocks ) ); },
+        save: function( props ) { return createElement( 'dialog', dialogProps( props.attributes ), props.attributes.addCloseButton ? createElement( 'button', { type: 'button', 'data-blocks-engine-dialog-close': 'true', 'aria-label': 'Close' }, 'Close' ) : null, createElement( InnerBlocks.Content ) ); }
+    } );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
+JS;
+        $view = <<<'JS'
+( function() {
+    function mount( dialog ) {
+        if ( dialog.dataset.blocksEngineMounted ) return;
+        var trigger = document.getElementById( dialog.getAttribute( 'data-blocks-engine-trigger' ) || '' );
+        if ( ! trigger ) return;
+        dialog.dataset.blocksEngineMounted = 'true';
+        trigger.addEventListener( 'click', function( event ) { event.preventDefault(); if ( dialog.showModal ) dialog.showModal(); else dialog.setAttribute( 'open', '' ); } );
+        dialog.addEventListener( 'click', function( event ) { if ( event.target === dialog || event.target.closest( '[data-blocks-engine-dialog-close]' ) ) dialog.close ? dialog.close() : dialog.removeAttribute( 'open' ); } );
+    }
+    function mountAll() { document.querySelectorAll( 'dialog[data-blocks-engine-trigger]' ).forEach( mount ); }
+    if ( 'loading' === document.readyState ) document.addEventListener( 'DOMContentLoaded', mountAll ); else mountAll();
+} )();
+JS;
+
+        return array(
+            'name' => self::LOCAL_NAME,
+            'block_json' => array(
+                'apiVersion' => 3,
+                'name' => $blockName,
+                'title' => 'Dialog',
+                'category' => 'widgets',
+                'description' => 'Editable dialog content opened by a page control.',
+                'editorScript' => 'file:./index.js',
+                'viewScript' => 'file:./view.js',
+                'attributes' => $attributes,
+                'supports' => array('html' => false, 'customClassName' => false),
+            ),
+            'assets' => array(
+                'index.js' => str_replace(array('__BLOCK_NAME__', '__ATTRIBUTES__'), array($blockName, json_encode($attributes, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)), $editor),
+            ),
+            'view_js' => $view,
+            'script_dependencies' => array('index.js' => array('wp-blocks', 'wp-block-editor', 'wp-element')),
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -349,6 +349,8 @@ final class HtmlTransformer
 
     private bool $responsiveMediaBlockGenerated = false;
 
+    private bool $capturedDialogBlockGenerated = false;
+
     /**
      * Block namespace for generated custom-block references. The ArtifactCompiler
      * sets this to the per-site companion-plugin namespace (`ssi-<site_slug>`) so
@@ -698,6 +700,7 @@ final class HtmlTransformer
         $this->nativeDisclosureRootIds = array();
         $this->generatedBlocks = array();
         $this->responsiveMediaBlockGenerated = false;
+        $this->capturedDialogBlockGenerated = false;
         $this->descriptionListBlockGenerated = false;
         $this->formSelectBlockGenerated = false;
         $this->formInputBlockGenerated = false;
@@ -4321,6 +4324,10 @@ final class HtmlTransformer
             }
         }
 
+        if ('dialog' === $tagName && 'true' === $this->attr($element, 'data-blocks-engine-captured-dialog')) {
+            return $this->capturedDialogBlock($element, $fallbacks);
+        }
+
         if ( $this->shouldPreserveDataAttributeRuntimeTarget($element) ) {
             return $this->htmlPreservationBlock($element);
         }
@@ -5342,6 +5349,45 @@ final class HtmlTransformer
 
         $blocks[] = $this->createBlock('core/paragraph', array( 'content' => $this->runtime->escapeHtml($text) ));
         return $blocks;
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks @return array<string, mixed> */
+    private function capturedDialogBlock(DOMElement $element, array &$fallbacks): array
+    {
+        $blockName = $this->generatedBlockNamespace . '/' . CapturedDialogBlockGenerator::LOCAL_NAME;
+        if (! $this->capturedDialogBlockGenerated) {
+            $this->generatedBlocks[] = (new CapturedDialogBlockGenerator())->definition($blockName);
+            $this->capturedDialogBlockGenerated = true;
+        }
+
+        $attrs = array_filter(array(
+            'dialogId' => trim($this->attr($element, 'id')),
+            'triggerId' => trim($this->attr($element, 'data-blocks-engine-trigger')),
+            'ariaLabel' => trim($this->attr($element, 'aria-label')),
+            'ariaLabelledby' => trim($this->attr($element, 'aria-labelledby')),
+            'ariaDescribedby' => trim($this->attr($element, 'aria-describedby')),
+            'className' => trim($this->attr($element, 'class')),
+            'addCloseButton' => 'true' === $this->attr($element, 'data-blocks-engine-add-close'),
+        ), static fn(mixed $value): bool => false !== $value && '' !== $value);
+        $children = $this->convertChildren($element, $fallbacks, true);
+        $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $opening = '<dialog';
+        foreach (array('dialogId' => 'id', 'className' => 'class', 'ariaLabel' => 'aria-label', 'ariaLabelledby' => 'aria-labelledby', 'ariaDescribedby' => 'aria-describedby', 'triggerId' => 'data-blocks-engine-trigger') as $key => $attribute) {
+            if (isset($attrs[$key])) $opening .= ' ' . $attribute . '="' . $escape((string) $attrs[$key]) . '"';
+        }
+        $opening .= '>';
+        if (! empty($attrs['addCloseButton'])) $opening .= '<button type="button" data-blocks-engine-dialog-close="true" aria-label="Close">Close</button>';
+        $innerContent = array($opening);
+        foreach ($children as $_) $innerContent[] = null;
+        $innerContent[] = '</dialog>';
+
+        return array(
+            'blockName' => $blockName,
+            'attrs' => $attrs,
+            'innerBlocks' => $children,
+            'innerHTML' => $opening . '</dialog>',
+            'innerContent' => $innerContent,
+        );
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -48,7 +48,8 @@ if ( ! function_exists('serialize_blocks') ) {
                 $inner .= $part;
             }
 
-            $serialized .= '<!-- wp:' . substr($name, 5) . $attrs . ' -->' . $inner . '<!-- /wp:' . substr($name, 5) . ' -->';
+            $commentName = str_starts_with($name, 'core/') ? substr($name, 5) : $name;
+            $serialized .= '<!-- wp:' . $commentName . $attrs . ' -->' . $inner . '<!-- /wp:' . $commentName . ' -->';
         }
 
         return $serialized;
@@ -3996,6 +3997,44 @@ $companionAbsent = $compiler->compile(
     array( 'files' => array( 'index.html' => '<main><h1>Plain</h1><p>No blocks</p></main>' ) )
 )->toArray();
 $assert(! array_key_exists('companion_plugin_payload', $companionAbsent['source_reports']), 'companion_plugin_payload is absent when no generated blocks exist');
+
+$capturedDialog = $compiler->compile(array(
+    'site' => array('name' => 'Captured Dialog Site', 'slug' => 'captured-dialog-site'),
+    'entrypoint' => 'website/index.html',
+    'files' => array(
+        array('path' => 'website/index.html', 'content' => '<main><a role="button" aria-haspopup="dialog" data-popupid="contact">Contact</a></main>'),
+        array('path' => 'capture-receipt.json', 'content' => json_encode(array(
+            'schema' => 'data-liberation/capture-receipt/v1',
+            'routes' => array(array('url' => 'https://example.com/', 'path' => 'website/index.html')),
+        ), JSON_UNESCAPED_SLASHES)),
+        array('path' => 'interaction-states.json', 'content' => json_encode(array(
+            'schema' => 'data-liberation/captured-interactions/v1',
+            'pages' => array(array(
+                'sourceUrl' => 'https://example.com/',
+                'states' => array(array(
+                    'status' => 'captured',
+                    'trigger' => array('selector' => 'body > main > a', 'tag' => 'a', 'ariaHaspopup' => 'dialog', 'dataBindings' => array('data-popupid' => 'contact')),
+                    'dialog' => array(
+                        'html' => '<div role="dialog" aria-label="Contact"><form action="https://provider.example/forms"><label>Name<input name="name"></label><script>window.provider=true</script></form></div>',
+                        'htmlBytes' => strlen('<div role="dialog" aria-label="Contact"><form action="https://provider.example/forms"><label>Name<input name="name"></label><script>window.provider=true</script></form></div>'),
+                        'htmlTruncated' => false,
+                    ),
+                )),
+            )),
+        ), JSON_UNESCAPED_SLASHES)),
+    ),
+))->toArray();
+$assert(1 === ($capturedDialog['source_reports']['captured_interactions']['projected_dialog_count'] ?? null), 'captured interaction reports project one matched dialog');
+$assert(str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), '<!-- wp:ssi-captured-dialog-site/captured-dialog'), 'captured dialogs serialize as a site companion block', (string) ($capturedDialog['serialized_blocks'] ?? ''));
+$assert(str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), '<dialog') && str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), 'data-blocks-engine-trigger='), 'captured dialog block preserves native dialog and trigger linkage');
+$assert(! str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), 'provider.example') && ! str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), 'window.provider'), 'captured dialogs remove provider endpoints and executable source code');
+$capturedDialogBlocks = $capturedDialog['source_reports']['companion_plugin_payload']['blocks'] ?? array();
+$capturedDialogBlock = current(array_filter($capturedDialogBlocks, static fn(array $block): bool => 'captured-dialog' === ($block['name'] ?? ''))) ?: array();
+$assert('ssi-captured-dialog-site/captured-dialog' === ($capturedDialogBlock['block_json']['name'] ?? null), 'captured dialog companion metadata matches the serialized block namespace');
+$assert(str_contains((string) ($capturedDialogBlock['view_js'] ?? ''), 'showModal'), 'captured dialog companion block carries scoped native dialog behavior');
+$assert(isset($capturedDialogBlock['assets']['index.js']), 'captured dialog companion block carries an editable InnerBlocks editor');
+$capturedDialogForms = array_values(array_filter($capturedDialog['source_reports']['artifact']['runtime_declarations'] ?? array(), static fn(array $declaration): bool => 'entity_collection' === ($declaration['kind'] ?? '') && 'forms' === ($declaration['type'] ?? '')));
+$assert(1 === count($capturedDialogForms), 'captured dialog forms continue through the generic form materialization declaration');
 
 // Runtime-island package producer (issue #491 slice 2): preserved runtime
 // islands are packaged into a generic, product-neutral envelope a downstream


### PR DESCRIPTION
Fixes #985.

## What

- Validates bounded `data-liberation/captured-interactions/v1` reports and matches states to source documents through the capture receipt route map.
- Projects safe dialog snapshots into native `<dialog>` elements while stripping source scripts, embedded runtimes, event handlers, and provider form endpoints.
- Converts projected dialogs into generated companion blocks with editable `InnerBlocks`, preserved accessibility relationships, deterministic trigger linkage, and scoped native `showModal()`/close behavior.
- Keeps forms inside dialogs on the existing generic form declaration path for downstream WordPress-owned provider binding.
- Corrects the no-WordPress test serializer to strip only the `core/` namespace, matching WordPress behavior for custom blocks.

## Verification

- `composer test`
- 278 parity fixtures passed.
- Package install proof passed.
- Contract coverage proves report projection, custom block serialization, trigger linkage, sanitization, companion payload generation, and form declarations.

## AI assistance

- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Cross-repository contract tracing, implementation, tests, and verification. Chris Huber selected the generated companion-block architecture and remains responsible for every line.
