### PR TITLE
fix(php-transformer): bound pseudo-form fallbacks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -13023,7 +13023,7 @@ final class HtmlTransformer
         $supersededRuntimeSelectors = $this->runtimeDomSelectorsForElement($element);
         if ( $replacesRuntimeIsland ) $supersededRuntimeSelectors[] = $this->runtimeIslandSelector($element);
 
-        return FallbackDiagnostic::build(array(
+        $finding = array(
             'type'            => 'html',
             'reason'          => 'form_requires_runtime',
             'diagnostic_code' => 'html_form_fallback',
@@ -13048,7 +13048,12 @@ final class HtmlTransformer
             'html'            => $boundedHtml['html'],
             'html_bytes'      => $boundedHtml['bytes'],
             'html_truncated'  => $boundedHtml['truncated'],
-        ), $this->fallbackProvenance);
+        );
+        if ( 'form' !== strtolower($element->tagName) ) {
+            $finding['form_boundary'] = $this->pseudoFormBoundaryMetadata($element);
+        }
+
+        return FallbackDiagnostic::build($finding, $this->fallbackProvenance);
     }
 
     /**
@@ -13056,6 +13061,16 @@ final class HtmlTransformer
      */
     private function formSuccessPanelMetadata(DOMElement $form): array
     {
+        if ( 'form' !== strtolower($form->tagName) ) {
+            foreach ( $this->descendantElements($form) as $descendant ) {
+                if ( $this->hasSuccessPanelSignal($descendant) ) {
+                    return $this->successPanelMetadata($descendant);
+                }
+            }
+
+            return array();
+        }
+
         for ( $sibling = $form->nextSibling; $sibling instanceof DOMNode; $sibling = $sibling->nextSibling ) {
             if ( XML_TEXT_NODE === $sibling->nodeType && '' === trim($sibling->textContent ?? '') ) {
                 continue;
@@ -13069,21 +13084,27 @@ final class HtmlTransformer
                 return array();
             }
 
-            $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($sibling));
-            return array_filter(array(
-                'selector'       => $this->elementSelector($sibling),
-                'id'             => $this->attr($sibling, 'id'),
-                'class'          => $this->attr($sibling, 'class'),
-                'role'           => $this->attr($sibling, 'role'),
-                'aria_live'      => $this->attr($sibling, 'aria-live'),
-                'text'           => $this->normalizedSuccessPanelText($sibling),
-                'html'           => $boundedHtml['html'],
-                'html_bytes'     => $boundedHtml['bytes'],
-                'html_truncated' => $boundedHtml['truncated'],
-            ), static fn (mixed $value): bool => is_bool($value) || is_int($value) || '' !== trim((string) $value));
+            return $this->successPanelMetadata($sibling);
         }
 
         return array();
+    }
+
+    /** @return array<string, mixed> */
+    private function successPanelMetadata(DOMElement $element): array
+    {
+        $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
+        return array_filter(array(
+            'selector'       => $this->elementSelector($element),
+            'id'             => $this->attr($element, 'id'),
+            'class'          => $this->attr($element, 'class'),
+            'role'           => $this->attr($element, 'role'),
+            'aria_live'      => $this->attr($element, 'aria-live'),
+            'text'           => $this->normalizedSuccessPanelText($element),
+            'html'           => $boundedHtml['html'],
+            'html_bytes'     => $boundedHtml['bytes'],
+            'html_truncated' => $boundedHtml['truncated'],
+        ), static fn (mixed $value): bool => is_bool($value) || is_int($value) || '' !== trim((string) $value));
     }
 
     private function normalizedSuccessPanelText(DOMElement $element): string
@@ -13129,6 +13150,12 @@ final class HtmlTransformer
             return false;
         }
 
+        // A pseudo-form must be a local interaction region, never the page shell
+        // that happens to contain navigation or editorial content plus controls.
+        if ( $this->pseudoFormContainsUnrelatedLandmark($element) ) {
+            return false;
+        }
+
         if ( ! $this->containerPairsDataEntryWithSubmit($element) ) {
             return false;
         }
