### PR TITLE
refactor: complete #998 pattern registry migration

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -123,7 +123,8 @@
       "php tests/unit/responsive-canvas-geometry.php",
       "php tests/unit/core-html-fallback-reduction.php",
       "php tests/unit/geometry-chain-coalescing.php",
-      "php tests/unit/pattern-recognizer-registry.php"
+      "php tests/unit/pattern-recognizer-registry.php",
+      "php tests/unit/pattern-registry-staged-dispatch.php"
     ],
     "test:parity": "php tests/parity/run.php",
     "test:migration:examples": "php tests/migration/examples.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -614,6 +614,47 @@ final class HtmlTransformer
                 $block = $this->placeholderMediaPattern->match($element, $context->presentationAttributesCallback(), fn (string $value): string => $this->runtime->escapeHtml($value), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block);
             }),
+            new CallbackPatternRecognizer('quote', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $fallbacks = array();
+                $block = $this->quotePattern->matchBlockquote($element, $fallbacks, fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement), fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags), fn (string $html): string => $this->runtime->stripAllTags($html), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), fn (string $inlineTagName): bool => $this->isInlineContentElement($inlineTagName), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
+            }),
+            new CallbackPatternRecognizer('figure-quote', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $blockquote = $this->firstChildElement($element, 'blockquote');
+                if (! $blockquote instanceof DOMElement) return null;
+                $fallbacks = array();
+                $block = $this->quotePattern->matchFigureBlockquote($element, $blockquote, $fallbacks, fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement), $context->innerHtmlCallback(), fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags), fn (string $html): string => $this->runtime->stripAllTags($html), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
+            }),
+            new CallbackPatternRecognizer('details', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $fallbacks = array();
+                $block = $this->detailsPattern->match($element, $fallbacks, fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
+            }),
+            new CallbackPatternRecognizer('disclosure', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->detailsPattern->matchDisclosure($element, fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('gallery', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->galleryPattern->match($element, fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link), fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $this->convertPictureElement($picture, $figure, $link), fn (DOMElement $figure): ?DOMElement => $this->figureLinkedMediaAnchor($figure), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('buttons-container', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->buttonsPattern->matchContainer($element, $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)), $context->innerHtmlCallback(), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block);
+            }),
+            new CallbackPatternRecognizer('button-anchor', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $fallbacks = array();
+                $block = $this->buttonsPattern->matchAnchor($element, fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)), fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), $context->createBlockCallback(), function (DOMElement $anchor) use (&$fallbacks): array {
+                    $fallbacks[] = FallbackDiagnostic::build(array('type' => 'html', 'reason' => 'stylable_button_accessible_name_requires_typed_companion', 'diagnostic_code' => 'html_stylable_button_accessible_name_fallback', 'source_format' => 'html', 'tag' => 'a', 'html' => $this->safeFallbackHtml($anchor)), $this->fallbackProvenance);
+                    return $this->htmlPreservationBlock($anchor);
+                });
+                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
+            }),
+            new CallbackPatternRecognizer('button', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
+                $block = $this->buttonsPattern->matchButton($element, $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)), fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), fn (DOMElement $sourceElement): bool => $sourceElement->parentNode instanceof DOMElement && in_array($this->authoredDisplay($sourceElement->parentNode), array('grid', 'inline-grid'), true), $context->createBlockCallback());
+                return new PatternRecognitionResult($block);
+            }),
             new AccordionPattern(),
             new SocialLinksPattern(),
             new NavigationPattern(),
@@ -4328,7 +4369,7 @@ final class HtmlTransformer
         return new PatternContext(
             fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
             fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement),
+            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
             $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
             fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
             fn (DOMElement $sourceElement, array $excludedTags): array => $this->convertPatternChildrenWithoutTags($sourceElement, $excludedTags),
@@ -4741,33 +4782,16 @@ final class HtmlTransformer
         }
 
         if ( 'blockquote' === $tagName ) {
-            return $this->quotePattern->matchBlockquote(
-                $element,
-                $fallbacks,
-                fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement),
-                fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags),
-                fn (string $html): string => $this->runtime->stripAllTags($html),
-                fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-                fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags),
-                fn (string $inlineTagName): bool => $this->isInlineContentElement($inlineTagName),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement)
-            );
+            return $this->recognizePatterns($element, $fallbacks, array('quote'));
         }
 
         if ( 'figure' === $tagName ) {
-            $gallery = $this->mediaGalleryBlockFromElement($element);
+            $gallery = $this->mediaGalleryBlockFromElement($element, $fallbacks);
             if ( null !== $gallery ) {
                 return $gallery;
             }
 
-            $codeWindow = $this->codeWindowPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode),
-                fn (DOMElement $sourceCode): string => $this->codeContent($sourceCode),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            $codeWindow = $this->recognizePatterns($element, $fallbacks, array('code-window'));
             if ( null !== $codeWindow ) {
                 return $codeWindow;
             }
