### PR TITLE
fix(php-transformer): coalesce deep media wrappers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -7573,7 +7573,7 @@ final class HtmlTransformer
         $sourceChild = is_int($provenanceId) ? $this->sameSourceGroupChainLeaf($element, (string) ($this->sourceProvenance[$provenanceId]['source_digest'] ?? '')) : null;
         if (! $sourceChild instanceof DOMElement && 'core/image' === ($childBlock['blockName'] ?? null)) $sourceChild = $this->imageLeafInGroupChain($element);
         if ( ! $sourceChild instanceof DOMElement
-            || ('core/image' === ($childBlock['blockName'] ?? null) && 'img' !== strtolower($sourceChild->tagName))
+            || ('core/image' === ($childBlock['blockName'] ?? null) && ! in_array(strtolower($sourceChild->tagName), array( 'img', 'svg' ), true) && ! str_contains($sourceChild->tagName, '-'))
             || $this->hasMotionStructureToken($sourceChild)
             || ($fullWidthTransparentShell ? ! $this->hasOnlyFullWidthTransparentBoxAffectingDeclarations($element) : ! $this->hasOnlyRenderNeutralBoxAffectingDeclarations($element))
             || ($fullWidthTransparentShell && ! $this->isNormalFlowFullWidthShellChild($sourceChild))
@@ -7629,8 +7629,17 @@ final class HtmlTransformer
     private function imageLeafInGroupChain(DOMElement $element): ?DOMElement
     {
         for ($child = $this->soleElementChild($element); $child instanceof DOMElement; $child = $this->soleElementChild($child)) {
-            if ('img' === strtolower($child->tagName)) return $child;
-            if (! in_array(strtolower($child->tagName), array('div', 'a'), true)) return null;
+            $tagName = strtolower($child->tagName);
+            if (in_array($tagName, array('img', 'svg'), true)) return $child;
+            // Captured media exports commonly place their native image behind a
+            // passive custom-element carrier. Its own conversion already proves
+            // it has no retained block boundary. Use the carrier as the source
+            // leaf so selector survival is checked against its actual identity.
+            if (str_contains($tagName, '-')) {
+                $mediaChild = $this->soleElementChild($child);
+                if ($mediaChild instanceof DOMElement && in_array(strtolower($mediaChild->tagName), array('img', 'svg'), true)) return $child;
+            }
+            if (! in_array($tagName, array('div', 'a'), true) && ! str_contains($tagName, '-')) return null;
         }
         return null;
     }

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -395,4 +395,21 @@ $deepStaged = $deepCompiler->compose($deepShared, array($deepReceipt))->toArray(
 $deepWhole = $deepCompiler->compile($deepArtifact)->toArray();
 $assert(($deepWhole['source_reports']['wordpress_site_plan'] ?? null) === ($deepStaged['source_reports']['wordpress_site_plan'] ?? null), 'Compiled receipt digests support deeply nested canonical block trees without weakening runtime declaration depth limits.');
 
+$svgMediaChain = '<svg viewBox="0 0 10 10" aria-label="Mark"><path d="M0 0h10v10H0z"/></svg>';
+for ($depth = 0; $depth < 44; ++$depth) $svgMediaChain = '<div class="depth-' . $depth . '">' . $svgMediaChain . '</div>';
+$wowMediaChain = '<wow-image class="captured-media"><img src="hero.jpg" alt="Hero"></wow-image>';
+for ($depth = 0; $depth < 39; ++$depth) $wowMediaChain = '<div class="depth-' . $depth . '">' . $wowMediaChain . '</div>';
+$deepMediaArtifact = array('entrypoint' => 'index.html', 'files' => array(
+    array('path' => 'index.html', 'content' => $svgMediaChain),
+    array('path' => 'post.html', 'content' => $wowMediaChain),
+));
+$deepMediaCompiler = new ArtifactCompiler();
+$deepMediaWhole = $deepMediaCompiler->compile($deepMediaArtifact)->toArray();
+$deepMediaShared = $deepMediaCompiler->prepareShared($deepMediaArtifact);
+$deepMediaReceipts = array();
+foreach ($deepMediaShared['analysis']['page_ids'] as $pageId) $deepMediaReceipts[] = $deepMediaCompiler->compilePage($deepMediaArtifact, $deepMediaShared, $pageId);
+$deepMediaStaged = $deepMediaCompiler->compose($deepMediaShared, array_reverse($deepMediaReceipts))->toArray();
+$assert('passed' === ($deepMediaWhole['source_reports']['editability_policy']['status'] ?? null) && 20 >= ($deepMediaWhole['source_reports']['editability_report']['metrics']['max_nesting_depth'] ?? PHP_INT_MAX), 'Depth-44 SVG and depth-39 custom media routes satisfy the unchanged editability nesting policy.');
+$assert($canonical($deepMediaWhole) === $canonical($deepMediaStaged), 'Deep media wrapper coalescing preserves direct and staged canonical equivalence.');
+
 fwrite(STDOUT, "Staged artifact compilation contract passed\n");

--- a/php-transformer/tests/fixtures/parity/html-inline-svg-local-use-symbol.json
+++ b/php-transformer/tests/fixtures/parity/html-inline-svg-local-use-symbol.json
@@ -22,13 +22,6 @@
     },
     {
       "path": "blocks.0.innerBlocks.0",
-      "name": "core/group",
-      "attrs": {
-        "className": "icon-row"
-      }
-    },
-    {
-      "path": "blocks.0.innerBlocks.0.innerBlocks.0",
       "name": "core/image"
     }
   ],

