### PR TITLE
fix(transformer): retain first-party runtime DOM selectors

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -109,10 +109,12 @@ final class ArtifactCompiler
             'files'      => $files,
         ));
         $this->indexFiles($normalized['files']);
+        $runtimeDomSelectors = $this->runtimeDomSelectors($html, $sourcePath, $normalized['files']);
 
         return array(
             'runtime_script_metadata'  => $this->runtimeScriptMetadataForSource($html, $sourcePath, $normalized['files']),
-            'runtime_dom_selectors'    => $this->runtimeDomSelectors($html, $sourcePath, $normalized['files']),
+            'runtime_dom_selectors'    => $runtimeDomSelectors,
+            'runtime_behavioral_selectors' => $runtimeDomSelectors,
             'runtime_canvas_selectors' => $this->runtimeCanvasSelectors($html, $sourcePath, $normalized['files']),
         );
     }
@@ -1878,6 +1880,7 @@ final class ArtifactCompiler
         $analysisCache = $this->cacheHtmlAnalysis
             ? $this->htmlTransformerAnalysisCache ??= new HtmlTransformerAnalysisCache()
             : new HtmlTransformerAnalysisCache();
+        $runtimeDomSelectors = $this->runtimeDomSelectors($html, $sourcePath, $files);
         $result = (new HtmlTransformer(analysisCache: $analysisCache))->transform($this->safeHtmlDocumentHtml($html, $sourcePath, $files), array(
             'source'                    => $sourcePath,
             'source_scope'              => $sourceScope,
@@ -1888,7 +1891,8 @@ final class ArtifactCompiler
             'skip_author_stylesheet_materialization' => true,
             'asset_metadata'            => $this->assetMetadataForSource($sourcePath, $files),
             'runtime_script_metadata'   => $this->runtimeScriptMetadataForSource($html, $sourcePath, $files),
-            'runtime_dom_selectors'     => $this->runtimeDomSelectors($html, $sourcePath, $files),
+            'runtime_dom_selectors'     => $runtimeDomSelectors,
+            'runtime_behavioral_selectors' => $runtimeDomSelectors,
             'runtime_canvas_selectors'  => $this->runtimeCanvasSelectors($html, $sourcePath, $files),
             'generated_block_namespace' => $generatedBlockNamespace,
             'generated_asset_root'       => $this->generatedAssetRoot,
@@ -3586,25 +3590,16 @@ final class ArtifactCompiler
         if ( preg_match_all('/document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                    continue;
-                }
                 $selectors[$selector] = true;
             }
         }
         if ( preg_match_all('/\b(?!document\b)[A-Za-z_$][A-Za-z0-9_$]*\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                    continue;
-                }
                 $selectors[$selector] = true;
             }
         }
         foreach ( $this->scriptDataAttributeSelectors($script) as $selector ) {
-            if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                continue;
-            }
             $selectors[$selector] = true;
         }
         foreach ( $this->scriptScopedElementSelectors($script, 'canvas') as $selector ) {
@@ -3619,9 +3614,6 @@ final class ArtifactCompiler
         if ( preg_match_all('/\.\s*closest\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                    continue;
-                }
                 $selectors[$selector] = true;
             }
         }
@@ -3636,16 +3628,19 @@ final class ArtifactCompiler
         }
 
         $selectorPattern = preg_quote($selector, '/');
