### PR TITLE
refactor: type navigation pattern context

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -27,6 +27,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MediaTextPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationUnderlineColorResolver;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ParameterTablePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
@@ -4443,7 +4444,6 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
             fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
             fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement, $logicalSourceElement),
-            $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
             new PatternRecursiveConverter(
                 function (DOMElement $sourceElement, bool $captureUnsupported): PatternConversionResult {
                     $fallbacks = array();
@@ -4459,10 +4459,13 @@ final class HtmlTransformer
                     return new PatternConversionResult($this->convertChildrenWithoutTags($sourceElement, $fallbacks, $excludedTags), $fallbacks);
                 }
             ),
-            fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
-            fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement)),
-            fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement),
+            new NavigationPatternContext(
+                $includeRuntimeDomTarget ? fn (DOMElement $sourceElement): bool => $this->isRuntimeDomTarget($sourceElement) : null,
+                fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
+                fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement)),
+                fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
+                fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement)
+            ),
             fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
             fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
             fn (string $url): string => $this->resolvedAssetImageUrl($url),
@@ -4504,9 +4507,11 @@ final class HtmlTransformer
                 'innerBlocks' => $innerBlocks,
             ),
             null,
-            null,
-            fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
-            fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement))
+            new NavigationPatternContext(
+                null,
+                fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
+                fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement))
+            )
         );
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -33,11 +33,12 @@ final class NavigationPattern implements PatternRecognizerInterface
         $presentationAttributes = $context->presentationAttributesCallback();
         $innerHtml = $context->innerHtmlCallback();
         $createBlock = $context->createBlockCallback();
