### PR TITLE
Fix structural markup leaking into RichText

### DIFF
--- a/php-transformer/src/Contract/EditabilityReport.php
+++ b/php-transformer/src/Contract/EditabilityReport.php
@@ -55,7 +55,7 @@ final class EditabilityReport
             'metrics' => $metrics,
             'deepest_block' => $deepestBlock,
             'block_types' => $blockTypes,
-            'signals' => array_slice($signals, 0, self::MAX_REPORTED_SIGNALS),
+            'signals' => $this->boundedSignals($signals),
             'signal_totals' => array(
                 'observed' => $signalCount,
                 'reported' => min($signalCount, self::MAX_REPORTED_SIGNALS),
@@ -118,7 +118,7 @@ final class EditabilityReport
             'metrics' => $totals,
             'block_types' => $blockTypes,
             'documents' => $reports,
-            'signals' => array_slice($signals, 0, self::MAX_REPORTED_SIGNALS),
+            'signals' => $this->boundedSignals($signals),
             'signal_totals' => array(
                 'observed' => $signalCount,
                 'reported' => min($signalCount, self::MAX_REPORTED_SIGNALS),
@@ -194,7 +194,7 @@ final class EditabilityReport
                 if (str_starts_with($class, 'blocks-engine-source-')) $metrics['source_marker_class_count']++;
                 if (str_starts_with($class, 'be-inline-geometry-')) $metrics['generated_geometry_class_count']++;
             }
-            $this->inspectAttributes($attrs, $name, $sourcePath, $blockPath, $metrics, $signals);
+            $this->inspectAttributes($attrs, $name, $sourcePath, $blockPath, $metrics, $signals, $provenanceByBlockPath[implode('.', $blockPath)] ?? array());
             if (array() !== $innerBlocks) $this->walk($innerBlocks, $depth + 1, $blockPath, $metrics, $blockTypes, $signals, $sourcePath, $generatedCarrierCss, $runtimeBlockPaths, $visualBlockPaths, $provenanceByBlockPath, $deepestBlock);
         }
     }
@@ -242,8 +242,8 @@ final class EditabilityReport
         return false;
     }
 
-    /** @param array<string,mixed> $attrs @param array<int,int> $path @param array<string,int|float> $metrics @param array<int,array<string,mixed>> $signals */
-    private function inspectAttributes(array $attrs, string $blockName, string $sourcePath, array $path, array &$metrics, array &$signals): void
+    /** @param array<string,mixed> $attrs @param array<int,int> $path @param array<string,int|float> $metrics @param array<int,array<string,mixed>> $signals @param array<string,mixed> $provenance */
+    private function inspectAttributes(array $attrs, string $blockName, string $sourcePath, array $path, array &$metrics, array &$signals, array $provenance): void
     {
         $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($attrs), \RecursiveIteratorIterator::LEAVES_ONLY);
         foreach ($iterator as $key => $value) {
@@ -258,7 +258,7 @@ final class EditabilityReport
                 $metrics['structural_rich_text_attribute_bytes'] += strlen($value);
                 $kind = 'structural_rich_text_attribute';
             }
-            $signals[] = $this->signal($kind, $sourcePath, $path, $blockName, (string) $key);
+            $signals[] = $this->signal($kind, $sourcePath, $path, $blockName, (string) $key, $provenance);
         }
     }
 
@@ -269,8 +269,8 @@ final class EditabilityReport
         return false;
     }
 
