### PR TITLE
Preserve binary artifacts in Figma CLI JSON

### DIFF
--- a/figma-transformer/bin/figma-transformer
+++ b/figma-transformer/bin/figma-transformer
@@ -452,6 +452,7 @@ function blocks_engine_figma_transformer_cli_diagnostic(string $code, string $me
  */
 function blocks_engine_figma_transformer_cli_json_encode(array $result): string
 {
+    $result['files'] = blocks_engine_figma_transformer_cli_json_files($result['files'] ?? array());
     $encoded = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR);
     if ( is_string($encoded) ) {
         return $encoded;
@@ -472,4 +473,33 @@ function blocks_engine_figma_transformer_cli_json_encode(array $result): string
         ),
         JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
     ) ?: '{"status":"error"}';
+}
+
+/**
+ * @param mixed $files
+ * @return array<int, mixed>
+ */
+function blocks_engine_figma_transformer_cli_json_files(mixed $files): array
+{
+    $jsonFiles = array();
+
+    foreach ( is_array($files) ? $files : array() as $file ) {
+        if ( is_array($file) && isset($file['content']) && is_scalar($file['content']) && ! blocks_engine_figma_transformer_cli_is_text_mime_type((string) ($file['mime_type'] ?? 'application/octet-stream')) ) {
+            $file['content_base64'] = base64_encode((string) $file['content']);
+            unset($file['content']);
+        }
+        $jsonFiles[] = $file;
+    }
+
+    return $jsonFiles;
+}
+
+function blocks_engine_figma_transformer_cli_is_text_mime_type(string $mimeType): bool
+{
+    $mimeType = strtolower(trim(explode(';', $mimeType, 2)[0]));
+
+    return str_starts_with($mimeType, 'text/')
+        || str_ends_with($mimeType, '+json')
+        || str_ends_with($mimeType, '+xml')
+        || in_array($mimeType, array('application/json', 'application/xml', 'application/javascript', 'image/svg+xml'), true);
 }

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -240,16 +240,31 @@ $assert(1 === ($vectorPlaceholderSignal['count'] ?? null), 'missing-emission-vec
 
 $cliOutputRoot = sys_get_temp_dir() . '/figma-transformer-cli-output-' . getmypid() . '-' . bin2hex(random_bytes(4));
 $cliScenegraphPath = $cliOutputRoot . '/scenegraph.json';
+$cliBinaryContent = "\x89PNG\r\n\x1a\n\x00\xff\xfe\x80binary";
+$cliSvgContent = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"></svg>';
 $cliScenegraph = array(
     'name'   => 'CLI Output Fixture',
     'assets' => array(
+        'cli-binary' => array(
+            'name'           => 'CLI Binary',
+            'mime_type'      => 'image/png',
+            'content_base64' => base64_encode($cliBinaryContent),
+        ),
         'cli-image' => array(
             'name'      => 'CLI Image',
             'mime_type' => 'image/svg+xml',
-            'content'   => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"></svg>',
+            'content'   => $cliSvgContent,
         ),
     ),
     'nodes'  => array(
+        array(
+            'id'       => 'cli:binary',
+            'type'     => 'RECTANGLE',
+            'name'     => 'CLI Binary Card',
+            'width'    => 40,
+            'height'   => 20,
+            'asset_id' => 'cli-binary',
+        ),
         array(
             'id'       => 'cli:1',
             'type'     => 'RECTANGLE',
@@ -262,10 +277,21 @@ $cliScenegraph = array(
 );
 mkdir($cliOutputRoot, 0777, true);
 file_put_contents($cliScenegraphPath, json_encode($cliScenegraph, JSON_UNESCAPED_SLASHES));
-$cliCommand = escapeshellarg(PHP_BINARY)
+$cliCommandBase = escapeshellarg(PHP_BINARY)
     . ' ' . escapeshellarg(__DIR__ . '/../../bin/figma-transformer')
-    . ' ' . escapeshellarg($cliScenegraphPath)
-    . ' --output-dir=' . escapeshellarg($cliOutputRoot . '/artifact');
+    . ' ' . escapeshellarg($cliScenegraphPath);
+$cliJsonTransport = shell_exec($cliCommandBase);
+$cliTransportResult = is_string($cliJsonTransport) ? json_decode($cliJsonTransport, true) : null;
+$cliTransportFiles = is_array($cliTransportResult) ? array_column($cliTransportResult['files'] ?? array(), null, 'path') : array();
+$cliBinaryTransportFile = $cliTransportFiles['assets/cli-binary.png'] ?? array();
+$cliSvgTransportFile = $cliTransportFiles['assets/cli-image.svg'] ?? array();
+$assert(is_array($cliTransportResult), 'cli-json-transport-parses');
+$assert(! array_key_exists('content', $cliBinaryTransportFile), 'cli-json-transport-omits-raw-binary-content');
+$assert($cliBinaryContent === base64_decode((string) ($cliBinaryTransportFile['content_base64'] ?? ''), true), 'cli-json-transport-base64-is-byte-identical');
+$assert($cliSvgContent === ($cliSvgTransportFile['content'] ?? null), 'cli-json-transport-preserves-textual-svg-content');
+$assert(! isset($cliSvgTransportFile['content_base64']), 'cli-json-transport-does-not-base64-textual-svg');
+
+$cliCommand = $cliCommandBase . ' --output-dir=' . escapeshellarg($cliOutputRoot . '/artifact');
 $cliJson = shell_exec($cliCommand);
 $cliResult = is_string($cliJson) ? json_decode($cliJson, true) : null;
 $assert(is_array($cliResult), 'cli-output-dir-json-result');
@@ -274,7 +300,8 @@ $assert($cliOutputRoot . '/artifact' === ($cliResult['output']['directory'] ?? n
 $assert(! isset($cliResult['files'][0]['content']), 'cli-output-dir-omits-file-content-from-json');
 $assert(is_file($cliOutputRoot . '/artifact/index.html'), 'cli-output-dir-writes-index');
 $assert(is_file($cliOutputRoot . '/artifact/style.css'), 'cli-output-dir-writes-style');
-$assert('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"></svg>' === file_get_contents($cliOutputRoot . '/artifact/assets/cli-image.svg'), 'cli-output-dir-preserves-asset-content');
+$assert($cliBinaryContent === file_get_contents($cliOutputRoot . '/artifact/assets/cli-binary.png'), 'cli-output-dir-preserves-binary-asset-content');
+$assert($cliSvgContent === file_get_contents($cliOutputRoot . '/artifact/assets/cli-image.svg'), 'cli-output-dir-preserves-asset-content');
 $assert(str_contains((string) file_get_contents($cliOutputRoot . '/artifact/style.css'), 'background-image:url("assets/cli-image.svg")'), 'cli-output-dir-preserves-asset-reference');
 $assert(str_contains($html, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"'), 'html-vector-blob-svg');
 $assert(str_contains($html, 'd="M0 0L10 0 10 10Z"'), 'html-vector-blob-path');


### PR DESCRIPTION
## Summary

- encode non-text CLI file payloads as `content_base64` instead of passing raw bytes through JSON UTF-8 substitution
- preserve textual HTML, CSS, JavaScript, JSON, XML, and SVG payloads as `content`
- keep `--output-dir` artifact bytes unchanged
- add binary PNG and textual SVG transport contracts

## Root Cause

The Figma CLI serialized raw PNG and JPEG bytes in each file's `content` field using `JSON_INVALID_UTF8_SUBSTITUTE`. Invalid byte sequences were irreversibly replaced even though file paths and metadata remained valid. Downstream compilation then received corrupt asset payloads and rejected local browser references as unresolved.

## Verification

- `composer --working-dir=figma-transformer test`
- PHP syntax checks for both changed files
- `git diff origin/trunk...HEAD --check`
- real FSE Pilot multi-page `.fig` transport: 51 files, 28 strict-decode binary payloads, 23 textual payloads, 26 valid PNG signatures, and 2 valid JPEG signatures
- canonical PHP compilation of the repaired real artifact reports `unresolved_local_browser_reference: 0` and serializes 164,110 block bytes

The real FSE artifact still fails separate existing editability and semantic-parity gates; this PR fixes the binary transport defect without weakening those gates.

Closes #990.

## AI Assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode and Homeboy diagnosed the binary JSON corruption, generated and promoted the transport patch, added contract coverage, and ran synthetic plus real-fixture verification. Chris Huber reviewed and remains responsible for every line.