### PR TITLE
fix(transformer): preserve native runtime DOM contracts

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -5585,7 +5585,7 @@ final class ArtifactCompiler
                 return 'failed';
             }
 
-            if ( 'preserved_runtime_island' === ($diagnostic['code'] ?? '') ) {
+            if ( in_array(($diagnostic['code'] ?? ''), array('preserved_runtime_island', 'runtime_dom_contract_preserved'), true) ) {
                 continue;
             }
 

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/DiagnosticsCollector.php
@@ -26,6 +26,7 @@ final class DiagnosticsCollector
      * @param array<int, array<string, mixed>>  $scriptMetadata       Static script metadata preserved as bounded data.
      * @param array<int, array<string, mixed>>  $fallbacks            Fallback diagnostics emitted during conversion.
      * @param array<int, array<string, mixed>>  $runtimeIslands       Preserved runtime islands.
+     * @param array<int, array<string, mixed>>  $runtimeDomPreservations Runtime contracts retained by native blocks.
      * @param array<string, mixed>              $blockValidityReport  Block serialization validity report.
      * @param array<string, mixed>              $semanticParityReport Semantic parity report.
      * @param array<string, mixed>              $contentRoundTripReport Content round-trip (hallucination) report.
@@ -36,6 +37,7 @@ final class DiagnosticsCollector
         array $scriptMetadata,
         array $fallbacks,
         array $runtimeIslands,
+        array $runtimeDomPreservations,
         array $blockValidityReport,
         array $semanticParityReport,
         array $contentRoundTripReport = array()
@@ -127,6 +129,20 @@ final class DiagnosticsCollector
                 'controls'                        => $island['controls'] ?? null,
                 'control'                         => $island['control'] ?? null,
                 'form'                            => $island['form'] ?? null,
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value);
+        }
+
+        foreach ( $runtimeDomPreservations as $preservation ) {
+            $diagnostics[] = array_filter(array(
+                'code'                => 'runtime_dom_contract_preserved',
+                'message'             => 'A script-addressed DOM contract was retained by a native Gutenberg block.',
+                'source'              => $transformerSource,
+                'severity'            => 'info',
+                'conversion_classification' => 'native_block_conversion',
+                'preservation_strategy' => 'native_block_dom_contract',
+                'block_name'          => $preservation['block_name'] ?? null,
+                'tag'                 => $preservation['tag'] ?? null,
+                'selector'            => $preservation['selector'] ?? null,
             ), static fn (mixed $value): bool => null !== $value && '' !== $value);
         }
 

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -761,6 +761,7 @@ final class HtmlTransformer
             $this->scriptMetadata,
             $fallbacks,
             $this->runtimeIslands,
+            array_values($this->runtimeDomPreservations),
             $blockValidityReport,
             $semanticParityReport,
             $contentRoundTripReport
@@ -824,6 +825,7 @@ final class HtmlTransformer
             'core_block_capabilities' => $capabilityMatrix,
             'head_metadata' => $headMetadata,
             'runtime_islands' => $this->runtimeIslands,
