### PR TITLE
Fix runtime block capability metadata resolution

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -108,6 +108,7 @@
       "php tests/unit/shell-landmark-policy.php",
        "php tests/unit/block-style-support-conversion.php",
        "php tests/unit/block-support-metadata-normalization.php",
+       "php tests/unit/block-metadata-capabilities.php",
       "php tests/unit/content-round-trip-reporter.php",
       "php tests/unit/content-round-trip-form-echo.php",
       "php tests/unit/corpus-detectors.php",

--- a/php-transformer/resources/wordpress-latest-core-block-metadata.json
+++ b/php-transformer/resources/wordpress-latest-core-block-metadata.json
@@ -1,0 +1,27 @@
+{
+    "schema": "blocks-engine/php-transformer/core-block-metadata/v1",
+    "source": "WordPress/wordpress-develop@7.1",
+    "blocks": {
+        "core/accordion": {
+            "allowedBlocks": ["core/accordion-item"],
+            "assets": {
+                "viewScriptModule": ["@wordpress/block-library/accordion/view"]
+            }
+        },
+        "core/accordion-item": {
+            "parent": ["core/accordion"],
+            "allowedBlocks": ["core/accordion-heading", "core/accordion-panel"],
+            "assets": {
+                "style": ["wp-block-accordion-item"]
+            }
+        },
+        "core/navigation": {
+            "dynamic": true,
+            "allowedBlocks": ["core/navigation-link", "core/search", "core/social-links", "core/page-list", "core/spacer", "core/home-link", "core/icon", "core/site-title", "core/site-logo", "core/navigation-submenu", "core/loginout", "core/buttons"],
+            "assets": {
+                "editorStyle": ["wp-block-navigation-editor"],
+                "style": ["wp-block-navigation"]
+            }
+        }
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -21,54 +21,6 @@ final class BlockFactory
      */
     private const GROUP_TAG_NAMES = array( 'div', 'header', 'nav', 'section', 'article', 'aside', 'footer', 'main', 'ul', 'ol', 'li' );
 
-    /**
-     * Blocks whose supports.layout accepts an authored layout attribute, per
-     * the vendored block-library block.json files. Blocks declaring
-     * layout {allowEditing:false} (quote, details, accordion items) manage
-     * their own layout and never accept one; blocks without layout support
-     * (list, paragraph, image) reject the attribute entirely.
-     *
-     * @var array<string, true>
-     */
-    private const LAYOUT_SUPPORTING_BLOCKS = array(
-        'core/accordion'           => true,
-        'core/buttons'             => true,
-        'core/column'              => true,
-        'core/comments-pagination' => true,
-        'core/cover'               => true,
-        'core/group'               => true,
-        'core/navigation'          => true,
-        'core/post-content'        => true,
-        'core/post-template'       => true,
-        'core/query'               => true,
-        'core/query-pagination'    => true,
-        'core/social-links'        => true,
-        'core/tab-list'            => true,
-        'core/tab-panel'           => true,
-        'core/term-template'       => true,
-        'core/terms-query'         => true,
-    );
-
-    /**
-     * The subset whose supports.layout permits switching to type grid
-     * (layout true, or an object without an allowSwitching:false pin to a
-     * fixed flex default).
-     *
-     * @var array<string, true>
-     */
-    private const GRID_LAYOUT_BLOCKS = array(
-        'core/accordion'     => true,
-        'core/column'        => true,
-        'core/cover'         => true,
-        'core/group'         => true,
-        'core/post-content'  => true,
-        'core/post-template' => true,
-        'core/query'         => true,
-        'core/tab-panel'     => true,
-        'core/term-template' => true,
-        'core/terms-query'   => true,
-    );
-
     private ?StyleAttributeMapper $styleMapper = null;
 
     private ?Runtime $runtime = null;
@@ -121,19 +73,6 @@ final class BlockFactory
         $attrs = $this->normalizeClassNameAttr($attrs);
 
         $attrs = $this->runtime()->normalizeBlockSupportAttributes($name, $attrs)['attrs'];
-
-        // Layout is a block-supports opt-in. Stamping it on a block whose
-        // supports do not accept an authored layout bakes is-layout-* classes
-        // into save markup the block's canonical save never emits, so
-        // downstream re-serialization rejects the block and reverts it.
-        if ( isset($attrs['layout']) ) {
-            $layoutType = is_array($attrs['layout']) ? strtolower((string) ($attrs['layout']['type'] ?? '')) : '';
-            if ( ! isset(self::LAYOUT_SUPPORTING_BLOCKS[$name])
-                || ( 'grid' === $layoutType && ! isset(self::GRID_LAYOUT_BLOCKS[$name]) )
-            ) {
-                unset($attrs['layout']);
-            }
-        }
 
         // These core save functions do not reproduce dimensions.maxWidth. Inline
         // max-width is retained by the generated geometry carrier stylesheet.

--- a/php-transformer/src/WordPress/Runtime.php
+++ b/php-transformer/src/WordPress/Runtime.php
@@ -56,10 +56,7 @@ final class Runtime
     private array $diagnostics = array();
 
     /** @var array<string, array<string, mixed>>|null */
-    private ?array $fallbackCoreBlockSupports = null;
-
-    /** @var array<string, array<string, array<string, mixed>>>|null */
-    private ?array $fallbackCoreBlockAttributes = null;
+    private ?array $fallbackCoreBlockMetadata = null;
 
     public function hasWordPress(): bool
     {
@@ -141,13 +138,12 @@ final class Runtime
             return false;
         }
 
-        $supports = $this->registeredBlockSupports($blockName);
-        if ( null === $supports ) {
-            $supports = $this->fallbackBlockSupports($blockName);
-        }
-        if ( null === $supports ) {
+        $metadata = $this->blockMetadata($blockName);
+        if ( null === $metadata ) {
             return false;
         }
+
+        $supports = $metadata['supports'];
 
         $border = $supports['border'] ?? $supports['__experimentalBorder'] ?? false;
         if ( true === $border ) {
@@ -166,8 +162,9 @@ final class Runtime
      */
     public function normalizeBlockSupportAttributes(string $blockName, array $attrs): array
     {
-        $supports = $this->registeredBlockSupports($blockName) ?? $this->fallbackBlockSupports($blockName);
-        if ( null === $supports ) return array( 'attrs' => $attrs, 'fallbackStyle' => array() );
+        $metadata = $this->blockMetadata($blockName);
+        if ( null === $metadata ) return array( 'attrs' => $attrs, 'fallbackStyle' => array() );
+        $supports = $metadata['supports'];
         $fallback = array();
         if ( isset($attrs['layout']) && ! $this->supportsFeature($supports, 'layout', 'layout') ) unset($attrs['layout']);
         if ( 'grid' === ($attrs['layout']['type'] ?? null) && ! $this->supportsFeature($supports, 'layout', 'grid') ) unset($attrs['layout']);
@@ -193,7 +190,7 @@ final class Runtime
     private function filterBorder(array &$style, array &$fallback, array $supports): void { $border = is_array($style['border'] ?? null) ? $style['border'] : array(); foreach ( array( 'color', 'style', 'width', 'radius' ) as $feature ) if ( isset($border[ $feature ]) && ! $this->supportsFeature($supports, 'border', $feature) ) { $fallback['border'][ $feature ] = $border[ $feature ]; unset($border[ $feature ]); } foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) { $sideBorder = is_array($border[ $side ] ?? null) ? $border[ $side ] : array(); foreach ( array( 'color', 'style', 'width' ) as $feature ) if ( isset($sideBorder[ $feature ]) && ! $this->supportsFeature($supports, 'border', $feature) ) { $fallback['border'][ $side ][ $feature ] = $sideBorder[ $feature ]; unset($sideBorder[ $feature ]); } if ( array() === $sideBorder ) unset($border[ $side ]); else $border[ $side ] = $sideBorder; } if ( array() === $border ) unset($style['border']); else $style['border'] = $border; }
 
     /** @param array<string, mixed> $supports */
-    private function supportsFeature(array $supports, string $group, string $feature, bool $colorDefaults = false, string $side = ''): bool { $declaration = 'border' === $group ? ($supports['border'] ?? $supports['__experimentalBorder'] ?? false) : ($supports[ $group ] ?? false); if ( true === $declaration ) return true; if ( ! is_array($declaration) || true === ($declaration['__experimentalSkipSerialization'] ?? false) ) return false; $skipped = $declaration['__experimentalSkipSerialization'] ?? array(); $skipFeature = lcfirst(str_replace('__experimental', '', $feature)); if ( is_array($skipped) && (in_array($feature, $skipped, true) || in_array($skipFeature, $skipped, true)) ) return false; if ( 'layout' === $group ) return 'grid' !== $feature || false !== ($declaration['allowSwitching'] ?? true); $value = $declaration[ $feature ] ?? ($colorDefaults ? true : false); return '' !== $side && is_array($value) ? in_array($side, $value, true) : true === $value; }
+    private function supportsFeature(array $supports, string $group, string $feature, bool $colorDefaults = false, string $side = ''): bool { $declaration = 'border' === $group ? ($supports['border'] ?? $supports['__experimentalBorder'] ?? false) : ($supports[ $group ] ?? false); if ( true === $declaration ) return true; if ( ! is_array($declaration) || true === ($declaration['__experimentalSkipSerialization'] ?? false) ) return false; $skipped = $declaration['__experimentalSkipSerialization'] ?? array(); $skipFeature = lcfirst(str_replace('__experimental', '', $feature)); if ( is_array($skipped) && (in_array($feature, $skipped, true) || in_array($skipFeature, $skipped, true)) ) return false; if ( 'layout' === $group ) return false !== ($declaration['allowEditing'] ?? true) && ( 'grid' !== $feature || false !== ($declaration['allowSwitching'] ?? true) ); $value = $declaration[ $feature ] ?? ($colorDefaults ? true : false); return '' !== $side && is_array($value) ? in_array($side, $value, true) : true === $value; }
 
     /**
      * @return array<int, string>
@@ -237,15 +234,20 @@ final class Runtime
     }
 
     /**
-     * Resolve support from the block type's registered declaration, never from a
-     * transformer-owned block-name allowlist.
+     * Resolve a block's declared capabilities from WordPress first, then the
+     * bundled core metadata snapshot for standalone transforms.
      *
-     * @return array<string, mixed>|null
+     * @return array{supports: array<string, mixed>, attributes: array<string, mixed>, parent: array<int, string>, allowedBlocks: mixed, dynamic: bool, assets: array<string, mixed>}|null
      */
-    private function registeredBlockSupports(string $blockName): ?array
+    public function blockMetadata(string $blockName): ?array
     {
         $blockType = $this->registeredBlockType($blockName);
-        return is_object($blockType) ? (is_array($blockType->supports ?? null) ? $blockType->supports : array()) : null;
+        if ( is_object($blockType) ) {
+            return $this->metadataFromRegisteredBlockType($blockType);
+        }
+
+        $this->loadFallbackCoreBlockMetadata();
+        return $this->fallbackCoreBlockMetadata[ $blockName ] ?? null;
     }
 
     private function registeredBlockType(string $blockName): ?object
@@ -263,48 +265,61 @@ final class Runtime
         return null;
     }
 
-    /**
-     * Standalone transforms have no WP_Block_Type_Registry. Load the generated
-     * latest WordPress declaration snapshot so the same block.json support check
-     * is still available. Live registered declarations always take precedence.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function fallbackBlockSupports(string $blockName): ?array
-    {
-        if ( null === $this->fallbackCoreBlockSupports ) {
-            $path = dirname(__DIR__, 2) . '/resources/wordpress-latest-core-block-supports.json';
-            $registry = is_file($path) ? json_decode((string) file_get_contents($path), true) : null;
-            $this->fallbackCoreBlockSupports = is_array($registry['blocks'] ?? null) ? $registry['blocks'] : array();
-        }
-
-        $supports = $this->fallbackCoreBlockSupports[ $blockName ] ?? null;
-        return is_array($supports) ? $supports : null;
-    }
-
-    /**
-     * Resolve attributes from a live registered declaration first, then from
-     * the generated core snapshot for standalone transforms. A registered
-     * declaration without attributes is authoritative and deliberately does
-     * not fall back to a possibly stale snapshot.
-     *
-     * @return array<string, array<string, mixed>>|null
-     */
+    /** @return array<string, array<string, mixed>>|null */
     private function blockAttributes(string $blockName): ?array
     {
-        $blockType = $this->registeredBlockType($blockName);
-        if ( is_object($blockType) ) {
-            return is_array($blockType->attributes ?? null) ? $blockType->attributes : array();
+        $metadata = $this->blockMetadata($blockName);
+        return is_array($metadata['attributes'] ?? null) ? $metadata['attributes'] : null;
+    }
+
+    /** @return array{supports: array<string, mixed>, attributes: array<string, mixed>, parent: array<int, string>, allowedBlocks: mixed, dynamic: bool, assets: array<string, mixed>} */
+    private function metadataFromRegisteredBlockType(object $blockType): array
+    {
+        $assets = array();
+        foreach ( array( 'editor_script_handles' => 'editorScript', 'script_handles' => 'script', 'view_script_handles' => 'viewScript', 'view_script_module_ids' => 'viewScriptModule', 'style_handles' => 'style', 'editor_style_handles' => 'editorStyle', 'view_style_handles' => 'viewStyle' ) as $property => $field ) {
+            if ( isset($blockType->{$property}) && is_array($blockType->{$property}) ) {
+                $assets[ $field ] = array_values($blockType->{$property});
+            }
         }
 
-        if ( null === $this->fallbackCoreBlockAttributes ) {
-            $path = dirname(__DIR__, 2) . '/resources/wordpress-latest-core-block-attributes.json';
-            $registry = is_file($path) ? json_decode((string) file_get_contents($path), true) : null;
-            $this->fallbackCoreBlockAttributes = is_array($registry['blocks'] ?? null) ? $registry['blocks'] : array();
-        }
+        return array(
+            'supports'      => is_array($blockType->supports ?? null) ? $blockType->supports : array(),
+            'attributes'    => is_array($blockType->attributes ?? null) ? $blockType->attributes : array(),
+            'parent'        => is_array($blockType->parent ?? null) ? array_values($blockType->parent) : array(),
+            'allowedBlocks' => $blockType->allowed_blocks ?? ($blockType->supports['allowedBlocks'] ?? null),
+            'dynamic'       => method_exists($blockType, 'is_dynamic') ? $blockType->is_dynamic() : null !== ($blockType->render_callback ?? null),
+            'assets'        => $assets,
+        );
+    }
 
-        $attributes = $this->fallbackCoreBlockAttributes[ $blockName ] ?? null;
-        return is_array($attributes) ? $attributes : null;
+    private function loadFallbackCoreBlockMetadata(): void
+    {
+        if ( null !== $this->fallbackCoreBlockMetadata ) return;
+
+        $resourceDirectory = dirname(__DIR__, 2) . '/resources/';
+        $supports = $this->snapshotBlocks($resourceDirectory . 'wordpress-latest-core-block-supports.json');
+        $attributes = $this->snapshotBlocks($resourceDirectory . 'wordpress-latest-core-block-attributes.json');
+        $capabilities = $this->snapshotBlocks($resourceDirectory . 'wordpress-latest-core-block-metadata.json');
+        $names = array_unique(array_merge(array_keys($supports), array_keys($attributes), array_keys($capabilities)));
+        $this->fallbackCoreBlockMetadata = array();
+        foreach ( $names as $name ) {
+            $capability = is_array($capabilities[ $name ] ?? null) ? $capabilities[ $name ] : array();
+            $this->fallbackCoreBlockMetadata[ $name ] = array(
+                'supports'      => is_array($supports[ $name ] ?? null) ? $supports[ $name ] : array(),
+                'attributes'    => is_array($attributes[ $name ] ?? null) ? $attributes[ $name ] : array(),
+                'parent'        => is_array($capability['parent'] ?? null) ? array_values($capability['parent']) : array(),
+                'allowedBlocks' => $capability['allowedBlocks'] ?? ($supports[ $name ]['allowedBlocks'] ?? null),
+                'dynamic'       => true === ($capability['dynamic'] ?? false),
+                'assets'        => is_array($capability['assets'] ?? null) ? $capability['assets'] : array(),
+            );
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function snapshotBlocks(string $path): array
+    {
+        $snapshot = is_file($path) ? json_decode((string) file_get_contents($path), true) : null;
+        return is_array($snapshot['blocks'] ?? null) ? $snapshot['blocks'] : array();
     }
 
     /**

--- a/php-transformer/tests/unit/block-metadata-capabilities.php
+++ b/php-transformer/tests/unit/block-metadata-capabilities.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\BlockFactory;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+
+$assert = static function (bool $condition, string $message): void {
+    if ( ! $condition ) {
+        throw new RuntimeException($message);
+    }
+};
+
+$runtime = new Runtime();
+$group = $runtime->blockMetadata('core/group');
+$accordion = $runtime->blockMetadata('core/accordion');
+$accordionItem = $runtime->blockMetadata('core/accordion-item');
+$navigation = $runtime->blockMetadata('core/navigation');
+$assert(is_array($group['supports']['layout'] ?? null), 'The snapshot must retain Group layout support.');
+$assert(true === ($group['allowedBlocks'] ?? false), 'The snapshot must retain Group allowed-block support.');
+$assert(array('core/accordion-item') === ($accordion['allowedBlocks'] ?? null), 'The snapshot must retain Accordion allowed blocks.');
+$assert(array('core/accordion') === ($accordionItem['parent'] ?? null), 'The snapshot must retain Accordion Item parent restrictions.');
+$assert(true === ($navigation['dynamic'] ?? false) && array('wp-block-navigation-editor') === ($navigation['assets']['editorStyle'] ?? null), 'The snapshot must retain dynamic and asset capabilities.');
+
+$factory = new BlockFactory();
+$assert('grid' === ($factory->create('core/group', array('layout' => array('type' => 'grid')))['attrs']['layout']['type'] ?? null), 'Snapshot metadata must preserve supported Group grid output.');
+$assert(! isset($factory->create('core/paragraph', array('layout' => array('type' => 'grid')))['attrs']['layout']), 'Snapshot metadata must reject Paragraph layout output.');
+$assert(! isset($factory->create('core/accordion-item', array('layout' => array('type' => 'flex')))['attrs']['layout']), 'Snapshot metadata must reject block-managed Accordion Item layout output.');
+
+eval(<<<'PHP'
+final class WP_Block_Type_Registry {
+    public static array $types = array();
+    public static function get_instance(): self { return new self(); }
+    public function get_all_registered(): array { return self::$types; }
+}
+PHP);
+
+WP_Block_Type_Registry::$types = array(
+    'core/accordion' => (object) array(
+        'name' => 'core/accordion',
+        'supports' => $accordion['supports'],
+        'attributes' => $accordion['attributes'],
+        'allowed_blocks' => $accordion['allowedBlocks'],
+        'view_script_module_ids' => $accordion['assets']['viewScriptModule'],
+    ),
+    'core/group' => (object) array(
+        'name' => 'core/group',
+        'supports' => $group['supports'],
+        'attributes' => $group['attributes'],
+        'parent' => $group['parent'],
+        'allowed_blocks' => $group['allowedBlocks'],
+    ),
+);
+$live = (new Runtime())->blockMetadata('core/group');
+$assert($group === $live && $accordion === (new Runtime())->blockMetadata('core/accordion'), 'Equivalent live declarations must match the bundled snapshot capabilities.');
+
+WP_Block_Type_Registry::$types['core/group'] = (object) array(
+    'name' => 'core/group',
+    'supports' => array('layout' => array('allowSwitching' => false)),
+    'attributes' => array('layout' => array('type' => 'object')),
+    'parent' => array('plugin/container'),
+    'allowed_blocks' => array('plugin/card'),
+    'render_callback' => static fn (): string => '',
+    'editor_script_handles' => array('plugin-group-editor'),
+    'style_handles' => array('plugin-group-style'),
+);
+$live = (new Runtime())->blockMetadata('core/group');
+$assert(array('plugin/container') === $live['parent'] && array('plugin/card') === $live['allowedBlocks'], 'Live parent and allowed blocks must override snapshot drift.');
+$assert(true === $live['dynamic'] && array('plugin-group-editor') === $live['assets']['editorScript'] && array('plugin-group-style') === $live['assets']['style'], 'Live dynamic and asset capabilities must override snapshot drift.');
+$assert(! isset((new BlockFactory())->create('core/group', array('layout' => array('type' => 'grid')))['attrs']['layout']), 'Live layout switching metadata must control emitted Group output.');
+
+fwrite(STDOUT, "Block metadata capability tests passed.\n");

--- a/php-transformer/tools/generate-core-block-metadata.php
+++ b/php-transformer/tools/generate-core-block-metadata.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Generate core capabilities that are not represented by support or attribute
+ * schemas. Runtime registration remains authoritative when WordPress is loaded.
+ *
+ * Usage:
+ *   php tools/generate-core-block-metadata.php <wp-includes/blocks> <output.json> <source-ref>
+ */
+
+if ( 4 !== count($argv) ) {
+    fwrite(STDERR, "Usage: php tools/generate-core-block-metadata.php <wp-includes/blocks> <output.json> <source-ref>\n");
+    exit(2);
+}
+
+$blocksDirectory = rtrim($argv[1], DIRECTORY_SEPARATOR);
+$outputPath = $argv[2];
+$sourceRef = trim($argv[3]);
+if ( ! is_dir($blocksDirectory) || '' === $sourceRef ) {
+    fwrite(STDERR, "A readable WordPress blocks directory and non-empty source ref are required.\n");
+    exit(2);
+}
+
+$blocks = array();
+foreach ( (array) glob($blocksDirectory . '/*/block.json') as $blockJsonPath ) {
+    $metadata = json_decode((string) file_get_contents($blockJsonPath), true);
+    if ( ! is_array($metadata) || ! is_string($metadata['name'] ?? null) || ! str_starts_with($metadata['name'], 'core/') ) {
+        continue;
+    }
+
+    $assets = array();
+    foreach ( array( 'editorScript', 'script', 'viewScript', 'viewScriptModule', 'style', 'editorStyle', 'viewStyle' ) as $field ) {
+        if ( isset($metadata[ $field ]) ) {
+            $assets[ $field ] = (array) $metadata[ $field ];
+        }
+    }
+    $blocks[ $metadata['name'] ] = array(
+        'parent'        => array_values(is_array($metadata['parent'] ?? null) ? $metadata['parent'] : array()),
+        'allowedBlocks' => $metadata['allowedBlocks'] ?? null,
+        'dynamic'       => isset($metadata['render']),
+        'assets'        => $assets,
+    );
+}
+ksort($blocks, SORT_STRING);
+
+$registry = array(
+    'schema'      => 'blocks-engine/php-transformer/core-block-metadata/v1',
+    'source'      => $sourceRef,
+    'block_count' => count($blocks),
+    'blocks'      => $blocks,
+);
+$json = json_encode($registry, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+if ( false === $json ) {
+    fwrite(STDERR, "Unable to encode the core-block metadata registry.\n");
+    exit(1);
+}
+
+$outputDirectory = dirname($outputPath);
+if ( ! is_dir($outputDirectory) && ! mkdir($outputDirectory, 0777, true) && ! is_dir($outputDirectory) ) {
+    fwrite(STDERR, "Unable to create output directory: {$outputDirectory}\n");
+    exit(1);
+}
+if ( false === file_put_contents($outputPath, $json . "\n") ) {
+    fwrite(STDERR, "Unable to write core-block metadata registry: {$outputPath}\n");
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf("Core block metadata registry: %d declarations written to %s\n", count($blocks), $outputPath));


### PR DESCRIPTION
## Summary
- resolve block capabilities from the live `WP_Block_Type_Registry` before bundled snapshot metadata
- remove `BlockFactory` layout/grid allowlists while retaining metadata-gated emitted layouts
- cover snapshot/live parity and live metadata drift for layout, parent, allowed blocks, dynamic state, and assets

Closes #996

## Testing
- `composer install --no-interaction --prefer-dist`
- `composer test`
- PHP lint for changed files
- `git diff --check`

AI assistance: OpenCode using OpenAI GPT-5.6 Terra was used to inspect the codebase, implement the change, and run verification. Chris remains responsible for every line.