### PR TITLE
fix: isolate HTML transform session state

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -114,6 +114,7 @@
       "php tests/unit/live-wp-parity-runner.php",
       "php tests/unit/deterministic-row-deduplicator.php",
       "php tests/unit/html-transformer-shared-analysis-cache.php",
+      "php tests/unit/html-transformer-session-state.php",
       "php tests/unit/reusable-component-recognition.php",
       "php tests/unit/compile-fragment-author-stylesheet.php",
       "php tests/unit/responsive-canvas-geometry.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -235,7 +235,7 @@ final class HtmlTransformer
     private readonly ReusableComponentRecognizer $reusableComponentRecognizer;
 
     /** @var array<string, string> */
-    private array $reusableComponentFingerprints = array();
+    private HtmlTransformerSession $session;
 
     /**
      * Text the transformer SYNTHESIZES from form controls (label + value/
@@ -245,9 +245,7 @@ final class HtmlTransformer
      *
      * @var array<int, string>
      */
-    private array $formControlEchoTexts = array();
 
-    private readonly FallbackEmitter $fallbackEmitter;
 
     /**
      * Responsive image markup core/image cannot represent without invalidating
@@ -256,20 +254,16 @@ final class HtmlTransformer
      *
      * @var array<int, array<string, mixed>>
      */
-    private array $responsiveImageFallbacks = array();
 
     /** @var array<string, bool> */
-    private array $responsiveImageFallbackSelectors = array();
 
     /**
      * @var array<string, string>
      */
-    private array $fallbackProvenance = array();
 
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $presentationProvenance = array();
 
     /**
      * Responsive/JS-revealed hidden base states normalized away during style
@@ -277,7 +271,6 @@ final class HtmlTransformer
      *
      * @var array<int, array<string, mixed>>
      */
-    private array $frozenHiddenStateFindings = array();
 
     /**
      * Whole-element link wrappers (an <a> wrapping block-level content) whose
@@ -288,33 +281,26 @@ final class HtmlTransformer
      *
      * @var array<int, array<string, mixed>>
      */
-    private array $droppedLinkWrapperFindings = array();
 
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $sourceProvenance = array();
 
     /** @var array<int, bool> */
-    private array $sourceBaseHiddenStates = array();
 
     /** @var array<string,true> */
-    private array $formControlSlotPaths = array();
 
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $structureProvenance = array();
 
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $scriptMetadata = array();
 
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $runtimeIslands = array();
 
     /**
      * Source elements whose subtree was folded into a native zero-JS disclosure
@@ -329,7 +315,6 @@ final class HtmlTransformer
      *
      * @var array<string, true>
      */
-    private array $nativeDisclosureRootIds = array();
 
     /**
      * Generated static-render custom-block definitions produced at `core/html`
@@ -339,17 +324,11 @@ final class HtmlTransformer
      *
      * @var array<int, array<string, mixed>>
      */
-    private array $generatedBlocks = array();
 
-    private bool $descriptionListBlockGenerated = false;
 
-    private bool $formSelectBlockGenerated = false;
 
-    private bool $formInputBlockGenerated = false;
 
-    private bool $responsiveMediaBlockGenerated = false;
 
-    private bool $capturedDialogBlockGenerated = false;
 
     /**
      * Block namespace for generated custom-block references. The ArtifactCompiler
@@ -357,99 +336,75 @@ final class HtmlTransformer
      * emitted references match the blocks SSI registers; standalone transforms
      * fall back to a generic namespace.
      */
-    private string $generatedBlockNamespace = 'custom';
 
-    private string $generatedAssetRoot = '';
 
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $runtimeScriptMetadata = array();
 
     /**
      * @var array<string, array<string, mixed>>
      */
-    private array $assetMetadata = array();
 
     /**
      * @var array<string, array<string, mixed>>
      */
-    private array $generatedAssets = array();
 
     /** @var array<string, string> */
