### PR TITLE
fix: preserve registry recursion fallbacks

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -634,8 +634,15 @@ final class HtmlTransformer
                 return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
             }),
             new CallbackPatternRecognizer('disclosure', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $block = $this->detailsPattern->matchDisclosure($element, fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block);
+                $converter = $context->recursiveConverter();
+                if ( null === $converter ) {
+                    return null;
+                }
+                $fallbacks = array();
+                $block = $this->detailsPattern->matchDisclosure($element, function (DOMElement $sourceElement) use ($converter, &$fallbacks): array {
+                    return $converter->children($sourceElement, $fallbacks, true);
+                }, $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
+                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
             }),
             new CallbackPatternRecognizer('gallery', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
                 $block = $this->galleryPattern->match($element, fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link), fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $this->convertPictureElement($picture, $figure, $link), fn (DOMElement $figure): ?DOMElement => $this->figureLinkedMediaAnchor($figure), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
@@ -4423,13 +4430,6 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
             fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
             $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
-            fn (DOMElement $sourceElement): array => $this->convertPatternChildren($sourceElement),
-            fn (DOMElement $sourceElement, array $excludedTags): array => $this->convertPatternChildrenWithoutTags($sourceElement, $excludedTags),
-            fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
-            fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement)),
-            fn (DOMElement $sourceElement): ?array => $this->convertPatternElement($sourceElement),
-            fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement),
             new PatternRecursiveConverter(
                 function (DOMElement $sourceElement, bool $captureUnsupported): PatternConversionResult {
                     $fallbacks = array();
@@ -4439,8 +4439,16 @@ final class HtmlTransformer
                     $fallbacks = array();
                     $block = $this->convertElement($sourceElement, $fallbacks, $captureUnsupported);
                     return new PatternConversionResult(null === $block ? array() : array($block), $fallbacks);
+                },
+                function (DOMElement $sourceElement, array $excludedTags): PatternConversionResult {
+                    $fallbacks = array();
+                    return new PatternConversionResult($this->convertChildrenWithoutTags($sourceElement, $fallbacks, $excludedTags), $fallbacks);
                 }
             ),
+            fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
+            fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement)),
+            fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
+            fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement),
             fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
             fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
             fn (string $url): string => $this->resolvedAssetImageUrl($url),
@@ -4463,34 +4471,6 @@ final class HtmlTransformer
     }
 
     /**
-     * @return array<int, array<string, mixed>>
-     */
-    private function convertPatternChildren(DOMElement $element): array
-    {
-        $fallbacks = array();
-        return $this->convertChildren($element, $fallbacks, true);
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function convertPatternElement(DOMElement $element): ?array
-    {
-        $fallbacks = array();
-        return $this->convertElement($element, $fallbacks, true);
-    }
-
-    /**
-     * @param array<int, string> $excludedTags
-     * @return array<int, array<string, mixed>>
-     */
-    private function convertPatternChildrenWithoutTags(DOMElement $element, array $excludedTags): array
-    {
-        $fallbacks = array();
-        return $this->convertChildrenWithoutTags($element, $fallbacks, $excludedTags);
-    }
-
-    /**
      * A side-effect-free pattern context for probing whether an element would
      * convert to a given block, without recording provenance or runtime islands.
      */
@@ -4504,7 +4484,6 @@ final class HtmlTransformer
                 'attrs'       => $attrs,
                 'innerBlocks' => $innerBlocks,
             ),
-            null,
             null,
             null,
             fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),

--- a/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
@@ -12,18 +12,18 @@ final class AccordionPattern implements PatternRecognizerInterface
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         $createBlock = $context->createBlockCallback();
-        $convertChildren = $context->convertChildrenCallback();
-        $convertChildrenWithoutTags = $context->convertChildrenWithoutTagsCallback();
+        $converter = $context->recursiveConverter();
         $presentationAttributes = $context->presentationAttributesCallback();
         $innerHtml = $context->innerHtmlCallback();
 