-        $isRuntimeDomTarget = $context->isRuntimeDomTargetCallback();
-        $navigationUnderlineColor = $context->navigationUnderlineColorCallback();
-        $resolvedStyle = $context->resolvedStyleCallback();
-        $navigationColorInteractionStates = $context->navigationColorInteractionStatesCallback();
-        $navigationOverlayMenu = $context->navigationOverlayMenuCallback();
+        $navigationContext = $context->navigationContext();
+        $isRuntimeDomTarget = $navigationContext?->runtimeDomTargetCallback();
+        $navigationUnderlineColor = $navigationContext?->underlineColorCallback();
+        $resolvedStyle = $navigationContext?->resolvedStyleCallback();
+        $navigationColorInteractionStates = $navigationContext?->colorInteractionStatesCallback();
+        $navigationOverlayMenu = $navigationContext?->overlayMenuCallback();
 
         if ( 'nav' !== strtolower($element->tagName) && ! $this->hasNavigationSignal($element) && ! $this->hasDirectListNavigationSignal($element) ) {
             return null;

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPatternContext.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Closure;
+use DOMElement;
+
+/** Navigation-only evidence and policy dependencies. */
+final class NavigationPatternContext
+{
+    private readonly ?Closure $runtimeDomTarget;
+    private readonly Closure $underlineColor;
+    private readonly Closure $resolvedStyle;
+    private readonly ?Closure $colorInteractionStates;
+    private readonly ?Closure $overlayMenu;
+
+    /**
+     * @param callable(DOMElement): bool|null $runtimeDomTarget
+     * @param callable(DOMElement, DOMElement): string $underlineColor
+     * @param callable(DOMElement): string $resolvedStyle
+     * @param callable(DOMElement): list<string>|null $colorInteractionStates
+     * @param callable(DOMElement): string|null $overlayMenu
+     */
+    public function __construct(
+        ?callable $runtimeDomTarget,
+        callable $underlineColor,
+        callable $resolvedStyle,
+        ?callable $colorInteractionStates = null,
+        ?callable $overlayMenu = null
+    ) {
+        $this->runtimeDomTarget       = null === $runtimeDomTarget ? null : Closure::fromCallable($runtimeDomTarget);
+        $this->underlineColor         = Closure::fromCallable($underlineColor);
+        $this->resolvedStyle          = Closure::fromCallable($resolvedStyle);
+        $this->colorInteractionStates = null === $colorInteractionStates ? null : Closure::fromCallable($colorInteractionStates);
+        $this->overlayMenu            = null === $overlayMenu ? null : Closure::fromCallable($overlayMenu);
+    }
+
+    public function runtimeDomTargetCallback(): ?Closure { return $this->runtimeDomTarget; }
+    public function underlineColorCallback(): Closure { return $this->underlineColor; }
+    public function resolvedStyleCallback(): Closure { return $this->resolvedStyle; }
+    public function colorInteractionStatesCallback(): ?Closure { return $this->colorInteractionStates; }
+    public function overlayMenuCallback(): ?Closure { return $this->overlayMenu; }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -11,12 +11,8 @@ final class PatternContext
      * @param callable(DOMElement): array<string, mixed> $presentationAttributes
      * @param callable(DOMElement): string $innerHtml
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
-     * @param callable(DOMElement): bool|null $isRuntimeDomTarget
      * @param PatternRecursiveConverter|null $recursiveConverter
-     * @param callable(DOMElement, DOMElement): string|null $navigationUnderlineColor
-     * @param callable(DOMElement): string|null $resolvedStyle
-     * @param callable(DOMElement): list<string>|null $navigationColorInteractionStates
-     * @param callable(DOMElement): string|null $navigationOverlayMenu
+     * @param NavigationPatternContext|null $navigationContext
      * @param callable(DOMElement): string|null $mergedPresentationStyle
      * @param callable(DOMElement): array<string, string>|null $htmlAttributes
      * @param callable(string): string|null $resolveAssetImageUrl
@@ -28,12 +24,8 @@ final class PatternContext
         private readonly mixed $presentationAttributes,
         private readonly mixed $innerHtml,
         private readonly mixed $createBlock,
-        private readonly mixed $isRuntimeDomTarget = null,
         private readonly ?PatternRecursiveConverter $recursiveConverter = null,
-        private readonly mixed $navigationUnderlineColor = null,
-        private readonly mixed $resolvedStyle = null,
-        private readonly mixed $navigationColorInteractionStates = null,
-        private readonly mixed $navigationOverlayMenu = null,
+        private readonly ?NavigationPatternContext $navigationContext = null,
         private readonly mixed $mergedPresentationStyle = null,
         private readonly mixed $htmlAttributes = null,
         private readonly mixed $resolveAssetImageUrl = null,
@@ -67,47 +59,8 @@ final class PatternContext
         return $this->createBlock;
     }
 
-    /**
-     * @return callable(DOMElement): bool|null
-     */
-    public function isRuntimeDomTargetCallback(): ?callable
-    {
-        return is_callable($this->isRuntimeDomTarget) ? $this->isRuntimeDomTarget : null;
-    }
-
-    /**
-     * @return callable(DOMElement, DOMElement): string|null
-     */
-    public function navigationUnderlineColorCallback(): ?callable
-    {
-        return is_callable($this->navigationUnderlineColor) ? $this->navigationUnderlineColor : null;
-    }
-
-    /**
-     * @return callable(DOMElement): string|null
-     */
-    public function resolvedStyleCallback(): ?callable
-    {
-        return is_callable($this->resolvedStyle) ? $this->resolvedStyle : null;
-    }
-
-    /**
-     * @return callable(DOMElement): list<string>|null
-     */
-    public function navigationColorInteractionStatesCallback(): ?callable
-    {
-        return is_callable($this->navigationColorInteractionStates) ? $this->navigationColorInteractionStates : null;
-    }
-
-    /**
-     * @return callable(DOMElement): string|null
-     */
-    public function navigationOverlayMenuCallback(): ?callable
-    {
-        return is_callable($this->navigationOverlayMenu) ? $this->navigationOverlayMenu : null;
-    }
-
     public function recursiveConverter(): ?PatternRecursiveConverter { return $this->recursiveConverter; }
+    public function navigationContext(): ?NavigationPatternContext { return $this->navigationContext; }
     public function mergedPresentationStyleCallback(): ?callable { return is_callable($this->mergedPresentationStyle) ? $this->mergedPresentationStyle : null; }
     public function htmlAttributesCallback(): ?callable { return is_callable($this->htmlAttributes) ? $this->htmlAttributes : null; }
     public function resolveAssetImageUrlCallback(): ?callable { return is_callable($this->resolveAssetImageUrl) ? $this->resolveAssetImageUrl : null; }

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -5,6 +5,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecursiveConverter;
@@ -67,10 +68,12 @@ $navigationContext = new PatternContext(
     static fn (DOMElement $source, array $excluded = array()): array => array(),
     $innerHtml,
     $createBlock,
-    null,
     $navigationConverter,
-    null,
-    static fn (DOMElement $source): string => ''
+    new NavigationPatternContext(
+        null,
+        static fn (DOMElement $item, DOMElement $anchor): string => '',
+        static fn (DOMElement $source): string => ''
+    )
 );
 $navigationResult = (new NavigationPattern())->recognize($navigationElement, $navigationContext);
 $assert('core/group' === ($navigationResult?->block()['blockName'] ?? null), 'Navigation brand carrier wins with a recursively converted brand.');


### PR DESCRIPTION
## Summary

- move Navigation-only evidence and policy callbacks into typed `NavigationPatternContext`
- replace five `mixed` fields and five callback getters in generic `PatternContext` with one typed dependency
- preserve separate normal, runtime-DOM-restricted, and probe context composition

This is the next bounded `PatternContext` simplification slice from #242. It establishes an explicit Navigation seam without rewriting Navigation's behavior-dense lowering internals.

## Stability proof

- 31 brand-anchor hoist assertions
- 41 brand-cue carrier assertions
- 12 staged-dispatch and probe assertions
- reused-transformer session parity
- full canonical and parity suites

## Verification

- `composer test`
- 280 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to trace Navigation-only dependencies, introduce the typed context boundary, preserve normal/restricted/probe policy composition, and run verification. Chris Huber is responsible for every line.