-    private array $nativeSearchTriggerCssRules = array();
 
     /** @var array<string, string> */
-    private array $nativeButtonStyleRules = array();
 
     /** @var array<string, string> Header anchor carriers keyed by generated class. */
-    private array $syntheticHeaderAnchorStyleRules = array();
 
     /** @var array<string, string> Header RichText carriers keyed by marker. */
-    private array $headerRichTextStyleRules = array();
 
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $gutenbergIncompatibilities = array();
 
     /**
      * @var array<string, string>
      */
-    private array $cssCustomProperties = array();
 
     /**
      * @var array<string, array<int, string>>
      */
-    private array $staticClassPromotions = array();
 
     /**
      * @var array<int, array{selector: string, declarations: array<string, string>}>
      */
-    private array $staticStyleRules = array();
 
     /**
      * @var array<int, array{selector: string, declarations: array<string, string>}>
      */
-    private array $conditionalStyleRules = array();
 
     /**
      * @var list<array{selector: string, base_selector: string, state: string, declarations: array<string, string>}>
      */
-    private array $navigationStateStyleRules = array();
 
     /** @var array<string, array<string, string>> */
-    private array $listNavigationPaddingFallbacks = array();
 
     /** @var array<string, string> */
-    private array $navigationLinkColorFallbacks = array();
 
     /** @var array<string, string> */
-    private array $navigationSubmenuBackgroundFallbacks = array();
 
     /** @var array<string, string> */
-    private array $navigationSpacingFallbacks = array();
 
     /** @var array<string, string> */
-    private array $buttonWrapperSpacingFallbacks = array();
 
     /** @var list<array{selector: string, property: string, value: string, conditions: list<string>, order: int}> Ordered crop declarations, including duplicates. */
-    private array $imageShapeStyleRules = array();
 
     /**
      * @var array<int, array{selector: string, pseudo: string, declarations: array<string, string>}>
      */
-    private array $staticPseudoElementStyleRules = array();
 
     /**
      * @var array<string, bool>
      */
-    private array $runtimeDomSelectors = array();
 
     /**
      * @var array<string, bool>
      */
-    private array $runtimeCanvasSelectors = array();
 
     /**
      * Source DOM selectors (id/class) the transformer intentionally removed
@@ -464,10 +419,8 @@ final class HtmlTransformer
      *
      * @var array<string, bool>
      */
-    private array $supersededRuntimeSelectors = array();
 
     /** @var array<string, string> Source tag names whose serialized blocks need provenance classes. */
-    private array $sourceTagMarkers = array();
 
     private const SYNTHETIC_PARAGRAPH_CLASS = 'blocks-engine-synthetic-paragraph';
 
@@ -531,123 +484,85 @@ final class HtmlTransformer
     private const CSS_OWNED_LAYOUT_ITEM_CLASS = 'blocks-engine-css-owned-layout-item';
 
     /** @var array<string, string> Source control DOM paths mapped to core/button wrapper classes. */
-    private array $sourceControlMarkers = array();
 
     /** @var array<string, string> Direct flex-child controls mapped to synthetic wrapper bridge CSS. */
-    private array $directFlexButtonStyleRules = array();
 
     /** @var array<string, string> Full-width controls mapped to synthetic wrapper bridge CSS. */
-    private array $fullWidthButtonStyleRules = array();
 
     /** @var array<string, string> Source wrapper paths promoted into core/button. */
-    private array $sourceButtonPresentationMarkers = array();
 
     /** @var array<string, true> Source controls that need selector projection. */
-    private array $sourceControlPaths = array();
 
     /** @var array<string, string> CSS-addressed inline leaves keyed by stable source DOM path. */
-    private array $sourceSemanticMarkers = array();
 
     /** @var array<string, string> Structural elements addressed by non-serializable source data attributes. */
-    private array $sourceAttributeMarkers = array();
 
     /** @var array<string, string> Source body children that need wrapper-safe selector projection. */