-        if ( null === $convertChildren || null === $convertChildrenWithoutTags || ! $this->hasAccordionSignal($element) || $this->hasRuntimeHeavyDescendant($element) ) {
+        if ( null === $converter || ! $this->hasAccordionSignal($element) || $this->hasRuntimeHeavyDescendant($element) ) {
             return null;
         }
 
+        $fallbacks = array();
         $items = array();
         foreach ( $this->directChildElements($element) as $child ) {
-            $item = $this->accordionItem($child, $innerHtml, $convertChildren, $convertChildrenWithoutTags, $createBlock, $presentationAttributes);
+            $item = $this->accordionItem($child, $fallbacks, $innerHtml, $converter, $createBlock, $presentationAttributes);
             if ( null === $item ) {
                 return null;
             }
@@ -35,11 +35,13 @@ final class AccordionPattern implements PatternRecognizerInterface
         }
 
         return new PatternRecognitionResult(
-            $createBlock('core/accordion', $presentationAttributes($element), $items, $element)
+            $createBlock('core/accordion', $presentationAttributes($element), $items, $element),
+            $fallbacks
         );
     }
 
-    private function accordionItem(DOMElement $item, callable $innerHtml, callable $convertChildren, callable $convertChildrenWithoutTags, callable $createBlock, callable $presentationAttributes): ?array
+    /** @param list<array<string, mixed>> $fallbacks */
+    private function accordionItem(DOMElement $item, array &$fallbacks, callable $innerHtml, PatternRecursiveConverter $converter, callable $createBlock, callable $presentationAttributes): ?array
     {
         if ( ! $this->isAccordionItemElement($item) || $this->hasRuntimeHeavyDescendant($item) ) {
             return null;
@@ -60,7 +62,9 @@ final class AccordionPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $panelBlocks = $panel instanceof DOMElement ? $convertChildren($panel) : $convertChildrenWithoutTags($item, array( 'summary' ));
+        $panelBlocks = $panel instanceof DOMElement
+            ? $converter->children($panel, $fallbacks, true)
+            : $converter->childrenWithoutTags($item, $fallbacks, array( 'summary' ));
         if ( array() === $panelBlocks ) {
             return null;
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -68,9 +68,10 @@ final class NavigationPattern implements PatternRecognizerInterface
         // current page in, and destinations left as inner-HTML hrefs rather than
         // a navigation-link `url`. The guard still catches every container the
         // carrier declines, so nothing it protected loses that protection.
-        $hoisted = $this->brandAnchorCarrier($element, $presentationAttributes, $innerHtml, $createBlock, $context->convertElementCallback(), $isRuntimeDomTarget, $navigationUnderlineColor, $resolvedStyle, $navigationColorInteractionStates, $navigationOverlayMenu);
+        $carrierFallbacks = array();
+        $hoisted = $this->brandAnchorCarrier($element, $carrierFallbacks, $presentationAttributes, $innerHtml, $createBlock, $context->recursiveConverter(), $isRuntimeDomTarget, $navigationUnderlineColor, $resolvedStyle, $navigationColorInteractionStates, $navigationOverlayMenu);
         if ( null !== $hoisted ) {
-            return new PatternRecognitionResult($hoisted);
+            return new PatternRecognitionResult($hoisted, $carrierFallbacks);
         }
 
         if ( $this->hasDirectBrandingAnchorBesideListNavigation($element, $innerHtml) ) {
@@ -173,11 +174,12 @@ final class NavigationPattern implements PatternRecognizerInterface
      * deferring the shapes it already recognises, so this covers exactly the
      * containers that would otherwise absorb the brand.
      *
+     * @param list<array<string, mixed>> $fallbacks
      * @return array<string, mixed>|null
      */
-    private function brandAnchorCarrier(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $convertElement, ?callable $isRuntimeDomTarget, ?callable $navigationUnderlineColor, ?callable $resolvedStyle = null, ?callable $navigationColorInteractionStates = null, ?callable $navigationOverlayMenu = null): ?array
+    private function brandAnchorCarrier(DOMElement $element, array &$fallbacks, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?PatternRecursiveConverter $converter, ?callable $isRuntimeDomTarget, ?callable $navigationUnderlineColor, ?callable $resolvedStyle = null, ?callable $navigationColorInteractionStates = null, ?callable $navigationOverlayMenu = null): ?array
     {
-        if ( null === $convertElement ) {
+        if ( null === $converter ) {
             return null;
         }
 
@@ -276,7 +278,7 @@ final class NavigationPattern implements PatternRecognizerInterface
 
         // An anchor that only converts to an HTML fallback would trade a menu
         // item for raw markup; keep today's shape rather than lose the block.
-        $brand = $convertElement($anchor);
+        $brand = $converter->element($anchor, $fallbacks, true);
         $brandName = is_array($brand) ? (string) ($brand['blockName'] ?? '') : '';
         if ( '' === $brandName || 'core/html' === $brandName ) {
             return null;
@@ -359,7 +361,7 @@ final class NavigationPattern implements PatternRecognizerInterface
 
         $extraBlocks = array();
         foreach ( $extras as $extra ) {
-            $extraBlock = $convertElement($extra);
+            $extraBlock = $converter->element($extra, $fallbacks, true);
             $extraName = is_array($extraBlock) ? (string) ($extraBlock['blockName'] ?? '') : '';
             if ( '' === $extraName || 'core/html' === $extraName ) {
                 return null;

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -12,14 +12,11 @@ final class PatternContext
      * @param callable(DOMElement): string $innerHtml
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
      * @param callable(DOMElement): bool|null $isRuntimeDomTarget
-     * @param callable(DOMElement): array<int, array<string, mixed>>|null $convertChildren
-     * @param callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null $convertChildrenWithoutTags
+     * @param PatternRecursiveConverter|null $recursiveConverter
      * @param callable(DOMElement, DOMElement): string|null $navigationUnderlineColor
      * @param callable(DOMElement): string|null $resolvedStyle
-     * @param callable(DOMElement): array<string, mixed>|null $convertElement
      * @param callable(DOMElement): list<string>|null $navigationColorInteractionStates
      * @param callable(DOMElement): string|null $navigationOverlayMenu
-     * @param PatternRecursiveConverter|null $recursiveConverter
      * @param callable(DOMElement): string|null $mergedPresentationStyle
      * @param callable(DOMElement): array<string, string>|null $htmlAttributes
      * @param callable(string): string|null $resolveAssetImageUrl
@@ -32,14 +29,11 @@ final class PatternContext
         private readonly mixed $innerHtml,
         private readonly mixed $createBlock,
         private readonly mixed $isRuntimeDomTarget = null,
-        private readonly mixed $convertChildren = null,
-        private readonly mixed $convertChildrenWithoutTags = null,
+        private readonly ?PatternRecursiveConverter $recursiveConverter = null,
         private readonly mixed $navigationUnderlineColor = null,
         private readonly mixed $resolvedStyle = null,
-        private readonly mixed $convertElement = null,
         private readonly mixed $navigationColorInteractionStates = null,
         private readonly mixed $navigationOverlayMenu = null,
-        private readonly ?PatternRecursiveConverter $recursiveConverter = null,
         private readonly mixed $mergedPresentationStyle = null,
         private readonly mixed $htmlAttributes = null,
         private readonly mixed $resolveAssetImageUrl = null,
@@ -79,35 +73,6 @@ final class PatternContext
     public function isRuntimeDomTargetCallback(): ?callable
     {
         return is_callable($this->isRuntimeDomTarget) ? $this->isRuntimeDomTarget : null;
-    }
-
-    /**
-     * @return callable(DOMElement): array<int, array<string, mixed>>|null
-     */
-    public function convertChildrenCallback(): ?callable
-    {
-        return is_callable($this->convertChildren) ? $this->convertChildren : null;
-    }
-
-    /**
-     * Convert one element to the block the generic pipeline would emit for it.
-     * A pattern that keeps a sibling element out of its own block needs the
-     * element's own conversion rather than its children's, so the sibling is
-     * emitted exactly as it would be anywhere else in the document.
-     *
-     * @return callable(DOMElement): array<string, mixed>|null
-     */
-    public function convertElementCallback(): ?callable
-    {
-        return is_callable($this->convertElement) ? $this->convertElement : null;
-    }
-
-    /**
-     * @return callable(DOMElement, array<int, string>): array<int, array<string, mixed>>|null
-     */
-    public function convertChildrenWithoutTagsCallback(): ?callable
-    {
-        return is_callable($this->convertChildrenWithoutTags) ? $this->convertChildrenWithoutTags : null;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecursiveConverter.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecursiveConverter.php
@@ -11,15 +11,18 @@ final class PatternRecursiveConverter
 {
     private readonly Closure $convertChildren;
     private readonly Closure $convertElement;
+    private readonly Closure $convertChildrenWithoutTags;
 
     /**
      * @param callable(DOMElement, bool): PatternConversionResult $convertChildren
      * @param callable(DOMElement, bool): PatternConversionResult $convertElement
+     * @param callable(DOMElement, list<string>): PatternConversionResult $convertChildrenWithoutTags
      */
-    public function __construct(callable $convertChildren, callable $convertElement)
+    public function __construct(callable $convertChildren, callable $convertElement, callable $convertChildrenWithoutTags)
     {
-        $this->convertChildren = Closure::fromCallable($convertChildren);
-        $this->convertElement  = Closure::fromCallable($convertElement);
+        $this->convertChildren            = Closure::fromCallable($convertChildren);
+        $this->convertElement             = Closure::fromCallable($convertElement);
+        $this->convertChildrenWithoutTags = Closure::fromCallable($convertChildrenWithoutTags);
     }
 
     /**
@@ -44,5 +47,18 @@ final class PatternRecursiveConverter
         $fallbacks = array_merge($fallbacks, $result->fallbacks());
 
         return $result->firstBlock();
+    }
+
+    /**
+     * @param list<array<string, mixed>> $fallbacks
+     * @param list<string> $excludedTags
+     * @return list<array<string, mixed>>
+     */
+    public function childrenWithoutTags(DOMElement $element, array &$fallbacks, array $excludedTags): array
+    {
+        $result    = ($this->convertChildrenWithoutTags)($element, $excludedTags);
+        $fallbacks = array_merge($fallbacks, $result->fallbacks());
+
+        return $result->blocks();
     }
 }

--- a/php-transformer/tests/unit/pattern-recursive-converter.php
+++ b/php-transformer/tests/unit/pattern-recursive-converter.php
@@ -28,6 +28,13 @@ $converter = new PatternRecursiveConverter(
             array( array( 'blockName' => 'core/group' ) ),
             array( array( 'diagnostic_code' => 'element_fallback' ) )
         );
+    },
+    static function (DOMElement $source, array $excludedTags) use (&$captureCalls): PatternConversionResult {
+        $captureCalls[] = array( 'without_tags', $excludedTags );
+        return new PatternConversionResult(
+            array( array( 'blockName' => 'core/quote' ) ),
+            array( array( 'diagnostic_code' => 'excluded_tags_fallback' ) )
+        );
     }
 );
 
@@ -47,7 +54,14 @@ if ( 'core/group' !== ($block['blockName'] ?? null) ) {
 if ( array( 'existing_fallback', 'child_fallback', 'element_fallback' ) !== array_column($fallbacks, 'diagnostic_code') ) {
     throw new RuntimeException('Element conversion must append fallback diagnostics in source order.');
 }
-if ( array( array( 'children', true ), array( 'element', false ) ) !== $captureCalls ) {
+$withoutTags = $converter->childrenWithoutTags($element, $fallbacks, array( 'summary' ));
+if ( 'core/quote' !== ($withoutTags[0]['blockName'] ?? null) ) {
+    throw new RuntimeException('Excluded-tag conversion must return every converted block.');
+}
+if ( array( 'existing_fallback', 'child_fallback', 'element_fallback', 'excluded_tags_fallback' ) !== array_column($fallbacks, 'diagnostic_code') ) {
+    throw new RuntimeException('Excluded-tag conversion must append fallback diagnostics in source order.');
+}
+if ( array( array( 'children', true ), array( 'element', false ), array( 'without_tags', array( 'summary' ) ) ) !== $captureCalls ) {
     throw new RuntimeException('Capture policy must pass through unchanged.');
 }
 
@@ -56,7 +70,8 @@ $emptyConverter = new PatternRecursiveConverter(
     static fn (DOMElement $source, bool $captureUnsupported): PatternConversionResult => new PatternConversionResult(
         array(),
         array( array( 'diagnostic_code' => 'empty_element_fallback' ) )
-    )
+    ),
+    static fn (DOMElement $source, array $excludedTags): PatternConversionResult => new PatternConversionResult(array())
 );
 $emptyFallbacks = array();
 if ( null !== $emptyConverter->element($element, $emptyFallbacks, true) ) {

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecursiveConverter;
 
 $assertions = 0;
 $assert = static function (bool $condition, string $message) use (&$assertions): void {
@@ -21,5 +25,59 @@ $assert('html_stylable_button_accessible_name_fallback' === ($button['fallbacks'
 
 $quoteWithNavigation = (new HtmlTransformer())->transform('<blockquote><nav><a href="/one">One</a><a href="/two">Two</a></nav></blockquote>')->toArray();
 $assert('core/quote' === ($quoteWithNavigation['blocks'][0]['blockName'] ?? null), 'Quote child lowering does not re-enter unrelated registry recognizers through the navigation probe.');
+
+$accordion = (new HtmlTransformer())->transform('<section class="faq"><div class="faq-item"><button aria-controls="a">A?</button><div id="a"><p>A.</p><object data="/a.pdf"></object></div></div><div class="faq-item"><button aria-controls="b">B?</button><div id="b"><p>B.</p></div></div></section>')->toArray();
+$assert('core/accordion' === ($accordion['blocks'][0]['blockName'] ?? null), 'Accordion recognition survives an unsupported panel child.');
+$assert('html_unsupported_element' === ($accordion['fallbacks'][0]['diagnostic_code'] ?? null), 'Accordion commits recursive panel diagnostics through its winning result.');
+
+$disclosure = (new HtmlTransformer())->transform('<div><button aria-expanded="false" aria-controls="answer">Question?</button><div id="answer"><p>Answer.</p><object data="/answer.pdf"></object></div></div>')->toArray();
+$assert('core/details' === ($disclosure['blocks'][0]['blockName'] ?? null), 'Disclosure recognition survives an unsupported panel child.');
+$assert('html_unsupported_element' === ($disclosure['fallbacks'][0]['diagnostic_code'] ?? null), 'Disclosure commits recursive panel diagnostics through its winning result.');
+
+$navigationDocument = new DOMDocument();
+$previous = libxml_use_internal_errors(true);
+$navigationDocument->loadHTML('<nav><a class="brand" href="/">Brand</a><ul><li><a href="/a">A</a></li><li><a href="/b">B</a></li></ul></nav>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+libxml_clear_errors();
+libxml_use_internal_errors($previous);
+$navigationElement = $navigationDocument->documentElement;
+if ( ! $navigationElement instanceof DOMElement ) {
+    throw new RuntimeException('Navigation fixture did not produce a DOM element.');
+}
+$innerHtml = static function (DOMElement $element): string {
+    $html = '';
+    foreach ( $element->childNodes as $child ) {
+        $html .= $element->ownerDocument?->saveHTML($child) ?: '';
+    }
+    return $html;
+};
+$createBlock = static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children );
+$recursiveCalls = 0;
+$navigationConverter = new PatternRecursiveConverter(
+    static fn (DOMElement $source, bool $captureUnsupported): PatternConversionResult => new PatternConversionResult(array()),
+    static function (DOMElement $source, bool $captureUnsupported) use (&$recursiveCalls): PatternConversionResult {
+        ++$recursiveCalls;
+        return new PatternConversionResult(
+            array( array( 'blockName' => 'core/paragraph', 'attrs' => array( 'content' => 'Brand' ), 'innerBlocks' => array() ) ),
+            array( array( 'diagnostic_code' => 'brand_fallback' ) )
+        );
+    },
+    static fn (DOMElement $source, array $excludedTags): PatternConversionResult => new PatternConversionResult(array())
+);
+$navigationContext = new PatternContext(
+    static fn (DOMElement $source, array $excluded = array()): array => array(),
+    $innerHtml,
+    $createBlock,
+    null,
+    $navigationConverter,
+    null,
+    static fn (DOMElement $source): string => ''
+);
+$navigationResult = (new NavigationPattern())->recognize($navigationElement, $navigationContext);
+$assert('core/group' === ($navigationResult?->block()['blockName'] ?? null), 'Navigation brand carrier wins with a recursively converted brand.');
+$assert('brand_fallback' === ($navigationResult?->fallbacks()[0]['diagnostic_code'] ?? null), 'Navigation commits recursive brand diagnostics through its winning carrier.');
+
+$probeContext = new PatternContext(static fn (DOMElement $source): array => array(), $innerHtml, $createBlock);
+(new NavigationPattern())->recognize($navigationElement, $probeContext);
+$assert(1 === $recursiveCalls, 'Navigation probe context performs no recursive conversion side effects.');
 
 echo "pattern registry staged dispatch passed ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary

- route Accordion, Disclosure, and Navigation brand-carrier recursion through `PatternRecursiveConverter`
- preserve recursive fallback diagnostics transactionally with the winning pattern result
- remove three parallel recursion callbacks from `PatternContext` and three fallback-discarding `HtmlTransformer` wrappers
- keep Navigation probe contexts recursion-free

Closes #919. This is the next bounded `PatternContext` simplification slice from #242.

## Behavior proof

- Accordion and Disclosure retain `html_unsupported_element` evidence from valid panels containing unsupported children
- Navigation retains recursive brand diagnostics only when the brand carrier wins
- Navigation probe context performs no recursive conversions
- excluded-tag conversion preserves fallback ordering through the typed converter

## Verification

- `composer test` on current `trunk`
- 12 staged-dispatch assertions
- 280 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to trace the remaining fallback-discarding recursion paths, consolidate them into the typed converter, add transactional behavior coverage, rebase onto current trunk, and run verification. Chris Huber is responsible for every line.