-        if ( ! preg_match_all('/querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\1\s*\)(.{0,700})/s', $script, $matches) ) {
+        if ( preg_match_all('/\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:document\s*\.\s*)?querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
+            foreach ($assignments as $assignment) {
+                if (preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:textContent|innerHTML|outerHTML|value|checked|selectedIndex|hidden|disabled|style|dataset)\b/', $script)) {
+                    return false;
+                }
+            }
+        }
+        if ( ! preg_match_all('/querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\1\s*\)([^;]{0,700})/', $script, $matches) ) {
             return false;
         }
 
         foreach ( $matches[2] as $tail ) {
-            $window = (string) $tail;
-            if ( ! str_contains($window, 'classList.') ) {
-                return false;
-            }
-            if ( preg_match('/\b(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|innerHTML|outerHTML|textContent|value|checked|selectedIndex|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\.\s*(?:hidden|disabled|style|dataset)\b/', $window) ) {
+            if ( preg_match('/\b(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|innerHTML|outerHTML|textContent|value|checked|selectedIndex|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\.\s*(?:classList|hidden|disabled|style|dataset)\b/', (string) $tail) ) {
                 return false;
             }
         }

--- a/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
+++ b/php-transformer/src/ArtifactCompiler/RuntimeDependencyParityReport.php
@@ -736,7 +736,7 @@ final class RuntimeDependencyParityReport
         if ( preg_match_all('/document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
+                if ( $this->isPresentationOnlyScriptSelector($script, $selector) ) {
                     continue;
                 }
                 $dependencies[] = array(
@@ -752,7 +752,7 @@ final class RuntimeDependencyParityReport
         if ( preg_match_all('/\b(?!document\b)[A-Za-z_$][A-Za-z0-9_$]*\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
+                if ( $this->isPresentationOnlyScriptSelector($script, $selector) ) {
                     continue;
                 }
                 $dependencies[] = array(
@@ -797,7 +797,7 @@ final class RuntimeDependencyParityReport
         if ( preg_match_all('/\.\s*closest\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
+                if ( $this->isPresentationOnlyScriptSelector($script, $selector) ) {
                     continue;
                 }
                 $dependencies[] = array(
@@ -811,7 +811,7 @@ final class RuntimeDependencyParityReport
         }
 
         foreach ( $this->scriptDataAttributeSelectors($script) as $selector ) {
-            if ( $this->isPresentationalRuntimeSelector($selector) ) {
+            if ( $this->isPresentationOnlyScriptSelector($script, $selector) ) {
                 continue;
             }
             $dependencies[] = array(
@@ -894,25 +894,16 @@ final class RuntimeDependencyParityReport
         if ( preg_match_all('/document\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                    continue;
-                }
                 $selectors[$selector] = true;
             }
         }
         if ( preg_match_all('/\b(?!document\b)[A-Za-z_$][A-Za-z0-9_$]*\s*\.\s*querySelector(?:All)?\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                    continue;
-                }
                 $selectors[$selector] = true;
             }
         }
         foreach ( $this->scriptDataAttributeSelectors($script) as $selector ) {
-            if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                continue;
-            }
             $selectors[$selector] = true;
         }
         foreach ( $this->scriptScopedElementSelectors($script, 'canvas') as $selector ) {
@@ -927,9 +918,6 @@ final class RuntimeDependencyParityReport
         if ( preg_match_all('/\.\s*closest\s*\(\s*(["\'])(' . $this->scriptSelectorPattern() . ')\1\s*\)/', $script, $matches) ) {
             foreach ( $matches[2] as $selector ) {
                 $selector = $this->canonicalRuntimeSelector((string) $selector);
-                if ( $this->isPresentationalRuntimeSelector($selector) ) {
-                    continue;
-                }
                 $selectors[$selector] = true;
             }
         }
@@ -1004,6 +992,33 @@ final class RuntimeDependencyParityReport
         }
 
         return false;
+    }
+
+    private function isPresentationOnlyScriptSelector(string $script, string $selector): bool
+    {
+        if ( ! $this->isPresentationalRuntimeSelector($selector) ) {
+            return false;
+        }
+
+        $selectorPattern = preg_quote($selector, '/');
+        if ( preg_match_all('/\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:document\s*\.\s*)?querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\2\s*\)/', $script, $assignments, PREG_SET_ORDER) ) {
+            foreach ($assignments as $assignment) {
+                if (preg_match('/\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\b' . preg_quote((string) $assignment[1], '/') . '\s*\.\s*(?:textContent|innerHTML|outerHTML|value|checked|selectedIndex|hidden|disabled|style|dataset)\b/', $script)) {
+                    return false;
+                }
+            }
+        }
+        if ( ! preg_match_all('/querySelector(?:All)?\s*\(\s*(["\'])' . $selectorPattern . '\1\s*\)([^;]{0,700})/', $script, $matches) ) {
+            return false;
+        }
+
+        foreach ( $matches[2] as $tail ) {
+            if ( preg_match('/\b(?:addEventListener|appendChild|removeChild|replaceChildren|insertAdjacentHTML|innerHTML|outerHTML|textContent|value|checked|selectedIndex|setAttribute|removeAttribute|toggleAttribute|getContext|submit|fetch)\b|\.\s*(?:classList|hidden|disabled|style|dataset)\b/', (string) $tail) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -713,6 +713,7 @@ final class HtmlTransformer
         $this->cssCustomProperties = $styleAnalysis['custom_properties'];
         $this->resetPresentationResolutionCache();
         $this->runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
+        $this->runtimeBehavioralSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_behavioral_selectors');
         $this->runtimeCanvasSelectors = $this->runtimeCanvasSelectorsFromOptions($options);
         $this->supersededRuntimeSelectors = array();
         $this->fallbackEmitter->configure($this->fallbackProvenance, $this->runtimeScriptMetadata, $this->runtimeCanvasSelectors);
@@ -4529,7 +4530,7 @@ final class HtmlTransformer
             return $this->capturedDialogBlock($element, $fallbacks);
         }
 
-        if ( $this->shouldPreserveDataAttributeRuntimeTarget($element) ) {
+        if ( $this->shouldPreserveDataAttributeRuntimeTarget($element) && ! in_array($tagName, array('p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'), true) ) {
             return $this->htmlPreservationBlock($element);
         }
 
@@ -4546,6 +4547,7 @@ final class HtmlTransformer
 
         if ( preg_match('/^h([1-6])$/', $tagName, $matches) ) {
             $content = $this->richTextContentWithMaterializedInlineStyles($element);
+            $content = $this->richTextContentWithRuntimeRootAttributes($element, $content);
             $content = $this->headingRichTextContent($content);
             if ( $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
                 return $this->htmlPreservationBlock($element);
@@ -4566,6 +4568,7 @@ final class HtmlTransformer
                 return $marquee;
             }
             $content = $this->richTextContentWithMaterializedInlineStyles($element);
+            $content = $this->richTextContentWithRuntimeRootAttributes($element, $content);
             $inlineSvgContent = $this->richTextContentWithMaterializedSvgImages($element, $content);
             if ( null !== $inlineSvgContent ) {
                 $content = $inlineSvgContent;
@@ -5602,7 +5605,7 @@ final class HtmlTransformer
                         'required_scripts' => $this->requiredScriptsForElement($sourceElement),
                     ));
                 } else {
-                    $this->recordNativeRuntimeDomPreservation($sourceElement, $name);
+                    $this->recordNativeRuntimeDomPreservation($sourceElement, $name, in_array($name, array('core/paragraph', 'core/heading'), true));
                 }
             }
             $this->sourceProvenance[$provenanceId] = $this->sourceProvenanceEntry($name, $sourceElement);
@@ -11584,22 +11587,18 @@ final class HtmlTransformer
     private function isRuntimeDomTarget(DOMElement $element): bool
     {
         $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && isset($this->runtimeDomSelectors['#' . $id]) && ! $this->isPresentationalAnimationSelector('#' . $id) ) {
+        if ( '' !== $id && isset($this->runtimeDomSelectors['#' . $id]) && ! $this->isPresentationalRuntimeSelector('#' . $id) ) {
             return true;
         }
 
         foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class && isset($this->runtimeDomSelectors['.' . $class]) && ! $this->isPresentationalAnimationSelector('.' . $class) ) {
+            if ( '' !== $class && isset($this->runtimeDomSelectors['.' . $class]) && ! $this->isPresentationalRuntimeSelector('.' . $class) ) {
                 return true;
             }
         }
 
         foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
-            if ( $this->isPresentationalAnimationSelector((string) $selector) ) {
-                continue;
-            }
-
-            if ( $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
+            if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
         }
@@ -11616,7 +11615,7 @@ final class HtmlTransformer
         foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) if ( '' !== $class && isset($this->runtimeDomSelectors['.' . $class]) ) $selectors[] = '.' . $class;
         foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
             if ( str_starts_with((string) $selector, '.') || str_starts_with((string) $selector, '#') || strtolower((string) $selector) === strtolower($element->tagName) ) continue;
-            if ( ! $this->isPresentationalAnimationSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) $selectors[] = (string) $selector;
+            if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) $selectors[] = (string) $selector;
         }
         return array_values(array_unique($selectors));
     }
@@ -11883,10 +11882,6 @@ final class HtmlTransformer
 
         foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
             if ( str_contains((string) $selector, '[') && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
-                if ( $this->isPresentationalAnimationSelector((string) $selector) ) {
-                    continue;
-                }
-
                 return true;
             }
         }
@@ -11918,6 +11913,11 @@ final class HtmlTransformer
         return false;
     }
 
+    private function isPresentationalRuntimeSelector(string $selector): bool
+    {
+        return $this->isPresentationalAnimationSelector($selector) && ! isset($this->runtimeBehavioralSelectors[$selector]);
+    }
+
     private function elementMatchesRuntimeSelector(DOMElement $element, string $selector): bool
     {
         $tag = strtolower($element->tagName);
@@ -11942,19 +11942,44 @@ final class HtmlTransformer
         $this->fallbackEmitter->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeIslands);
     }
 
-    private function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName): void
+    private function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName, bool $includeRichTextDescendants = false): void
     {
+        $elements = array($element);
+        if ($includeRichTextDescendants) {
+            foreach ($this->descendantElements($element) as $descendant) {
+                if ($this->isInlineContentElement(strtolower($descendant->tagName))) {
+                    $elements[] = $descendant;
+                }
+            }
+        }
+        foreach ($elements as $target) {
+            foreach ($this->runtimeDomSelectorsForElement($target) as $selector) {
+                $key = $blockName . "\n" . $selector;
+                if (isset($this->runtimeDomPreservations[$key])) {
+                    continue;
+                }
+                $this->runtimeDomPreservations[$key] = array(
+                    'block_name' => $blockName,
+                    'tag' => strtolower($target->tagName),
+                    'selector' => $selector,
+                );
+            }
+        }
+    }
+
+    private function richTextContentWithRuntimeRootAttributes(DOMElement $element, string $content): string
+    {
+        $attributes = array();
         foreach ($this->runtimeDomSelectorsForElement($element) as $selector) {
-            $key = $blockName . "\n" . $selector;
-            if (isset($this->runtimeDomPreservations[$key])) {
+            if (!preg_match('/\[(data-[A-Za-z][A-Za-z0-9_-]*)/', $selector, $match)) {
                 continue;
             }
-            $this->runtimeDomPreservations[$key] = array(
-                'block_name' => $blockName,
-                'tag' => strtolower($element->tagName),
-                'selector' => $selector,
-            );
+            $name = strtolower((string) $match[1]);
+            if ($element->hasAttribute($name)) {
+                $attributes[$name] = $element->getAttribute($name);
+            }
         }
+        return array() === $attributes ? $content : '<mark' . $this->htmlAttributeString($attributes) . '>' . $content . '</mark>';
     }
 
     private function canRetainRuntimeDomContractNatively(DOMElement $element, string $blockName): bool

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -65,6 +65,7 @@ final class HtmlTransformerSession
     public array $imageShapeStyleRules = array();
     public array $staticPseudoElementStyleRules = array();
     public array $runtimeDomSelectors = array();
+    public array $runtimeBehavioralSelectors = array();
     public array $runtimeCanvasSelectors = array();
     public array $supersededRuntimeSelectors = array();
     public array $sourceTagMarkers = array();

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3312,6 +3312,33 @@ $assert(null === $selfRumFinding, 'telemetry script self-target is not reported 
 $assert(null !== $selfRumDependency, 'runtime dependency parity records telemetry script self-target dependency');
 $assert('script' === ($selfRumDependency['target_kind'] ?? ''), 'runtime dependency parity identifies telemetry script self-target kind');
 
+$firstPartyRuntimeContracts = $compiler->compile(
+    array(
+        'entrypoint' => 'index.html',
+        'files'      => array(
+            'index.html' => '<main><p id="clock" class="clock" data-counter="clock">0 <span id="score">score</span></p><script src="js/clock.js"></script></main>',
+            'js/clock.js' => 'document.getElementById("clock").textContent = "1"; document.querySelector(".clock").classList.add("ready"); document.querySelector("[data-counter]").textContent = "2"; document.querySelector("#score").textContent = "3";',
+        ),
+    )
+)->toArray();
+$firstPartyRuntimeMarkup = (string) ($firstPartyRuntimeContracts['serialized_blocks'] ?? '');
+$firstPartyRuntimeDependencies = array_column($firstPartyRuntimeContracts['source_reports']['runtime_dependency_parity']['dependencies'] ?? array(), null, 'selector');
+$firstPartyRuntimeDiagnostics = array_values(array_filter($firstPartyRuntimeContracts['diagnostics'] ?? array(), static fn (array $diagnostic): bool => 'runtime_dom_contract_preserved' === ($diagnostic['code'] ?? '')));
+$firstPartyRuntimeDiagnosticSelectors = array_column($firstPartyRuntimeDiagnostics, 'selector');
+$assert('pass' === ($firstPartyRuntimeContracts['source_reports']['runtime_dependency_parity']['status'] ?? '') && array() === ($firstPartyRuntimeContracts['source_reports']['runtime_dependency_parity']['findings'] ?? array()), 'first-party ID, class, and data-attribute runtime selectors pass only when their generated contracts are present');
+foreach (array('#clock', '.clock', '[data-counter]', '#score') as $selector) {
+    $assert(true === ($firstPartyRuntimeDependencies[$selector]['generated_present'] ?? null), 'first-party runtime dependency parity preserves ' . $selector);
+    $assert(in_array($selector, $firstPartyRuntimeDiagnosticSelectors, true), 'native preservation diagnostics identify ' . $selector);
+}
+$assert(str_contains($firstPartyRuntimeMarkup, 'id="clock" class="clock"') && str_contains($firstPartyRuntimeMarkup, '<mark data-counter="clock">') && str_contains($firstPartyRuntimeMarkup, '<span id="score">score</span>'), 'native RichText output retains required ID, class, and data attributes for first-party runtime selectors', $firstPartyRuntimeMarkup);
+$missingRuntimeContract = (new \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\RuntimeDependencyParityReport())->fromArtifact(
+    array(array('path' => 'js/clock.js', 'kind' => 'js', 'content' => 'document.querySelector("[data-counter]").textContent = "2";')),
+    '<main><p data-counter="clock">0</p></main>',
+    '<!-- wp:paragraph --><p>0</p><!-- /wp:paragraph -->',
+    'index.html'
+);
+$assert('warning' === ($missingRuntimeContract['status'] ?? '') && 'runtime_dependency_target_missing' === ($missingRuntimeContract['findings'][0]['code'] ?? ''), 'runtime dependency parity fails closed when a required source selector is absent from generated markup');
+
 $expandedRuntimeTargetsSite = $compiler->compile(
     array(
         'entrypoint' => 'index.html',

--- a/php-transformer/tests/fixtures/parity/artifact-first-party-runtime-dom-contracts.json
+++ b/php-transformer/tests/fixtures/parity/artifact-first-party-runtime-dom-contracts.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "artifact-first-party-runtime-dom-contracts",
+  "description": "Preserves first-party ID, class, and data-attribute DOM contracts in native RichText output.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/artifact-first-party-runtime-dom-contracts.json",
+    "notes": "Covers first-party runtime selector discovery and native DOM contract preservation."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Runtime dependency parity is an upstream artifact compiler contract with no legacy comparison."
+  },
+  "operation": "artifact_compiler.compile",
+  "input": {
+    "artifact": {
+      "entrypoint": "index.html",
+      "files": [
+        {
+          "path": "index.html",
+          "kind": "html",
+          "content": "<main><p id=\"clock\" class=\"clock\" data-counter=\"clock\">0 <span id=\"score\">score</span></p><script src=\"js/clock.js\"></script></main>"
+        },
+        {
+          "path": "js/clock.js",
+          "kind": "js",
+          "content": "document.getElementById('clock').textContent = '1'; document.querySelector('.clock').classList.add('ready'); document.querySelector('[data-counter]').textContent = '2'; document.querySelector('#score').textContent = '3';"
+        }
+      ]
+    }
+  },
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.runtime_dependency_parity.status", "assert": "equals", "value": "pass" },
+    { "path": "source_reports.runtime_dependency_parity.dependencies", "assert": "count", "count": 4 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "id=\"clock\" class=\"clock\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "data-counter=\"clock\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "id=\"score\"" }
+  ]
+}


### PR DESCRIPTION
## Summary
- discover first-party ID, class, and data-attribute selectors when their script use mutates DOM or binds behavior
- retain runtime-selected data attributes through native RichText and report each native inline target
- fail runtime dependency parity when a source selector is absent from generated markup

## Validation
- `composer --working-dir=php-transformer test`
- 279 PHP transformer parity fixtures

Follow-up for reopened #1035 after merged #1045.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent inspected the post-merge review findings, implemented first-party runtime selector preservation and parity coverage, and ran the PHP transformer verification. Chris Huber remains responsible for the changes.