-    private array $sourceRootChildMarkers = array();
 
     /** @var list<string> Source body-state classes referenced by authored CSS. */
-    private array $sourceBodyProjectionClasses = array();
 
     /** @var array<string, array{selector: string, min_width: string}> */
-    private array $responsiveGeometryAmbiguities = array();
 
     /** @var array<string, string> Native tables whose descendant selectors need structural projection. */
-    private array $sourceTableMarkers = array();
 
     /** @var array<int, bool> */
-    private array $sourceTableRepresentability = array();
 
     /** @var array<int, array<int, string>> */
-    private array $sourceTableDescendantPaths = array();
 
     /** @var array<string, string> CSS-addressed RichText spans keyed by stable source DOM path. */
-    private array $sourceRichTextSemanticMarkers = array();
 
     /** @var array<int, array{selector: string, direct_child_count: int, block_child_count: int, source_tags: list<string>, block_tags: list<string>}> */
-    private array $authorLayoutTopologies = array();
 
-    private bool $authorLayoutBlockGenerated = false;
 
-    private string $combinedAuthorCss = '';
 
-    private ?DOMElement $authorStyleSourceBody = null;
 
     /** @var list<DOMElement> */
-    private array $authorStyleSourceElements = array();
 
 	/** @var array<string, list<DOMElement>> */
-	private array $authorStyleSourceElementsByTag = array();
 
 	/** @var array<string, list<DOMElement>> */
-	private array $authorStyleSourceElementsById = array();
 
 	/** @var array<string, list<DOMElement>> */
-	private array $authorStyleSourceElementsByClass = array();
 
 	/** @var array<string, true> */
-	private array $authorStyleSourceTags = array();
 
 	/** @var array<string, true> */
-	private array $authorStyleSourceIds = array();
 
 	/** @var array<string, true> */
-	private array $authorStyleSourceClasses = array();
 
     /** @var array<string, list<DOMElement>> */
-    private array $authorSourceSelectorMatches = array();
 
     /** @var array<string, array<string, mixed>> */
-    private array $parsedCssSelectors = array();
 
-    private ?CssSelectorMatchCache $authorSelectorMatchCache = null;
 
     /** @var list<array{selector:string,parsed:array<string,mixed>}> */
-    private array $authorSelectors = array();
 
     /** @var list<array{order: int, declarations: array<string, string>, selectors: list<array{selector: string, parsed: array<string, mixed>, direct_child_parsed: array<string, mixed>}>}> */
-    private array $authorStyleRules = array();
 
     /** @var array<string, array<string, mixed>> */
-    private array $authorStyleRuleCandidateIndexes = array();
 
-    private string $authorMarkerSeed = '';
 
-    private int $authorMarkerCounter = 0;
 
-    private string $authorMarkerCollisionText = '';
 
     /** @var list<array{path: string, content: string, source_hash: string}> */
-    private array $authorStylesheetAssets = array();
 
-    private string $formLayoutCss = '';
 
     /** A collision-checked custom element used solely to retain type specificity. */
-    private string $authorSpecificityShim = '';
 
-    private string $authorClassSpecificityShim = '';
 
-    private string $authorIdSpecificityShim = '';
 
-    private int $nextSourceProvenanceId = 1;
 
-    private bool $preserveShellLandmarks = false;
 