-    /** @param array<int,int> $path @return array<string,mixed> */
-    private function signal(string $kind, string $sourcePath, array $path, string $blockName, string $attribute = ''): array
+    /** @param array<int,int> $path @param array<string,mixed> $provenance @return array<string,mixed> */
+    private function signal(string $kind, string $sourcePath, array $path, string $blockName, string $attribute = '', array $provenance = array()): array
     {
         return array_filter(array(
             'kind' => $kind,
@@ -278,6 +278,17 @@ final class EditabilityReport
             'block_path' => implode('.', $path),
             'block_name' => $blockName,
             'attribute' => $attribute,
+            'source_selector' => is_string($provenance['selector'] ?? null) ? $provenance['selector'] : '',
+            'source_fragment' => is_string($provenance['source_fragment'] ?? null) ? substr($provenance['source_fragment'], 0, 512) : '',
         ), static fn(string $value): bool => '' !== $value);
+    }
+
+    /** @param array<int,array<string,mixed>> $signals @return array<int,array<string,mixed>> */
+    private function boundedSignals(array $signals): array
+    {
+        // Preserve actionable policy failures when a noisy document reaches the
+        // evidence cap; aggregate counts still describe omitted lower-priority facts.
+        usort($signals, static fn(array $left, array $right): int => ('structural_rich_text_attribute' === ($right['kind'] ?? '')) <=> ('structural_rich_text_attribute' === ($left['kind'] ?? '')));
+        return array_slice($signals, 0, self::MAX_REPORTED_SIGNALS);
     }
 }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4610,6 +4610,15 @@ final class HtmlTransformer
 
             $richTextMarker = $this->richTextMarkerForElement($element);
             if ( '' !== $richTextMarker ) {
+                // RichText only accepts phrasing content. Keep a selector-addressed
+                // inline wrapper editable when it contains layout/content blocks by
+                // lowering its children instead of storing structural HTML in content.
+                if ( $this->hasBlockContentChildren($element) || $this->richTextContentHasStructuralHtml($this->innerHtml($element)) ) {
+                    $children = $this->convertChildren($element, $fallbacks, true);
+                    if ( array() !== $children ) {
+                        return $this->createBlock('core/group', $this->presentationAttributes($element), $children, $element);
+                    }
+                }
                 $content = $this->innerHtml($element);
                 if ( '' !== trim($this->runtime->stripAllTags($content)) ) {
                     $declarations = $this->richTextInlineVisualDeclarations($element);
@@ -5483,6 +5492,17 @@ final class HtmlTransformer
      */
     private function createBlock(string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
     {
+        if ( $sourceElement instanceof DOMElement
+            && in_array($name, array( 'core/paragraph', 'core/heading', 'core/list-item' ), true)
+            && $this->richTextContentHasStructuralHtml((string) ($attrs['content'] ?? ''))
+        ) {
+            $structuralFallbacks = array();
+            $children = $this->convertChildren($sourceElement, $structuralFallbacks, true);
+            if ( array() !== $children ) {
+                return $this->createBlock('core/group', $this->presentationAttributes($sourceElement), $children, $sourceElement, $logicalSourceElement);
+            }
+        }
+
         $preserveInlineLayoutLeaf = ! empty($attrs['preserveInlineLayoutLeaf']);
         unset($attrs['preserveInlineLayoutLeaf']);
         if ( ! $preserveInlineLayoutLeaf ) {
@@ -7039,6 +7059,11 @@ final class HtmlTransformer
     private function richTextRequiresHtmlFallback(string $content): bool
     {
         return (bool) preg_match('/<(?:svg|canvas|img|picture|video|audio|iframe|object|embed|input|button|select|textarea|form)\b/i', $content);
+    }
+
+    private function richTextContentHasStructuralHtml(string $content): bool
+    {
+        return (bool) preg_match('/<(?:address|article|aside|blockquote|details|div|dl|figure|h[1-6]|hr|main|menu|nav|ol|p|pre|section|table|ul)\b/i', $content);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/QuotePattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/QuotePattern.php
@@ -131,6 +131,13 @@ final class QuotePattern
      */
     private function phrasingQuoteChildren(DOMElement $element, string $value, callable $isInlineContentElement, callable $createBlock): array
     {
+        // A blockquote may be wrapped in phrasing elements while still carrying
+        // structural descendants. Send that shape through child lowering so the
+        // structural nodes become inner blocks rather than paragraph RichText.
+        if ( preg_match('/<(?:address|article|aside|blockquote|details|div|dl|figure|h[1-6]|hr|main|menu|nav|ol|p|pre|section|table|ul)\b/i', $value) ) {
+            return array();
+        }
+
         $isDirectText = true;
         foreach ( $element->childNodes as $child ) {
             if ( XML_TEXT_NODE === $child->nodeType ) {

--- a/php-transformer/tests/unit/editability-report.php
+++ b/php-transformer/tests/unit/editability-report.php
@@ -65,6 +65,23 @@ if ('structural_rich_text_attribute' !== ($richTextReport['signals'][0]['kind'] 
 $richTextPolicy = (new EditabilityPolicy())->evaluate($richTextReport);
 if ('failed' !== $richTextPolicy['status'] || 'required' !== $richTextPolicy['enforcement'] || 'structural_rich_text_attribute_count' !== ($richTextPolicy['failures'][0]['metric'] ?? null) || 'standalone.html' !== ($richTextPolicy['failures'][0]['source_path'] ?? null)) throw new RuntimeException('Standalone reports fail the bounded meaningful-editability policy with source-path attribution.');
 
+$structuralFixture = array(
+    array('blockName' => 'core/paragraph', 'attrs' => array('content' => '<div><h2>Heading</h2></div>'), 'innerBlocks' => array()),
+    array('blockName' => 'core/heading', 'attrs' => array('content' => '<section><p>Copy</p></section>'), 'innerBlocks' => array()),
+    array('blockName' => 'core/list-item', 'attrs' => array('content' => '<figure><img src="card.jpg" alt="Card"></figure>'), 'innerBlocks' => array()),
+);
+$structuralProvenance = array(
+    array('block_path' => 'blocks.0', 'selector' => '.quote > span', 'source_fragment' => '<span><div><h2>Heading</h2></div></span>'),
+    array('block_path' => 'blocks.1', 'selector' => '.feature > em', 'source_fragment' => '<em><section><p>Copy</p></section></em>'),
+    array('block_path' => 'blocks.2', 'selector' => '.cards > li', 'source_fragment' => '<li><figure><img src="card.jpg" alt="Card"></figure></li>'),
+);
+$structuralFixtureReport = (new EditabilityReport())->fromBlocks($structuralFixture, 'fixture.html', '', '', array(), array(), $structuralProvenance);
+$structuralSignals = array_values(array_filter($structuralFixtureReport['signals'], static fn(array $signal): bool => 'structural_rich_text_attribute' === ($signal['kind'] ?? '')));
+if (3 !== ($structuralFixtureReport['metrics']['structural_rich_text_attribute_count'] ?? null) || array('0', '1', '2') !== array_column($structuralSignals, 'block_path') || array('core/paragraph', 'core/heading', 'core/list-item') !== array_column($structuralSignals, 'block_name') || array('.quote > span', '.feature > em', '.cards > li') !== array_column($structuralSignals, 'source_selector') || !str_contains((string) ($structuralSignals[2]['source_fragment'] ?? ''), 'card.jpg')) throw new RuntimeException('Structural RichText fixtures attribute every affected attribute to its block, selector, and bounded source fragment.');
+
+$noisySignals = (new EditabilityReport())->fromBlocks(array_merge(array_fill(0, 100, array('blockName' => 'core/group', 'attrs' => array(), 'innerBlocks' => array(), 'innerHTML' => '')), $structuralFixture), 'fixture.html', '', '', array(), array(), $structuralProvenance)['signals'];
+if (3 !== count(array_filter($noisySignals, static fn(array $signal): bool => 'structural_rich_text_attribute' === ($signal['kind'] ?? '')))) throw new RuntimeException('Bounded evidence retains every structural RichText finding ahead of lower-priority wrapper signals.');
+
 $intentionalEmpties = (new EditabilityReport())->fromBlocks(array(
     array('blockName' => 'core/group', 'attrs' => array('className' => 'be-inline-geometry-deadbeef'), 'innerBlocks' => array(), 'innerHTML' => ''),
     array('blockName' => 'core/group', 'attrs' => array('style' => array('color' => array('text' => '#123456'))), 'innerBlocks' => array(), 'innerHTML' => ''),

--- a/php-transformer/tests/unit/list-item-lowering.php
+++ b/php-transformer/tests/unit/list-item-lowering.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\BlockValidityValidator;
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $native = (new HtmlTransformer())->transform('<ul><li>Plain <strong>copy</strong><ul><li>Nested</li></ul></li></ul>')->toArray();
 if ('core/list' !== ($native['blocks'][0]['blockName'] ?? null)) throw new RuntimeException('RichText lists must remain native core/list output.');
@@ -31,5 +33,23 @@ $inlineFlow = (new HtmlTransformer())->transform('<ol><li><span>1</span><div><st
 $inlineFlowMarkup = (string) ($inlineFlow['serialized_blocks'] ?? '');
 if (!str_contains($inlineFlowMarkup, '<p class="blocks-engine-synthetic-paragraph"><strong>Observe</strong></p>')) throw new RuntimeException('Standalone inline content in a structural item must use a margin-neutral synthetic paragraph.');
 if ('pass' !== ($inlineFlow['source_reports']['wp_block_validity']['status'] ?? null)) throw new RuntimeException('Structural item inline carriers must remain Gutenberg-valid.');
+
+$markedStructural = (new HtmlTransformer())->transform('<style>.quote span{color:#123}</style><div class="quote"><span><div><h3>Quote <em>heading</em></h3><p>Body <a href="/source">link</a></p><img src="quote.jpg" alt="Quote"></div></span></div>')->toArray();
+$markedBlocks = $markedStructural['blocks'] ?? array();
+$markedMarkup = (string) ($markedStructural['serialized_blocks'] ?? '');
+$markedReport = $markedStructural['source_reports']['editability_report'] ?? array();
+if ('core/group' !== ($markedBlocks[0]['innerBlocks'][0]['blockName'] ?? null) || 'core/group' !== ($markedBlocks[0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? null) || 'core/heading' !== ($markedBlocks[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] ?? null) || 'core/paragraph' !== ($markedBlocks[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][1]['blockName'] ?? null) || 'core/image' !== ($markedBlocks[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][2]['blockName'] ?? null) || 0 !== ($markedReport['metrics']['structural_rich_text_attribute_count'] ?? -1)) throw new RuntimeException('Selector-addressed inline containers lower structural children to native editable blocks instead of RichText attributes.');
+if (!str_contains($markedMarkup, '<em>heading</em>') || !str_contains($markedMarkup, '<a href="/source">link</a>') || 'pass' !== ((new BlockValidityValidator())->validateBlocks($markedBlocks)['status'] ?? '')) throw new RuntimeException('Structural lowering retains genuine inline formatting and Gutenberg block validity.');
+$runtime = new Runtime();
+$persisted = $runtime->parseBlocks($runtime->serializeBlocks($markedBlocks));
+$persisted[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][0]['innerHTML'] = '<h3 class="wp-block-heading">Edited <em>heading</em></h3>';
+$persisted[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][0]['innerContent'] = array('<h3 class="wp-block-heading">Edited <em>heading</em></h3>');
+$persisted[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][1]['innerHTML'] = '<p>Edited <a href="/updated">link</a></p>';
+$persisted[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][1]['innerContent'] = array('<p>Edited <a href="/updated">link</a></p>');
+$edited = $runtime->serializeBlocks($persisted);
+if (!str_contains($edited, 'Edited <em>heading</em>') || !str_contains($edited, '<a href="/updated">link</a>') || 'pass' !== ((new BlockValidityValidator())->validateBlocks($runtime->parseBlocks($edited))['status'] ?? '')) throw new RuntimeException('Native structural children persist text and link edits through parse and serialize.');
+
+$structuralQuote = (new HtmlTransformer())->transform('<style>.quote span{color:#123}</style><blockquote class="quote"><span><div><p>Quoted <strong>copy</strong> <a href="/quote">link</a></p></div></span></blockquote>')->toArray();
+if (0 !== ($structuralQuote['source_reports']['editability_report']['metrics']['structural_rich_text_attribute_count'] ?? -1) || !str_contains((string) ($structuralQuote['serialized_blocks'] ?? ''), '<strong>copy</strong>') || !str_contains((string) ($structuralQuote['serialized_blocks'] ?? ''), '<a href="/quote">link</a>') || 'pass' !== ((new BlockValidityValidator())->validateBlocks($structuralQuote['blocks'] ?? array())['status'] ?? '')) throw new RuntimeException('Structural blockquotes lower nested layout to native children while retaining valid inline RichText formats.');
 
 fwrite(STDOUT, "list item lowering contract passed\n");


### PR DESCRIPTION
## Summary
- lower selector-addressed structural RichText and phrasing-wrapped quote content into native inner blocks
- retain inline emphasis and links as valid RichText, with parse/serialize edit-persistence coverage
- prioritize and enrich bounded structural RichText findings with block, attribute, selector, and source-fragment attribution

Closes #1038

## Tests
- `composer --working-dir=php-transformer test`
- supplied representative artifact: `structural_rich_text_attribute_count=0`

## AI assistance
OpenAI GPT-5.6-sol via an OpenCode general coding subagent implemented the conversion and report changes. OpenAI gpt-5.6-terra via an OpenCode general coding subagent resumed the task, inspected the preserved commit, rebased it, and verified the focused, full-suite, and representative-artifact results. Chris Huber remains responsible for every line.