### PR TITLE
Preserve SVG box variables on image carriers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -553,11 +553,21 @@ trait SvgMaterializationTrait
             return false;
         }
 
-        // The materialized SVG renders in a separate image document. Color
-        // inheritance and custom properties are resolved before this gate; any
-        // unresolved value would still be document-context dependent.
-        if ( preg_match('/\bcurrentColor\b|var\s*\(/i', $html) ) {
+        // The materialized SVG renders in a separate image document. Paint and
+        // content custom properties must be resolved, but root box geometry is
+        // transferred to the native image carrier and may retain author vars.
+        if ( preg_match('/\bcurrentColor\b/i', $html) ) {
             return false;
+        }
+        $htmlWithoutRootStyle = preg_replace('/(<svg\b[^>]*?)\sstyle\s*=\s*(["\'])(.*?)\2/i', '$1', $html, 1) ?? $html;
+        if ( preg_match('/var\s*\(/i', $htmlWithoutRootStyle) ) {
+            return false;
+        }
+        $boxProperties = array_flip(array( 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'aspect-ratio' ));
+        foreach ( $this->cssDeclarations($this->attr($element, 'style')) as $property => $value ) {
+            if ( preg_match('/var\s*\(/i', $value) && ! isset($boxProperties[strtolower($property)]) ) {
+                return false;
+            }
         }
         if ( preg_match('/\s(?:href|xlink:href)\s*=\s*(["\'])(?!#)[^"\']+\1/i', $html) ) {
             return false;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1842,6 +1842,12 @@ $assert('core/image' === ($exportedSvgMetadata['blocks'][0]['blockName'] ?? '') 
 $exportedSvgFilter = ( new HtmlTransformer() )->transform('<svg viewBox="0 0 40 40" focusable="false"><defs><filter id="shadow"><feGaussianBlur stdDeviation="2" result="blur"></feGaussianBlur><feOffset in="blur" x="1" y="1" result="offset"></feOffset><feColorMatrix in="offset" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 .5 0"></feColorMatrix></filter></defs><rect data-testid="shape" width="40" height="40" filter="url(#shadow)"></rect></svg>')->toArray();
 $assert('core/image' === ($exportedSvgFilter['blocks'][0]['blockName'] ?? '') && array() === ($exportedSvgFilter['fallbacks'] ?? array()), 'passive exported SVG filter primitives materialize without raw HTML fallback');
 
+$exportedSvgBoxVariables = ( new HtmlTransformer() )->transform('<div><svg viewBox="0 0 24 24" width="24" height="24" style="height:1em;min-height:calc(var(--nav-icon-width)*1px);min-width:calc(var(--nav-icon-width)*1px);width:1em"><path fill-rule="evenodd" d="M15 5 L16 6 L9 12 L16 18 L15 19 L8 12 Z"></path></svg></div>')->toArray();
+$assert('core/image' === ($exportedSvgBoxVariables['blocks'][0]['blockName'] ?? '') && array() === ($exportedSvgBoxVariables['fallbacks'] ?? array()), 'passive SVG root box variables transfer to native image geometry without raw HTML fallback');
+
+$exportedSvgPaintVariable = ( new HtmlTransformer() )->transform('<div><svg viewBox="0 0 24 24" style="fill:var(--icon-color)"><path d="M0 0h24v24H0z"></path></svg></div>')->toArray();
+$assert('core/html' === ($exportedSvgPaintVariable['blocks'][0]['blockName'] ?? ''), 'SVG paint variables remain inline because an image document cannot inherit the source custom property');
+
 $complexSvgAsset = ( new HtmlTransformer() )->transform(
     '<svg role="img" aria-label="Site illustration" viewBox="0 0 400 200"><title>Site illustration</title><path d="M0 0h400v200H0z"></path></svg>'
 )->toArray();


### PR DESCRIPTION
## Summary

- allow root SVG media-box custom properties to transfer to generated native image carrier geometry
- continue rejecting unresolved custom properties in SVG paint and content, which cannot inherit into the materialized image document
- replace the final four Search-page `core/html` SVG blocks found by the Nicole Louise Events acceptance corpus

Follow-up to #1010.

## Verification

- `composer test`
- 278 PHP transformer parity fixtures passed
- package install proof passed
- focused HTML-to-block contract passed after rebasing onto merged `trunk`
- corpus reproduction: four 24x24 passive arrow SVGs using root `min-width`/`min-height: calc(var(--nav-icon-width) * 1px)` remained as `core/html`; the added contract reproduces that shape
- negative contract keeps `fill: var(--icon-color)` inline
- `git diff --check origin/trunk...HEAD`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode extracted the residual corpus blocks, traced the native-image compatibility gate, implemented the bounded geometry exception and negative paint-variable contract, and ran the full suite. Chris Huber is responsible for every line.