### PR TITLE
fix(php-transformer): coalesce inline stylesheet bundles

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -538,6 +538,7 @@ final class ArtifactCompiler
             $assets[] = $wordpressCompatAsset;
         }
         $assets = $this->deduplicateVisualAssets($assets);
+        $assets = $this->coalesceStylesheetAssets($assets);
         $diagnostics = array_merge($diagnostics, $allDiagnostics);
         $serializedBlocks = $entryBlocks['serialized_blocks'];
         if ( '' === $serializedBlocks && ! empty($documents['documents'][0]['block_markup']) ) {
@@ -1080,6 +1081,85 @@ final class ArtifactCompiler
             $deduplicated[$index]['component_occurrences_omitted'] = max(0, array_sum(is_array($deduplicated[$index]['component_occurrence_counts'] ?? null) ? $deduplicated[$index]['component_occurrence_counts'] : array()) - count($rows));
         }
         return $deduplicated;
+    }
+
+    /**
+     * Coalesce only adjacent stylesheet assets with the same runtime contract.
+     * Keeping the run contiguous preserves the existing cascade order while
+     * bounding bootstrap records for fragmented inline author styles.
+     *
+     * @param array<int,array<string,mixed>> $assets
+     * @return array<int,array<string,mixed>>
+     */
+    private function coalesceStylesheetAssets(array $assets): array
+    {
+        $coalesced = array();
+        $run = array();
+        $runKey = '';
+        $flush = static function () use (&$coalesced, &$run, &$runKey): void {
+            if ( array() === $run ) {
+                return;
+            }
+            if ( 1 === count($run) ) {
+                $coalesced[] = $run[0];
+                $run = array();
+                $runKey = '';
+                return;
+            }
+            $content = implode("\n", array_map(static fn (array $asset): string => rtrim((string) $asset['content']) . "\n", $run));
+            $hash = hash('sha256', $content);
+            $pathHash = hash('sha256', $runKey . "\0" . $content);
+            $bundle = $run[0];
+            $bundle['source'] = 'stylesheet-bundle';
+            $bundle['path'] = 'assets/css/stylesheet-bundle-' . substr($pathHash, 0, 16) . '.css';
+            $bundle['target_path'] = $bundle['path'];
+            $bundle['content'] = $content;
+            $bundle['bytes'] = strlen($content);
+            $bundle['hash'] = $hash;
+            $bundle['source_hash'] = $hash;
+            $bundle['source_paths'] = array_values(array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $run));
+            $bundle['source_hashes'] = array_values(array_map(static fn (array $asset): string => (string) ($asset['hash'] ?? ''), $run));
+            $coalesced[] = $bundle;
+            $run = array();
+            $runKey = '';
+        };
+        foreach ( $assets as $asset ) {
+            if ( ! $this->isCoalescibleStylesheetAsset($asset) ) {
+                $flush();
+                $coalesced[] = $asset;
+                continue;
+            }
+            $key = $this->stylesheetBundleKey($asset);
+            if ( array() !== $run && $key !== $runKey ) {
+                $flush();
+            }
+            $run[] = $asset;
+            $runKey = $key;
+        }
+        $flush();
+        return $coalesced;
+    }
+
+    /** @param array<string,mixed> $asset */
+    private function isCoalescibleStylesheetAsset(array $asset): bool
+    {
+        return 'css' === ($asset['kind'] ?? null)
+            && 'stylesheet' === ($asset['role'] ?? null)
+            && 'inline-style' === ($asset['source'] ?? null)
+            && is_string($asset['content'] ?? null)
+            && '' !== (string) $asset['content'];
+    }
+
+    /** @param array<string,mixed> $asset */
+    private function stylesheetBundleKey(array $asset): string
+    {
+        return json_encode(array(
+            'compilation' => $asset['compilation'] ?? array('scope' => 'shared'),
+            'source' => $asset['source'] ?? '',
+            'target' => $asset['stylesheet_target'] ?? 'both',
+            'placement' => $asset['stylesheet_placement'] ?? '',
+            'media' => $asset['media'] ?? '',
+        ), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     }
 
     /** @param array<string, mixed> $entryEvidence @param array<string, array<string, mixed>> $documents @param array<int, array<string, mixed>> $assets */

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -135,6 +135,29 @@ $inlineEntryArtifact['entrypoints'] = array('about.html');
 $inlineSitePlan = $compiler->compile($inlineEntryArtifact)->toArray()['source_reports']['wordpress_site_plan'] ?? array();
 $inlineAssets = array_column($inlineSitePlan['assets'] ?? array(), null, 'source_path');
 $assert('about.html' === ($inlineAssets['about.inline.css']['scopes'][0]['source_path'] ?? null) && false === ($inlineAssets['about.inline.css']['scopes'][0]['front_page'] ?? null), 'Inferred inline stylesheet ownership follows its canonical non-root route even when that page is the compiler entrypoint.');
+$bundledPages = array();
+foreach (array('index.html', 'about.html', 'posts/news.html') as $page) {
+    $styles = '';
+    for ($index = 0; $index < 8; ++$index) {
+        $styles .= '<style>.cascade-' . $index . '{color:#' . $index . $index . $index . '}</style>';
+    }
+    $styles .= '<style media="(max-width: 48rem)">.responsive-' . str_replace(array('/', '.'), '-', $page) . '{display:block}</style>';
+    $bundledPages[] = array('path' => $page, 'content' => '<link rel="stylesheet" href="' . ('index.html' === $page ? 'assets/shared.css' : str_repeat('../', substr_count($page, '/')) . 'assets/shared.css') . '">' . $styles . '<main>Bundled ' . $page . '</main>');
+}
+$bundledArtifact = array('entrypoint' => 'index.html', 'files' => array_merge(array(array('path' => 'assets/shared.css', 'content' => '.shared{display:grid}', 'metadata' => array('compilation' => array('scope' => 'shared')))), $bundledPages));
+$bundleCompiler = new ArtifactCompiler();
+$bundledWhole = $bundleCompiler->compile($bundledArtifact)->toArray();
+$bundledShared = $bundleCompiler->prepareShared($bundledArtifact);
+$bundledReceipts = array();
+foreach ($bundledShared['analysis']['page_ids'] as $pageId) $bundledReceipts[] = $bundleCompiler->compilePage($bundledArtifact, $bundledShared, $pageId);
+$bundledStaged = $bundleCompiler->compose($bundledShared, array_reverse($bundledReceipts))->toArray();
+$bundledPlan = $bundledWhole['source_reports']['wordpress_site_plan'] ?? array();
+$bundledCss = array_values(array_filter($bundledPlan['assets'] ?? array(), static fn(array $asset): bool => 'css' === ($asset['kind'] ?? null)));
+$bundledBootstrap = (string) ((array_column($bundledPlan['writes'] ?? array(), null, 'target_path')['functions.php']['payload']['data'] ?? ''));
+$assert(8 === count($bundledCss) && 8 === substr_count($bundledBootstrap, 'wp_enqueue_style(') && 2 === substr_count($bundledBootstrap, 'is_front_page()'), 'Three-page inline-style fragmentation coalesces into one shared and two bounded stylesheet records per route, plus the existing global engine-support stylesheet.');
+$indexBundle = current(array_filter($bundledCss, static fn(array $asset): bool => 'page' === ($asset['scopes'][0]['kind'] ?? null) && true === ($asset['scopes'][0]['front_page'] ?? null) && '' === ($asset['media'] ?? '')));
+$assert(is_array($indexBundle) && str_contains((string) ($indexBundle['content'] ?? ''), '.cascade-0{color:#000}') && strpos((string) $indexBundle['content'], '.cascade-0{color:#000}') < strpos((string) $indexBundle['content'], '.cascade-7{color:#777}') && hash('sha256', (string) $indexBundle['content']) === ($indexBundle['content_hash'] ?? null), 'A coalesced route bundle preserves author cascade order and content-addressed identity.');
+$assert($canonical($bundledWhole['source_reports']['wordpress_site_plan'] ?? array()) === $canonical($bundledStaged['source_reports']['wordpress_site_plan'] ?? array()) && $canonical($bundledWhole['diagnostics'] ?? array()) === $canonical($bundledStaged['diagnostics'] ?? array()), 'Bounded stylesheet bundles preserve direct and staged canonical plans and diagnostics.');
 $formsDeclaration = current(array_filter($whole['source_reports']['wordpress_site_plan']['runtime_declarations'] ?? array(), static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)));
 $assert(29 === count($formsDeclaration['payload']['entities'] ?? array()) && $formsPayloadBytes === strlen(RuntimeDeclarations::canonicalJson($formsDeclaration['payload'] ?? null)), 'Compilation retains the complete bounded 29-form runtime declaration.');
 


### PR DESCRIPTION
## Summary
- coalesce adjacent inline-style fragments only when runtime ownership, target, placement, and media semantics match
- retain linked stylesheet identities and preserve source cascade order with content-addressed bundle paths
- add a multi-page direct/staged fixture covering bounded frontend/editor bootstrap records, shared CSS reuse, media and ownership boundaries, order, identity, and diagnostics

Closes #1026

## Validation
- `composer test`
- `composer test:wordpress-integration` (skipped: `WP_TESTS_DIR` unavailable in this worktree)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the CSS asset pipeline, implemented bounded coalescing, and added/ran contract coverage. Chris Huber remains responsible for every line.