### PR TITLE
refactor: make CSS value splitting syntax-aware

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -290,7 +290,7 @@ final class CoverPattern implements PatternRecognizerInterface
         }
 
         $urlLayers = 0;
-        foreach ( $this->splitTopLevel($value, array( ',' )) as $layer ) {
+        foreach ( CssValueSplitter::splitTopLevel($value, array( ',' )) as $layer ) {
             if ( preg_match('/\burl\s*\(/i', $layer) && 2 <= ++$urlLayers ) {
                 return true;
             }
@@ -350,7 +350,7 @@ final class CoverPattern implements PatternRecognizerInterface
             return;
         }
 
-        $layers         = $this->splitTopLevel($gradient, array( ',' ));
+        $layers         = CssValueSplitter::splitTopLevel($gradient, array( ',' ));
         $gradientLayers = array();
         $hasDesignLayer = false;
         foreach ( $layers as $layer ) {
@@ -404,7 +404,7 @@ final class CoverPattern implements PatternRecognizerInterface
         }
 
         $type  = strtolower($matches[2]);
-        $stops = $this->splitTopLevel($matches[3], array( ',' ));
+        $stops = CssValueSplitter::splitTopLevel($matches[3], array( ',' ));
         if ( count($stops) >= 3 && $this->isGradientPrelude($type, $stops[0]) ) {
             array_shift($stops);
         }
@@ -539,76 +539,4 @@ final class CoverPattern implements PatternRecognizerInterface
         }
     }
 
-    /**
-     * @param array<int, string> $delimiters
-     * @return array<int, string>
-     */
-    private function splitTopLevel(string $input, array $delimiters): array
-    {
-        $masked = $this->maskQuotedAndEscapedCharacters($input);
-        $parts  = CssValueSplitter::splitTopLevel($masked, $delimiters);
-
-        return $this->restoreSplitParts($input, $masked, $parts);
-    }
-
-    private function maskQuotedAndEscapedCharacters(string $input): string
-    {
-        $masked = '';
-        $quote  = null;
-        $length = strlen($input);
-
-        for ( $index = 0; $index < $length; ++$index ) {
-            $character = $input[ $index ];
-            if ( '\\' === $character ) {
-                $masked .= 'x';
-                if ( $index + 1 < $length ) {
-                    $masked .= 'x';
-                    ++$index;
-                }
-                continue;
-            }
-
-            if ( null !== $quote ) {
-                if ( $quote === $character ) {
-                    $masked .= $character;
-                    $quote   = null;
-                } else {
-                    $masked .= 'x';
-                }
-                continue;
-            }
-
-            if ( '"' === $character || "'" === $character ) {
-                $quote  = $character;
-                $masked .= $character;
-                continue;
-            }
-
-            $masked .= $character;
-        }
-
-        return $masked;
-    }
-
-    /**
-     * @param array<int, string> $maskedParts
-     * @return array<int, string>
-     */
-    private function restoreSplitParts(string $input, string $masked, array $maskedParts): array
-    {
-        $parts  = array();
-        $offset = 0;
-
-        foreach ( $maskedParts as $maskedPart ) {
-            $start = strpos($masked, $maskedPart, $offset);
-            if ( false === $start ) {
-                return array();
-            }
-
-            $parts[] = substr($input, $start, strlen($maskedPart));
-            $offset  = $start + strlen($maskedPart);
-        }
-
-        return $parts;
-    }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverStyleResolver.php
@@ -33,8 +33,8 @@ final class CoverStyleResolver
         }
 
         $declarations = array();
