### PR TITLE
Bind captured dialogs to responsive trigger sets

### DIFF
--- a/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
+++ b/php-transformer/src/ArtifactCompiler/CapturedDialogProjector.php
@@ -110,9 +110,9 @@ final class CapturedDialogProjector
                 $diagnostics[] = $this->diagnostic('captured_dialog_unsafe_or_truncated', 'warning', 'A captured dialog was ignored because its HTML is empty, truncated, or exceeds the byte limit.', array('source_path' => $sourcePath));
                 continue;
             }
-            $trigger = $this->findTrigger($document, $state['trigger']);
-            if (! $trigger instanceof DOMElement) {
-                $diagnostics[] = $this->diagnostic('captured_dialog_trigger_unmatched', 'warning', 'A captured dialog trigger did not match exactly one source element.', array('source_path' => $sourcePath, 'selector' => (string) ($state['trigger']['selector'] ?? '')));
+            $triggers = $this->findTriggers($document, $state['trigger']);
+            if (array() === $triggers) {
+                $diagnostics[] = $this->diagnostic('captured_dialog_trigger_unmatched', 'warning', 'A captured dialog trigger did not match a bounded source element set.', array('source_path' => $sourcePath, 'selector' => (string) ($state['trigger']['selector'] ?? '')));
                 continue;
             }
             $fragment = $this->safeDialogFragment($dialogHtml);
@@ -122,16 +122,20 @@ final class CapturedDialogProjector
             }
 
             $identity = substr(hash('sha256', $sourcePath . "\n" . ($state['trigger']['selector'] ?? '') . "\n" . $dialogHtml), 0, 16);
-            $triggerId = trim($trigger->getAttribute('id'));
-            if ('' === $triggerId) {
-                $triggerId = 'blocks-engine-dialog-trigger-' . $identity;
-                $trigger->setAttribute('id', $triggerId);
+            $triggerIds = array();
+            foreach ($triggers as $triggerIndex => $trigger) {
+                $triggerId = trim($trigger->getAttribute('id'));
+                if ('' === $triggerId) {
+                    $triggerId = 'blocks-engine-dialog-trigger-' . $identity . '-' . ($triggerIndex + 1);
+                    $trigger->setAttribute('id', $triggerId);
+                }
+                $triggerIds[] = $triggerId;
             }
             $dialogId = 'blocks-engine-dialog-' . $identity;
             $dialogElement = $document->createElement('dialog');
             $dialogElement->setAttribute('id', $dialogId);
             $dialogElement->setAttribute('data-blocks-engine-captured-dialog', 'true');
-            $dialogElement->setAttribute('data-blocks-engine-trigger', $triggerId);
+            $dialogElement->setAttribute('data-blocks-engine-triggers', implode(' ', $triggerIds));
             if (is_string($fragment['class']) && '' !== $fragment['class']) $dialogElement->setAttribute('class', $fragment['class']);
             if (is_string($fragment['aria_label']) && '' !== $fragment['aria_label']) $dialogElement->setAttribute('aria-label', $fragment['aria_label']);
             if (is_string($fragment['aria_labelledby']) && '' !== $fragment['aria_labelledby']) $dialogElement->setAttribute('aria-labelledby', $fragment['aria_labelledby']);
@@ -149,8 +153,8 @@ final class CapturedDialogProjector
         return array('html' => is_string($output) ? $output : $html, 'diagnostics' => $diagnostics, 'projected_count' => $projected);
     }
 
-    /** @param array<string, mixed> $trigger */
-    private function findTrigger(DOMDocument $document, array $trigger): ?DOMElement
+    /** @param array<string, mixed> $trigger @return array<int, DOMElement> */
+    private function findTriggers(DOMDocument $document, array $trigger): array
     {
         $xpath = new DOMXPath($document);
         $selector = is_string($trigger['selector'] ?? null) ? trim($trigger['selector']) : '';
@@ -166,13 +170,18 @@ final class CapturedDialogProjector
                 }
             }
         }
-        if ('' === $query) return null;
+        if ('' === $query) return array();
         $matches = $xpath->query($query);
-        if (false === $matches || 1 !== $matches->length) return null;
-        $element = $matches->item(0);
-        if (! $element instanceof DOMElement) return null;
+        if (false === $matches || 0 === $matches->length || $matches->length > self::MAX_STATES_PER_PAGE) return array();
         $tag = is_string($trigger['tag'] ?? null) ? strtolower($trigger['tag']) : '';
