### PR TITLE
refactor: type recursive pattern conversion

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -125,6 +125,7 @@
       "php tests/unit/core-html-fallback-reduction.php",
       "php tests/unit/inert-capture-scaffolding.php",
       "php tests/unit/geometry-chain-coalescing.php",
+      "php tests/unit/pattern-recursive-converter.php",
       "php tests/unit/pattern-recognizer-registry.php",
       "php tests/unit/pattern-registry-staged-dispatch.php"
     ],

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -30,8 +30,10 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPatte
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationUnderlineColorResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ParameterTablePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognitionResult;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecursiveConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
@@ -4426,15 +4428,17 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement): ?array => $this->convertPatternElement($sourceElement),
             fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
             fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement),
-            function (DOMElement $sourceElement, bool $captureUnsupported): \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult {
-                $fallbacks = array();
-                return new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult($this->convertChildren($sourceElement, $fallbacks, $captureUnsupported), $fallbacks);
-            },
-            function (DOMElement $sourceElement, bool $captureUnsupported): \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult {
-                $fallbacks = array();
-                $block = $this->convertElement($sourceElement, $fallbacks, $captureUnsupported);
-                return new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult(null === $block ? array() : array($block), $fallbacks);
-            },
+            new PatternRecursiveConverter(
+                function (DOMElement $sourceElement, bool $captureUnsupported): PatternConversionResult {
+                    $fallbacks = array();
+                    return new PatternConversionResult($this->convertChildren($sourceElement, $fallbacks, $captureUnsupported), $fallbacks);
+                },
+                function (DOMElement $sourceElement, bool $captureUnsupported): PatternConversionResult {
+                    $fallbacks = array();
+                    $block = $this->convertElement($sourceElement, $fallbacks, $captureUnsupported);
+                    return new PatternConversionResult(null === $block ? array() : array($block), $fallbacks);
+                }
+            ),
             fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
             fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
             fn (string $url): string => $this->resolvedAssetImageUrl($url),

--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -11,15 +11,14 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
  * converts them to a core/columns block of core/column children.
  *
  * Extracted verbatim from HtmlTransformer::columnsBlockFromElement() and its
- * private helpers. The recognizer needs three coupling points from the host
- * transformer, supplied as callables so behavior is byte-identical:
+ * private helpers. The matcher keeps its frozen callback contract while the
+ * registry supplies recursive conversion through PatternRecursiveConverter:
  *   - $convertChildren: convertChildren($child, $fallbacks, true) for wrapper
  *     columns (recursion that may emit fallbacks).
  *   - $convertElement:  convertElement($child, $fallbacks, true) for non-wrapper
  *     children (single-element recursion that may return null / emit fallbacks).
- *   - $fallbacks (by reference): the mutable accumulator. Per-child fallbacks are
- *     collected into a local list and array_push'd onto the host accumulator,
- *     preserving the original ordering and counts.
+ *   - $fallbacks (by reference): the local transactional accumulator. Per-child
+ *     fallbacks are committed only if this recognizer wins.
  *
  * This recognizer is invoked at its specific div/section-like call site only and
  * is intentionally NOT registered in PatternRecognizerRegistry: looksLikeColumnsContainer
@@ -33,20 +32,23 @@ final class ColumnsPattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        $children = $context->convertChildrenWithFallbacksCallback();
-        $convert = $context->convertElementWithFallbacksCallback();
-        $style = $context->structuralPresentationStyleCallback();
-        if (null === $children || null === $convert || null === $style) return null;
+        $converter = $context->recursiveConverter();
+        $style     = $context->structuralPresentationStyleCallback();
+        if ( null === $converter || null === $style ) {
+            return null;
+        }
+
         $fallbacks = array();
