### PR TITLE
Materialize annotated passive SVGs as native images

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -934,7 +934,8 @@ trait SvgMaterializationTrait
 
         foreach ( $this->htmlAttributes($element) as $name => $value ) {
             $name = strtolower($name);
-            if ( ! isset($allowedAttributes[$name]) || preg_match('/^on[a-z]+$/i', $name) || preg_match('/javascript\s*:|\b(?:expression|behavior)\s*:/i', $value) ) {
+            $isInertDataAttribute = str_starts_with($name, 'data-') && 'data-dom-store' !== $name;
+            if ( (! isset($allowedAttributes[$name]) && ! $isInertDataAttribute) || preg_match('/^on[a-z]+$/i', $name) || preg_match('/javascript\s*:|\b(?:expression|behavior)\s*:/i', $value) ) {
                 return false;
             }
             if ( preg_match('/(?:^|:)href$/i', $name) && ! str_starts_with(trim($value), '#') ) {

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -862,6 +862,11 @@ $exportedSvgArtwork = ( new HtmlTransformer() )->transform(
 $exportedSvgMarkup = (string) ($exportedSvgArtwork['serialized_blocks'] ?? '');
 $assert('core/image' === ($exportedSvgArtwork['blocks'][0]['blockName'] ?? '') && ! str_contains($exportedSvgMarkup, '<!-- wp:html'), 'passive exported SVG metadata remains native core/image artwork');
 
+$annotatedSvgArtwork = ( new HtmlTransformer() )->transform(
+    '<main><svg viewBox="0 0 24 24" data-producer-node="vector" data-source-node-id="icon:1"><path d="M2 12h20"></path></svg></main>'
+)->toArray();
+$assert('core/image' === ($annotatedSvgArtwork['blocks'][0]['blockName'] ?? '') && array() === ($annotatedSvgArtwork['fallbacks'] ?? array()), 'passive SVG producer data attributes remain native core/image metadata');
+
 $positionedFillSvg = ( new HtmlTransformer() )->transform(
     '<style>.hero-media{position:relative;width:1280px;height:760px}@media(max-width:700px){.hero-media{width:320px;height:240px}}</style><main><div class="hero-media"><svg class="hero-art" width="100%" height="100%" style="object-fit:cover" viewBox="0 0 1280 728.88"><rect width="1280" height="728.88" fill="#111"/></svg></div></main>'
 )->toArray();


### PR DESCRIPTION
## Summary
- allow ordinary inert `data-*` metadata on otherwise passive inline SVG artwork
- preserve the `data-dom-store` document-context exception for referenced symbol stores
- cover annotated SVG materialization as native `core/image` with zero fallback diagnostics

Closes #1062.

## Verification
- `composer test` in `php-transformer`
- `composer test` in `figma-transformer`
- focused referenced SVG-store contract
- fresh canonical Studio/SSI acceptance identified all 14 remaining `core/html` blocks as passive annotated SVGs; the post-fix rerun will be attached after rebuilding the combined package

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to run end-to-end WordPress acceptance, isolate the SVG classifier boundary, implement the focused change, and run regression verification. Chris Huber reviewed and remains responsible for the change.