### PR TITLE
refactor: make pattern results truthful

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -47,7 +47,7 @@ final class ColumnsPattern implements PatternRecognizerInterface
             $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
             return $result->firstBlock();
         }, $context->presentationAttributesCallback(), $style, $context->createBlockCallback());
-        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks, array(), array('fallbacks'));
+        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -49,7 +49,7 @@ final class CoverPattern implements PatternRecognizerInterface
             $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
             return $result->blocks();
         }, $context->presentationAttributesCallback(), $style, $attrs, $url, $context->createBlockCallback());
-        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks, array(), array('fallbacks'));
+        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
@@ -40,7 +40,7 @@ final class MediaTextPattern implements PatternRecognizerInterface
             $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
             return $result->firstBlock();
         }, $attrs, $style, $html, $url, $context->createBlockCallback());
-        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks, array(), array('fallbacks'));
+        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognitionResult.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognitionResult.php
@@ -3,23 +3,16 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
-/**
- * The complete, ordered-recognizer outcome. Effects are data, never hidden in
- * a recognizer callback, so the dispatcher can commit them with the block.
- */
+/** The block and fallback diagnostics committed when an ordered recognizer wins. */
 final class PatternRecognitionResult
 {
     /**
      * @param array<string, mixed> $block
      * @param list<array<string, mixed>> $fallbacks
-     * @param list<array<string, mixed>> $provenance
-     * @param list<string> $declaredSideEffects
      */
     public function __construct(
         private readonly array $block,
-        private readonly array $fallbacks = array(),
-        private readonly array $provenance = array(),
-        private readonly array $declaredSideEffects = array()
+        private readonly array $fallbacks = array()
     ) {
     }
 
@@ -33,17 +26,5 @@ final class PatternRecognitionResult
     public function fallbacks(): array
     {
         return $this->fallbacks;
-    }
-
-    /** @return list<array<string, mixed>> */
-    public function provenance(): array
-    {
-        return $this->provenance;
-    }
-
-    /** @return list<string> */
-    public function declaredSideEffects(): array
-    {
-        return $this->declaredSideEffects;
     }
 }

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -29,29 +29,42 @@ $context = new PatternContext(
     static fn (DOMElement $source): string => '',
     static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name )
 );
-$first = new class implements PatternRecognizerInterface {
+$calls = new ArrayObject();
+$declined = new class($calls) implements PatternRecognizerInterface {
+    public function __construct(private readonly ArrayObject $calls) {}
+
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
+        $this->calls[] = 'declined';
+        return null;
+    }
+};
+$first = new class($calls) implements PatternRecognizerInterface {
+    public function __construct(private readonly ArrayObject $calls) {}
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $this->calls[] = 'first';
         return new PatternRecognitionResult(
             array( 'blockName' => 'first' ),
-            array( array( 'type' => 'fallback' ) ),
-            array( array( 'source' => 'first' ) ),
-            array( 'records_fallback' )
+            array( array( 'type' => 'fallback' ) )
         );
     }
 };
-$second = new class implements PatternRecognizerInterface {
+$second = new class($calls) implements PatternRecognizerInterface {
+    public function __construct(private readonly ArrayObject $calls) {}
+
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
+        $this->calls[] = 'second';
         throw new RuntimeException('Ordered registry invoked a lower-precedence recognizer.');
     }
 };
 
-$result = ( new PatternRecognizerRegistry( array( $first, $second ) ) )->firstMatch($element, $context);
+$result = ( new PatternRecognizerRegistry( array( $declined, $first, $second ) ) )->firstMatch($element, $context);
 $assertSame('first', $result?->block()['blockName'] ?? null, 'First matching recognizer wins.');
 $assertSame(array( array( 'type' => 'fallback' ) ), $result?->fallbacks(), 'Result keeps fallbacks with its block.');
-$assertSame(array( array( 'source' => 'first' ) ), $result?->provenance(), 'Result keeps provenance with its block.');
-$assertSame(array( 'records_fallback' ), $result?->declaredSideEffects(), 'Result declares committed side effects.');
+$assertSame(array( 'declined', 'first' ), $calls->getArrayCopy(), 'Declined recognizers contribute no result and dispatch stops after the winner.');
 
 echo "pattern recognizer registry ok\n";
 exit(0 === $failures ? 0 : 1);


### PR DESCRIPTION
## Summary

- remove unused provenance and declared-side-effect fields from `PatternRecognitionResult`
- simplify recognizers that declared fallback effects the dispatcher never read
- make the registry test prove the actual contract: declines contribute no result, the first winner stops dispatch, and the winner carries its fallback diagnostics

This is a behavior-preserving simplification slice from #242 following the ordered recognizer registry migration.

## Verification

- `composer test`
- 280 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to trace recognizer result consumers, remove the unused contract fields, strengthen ordered-dispatch coverage, and run verification. Chris Huber is responsible for every line.
