### PR TITLE
fix: coalesce inline stylesheet runtime assets

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -108,6 +108,11 @@ final class WordPressSitePlan
         $runtimeDeclarations = $this->canonicalEntityBindings($runtimeDeclarations, $references, $routeMap, $pages);
         $pages = $this->pageHierarchy($pages, $routeMap);
         $assets = $this->scopeAssets($assets, $pages);
+        $assets = $this->coalesceInlineStylesheets($assets);
+        // Coalescing changes the asset set, so refresh the token catalog used by
+        // subsequent theme, template, and write projections.
+        $tokens = $this->tokens($assets);
+        $references = new AssetReferenceCanonicalizer($tokens, self::entryRootFromDocuments($documents));
         $projector = new ThemeJsonProjection();
         $themeProjection = $projector->project($assets);
         $assets = $themeProjection['assets'];
@@ -726,6 +731,55 @@ final class WordPressSitePlan
         }
         unset($asset);
         return $assets;
+    }
+
+    /**
+     * Inline style elements have no independently addressable browser resource
+     * after compilation. Bundle adjacent rows with the same runtime semantics
+     * so one source document cannot expand bootstrap work without bound.
+     *
+     * @param array<int,array<string,mixed>> $assets
+     * @return array<int,array<string,mixed>>
+     */
+    private function coalesceInlineStylesheets(array $assets): array
+    {
+        $coalesced = array();
+        foreach ($assets as $asset) {
+            if (!$this->isCoalescibleInlineStylesheet($asset)) {
+                $coalesced[] = $asset;
+                continue;
+            }
+            $asset['stylesheet_placement'] = (string) ($asset['stylesheet_placement'] ?? 'author') ?: 'author';
+            $last = count($coalesced) - 1;
+            if ($last < 0 || !$this->sameStylesheetRuntime($coalesced[$last], $asset)) {
+                $coalesced[] = $asset;
+                continue;
+            }
+            $content = (string) $coalesced[$last]['content'] . "\n" . (string) $asset['content'];
+            $coalesced[$last]['content'] = $content;
+            $coalesced[$last]['bytes'] = strlen($content);
+            $coalesced[$last]['hash'] = self::contentHash($content);
+            $coalesced[$last]['content_hash'] = self::contentHash($content);
+        }
+        return $coalesced;
+    }
+
+    /** @param array<string,mixed> $asset */
+    private function isCoalescibleInlineStylesheet(array $asset): bool
+    {
+        return 'css' === ($asset['kind'] ?? null)
+            && 'inline-style' === ($asset['source'] ?? null)
+            && is_string($asset['content'] ?? null);
+    }
+
+    /** @param array<string,mixed> $left @param array<string,mixed> $right */
+    private function sameStylesheetRuntime(array $left, array $right): bool
+    {
+        return $this->isCoalescibleInlineStylesheet($left)
+            && ($left['scopes'] ?? null) === ($right['scopes'] ?? null)
+            && ($left['stylesheet_target'] ?? 'both') === ($right['stylesheet_target'] ?? 'both')
+            && ($left['stylesheet_placement'] ?? 'author') === ($right['stylesheet_placement'] ?? 'author')
+            && ($left['media'] ?? '') === ($right['media'] ?? '');
     }
 
     /** @param array<int,array<string,mixed>> $assets @param array<int,mixed> $declarations @return array<int,array<string,mixed>> */

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -135,6 +135,37 @@ $inlineEntryArtifact['entrypoints'] = array('about.html');
 $inlineSitePlan = $compiler->compile($inlineEntryArtifact)->toArray()['source_reports']['wordpress_site_plan'] ?? array();
 $inlineAssets = array_column($inlineSitePlan['assets'] ?? array(), null, 'source_path');
 $assert('about.html' === ($inlineAssets['about.inline.css']['scopes'][0]['source_path'] ?? null) && false === ($inlineAssets['about.inline.css']['scopes'][0]['front_page'] ?? null), 'Inferred inline stylesheet ownership follows its canonical non-root route even when that page is the compiler entrypoint.');