-        return '' === $tag || $tag === strtolower($element->tagName) ? $element : null;
+        $elements = array();
+        foreach ($matches as $element) {
+            if (! $element instanceof DOMElement || ('' !== $tag && $tag !== strtolower($element->tagName))) continue;
+            $popup = strtolower(trim($element->getAttribute('aria-haspopup')));
+            if (! in_array($popup, array('dialog', 'true'), true)) continue;
+            $elements[] = $element;
+        }
+        return $elements;
     }
 
     /** @return array{nodes:array<int, \DOMNode>, class:string, aria_label:string, aria_labelledby:string, aria_describedby:string, has_close_control:bool}|null */

--- a/php-transformer/src/HtmlToBlocks/CapturedDialogBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/CapturedDialogBlockGenerator.php
@@ -13,7 +13,7 @@ final class CapturedDialogBlockGenerator
     {
         $attributes = array(
             'dialogId' => array('type' => 'string', 'default' => ''),
-            'triggerId' => array('type' => 'string', 'default' => ''),
+            'triggerIds' => array('type' => 'array', 'default' => array(), 'items' => array('type' => 'string')),
             'ariaLabel' => array('type' => 'string', 'default' => ''),
             'ariaLabelledby' => array('type' => 'string', 'default' => ''),
             'ariaDescribedby' => array('type' => 'string', 'default' => ''),
@@ -25,7 +25,7 @@ final class CapturedDialogBlockGenerator
     var createElement = element.createElement;
     var InnerBlocks = blockEditor.InnerBlocks;
     function dialogProps( attrs ) {
-        return { id: attrs.dialogId || undefined, className: attrs.className || undefined, 'aria-label': attrs.ariaLabel || undefined, 'aria-labelledby': attrs.ariaLabelledby || undefined, 'aria-describedby': attrs.ariaDescribedby || undefined, 'data-blocks-engine-trigger': attrs.triggerId || undefined };
+        return { id: attrs.dialogId || undefined, className: attrs.className || undefined, 'aria-label': attrs.ariaLabel || undefined, 'aria-labelledby': attrs.ariaLabelledby || undefined, 'aria-describedby': attrs.ariaDescribedby || undefined, 'data-blocks-engine-triggers': ( attrs.triggerIds || [] ).join( ' ' ) || undefined };
     }
     blocks.registerBlockType( '__BLOCK_NAME__', {
         attributes: __ATTRIBUTES__,
@@ -39,13 +39,13 @@ JS;
 ( function() {
     function mount( dialog ) {
         if ( dialog.dataset.blocksEngineMounted ) return;
-        var trigger = document.getElementById( dialog.getAttribute( 'data-blocks-engine-trigger' ) || '' );
-        if ( ! trigger ) return;
+        var triggers = ( dialog.getAttribute( 'data-blocks-engine-triggers' ) || '' ).split( /\s+/ ).map( function( id ) { return document.getElementById( id ); } ).filter( Boolean );
+        if ( ! triggers.length ) return;
         dialog.dataset.blocksEngineMounted = 'true';
-        trigger.addEventListener( 'click', function( event ) { event.preventDefault(); if ( dialog.showModal ) dialog.showModal(); else dialog.setAttribute( 'open', '' ); } );
+        triggers.forEach( function( trigger ) { trigger.addEventListener( 'click', function( event ) { event.preventDefault(); if ( dialog.showModal ) dialog.showModal(); else dialog.setAttribute( 'open', '' ); } ); } );
         dialog.addEventListener( 'click', function( event ) { if ( event.target === dialog || event.target.closest( '[data-blocks-engine-dialog-close]' ) ) dialog.close ? dialog.close() : dialog.removeAttribute( 'open' ); } );
     }
-    function mountAll() { document.querySelectorAll( 'dialog[data-blocks-engine-trigger]' ).forEach( mount ); }
+    function mountAll() { document.querySelectorAll( 'dialog[data-blocks-engine-triggers]' ).forEach( mount ); }
     if ( 'loading' === document.readyState ) document.addEventListener( 'DOMContentLoaded', mountAll ); else mountAll();
 } )();
 JS;

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -5362,19 +5362,20 @@ final class HtmlTransformer
 
         $attrs = array_filter(array(
             'dialogId' => trim($this->attr($element, 'id')),
-            'triggerId' => trim($this->attr($element, 'data-blocks-engine-trigger')),
+            'triggerIds' => array_values(array_filter(preg_split('/\s+/', trim($this->attr($element, 'data-blocks-engine-triggers'))) ?: array())),
             'ariaLabel' => trim($this->attr($element, 'aria-label')),
             'ariaLabelledby' => trim($this->attr($element, 'aria-labelledby')),
             'ariaDescribedby' => trim($this->attr($element, 'aria-describedby')),
             'className' => trim($this->attr($element, 'class')),
             'addCloseButton' => 'true' === $this->attr($element, 'data-blocks-engine-add-close'),
-        ), static fn(mixed $value): bool => false !== $value && '' !== $value);
+        ), static fn(mixed $value): bool => false !== $value && '' !== $value && array() !== $value);
         $children = $this->convertChildren($element, $fallbacks, true);
         $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $opening = '<dialog';
-        foreach (array('dialogId' => 'id', 'className' => 'class', 'ariaLabel' => 'aria-label', 'ariaLabelledby' => 'aria-labelledby', 'ariaDescribedby' => 'aria-describedby', 'triggerId' => 'data-blocks-engine-trigger') as $key => $attribute) {
+        foreach (array('dialogId' => 'id', 'className' => 'class', 'ariaLabel' => 'aria-label', 'ariaLabelledby' => 'aria-labelledby', 'ariaDescribedby' => 'aria-describedby') as $key => $attribute) {
             if (isset($attrs[$key])) $opening .= ' ' . $attribute . '="' . $escape((string) $attrs[$key]) . '"';
         }
+        if (isset($attrs['triggerIds'])) $opening .= ' data-blocks-engine-triggers="' . $escape(implode(' ', $attrs['triggerIds'])) . '"';
         $opening .= '>';
         if (! empty($attrs['addCloseButton'])) $opening .= '<button type="button" data-blocks-engine-dialog-close="true" aria-label="Close">Close</button>';
         $innerContent = array($opening);

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -4026,7 +4026,7 @@ $capturedDialog = $compiler->compile(array(
 ))->toArray();
 $assert(1 === ($capturedDialog['source_reports']['captured_interactions']['projected_dialog_count'] ?? null), 'captured interaction reports project one matched dialog');
 $assert(str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), '<!-- wp:ssi-captured-dialog-site/captured-dialog'), 'captured dialogs serialize as a site companion block', (string) ($capturedDialog['serialized_blocks'] ?? ''));
-$assert(str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), '<dialog') && str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), 'data-blocks-engine-trigger='), 'captured dialog block preserves native dialog and trigger linkage');
+$assert(str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), '<dialog') && str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), 'data-blocks-engine-triggers='), 'captured dialog block preserves native dialog and trigger linkage');
 $assert(! str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), 'provider.example') && ! str_contains((string) ($capturedDialog['serialized_blocks'] ?? ''), 'window.provider'), 'captured dialogs remove provider endpoints and executable source code');
 $capturedDialogBlocks = $capturedDialog['source_reports']['companion_plugin_payload']['blocks'] ?? array();
 $capturedDialogBlock = current(array_filter($capturedDialogBlocks, static fn(array $block): bool => 'captured-dialog' === ($block['name'] ?? ''))) ?: array();


### PR DESCRIPTION
Follow-up to #986. Refs #985.

## What

Roeeby acceptance showed that responsive source captures can legitimately contain multiple desktop/mobile controls with the same declarative popup binding. The initial projector failed closed when that binding matched more than one source element.

- Treats up to eight equivalent declarative matches as one bounded responsive trigger set.
- Assigns deterministic IDs to every matched source control.
- Stores `triggerIds` on the generated block and binds each control to the same native dialog.
- Continues rejecting empty, oversized, tag-mismatched, or non-dialog trigger sets.

## Verification

- `composer test`: canonical contracts, 278 parity fixtures, and package-install proof passed.
- Full Roeeby V4 compile: one interaction projected, one companion dialog block emitted, two responsive block references linked, and one form entity declared.
- Roeeby remains failed only on its pre-existing editability policy findings.

## AI assistance

- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Roeeby acceptance diagnosis, bounded responsive-trigger implementation, tests, and verification. Chris Huber remains responsible for every line.