-        $block = $this->match($element, $fallbacks, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($children): array {
-            $result = $children($sourceElement, $captureUnsupported);
-            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
-            return $result->blocks();
-        }, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($convert): ?array {
-            $result = $convert($sourceElement, $captureUnsupported);
-            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
-            return $result->firstBlock();
-        }, $context->presentationAttributesCallback(), $style, $context->createBlockCallback());
+        $block = $this->match(
+            $element,
+            $fallbacks,
+            array($converter, 'children'),
+            array($converter, 'element'),
+            $context->presentationAttributesCallback(),
+            $style,
+            $context->createBlockCallback()
+        );
+
         return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -42,13 +42,26 @@ final class CoverPattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        $children = $context->convertChildrenWithFallbacksCallback(); $style = $context->mergedPresentationStyleCallback(); $attrs = $context->htmlAttributesCallback(); $url = $context->resolveAssetImageUrlCallback();
-        if (null === $children || null === $style || null === $attrs || null === $url) return null;
-        $fallbacks = array(); $block = $this->match($element, $fallbacks, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($children): array {
-            $result = $children($sourceElement, $captureUnsupported);
-            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
-            return $result->blocks();
-        }, $context->presentationAttributesCallback(), $style, $attrs, $url, $context->createBlockCallback());
+        $converter = $context->recursiveConverter();
+        $style     = $context->mergedPresentationStyleCallback();
+        $attrs     = $context->htmlAttributesCallback();
+        $url       = $context->resolveAssetImageUrlCallback();
+        if ( null === $converter || null === $style || null === $attrs || null === $url ) {
+            return null;
+        }
+
+        $fallbacks = array();
+        $block = $this->match(
+            $element,
+            $fallbacks,
+            array($converter, 'children'),
+            $context->presentationAttributesCallback(),
+            $style,
+            $attrs,
+            $url,
+            $context->createBlockCallback()
+        );
+
         return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
@@ -29,17 +29,28 @@ final class MediaTextPattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        $children = $context->convertChildrenWithFallbacksCallback(); $convert = $context->convertElementWithFallbacksCallback(); $attrs = $context->mediaTextPresentationAttributesCallback(); $style = $context->mediaTextPresentationStyleCallback(); $html = $context->htmlAttributesCallback(); $url = $context->resolveAssetImageUrlCallback();
-        if (null === $children || null === $convert || null === $attrs || null === $style || null === $html || null === $url) return null;
-        $fallbacks = array(); $block = $this->match($element, $fallbacks, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($children): array {
-            $result = $children($sourceElement, $captureUnsupported);
-            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
-            return $result->blocks();
-        }, static function (DOMElement $sourceElement, array &$sourceFallbacks, bool $captureUnsupported) use ($convert): ?array {
-            $result = $convert($sourceElement, $captureUnsupported);
-            $sourceFallbacks = array_merge($sourceFallbacks, $result->fallbacks());
-            return $result->firstBlock();
-        }, $attrs, $style, $html, $url, $context->createBlockCallback());
+        $converter = $context->recursiveConverter();
+        $attrs     = $context->mediaTextPresentationAttributesCallback();
+        $style     = $context->mediaTextPresentationStyleCallback();
+        $html      = $context->htmlAttributesCallback();
+        $url       = $context->resolveAssetImageUrlCallback();
+        if ( null === $converter || null === $attrs || null === $style || null === $html || null === $url ) {
+            return null;
+        }
+
+        $fallbacks = array();
+        $block = $this->match(
+            $element,
+            $fallbacks,
+            array($converter, 'children'),
+            array($converter, 'element'),
+            $attrs,
+            $style,
+            $html,
+            $url,
+            $context->createBlockCallback()
+        );
+
         return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -19,8 +19,7 @@ final class PatternContext
      * @param callable(DOMElement): array<string, mixed>|null $convertElement
      * @param callable(DOMElement): list<string>|null $navigationColorInteractionStates
      * @param callable(DOMElement): string|null $navigationOverlayMenu