+
+$inlineStyles = static function (string $prefix, int $count, string $media = ''): string {
+    $styles = array();
+    for ($index = 0; $index < $count; ++$index) $styles[] = '<style' . ('' === $media ? '' : ' media="' . $media . '"') . '>main{--' . $prefix . '-' . $index . ':' . $index . '}</style>';
+    return implode('', $styles);
+};
+$coalescingArtifact = array('entrypoints' => array('index.html', 'about.html', 'notes/post.html', 'shared.html', 'shared-two.html'), 'files' => array(
+    array('path' => 'index.html', 'content' => $inlineStyles('home-before', 12) . $inlineStyles('home-narrow', 12, '(max-width: 600px)') . $inlineStyles('home-after', 12) . '<main>Home</main>'),
+    array('path' => 'about.html', 'content' => $inlineStyles('about', 24) . '<main>About</main>'),
+    array('path' => 'notes/post.html', 'content' => $inlineStyles('post', 24) . '<main>Post</main>', 'metadata' => array('post_type' => 'post')),
+    array('path' => 'shared.html', 'content' => $inlineStyles('shared', 24) . '<main>Shared</main>', 'metadata' => array('compilation' => array('scope' => 'shared'))),
+    array('path' => 'shared-two.html', 'content' => $inlineStyles('shared', 24) . '<main>Shared again</main>', 'metadata' => array('compilation' => array('scope' => 'shared'))),
+));
+$coalescedWhole = $compiler->compile($coalescingArtifact)->toArray();
+$coalescedPlan = $coalescedWhole['source_reports']['wordpress_site_plan'] ?? array();
+$coalescedAssets = array_values(array_filter($coalescedPlan['assets'] ?? array(), static fn(array $asset): bool => 'inline-style' === ($asset['source'] ?? null)));
+$homeAssets = array_values(array_filter($coalescedAssets, static fn(array $asset): bool => 'index.html' === ($asset['scopes'][0]['source_path'] ?? null)));
+$aboutAssets = array_values(array_filter($coalescedAssets, static fn(array $asset): bool => 'about.html' === ($asset['scopes'][0]['source_path'] ?? null)));
+$postAssets = array_values(array_filter($coalescedAssets, static fn(array $asset): bool => 'notes/post.html' === ($asset['scopes'][0]['source_path'] ?? null)));
+$globalAssets = array_values(array_filter($coalescedAssets, static fn(array $asset): bool => 'global' === ($asset['scopes'][0]['kind'] ?? null)));
+$homeCss = implode("\n", array_column($homeAssets, 'content'));
+$coalescedWrites = array_column($coalescedPlan['writes'] ?? array(), null, 'target_path');
+$coalescedBootstrap = (string) ($coalescedWrites['functions.php']['payload']['data'] ?? '');
+$coalescedShared = $compiler->prepareShared($coalescingArtifact);
+$coalescedPages = array();
+foreach (array('index.html', 'about.html', 'notes/post.html') as $pageId) $coalescedPages[] = $compiler->preparePage($coalescingArtifact, $coalescedShared, $pageId);
+$coalescedStaged = $compiler->compose($coalescedShared, array_reverse($coalescedPages))->toArray()['source_reports']['wordpress_site_plan'] ?? array();
+$assert(3 === count($homeAssets) && 1 === count($aboutAssets) && 1 === count($postAssets) && 1 === count($globalAssets) && 6 === count($coalescedAssets), 'Many inline styles and duplicate shared CSS coalesce into one asset per contiguous runtime media scope, rather than one asset per source style.');
+$assert(strpos($homeCss, '--home-before-0') < strpos($homeCss, '--home-before-11') && strpos($homeCss, '--home-before-11') < strpos($homeCss, '--home-narrow-0') && strpos($homeCss, '--home-narrow-11') < strpos($homeCss, '--home-after-0') && strpos($homeCss, '--home-after-0') < strpos($homeCss, '--home-after-11') && 'author' === ($homeAssets[0]['stylesheet_placement'] ?? null), 'Coalesced author CSS retains exact source cascade order and keeps media boundaries as separate runtime assets.');
+$frontendStyles = array_values(array_filter($coalescedPlan['assets'] ?? array(), static fn(array $asset): bool => 'css' === ($asset['kind'] ?? null) && 'editor' !== ($asset['stylesheet_target'] ?? 'both')));
+$assert('post' === ($postAssets[0]['scopes'][0]['kind'] ?? null) && 'global' === ($globalAssets[0]['scopes'][0]['kind'] ?? null) && count($frontendStyles) === substr_count($coalescedBootstrap, 'wp_enqueue_style(') && $coalescedPlan === $coalescedStaged, 'Coalescing preserves page, post, and global ownership while direct and staged compilation emit the same bounded bootstrap plan.');
 $formsDeclaration = current(array_filter($whole['source_reports']['wordpress_site_plan']['runtime_declarations'] ?? array(), static fn(array $declaration): bool => 'forms' === ($declaration['type'] ?? null)));
 $assert(29 === count($formsDeclaration['payload']['entities'] ?? array()) && $formsPayloadBytes === strlen(RuntimeDeclarations::canonicalJson($formsDeclaration['payload'] ?? null)), 'Compilation retains the complete bounded 29-form runtime declaration.');
 


### PR DESCRIPTION
## Summary
- coalesce adjacent inline stylesheet assets with identical scope, target, placement, and media semantics
- retain ordered CSS concatenation and regenerate plan tokens after asset coalescing
- cover bounded page, post, global, responsive-media, shared, and staged compilation behavior

Fixes #1026

## Tests
- `php php-transformer/tests/contract/staged-artifact-compilation.php`
- `composer --working-dir=php-transformer test`

## AI assistance
OpenAI GPT-5.6-sol via OpenCode general coding subagent implemented and tested the compiler/site-plan coalescing change. Chris Huber remains responsible for every line.