@@ -4797,18 +4821,7 @@ final class HtmlTransformer
 
             $blockquote = $this->firstChildElement($element, 'blockquote');
             if ( $blockquote instanceof DOMElement ) {
-                return $this->quotePattern->matchFigureBlockquote(
-                    $element,
-                    $blockquote,
-                    $fallbacks,
-                    fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement),
-                    fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                    fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags),
-                    fn (string $html): string => $this->runtime->stripAllTags($html),
-                    fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                    fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags),
-                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-                );
+                return $this->recognizePatterns($element, $fallbacks, array('figure-quote'));
             }
 
             return $this->convertFigureGeneric($element, $fallbacks);
@@ -4912,14 +4925,7 @@ final class HtmlTransformer
         }
 
         if ( 'details' === $tagName ) {
-            return $this->detailsPattern->match(
-                $element,
-                $fallbacks,
-                fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags),
-                fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            return $this->recognizePatterns($element, $fallbacks, array('details'));
         }
 
         if ( 'a' === $tagName ) {
@@ -5144,13 +5150,7 @@ final class HtmlTransformer
                     return $metadataGrid;
                 }
 
-                $disclosure = $this->detailsPattern->matchDisclosure(
-                    $element,
-                    fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
-                    fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-                    fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                    fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-                );
+                $disclosure = $this->recognizePatterns($element, $fallbacks, array('disclosure'));
                 if ( null !== $disclosure ) {
                     $this->nativeDisclosureRootIds[ $element->getNodePath() ?? '' ] = true;
 
@@ -5172,7 +5172,7 @@ final class HtmlTransformer
                 return $columns;
             }
 
-            $gallery = $this->mediaGalleryBlockFromElement($element);
+            $gallery = $this->mediaGalleryBlockFromElement($element, $fallbacks);
             if ( null !== $gallery ) {
                 return $gallery;
             }
@@ -5207,15 +5207,7 @@ final class HtmlTransformer
                 return $standaloneSearch;
             }
 
-            $buttons = $this->buttonsPattern->matchContainer(
-                $element,
-                fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-                fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)),
-                fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-                fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
-                fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement)
-            );
+            $buttons = $this->recognizePatterns($element, $fallbacks, array('buttons-container'));
             if ( null !== $buttons ) {
                 return $buttons;
             }
@@ -5347,7 +5339,7 @@ final class HtmlTransformer
     /**
      * @return array<string, mixed>|null
      */
-    private function mediaGalleryBlockFromElement(DOMElement $element): ?array
+    private function mediaGalleryBlockFromElement(DOMElement $element, array &$fallbacks): ?array
     {
         if ( ! $this->isGalleryCompatibleMediaLayout($element) ) {
             return null;
@@ -5359,15 +5351,7 @@ final class HtmlTransformer
             return $this->hasGalleryMediaItems($element) ? $this->responsiveMediaBlock($element) : null;
         }
 
-        return $this->galleryPattern->match(
-            $element,
-            fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link),
-            fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $this->convertPictureElement($picture, $figure, $link),
-            fn (DOMElement $figure): ?DOMElement => $this->figureLinkedMediaAnchor($figure),
-            fn (DOMElement $sourceElement): array => $this->presentationAttributes($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-        );
+        return $this->recognizePatterns($element, $fallbacks, array('gallery'));
     }
 
     private function isGalleryCompatibleMediaLayout(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -10,7 +10,7 @@ final class PatternContext
     /**
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
      * @param callable(DOMElement): string $innerHtml
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
+     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
      * @param callable(DOMElement): bool|null $isRuntimeDomTarget
      * @param callable(DOMElement): array<int, array<string, mixed>>|null $convertChildren
      * @param callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null $convertChildrenWithoutTags
@@ -68,7 +68,7 @@ final class PatternContext
     }
 
     /**
-     * @return callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed>
+     * @return callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed>
      */
     public function createBlockCallback(): callable
     {

--- a/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
@@ -22,39 +22,12 @@ trait ButtonLinkDispatchTrait
             return $linkedLogo;
         }
 
-        $button = $this->buttonsPattern->matchAnchor(
-            $element,
-            fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
-            fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-            fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)),
-            fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-            fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
-            fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
-            function (DOMElement $anchor) use (&$fallbacks): array {
-                $fallbacks[] = \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackDiagnostic::build(array(
-                    'type'            => 'html',
-                    'reason'          => 'stylable_button_accessible_name_requires_typed_companion',
-                    'diagnostic_code' => 'html_stylable_button_accessible_name_fallback',
-                    'source_format'   => 'html',
-                    'tag'             => 'a',
-                    'html'            => $this->safeFallbackHtml($anchor),
-                ), $this->fallbackProvenance);
-                return $this->htmlPreservationBlock($anchor);
-            }
-        );
+        $button = $this->recognizePatterns($element, $fallbacks, array('button-anchor'));
         if ( null !== $button ) {
             return $button;
         }
 