-     * @param callable(DOMElement, bool): PatternConversionResult|null $convertChildrenWithFallbacks
-     * @param callable(DOMElement, bool): PatternConversionResult|null $convertElementWithFallbacks
+     * @param PatternRecursiveConverter|null $recursiveConverter
      * @param callable(DOMElement): string|null $mergedPresentationStyle
      * @param callable(DOMElement): array<string, string>|null $htmlAttributes
      * @param callable(string): string|null $resolveAssetImageUrl
@@ -40,8 +39,7 @@ final class PatternContext
         private readonly mixed $convertElement = null,
         private readonly mixed $navigationColorInteractionStates = null,
         private readonly mixed $navigationOverlayMenu = null,
-        private readonly mixed $convertChildrenWithFallbacks = null,
-        private readonly mixed $convertElementWithFallbacks = null,
+        private readonly ?PatternRecursiveConverter $recursiveConverter = null,
         private readonly mixed $mergedPresentationStyle = null,
         private readonly mixed $htmlAttributes = null,
         private readonly mixed $resolveAssetImageUrl = null,
@@ -144,8 +142,7 @@ final class PatternContext
         return is_callable($this->navigationOverlayMenu) ? $this->navigationOverlayMenu : null;
     }
 
-    public function convertChildrenWithFallbacksCallback(): ?callable { return is_callable($this->convertChildrenWithFallbacks) ? $this->convertChildrenWithFallbacks : null; }
-    public function convertElementWithFallbacksCallback(): ?callable { return is_callable($this->convertElementWithFallbacks) ? $this->convertElementWithFallbacks : null; }
+    public function recursiveConverter(): ?PatternRecursiveConverter { return $this->recursiveConverter; }
     public function mergedPresentationStyleCallback(): ?callable { return is_callable($this->mergedPresentationStyle) ? $this->mergedPresentationStyle : null; }
     public function htmlAttributesCallback(): ?callable { return is_callable($this->htmlAttributes) ? $this->htmlAttributes : null; }
     public function resolveAssetImageUrlCallback(): ?callable { return is_callable($this->resolveAssetImageUrl) ? $this->resolveAssetImageUrl : null; }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecursiveConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecursiveConverter.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Closure;
