### PR TITLE
Project captured canvas constraints responsively

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -116,6 +116,7 @@
       "php tests/unit/html-transformer-shared-analysis-cache.php",
       "php tests/unit/reusable-component-recognition.php",
       "php tests/unit/compile-fragment-author-stylesheet.php",
+      "php tests/unit/responsive-canvas-geometry.php",
       "php tests/unit/core-html-fallback-reduction.php"
     ],
     "test:parity": "php tests/parity/run.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -555,6 +555,9 @@ final class HtmlTransformer
     /** @var list<string> Source body-state classes referenced by authored CSS. */
     private array $sourceBodyProjectionClasses = array();
 
+    /** @var array<string, array{selector: string, min_width: string}> */
+    private array $responsiveGeometryAmbiguities = array();
+
     /** @var array<string, string> Native tables whose descendant selectors need structural projection. */
     private array $sourceTableMarkers = array();
 
@@ -730,6 +733,7 @@ final class HtmlTransformer
         $this->sourceAttributeMarkers = array();
         $this->sourceRootChildMarkers = array();
         $this->sourceBodyProjectionClasses = array();
+        $this->responsiveGeometryAmbiguities = array();
         $this->sourceTableMarkers = array();
         $this->sourceTableRepresentability = array();
         $this->sourceTableDescendantPaths = array();
@@ -912,6 +916,16 @@ final class HtmlTransformer
             $semanticParityReport,
             $contentRoundTripReport
         );