-        $logo = $this->logoPattern->match(
-            $element,
-            fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-            fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)),
-            fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement)
-        );
+        $logo = $this->recognizePatterns($element, $fallbacks, array('logo'));
         if ( null !== $logo ) {
             return $logo;
         }
@@ -137,14 +110,7 @@ trait ButtonLinkDispatchTrait
             return $this->htmlPreservationBlock($element);
         }
 
-        return $this->buttonsPattern->matchButton(
-            $element,
-            fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-            fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)),
-            fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
-            fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
-            fn (DOMElement $sourceElement): bool => $sourceElement->parentNode instanceof DOMElement && in_array($this->authoredDisplay($sourceElement->parentNode), array( 'grid', 'inline-grid' ), true),
-            fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-        );
+        $fallbacks = array();
+        return $this->recognizePatterns($element, $fallbacks, array('button'));
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -561,7 +561,11 @@ trait NavigationToggleSuppressionTrait
 
     private function convertsToCoreNavigation(DOMElement $element): bool
     {
-        $navigation = $this->patternRecognizers->firstMatch($element, $this->probePatternContext());
+        $navigation = $this->patternRecognizers->firstMatch(
+            $element,
+            $this->probePatternContext(),
+            array( \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern::class )
+        );
 
         return null !== $navigation && 'core/navigation' === ($navigation->block()['blockName'] ?? '');
     }

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$assertions = 0;
+$assert = static function (bool $condition, string $message) use (&$assertions): void {
+    ++$assertions;
+    if (! $condition) throw new RuntimeException($message);
+};
+
+$details = (new HtmlTransformer())->transform('<details><summary>More</summary><object data="/more.pdf"></object></details>')->toArray();
+$assert('core/details' === ($details['blocks'][0]['blockName'] ?? null), 'Native details remains ahead of generic container lowering.');
+$assert('html_unsupported_element' === ($details['fallbacks'][0]['diagnostic_code'] ?? null), 'Details commits child fallback diagnostics through the registry result.');
+
+$button = (new HtmlTransformer())->transform('<a href="/go" aria-label="Open" style="display:inline-block;background:#000;color:#fff;padding:1rem">Go</a>')->toArray();
+$assert('core/html' === ($button['blocks'][0]['blockName'] ?? null), 'Button recognition remains ahead of generic anchor lowering when its accessible-name fallback wins.');
+$assert('html_stylable_button_accessible_name_fallback' === ($button['fallbacks'][0]['diagnostic_code'] ?? null), 'Button fallback is committed by the staged registry dispatcher.');
+
+$quoteWithNavigation = (new HtmlTransformer())->transform('<blockquote><nav><a href="/one">One</a><a href="/two">Two</a></nav></blockquote>')->toArray();
+$assert('core/quote' === ($quoteWithNavigation['blocks'][0]['blockName'] ?? null), 'Quote child lowering does not re-enter unrelated registry recognizers through the navigation probe.');
+
+echo "pattern registry staged dispatch passed ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- complete the ordered typed registry migration left after #1037
- route Quote, Gallery, Buttons, and Details semantic recognition through staged registry dispatch
- scope navigation probing to `NavigationPattern` to prevent recursive unrelated recognition

## Verification
- `php tests/unit/pattern-recognizer-registry.php`
- `php tests/unit/pattern-registry-staged-dispatch.php`
- `composer test` (canonical, unit, 278 parity fixtures, packaging install proof)

Follow-up for #998 and #1037.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to inspect the completion delta, apply it onto current trunk, resolve compatibility against newer changes, and run verification. Chris Huber is responsible for every line.