### PR TITLE
Fix converted navigation submenu clipping

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1294,6 +1294,14 @@ final class HtmlTransformer
             if ( '' !== $mobileOverlayBackground ) {
                 $afterAuthorCssParts[] = '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation__responsive-container.is-menu-open{background:' . $mobileOverlayBackground . '!important}';
             }
+            if ( str_contains($serializedBlocks, 'wp:navigation-submenu') ) {
+                // Source shell containers commonly clip their original, in-flow
+                // menu. Core's generated desktop submenu extends outside that
+                // box, so release only converted Group ancestors that contain it.
+                // Zero specificity lets an authored !important overflow remain
+                // authoritative, and leaves Core's mobile overlay untouched.
+                $afterAuthorCssParts[] = ':where(.wp-block-group:has(.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation-submenu)){overflow:visible!important}';
+            }
         }
         if ( str_contains($serializedBlocks, 'blocks-engine-inline-navigation') ) {
             $afterAuthorCssParts[] = '.wp-block-navigation.blocks-engine-native-responsive-navigation.blocks-engine-inline-navigation{display:inline-flex!important}';

--- a/php-transformer/tests/unit/navigation-brand-cue-carrier.php
+++ b/php-transformer/tests/unit/navigation-brand-cue-carrier.php
@@ -548,6 +548,27 @@ $assert(
     'blocks=' . json_encode($submenuBlocks) . ' css=' . substr($submenuCss, -700)
 );
 
+$clippedSubmenu = $transform(
+    '<style>#header-wrapper .container{display:table;overflow:hidden;position:relative}</style>'
+        . '<header id="header-wrapper"><div class="container"><nav><ul>'
+        . '<li><a href="/services">Services</a><ul><li><a href="/design">Design</a></li></ul></li>'
+        . '<li><a href="/about">About</a></li></ul></nav></div></header>'
+);
+$clippedSubmenuCss = implode("\n", array_map(
+    static fn (array $asset): string => 'css' === ($asset['kind'] ?? '') ? (string) ($asset['content'] ?? '') : '',
+    is_array($clippedSubmenu['assets'] ?? null) ? $clippedSubmenu['assets'] : array()
+));
+$assert(
+    str_contains(
+        $clippedSubmenuCss,
+        ':where(.wp-block-group:has(.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation-submenu)){overflow:visible!important}'
+    )
+        && ! str_contains($clippedSubmenuCss, '.wp-block-navigation.blocks-engine-list-navigation{overflow:visible')
+        && ! str_contains($clippedSubmenuCss, '.wp-block-navigation__responsive-container{overflow:visible'),
+    'a native submenu releases only its converted Group ancestors from source overflow clipping',
+    substr($clippedSubmenuCss, -900)
+);
+
 $inlineColour = $transform(
     '<nav><a href="/" style="color:#aa1100">Home</a><a href="/about" style="color:#aa1100">About</a></nav>'
 );


### PR DESCRIPTION
## Summary

- release converted Group ancestors from source overflow clipping when a native navigation submenu exists
- keep the override zero-specificity and scoped away from Core navigation and responsive-container overflow
- preserve authored important declarations and mobile overlay behavior

Closes #1004.

## Verification

- `cd php-transformer && composer validate --strict`
- `cd php-transformer && composer test`
- 278 parity fixtures and 41 navigation carrier assertions passed

## AI assistance

OpenAI gpt-5.6-terra and gpt-5.6-sol via OpenCode implemented and independently reviewed the candidate, trunk compatibility, and verification evidence. Chris Huber reviewed and is responsible for every line.