+        foreach ( $this->responsiveGeometryAmbiguities as $ambiguity ) {
+            $diagnostics[] = array(
+                'code' => 'responsive_geometry_ambiguous_min_width',
+                'message' => 'A wide minimum-width rule matches both page-shell and authored content surfaces, so it was retained without a responsive projection.',
+                'source' => self::class,
+                'severity' => 'warning',
+                'selector' => $ambiguity['selector'],
+                'min_width' => $ambiguity['min_width'],
+            );
+        }
         $headMetadata = $this->headMetadataReport($html);
         if ( array() !== $headMetadata ) {
             $diagnostics[] = array(
@@ -3133,6 +3147,7 @@ final class HtmlTransformer
     private function rewriteAuthorStylesheet(string $stylesheet): string
     {
         return ( new CssStylesheetTransformer() )->transformStyleRules($stylesheet, function (string $prelude, string $body): string {
+            $body = $this->projectResponsiveCanvasMinimumWidth($prelude, $body);
             $declarations = $this->cssDeclarations($body);
             $margins = array_filter($declarations, static fn (string $name): bool => 'margin' === $name || str_starts_with($name, 'margin-'), ARRAY_FILTER_USE_KEY);
             $imagePrelude = $this->projectAuthorImageSelectorPrelude($prelude);
@@ -3153,6 +3168,102 @@ final class HtmlTransformer
                 : $this->rewriteAuthorStyleRule($prelude, $this->cssDeclarationString($inner));
             return $rules . $this->rewriteAuthorSelectorPrelude($prelude, true) . '{' . $this->cssDeclarationString($margins) . '}' . $imageRule . $svgImageRule;
         });
+    }
+
+    /**
+     * Captured builders commonly impose a desktop canvas minimum on a document
+     * root and its immediate section strips. That is runtime viewport scaffolding,
+     * not an authored content constraint: retaining it forces a desktop-wide
+     * WordPress document on narrow viewports. Only project broad absolute values
+     * when every matched source element is a structural shell or section surface.
+     */
+    private function projectResponsiveCanvasMinimumWidth(string $prelude, string $body): string
+    {
+        $declarations = $this->cssDeclarations($body);
+        $minimumWidth = (string) ($declarations['min-width'] ?? '');
+        if ( ! $this->isWideAbsoluteMinimumWidth($minimumWidth) ) {
+            return $body;
+        }
+
+        $selectors = CssStylesheetTransformer::splitSelectorList($prelude);
+        if ( null === $selectors || ! $this->authorStyleSourceBody instanceof DOMElement ) {
+            return $body;
+        }
+
+        $matchedSurface = false;
+        foreach ( $selectors as $selector ) {
+            $parsed = $this->parsedCssSelector($selector);
+            if ( ! $parsed['supported'] ) {
+                return $body;
+            }
+            $matches = $this->matchingAuthorSourceElements($selector, $parsed);
+            if ( array() === $matches ) {
+                continue;
+            }
+            $matchedSurface = true;
+            $shellMatches = array_filter($matches, fn (DOMElement $element): bool => $this->isPageShellOrSectionSurface($element));
+            if ( count($shellMatches) !== count($matches) ) {
+                if ( array() !== $shellMatches ) {
+                    $this->responsiveGeometryAmbiguities[$selector . "\0" . $minimumWidth] = array('selector' => $selector, 'min_width' => $minimumWidth);
+                }
+                return $body;
+            }
+        }
+
+        if ( ! $matchedSurface ) {
+            return $body;
+        }
+
+        $important = $this->cssValueIsImportant($minimumWidth) ? '!important' : '';
+        $retained = array();
+        foreach ( CssValueSplitter::splitTopLevel($body, array( ';' )) as $declaration ) {
+            if ( 'min-width' !== strtolower(trim(strtok($declaration, ':'))) ) {
+                $retained[] = $declaration;
+            }
+        }
+        $retained[] = 'min-width:0' . $important;
+        $retained[] = 'max-width:100%' . $important;
+        return implode(';', $retained);
+    }
+
+    private function isWideAbsoluteMinimumWidth(string $value): bool
+    {
+        $value = $this->cssValueWithoutImportant($value);
+        if ( 1 !== preg_match('/^(\d+(?:\.\d+)?)\s*(px|r?em)$/i', $value, $matches) ) {
+            return false;
+        }
+        $pixels = (float) $matches[1];
+        if ( 'px' !== strtolower($matches[2]) ) {
+            $pixels *= self::ROOT_FONT_SIZE_PX;
+        }
+        return $pixels >= 640;
+    }
+
+    private function isPageShellOrSectionSurface(DOMElement $element): bool
+    {
+        if ( $element->parentNode === $this->authorStyleSourceBody ) {
+            return true;
+        }
+
+        if ( in_array(strtolower($element->tagName), array( 'header', 'main', 'footer', 'section' ), true) ) {
+            return true;
+        }
+
+        $parent = $element->parentNode;
+        return $parent instanceof DOMElement
+            && $parent->parentNode === $this->authorStyleSourceBody
+            && $this->elementChildCount($parent) > 1;
+    }
+
+    private function elementChildCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+        return $count;
     }
 
     private function rewriteAuthorStyleRule(string $prelude, string $body): string

--- a/php-transformer/tests/unit/responsive-canvas-geometry.php
+++ b/php-transformer/tests/unit/responsive-canvas-geometry.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, "FAIL: {$message}\n");
+};
+$css = static function (array $result): string {
+    foreach ( $result['assets'] ?? array() as $asset ) {
+        if ( 'author-css' === ($asset['source'] ?? '') ) {
+            return (string) ($asset['content'] ?? '');
+        }
+    }
+    return '';
+};
+
+$result = (new HtmlTransformer())->transform(
+    '<style>#page-shell{min-width:980px;background:#fff}.page-strip{min-width:980px;padding:24px}.product-card{min-width:42rem;width:30rem}</style>'
+    . '<div id="page-shell"><header class="page-strip"><p>Header</p></header><main class="page-strip"><section><p>Body</p></section><div class="product-card"><p>Card</p></div></main><footer class="page-strip"><p>Footer</p></footer></div>'
+)->toArray();
+$authorCss = $css($result);
+
+$assert(! str_contains($authorCss, '#page-shell{min-width:980px') && ! str_contains($authorCss, '.page-strip{min-width:980px'), 'desktop canvas minimum widths are removed from page shell and section strips');
+$assert(substr_count($authorCss, 'min-width:0') === 2 && substr_count($authorCss, 'max-width:100%') === 2, 'page shell and section strips receive bounded responsive geometry');
+$assert(str_contains($authorCss, '#page-shell{background:#fff;min-width:0;max-width:100%}') && str_contains($authorCss, '.page-strip{padding:24px;min-width:0;max-width:100%}'), 'desktop paint and section spacing survive the responsive projection');
+$assert(str_contains($authorCss, '.product-card{min-width:42rem;width:30rem}'), 'authored content minimum widths remain unchanged');
+
+$unmatched = (new HtmlTransformer())->transform('<style>.desktop-shell{min-width:980px}</style><main><p>Content</p></main>')->toArray();
+$assert(str_contains($css($unmatched), '.desktop-shell{min-width:980px}'), 'unmatched author selectors retain their minimum widths');
+
+$ambiguous = (new HtmlTransformer())->transform(
+    '<style>.wide{min-width:980px}</style><div class="wide"><section><p>Shell</p></section></div><div><p class="wide">Content</p></div>'
+)->toArray();
+$assert(str_contains($css($ambiguous), '.wide{min-width:980px}'), 'mixed shell and content selectors retain the authored minimum width');
+$assert(
+    in_array('responsive_geometry_ambiguous_min_width', array_column($ambiguous['diagnostics'] ?? array(), 'code'), true),
+    'mixed shell and content minimum-width selectors remain intact and emit a diagnostic'
+);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Responsive canvas geometry unit tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+fwrite(STDOUT, "Responsive canvas geometry unit tests: {$passes} passed\n");


### PR DESCRIPTION
## Summary

- distinguish wide captured page-shell/section minimum widths from authored content constraints
- project structural canvas surfaces to bounded responsive geometry while preserving desktop paint and spacing
- retain ambiguous mixed selectors and emit deterministic diagnostics
- add canonical responsive-geometry coverage

## Verification

- `composer --working-dir=php-transformer test:canonical`
- `git diff --check`

Closes #983

## AI assistance

OpenAI GPT-5.6-sol via OpenCode general coding agents diagnosed and implemented the transformer change and tests. OpenAI GPT-5.6-sol via OpenCode reviewed the final diff and reran the canonical suite. Chris Huber remains responsible for every line.