-    private bool $fallbackReductionMode = false;
 
     public function __construct(
         private readonly Runtime $runtime = new Runtime(),
         private readonly HtmlTransformerAnalysisCache $analysisCache = new HtmlTransformerAnalysisCache()
     )
     {
+        $this->session = new HtmlTransformerSession(
+            $this->runtime,
+            fn (DOMElement $element): array => $this->sourceContext($element)
+        );
         $this->blockFactory      = new BlockFactory();
         $this->backgroundImageExtractor = new BackgroundImageExtractor();
         $this->buttonsPattern    = new ButtonsPattern();
@@ -674,10 +589,23 @@ final class HtmlTransformer
         $this->semanticParityReporter = new SemanticParityReporter($this->runtime);
         $this->contentRoundTripReporter = new ContentRoundTripReporter();
         $this->reusableComponentRecognizer = new ReusableComponentRecognizer();
-        $this->fallbackEmitter = new FallbackEmitter(
-            $this->runtime,
-            fn (DOMElement $element): array => $this->sourceContext($element)
-        );
+    }
+
+    public function &__get(string $name): mixed
+    {
+        $value =& $this->session->{$name};
+
+        return $value;
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        $this->session->{$name} = $value;
+    }
+
+    public function __isset(string $name): bool
+    {
+        return isset($this->session->{$name});
     }
 
     /**
@@ -685,87 +613,19 @@ final class HtmlTransformer
      */
     public function transform(string $html, array $options = array()): TransformerResult
     {
-        $context                  = TransformationOptions::context($options);
-        $startedAt                = hrtime(true);
+        $this->session = new HtmlTransformerSession(
+            $this->runtime,
+            fn (DOMElement $element): array => $this->sourceContext($element)
+        );
+        $context = TransformationOptions::context($options);
+        $startedAt = hrtime(true);
         $this->fallbackProvenance = TransformationOptions::provenance($options);
-        $this->presentationProvenance = array();
-        $this->frozenHiddenStateFindings = array();
-        $this->droppedLinkWrapperFindings = array();
-        $this->sourceProvenance = array();
-        $this->sourceBaseHiddenStates = array();
-        $this->formControlSlotPaths = array();
-        $this->structureProvenance = array();
-        $this->scriptMetadata = array();
-        $this->runtimeIslands = array();
-        $this->nativeDisclosureRootIds = array();
-        $this->generatedBlocks = array();
-        $this->responsiveMediaBlockGenerated = false;
-        $this->capturedDialogBlockGenerated = false;
-        $this->descriptionListBlockGenerated = false;
-        $this->formSelectBlockGenerated = false;
-        $this->formInputBlockGenerated = false;
-        $this->formControlEchoTexts = array();
-        $this->responsiveImageFallbacks = array();
-        $this->responsiveImageFallbackSelectors = array();
         $this->generatedBlockNamespace = $this->generatedBlockNamespaceFromOptions($options);
         $this->generatedAssetRoot = trim((string) ($options['generated_asset_root'] ?? ''), '/');
         $this->preserveShellLandmarks = !empty($options['extract_global_shell']);
         $this->fallbackReductionMode = !empty($options['fallback_reduction_mode']);
-        $this->fallbackEmitter->resetGeneratedBlocks();
         $this->runtimeScriptMetadata = $this->runtimeScriptMetadataFromOptions($options);
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
-        $this->generatedAssets = array();
-        $this->reusableComponentFingerprints = array();
-        $this->nativeSearchTriggerCssRules = array();
-        $this->nativeButtonStyleRules = array();
-        $this->listNavigationPaddingFallbacks = array();
-        $this->navigationLinkColorFallbacks = array();
-        $this->navigationSubmenuBackgroundFallbacks = array();
-        $this->navigationSpacingFallbacks = array();
-        $this->buttonWrapperSpacingFallbacks = array();
-        $this->syntheticHeaderAnchorStyleRules = array();
-        $this->headerRichTextStyleRules = array();
-        $this->gutenbergIncompatibilities = array();
-        $this->sourceTagMarkers = array();
-        $this->sourceControlMarkers = array();
-        $this->directFlexButtonStyleRules = array();
-        $this->fullWidthButtonStyleRules = array();
-        $this->sourceButtonPresentationMarkers = array();
-        $this->sourceControlPaths = array();
-        $this->sourceSemanticMarkers = array();
-        $this->sourceAttributeMarkers = array();
-        $this->sourceRootChildMarkers = array();
-        $this->sourceBodyProjectionClasses = array();
-        $this->responsiveGeometryAmbiguities = array();
-        $this->sourceTableMarkers = array();
-        $this->sourceTableRepresentability = array();
-        $this->sourceTableDescendantPaths = array();
-        $this->sourceRichTextSemanticMarkers = array();
-        $this->authorLayoutTopologies = array();
-        $this->authorLayoutBlockGenerated = false;
-        $this->combinedAuthorCss = '';
-        $this->authorStyleSourceBody = null;
-        $this->authorStyleSourceElements = array();
-		$this->authorStyleSourceElementsByTag = array();
-		$this->authorStyleSourceElementsById = array();
-		$this->authorStyleSourceElementsByClass = array();
-		$this->authorStyleSourceTags = array();
-		$this->authorStyleSourceIds = array();
-		$this->authorStyleSourceClasses = array();
-        $this->authorSourceSelectorMatches = array();
-        $this->parsedCssSelectors = array();
-        $this->authorSelectorMatchCache = null;
-        $this->authorSelectors = array();
-        $this->authorStyleRules = array();
-        $this->authorStyleRuleCandidateIndexes = array();
-        $this->authorMarkerSeed = '';
-        $this->authorMarkerCounter = 0;
-        $this->authorMarkerCollisionText = '';
-        $this->authorStylesheetAssets = array();
-        $this->formLayoutCss = '';
-        $this->authorSpecificityShim = '';
-        $this->authorClassSpecificityShim = '';
-        $this->authorIdSpecificityShim = '';
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $staticCss = (string) ($options['static_css'] ?? '');
         $styleAnalysisKey = $this->styleAnalysisKey($html, $staticCss);

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Closure;
+use DOMElement;
+
+/**
+ * Mutable data accumulated while converting one HTML document.
+ *
+ * A fresh session is installed for every transform so a reused transformer
+ * retains only its immutable collaborators and shared analysis cache.
+ */
+final class HtmlTransformerSession
+{
+    public array $reusableComponentFingerprints = array();
+    public array $formControlEchoTexts = array();
+    public array $responsiveImageFallbacks = array();
+    public array $responsiveImageFallbackSelectors = array();
+    public array $fallbackProvenance = array();
+    public array $presentationProvenance = array();
+    public array $frozenHiddenStateFindings = array();
+    public array $droppedLinkWrapperFindings = array();
+    public array $sourceProvenance = array();
+    public array $sourceBaseHiddenStates = array();
+    public array $formControlSlotPaths = array();
+    public array $structureProvenance = array();
+    public array $scriptMetadata = array();
+    public array $runtimeIslands = array();
+    public array $nativeDisclosureRootIds = array();
+    public array $generatedBlocks = array();
+    public bool $descriptionListBlockGenerated = false;
+    public bool $formSelectBlockGenerated = false;
+    public bool $formInputBlockGenerated = false;
+    public bool $responsiveMediaBlockGenerated = false;
+    public bool $capturedDialogBlockGenerated = false;
+    public string $generatedBlockNamespace = 'custom';
+    public string $generatedAssetRoot = '';
+    public array $runtimeScriptMetadata = array();
+    public array $assetMetadata = array();
+    public array $generatedAssets = array();
+    public array $nativeSearchTriggerCssRules = array();
+    public array $nativeButtonStyleRules = array();
+    public array $syntheticHeaderAnchorStyleRules = array();
+    public array $headerRichTextStyleRules = array();
+    public array $gutenbergIncompatibilities = array();
+    public array $cssCustomProperties = array();
+    public array $staticClassPromotions = array();
+    public array $staticStyleRules = array();
+    public array $conditionalStyleRules = array();
+    public array $navigationStateStyleRules = array();
+    public array $listNavigationPaddingFallbacks = array();
+    public array $navigationLinkColorFallbacks = array();
+    public array $navigationSubmenuBackgroundFallbacks = array();
+    public array $navigationSpacingFallbacks = array();
+    public array $buttonWrapperSpacingFallbacks = array();
+    public array $imageShapeStyleRules = array();
+    public array $staticPseudoElementStyleRules = array();
+    public array $runtimeDomSelectors = array();
+    public array $runtimeCanvasSelectors = array();
+    public array $supersededRuntimeSelectors = array();
+    public array $sourceTagMarkers = array();
+    public array $sourceControlMarkers = array();
+    public array $directFlexButtonStyleRules = array();
+    public array $fullWidthButtonStyleRules = array();
+    public array $sourceButtonPresentationMarkers = array();
+    public array $sourceControlPaths = array();
+    public array $sourceSemanticMarkers = array();
+    public array $sourceAttributeMarkers = array();
+    public array $sourceRootChildMarkers = array();
+    public array $sourceBodyProjectionClasses = array();
+    public array $responsiveGeometryAmbiguities = array();
+    public array $sourceTableMarkers = array();
+    public array $sourceTableRepresentability = array();
+    public array $sourceTableDescendantPaths = array();
+    public array $sourceRichTextSemanticMarkers = array();
+    public array $authorLayoutTopologies = array();
+    public bool $authorLayoutBlockGenerated = false;
+    public string $combinedAuthorCss = '';
+    public ?DOMElement $authorStyleSourceBody = null;
+    public array $authorStyleSourceElements = array();
+    public array $authorStyleSourceElementsByTag = array();
+    public array $authorStyleSourceElementsById = array();
+    public array $authorStyleSourceElementsByClass = array();
+    public array $authorStyleSourceTags = array();
+    public array $authorStyleSourceIds = array();
+    public array $authorStyleSourceClasses = array();
+    public array $authorSourceSelectorMatches = array();
+    public array $parsedCssSelectors = array();
+    public ?CssSelectorMatchCache $authorSelectorMatchCache = null;
+    public array $authorSelectors = array();
+    public array $authorStyleRules = array();
+    public array $authorStyleRuleCandidateIndexes = array();
+    public string $authorMarkerSeed = '';
+    public int $authorMarkerCounter = 0;
+    public string $authorMarkerCollisionText = '';
+    public array $authorStylesheetAssets = array();
+    public string $formLayoutCss = '';
+    public string $authorSpecificityShim = '';
+    public string $authorClassSpecificityShim = '';
+    public string $authorIdSpecificityShim = '';
+    public int $nextSourceProvenanceId = 1;
+    public bool $preserveShellLandmarks = false;
+    public bool $fallbackReductionMode = false;
+    public array $presentationAttributesCache = array();
+    public array $presentationDeclarationsCache = array();
+    public array $mergedPresentationStyleCache = array();
+    public array $mediaTextPresentationStyleCache = array();
+    public array $generatedGeometryRules = array();
+    public ?GeometryCarrierClassAllocator $geometryCarrierClassAllocator = null;
+    public ?CssSelectorMatchCache $sourceSelectorMatchCache = null;
+    public array $styleRuleCandidateIndexes = array();
+    public array $authorDeclaredPropertyValuesCache = array();
+    public readonly FallbackEmitter $fallbackEmitter;
+
+    /** @param Closure(DOMElement): array<string, mixed> $sourceContextResolver */
+    public function __construct(Runtime $runtime, Closure $sourceContextResolver)
+    {
+        $this->fallbackEmitter = new FallbackEmitter($runtime, $sourceContextResolver);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -35,22 +35,18 @@ trait StyleResolutionTrait
      *
      * @var array<string, array<string, mixed>>
      */
-    private array $presentationAttributesCache = array();
 
     /**
      * @var array<string, array<string, string>>
      */
-    private array $presentationDeclarationsCache = array();
 
     /**
      * @var array<string, string>
      */
-    private array $mergedPresentationStyleCache = array();
 
     /**
      * @var array<string, string>
      */
-    private array $mediaTextPresentationStyleCache = array();
 
     /**
      * Inline presentation declarations which core block supports cannot serialize
@@ -58,15 +54,11 @@ trait StyleResolutionTrait
      *
      * @var array<string, string>
      */
-    private array $generatedGeometryRules = array();
 
-    private ?GeometryCarrierClassAllocator $geometryCarrierClassAllocator = null;
 
     /** Source-selector cache remains valid only between source-DOM mutations. */
-    private ?CssSelectorMatchCache $sourceSelectorMatchCache = null;
 
     /** @var array<string, array<string, mixed>> */
-    private array $styleRuleCandidateIndexes = array();
 
     /**
      * Author-declared values for the properties an element's inline style could
@@ -75,7 +67,6 @@ trait StyleResolutionTrait
      *
      * @var array<string, array<string, array<int, string>>>
      */
-    private array $authorDeclaredPropertyValuesCache = array();
 
     /**
      * @return list<string>
@@ -181,15 +172,7 @@ trait StyleResolutionTrait
 
     private function resetPresentationResolutionCache(): void
     {
-        $this->presentationAttributesCache = array();
-        $this->presentationDeclarationsCache = array();
-        $this->mergedPresentationStyleCache = array();
-        $this->mediaTextPresentationStyleCache = array();
-        $this->generatedGeometryRules = array();
-        $this->geometryCarrierClassAllocator = null;
-        $this->authorDeclaredPropertyValuesCache = array();
         $this->sourceSelectorMatchCache = new CssSelectorMatchCache();
-        $this->styleRuleCandidateIndexes = array();
     }
 
     private function styleAttributeMapper(): StyleAttributeMapper

--- a/php-transformer/tests/unit/html-transformer-session-state.php
+++ b/php-transformer/tests/unit/html-transformer-session-state.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$assert = static function (bool $condition, string $message): void {
+    if ( ! $condition ) {
+        throw new RuntimeException($message);
+    }
+};
+
+$withoutDurations = static function (array $value) use (&$withoutDurations): array {
+    foreach ( $value as $key => &$item ) {
+        if ( 'transform_duration_ms' === $key ) {
+            unset($value[$key]);
+        } elseif ( is_array($item) ) {
+            $item = $withoutDurations($item);
+        }
+    }
+    unset($item);
+
+    return $value;
+};
+
+$tiles = '<my-pricing><div class="tier"><h3>Basic</h3><p>$9</p></div><div class="tier"><h3>Pro</h3><p>$19</p></div><div class="tier"><h3>Max</h3><p>$49</p></div></my-pricing>';
+$svg = '<main><svg viewBox="0 0 10 10" role="img" aria-label="Map"><path d="M0 0h10v10z"/></svg></main>';
+$script = '<main><script src="widget.js"></script><canvas id="map">Map</canvas></main>';
+$styled = '<style>.card{display:grid;gap:1rem;color:#123}.card .title{font-weight:700}</style><main class="card"><h2 class="title">Styled</h2></main>';
+
+$families = array(
+    'generated blocks and provenance' => array(
+        'seed' => array($tiles, array('generated_block_namespace' => 'seed-blocks')),
+        'target' => array($tiles, array('generated_block_namespace' => 'target-blocks')),
+        'assertion' => static fn (array $result): bool => 'target-blocks/' === substr((string) ($result['blocks'][0]['blockName'] ?? ''), 0, 14)
+            && 1 === count($result['source_reports']['generated_blocks'] ?? array()),
+    ),
+    'materialized assets' => array(
+        'seed' => array($svg, array('generated_asset_root' => 'seed')),
+        'target' => array($svg, array('generated_asset_root' => 'target')),
+        'assertion' => static fn (array $result): bool => 1 === count(array_filter(
+            $result['assets'] ?? array(),
+            static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? '') && str_starts_with((string) ($asset['path'] ?? ''), 'target/')
+        )),
+    ),
+    'fallback and runtime findings' => array(
+        'seed' => array($script, array('runtime_canvas_selectors' => array('#map'))),
+        'target' => array('<main><script src="target.js"></script><canvas id="target-map">Map</canvas></main>', array('runtime_canvas_selectors' => array('#target-map'))),
+        'assertion' => static fn (array $result): bool => 2 === count($result['source_reports']['runtime_islands'] ?? array())
+            && str_contains(json_encode($result['fallbacks'] ?? array()) ?: '', 'target.js'),
+    ),
+    'author style and selector state' => array(
+        'seed' => array($styled, array('static_css' => '.card{color:#f00}')),
+        'target' => array(str_replace('Styled', 'Target', $styled), array('static_css' => '.card{color:#0a0}')),
+        'assertion' => static fn (array $result): bool => str_contains(
+            implode('', array_column(array_filter($result['assets'] ?? array(), static fn (array $asset): bool => 'author-css' === ($asset['source'] ?? '')), 'content')),
+            '#0a0'
+        ),
+    ),
+);
+
+foreach ( $families as $name => $family ) {
+    $reused = new HtmlTransformer();
+    $reused->transform(...$family['seed']);
+    $reusedResult = $reused->transform(...$family['target'])->toArray();
+    $freshResult = (new HtmlTransformer())->transform(...$family['target'])->toArray();
+
+    $assert(($family['assertion'])($freshResult), $name . ' fixture must exercise its stateful output family.');
+    $assert(
+        $withoutDurations($freshResult) === $withoutDurations($reusedResult),
+        $name . ' must produce identical fresh and reused-instance output.'
+    );
+}
+
+fwrite(STDOUT, "HTML transformer session state passed\n");

--- a/php-transformer/tests/unit/media-text-pattern.php
+++ b/php-transformer/tests/unit/media-text-pattern.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerSession;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MediaTextPattern;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
@@ -948,11 +949,12 @@ $memoizedTransformer = new HtmlTransformer();
 $memoizedElement = $elementFromHtml('<section style="display:flex"><img src="memo.jpg"><div><p>Memo</p></div></section>');
 $mediaStyleMethod = new ReflectionMethod(HtmlTransformer::class, 'mediaTextPresentationStyle');
 $presentationKeyMethod = new ReflectionMethod(HtmlTransformer::class, 'presentationCacheKey');
-$mediaStyleCacheProperty = new ReflectionProperty(HtmlTransformer::class, 'mediaTextPresentationStyleCache');
+$sessionProperty = new ReflectionProperty(HtmlTransformer::class, 'session');
+$mediaStyleCacheProperty = new ReflectionProperty(HtmlTransformerSession::class, 'mediaTextPresentationStyleCache');
 $firstMediaStyle = $mediaStyleMethod->invoke($memoizedTransformer, $memoizedElement);
 $memoizedElement->setAttribute('style', 'display:grid');
 $secondMediaStyle = $mediaStyleMethod->invoke($memoizedTransformer, $memoizedElement);
-$mediaStyleCache = $mediaStyleCacheProperty->getValue($memoizedTransformer);
+$mediaStyleCache = $mediaStyleCacheProperty->getValue($sessionProperty->getValue($memoizedTransformer));
 $presentationKey = $presentationKeyMethod->invoke($memoizedTransformer, $memoizedElement);
 $assertSame('display:flex', $firstMediaStyle, 'Media-text presentation style resolves initial authored style.');
 $assertSame($firstMediaStyle, $secondMediaStyle, 'Media-text presentation style reuses cached value for same DOM node.');


### PR DESCRIPTION
## Summary
- move all mutable HTML conversion accumulators into a fresh per-transform session
- retain immutable collaborators and shared analysis cache on `HtmlTransformer`
- cover fresh versus reused instances across generated blocks, assets, runtime findings, and author styles

## Tests
- `composer test`
- `composer validate --strict`
- `git diff --check`

Fixes #997

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode mapped the mutable transform state, implemented the session extraction, and ran the verification suite. Chris Huber remains responsible for every line.