### PR TITLE
Compose stylesheet analysis by payload

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -45,6 +45,30 @@ final class ArtifactCompiler
 
     private ?HtmlTransformerAnalysisCache $htmlTransformerAnalysisCache = null;
 
+    public function __construct(private readonly bool $cacheHtmlAnalysis = true)
+    {
+    }
+
+    /** @return array<string, int> */
+    public function htmlAnalysisCacheMetrics(): array
+    {
+        $cache = $this->htmlTransformerAnalysisCache;
+        if ( ! $cache instanceof HtmlTransformerAnalysisCache ) {
+            return array();
+        }
+
+        return array(
+            'style_builds' => $cache->styleBuilds,
+            'style_hits' => $cache->styleHits,
+            'style_evictions' => $cache->styleEvictions,
+            'style_bytes' => $cache->styleBytes,
+            'author_builds' => $cache->authorSelectorBuilds,
+            'author_hits' => $cache->authorSelectorHits,
+            'author_evictions' => $cache->authorSelectorEvictions,
+            'author_bytes' => $cache->authorSelectorBytes,
+        );
+    }
+
     private string $generatedAssetRoot = '';
 
     /** @var array<string, array<string, mixed>> */
@@ -182,7 +206,7 @@ final class ArtifactCompiler
         $startedAt = hrtime(true);
 		$this->themeStaticCssCache = array();
 		$this->wordpressCompatCssCache = array();
-        $this->htmlTransformerAnalysisCache = new HtmlTransformerAnalysisCache();
+        $this->htmlTransformerAnalysisCache = $this->cacheHtmlAnalysis ? new HtmlTransformerAnalysisCache() : null;
         $normalized = ( new ArtifactNormalizer() )->normalize($artifact);
         $capturedDialogs = ( new CapturedDialogProjector() )->project($normalized['files']);
         $normalized['files'] = $capturedDialogs['files'];
@@ -1101,11 +1125,16 @@ final class ArtifactCompiler
             );
         }
 