+use DOMElement;
+
+/** Recursively converts pattern content while keeping its diagnostics transactional. */
+final class PatternRecursiveConverter
+{
+    private readonly Closure $convertChildren;
+    private readonly Closure $convertElement;
+
+    /**
+     * @param callable(DOMElement, bool): PatternConversionResult $convertChildren
+     * @param callable(DOMElement, bool): PatternConversionResult $convertElement
+     */
+    public function __construct(callable $convertChildren, callable $convertElement)
+    {
+        $this->convertChildren = Closure::fromCallable($convertChildren);
+        $this->convertElement  = Closure::fromCallable($convertElement);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $fallbacks
+     * @return list<array<string, mixed>>
+     */
+    public function children(DOMElement $element, array &$fallbacks, bool $captureUnsupported): array
+    {
+        $result    = ($this->convertChildren)($element, $captureUnsupported);
+        $fallbacks = array_merge($fallbacks, $result->fallbacks());
+
+        return $result->blocks();
+    }
+
+    /**
+     * @param list<array<string, mixed>> $fallbacks
+     * @return array<string, mixed>|null
+     */
+    public function element(DOMElement $element, array &$fallbacks, bool $captureUnsupported): ?array
+    {
+        $result    = ($this->convertElement)($element, $captureUnsupported);
+        $fallbacks = array_merge($fallbacks, $result->fallbacks());
+
+        return $result->firstBlock();
+    }
+}

--- a/php-transformer/tests/unit/pattern-recursive-converter.php
+++ b/php-transformer/tests/unit/pattern-recursive-converter.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecursiveConverter;
+
+$document = new DOMDocument();
+$document->loadHTML('<div></div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+$element = $document->documentElement;
+if ( ! $element instanceof DOMElement ) {
+    throw new RuntimeException('Fixture did not produce a DOM element.');
+}
+
+$captureCalls = array();
+$converter = new PatternRecursiveConverter(
+    static function (DOMElement $source, bool $captureUnsupported) use (&$captureCalls): PatternConversionResult {
+        $captureCalls[] = array( 'children', $captureUnsupported );
+        return new PatternConversionResult(
+            array( array( 'blockName' => 'core/paragraph' ) ),
+            array( array( 'diagnostic_code' => 'child_fallback' ) )
+        );
+    },
+    static function (DOMElement $source, bool $captureUnsupported) use (&$captureCalls): PatternConversionResult {
+        $captureCalls[] = array( 'element', $captureUnsupported );
+        return new PatternConversionResult(
+            array( array( 'blockName' => 'core/group' ) ),
+            array( array( 'diagnostic_code' => 'element_fallback' ) )
+        );
+    }
+);
+
+$fallbacks = array( array( 'diagnostic_code' => 'existing_fallback' ) );
+$blocks = $converter->children($element, $fallbacks, true);
+if ( array( array( 'blockName' => 'core/paragraph' ) ) !== $blocks ) {
+    throw new RuntimeException('Child conversion must return every converted block.');
+}
+if ( array( 'existing_fallback', 'child_fallback' ) !== array_column($fallbacks, 'diagnostic_code') ) {
+    throw new RuntimeException('Child conversion must append fallback diagnostics in source order.');
+}
+
+$block = $converter->element($element, $fallbacks, false);
+if ( 'core/group' !== ($block['blockName'] ?? null) ) {
+    throw new RuntimeException('Element conversion must return its converted block.');
+}
+if ( array( 'existing_fallback', 'child_fallback', 'element_fallback' ) !== array_column($fallbacks, 'diagnostic_code') ) {
+    throw new RuntimeException('Element conversion must append fallback diagnostics in source order.');
+}
+if ( array( array( 'children', true ), array( 'element', false ) ) !== $captureCalls ) {
+    throw new RuntimeException('Capture policy must pass through unchanged.');
+}
+
+$emptyConverter = new PatternRecursiveConverter(
+    static fn (DOMElement $source, bool $captureUnsupported): PatternConversionResult => new PatternConversionResult(array()),
+    static fn (DOMElement $source, bool $captureUnsupported): PatternConversionResult => new PatternConversionResult(
+        array(),
+        array( array( 'diagnostic_code' => 'empty_element_fallback' ) )
+    )
+);
+$emptyFallbacks = array();
+if ( null !== $emptyConverter->element($element, $emptyFallbacks, true) ) {
+    throw new RuntimeException('Empty element conversion must remain nullable.');
+}
+if ( array( 'empty_element_fallback' ) !== array_column($emptyFallbacks, 'diagnostic_code') ) {
+    throw new RuntimeException('Empty element conversion must retain its diagnostics.');
+}
+
+echo "pattern recursive converter ok\n";


### PR DESCRIPTION
## Summary

- replace two `mixed` recursive-conversion callbacks in `PatternContext` with one typed `PatternRecursiveConverter`
- centralize fallback ordering and block projection for Columns, Cover, and Media/Text recognition
- remove six repeated per-recognition adapter closures while preserving the frozen public matcher contracts

This is the next bounded `PatternContext` simplification slice from #242. It keeps #919 transactional diagnostic behavior explicit: recursive findings enter a recognizer-local accumulator and are committed only when that recognizer wins.

## Compatibility and stability proof

- Cover and Media/Text frozen matcher signatures remain unchanged
- rejected Cover candidates continue to discard recursive findings
- child and element findings append in exact source order
- unsupported-capture policy passes through unchanged
- ordered registry and staged-dispatch contracts pass

## Verification

- `composer test`
- 280 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to trace recursive pattern conversion and fallback ownership, introduce the typed conversion boundary, preserve compatibility contracts, add focused behavior coverage, and run verification. Chris Huber is responsible for every line.