### PR TITLE
fix(php-transformer): materialize authored marquees

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -65,6 +65,7 @@
       "php tests/unit/asset-reference-canonicalizer-memory.php",
       "php tests/unit/srcset-parser.php",
        "php tests/unit/responsive-media-block.php",
+       "php tests/unit/authored-marquee-block.php",
        "php tests/unit/responsive-document-variants.php",
        "php tests/unit/editability-report.php",
       "php tests/unit/core-block-capability-matrix.php",

--- a/php-transformer/src/HtmlToBlocks/AuthoredMarqueeBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthoredMarqueeBlockGenerator.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/** Builds an editable, bounded companion block for authored text marquees. */
+final class AuthoredMarqueeBlockGenerator
+{
+    public const LOCAL_NAME = 'authored-marquee';
+
+    /** @return array<string, mixed> */
+    public function blockJson(string $namespace): array
+    {
+        return array(
+            'apiVersion' => 3,
+            'name' => $namespace . '/' . self::LOCAL_NAME,
+            'title' => 'Animated Text',
+            'category' => 'text',
+            'description' => 'Editable scrolling text that respects reduced motion.',
+            'editorScript' => 'file:./index.js',
+            'attributes' => array(
+                'content' => array( 'type' => 'string', 'default' => '' ),
+                'direction' => array( 'type' => 'string', 'default' => 'left' ),
+                'duration' => array( 'type' => 'number', 'default' => 40 ),
+            ),
+            'supports' => array( 'html' => false ),
+            'render' => 'file:./render.php',
+        );
+    }
+
+    /** @return array<string, string> */
+    public function assets(string $blockName): array
+    {
+        $script = <<<'JS'
+( function( blocks, blockEditor, element ) {
+    var createElement = element.createElement;
+    function edit( props ) {
+        return createElement( 'div', blockEditor.useBlockProps(), createElement( blockEditor.RichText, {
+            tagName: 'p',
+            value: props.attributes.content || '',
+            onChange: function( content ) { props.setAttributes( { content: content } ); },
+            placeholder: 'Animated text'
+        } ) );
+    }
+    blocks.registerBlockType( '__BLOCK_NAME__', {
+        attributes: { content: { type: 'string', default: '' }, direction: { type: 'string', default: 'left' }, duration: { type: 'number', default: 40 } },
+        supports: { html: false },
+        edit: edit,
+        save: function() { return null; }
+    } );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
+JS;
+
+        $render = <<<'PHP'
+<?php
+$content = isset( $attributes['content'] ) ? wp_kses_post( (string) $attributes['content'] ) : '';
+$direction = 'right' === ( $attributes['direction'] ?? '' ) ? 'right' : 'left';
+$duration = isset( $attributes['duration'] ) ? (float) $attributes['duration'] : 40;
+$duration = min( 600, max( 1, $duration ) );
+?>
+<div <?php echo get_block_wrapper_attributes( array( 'class' => 'blocks-engine-authored-marquee', 'style' => '--blocks-engine-marquee-duration:' . esc_attr( $duration ) . 's' ) ); ?> data-direction="<?php echo esc_attr( $direction ); ?>">
+    <div class="blocks-engine-authored-marquee__viewport">
+        <div class="blocks-engine-authored-marquee__track"><span class="blocks-engine-authored-marquee__content"><?php echo $content; ?></span><span class="blocks-engine-authored-marquee__content" aria-hidden="true"><?php echo $content; ?></span></div>
+    </div>
+</div>
+<style>
+.blocks-engine-authored-marquee{max-width:100%;min-width:0}.blocks-engine-authored-marquee__viewport{max-width:100%;overflow-x:clip}@supports not (overflow:clip){.blocks-engine-authored-marquee__viewport{overflow:hidden}}.blocks-engine-authored-marquee__track{display:flex;width:max-content;min-width:100%;animation:blocks-engine-authored-marquee var(--blocks-engine-marquee-duration,40s) linear infinite}.blocks-engine-authored-marquee[data-direction="right"] .blocks-engine-authored-marquee__track{animation-direction:reverse}.blocks-engine-authored-marquee__content{flex:none;padding-inline-end:1rem}.blocks-engine-authored-marquee__content[aria-hidden="true"]{user-select:none}@keyframes blocks-engine-authored-marquee{to{transform:translateX(-50%)}}@media (prefers-reduced-motion:reduce){.blocks-engine-authored-marquee__track{width:auto;white-space:normal;animation:none;transform:none}.blocks-engine-authored-marquee__content[aria-hidden="true"]{display:none}}
+</style>
+PHP;
+
+        return array( 'index.js' => str_replace('__BLOCK_NAME__', $blockName, $script), 'render.php' => $render );
+    }
+
+    /** @return array<string, mixed> */
+    public function definition(string $namespace): array
+    {
+        return array(
+            'name' => self::LOCAL_NAME,
+            'block_json' => $this->blockJson($namespace),
+            'assets' => $this->assets($namespace . '/' . self::LOCAL_NAME),
+            'script_dependencies' => array( 'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) ),
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4503,6 +4503,10 @@ final class HtmlTransformer
         }
 
         if ( 'p' === $tagName ) {
+            $marquee = $this->authoredMarqueeBlock($element);
+            if ( null !== $marquee ) {
+                return $marquee;
+            }
             $content = $this->richTextContentWithMaterializedInlineStyles($element);
             $inlineSvgContent = $this->richTextContentWithMaterializedSvgImages($element, $content);
             if ( null !== $inlineSvgContent ) {
@@ -14454,6 +14458,59 @@ final class HtmlTransformer
             array(),
             $element
         );
+    }
+
+    /** @return array<string, mixed>|null */
+    private function authoredMarqueeBlock(DOMElement $element): ?array
+    {
+        $track = null;
+        foreach ( $element->getElementsByTagName('*') as $candidate ) {
+            if ( $candidate instanceof DOMElement && in_array($this->attr($candidate, 'data-marquee-animation'), array( 'left', 'right' ), true) ) {
+                $track = $candidate;
+                break;
+            }
+        }
+        if ( ! $track instanceof DOMElement ) {
+            return null;
+        }
+
+        $content = '';
+        foreach ( $track->getElementsByTagName('*') as $candidate ) {
+            if ( ! $candidate instanceof DOMElement || 'true' === $this->attr($candidate, 'aria-hidden') || 0 !== $candidate->childElementCount ) {
+                continue;
+            }
+            $text = trim($candidate->textContent ?? '');
+            if ( '' !== $text ) {
+                $content = $this->runtime->escapeHtml($text);
+                break;
+            }
+        }
+        if ( '' === $content ) {
+            return null;
+        }
+
+        if ( ! $this->authoredMarqueeBlockGenerated ) {
+            $this->generatedBlocks[] = ( new AuthoredMarqueeBlockGenerator() )->definition($this->generatedBlockNamespace);
+            $this->authoredMarqueeBlockGenerated = true;
+        }
+
+        $duration = 40.0;
+        $durationCandidates = array( $this->cssDeclarations($this->attr($track, 'style'))['--marquee-duration'] ?? '' );
+        for ( $carrier = $element; $carrier instanceof DOMElement && 'body' !== strtolower($carrier->tagName); $carrier = $carrier->parentNode instanceof DOMElement ? $carrier->parentNode : null ) {
+            $durationCandidates[] = $this->cssDeclarations($this->attr($carrier, 'style'))['--marquee-duration'] ?? '';
+        }
+        foreach ( $durationCandidates as $value ) {
+            if ( preg_match('/^([0-9]+(?:\.[0-9]+)?)s$/', trim((string) $value), $matches) ) {
+                $duration = (float) $matches[1];
+                break;
+            }
+        }
+
+        return $this->createBlock($this->generatedBlockNamespace . '/' . AuthoredMarqueeBlockGenerator::LOCAL_NAME, array(
+            'content' => $content,
+            'direction' => $this->attr($track, 'data-marquee-animation'),
+            'duration' => min(600, max(1, $duration)),
+        ), array(), $element);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -38,6 +38,7 @@ final class HtmlTransformerSession
     public bool $formSelectBlockGenerated = false;
     public bool $formInputBlockGenerated = false;
     public bool $responsiveMediaBlockGenerated = false;
+    public bool $authoredMarqueeBlockGenerated = false;
     public bool $emptyRuntimeTargetGenerated = false;
     public bool $capturedDialogBlockGenerated = false;
     public string $generatedBlockNamespace = 'custom';

--- a/php-transformer/tests/unit/authored-marquee-block.php
+++ b/php-transformer/tests/unit/authored-marquee-block.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\AuthoredMarqueeBlockGenerator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+
+$assert = static function (bool $condition, string $message): void {
+    if ( ! $condition ) {
+        fwrite(STDERR, 'FAIL: ' . $message . PHP_EOL);
+        exit(1);
+    }
+};
+
+$source = '<div style="--marquee-duration: 17.5s"><p><span data-marquee-animation="left"><span><span>Protecting what matters</span></span><span aria-hidden="true">Protecting what matters</span></span></p></div>';
+$result = ( new HtmlTransformer() )->transform($source)->toArray();
+$block = $result['blocks'][0] ?? array();
+$assert('custom/authored-marquee' === ($block['blockName'] ?? null), 'generic marquee metadata uses the authored marquee companion');
+$assert('Protecting what matters' === ($block['attrs']['content'] ?? null), 'the first visible authored text remains directly editable');
+$assert('left' === ($block['attrs']['direction'] ?? null) && 17.5 === ($block['attrs']['duration'] ?? null), 'direction and timing intent are preserved');
+$assert(!str_contains((string) ($result['serialized_blocks'] ?? ''), '<!-- wp:html'), 'marquee content emits no raw HTML block');
+$definition = $result['source_reports']['generated_blocks'][0] ?? array();
+$render = (string) ($definition['assets']['render.php'] ?? '');
+$editor = (string) ($definition['assets']['index.js'] ?? '');
+$assert(str_contains($editor, 'RichText') && !str_contains($editor, 'RawHTML'), 'the companion edits one text value without duplicating editor content');
+$assert(str_contains($render, 'overflow-x:clip') && str_contains($render, 'max-width:100%') && str_contains($render, 'aria-hidden="true"'), 'the runtime contract clips duplicate tracks inside a bounded viewport');
+$assert(str_contains($render, 'prefers-reduced-motion:reduce') && str_contains($render, 'animation:none') && str_contains($render, 'display:none'), 'reduced motion leaves one readable static track');
+$serialized = ( new Runtime() )->serializeBlocks(array($block));
+$assert('custom/authored-marquee' === (new Runtime())->parseBlocks($serialized)[0]['blockName'], 'the companion reference persists through parse and serialize');
+
+fwrite(STDOUT, "Authored marquee companion tests passed\n");


### PR DESCRIPTION
## Summary

- convert generic `data-marquee-animation` text carriers into one editable typed companion block
- preserve authored direction and timing while rendering a clipped, duplicated runtime track
- provide reduced-motion static content and parse/serialize coverage

Closes #1041

## Testing

- `php tests/unit/authored-marquee-block.php`
- `composer test`
- Raw artifact validation against the supplied desktop/mobile evidence: both marquee instances preserve source text and durations without marquee `core/html`.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode general coding subagent was used to inspect the source artifact, implement the companion primitive, and run tests. Chris Huber remains responsible for every line.