### PR TITLE
Fix inert capture scaffolding fallbacks

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -122,6 +122,7 @@
       "php tests/unit/compile-fragment-author-stylesheet.php",
       "php tests/unit/responsive-canvas-geometry.php",
       "php tests/unit/core-html-fallback-reduction.php",
+      "php tests/unit/inert-capture-scaffolding.php",
       "php tests/unit/geometry-chain-coalescing.php",
       "php tests/unit/pattern-recognizer-registry.php"
     ],

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4437,6 +4437,13 @@ final class HtmlTransformer
         $this->invalidateSourceSelectorMatchCache();
         $tagName = strtolower($element->tagName);
 
+        // Capturers sometimes append hidden, sourceless frames as internal
+        // scaffolding. They cannot render or load anything, so omit them before
+        // media dispatch can turn them into fallback/runtime-island evidence.
+        if ( 'iframe' === $tagName && $this->isInertHiddenCaptureIframe($element) ) {
+            return null;
+        }
+
         // A direct phrasing child participates in its parent's flex or grid
         // layout. Preserve that source element as the editable leaf rather
         // than introducing a paragraph wrapper with core paragraph margins.
@@ -14520,19 +14527,101 @@ final class HtmlTransformer
 
     private function isInertHiddenSvgStorage(DOMElement $element): bool
     {
-        if ( $this->svgHasDrawableContent($element)
-            || 0 < $element->getElementsByTagName('use')->length
-            || '' !== trim($element->textContent ?? '')
+        if ( ! $this->sourceElementStartsHidden($element)
+            || $this->hasConditionalStyleFamily($element, 'layout')
+            || $this->hasConditionalStyleFamily($element, 'visibility')
+            || $this->hasConditionalStyleFamily($element, 'opacity')
             || '' !== trim($this->attr($element, 'aria-label'))
             || '' !== trim($this->attr($element, 'aria-labelledby'))
-            || '' !== trim($this->attr($element, 'title')) ) {
+            || '' !== trim($this->attr($element, 'title'))
+            || ! $this->hasOnlySvgDefinitions($element)
+            || $this->hiddenSvgStoreHasExternalReference($element) ) {
             return false;
         }
 
-        $style = strtolower($this->attr($element, 'style'));
-        return 'true' === strtolower($this->attr($element, 'aria-hidden'))
-            || str_contains($style, 'display:none')
-            || str_contains($style, 'display: none');
+        return true;
+    }
+
+    private function isInertHiddenCaptureIframe(DOMElement $element): bool
+    {
+        if ( ! $this->sourceElementStartsHidden($element)
+            || $this->hasConditionalStyleFamily($element, 'layout')
+            || $this->hasConditionalStyleFamily($element, 'visibility')
+            || $this->hasConditionalStyleFamily($element, 'opacity')
+            || $this->isRuntimeDomTarget($element)
+            || '' !== trim($this->attr($element, 'src'))
+            || '' !== trim($this->attr($element, 'srcdoc'))
+            || '' !== trim($this->attr($element, 'name'))
+            || '' !== trim($element->textContent ?? '')
+            || 0 !== $this->childElementCount($element)
+            || array() !== $this->eventMetadata($element)
+            || array() !== $this->safeDataAttributes($element) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function hasOnlySvgDefinitions(DOMElement $element): bool
+    {
+        $hasDefinition = false;
+        foreach ( $element->childNodes as $child ) {
+            if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+            if ( ! $child instanceof DOMElement || ! in_array(strtolower($child->tagName), array( 'defs', 'symbol' ), true) ) {
+                return false;
+            }
+            $hasDefinition = true;
+        }
+
+        return $hasDefinition;
+    }
+
+    private function hiddenSvgStoreHasExternalReference(DOMElement $store): bool
+    {
+        $ids = array();
+        foreach ( $store->getElementsByTagName('*') as $definition ) {
+            if ( $definition instanceof DOMElement && '' !== trim($this->attr($definition, 'id')) ) {
+                $ids[] = trim($this->attr($definition, 'id'));
+            }
+        }
+        if ( array() === $ids || ! $store->ownerDocument instanceof DOMDocument ) {
+            return false;
+        }
+
+        foreach ( $store->ownerDocument->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement || $this->isDescendantOf($candidate, $store) ) {
+                continue;
+            }
+            foreach ( $candidate->attributes as $attribute ) {
+                foreach ( $ids as $id ) {
+                    if ( preg_match('/(?:^|[\\s,(])(?:url\\(\\s*["\']?#' . preg_quote($id, '/') . '["\']?\\s*\\)|#' . preg_quote($id, '/') . '(?:$|[\\s,)]))/', $attribute->value) ) {
+                        return true;
+                    }
+                }
+            }
+            if ( 'style' === strtolower($candidate->tagName) ) {
+                foreach ( $ids as $id ) {
+                    if ( preg_match('/url\\(\\s*["\']?#' . preg_quote($id, '/') . '["\']?\\s*\\)/', $candidate->textContent ?? '') ) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function isDescendantOf(DOMElement $element, DOMElement $ancestor): bool
+    {
+        for ( $node = $element; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $node->isSameNode($ancestor) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -41,7 +41,7 @@ trait SvgMaterializationTrait
                 ? $this->ensureInlineSvgBoxStyle($html, $element)
                 : $this->ensureInlineSvgSizing($html, $element)
         );
-        $html = $this->resolveMaterializedSvgColors($html, $element);
+        $html = $this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element);
         $imageBlock = $this->inlineSvgImageBlockFromMarkup($element, $html);
         if ( null !== $imageBlock ) {
             return $imageBlock;
@@ -228,7 +228,7 @@ trait SvgMaterializationTrait
                 ? $this->ensureInlineSvgBoxStyle($html, $element)
                 : $this->ensureInlineSvgSizing($html, $element)
         );
-        $attrs = $this->inlineSvgImageAttributesFromMarkup($element, $this->resolveMaterializedSvgColors($html, $element), true);
+        $attrs = $this->inlineSvgImageAttributesFromMarkup($element, $this->inlineSvgMaterializationMarkup($this->resolveMaterializedSvgColors($html, $element), $element), true);
         if ( null === $attrs ) {
             return null;
         }
@@ -370,6 +370,64 @@ trait SvgMaterializationTrait
         $html = preg_replace('/<!--.*?-->/s', '', $html) ?? $html;
         $html = preg_replace('/>\s+</', '><', $html) ?? $html;
         return trim($html);
+    }
+
+    /**
+     * SVG image assets are standalone documents. Copy local definitions used by
+     * the image into its payload so a document-level capture store is not needed
+     * at render time.
+     */
+    private function inlineSvgMaterializationMarkup(string $html, DOMElement $element): string
+    {
+        if ( ! $element->ownerDocument instanceof \DOMDocument || 0 === $element->getElementsByTagName('use')->length ) {
+            return $html;
+        }
+
+        $references = array();
+        foreach ( $element->getElementsByTagName('use') as $use ) {
+            if ( ! $use instanceof DOMElement ) {
+                continue;
+            }
+            $href = trim($this->attr($use, 'href'));
+            if ( '' === $href ) {
+                $href = trim($this->attr($use, 'xlink:href'));
+            }
+            if ( preg_match('/^#(.+)$/', $href, $match) ) {
+                $references[$match[1]] = true;
+            }
+        }
+        if ( array() === $references ) {
+            return $html;
+        }
+
+        $definitions = array();
+        foreach ( $element->ownerDocument->getElementsByTagName('defs') as $defs ) {
+            if ( ! $defs instanceof DOMElement || $this->svgDefinitionBelongsTo($defs, $element) ) {
+                continue;
+            }
+            foreach ( $defs->getElementsByTagName('*') as $definition ) {
+                if ( $definition instanceof DOMElement && isset($references[trim($this->attr($definition, 'id'))]) ) {
+                    $definitions[] = $this->safeFallbackHtml($defs);
+                    break;
+                }
+            }
+        }
+        if ( array() === $definitions ) {
+            return $html;
+        }
+
+        return preg_replace('/<\/svg>\s*$/i', implode('', array_unique($definitions)) . '</svg>', $html, 1) ?? $html;
+    }
+
+    private function svgDefinitionBelongsTo(DOMElement $definition, DOMElement $svg): bool
+    {
+        for ( $node = $definition; $node instanceof DOMElement; $node = $node->parentNode ) {
+            if ( $node->isSameNode($svg) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function svgImageAssetIdentity(string $html): string

--- a/php-transformer/tests/unit/inert-capture-scaffolding.php
+++ b/php-transformer/tests/unit/inert-capture-scaffolding.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+$assertions = 0;
+$assert = static function (bool $condition, string $label) use (&$assertions): void {
+    ++$assertions;
+    if ( ! $condition ) {
+        throw new RuntimeException($label);
+    }
+};
+
+$transform = static fn (string $html): array => ( new HtmlTransformer() )->transform($html)->toArray();
+
+$inertIframe = $transform('<main><iframe title="archetype" style="display:none;visibility:hidden"></iframe><p>Visible copy</p></main>');
+$assert(array() === ($inertIframe['fallbacks'] ?? array()), 'hidden sourceless iframe emits no fallback');
+$assert(array() === ($inertIframe['source_reports']['runtime_islands'] ?? array()), 'hidden sourceless iframe emits no runtime island');
+$assert(str_contains((string) ($inertIframe['serialized_blocks'] ?? ''), 'Visible copy') && ! str_contains((string) ($inertIframe['serialized_blocks'] ?? ''), 'archetype'), 'hidden sourceless iframe emits no block');
+
+$unreferencedStore = $transform('<main><svg data-dom-store style="display:none"><defs><symbol id="unused"><path d="M0 0h1v1z"/></symbol></defs></svg><p>Visible copy</p></main>');
+$assert(array() === ($unreferencedStore['fallbacks'] ?? array()), 'hidden unreferenced SVG store emits no fallback');
+$assert(! str_contains((string) ($unreferencedStore['serialized_blocks'] ?? ''), 'unused'), 'hidden unreferenced SVG store emits no raw HTML');
+
+$referencedStore = $transform('<main><svg data-dom-store style="display:none"><defs><symbol id="mark"><path d="M0 0h1v1z"/></symbol></defs></svg><svg viewBox="0 0 1 1"><use href="#mark"/></svg></main>');
+$assert(str_contains((string) ($referencedStore['serialized_blocks'] ?? ''), 'id="mark"'), 'referenced SVG store remains available');
+$materializedSvg = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), array_filter($referencedStore['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? ''))));
+$assert(str_contains($materializedSvg, 'id="mark"') && str_contains($materializedSvg, 'href="#mark"'), 'referenced SVG symbols remain available to materialized images');
+
+$visibleIframe = $transform('<main><iframe title="HubSpot form" src="https://forms.hsforms.com/widget" width="600" height="400"></iframe></main>');
+$iframeFallbacks = array_values(array_filter($visibleIframe['fallbacks'] ?? array(), static fn (array $fallback): bool => 'iframe' === ($fallback['tag'] ?? '')));
+$assert(1 === count($iframeFallbacks), 'visible HubSpot iframe remains a bounded external embed');
+$assert('https://forms.hsforms.com/widget' === ($iframeFallbacks[0]['attributes']['src'] ?? ''), 'visible HubSpot iframe source is retained');
+
+$hiddenSourcedIframe = $transform('<main><iframe title="third-party embed" style="display:none" src="https://example.test/embed"></iframe></main>');
+$assert(1 === count($hiddenSourcedIframe['fallbacks'] ?? array()), 'hidden sourced iframe remains preserved');
+
+echo "OK: inert capture scaffolding passed ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- discard hidden sourceless capture iframes before fallback and runtime-island classification
- discard hidden definition-only SVG stores only when their identifiers are unreferenced
- materialize local SVG definitions into referenced SVG image assets

Closes #1040

## Testing
- `php tests/unit/inert-capture-scaffolding.php`
- `php tests/contract/run.php`
- `composer test`

## AI assistance
OpenAI GPT-5.6-sol via OpenCode general coding subagent implemented the guard and fixtures, ran the test suite, and prepared this PR. Chris Huber remains responsible for every line.