-        foreach ( $this->splitTopLevel($style, array( ';' )) as $declaration ) {
-            $parts = $this->splitTopLevel($declaration, array( ':' ));
+        foreach ( CssValueSplitter::splitTopLevel($style, array( ';' )) as $declaration ) {
+            $parts = CssValueSplitter::splitTopLevel($declaration, array( ':' ));
             if ( count($parts) < 2 ) {
                 continue;
             }
@@ -96,7 +96,7 @@ final class CoverStyleResolver
         }
 
         $value    = (string) $declarations[ $property ];
-        $layers   = $this->splitTopLevel($value, array( ',' ));
+        $layers   = CssValueSplitter::splitTopLevel($value, array( ',' ));
         $urlIndex = null;
         foreach ( $layers as $index => $layer ) {
             if ( preg_match('/\burl\s*\(/i', $layer) ) {
@@ -114,7 +114,7 @@ final class CoverStyleResolver
                 continue;
             }
 
-            $stops = $this->splitTopLevel($matches[1], array( ',' ));
+            $stops = CssValueSplitter::splitTopLevel($matches[1], array( ',' ));
             if ( 3 === count($stops) && $this->isVerticalGradientDirection($stops[0]) ) {
                 array_shift($stops);
             }
@@ -175,7 +175,7 @@ final class CoverStyleResolver
             return null;
         }
 
-        $parts = $this->splitTopLevelWhitespace($value);
+        $parts = CssValueSplitter::splitTopLevelWhitespace($value);
         if ( count($parts) < 1 || count($parts) > 2 ) {
             return null;
         }
@@ -222,8 +222,8 @@ final class CoverStyleResolver
         foreach ( array_reverse(array_keys($declarations)) as $name ) {
             if ( 'background-size' === $name ) {
                 $size = strtolower(trim((string) $declarations[ $name ]));
-                foreach ( $this->splitTopLevel($size, array( ',' )) as $layerSize ) {
-                    if ( array( 'cover' ) === $this->splitTopLevelWhitespace($layerSize) ) {
+                foreach ( CssValueSplitter::splitTopLevel($size, array( ',' )) as $layerSize ) {
+                    if ( array( 'cover' ) === CssValueSplitter::splitTopLevelWhitespace($layerSize) ) {
                         return true;
                     }
                 }
@@ -232,10 +232,10 @@ final class CoverStyleResolver
 
             if ( 'background' === $name ) {
                 $background = (string) $declarations[ $name ];
-                foreach ( $this->splitTopLevel($background, array( ',' )) as $layer ) {
-                    $slashParts = $this->splitTopLevel($layer, array( '/' ));
+                foreach ( CssValueSplitter::splitTopLevel($background, array( ',' )) as $layer ) {
+                    $slashParts = CssValueSplitter::splitTopLevel($layer, array( '/' ));
                     foreach ( array_slice($slashParts, 1) as $sizeAndRepeat ) {
-                        $tokens = $this->splitTopLevelWhitespace(strtolower($sizeAndRepeat));
+                        $tokens = CssValueSplitter::splitTopLevelWhitespace(strtolower($sizeAndRepeat));
                         if ( 'cover' === ($tokens[0] ?? '') ) {
                             return true;
                         }
@@ -272,8 +272,8 @@ final class CoverStyleResolver
                 $repeatingTokens[] = 'round';
                 $repeatingTokens[] = 'space';
             }
-            foreach ( $this->splitTopLevel($value, array( ',' )) as $layer ) {
-                $tokens = $this->splitTopLevelWhitespace($layer);
+            foreach ( CssValueSplitter::splitTopLevel($value, array( ',' )) as $layer ) {
+                $tokens = CssValueSplitter::splitTopLevelWhitespace($layer);
                 foreach ( $tokens as $token ) {
                     if ( in_array($token, $repeatingTokens, true) ) {
                         return true;
@@ -309,7 +309,7 @@ final class CoverStyleResolver
     private function overlayColor(string $literal): ?array
     {
         $literal = strtolower(trim($literal));
-        $parts   = $this->splitTopLevelWhitespace($literal);
+        $parts   = CssValueSplitter::splitTopLevelWhitespace($literal);
         if ( count($parts) < 1 || count($parts) > 3 ) {
             return null;
         }
@@ -381,90 +381,6 @@ final class CoverStyleResolver
             '/^(?:-?(?:\d+(?:\.\d+)?|\.\d+)(?:%|[a-z]+)?|(?:calc|min|max|clamp|var)\(.*\))$/is',
             trim($value)
         );
-    }
-
-    /**
-     * @param array<int, string> $delimiters
-     * @return array<int, string>
-     */
-    private function splitTopLevel(string $input, array $delimiters): array
-    {
-        $masked = $this->maskQuotedAndEscapedCharacters($input);
-        $parts  = CssValueSplitter::splitTopLevel($masked, $delimiters);
-
-        return $this->restoreSplitParts($input, $masked, $parts);
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function splitTopLevelWhitespace(string $input): array
-    {
-        $masked = $this->maskQuotedAndEscapedCharacters($input);
-        $parts  = CssValueSplitter::splitTopLevelWhitespace($masked);
-
-        return $this->restoreSplitParts($input, $masked, $parts);
-    }
-
-    private function maskQuotedAndEscapedCharacters(string $input): string
-    {
-        $masked = '';
-        $quote  = null;
-        $length = strlen($input);
-
-        for ( $index = 0; $index < $length; ++$index ) {
-            $character = $input[ $index ];
-            if ( '\\' === $character ) {
-                $masked .= 'x';
-                if ( $index + 1 < $length ) {
-                    $masked .= 'x';
-                    ++$index;
-                }
-                continue;
-            }
-
-            if ( null !== $quote ) {
-                if ( $quote === $character ) {
-                    $masked .= $character;
-                    $quote   = null;
-                } else {
-                    $masked .= 'x';
-                }
-                continue;
-            }
-
-            if ( '"' === $character || "'" === $character ) {
-                $quote  = $character;
-                $masked .= $character;
-                continue;
-            }
-
-            $masked .= $character;
-        }
-
-        return $masked;
-    }
-
-    /**
-     * @param array<int, string> $maskedParts
-     * @return array<int, string>
-     */
-    private function restoreSplitParts(string $input, string $masked, array $maskedParts): array
-    {
-        $parts  = array();
-        $offset = 0;
-
-        foreach ( $maskedParts as $maskedPart ) {
-            $start = strpos($masked, $maskedPart, $offset);
-            if ( false === $start ) {
-                return array();
-            }
-
-            $parts[] = substr($input, $start, strlen($maskedPart));
-            $offset  = $start + strlen($maskedPart);
-        }
-
-        return $parts;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Style/CssValueSplitter.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssValueSplitter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
 
 /**
- * Parenthesis-depth-aware splitting for CSS declaration lists and values.
+ * Syntax-aware splitting for CSS declaration lists and values.
  *
  * Naive `explode(';', ...)`, `explode(',', ...)`, and `preg_split('/\s+/', ...)`
  * over CSS values break apart the inside of functional notation —
@@ -15,43 +15,22 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
  * which is what produces "unexpected or invalid content" and mangled spacing.
  *
  * Every method here only treats a delimiter as a separator when it appears at
- * paren depth 0, so functional values stay whole.
+ * paren depth 0 and outside quotes or escapes, so CSS tokens stay whole.
  */
 final class CssValueSplitter
 {
     /**
      * Split on any of the given single-character delimiters, but only when the
-     * delimiter occurs outside of `(...)`. Empty/whitespace-only segments are
-     * dropped and remaining segments are trimmed.
+     * delimiter occurs outside of `(...)`, quotes, and escapes.
+     * Empty/whitespace-only segments are dropped and remaining segments are
+     * trimmed.
      *
      * @param array<int, string> $delimiters
      * @return array<int, string>
      */
     public static function splitTopLevel(string $input, array $delimiters): array
     {
-        $parts  = array();
-        $buffer = '';
-        $depth  = 0;
-        $length = strlen($input);
-
-        for ( $index = 0; $index < $length; ++$index ) {
-            $char = $input[ $index ];
-            if ( '(' === $char ) {
-                ++$depth;
-            } elseif ( ')' === $char && $depth > 0 ) {
-                --$depth;
-            }
-
-            if ( 0 === $depth && in_array($char, $delimiters, true) ) {
-                $parts[] = $buffer;
-                $buffer  = '';
-                continue;
-            }
-
-            $buffer .= $char;
-        }
-
-        $parts[] = $buffer;
+        $parts = self::split($input, $delimiters, false);
 
         $trimmed = array();
         foreach ( $parts as $part ) {
@@ -65,8 +44,8 @@ final class CssValueSplitter
     }
 
     /**
-     * Split on top-level whitespace runs, keeping functional values whole. This
-     * is the paren-aware replacement for `preg_split('/\s+/', ...)` over CSS
+     * Split on top-level whitespace runs, keeping CSS tokens whole. This is the
+     * syntax-aware replacement for `preg_split('/\s+/', ...)` over CSS
      * shorthand values such as `padding: clamp(3.5rem, 8vw, 6.5rem) 0` or
      * `border: 1px solid rgba(0, 0, 0, .1)`.
      *
@@ -74,31 +53,64 @@ final class CssValueSplitter
      */
     public static function splitTopLevelWhitespace(string $input): array
     {
+        return self::split($input, array(), true);
+    }
+
+    /**
+     * @param array<int, string> $delimiters
+     * @return array<int, string>
+     */
+    private static function split(string $input, array $delimiters, bool $splitWhitespace): array
+    {
         $parts  = array();
         $buffer = '';
         $depth  = 0;
+        $quote  = null;
         $length = strlen($input);
 
         for ( $index = 0; $index < $length; ++$index ) {
             $char = $input[ $index ];
+            if ( '\\' === $char ) {
+                $buffer .= $char;
+                if ( $index + 1 < $length ) {
+                    $buffer .= $input[ ++$index ];
+                }
+                continue;
+            }
+
+            if ( null !== $quote ) {
+                $buffer .= $char;
+                if ( $quote === $char ) {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ( '"' === $char || "'" === $char ) {
+                $quote  = $char;
+                $buffer .= $char;
+                continue;
+            }
+
             if ( '(' === $char ) {
                 ++$depth;
             } elseif ( ')' === $char && $depth > 0 ) {
                 --$depth;
             }
 
-            if ( 0 === $depth && '' === trim($char) ) {
-                if ( '' !== $buffer ) {
+            $isDelimiter = $splitWhitespace ? '' === trim($char) : in_array($char, $delimiters, true);
+            if ( 0 === $depth && $isDelimiter ) {
+                if ( ! $splitWhitespace || '' !== $buffer ) {
                     $parts[] = $buffer;
-                    $buffer  = '';
                 }
+                $buffer = '';
                 continue;
             }
 
             $buffer .= $char;
         }
 
-        if ( '' !== $buffer ) {
+        if ( ! $splitWhitespace || '' !== $buffer ) {
             $parts[] = $buffer;
         }
 
@@ -114,10 +126,30 @@ final class CssValueSplitter
     public static function hasBalancedParens(string $value): bool
     {
         $depth  = 0;
+        $quote  = null;
         $length = strlen($value);
 
         for ( $index = 0; $index < $length; ++$index ) {
             $char = $value[ $index ];
+            if ( '\\' === $char ) {
+                if ( $index + 1 < $length ) {
+                    ++$index;
+                }
+                continue;
+            }
+
+            if ( null !== $quote ) {
+                if ( $quote === $char ) {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ( '"' === $char || "'" === $char ) {
+                $quote = $char;
+                continue;
+            }
+
             if ( '(' === $char ) {
                 ++$depth;
             } elseif ( ')' === $char ) {

--- a/php-transformer/tests/unit/css-value-splitter.php
+++ b/php-transformer/tests/unit/css-value-splitter.php
@@ -71,6 +71,30 @@ $assert(
     CssValueSplitter::splitTopLevel('color: red; background: rgba(1, 2, 3, .4)', array( ';' )) === array( 'color: red', 'background: rgba(1, 2, 3, .4)' ),
     '3: declaration list splits on top-level semicolons only'
 );
+$assert(
+    CssValueSplitter::splitTopLevel('content: "a;b"; color: red', array( ';' )) === array( 'content: "a;b"', 'color: red' ),
+    '3b: quoted semicolons stay in their declaration'
+);
+$assert(
+    CssValueSplitter::splitTopLevel('"A,B", serif', array( ',' )) === array( '"A,B"', 'serif' ),
+    '3c: quoted commas stay in their value'
+);
+$assert(
+    CssValueSplitter::splitTopLevel('foo\\,bar,baz', array( ',' )) === array( 'foo\\,bar', 'baz' ),
+    '3d: escaped delimiters stay in their value'
+);
+$assert(
+    CssValueSplitter::splitTopLevel('"A\\", B", serif', array( ',' )) === array( '"A\\", B"', 'serif' ),
+    '3e: escaped quotes do not end a quoted value'
+);
+$assert(
+    CssValueSplitter::splitTopLevelWhitespace('"A B" serif') === array( '"A B"', 'serif' ),
+    '3f: quoted whitespace stays in its value'
+);
+$assert(
+    CssValueSplitter::splitTopLevelWhitespace('A\\ B serif') === array( 'A\\ B', 'serif' ),
+    '3g: escaped whitespace stays in its value'
+);
 
 // ---------------------------------------------------------------------------
 // 4. Balanced-paren detection (validity guard primitive).
@@ -79,6 +103,8 @@ $assert(CssValueSplitter::hasBalancedParens('rgba(251, 247, 241, .95)'), '4: com
 $assert(! CssValueSplitter::hasBalancedParens('rgba(251,'), '4b: truncated rgba() is unbalanced');
 $assert(! CssValueSplitter::hasBalancedParens('foo)bar'), '4c: stray close paren is unbalanced');
 $assert(CssValueSplitter::hasBalancedParens('linear-gradient(90deg, rgba(0,0,0,.5), #fff)'), '4d: nested functions are balanced');
+$assert(CssValueSplitter::hasBalancedParens('url("data:image/svg+xml,<svg>)</svg>")'), '4e: quoted parentheses do not affect balance');
+$assert(CssValueSplitter::hasBalancedParens('foo\\)bar'), '4f: escaped parentheses do not affect balance');
 
 // ---------------------------------------------------------------------------
 // 5. Mapper: function values survive end-to-end and stay whole.


### PR DESCRIPTION
## Summary

- make the shared CSS value splitter honor quoted and escaped characters as well as parenthesis depth
- remove duplicate mask-and-restore splitting implementations from Cover recognition
- cover quoted delimiters, escaped delimiters, escaped quotes, whitespace, and parentheses directly in the shared primitive

This is a parity-preserving simplification slice from #242. It deletes 205 lines while adding 107, leaving one canonical CSS lexical boundary for all transformer callers.

## Verification

- `composer test`
- 32 focused CSS splitter assertions
- 280 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to audit duplicated CSS splitting paths, consolidate quote and escape handling in the shared primitive, add focused coverage, and run verification. Chris Huber is responsible for every line.