### PR TITLE
refactor: reuse pattern execution contexts

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -229,6 +229,12 @@ final class HtmlTransformer
 
     private readonly PatternRecognizerRegistry $patternRecognizers;
 
+    private readonly PatternContext $patternContext;
+
+    private readonly PatternContext $patternContextWithoutRuntimeDomTarget;
+
+    private readonly PatternContext $patternProbeContext;
+
     private readonly NavigationUnderlineColorResolver $navigationUnderlineColorResolver;
 
     private readonly NavigationBlockNormalizer $navigationBlockNormalizer;
@@ -674,6 +680,9 @@ final class HtmlTransformer
         $this->semanticParityReporter = new SemanticParityReporter($this->runtime);
         $this->contentRoundTripReporter = new ContentRoundTripReporter();
         $this->reusableComponentRecognizer = new ReusableComponentRecognizer();
+        $this->patternContext = $this->createPatternContext(true);
+        $this->patternContextWithoutRuntimeDomTarget = $this->createPatternContext(false);
+        $this->patternProbeContext = $this->createProbePatternContext();
     }
 
     public function &__get(string $name): mixed
@@ -4425,6 +4434,11 @@ final class HtmlTransformer
 
     private function patternContext(bool $includeRuntimeDomTarget = true): PatternContext
     {
+        return $includeRuntimeDomTarget ? $this->patternContext : $this->patternContextWithoutRuntimeDomTarget;
+    }
+
+    private function createPatternContext(bool $includeRuntimeDomTarget): PatternContext
+    {
         return new PatternContext(
             fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
             fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
@@ -4475,6 +4489,11 @@ final class HtmlTransformer
      * convert to a given block, without recording provenance or runtime islands.
      */
     private function probePatternContext(): PatternContext
+    {
+        return $this->patternProbeContext;
+    }
+
+    private function createProbePatternContext(): PatternContext
     {
         return new PatternContext(
             fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),

--- a/php-transformer/tests/unit/html-transformer-session-state.php
+++ b/php-transformer/tests/unit/html-transformer-session-state.php
@@ -28,6 +28,7 @@ $tiles = '<my-pricing><div class="tier"><h3>Basic</h3><p>$9</p></div><div class=
 $svg = '<main><svg viewBox="0 0 10 10" role="img" aria-label="Map"><path d="M0 0h10v10z"/></svg></main>';
 $script = '<main><script src="widget.js"></script><canvas id="map">Map</canvas></main>';
 $styled = '<style>.card{display:grid;gap:1rem;color:#123}.card .title{font-weight:700}</style><main class="card"><h2 class="title">Styled</h2></main>';
+$accordion = static fn (string $label, string $answer): string => '<section class="faq"><div class="faq-item"><button aria-controls="a">' . $label . ' A?</button><div id="a"><p>' . $answer . ' A.</p></div></div><div class="faq-item"><button aria-controls="b">' . $label . ' B?</button><div id="b"><p>' . $answer . ' B.</p></div></div></section>';
 
 $families = array(
     'generated blocks and provenance' => array(
@@ -57,6 +58,13 @@ $families = array(
             implode('', array_column(array_filter($result['assets'] ?? array(), static fn (array $asset): bool => 'author-css' === ($asset['source'] ?? '')), 'content')),
             '#0a0'
         ),
+    ),
+    'reused pattern execution context' => array(
+        'seed' => array($accordion('Seed', 'Old'), array()),
+        'target' => array($accordion('Target', 'Current'), array()),
+        'assertion' => static fn (array $result): bool => 'core/accordion' === ($result['blocks'][0]['blockName'] ?? null)
+            && 'Target A?' === ($result['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['title'] ?? null)
+            && 'Current B.' === ($result['blocks'][0]['innerBlocks'][1]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] ?? null),
     ),
 );
 


### PR DESCRIPTION
## Summary

- construct the normal, runtime-DOM-restricted, and probe `PatternContext` graphs once per `HtmlTransformer`
- reuse those immutable service graphs across recognition attempts and sequential transforms
- keep per-transform data in `HtmlTransformerSession`; cached closures continue resolving the current session through the transformer

This is a bounded maintainability/performance slice from #242. It removes repeated allocation of the full callback graph and `PatternRecursiveConverter` on every `recognizePatterns()` call while preserving the explicit normal/restricted/probe policy boundaries.

## Behavior and performance proof

- fresh and reused transformer instances produce identical patterned output across sequential transforms
- staged dispatch and probe contracts remain green
- five alternating baseline/candidate benchmark pairs over 1,500 nested-container transformations were faster in every pair
- median elapsed time improved from 1319.6 ms to 1256.8 ms (4.8%)

The timing benchmark is external evidence rather than a brittle CI threshold.

## Verification

- `composer test`
- 280 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to trace context construction frequency and session capture semantics, implement constructor-owned context reuse, add reused-instance behavior coverage, benchmark against the merged baseline, and run verification. Chris Huber is responsible for every line.