-        $result = (new HtmlTransformer(analysisCache: $this->htmlTransformerAnalysisCache ??= new HtmlTransformerAnalysisCache()))->transform($this->safeHtmlDocumentHtml($html, $sourcePath, $files), array(
+        $stylesheetPayloads = $this->linkedStylesheetPayloads($html, $sourcePath, $files);
+        $analysisCache = $this->cacheHtmlAnalysis
+            ? $this->htmlTransformerAnalysisCache ??= new HtmlTransformerAnalysisCache()
+            : new HtmlTransformerAnalysisCache();
+        $result = (new HtmlTransformer(analysisCache: $analysisCache))->transform($this->safeHtmlDocumentHtml($html, $sourcePath, $files), array(
             'source'                    => $sourcePath,
             'source_scope'              => $sourceScope,
             'declarative_state_html'    => $html,
             'static_css'                => $this->linkedStylesheetCss($html, $sourcePath, $files),
+            'stylesheet_payloads'       => $stylesheetPayloads,
             'author_stylesheet_assets'  => $this->stylesheetAssetsForSource($html, $sourcePath, $files),
             'skip_author_stylesheet_materialization' => true,
             'asset_metadata'            => $this->assetMetadataForSource($sourcePath, $files),
@@ -1491,15 +1520,29 @@ final class ArtifactCompiler
      */
     private function linkedStylesheetCss(string $html, string $sourcePath, array $files): string
     {
-        $css = array();
+        return trim(implode("\n", array_column($this->linkedStylesheetPayloads($html, $sourcePath, $files), 'content')));
+    }
+
+    /**
+     * Keep source stylesheet boundaries intact for payload-addressed analysis.
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @return list<array{content: string, source_hash: string}>
+     */
+    private function linkedStylesheetPayloads(string $html, string $sourcePath, array $files): array
+    {
+        $payloads = array();
         foreach ( $this->stylesheetAssetsForSource($html, $sourcePath, $files) as $stylesheet ) {
             $content = (string) ($stylesheet['content'] ?? '');
             if ( '' !== trim($content) ) {
-                $css[] = $this->artifactRelativeStylesheetContent($content, (string) ($stylesheet['source_path'] ?? $sourcePath), $files);
+                $payloads[] = array(
+                    'content' => $this->artifactRelativeStylesheetContent($content, (string) ($stylesheet['source_path'] ?? $sourcePath), $files),
+                    'source_hash' => (string) ($stylesheet['source_hash'] ?? hash('sha256', $content)),
+                );
             }
         }
 
-        return trim(implode("\n", $css));
+        return $payloads;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -632,33 +632,13 @@ final class HtmlTransformer
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $staticCss = (string) ($options['static_css'] ?? '');
-        $styleAnalysisKey = $this->styleAnalysisKey($html, $staticCss);
-        if ( isset($this->analysisCache->styles[$styleAnalysisKey]) ) {
-            ++$this->analysisCache->styleHits;
-            $styleAnalysis = $this->analysisCache->styles[$styleAnalysisKey];
-            $this->staticStyleRules = $styleAnalysis['static'];
-            $this->conditionalStyleRules = $styleAnalysis['conditional'];
-            $this->navigationStateStyleRules = $styleAnalysis['navigation_state'];
-            $this->imageShapeStyleRules = $styleAnalysis['image_shape'];
-            $this->staticPseudoElementStyleRules = $styleAnalysis['pseudo'];
-            $this->cssCustomProperties = $styleAnalysis['custom_properties'];
-        } else {
-            ++$this->analysisCache->styleBuilds;
-            $this->staticStyleRules = $this->staticStyleRules($html, $staticCss);
-            $this->conditionalStyleRules = $this->conditionalStyleRules($html, $staticCss);
-            $this->navigationStateStyleRules = $this->navigationStateStyleRules($html, $staticCss);
-            $this->imageShapeStyleRules = $this->imageShapeStyleRules($html, $staticCss);
-            $this->staticPseudoElementStyleRules = $this->staticPseudoElementStyleRules($html, $staticCss);
-            $this->cssCustomProperties = $this->cssCustomProperties($html, $staticCss);
-            $this->analysisCache->rememberStyle($styleAnalysisKey, array(
-                'static' => $this->staticStyleRules,
-                'conditional' => $this->conditionalStyleRules,
-                'navigation_state' => $this->navigationStateStyleRules,
-                'image_shape' => $this->imageShapeStyleRules,
-                'pseudo' => $this->staticPseudoElementStyleRules,
-                'custom_properties' => $this->cssCustomProperties,
-            ));
-        }
+        $styleAnalysis = $this->composedStyleAnalysis($this->stylesheetPayloads($html, $staticCss));
+        $this->staticStyleRules = $styleAnalysis['static'];
+        $this->conditionalStyleRules = $styleAnalysis['conditional'];
+        $this->navigationStateStyleRules = $styleAnalysis['navigation_state'];
+        $this->imageShapeStyleRules = $styleAnalysis['image_shape'];
+        $this->staticPseudoElementStyleRules = $styleAnalysis['pseudo'];
+        $this->cssCustomProperties = $styleAnalysis['custom_properties'];
         $this->resetPresentationResolutionCache();
         $this->runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
         $this->runtimeCanvasSelectors = $this->runtimeCanvasSelectorsFromOptions($options);
@@ -2727,44 +2707,10 @@ final class HtmlTransformer
             }
         }
 
-		$authorAnalysisKey = hash('sha256', $this->combinedAuthorCss);
-        if ( isset($this->analysisCache->authorSelectorAnalyses[$authorAnalysisKey]) ) {
-            ++$this->analysisCache->authorSelectorHits;
-            $authorAnalysis = $this->analysisCache->authorSelectorAnalyses[$authorAnalysisKey];
-            $sourceTagSelectorNames = $authorAnalysis['source_tags'];
-            $authorSelectors = $authorAnalysis['selectors'];
-            $authorStyleRules = $authorAnalysis['rules'];
-        } else {
-			++$this->analysisCache->authorSelectorBuilds;
-			$sourceTagSelectorNames = array();
-			$authorSelectors = array();
-			$authorStyleRules = array();
-			( new CssStylesheetTransformer() )->transform($this->combinedAuthorCss, function (string $prelude, string $body) use (&$sourceTagSelectorNames, &$authorSelectors, &$authorStyleRules): string {
-				$ruleSelectors = array();
-				foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
-					$parsed = $this->parsedCssSelector($selector);
-					$authorSelectors[] = array('selector' => $selector, 'parsed' => $parsed);
-					$directSelector = preg_replace('/::[a-z-]+(?:\([^)]*\))?$/i', '', trim($selector)) ?? $selector;
-					$ruleSelectors[] = array('selector' => $selector, 'parsed' => $parsed, 'direct_child_parsed' => $this->parsedCssSelector($directSelector));
-					foreach ( $parsed['type_spans'] ?? array() as $typeSpan ) {
-						$tagName = strtolower($typeSpan['name']);
-						if ( in_array($tagName, array( 'div', 'li', 'nav', 'p' ), true) ) {
-							$sourceTagSelectorNames[$tagName] = true;
-						}
-					}
-				}
-				if ( array() !== $ruleSelectors ) {
-					$authorStyleRules[] = array('order' => count($authorStyleRules), 'declarations' => $this->cssDeclarations($body), 'selectors' => $ruleSelectors);
-				}
-				return $prelude;
-			});
-			++$this->analysisCache->authorStyleRuleBuilds;
-            $this->analysisCache->rememberAuthorSelectors($authorAnalysisKey, array(
-                'source_tags' => $sourceTagSelectorNames,
-                'selectors' => $authorSelectors,
-				'rules' => $authorStyleRules,
-            ));
-        }
+        $authorAnalysis = $this->composedAuthorSelectorAnalysis($this->authorStylesheetPayloads($html, $staticCss));
+        $sourceTagSelectorNames = $authorAnalysis['source_tags'];
+        $authorSelectors = $authorAnalysis['selectors'];
+        $authorStyleRules = $authorAnalysis['rules'];
         foreach ( array_keys($sourceTagSelectorNames) as $tagName ) {
             $this->sourceTagMarkers[ $tagName ] = $this->allocateAuthorMarker('source-' . $tagName);
         }
@@ -2969,14 +2915,136 @@ final class HtmlTransformer
         return trim(implode("\n\n", $cssParts));
     }
 
-    private function styleAnalysisKey(string $html, string $staticCss): string
+    /** @return list<string> */
+    private function stylesheetPayloads(string $html, string $staticCss): array
     {
-        $inlineStyles = array();
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            $inlineStyles = array_map('trim', $matches[1]);
+        $payloads = array();
+        foreach ( array_merge(array($staticCss), $this->inlineStylesheetPayloads($html)) as $payload ) {
+            $payload = trim($payload);
+            if ( '' !== $payload ) {
+                $payloads[] = $payload;
+            }
         }
 
-        return hash('sha256', trim($staticCss) . "\0" . implode("\0", $inlineStyles));
+        return $payloads;
+    }
+
+    /** @return list<string> */
+    private function authorStylesheetPayloads(string $html, string $staticCss): array
+    {
+        if ( array() !== $this->authorStylesheetAssets ) {
+            return array_values(array_filter(array_column($this->authorStylesheetAssets, 'content'), static fn (string $payload): bool => '' !== trim($payload)));
+        }
+
+        $payloads = array();
+        foreach ( array_merge(array($staticCss), $this->inlineStylesheetPayloads($html)) as $payload ) {
+            $payload = trim(html_entity_decode($payload, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            if ( '' !== $payload ) {
+                $payloads[] = $payload;
+            }
+        }
+
+        return $payloads;
+    }
+
+    /** @return list<string> */
+    private function inlineStylesheetPayloads(string $html): array
+    {
+        if ( ! preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
+            return array();
+        }
+
+        return array_map(static fn (string $payload): string => trim($payload), $matches[1]);
+    }
+
+    /** @return array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array} */
+    private function composedStyleAnalysis(array $payloads): array
+    {
+        $composed = array('static' => array(), 'conditional' => array(), 'navigation_state' => array(), 'image_shape' => array(), 'pseudo' => array(), 'custom_properties' => array());
+        foreach ( $payloads as $payload ) {
+            $key = hash('sha256', $payload);
+            $analysis = $this->analysisCache->style($key);
+            if ( null === $analysis ) {
+                ++$this->analysisCache->styleBuilds;
+                $analysis = array(
+                    'static' => $this->staticStyleRules('', $payload),
+                    'conditional' => $this->conditionalStyleRules('', $payload),
+                    'navigation_state' => $this->navigationStateStyleRules('', $payload),
+                    'image_shape' => $this->imageShapeStyleRules('', $payload),
+                    'pseudo' => $this->staticPseudoElementStyleRules('', $payload),
+                    'custom_properties' => $this->cssCustomProperties('', $payload),
+                );
+                $this->analysisCache->rememberStyle($key, $analysis);
+            } else {
+                ++$this->analysisCache->styleHits;
+            }
+            foreach ( array('static', 'conditional', 'navigation_state', 'pseudo') as $part ) {
+                $composed[$part] = array_merge($composed[$part], $analysis[$part]);
+            }
+            foreach ( $analysis['image_shape'] as $rule ) {
+                $rule['order'] = count($composed['image_shape']);
+                $composed['image_shape'][] = $rule;
+            }
+            $composed['custom_properties'] = array_merge($composed['custom_properties'], $analysis['custom_properties']);
+        }
+
+        return $composed;
+    }
+
+    /** @return array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} */
+    private function composedAuthorSelectorAnalysis(array $payloads): array
+    {
+        $composed = array('source_tags' => array(), 'selectors' => array(), 'rules' => array());
+        foreach ( $payloads as $payload ) {
+            $key = hash('sha256', $payload);
+            $analysis = $this->analysisCache->authorSelectors($key);
+            if ( null === $analysis ) {
+                ++$this->analysisCache->authorSelectorBuilds;
+                $analysis = $this->authorSelectorAnalysis($payload);
+                ++$this->analysisCache->authorStyleRuleBuilds;
+                $this->analysisCache->rememberAuthorSelectors($key, $analysis);
+            } else {
+                ++$this->analysisCache->authorSelectorHits;
+            }
+            $composed['source_tags'] += $analysis['source_tags'];
+            $composed['selectors'] = array_merge($composed['selectors'], $analysis['selectors']);
+            foreach ( $analysis['rules'] as $rule ) {
+                $rule['order'] = count($composed['rules']);
+                $composed['rules'][] = $rule;
+            }
+        }
+
+        return $composed;
+    }
+
+    /** @return array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} */
+    private function authorSelectorAnalysis(string $css): array
+    {
+        $sourceTags = array();
+        $selectors = array();
+        $rules = array();
+        (new CssStylesheetTransformer())->transform($css, function (string $prelude, string $body) use (&$sourceTags, &$selectors, &$rules): string {
+            $ruleSelectors = array();
+            foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
+                $parsed = $this->parsedCssSelector($selector);
+                $selectors[] = array('selector' => $selector, 'parsed' => $parsed);
+                $directSelector = preg_replace('/::[a-z-]+(?:\([^)]*\))?$/i', '', trim($selector)) ?? $selector;
+                $ruleSelectors[] = array('selector' => $selector, 'parsed' => $parsed, 'direct_child_parsed' => $this->parsedCssSelector($directSelector));
+                foreach ( $parsed['type_spans'] ?? array() as $typeSpan ) {
+                    $tagName = strtolower($typeSpan['name']);
+                    if ( in_array($tagName, array('div', 'li', 'nav', 'p'), true) ) {
+                        $sourceTags[$tagName] = true;
+                    }
+                }
+            }
+            if ( array() !== $ruleSelectors ) {
+                $rules[] = array('order' => count($rules), 'declarations' => $this->cssDeclarations($body), 'selectors' => $ruleSelectors);
+            }
+
+            return $prelude;
+        });
+
+        return array('source_tags' => $sourceTags, 'selectors' => $selectors, 'rules' => $rules);
     }
 
     /** @param array<string, mixed> $options @return list<array{path: string, source_path: string, content: string, source_hash: string, media: string}> */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -632,7 +632,7 @@ final class HtmlTransformer
         $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $staticCss = (string) ($options['static_css'] ?? '');
-        $styleAnalysis = $this->composedStyleAnalysis($this->stylesheetPayloads($html, $staticCss));
+        $styleAnalysis = $this->composedStyleAnalysis($this->stylesheetPayloads($html, $staticCss, $options));
         $this->staticStyleRules = $styleAnalysis['static'];
         $this->conditionalStyleRules = $styleAnalysis['conditional'];
         $this->navigationStateStyleRules = $styleAnalysis['navigation_state'];
@@ -2916,35 +2916,55 @@ final class HtmlTransformer
     }
 
     /** @return list<string> */
-    private function stylesheetPayloads(string $html, string $staticCss): array
+    private function stylesheetPayloads(string $html, string $staticCss, array $options): array
     {
+        $staticPayloads = $this->staticStylesheetPayloads($staticCss, $options);
+        $inlinePayloads = $this->inlineStylesheetPayloads($html);
+        $payloads = array_merge($staticPayloads, $inlinePayloads);
+        if ( ! $this->hasSafeStylesheetBoundaries($payloads) ) {
+            // Preserve the legacy parser's recovery across a concatenated stream.
+            $combined = trim($staticCss . ('' === trim($staticCss) || array() === $inlinePayloads ? '' : "\n") . implode("\n", $inlinePayloads));
+            return '' === $combined ? array() : array($combined);
+        }
+
+        return array_values(array_filter(array_map('trim', $payloads), static fn (string $payload): bool => '' !== $payload));
+    }
+
+    /** @param array<string, mixed> $options @return list<string> */
+    private function staticStylesheetPayloads(string $staticCss, array $options): array
+    {
+        if ( ! is_array($options['stylesheet_payloads'] ?? null) ) {
+            return array($staticCss);
+        }
         $payloads = array();
-        foreach ( array_merge(array($staticCss), $this->inlineStylesheetPayloads($html)) as $payload ) {
-            $payload = trim($payload);
-            if ( '' !== $payload ) {
-                $payloads[] = $payload;
+        foreach ( $options['stylesheet_payloads'] as $payload ) {
+            if ( is_array($payload) && is_string($payload['content'] ?? null) ) {
+                $payloads[] = $payload['content'];
             }
         }
 
-        return $payloads;
+        return array() === $payloads ? array($staticCss) : $payloads;
     }
 
     /** @return list<string> */
     private function authorStylesheetPayloads(string $html, string $staticCss): array
     {
         if ( array() !== $this->authorStylesheetAssets ) {
-            return array_values(array_filter(array_column($this->authorStylesheetAssets, 'content'), static fn (string $payload): bool => '' !== trim($payload)));
+            $payloads = array_values(array_filter(array_column($this->authorStylesheetAssets, 'content'), static fn (string $payload): bool => '' !== trim($payload)));
+            return $this->hasSafeStylesheetBoundaries($payloads) ? $payloads : array(implode("\n\n", $payloads));
         }
 
         $payloads = array();
-        foreach ( array_merge(array($staticCss), $this->inlineStylesheetPayloads($html)) as $payload ) {
+        // This order is intentionally distinct from presentation analysis: it
+        // matches combinedAuthorStylesheet(), which emits inline CSS first.
+        foreach ( array_merge($this->inlineStylesheetPayloads($html), array($staticCss)) as $payload ) {
             $payload = trim(html_entity_decode($payload, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
             if ( '' !== $payload ) {
                 $payloads[] = $payload;
             }
         }
 
-        return $payloads;
+        return $this->hasSafeStylesheetBoundaries($payloads) ? $payloads : array(implode("\n\n", $payloads));
     }
 
     /** @return list<string> */
@@ -2957,10 +2977,57 @@ final class HtmlTransformer
         return array_map(static fn (string $payload): string => trim($payload), $matches[1]);
     }
 
+    /** @param list<string> $payloads */
+    private function hasSafeStylesheetBoundaries(array $payloads): bool
+    {
+        foreach ( $payloads as $payload ) {
+            $depth = 0;
+            $quote = '';
+            $comment = false;
+            for ( $index = 0, $length = strlen($payload); $index < $length; ++$index ) {
+                $character = $payload[$index];
+                $next = $index + 1 < $length ? $payload[$index + 1] : '';
+                if ( $comment ) {
+                    if ( '*' === $character && '/' === $next ) {
+                        $comment = false;
+                        ++$index;
+                    }
+                    continue;
+                }
+                if ( '' !== $quote ) {
+                    if ( '\\' === $character ) {
+                        ++$index;
+                    } elseif ( $quote === $character ) {
+                        $quote = '';
+                    }
+                    continue;
+                }
+                if ( '/' === $character && '*' === $next ) {
+                    $comment = true;
+                    ++$index;
+                } elseif ( '"' === $character || "'" === $character ) {
+                    $quote = $character;
+                } elseif ( '{' === $character ) {
+                    ++$depth;
+                } elseif ( '}' === $character ) {
+                    --$depth;
+                    if ( $depth < 0 ) {
+                        return false;
+                    }
+                }
+            }
+            if ( $comment || '' !== $quote || 0 !== $depth ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /** @return array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array} */
     private function composedStyleAnalysis(array $payloads): array
     {
-        $composed = array('static' => array(), 'conditional' => array(), 'navigation_state' => array(), 'image_shape' => array(), 'pseudo' => array(), 'custom_properties' => array());
+        $composed = array('static' => array(), 'conditional' => array(), 'navigation_state' => array(), 'image_shape' => array(), 'pseudo' => array(), 'custom_properties' => array('root' => array(), 'fallback' => array()));
         foreach ( $payloads as $payload ) {
             $key = hash('sha256', $payload);
             $analysis = $this->analysisCache->style($key);
@@ -2972,7 +3039,7 @@ final class HtmlTransformer
                     'navigation_state' => $this->navigationStateStyleRules('', $payload),
                     'image_shape' => $this->imageShapeStyleRules('', $payload),
                     'pseudo' => $this->staticPseudoElementStyleRules('', $payload),
-                    'custom_properties' => $this->cssCustomProperties('', $payload),
+                    'custom_properties' => $this->cssCustomPropertyAnalysis($payload),
                 );
                 $this->analysisCache->rememberStyle($key, $analysis);
             } else {
@@ -2985,10 +3052,45 @@ final class HtmlTransformer
                 $rule['order'] = count($composed['image_shape']);
                 $composed['image_shape'][] = $rule;
             }
-            $composed['custom_properties'] = array_merge($composed['custom_properties'], $analysis['custom_properties']);
+            $composed['custom_properties']['root'] = array_merge($composed['custom_properties']['root'], $analysis['custom_properties']['root']);
+            $composed['custom_properties']['fallback'] = array_merge($composed['custom_properties']['fallback'], $analysis['custom_properties']['fallback']);
         }
 
+        $composed['custom_properties'] = array() !== $composed['custom_properties']['root']
+            ? $composed['custom_properties']['root']
+            : $composed['custom_properties']['fallback'];
+
         return $composed;
+    }
+
+    /** @return array{root: array<string, string>, fallback: array<string, string>} */
+    private function cssCustomPropertyAnalysis(string $css): array
+    {
+        $root = array();
+        (new CssStylesheetTransformer())->transform($css, static function (string $prelude, string $body) use (&$root): string {
+            $selectors = CssStylesheetTransformer::splitSelectorList($prelude);
+            if ( null === $selectors || ! array_filter($selectors, static function (string $selector): bool {
+                $selector = preg_replace('/\/\*.*?\*\//s', '', $selector) ?? $selector;
+                return in_array(strtolower(trim($selector)), array(':root', 'html'), true);
+            }) ) {
+                return $prelude;
+            }
+            if ( preg_match_all('/(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+)/', $body, $matches, PREG_SET_ORDER) ) {
+                foreach ( $matches as $match ) {
+                    $root[(string) $match[1]] = trim((string) $match[2]);
+                }
+            }
+
+            return $prelude;
+        });
+        $fallback = array();
+        if ( preg_match_all('/(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+)/', $css, $matches, PREG_SET_ORDER) ) {
+            foreach ( $matches as $match ) {
+                $fallback[(string) $match[1]] = trim((string) $match[2]);
+            }
+        }
+
+        return array('root' => $root, 'fallback' => $fallback);
     }
 
     /** @return array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -12,6 +12,8 @@ final class HtmlTransformerAnalysisCache
     // cache small even when every route contributes a local stylesheet.
     private const MAX_PAYLOAD_ENTRIES = 16;
 
+    private const MAX_PAYLOAD_BYTES = 1048576;
+
     /** @var array<string, array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array}> */
     public array $styles = array();
 
@@ -21,6 +23,10 @@ final class HtmlTransformerAnalysisCache
 
     public int $styleEvictions = 0;
 
+    public int $styleBytes = 0;
+
+    public int $styleEvictedBytes = 0;
+
     /** @var array<string, array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>}>} */
     public array $authorSelectorAnalyses = array();
 
@@ -29,6 +35,10 @@ final class HtmlTransformerAnalysisCache
     public int $authorSelectorHits = 0;
 
     public int $authorSelectorEvictions = 0;
+
+    public int $authorSelectorBytes = 0;
+
+    public int $authorSelectorEvictedBytes = 0;
 
     public int $authorSelectorClassTokenBuilds = 0;
 
@@ -59,11 +69,20 @@ final class HtmlTransformerAnalysisCache
     /** @param array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array} $analysis */
     public function rememberStyle(string $key, array $analysis): void
     {
-        if ( count($this->styles) >= self::MAX_PAYLOAD_ENTRIES ) {
-            array_shift($this->styles);
+        $bytes = $this->analysisBytes($analysis);
+        if ( $bytes > self::MAX_PAYLOAD_BYTES ) {
             ++$this->styleEvictions;
+            $this->styleEvictedBytes += $bytes;
+            return;
+        }
+        while ( count($this->styles) >= self::MAX_PAYLOAD_ENTRIES || $this->styleBytes + $bytes > self::MAX_PAYLOAD_BYTES ) {
+            $evicted = array_shift($this->styles);
+            ++$this->styleEvictions;
+            $this->styleBytes -= $this->analysisBytes($evicted);
+            $this->styleEvictedBytes += $this->analysisBytes($evicted);
         }
         $this->styles[$key] = $analysis;
+        $this->styleBytes += $bytes;
     }
 
     public function style(string $key): ?array
@@ -81,11 +100,20 @@ final class HtmlTransformerAnalysisCache
     /** @param array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} $analysis */
     public function rememberAuthorSelectors(string $key, array $analysis): void
     {
-        if ( count($this->authorSelectorAnalyses) >= self::MAX_PAYLOAD_ENTRIES ) {
-            array_shift($this->authorSelectorAnalyses);
+        $bytes = $this->analysisBytes($analysis);
+        if ( $bytes > self::MAX_PAYLOAD_BYTES ) {
             ++$this->authorSelectorEvictions;
+            $this->authorSelectorEvictedBytes += $bytes;
+            return;
+        }
+        while ( count($this->authorSelectorAnalyses) >= self::MAX_PAYLOAD_ENTRIES || $this->authorSelectorBytes + $bytes > self::MAX_PAYLOAD_BYTES ) {
+            $evicted = array_shift($this->authorSelectorAnalyses);
+            ++$this->authorSelectorEvictions;
+            $this->authorSelectorBytes -= $this->analysisBytes($evicted);
+            $this->authorSelectorEvictedBytes += $this->analysisBytes($evicted);
         }
         $this->authorSelectorAnalyses[$key] = $analysis;
+        $this->authorSelectorBytes += $bytes;
     }
 
     public function authorSelectors(string $key): ?array
@@ -98,5 +126,10 @@ final class HtmlTransformerAnalysisCache
         $this->authorSelectorAnalyses[$key] = $analysis;
 
         return $analysis;
+    }
+
+    private function analysisBytes(array $analysis): int
+    {
+        return strlen(serialize($analysis));
     }
 }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -8,9 +8,9 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
  */
 final class HtmlTransformerAnalysisCache
 {
-    // Full parsed CSS analyses can be large; eight covers shared site styles
-    // without retaining an unbounded corpus of route-specific stylesheets.
-    private const MAX_ENTRIES = 8;
+    // Payload analyses contain parsed selector graphs, so keep the site-scoped
+    // cache small even when every route contributes a local stylesheet.
+    private const MAX_PAYLOAD_ENTRIES = 16;
 
     /** @var array<string, array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array}> */
     public array $styles = array();
@@ -19,12 +19,16 @@ final class HtmlTransformerAnalysisCache
 
     public int $styleHits = 0;
 
+    public int $styleEvictions = 0;
+
     /** @var array<string, array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>}>} */
     public array $authorSelectorAnalyses = array();
 
     public int $authorSelectorBuilds = 0;
 
     public int $authorSelectorHits = 0;
+
+    public int $authorSelectorEvictions = 0;
 
     public int $authorSelectorClassTokenBuilds = 0;
 
@@ -55,18 +59,44 @@ final class HtmlTransformerAnalysisCache
     /** @param array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array} $analysis */
     public function rememberStyle(string $key, array $analysis): void
     {
-        if ( count($this->styles) >= self::MAX_ENTRIES ) {
+        if ( count($this->styles) >= self::MAX_PAYLOAD_ENTRIES ) {
             array_shift($this->styles);
+            ++$this->styleEvictions;
         }
         $this->styles[$key] = $analysis;
+    }
+
+    public function style(string $key): ?array
+    {
+        if ( ! isset($this->styles[$key]) ) {
+            return null;
+        }
+        $analysis = $this->styles[$key];
+        unset($this->styles[$key]);
+        $this->styles[$key] = $analysis;
+
+        return $analysis;
     }
 
     /** @param array{source_tags: array<string, bool>, selectors: list<array{selector: string, parsed: array<string, mixed>}>, rules: list<array<string, mixed>>} $analysis */
     public function rememberAuthorSelectors(string $key, array $analysis): void
     {
-        if ( count($this->authorSelectorAnalyses) >= self::MAX_ENTRIES ) {
+        if ( count($this->authorSelectorAnalyses) >= self::MAX_PAYLOAD_ENTRIES ) {
             array_shift($this->authorSelectorAnalyses);
+            ++$this->authorSelectorEvictions;
         }
         $this->authorSelectorAnalyses[$key] = $analysis;
+    }
+
+    public function authorSelectors(string $key): ?array
+    {
+        if ( ! isset($this->authorSelectorAnalyses[$key]) ) {
+            return null;
+        }
+        $analysis = $this->authorSelectorAnalyses[$key];
+        unset($this->authorSelectorAnalyses[$key]);
+        $this->authorSelectorAnalyses[$key] = $analysis;
+
+        return $analysis;
     }
 }

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -83,6 +83,26 @@ $assert($withoutDurations($isolatedSitePlan) === $withoutDurations($cachedSitePl
 $artifactMetrics = $cachedCompiler->htmlAnalysisCacheMetrics();
 $assert(($artifactMetrics['style_builds'] ?? 0) === 55 && ($artifactMetrics['style_hits'] ?? 0) >= 53 && ($artifactMetrics['style_bytes'] ?? 0) > 0, 'Artifact compiler exposes bounded source-payload cache build, hit, and byte counters.');
 
+$byteBudgetCache = new HtmlTransformerAnalysisCache();
+$byteBudgetPayloads = array();
+for ( $payloadIndex = 0; $payloadIndex < 8; ++$payloadIndex ) {
+    $rules = array();
+    for ( $ruleIndex = 0; $ruleIndex < 600; ++$ruleIndex ) {
+        $rules[] = '.budget-' . $payloadIndex . '-noise-' . $ruleIndex . '{color:#123456;padding:1px;margin:2px}';
+    }
+    $rules[] = '.budget-' . $payloadIndex . '-target{color:blue}';
+    $byteBudgetPayloads[] = implode('', $rules);
+}
+foreach ( $byteBudgetPayloads as $payloadIndex => $payload ) {
+    (new HtmlTransformer(analysisCache: $byteBudgetCache))->transform('<main class="budget-' . $payloadIndex . '-target">Budget</main>', array('static_css' => $payload, 'skip_author_stylesheet_materialization' => true));
+}
+$rebuild = (new HtmlTransformer(analysisCache: $byteBudgetCache))->transform('<main class="budget-0-target">Budget</main>', array('static_css' => $byteBudgetPayloads[0], 'skip_author_stylesheet_materialization' => true))->toArray();
+$isolatedRebuild = (new HtmlTransformer())->transform('<main class="budget-0-target">Budget</main>', array('static_css' => $byteBudgetPayloads[0], 'skip_author_stylesheet_materialization' => true))->toArray();
+$assert($withoutDurations($isolatedRebuild) === $withoutDurations($rebuild), 'Byte-budget eviction rebuilds must preserve isolated canonical output.');
+$assert(9 === $byteBudgetCache->styleBuilds && $byteBudgetCache->styleEvictions > 0, 'The byte-bound style LRU evicts the oldest payload and deterministically rebuilds it on a later miss.');
+$assert($byteBudgetCache->styleBytes <= 1048576 && $byteBudgetCache->authorSelectorBytes <= 1048576, 'Retained payload analysis bytes remain bounded by the 1 MiB cache budget.');
+$assert($byteBudgetCache->styleBytes + $byteBudgetCache->styleEvictedBytes > 1048576 && $byteBudgetCache->authorSelectorEvictedBytes > 0, 'Eviction counters report analysis graphs beyond the retained 1 MiB byte budget.');
+
 $selectorCache = new HtmlTransformerAnalysisCache();
 $selectorHtml = '<style>.card{color:red}.card.featured[data-state="ready"]{color:green}.card .title{font-weight:700}.card.featured .title{color:blue}</style><section class="card featured" data-state="ready"><h2 class="title">One</h2></section><section class="card featured" data-state="ready"><h2 class="title">Two</h2></section>';
 (new HtmlTransformer(analysisCache: $selectorCache))->transform($selectorHtml);
@@ -107,4 +127,4 @@ $candidateResult = (new HtmlTransformer(analysisCache: $candidateCache))->transf
 $assert('blue' === ($candidateResult['blocks'][0]['attrs']['style']['color']['text'] ?? ''), 'Rightmost class candidates preserve duplicate matching-key cascade order.');
 $assert(4 === $candidateCache->sourceStyleCandidateRuleChecks && 305 === $candidateCache->sourceStyleCandidateRulesSkipped, 'Indexed collection walks check four relevant rule candidates while deterministically skipping 305 irrelevant candidates.');
 
-fwrite(STDOUT, sprintf("HTML transformer shared analysis cache passed: 54 pages, %.1fms, style builds=%d hits=%d evictions=%d entries=%d bytes=%d; author builds=%d hits=%d evictions=%d entries=%d bytes=%d\n", $elapsedMs, $cache->styleBuilds, $cache->styleHits, $cache->styleEvictions, count($cache->styles), $cache->styleBytes, $cache->authorSelectorBuilds, $cache->authorSelectorHits, $cache->authorSelectorEvictions, count($cache->authorSelectorAnalyses), $cache->authorSelectorBytes));
+fwrite(STDOUT, sprintf("HTML transformer shared analysis cache passed: 54 pages, %.1fms, style builds=%d hits=%d evictions=%d entries=%d bytes=%d; author builds=%d hits=%d evictions=%d entries=%d bytes=%d; byte budget style builds=%d evictions=%d retained=%d evicted=%d author builds=%d evictions=%d retained=%d evicted=%d\n", $elapsedMs, $cache->styleBuilds, $cache->styleHits, $cache->styleEvictions, count($cache->styles), $cache->styleBytes, $cache->authorSelectorBuilds, $cache->authorSelectorHits, $cache->authorSelectorEvictions, count($cache->authorSelectorAnalyses), $cache->authorSelectorBytes, $byteBudgetCache->styleBuilds, $byteBudgetCache->styleEvictions, $byteBudgetCache->styleBytes, $byteBudgetCache->styleEvictedBytes, $byteBudgetCache->authorSelectorBuilds, $byteBudgetCache->authorSelectorEvictions, $byteBudgetCache->authorSelectorBytes, $byteBudgetCache->authorSelectorEvictedBytes));

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -5,6 +5,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerAnalysisCache;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 
 $assert = static function (bool $condition, string $message): void {
     if ( ! $condition ) {
@@ -50,6 +51,37 @@ $assert(55 === $cache->authorSelectorBuilds && 53 === $cache->authorSelectorHits
 $assert(55 === $cache->authorStyleRuleBuilds, 'Author stylesheet rules and declaration maps must be built once per immutable payload.');
 $assert(16 === count($cache->styles) && 16 === count($cache->authorSelectorAnalyses), 'Payload analysis caches retain at most sixteen parsed graphs.');
 $assert(39 === $cache->styleEvictions && 39 === $cache->authorSelectorEvictions, 'Route-local payloads must evict only least-recently-used payload analyses.');
+$assert($cache->styleBytes > 0 && $cache->authorSelectorBytes > 0, 'Retained analysis byte estimates are observable.');
+
+$semanticCases = array(
+    array('html' => '<style>.card{color:blue}</style><main class="card">Cascade</main>', 'options' => array('static_css' => '.card{color:red}', 'stylesheet_payloads' => array(array('content' => '.card{color:red}')))),
+    array('html' => '<style>.scope{--tone:scoped}</style><main class="card scope">Variables</main>', 'options' => array('static_css' => ':root{--tone:root}.card{color:var(--tone)}', 'stylesheet_payloads' => array(array('content' => ':root{--tone:root}'), array('content' => '.card{color:var(--tone)}')))),
+    array('html' => '<style>@media (min-width:1px){.card{color:blue}}.card{color:green}</style><main class="card">Media</main>', 'options' => array('static_css' => '.card{color:red}', 'stylesheet_payloads' => array(array('content' => '.card{color:red}')))),
+    array('html' => '<style>.card{color:blue}</style><main class="card">Duplicate</main>', 'options' => array('static_css' => '.card{color:red}.card{color:purple}', 'stylesheet_payloads' => array(array('content' => '.card{color:red}'), array('content' => '.card{color:purple}')))),
+    array('html' => '<style>color:blue}</style><main class="card">Malformed</main>', 'options' => array('static_css' => '.card{', 'stylesheet_payloads' => array(array('content' => '.card{')))),
+);
+foreach ( $semanticCases as $case ) {
+    $caseCache = new HtmlTransformerAnalysisCache();
+    $cached = (new HtmlTransformer(analysisCache: $caseCache))->transform($case['html'], $case['options'])->toArray();
+    $isolated = (new HtmlTransformer())->transform($case['html'], $case['options'])->toArray();
+    $assert($withoutDurations($isolated) === $withoutDurations($cached), 'Payload composition must preserve cascade, variables, conditions, duplicate rules, provenance, and malformed-stream recovery.');
+}
+
+$artifactFiles = array('shared.css' => ':root{--brand:#123456}.card{display:grid;color:var(--brand)}@media (min-width:1px){.card{padding:1px}}');
+for ( $index = 0; $index < 54; ++$index ) {
+    $path = 0 === $index ? 'index.html' : 'pages/' . $index . '.html';
+    $artifactFiles[$path] = '<link rel="stylesheet" href="' . (0 === $index ? 'shared.css' : '../shared.css') . '"><style>.page-' . $index . '{padding:' . $index . 'px}</style><main class="card page-' . $index . '"><h1>Page ' . $index . '</h1></main>';
+}
+$artifact = array('entrypoint' => 'index.html', 'files' => $artifactFiles);
+$cachedCompiler = new ArtifactCompiler();
+$cachedPlan = $cachedCompiler->compile($artifact)->toArray();
+$isolatedPlan = (new ArtifactCompiler(cacheHtmlAnalysis: false))->compile($artifact)->toArray();
+$cachedSitePlan = $cachedPlan['source_reports']['wordpress_site_plan'] ?? array();
+$isolatedSitePlan = $isolatedPlan['source_reports']['wordpress_site_plan'] ?? array();
+$assert(array() !== $cachedSitePlan && array() !== $isolatedSitePlan, 'The repeated-CSS artifact must produce canonical WordPress site plans.');
+$assert($withoutDurations($isolatedSitePlan) === $withoutDurations($cachedSitePlan), 'A 54-page artifact must produce the same canonical WordPress site plan with cached and isolated stylesheet analysis.');
+$artifactMetrics = $cachedCompiler->htmlAnalysisCacheMetrics();
+$assert(($artifactMetrics['style_builds'] ?? 0) === 55 && ($artifactMetrics['style_hits'] ?? 0) >= 53 && ($artifactMetrics['style_bytes'] ?? 0) > 0, 'Artifact compiler exposes bounded source-payload cache build, hit, and byte counters.');
 
 $selectorCache = new HtmlTransformerAnalysisCache();
 $selectorHtml = '<style>.card{color:red}.card.featured[data-state="ready"]{color:green}.card .title{font-weight:700}.card.featured .title{color:blue}</style><section class="card featured" data-state="ready"><h2 class="title">One</h2></section><section class="card featured" data-state="ready"><h2 class="title">Two</h2></section>';
@@ -75,4 +107,4 @@ $candidateResult = (new HtmlTransformer(analysisCache: $candidateCache))->transf
 $assert('blue' === ($candidateResult['blocks'][0]['attrs']['style']['color']['text'] ?? ''), 'Rightmost class candidates preserve duplicate matching-key cascade order.');
 $assert(4 === $candidateCache->sourceStyleCandidateRuleChecks && 305 === $candidateCache->sourceStyleCandidateRulesSkipped, 'Indexed collection walks check four relevant rule candidates while deterministically skipping 305 irrelevant candidates.');
 
-fwrite(STDOUT, sprintf("HTML transformer shared analysis cache passed: 54 pages, %.1fms, style builds=%d hits=%d evictions=%d entries=%d; author builds=%d hits=%d evictions=%d entries=%d\n", $elapsedMs, $cache->styleBuilds, $cache->styleHits, $cache->styleEvictions, count($cache->styles), $cache->authorSelectorBuilds, $cache->authorSelectorHits, $cache->authorSelectorEvictions, count($cache->authorSelectorAnalyses)));
+fwrite(STDOUT, sprintf("HTML transformer shared analysis cache passed: 54 pages, %.1fms, style builds=%d hits=%d evictions=%d entries=%d bytes=%d; author builds=%d hits=%d evictions=%d entries=%d bytes=%d\n", $elapsedMs, $cache->styleBuilds, $cache->styleHits, $cache->styleEvictions, count($cache->styles), $cache->styleBytes, $cache->authorSelectorBuilds, $cache->authorSelectorHits, $cache->authorSelectorEvictions, count($cache->authorSelectorAnalyses), $cache->authorSelectorBytes));

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -28,12 +28,12 @@ $withoutDurations = static function (array $value) use (&$withoutDurations): arr
 
 $css = ':root{--brand:#123456}.card{display:grid;color:var(--brand)}.card img{aspect-ratio:4/3;object-fit:cover}';
 $options = array('static_css' => $css, 'skip_author_stylesheet_materialization' => true);
-$pages = array(
-    '<main class="card"><h1>First</h1><img src="first.jpg" alt="First"></main>',
-    '<main class="card"><h1>Second</h1><img src="second.jpg" alt="Second"></main>',
-    '<main class="card"><h1>Third</h1><img src="third.jpg" alt="Third"></main>',
-);
+$pages = array();
+for ( $index = 0; $index < 54; ++$index ) {
+    $pages[] = '<style>.page-' . $index . '{padding:' . $index . 'px}</style><main class="card page-' . $index . '"><h1>Page ' . $index . '</h1><img src="page-' . $index . '.jpg" alt="Page ' . $index . '"></main>';
+}
 $cache = new HtmlTransformerAnalysisCache();
+$startedAt = hrtime(true);
 
 foreach ( $pages as $html ) {
     $shared = (new HtmlTransformer(analysisCache: $cache))->transform($html, $options)->toArray();
@@ -44,28 +44,12 @@ foreach ( $pages as $html ) {
     );
 }
 
-$assert(1 === $cache->styleBuilds, 'Identical static and inline CSS must be analyzed once across fresh page transformers.');
-$assert(1 === $cache->authorSelectorBuilds, 'Identical author selectors must be parsed once across fresh page transformers.');
-$assert(1 === $cache->authorStyleRuleBuilds, 'Author stylesheet rules and declaration maps must be built once rather than traversed per element.');
-$assert(2 === $cache->styleHits, 'Repeated stylesheet inputs must hit the shared analysis cache for every later document.');
-$assert(2 === $cache->authorSelectorHits, 'Repeated author stylesheet inputs must hit the shared selector cache for every later document.');
-
-$alternateCss = '.alternate{color:rebeccapurple}';
-(new HtmlTransformer(analysisCache: $cache))->transform('<main class="alternate">Alternate</main>', array('static_css' => $alternateCss, 'skip_author_stylesheet_materialization' => true));
-(new HtmlTransformer(analysisCache: $cache))->transform('<main class="card">Again</main>', $options);
-$assert(2 === $cache->styleBuilds && 3 === $cache->styleHits, 'A previously analyzed stylesheet must remain reusable after a different document stylesheet.');
-$assert(2 === $cache->authorSelectorBuilds && 3 === $cache->authorSelectorHits, 'A previously parsed author stylesheet must remain reusable after a different document stylesheet.');
-
-for ( $index = 0; $index < 7; ++$index ) {
-    $class = 'eviction-' . $index;
-    (new HtmlTransformer(analysisCache: $cache))->transform('<main class="' . $class . '">Eviction</main>', array('static_css' => '.' . $class . '{color:#' . $index . $index . $index . '}', 'skip_author_stylesheet_materialization' => true));
-}
-$evicted = (new HtmlTransformer(analysisCache: $cache))->transform('<main class="card">Evicted</main>', $options)->toArray();
-$isolated = (new HtmlTransformer())->transform('<main class="card">Evicted</main>', $options)->toArray();
-$assert($withoutDurations($isolated) === $withoutDurations($evicted), 'Rebuilt stylesheet analysis after eviction must preserve isolated transform output.');
-$assert(8 === count($cache->styles) && 8 === count($cache->authorSelectorAnalyses), 'Shared analysis caches retain at most eight stylesheet entries.');
-$assert(10 === $cache->styleBuilds && 3 === $cache->styleHits, 'The oldest stylesheet analysis is evicted after the eight-entry bound is reached.');
-$assert(10 === $cache->authorSelectorBuilds && 3 === $cache->authorSelectorHits, 'The oldest author selector analysis is evicted after the eight-entry bound is reached.');
+$elapsedMs = (hrtime(true) - $startedAt) / 1_000_000;
+$assert(55 === $cache->styleBuilds && 53 === $cache->styleHits, '54 pages with one shared payload must analyze 55 unique payloads and hit the shared payload 53 times.');
+$assert(55 === $cache->authorSelectorBuilds && 53 === $cache->authorSelectorHits, 'Author selector analysis must reuse the shared payload independently of page-local CSS.');
+$assert(55 === $cache->authorStyleRuleBuilds, 'Author stylesheet rules and declaration maps must be built once per immutable payload.');
+$assert(16 === count($cache->styles) && 16 === count($cache->authorSelectorAnalyses), 'Payload analysis caches retain at most sixteen parsed graphs.');
+$assert(39 === $cache->styleEvictions && 39 === $cache->authorSelectorEvictions, 'Route-local payloads must evict only least-recently-used payload analyses.');
 
 $selectorCache = new HtmlTransformerAnalysisCache();
 $selectorHtml = '<style>.card{color:red}.card.featured[data-state="ready"]{color:green}.card .title{font-weight:700}.card.featured .title{color:blue}</style><section class="card featured" data-state="ready"><h2 class="title">One</h2></section><section class="card featured" data-state="ready"><h2 class="title">Two</h2></section>';
@@ -91,4 +75,4 @@ $candidateResult = (new HtmlTransformer(analysisCache: $candidateCache))->transf
 $assert('blue' === ($candidateResult['blocks'][0]['attrs']['style']['color']['text'] ?? ''), 'Rightmost class candidates preserve duplicate matching-key cascade order.');
 $assert(4 === $candidateCache->sourceStyleCandidateRuleChecks && 305 === $candidateCache->sourceStyleCandidateRulesSkipped, 'Indexed collection walks check four relevant rule candidates while deterministically skipping 305 irrelevant candidates.');
 
-fwrite(STDOUT, "HTML transformer shared analysis cache passed\n");
+fwrite(STDOUT, sprintf("HTML transformer shared analysis cache passed: 54 pages, %.1fms, style builds=%d hits=%d evictions=%d entries=%d; author builds=%d hits=%d evictions=%d entries=%d\n", $elapsedMs, $cache->styleBuilds, $cache->styleHits, $cache->styleEvictions, count($cache->styles), $cache->authorSelectorBuilds, $cache->authorSelectorHits, $cache->authorSelectorEvictions, count($cache->authorSelectorAnalyses)));


### PR DESCRIPTION
## Summary
- reuse parsed stylesheet and author-selector analysis by canonical payload hash across route transforms
- preserve source order, cascade, custom-property, and malformed-CSS semantics
- bound each analysis cache to 16 entries and 1 MiB with least-recently-used eviction
- report retained and evicted bytes for deterministic observability

This targets repeated route-local analysis identified as a dominant cost in a 59-route, 203 MB artifact profile while retaining isolated-transform equality.

Closes #879.

## Testing
- `composer validate --strict`
- `composer test`
- 278 PHP transformer parity fixtures
- package install proof
- byte-pressure, source-order, canonical-equality, and malformed-CSS coverage

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode assisted with corpus profiling, implementation review, adversarial semantic coverage, and verification. Chris Huber reviewed and is responsible for the changes.