### PR TITLE
Expose responsive media as content-only editable

### DIFF
--- a/php-transformer/src/HtmlToBlocks/ResponsiveMediaBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/ResponsiveMediaBlockGenerator.php
@@ -20,7 +20,7 @@ final class ResponsiveMediaBlockGenerator
             'description' => 'An editable responsive or linked image.',
             'editorScript' => 'file:./index.js',
             'attributes' => array(
-                'content' => array( 'type' => 'string', 'default' => '' ),
+                'content' => array( 'type' => 'string', 'default' => '', 'role' => 'content' ),
             ),
             'supports' => array( 'html' => false ),
         );
@@ -40,7 +40,7 @@ final class ResponsiveMediaBlockGenerator
         } ) );
     }
     blocks.registerBlockType( '__BLOCK_NAME__', {
-        attributes: { content: { type: 'string', default: '' } },
+        attributes: { content: { type: 'string', default: '', role: 'content' } },
         supports: { html: false },
         edit: edit,
         save: function() { return null; }

--- a/php-transformer/tests/unit/responsive-media-block.php
+++ b/php-transformer/tests/unit/responsive-media-block.php
@@ -26,6 +26,20 @@ $payload = ( new CompanionPluginPayload() )->fromBlockTypes(array(), array(), ar
 $assert(ResponsiveMediaBlockGenerator::RENDERER === ($payload['blocks'][0]['renderer'] ?? null) && !isset($payload['blocks'][0]['render']), 'the audited renderer identifier survives companion payload normalization');
 $editor = (string) ($definition['assets']['index.js'] ?? '');
 $assert(str_contains($editor, "registerBlockType( 'ssi-example/responsive-media'") && str_contains($editor, 'TextareaControl') && str_contains($editor, 'save: function() { return null; }') && !str_contains($editor, 'RawHTML'), 'the editor registers an editable dynamic block with no unsafe markup preview');
+$editorSchemaRunner = <<<'JS'
+const vm = require( 'node:vm' );
+let settings;
+vm.runInNewContext( Buffer.from( process.argv[ 1 ], 'base64' ).toString(), {
+    window: { wp: {
+        blocks: { registerBlockType: ( name, blockSettings ) => { settings = blockSettings; } },
+        blockEditor: {}, components: {}, element: {}
+    } }
+} );
+process.stdout.write( JSON.stringify( settings.attributes ) );
+JS;
+$editorAttributes = json_decode((string) shell_exec('node -e ' . escapeshellarg($editorSchemaRunner) . ' ' . escapeshellarg(base64_encode($editor))), true);
+$assert(($definition['block_json']['attributes'] ?? null) === $editorAttributes, 'the editor registration attribute schema exactly matches generated block metadata');
+$assert('content' === ($editorAttributes['content']['role'] ?? null), 'the editor registration marks responsive media HTML as Gutenberg content');
 
 $source = '<a class="social" href="/profile" target="_blank" rel="noopener" aria-label="Profile"><picture class="hero"><source media="(min-width: 800px)" type="image/webp" srcset="hero,wide.webp 1200w, hero.webp 600w" sizes="100vw"><img class="avatar" src="hero.jpg" srcset="hero.jpg 1x, hero-2x.jpg 2x" sizes="100vw" width="44" height="44" alt="Profile"></picture></a>';
 $result = ( new HtmlTransformer() )->transform($source)->toArray();


### PR DESCRIPTION
## Summary

- declare the generated responsive-media `content` attribute with Gutenberg `role: content`
- keep PHP `block.json` metadata and editor-side registration schemas identical
- execute the generated editor registration in Node to prevent schema drift

Closes #1081.

## Verification

- `cd php-transformer && composer test`
- 280 PHP transformer parity fixtures pass
- package install proof passes
- focused generated PHP/JS attribute-schema parity passes

Blocks Engine does not currently include a browser-level Gutenberg harness, so the behavioral proof is the role contract consumed by WordPress `contentOnly`, not an editor interaction test.

## AI assistance

- **AI assistance:** Yes
- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Tracing generated companion metadata, implementing matching PHP/JavaScript schemas, and adding executable parity coverage. Chris Huber reviewed the diff and remains responsible for every line.