### PR TITLE
Refactor typed pattern recognizer results

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -117,7 +117,8 @@
       "php tests/unit/reusable-component-recognition.php",
       "php tests/unit/compile-fragment-author-stylesheet.php",
       "php tests/unit/responsive-canvas-geometry.php",
-      "php tests/unit/core-html-fallback-reduction.php"
+      "php tests/unit/core-html-fallback-reduction.php",
+      "php tests/unit/pattern-recognizer-registry.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4529,7 +4529,7 @@ final class HtmlTransformer
         if ( 'ul' === $tagName || 'ol' === $tagName ) {
             $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
             if ( null !== $navigation ) {
-                return $this->rememberAccordionDisclosureRoot($navigation, $element);
+                return $this->rememberAccordionDisclosureRoot($navigation->block(), $element);
             }
 
             if ( $this->isStructuredCardList($element) ) {
@@ -4916,7 +4916,7 @@ final class HtmlTransformer
         if ( 'nav' === $tagName ) {
             $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext(false));
             if ( null !== $navigation ) {
-                return $this->rememberAccordionDisclosureRoot($navigation, $element);
+                return $this->rememberAccordionDisclosureRoot($navigation->block(), $element);
             }
 
             $inlineNavigation = $this->inlineNavigationGroupBlockFromElement($element);
@@ -5027,7 +5027,7 @@ final class HtmlTransformer
             if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
                 $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
                 if ( null !== $navigation ) {
-                    return $this->rememberAccordionDisclosureRoot($navigation, $element);
+                    return $this->rememberAccordionDisclosureRoot($navigation->block(), $element);
                 }
             }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
@@ -9,10 +9,7 @@ final class AccordionPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
 
-    /**
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, PatternContext $context): ?array
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         $createBlock = $context->createBlockCallback();
         $convertChildren = $context->convertChildrenCallback();
@@ -37,7 +34,9 @@ final class AccordionPattern implements PatternRecognizerInterface
             return null;
         }
 
-        return $createBlock('core/accordion', $presentationAttributes($element), $items, $element);
+        return new PatternRecognitionResult(
+            $createBlock('core/accordion', $presentationAttributes($element), $items, $element)
+        );
     }
 
     private function accordionItem(DOMElement $item, callable $innerHtml, callable $convertChildren, callable $convertChildrenWithoutTags, callable $createBlock, callable $presentationAttributes): ?array

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -28,10 +28,7 @@ final class NavigationPattern implements PatternRecognizerInterface
 
     private const INLINE_NAVIGATION_CLASS = 'blocks-engine-inline-navigation';
 
-    /**
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, PatternContext $context): ?array
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         $presentationAttributes = $context->presentationAttributesCallback();
         $innerHtml = $context->innerHtmlCallback();
@@ -73,7 +70,7 @@ final class NavigationPattern implements PatternRecognizerInterface
         // carrier declines, so nothing it protected loses that protection.
         $hoisted = $this->brandAnchorCarrier($element, $presentationAttributes, $innerHtml, $createBlock, $context->convertElementCallback(), $isRuntimeDomTarget, $navigationUnderlineColor, $resolvedStyle, $navigationColorInteractionStates, $navigationOverlayMenu);
         if ( null !== $hoisted ) {
-            return $hoisted;
+            return new PatternRecognitionResult($hoisted);
         }
 
         if ( $this->hasDirectBrandingAnchorBesideListNavigation($element, $innerHtml) ) {
@@ -127,7 +124,7 @@ final class NavigationPattern implements PatternRecognizerInterface
         $navigation = $createBlock('core/navigation', $navigationAttrs, $links, $element);
 
         if ( ! $label instanceof DOMElement ) {
-            return $navigation;
+            return new PatternRecognitionResult($navigation);
         }
 
         $labelTag = strtolower($label->tagName);
@@ -140,7 +137,9 @@ final class NavigationPattern implements PatternRecognizerInterface
                 'content' => $innerHtml($label),
             )), array(), $label);
 
-        return $createBlock('core/group', array_merge($presentationAttributes($element), array( 'tagName' => 'div' )), array( $labelBlock, $navigation ), $element);
+        return new PatternRecognitionResult(
+            $createBlock('core/group', array_merge($presentationAttributes($element), array( 'tagName' => 'div' )), array( $labelBlock, $navigation ), $element)
+        );
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognitionResult.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognitionResult.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+/**
+ * The complete, ordered-recognizer outcome. Effects are data, never hidden in
+ * a recognizer callback, so the dispatcher can commit them with the block.
+ */
+final class PatternRecognitionResult
+{
+    /**
+     * @param array<string, mixed> $block
+     * @param list<array<string, mixed>> $fallbacks
+     * @param list<array<string, mixed>> $provenance
+     * @param list<string> $declaredSideEffects
+     */
+    public function __construct(
+        private readonly array $block,
+        private readonly array $fallbacks = array(),
+        private readonly array $provenance = array(),
+        private readonly array $declaredSideEffects = array()
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function block(): array
+    {
+        return $this->block;
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fallbacks(): array
+    {
+        return $this->fallbacks;
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function provenance(): array
+    {
+        return $this->provenance;
+    }
+
+    /** @return list<string> */
+    public function declaredSideEffects(): array
+    {
+        return $this->declaredSideEffects;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerInterface.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerInterface.php
@@ -7,8 +7,5 @@ use DOMElement;
 
 interface PatternRecognizerInterface
 {
-    /**
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, PatternContext $context): ?array;
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult;
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
@@ -14,15 +14,12 @@ final class PatternRecognizerRegistry
     {
     }
 
-    /**
-     * @return array<string, mixed>|null
-     */
-    public function firstMatch(DOMElement $element, PatternContext $context): ?array
+    public function firstMatch(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         foreach ( $this->recognizers as $recognizer ) {
-            $block = $recognizer->match($element, $context);
-            if ( null !== $block ) {
-                return $block;
+            $result = $recognizer->recognize($element, $context);
+            if ( null !== $result ) {
+                return $result;
             }
         }
 

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -563,7 +563,7 @@ trait NavigationToggleSuppressionTrait
     {
         $navigation = $this->patternRecognizers->firstMatch($element, $this->probePatternContext());
 
-        return null !== $navigation && 'core/navigation' === ($navigation['blockName'] ?? '');
+        return null !== $navigation && 'core/navigation' === ($navigation->block()['blockName'] ?? '');
     }
 
     private function elementWithId(DOMElement $context, string $id): ?DOMElement

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -17,6 +17,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\TableClassificationPolic
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerInterface;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognitionResult;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
 use Automattic\BlocksEngine\PhpTransformer\StaticSite\MaterializationView;
@@ -355,9 +356,9 @@ $registryDocument->loadHTML('<div></div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_N
 $registryElement = $registryDocument->getElementsByTagName('div')->item(0);
 $registry = new PatternRecognizerRegistry(array(
     new class implements PatternRecognizerInterface {
-        public function match(DOMElement $element, PatternContext $context): ?array
+        public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
         {
-            return 'div' === strtolower($element->tagName) ? array('blockName' => 'core/group') : null;
+            return 'div' === strtolower($element->tagName) ? new PatternRecognitionResult(array('blockName' => 'core/group')) : null;
         }
     },
 ));
@@ -367,7 +368,7 @@ $registryContext = new PatternContext(
     static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $innerBlocks)
 );
 $assert($registryElement instanceof DOMElement, 'pattern registry fixture element parses');
-$assert('core/group' === ($registry->firstMatch($registryElement, $registryContext)['blockName'] ?? null), 'pattern registry returns the first recognizer match');
+$assert('core/group' === ($registry->firstMatch($registryElement, $registryContext)?->block()['blockName'] ?? null), 'pattern registry returns the first recognizer match');
 
 $tableElement = static function (string $html): DOMElement {
     $document = new DOMDocument();

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognitionResult;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerInterface;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+
+$failures = 0;
+$assertSame = static function (mixed $expected, mixed $actual, string $message) use (&$failures): void {
+    if ( $expected === $actual ) {
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+};
+
+$document = new DOMDocument();
+$document->loadHTML('<div></div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+$element = $document->documentElement;
+if ( ! $element instanceof DOMElement ) {
+    throw new RuntimeException('Fixture did not produce a DOM element.');
+}
+
+$context = new PatternContext(
+    static fn (DOMElement $source): array => array(),
+    static fn (DOMElement $source): string => '',
+    static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name )
+);
+$first = new class implements PatternRecognizerInterface {
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        return new PatternRecognitionResult(
+            array( 'blockName' => 'first' ),
+            array( array( 'type' => 'fallback' ) ),
+            array( array( 'source' => 'first' ) ),
+            array( 'records_fallback' )
+        );
+    }
+};
+$second = new class implements PatternRecognizerInterface {
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        throw new RuntimeException('Ordered registry invoked a lower-precedence recognizer.');
+    }
+};
+
+$result = ( new PatternRecognizerRegistry( array( $first, $second ) ) )->firstMatch($element, $context);
+$assertSame('first', $result?->block()['blockName'] ?? null, 'First matching recognizer wins.');
+$assertSame(array( array( 'type' => 'fallback' ) ), $result?->fallbacks(), 'Result keeps fallbacks with its block.');
+$assertSame(array( array( 'source' => 'first' ) ), $result?->provenance(), 'Result keeps provenance with its block.');
+$assertSame(array( 'records_fallback' ), $result?->declaredSideEffects(), 'Result declares committed side effects.');
+
+echo "pattern recognizer registry ok\n";
+exit(0 === $failures ? 0 : 1);


### PR DESCRIPTION
## Summary
- return a typed result from ordered reusable pattern recognizers
- migrate accordion and navigation registry recognizers without changing dispatch order or block output
- add precedence and result side-effect payload coverage

## Testing
- `composer test`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the typed recognizer result contract, updated call sites and tests, and ran the test suite. Chris Huber remains responsible for the change.