@@ -13148,28 +13175,81 @@ final class HtmlTransformer
     }
 
     /**
-     * Whether a container holds at least one data-entry control AND at least one
-     * submit-like control. Reuses the issue #315 control-detection helpers
-     * (formControlElements / isDataEntryControl) so detection stays in one place.
+     * Whether a container holds a local, labeled data-entry control and a submit
+     * action. Unlike a real form, a div gives a plain button no submit ownership,
+     * so its action must be explicit in type or semantics.
      */
     private function containerPairsDataEntryWithSubmit(DOMElement $element): bool
     {
         $hasDataEntry = false;
+        $hasFieldLabel = false;
         $hasSubmit = false;
+        $hasActionControl = false;
+        $hasContainerAction = '' !== trim($this->attr($element, 'action')) || '' !== trim($this->attr($element, 'method')) || '' !== trim($this->attr($element, 'data-action'));
 
         foreach ( $this->formControlElements($element) as $control ) {
-            if ( $this->isPseudoFormDataEntryControl($control) ) {
+            if ( $this->isPseudoFormDataEntryControl($control) && ! $this->hasStandaloneSearchSignal($element, $control) ) {
                 $hasDataEntry = true;
-            } elseif ( $this->isSubmitLikeControl($control) ) {
-                $hasSubmit = true;
+                $hasFieldLabel = $hasFieldLabel || '' !== trim($this->formControlLabel($control)) || '' !== trim($this->attr($control, 'aria-label')) || '' !== trim($this->attr($control, 'name'));
+            } elseif ( 'button' === strtolower($control->tagName) || ( 'input' === strtolower($control->tagName) && ! in_array($this->formControlType($control), array( 'reset', 'button' ), true) ) ) {
+                $hasActionControl = true;
+                $hasSubmit = $hasSubmit || $this->isPseudoFormSubmitControl($control);
             }
 
-            if ( $hasDataEntry && $hasSubmit ) {
+            if ( $hasDataEntry && $hasFieldLabel && ( $hasSubmit || ( $hasContainerAction && $hasActionControl ) ) ) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function isPseudoFormSubmitControl(DOMElement $control): bool
+    {
+        $type = $this->formControlType($control);
+        if ( in_array($type, array( 'submit', 'image' ), true) ) {
+            return true;
+        }
+
+        return $this->hasSubmitSemantics($control);
+    }
+
+    private function pseudoFormContainsUnrelatedLandmark(DOMElement $element): bool
+    {
+        foreach ( $this->descendantElements($element) as $descendant ) {
+            $tagName = strtolower($descendant->tagName);
+            $role = strtolower($this->attr($descendant, 'role'));
+            if ( in_array($tagName, array( 'article', 'nav', 'header', 'footer', 'main' ), true)
+                || in_array($role, array( 'article', 'navigation', 'banner', 'contentinfo', 'main' ), true) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pseudoFormBoundaryMetadata(DOMElement $element): array
+    {
+        $rejectedAncestors = array();
+        for ( $ancestor = $element->parentNode; $ancestor instanceof DOMElement && count($rejectedAncestors) < 4; $ancestor = $ancestor->parentNode ) {
+            if ( ! $this->pseudoFormContainsUnrelatedLandmark($ancestor) && ! $this->containerPairsDataEntryWithSubmit($ancestor) ) {
+                continue;
+            }
+            $rejectedAncestors[] = array(
+                'selector' => $this->elementSelector($ancestor),
+                'reason'   => $this->pseudoFormContainsUnrelatedLandmark($ancestor) ? 'contains_unrelated_landmark' : 'contains_nested_coherent_form',
+            );
+        }
+
+        return array(
+            'schema' => 'generic/form-boundary/v1',
+            'selector' => $this->elementSelector($element),
+            'selection_basis' => array( 'local_controls', 'associated_label', 'submit_semantics' ),
+            'rejected_ancestors' => $rejectedAncestors,
+        );
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -786,6 +786,24 @@ $assert('form' === ($newsletterFallbackDiagnostic['suggested_primitive'] ?? ''),
 $assert('form_provider' === ($newsletterFallbackDiagnostic['materialization_target']['provider_role'] ?? ''), 'static newsletter form declares the form provider materialization role');
 $assert(0 === substr_count((string) ($newsletterFallback['serialized_blocks'] ?? ''), '<!-- wp:html'), 'readable newsletter form output avoids core/html while keeping fallback metadata explicit');
 
+$nestedPseudoForm = ( new HtmlTransformer() )->transform(
+    '<article><nav aria-label="Blog"><a href="/posts">Posts</a></nav><div class="content-wrapper"><h1>Article title</h1><p>Article copy stays editable.</p><div class="contact-panel" action="/contact"><label for="contact-email">Email</label><input id="contact-email" name="email" type="email"><button>Send message</button><p role="status">Thanks, we will reply shortly.</p></div><p>Related reading.</p></div></article>'
+)->toArray();
+$nestedPseudoFallback = $nestedPseudoForm['fallbacks'][0] ?? array();
+$nestedPseudoBoundary = $nestedPseudoFallback['form_boundary'] ?? array();
+$assert(1 === count($nestedPseudoForm['fallbacks'] ?? array()) && 'contact-panel' === ($nestedPseudoFallback['form']['class'] ?? ''), 'nested pseudo-form selects the local control region instead of its article wrapper');
+$assert('/contact' === ($nestedPseudoFallback['form']['action'] ?? '') && 'Email' === ($nestedPseudoFallback['controls'][0]['label'] ?? '') && 'Send message' === ($nestedPseudoFallback['controls'][1]['text'] ?? '') && 'Thanks, we will reply shortly.' === ($nestedPseudoFallback['success_panel']['text'] ?? ''), 'nested pseudo-form preserves action, associated label, submit text, and success-state metadata');
+$assert('generic/form-boundary/v1' === ($nestedPseudoBoundary['schema'] ?? '') && array( 'local_controls', 'associated_label', 'submit_semantics' ) === ($nestedPseudoBoundary['selection_basis'] ?? array()) && in_array('contains_unrelated_landmark', array_column($nestedPseudoBoundary['rejected_ancestors'] ?? array(), 'reason'), true), 'pseudo-form diagnostics explain the local boundary and rejected editorial ancestors');
+$assert(str_contains((string) ($nestedPseudoForm['serialized_blocks'] ?? ''), 'Article title') && str_contains((string) ($nestedPseudoForm['serialized_blocks'] ?? ''), 'Related reading.') && ! str_contains((string) ($nestedPseudoFallback['html'] ?? ''), 'Article title'), 'surrounding article content remains native blocks and outside pseudo-form fallback metadata');
+$actionPseudoForm = ( new HtmlTransformer() )->transform('<div action="/request-quote"><label for="quote-email">Email</label><input id="quote-email" name="email" type="email"><button>Continue</button></div>')->toArray();
+$assert('/request-quote' === ($actionPseudoForm['fallbacks'][0]['form']['action'] ?? '') && 'Continue' === ($actionPseudoForm['fallbacks'][0]['controls'][1]['text'] ?? ''), 'explicit local action semantics retain a coherent pseudo-form with a neutral submit label');
+
+$broadPseudoForm = ( new HtmlTransformer() )->transform(
+    '<div id="content-wrapper"><nav aria-label="Blog"><a href="/posts">Posts</a></nav><article><h1>Post title</h1><div class="search"><input class="search-input" type="text" placeholder="Search"></div><button aria-label="Share via Facebook">Share</button><p>Long article copy.</p></article></div>'
+)->toArray();
+$assert(array() === array_values(array_filter($broadPseudoForm['fallbacks'] ?? array(), static fn (array $fallback): bool => 'html_form_fallback' === ($fallback['diagnostic_code'] ?? ''))), 'search fields and unrelated buttons never promote a content wrapper to a pseudo-form');
+$assert(str_contains((string) ($broadPseudoForm['serialized_blocks'] ?? ''), 'Post title') && str_contains((string) ($broadPseudoForm['serialized_blocks'] ?? ''), 'Long article copy.'), 'rejected broad pseudo-form candidates remain ordinary native content');
+
 $commerceControls = ( new HtmlTransformer() )->transform(
     '<main><ul class="products"><li><article class="product-card"><h3>Tour Tee</h3><p>Heavy cotton shirt.</p><div class="price">$30</div><div aria-label="Quantity"><button data-dir="down" aria-label="Decrease quantity">-</button><span aria-live="polite">1</span><button data-dir="up" aria-label="Increase quantity">+</button></div><button class="add-to-cart">Add to cart</button></article></li><li><article class="product-card"><h3>Signed CD</h3><p>Hand-signed disc.</p><div class="price">$15</div><div aria-label="Quantity"><button data-dir="down" aria-label="Decrease quantity">-</button><span aria-live="polite">1</span><button data-dir="up" aria-label="Increase quantity">+</button></div><button class="add-to-cart">Add to cart</button></article></li></ul></main>'
 )->toArray();


### PR DESCRIPTION
## Summary
- select only local coherent div-based pseudo-form regions using labeled controls plus explicit submit or action semantics
- reject page, navigation, and editorial wrapper candidates; emit bounded form-boundary diagnostics for accepted pseudo-forms
- preserve pseudo-form success panels within the selected local region

Closes #1043

## Testing
- `php tests/contract/run.php`
- `composer run test:parity` (278 fixtures)
- `composer test`

## AI assistance
OpenAI GPT-5.6-terra via OpenCode general coding subagent inspected the supplied validation evidence, implemented the boundary selection and diagnostics, and ran the test suite. Chris Huber remains responsible for every line.