### PR TITLE
Remove dangling responsive-media render asset metadata

### DIFF
--- a/php-transformer/src/HtmlToBlocks/ResponsiveMediaBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/ResponsiveMediaBlockGenerator.php
@@ -23,7 +23,6 @@ final class ResponsiveMediaBlockGenerator
                 'content' => array( 'type' => 'string', 'default' => '' ),
             ),
             'supports' => array( 'html' => false ),
-            'render' => 'file:./render.php',
         );
     }
 

--- a/php-transformer/tests/unit/responsive-media-block.php
+++ b/php-transformer/tests/unit/responsive-media-block.php
@@ -19,6 +19,7 @@ $definition = $generator->definition('ssi-example');
 $assert('ssi-example/responsive-media' === ($definition['block_json']['name'] ?? null), 'one namespaced responsive-media block type is defined');
 $assert(false === ($definition['block_json']['supports']['html'] ?? null), 'the companion disables raw HTML editing');
 $assert('file:./index.js' === ($definition['block_json']['editorScript'] ?? null), 'the companion declares its editor script');
+$assert(!isset($definition['block_json']['render']), 'the companion metadata does not reference a producer-authored render asset');
 $assert(array('wp-blocks', 'wp-block-editor', 'wp-components', 'wp-element') === ($definition['script_dependencies']['index.js'] ?? null), 'the companion declares editor dependencies');
 $assert(ResponsiveMediaBlockGenerator::RENDERER === ($definition['renderer'] ?? null) && !isset($definition['render']), 'the companion delegates runtime rendering through an audited identifier without producer-authored PHP');
 $payload = ( new CompanionPluginPayload() )->fromBlockTypes(array(), array(), array(), array($definition));


### PR DESCRIPTION
## Summary

- remove the obsolete `file:./render.php` reference from responsive-media block metadata
- retain the audited Static Site Importer renderer identifier
- add a focused regression assertion for the metadata contract

Closes #991.

## Testing

- `cd php-transformer && composer test`
- 278 parity fixtures passed
- package install proof passed

## AI assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the artifact failure, implemented the two-line fix, and ran the verification suite. Chris Huber directed and reviewed the work.