### PR TITLE
Refactor semantic recognizers into staged registry

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -16,6 +16,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsC
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\SemanticParityReporter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\AccordionPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CallbackPatternRecognizer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPattern;
@@ -29,6 +30,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPatte
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationUnderlineColorResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ParameterTablePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognitionResult;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
@@ -585,6 +587,33 @@ final class HtmlTransformer
         $this->quotePattern      = new QuotePattern();
         $this->spacerPattern     = new SpacerPattern();
         $this->patternRecognizers = new PatternRecognizerRegistry(array(
+            $this->mediaTextPattern,
+            $this->coverPattern,
+            $this->columnsPattern,
+            new CallbackPatternRecognizer('math', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->mathPattern->match($element, fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement), fn (string $text): string => $this->runtime->escapeHtml($text), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('parameter-table', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->parameterTablePattern->match($element, $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('spacer', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->spacerPattern->match($element, fn (DOMElement $sourceElement): int => $this->childElementCount($sourceElement), fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), fn (DOMElement $sourceElement, string $className): bool => $this->hasClass($sourceElement, $className), $context->presentationAttributesCallback(), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('code-window', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->codeWindowPattern->match($element, $context->presentationAttributesCallback(), $context->innerHtmlCallback(), fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode), fn (DOMElement $sourceCode): string => $this->codeContent($sourceCode), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('logo', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->logoPattern->match($element, $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement), fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('placeholder-media', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->placeholderMediaPattern->match($element, $context->presentationAttributesCallback(), fn (string $value): string => $this->runtime->escapeHtml($value), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
             new AccordionPattern(),
             new SocialLinksPattern(),
             new NavigationPattern(),
@@ -4295,8 +4324,35 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement)),
             fn (DOMElement $sourceElement): ?array => $this->convertPatternElement($sourceElement),
             fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement)
+            fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement),
+            function (DOMElement $sourceElement, bool $captureUnsupported): \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult {
+                $fallbacks = array();
+                return new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult($this->convertChildren($sourceElement, $fallbacks, $captureUnsupported), $fallbacks);
+            },
+            function (DOMElement $sourceElement, bool $captureUnsupported): \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult {
+                $fallbacks = array();
+                $block = $this->convertElement($sourceElement, $fallbacks, $captureUnsupported);
+                return new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult(null === $block ? array() : array($block), $fallbacks);
+            },
+            fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
+            fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
+            fn (string $url): string => $this->resolvedAssetImageUrl($url),
+            fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->mediaTextPresentationAttributes($sourceElement, $excludedGeometryProperties),
+            fn (DOMElement $sourceElement): string => $this->mediaTextPresentationStyle($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->cssDeclarationString($this->structuralPresentationDeclarations($sourceElement))
         );
+    }
+
+    /** @param list<class-string<\Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerInterface>> $allowed */
+    private function recognizePatterns(DOMElement $element, array &$fallbacks, array $allowed, bool $includeRuntimeDomTarget = true): ?array
+    {
+        $result = $this->patternRecognizers->firstMatch($element, $this->patternContext($includeRuntimeDomTarget), $allowed);
+        if (null === $result) return null;
+        // Results own fallback payloads until their block wins the ordered stage.
+        // Assign rather than mutating a variadic argument so reference-backed
+        // child conversion diagnostics retain their exact order.
+        $fallbacks = array_merge($fallbacks, $result->fallbacks());
+        return $result->block();
     }
 
     /**
@@ -4415,15 +4471,7 @@ final class HtmlTransformer
             return null;
         }
 
-        $mathBlock = $this->mathPattern->match(
-            $element,
-            fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
-            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
-            fn (string $text): string => $this->runtime->escapeHtml($text),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-        );
+        $mathBlock = $this->recognizePatterns($element, $fallbacks, array('math'));
         if ( null !== $mathBlock ) {
             return $mathBlock;
         }
@@ -4596,9 +4644,9 @@ final class HtmlTransformer
         }
 
         if ( 'ul' === $tagName || 'ol' === $tagName ) {
-            $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
+            $navigation = $this->recognizePatterns($element, $fallbacks, array(AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class));
             if ( null !== $navigation ) {
-                return $this->rememberAccordionDisclosureRoot($navigation->block(), $element);
+                return $this->rememberAccordionDisclosureRoot($navigation, $element);
             }
 
             if ( $this->isStructuredCardList($element) ) {
@@ -4838,12 +4886,7 @@ final class HtmlTransformer
             return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), $this->tableAttributes($element)), array(), $element);
         }
 
-        $parameterTable = $this->parameterTablePattern->match(
-            $element,
-            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-        );
+        $parameterTable = $this->recognizePatterns($element, $fallbacks, array('parameter-table'));
         if ( null !== $parameterTable ) {
             return $parameterTable;
         }
@@ -4979,9 +5022,9 @@ final class HtmlTransformer
         }
 
         if ( 'nav' === $tagName ) {
-            $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext(false));
+            $navigation = $this->recognizePatterns($element, $fallbacks, array(AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class), false);
             if ( null !== $navigation ) {
-                return $this->rememberAccordionDisclosureRoot($navigation->block(), $element);
+                return $this->rememberAccordionDisclosureRoot($navigation, $element);
             }
 
             $inlineNavigation = $this->inlineNavigationGroupBlockFromElement($element);
@@ -5027,17 +5070,7 @@ final class HtmlTransformer
                 // media-text candidates are by definition authored flex/grid
                 // containers, so they must be recognized before the layout is
                 // demoted to a css-owned core/group.
-                $mediaText = $this->mediaTextPattern->match(
-                    $element,
-                    $fallbacks,
-                    fn (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported): array => $this->convertChildren($sourceElement, $sourceFallbacks, $captureUnsupported),
-                    fn (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported): ?array => $this->convertElement($sourceElement, $sourceFallbacks, $captureUnsupported),
-                    fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->mediaTextPresentationAttributes($sourceElement, $excludedGeometryProperties),
-                    fn (DOMElement $sourceElement): string => $this->mediaTextPresentationStyle($sourceElement),
-                    fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
-                    fn (string $url): string => $this->resolvedAssetImageUrl($url),
-                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-                );
+                $mediaText = $this->recognizePatterns($element, $fallbacks, array(MediaTextPattern::class));
                 if ( null !== $mediaText ) {
                     return $mediaText;
                 }
@@ -5071,26 +5104,12 @@ final class HtmlTransformer
                 return $this->authorLayoutBlockFromElement($element, $fallbacks);
             }
 
-            $logo = $this->logoPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
-                fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            $logo = $this->recognizePatterns($element, $fallbacks, array('logo'));
             if ( null !== $logo ) {
                 return $logo;
             }
 
-            $spacer = $this->spacerPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): int => $this->childElementCount($sourceElement),
-                fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
-                fn (DOMElement $sourceElement, string $className): bool => $this->hasClass($sourceElement, $className),
-                fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            $spacer = $this->recognizePatterns($element, $fallbacks, array('spacer'));
             if ( null !== $spacer ) {
                 return $spacer;
             }
@@ -5101,9 +5120,9 @@ final class HtmlTransformer
             }
 
             if ( ! $this->shouldDeferNavigationPatternToChildren($element) ) {
-                $navigation = $this->patternRecognizers->firstMatch($element, $this->patternContext());
+                $navigation = $this->recognizePatterns($element, $fallbacks, array(AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class));
                 if ( null !== $navigation ) {
-                    return $this->rememberAccordionDisclosureRoot($navigation->block(), $element);
+                    return $this->rememberAccordionDisclosureRoot($navigation, $element);
                 }
             }
 
@@ -5126,16 +5145,7 @@ final class HtmlTransformer
                     return $disclosure;
                 }
 
-                $cover = $this->coverPattern->match(
-                    $element,
-                    $fallbacks,
-                    fn (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported): array => $this->convertChildren($sourceElement, $sourceFallbacks, $captureUnsupported),
-                    fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-                    fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
-                    fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
-                    fn (string $url): string => $this->resolvedAssetImageUrl($url),
-                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-                );
+                $cover = $this->recognizePatterns($element, $fallbacks, array(CoverPattern::class));
                 if ( null !== $cover ) {
                     return $cover;
                 }
@@ -5145,15 +5155,7 @@ final class HtmlTransformer
                 // definition authored flex/grid containers.
             }
 
-            $columns = $this->columnsPattern->match(
-                $element,
-                $fallbacks,
-                fn (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported): array => $this->convertChildren($sourceElement, $sourceFallbacks, $captureUnsupported),
-                fn (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported): ?array => $this->convertElement($sourceElement, $sourceFallbacks, $captureUnsupported),
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->cssDeclarationString($this->structuralPresentationDeclarations($sourceElement)),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            $columns = $this->recognizePatterns($element, $fallbacks, array(ColumnsPattern::class));
             if ( null !== $columns ) {
                 return $columns;
             }
@@ -5163,14 +5165,7 @@ final class HtmlTransformer
                 return $gallery;
             }
 
-            $codeWindow = $this->codeWindowPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode),
-                fn (DOMElement $sourceCode): string => $this->codeContent($sourceCode),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            $codeWindow = $this->recognizePatterns($element, $fallbacks, array('code-window'));
             if ( null !== $codeWindow ) {
                 return $codeWindow;
             }
@@ -5306,12 +5301,7 @@ final class HtmlTransformer
      */
     private function convertMediaDispatchElement(DOMElement $element, string $tagName, array &$fallbacks): array
     {
-        $placeholderMedia = $this->placeholderMediaPattern->match(
-            $element,
-            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-            fn (string $value): string => $this->runtime->escapeHtml($value),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-        );
+        $placeholderMedia = $this->recognizePatterns($element, $fallbacks, array('placeholder-media'));
         if ( null !== $placeholderMedia ) {
             return array( 'handled' => true, 'block' => $placeholderMedia );
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/CallbackPatternRecognizer.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CallbackPatternRecognizer.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+/** Adapts established semantic matchers to the ordered recognizer registry. */
+final class CallbackPatternRecognizer implements PatternRecognizerInterface
+{
+    /** @param callable(DOMElement, PatternContext): PatternRecognitionResult|null $recognize */
+    public function __construct(private readonly string $name, private readonly mixed $recognize)
+    {
+    }
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        return ($this->recognize)($element, $context);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -26,10 +26,29 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
  * is a broad flex/grid/class heuristic that would misfire ahead of more specific
  * recognizers in the shared dispatch.
  */
-final class ColumnsPattern
+final class ColumnsPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
     use PatternGateHelpersTrait;
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $children = $context->convertChildrenWithFallbacksCallback();
+        $convert = $context->convertElementWithFallbacksCallback();
+        $style = $context->structuralPresentationStyleCallback();
+        if (null === $children || null === $convert || null === $style) return null;
+        $fallbacks = array();
+        $block = $this->match($element, $fallbacks, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($children): array {
+            $result = $children($sourceElement, $captureUnsupported);
+            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
+            return $result->blocks();
+        }, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($convert): ?array {
+            $result = $convert($sourceElement, $captureUnsupported);
+            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
+            return $result->firstBlock();
+        }, $context->presentationAttributesCallback(), $style, $context->createBlockCallback());
+        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks, array(), array('fallbacks'));
+    }
 
     /**
      * @param array<int, array<string, mixed>> $fallbacks

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -27,7 +27,7 @@ use Throwable;
  * |
  * `-- core/cover
  */
-final class CoverPattern
+final class CoverPattern implements PatternRecognizerInterface
 {
     use PatternGateHelpersTrait;
 
@@ -38,6 +38,18 @@ final class CoverPattern
     {
         $this->styleResolver = new CoverStyleResolver();
         $this->backgroundImageExtractor = new BackgroundImageExtractor();
+    }
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $children = $context->convertChildrenWithFallbacksCallback(); $style = $context->mergedPresentationStyleCallback(); $attrs = $context->htmlAttributesCallback(); $url = $context->resolveAssetImageUrlCallback();
+        if (null === $children || null === $style || null === $attrs || null === $url) return null;
+        $fallbacks = array(); $block = $this->match($element, $fallbacks, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($children): array {
+            $result = $children($sourceElement, $captureUnsupported);
+            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
+            return $result->blocks();
+        }, $context->presentationAttributesCallback(), $style, $attrs, $url, $context->createBlockCallback());
+        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks, array(), array('fallbacks'));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
@@ -22,10 +22,26 @@ use DOMElement;
  * |
  * `-- core/media-text
  */
-final class MediaTextPattern
+final class MediaTextPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
     use PatternGateHelpersTrait;
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $children = $context->convertChildrenWithFallbacksCallback(); $convert = $context->convertElementWithFallbacksCallback(); $attrs = $context->mediaTextPresentationAttributesCallback(); $style = $context->mediaTextPresentationStyleCallback(); $html = $context->htmlAttributesCallback(); $url = $context->resolveAssetImageUrlCallback();
+        if (null === $children || null === $convert || null === $attrs || null === $style || null === $html || null === $url) return null;
+        $fallbacks = array(); $block = $this->match($element, $fallbacks, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($children): array {
+            $result = $children($sourceElement, $captureUnsupported);
+            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
+            return $result->blocks();
+        }, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($convert): ?array {
+            $result = $convert($sourceElement, $captureUnsupported);
+            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
+            return $result->firstBlock();
+        }, $attrs, $style, $html, $url, $context->createBlockCallback());
+        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks, array(), array('fallbacks'));
+    }
 
     /**
      * @param array<int, array<string, mixed>> $fallbacks

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -19,6 +19,14 @@ final class PatternContext
      * @param callable(DOMElement): array<string, mixed>|null $convertElement
      * @param callable(DOMElement): list<string>|null $navigationColorInteractionStates
      * @param callable(DOMElement): string|null $navigationOverlayMenu
+     * @param callable(DOMElement, bool): PatternConversionResult|null $convertChildrenWithFallbacks
+     * @param callable(DOMElement, bool): PatternConversionResult|null $convertElementWithFallbacks
+     * @param callable(DOMElement): string|null $mergedPresentationStyle
+     * @param callable(DOMElement): array<string, string>|null $htmlAttributes
+     * @param callable(string): string|null $resolveAssetImageUrl
+     * @param callable(DOMElement, array<int, string>): array<string, mixed>|null $mediaTextPresentationAttributes
+     * @param callable(DOMElement): string|null $mediaTextPresentationStyle
+     * @param callable(DOMElement): string|null $structuralPresentationStyle
      */
     public function __construct(
         private readonly mixed $presentationAttributes,
@@ -31,7 +39,15 @@ final class PatternContext
         private readonly mixed $resolvedStyle = null,
         private readonly mixed $convertElement = null,
         private readonly mixed $navigationColorInteractionStates = null,
-        private readonly mixed $navigationOverlayMenu = null
+        private readonly mixed $navigationOverlayMenu = null,
+        private readonly mixed $convertChildrenWithFallbacks = null,
+        private readonly mixed $convertElementWithFallbacks = null,
+        private readonly mixed $mergedPresentationStyle = null,
+        private readonly mixed $htmlAttributes = null,
+        private readonly mixed $resolveAssetImageUrl = null,
+        private readonly mixed $mediaTextPresentationAttributes = null,
+        private readonly mixed $mediaTextPresentationStyle = null,
+        private readonly mixed $structuralPresentationStyle = null
     ) {
     }
 
@@ -127,4 +143,13 @@ final class PatternContext
     {
         return is_callable($this->navigationOverlayMenu) ? $this->navigationOverlayMenu : null;
     }
+
+    public function convertChildrenWithFallbacksCallback(): ?callable { return is_callable($this->convertChildrenWithFallbacks) ? $this->convertChildrenWithFallbacks : null; }
+    public function convertElementWithFallbacksCallback(): ?callable { return is_callable($this->convertElementWithFallbacks) ? $this->convertElementWithFallbacks : null; }
+    public function mergedPresentationStyleCallback(): ?callable { return is_callable($this->mergedPresentationStyle) ? $this->mergedPresentationStyle : null; }
+    public function htmlAttributesCallback(): ?callable { return is_callable($this->htmlAttributes) ? $this->htmlAttributes : null; }
+    public function resolveAssetImageUrlCallback(): ?callable { return is_callable($this->resolveAssetImageUrl) ? $this->resolveAssetImageUrl : null; }
+    public function mediaTextPresentationAttributesCallback(): ?callable { return is_callable($this->mediaTextPresentationAttributes) ? $this->mediaTextPresentationAttributes : null; }
+    public function mediaTextPresentationStyleCallback(): ?callable { return is_callable($this->mediaTextPresentationStyle) ? $this->mediaTextPresentationStyle : null; }
+    public function structuralPresentationStyleCallback(): ?callable { return is_callable($this->structuralPresentationStyle) ? $this->structuralPresentationStyle : null; }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternConversionResult.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternConversionResult.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+/** A conversion performed while recognizing a pattern, including diagnostics. */
+final class PatternConversionResult
+{
+    /**
+     * @param list<array<string, mixed>> $blocks
+     * @param list<array<string, mixed>> $fallbacks
+     */
+    public function __construct(private readonly array $blocks, private readonly array $fallbacks = array())
+    {
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function blocks(): array { return $this->blocks; }
+
+    /** @return array<string, mixed>|null */
+    public function firstBlock(): ?array { return $this->blocks[0] ?? null; }
+
+    /** @return list<array<string, mixed>> */
+    public function fallbacks(): array { return $this->fallbacks; }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
@@ -14,9 +14,14 @@ final class PatternRecognizerRegistry
     {
     }
 
-    public function firstMatch(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    /** @param list<class-string<PatternRecognizerInterface>|string> $allowed */
+    public function firstMatch(DOMElement $element, PatternContext $context, array $allowed = array()): ?PatternRecognitionResult
     {
         foreach ( $this->recognizers as $recognizer ) {
+            $name = $recognizer instanceof CallbackPatternRecognizer ? $recognizer->name() : $recognizer::class;
+            if ( array() !== $allowed && ! in_array($name, $allowed, true) ) {
+                continue;
+            }
             $result = $recognizer->recognize($element, $context);
             if ( null !== $result ) {
                 return $result;


### PR DESCRIPTION
Closes #998.

## Summary
- route every reusable semantic recognizer through the ordered typed registry: media text, cover, columns, math, parameter table, spacer, code-window, logo, placeholder media, quote, figure quote, native details, disclosure, gallery, button containers, button anchors, buttons, accordion, social links, and navigation
- preserve staged dispatch precedence, typed fallback/provenance propagation, and existing block output
- restrict the navigation-only probe to `NavigationPattern`, preventing registry re-entry while quote children lower

## Remaining Direct Semantic Dispatch
None. `QuotePattern`, `GalleryPattern`, `ButtonsPattern`, and `DetailsPattern` are called only by registry callbacks. Native `details` lowers to `core/details` through the registered `details` recognizer; it is not a primitive lowering because it extracts summary/open state and converts non-summary children.

## Verification
- `COMPOSER_PROCESS_TIMEOUT=1800 composer test`
  - canonical suite passed
  - 278 parity fixtures passed
  - package install proof passed

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode was used to inspect the existing migration, complete the remaining typed registry dispatch, fix the navigation probe recursion, add focused precedence/fallback coverage, and run the test suite. Chris remains responsible for every line.