### PR TITLE
refactor: expose srcset parser contract

### DIFF
--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -38,6 +38,7 @@ PHP Transformer does not own product workflows such as importer admin screens, u
 Consumers should treat these classes and interface as the public entrypoints for the current package:
 
 - `Contract\TransformerResult` - stable result envelope. Use `toArray()` for complete compatibility boundaries or `toWordPressSitePlanView()` for bounded WordPress materialization handoffs.
+- `AssetAnalysis\SrcsetParser` - parses, lists, and rewrites `srcset` candidates while preserving URL-internal commas and descriptors.
 - `HtmlToBlocks\HtmlTransformer` - converts supported HTML elements into WordPress block arrays and serialized block markup. Unsupported top-level HTML is reported in `fallbacks`.
 - `FormatBridge\FormatBridge` - normalizes and converts declared `html`, `markdown`, and serialized `blocks` content through `convertResult()`. Markdown support is optional: the adapter registers only when `league/commonmark` + `league/html-to-markdown` are loadable (vendored copies may omit them and `FormatBridge/MarkdownAdapter.php` entirely), otherwise markdown conversion fails cleanly as `unsupported_source_format` and `supportedFormats()` omits `markdown`.
 - `FormatBridge\FormatAdapterInterface` - adapter contract for adding formats to `FormatBridge` when a consumer genuinely needs a package-level extension point.

--- a/php-transformer/src/AssetAnalysis/SrcsetParser.php
+++ b/php-transformer/src/AssetAnalysis/SrcsetParser.php
@@ -3,7 +3,15 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\AssetAnalysis;
 
-/** Parses srcset candidates without treating URL-internal commas as separators. */
+/**
+ * Public srcset parsing contract for transformer consumers.
+ *
+ * Candidate order and descriptors are preserved. Parsing is deliberately
+ * lossless rather than validating URL schemes or descriptor grammar; callers
+ * own those policies.
+ *
+ * @api
+ */
 final class SrcsetParser
 {
     /** @return array<int,array{url:string,descriptor:string}> */

--- a/php-transformer/tests/unit/srcset-parser.php
+++ b/php-transformer/tests/unit/srcset-parser.php
@@ -20,9 +20,26 @@ if (array($data, 'image-2x.png') !== array_column($mixed, 'url')) {
     throw new RuntimeException('Data URL commas must remain within their srcset candidate.');
 }
 
+$bounded = SrcsetParser::parse(', image.png type(image/png, avif),, image-wide.png 1200w,');
+if (
+    array('image.png', 'image-wide.png') !== SrcsetParser::urls(', image.png type(image/png, avif),, image-wide.png 1200w,')
+    || array('type(image/png, avif)', '1200w') !== array_column($bounded, 'descriptor')
+) {
+    throw new RuntimeException('Separators and descriptor-internal commas must preserve ordered candidates.');
+}
+
 $rewritten = SrcsetParser::rewrite($srcset, static fn(string $url): string => 'asset:' . hash('sha256', $url));
 if (2 !== substr_count($rewritten, 'asset:') || !str_contains($rewritten, ' 1x, ') || !str_ends_with($rewritten, ' 2x')) {
     throw new RuntimeException('Srcset rewriting must preserve candidate descriptors.');
+}
+
+$policyCalls = array();
+$policyRewrite = SrcsetParser::rewrite('one.png, two.png 2x', static function (string $url) use (&$policyCalls): string {
+    $policyCalls[] = $url;
+    return '/assets/' . $url;
+});
+if (array('one.png', 'two.png') !== $policyCalls || '/assets/one.png, /assets/two.png 2x' !== $policyRewrite) {
+    throw new RuntimeException('Srcset rewriting must delegate URL policy once per ordered candidate.');
 }
 
 fwrite(STDOUT, "Srcset parser contract passed\n");


### PR DESCRIPTION
## Summary

- declare `AssetAnalysis\SrcsetParser` as a supported PHP Transformer consumer API
- document its lossless parsing and caller-owned policy boundary
- extend contract coverage for repeated separators, descriptor-internal commas, ordered URL projection, and rewrite callback semantics

This is the upstream half of the first deduplication slice from #242 and Automattic/static-site-importer#1201. The parser implementation already ships in PHP Transformer 0.5.0; this PR formalizes the contract SSI can consume instead of maintaining a divergent copy.

## Verification

- `composer test`
- 278 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to inspect the existing parser and consumer duplication, implement the public contract and tests, and run verification. Chris Huber is responsible for every line.