+            'runtime_dom_contracts' => array_values($this->runtimeDomPreservations),
             'generated_blocks' => $this->generatedBlocks,
             'gutenberg_gaps' => $this->descriptionListBlockGenerated ? array(
                 array(
@@ -5601,10 +5603,14 @@ final class HtmlTransformer
             $this->recordStructureProvenance($name, $attrs, $sourceElement);
             if ( $this->isRuntimeDomTarget($sourceElement) && ! $this->isFormControlElement($sourceElement) && ! in_array($sourceTagName, array( 'canvas', 'form', 'script' ), true) ) {
                 $runtimeOwned = true;
-                $this->recordRuntimeIsland($sourceElement, 'dom', 'runtime_dom_target', 'client_script_execution', array(
-                    'events'          => $this->eventMetadata($sourceElement),
-                    'required_scripts' => $this->requiredScriptsForElement($sourceElement),
-                ));
+                if ( ! $this->canRetainRuntimeDomContractNatively($sourceElement, $name) ) {
+                    $this->recordRuntimeIsland($sourceElement, 'dom', 'runtime_dom_target', 'client_script_execution', array(
+                        'events'          => $this->eventMetadata($sourceElement),
+                        'required_scripts' => $this->requiredScriptsForElement($sourceElement),
+                    ));
+                } else {
+                    $this->recordNativeRuntimeDomPreservation($sourceElement, $name);
+                }
             }
             $this->sourceProvenance[$provenanceId] = $this->sourceProvenanceEntry($name, $sourceElement);
             $this->sourceBaseHiddenStates[$provenanceId] = $this->sourceElementStartsHidden($sourceElement);
@@ -11932,6 +11938,46 @@ final class HtmlTransformer
     private function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata = array()): void
     {
         $this->fallbackEmitter->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeIslands);
+    }
+
+    private function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName): void
+    {
+        foreach ($this->runtimeDomSelectorsForElement($element) as $selector) {
+            $key = $blockName . "\n" . $selector;
+            if (isset($this->runtimeDomPreservations[$key])) {
+                continue;
+            }
+            $this->runtimeDomPreservations[$key] = array(
+                'block_name' => $blockName,
+                'tag' => strtolower($element->tagName),
+                'selector' => $selector,
+            );
+        }
+    }
+
+    private function canRetainRuntimeDomContractNatively(DOMElement $element, string $blockName): bool
+    {
+        if ( ! in_array($blockName, array('core/group', 'core/paragraph', 'core/heading'), true) ) {
+            return false;
+        }
+
+        // Group can serialize these semantic wrappers exactly. Generic div app
+        // surfaces retain their existing bounded-island treatment.
+        if ('core/group' === $blockName && ! in_array(strtolower($element->tagName), array('article', 'aside', 'footer', 'header', 'main', 'section'), true)) {
+            return false;
+        }
+
+        if (array_intersect($this->runtimeAppShellSignals($element), array('app_root_token', 'workspace_surface'))) {
+            return false;
+        }
+
+        foreach ($this->descendantElements($element) as $descendant) {
+            if (in_array(strtolower($descendant->tagName), array('button', 'input', 'select', 'textarea', 'canvas', 'form', 'template'), true)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -32,6 +32,7 @@ final class HtmlTransformerSession
     public array $structureProvenance = array();
     public array $scriptMetadata = array();
     public array $runtimeIslands = array();
+    public array $runtimeDomPreservations = array();
     public array $nativeDisclosureRootIds = array();
     public array $generatedBlocks = array();
     public bool $descriptionListBlockGenerated = false;

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1351,6 +1351,43 @@ $runtimeClockMarkup = (string) ($runtimeClock['serialized_blocks'] ?? '');
 $assert(str_contains($runtimeClockMarkup, 'className":"clock-time blocks-engine-editor-anchor-clock-time blocks-engine-synthetic-paragraph') && 0 === substr_count($runtimeClockMarkup, '<!-- wp:html'), 'selector-addressed inline clock values remain one native RichText run inside a CSS-owned flex ancestor', $runtimeClockMarkup);
 $assert(str_contains($runtimeClockMarkup, 'id="hours"') && str_contains($runtimeClockMarkup, 'id="colon"') && str_contains($runtimeClockMarkup, 'id="minutes"') && str_contains($runtimeClockMarkup, 'id="ampm"') && str_contains($runtimeClockMarkup, 'id="timezone"'), 'native runtime text run retains every script-addressed id', $runtimeClockMarkup);
 $assert(! str_contains($runtimeClockMarkup, 'Initial State'), 'source comments do not become visible RichText editor content', $runtimeClockMarkup);
+$runtimeClockRoundTrip = new \Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime();
+$runtimeClockEdited = $runtimeClockRoundTrip->parseBlocks($runtimeClockMarkup);
+$editRuntimeClock = static function (array &$blocks) use (&$editRuntimeClock): void {
+    foreach ($blocks as &$block) {
+        if (is_array($block['innerContent'] ?? null)) {
+            foreach ($block['innerContent'] as &$content) {
+                if (is_string($content)) {
+                    $content = str_replace('id="hours" style="margin:0;padding:0;background-color:transparent;color:inherit">12</mark>', 'id="hours" style="margin:0;padding:0;background-color:transparent;color:inherit">13</mark>', $content);
+                }
+            }
+            unset($content);
+        }
+        if (is_array($block['innerBlocks'] ?? null)) {
+            $editRuntimeClock($block['innerBlocks']);
+        }
+    }
+    unset($block);
+};
+$editRuntimeClock($runtimeClockEdited);
+$runtimeClockEditedMarkup = $runtimeClockRoundTrip->serializeBlocks($runtimeClockEdited);
+$runtimeClockRendered = $runtimeClockRoundTrip->renderBlocks($runtimeClockEdited);
+$assert(str_contains($runtimeClockEditedMarkup, 'id="hours" style="margin:0;padding:0;background-color:transparent;color:inherit">13</mark>') && str_contains($runtimeClockRendered, 'id="minutes"') && ! str_contains($runtimeClockEditedMarkup, '<!-- wp:html'), 'native runtime RichText survives parse, edit, serialize, and render without becoming Custom HTML', $runtimeClockEditedMarkup);
+
+$runtimeGroup = ( new HtmlTransformer() )->transform(
+    '<section id="scoreboard"><p>Score: <span id="score">0</span></p></section>',
+    array('runtime_dom_selectors' => array('#scoreboard', '#score'))
+)->toArray();
+$runtimeGroupMarkup = (string) ($runtimeGroup['serialized_blocks'] ?? '');
+$runtimeGroupDiagnostics = array_values(array_filter($runtimeGroup['diagnostics'] ?? array(), static fn (array $diagnostic): bool => 'runtime_dom_contract_preserved' === ($diagnostic['code'] ?? '')));
+$assert('core/group' === ($runtimeGroup['blocks'][0]['blockName'] ?? '') && str_contains($runtimeGroupMarkup, 'id="scoreboard"') && str_contains($runtimeGroupMarkup, 'id="score"') && ! str_contains($runtimeGroupMarkup, '<!-- wp:html') && 1 <= count($runtimeGroupDiagnostics), 'script-addressed container remains a native Group with a stable native-preservation diagnostic', $runtimeGroupMarkup);
+
+$mixedCanvasRuntime = ( new HtmlTransformer() )->transform(
+    '<section class="demo"><p>Editable <span id="count">0</span></p><canvas id="chart">Chart</canvas><p>Still editable</p></section>',
+    array('runtime_dom_selectors' => array('#count'), 'runtime_canvas_selectors' => array('#chart'))
+)->toArray();
+$mixedCanvasMarkup = (string) ($mixedCanvasRuntime['serialized_blocks'] ?? '');
+$assert(1 === substr_count($mixedCanvasMarkup, '<!-- wp:html') && str_contains($mixedCanvasMarkup, '<canvas id="chart">Chart</canvas>') && str_contains($mixedCanvasMarkup, 'Editable <span id="count">0</span>') && str_contains($mixedCanvasMarkup, 'Still editable'), 'an irreducible canvas remains one bounded runtime island without forcing editable siblings into Custom HTML', $mixedCanvasMarkup);
 
 $emptyRuntimeText = ( new HtmlTransformer() )->transform(
     '<footer class="footer"><div id="runtime-status" class="runtime-status"></div></footer>',


### PR DESCRIPTION
## Summary
- distinguish script-addressed DOM contracts preserved by native paragraph, heading, and semantic Group blocks from irreducible runtime islands
- retain bounded islands for generic application surfaces and descendants requiring native canvas or interactive DOM
- add parse/edit/serialize/render, native Group, mixed canvas, editor CSS, and diagnostic contract coverage

## Validation
- `composer --working-dir=php-transformer test`
- `php tests/contract/run.php && php tests/parity/run.php`

Closes #1035.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent inspected the WordPress 7.1 and current Gutenberg serialization contracts, implemented the runtime-aware conversion and diagnostics, and ran the focused and full PHP transformer verification. Chris Huber remains responsible for the changes.