### PR TITLE
Preserve partial legacy staged composition

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -427,7 +427,7 @@ final class ArtifactCompiler
         }
         $this->assertUniqueComposedPaths($files);
         $expectedPageIds = is_array($sharedPlan['analysis']['page_ids'] ?? null) ? $sharedPlan['analysis']['page_ids'] : array();
-        if (array() !== $expectedPageIds && array_values($expectedPageIds) !== array_keys($seen)) {
+        if ($hasReceipts && array() !== $expectedPageIds && array_values($expectedPageIds) !== array_keys($seen)) {
             throw new \InvalidArgumentException('Composition requires exactly one compiled page plan for every page declared by the shared plan.');
         }
         $artifact = $sharedArtifact;

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -53,6 +53,8 @@ $assert(1 === ($compiledPages['about.html']['work']['compiled_document_count'] ?
 $resumedShared = json_decode(json_encode($shared, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
 $resumedPages = json_decode(json_encode(array($pages['contact.html'], $pages['index.html'], $pages['about.html']), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
 $staged = $compiler->compose($resumedShared, $resumedPages)->toArray();
+$partialLegacy = $compiler->compose($resumedShared, array($pages['index.html']))->toArray();
+$assert(array('index.html') === array_column($partialLegacy['source_reports']['wordpress_site_plan']['pages'] ?? array(), 'source_path'), 'Legacy prepared envelopes retain partial composition for batch-local page sets.');
 $whole = $compiler->compile($artifact)->toArray();
 $assert(($whole['source_reports']['wordpress_site_plan'] ?? array()) === ($staged['source_reports']['wordpress_site_plan'] ?? array()), 'Whole and staged compilation yield byte-for-byte equivalent canonical site plans, including source-operation provenance and hashes.');
 $assert(($whole['source_reports']['materialization_plan'] ?? array()) === ($staged['source_reports']['materialization_plan'] ?? array()), 'Whole and staged compilation yield byte-for-byte equivalent materialization receipts.');


### PR DESCRIPTION
## Summary

- apply complete page-set validation only to compiled v2 receipts
- preserve legacy prepared-envelope composition for batch-local page subsets
- add contract coverage distinguishing partial legacy composition from incomplete compiled receipt rejection

## Verification

- `composer test`
- `SSI_BLOCKS_ENGINE_PHP_TRANSFORMER=/Users/chubes/Developer/blocks-engine@fix-partial-legacy-composition/php-transformer php tests/smoke-url-batch-import.php` in Static Site Importer

Closes #1028.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode helped trace the downstream SSI regression, implement the scoped compatibility fix, and run the upstream and cross-repository verification. Chris Huber reviewed and remains responsible for every line.