--- a/php-transformer/tests/fixtures/parity/html-linked-card-anchor-grid.json
+++ b/php-transformer/tests/fixtures/parity/html-linked-card-anchor-grid.json
@@ -19,7 +19,7 @@
     { "path": "blocks.0", "name": "core/group" },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-grid" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-card featured" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "article-thumb" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/image" },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "article-card-body" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.1", "name": "core/heading", "attrs": { "className": "article-headline", "content": "<a href=\"/story-one\">City Hall Rewrites the Map</a>", "level": 3 } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "article-card" } },

--- a/php-transformer/tests/unit/geometry-chain-coalescing.php
+++ b/php-transformer/tests/unit/geometry-chain-coalescing.php
@@ -18,6 +18,21 @@ $assert('core/image' === ($image['blockName'] ?? null) && array() === ($image['i
 $assert(str_contains((string) ($image['attrs']['className'] ?? ''), 'image-carrier') && str_contains((string) ($image['attrs']['className'] ?? ''), 'blocks-engine-synthetic-image-figure'), 'Coalescing moves the carrier selector and synthetic figure class onto the image block.');
 $assert('640px' === ($image['attrs']['width'] ?? null) && '360px' === ($image['attrs']['height'] ?? null) && str_contains($markup, 'src="hero.jpg"'), 'Image geometry and source survive coalescing.');
 
+$maxDepth = static function (array $blocks, int $depth = 0) use (&$maxDepth): int {
+    $maximum = $depth;
+    foreach ($blocks as $block) $maximum = max($maximum, $maxDepth($block['innerBlocks'] ?? array(), $depth + 1));
+    return $maximum;
+};
+$svgChain = '<svg viewBox="0 0 10 10" aria-label="Mark"><path d="M0 0h10v10H0z"/></svg>';
+for ($depth = 0; $depth < 44; ++$depth) $svgChain = '<div class="depth-' . $depth . '">' . $svgChain . '</div>';
+$deepSvg = $transform($svgChain);
+$assert('core/image' === ($deepSvg['blocks'][0]['blockName'] ?? null) && $maxDepth($deepSvg['blocks'] ?? array()) <= 20 && 1 === count(array_filter($deepSvg['assets'] ?? array(), static fn (array $asset): bool => 'svg' === ($asset['kind'] ?? null))), 'A depth-44 passive SVG image chain coalesces to one native image without losing its materialized asset.');
+
+$wowChain = '<wow-image class="captured-media"><img src="hero.jpg" alt="Hero"></wow-image>';
+for ($depth = 0; $depth < 39; ++$depth) $wowChain = '<div class="depth-' . $depth . '">' . $wowChain . '</div>';
+$deepWow = $transform($wowChain);
+$assert('core/image' === ($deepWow['blocks'][0]['blockName'] ?? null) && $maxDepth($deepWow['blocks'] ?? array()) <= 20 && str_contains((string) ($deepWow['blocks'][0]['attrs']['className'] ?? ''), 'captured-media') && str_contains((string) ($deepWow['serialized_blocks'] ?? ''), 'src="hero.jpg"'), 'A depth-39 custom media chain coalesces while preserving media selector ownership and image semantics.');
+
 $fullWidth = $transform('<div style="width:100%"><div class="surface"><p>Copy</p></div></div>');
 $fullWidthBlock = $fullWidth['blocks'][0] ?? array();
 $assert('core/group' === ($fullWidthBlock['blockName'] ?? null) && str_contains((string) ($fullWidthBlock['attrs']['className'] ?? ''), 'surface') && str_contains((string) ($fullWidthBlock['attrs']['className'] ?? ''), 'be-inline-geometry-') && str_contains($engineCss($fullWidth), 'width:100% !important'), 'A full-width transparent normal-flow shell coalesces its generated width carrier onto the surviving group.');
@@ -52,5 +67,8 @@ $assert('core/group' === ($selectorOwned['blocks'][0]['blockName'] ?? null), 'A 
 
 $slider = $transform('<div class="slider image-carrier"><img src="hero.jpg" alt="Hero"></div>');
 $assert('core/group' === ($slider['blocks'][0]['blockName'] ?? null), 'Runtime-shaped slider topology is never flattened around media.');
+
+$customSelectorOwned = $transform('<style>.shell wow-image{border:1px solid red}</style><div class="shell"><wow-image><img src="hero.jpg" alt="Hero"></wow-image></div>');
+$assert('core/group' === ($customSelectorOwned['blocks'][0]['blockName'] ?? null), 'A custom media carrier whose ancestor selector relationship would change retains its wrapper.');
 
 fwrite(STDOUT, "Geometry chain coalescing contract passed\n");


### PR DESCRIPTION
## Summary
- coalesce render-neutral wrapper chains that terminate in passive SVG or custom-element media carriers
- retain the existing runtime, layout, selector, interaction, and geometry safeguards
- add depth-44 SVG and depth-39 custom-media coverage with unchanged editability policy and staged equivalence

Closes #1039

## Testing
- `composer --working-dir=php-transformer test`

## AI assistance
OpenAI GPT-5.6-sol via OpenCode general coding subagent was used to trace the media-wrapper paths, implement the change, and run tests. Chris Huber remains responsible for every line.