### PR TITLE
Normalize route state in shared navigation shells

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlan.php
@@ -665,21 +665,49 @@ final class WordPressSitePlan
 
     private static function normalizeNestedChromeMarkup(string $markup): string
     {
-        $markup = self::withoutCurrentNavigationState($markup);
+        $markup = self::withoutCurrentNavigationState($markup, true);
         return preg_replace('/\s*blocks-engine-source-[a-z0-9_-]+-[a-f0-9]{6,}-[0-9]+/', '', $markup) ?? $markup;
     }
 
-    private static function withoutCurrentNavigationState(string $markup): string
+    private static function withoutCurrentNavigationState(string $markup, bool $semanticIdentity = false): string
     {
-        return preg_replace_callback('/<!--\s*wp:(navigation(?:-link|-submenu)?)\s+(\{.*?\})\s*(\/)?-->/s', static function (array $match): string {
+        $stateCarrierCounts = array();
+        $linkColorCounts = array();
+        $linkCount = 0;
+        preg_match_all('/<!--\s*wp:navigation(?:-link|-submenu)?\s+(\{.*?\})\s*(?:\/)?-->/s', $markup, $navigationMatches);
+        foreach ($navigationMatches[0] as $index => $opening) {
+            $attributes = $navigationMatches[1][$index];
+            $attrs = json_decode($attributes, true);
+            if (!is_array($attrs)) continue;
+            $isLink = !preg_match('/<!--\s*wp:navigation\s/', $opening);
+            if ($isLink) ++$linkCount;
+            foreach (preg_split('/\s+/', trim((string) ($attrs['className'] ?? ''))) ?: array() as $class) {
+                if (preg_match('/^blocks-engine-navigation-link-color-states-\d+$/', $class)) $stateCarrierCounts[$class] = ($stateCarrierCounts[$class] ?? 0) + 1;
+                if ($isLink && preg_match('/^blocks-engine-navigation-link-color-[a-f0-9]{64}$/', $class)) $linkColorCounts[$class] = ($linkColorCounts[$class] ?? 0) + 1;
+            }
+        }
+        $sharedLinkColors = array_keys(array_filter($linkColorCounts, static fn(int $count): bool => 1 < $linkCount && $linkCount - 1 === $count));
+        return preg_replace_callback('/<!--\s*wp:(navigation(?:-link|-submenu)?)\s+(\{.*?\})\s*(\/)?-->/s', static function (array $match) use ($semanticIdentity, $stateCarrierCounts, $sharedLinkColors): string {
             $attrs = json_decode($match[2], true);
             if (!is_array($attrs)) return $match[0];
-            $class = (string) ($attrs['className'] ?? '');
-            if (!str_contains($class, 'blocks-engine-current-navigation-item')) return $match[0];
-            $attrs['className'] = trim(str_replace(array('blocks-engine-current-navigation-item', 'blocks-engine-current-navigation-underline', 'current', 'active', 'selected'), '', $class));
+            $classes = preg_split('/\s+/', trim((string) ($attrs['className'] ?? ''))) ?: array();
+            $current = in_array('blocks-engine-current-navigation-item', $classes, true);
+            if (!$current && !$semanticIdentity) return $match[0];
+            $isLink = 'navigation' !== $match[1];
+            $classes = array_values(array_filter($classes, static function (string $class) use ($current, $semanticIdentity, $stateCarrierCounts): bool {
+                if ($current && in_array($class, array('blocks-engine-current-navigation-item', 'blocks-engine-current-navigation-underline', 'current', 'active', 'selected'), true)) return false;
+                if (($current || $semanticIdentity) && preg_match('/^blocks-engine-navigation-current-color-[a-f0-9]{64}$/', $class)) return false;
+                if ($current && preg_match('/^blocks-engine-navigation-link-color-[a-f0-9]{64}$/', $class)) return false;
+                if ($semanticIdentity && $current && 1 === ($stateCarrierCounts[$class] ?? 0)) return false;
+                if ($current && preg_match('/^be-inline-geometry-[a-f0-9]{64}$/', $class)) return false;
+                return true;
+            }));
+            if ($semanticIdentity && $current && $isLink) $classes = array_values(array_unique(array_merge($classes, $sharedLinkColors)));
+            $attrs['className'] = implode(' ', $classes);
             if ('' === $attrs['className']) unset($attrs['className']);
-            unset($attrs['anchor'], $attrs['anchorClassName'], $attrs['color'], $attrs['style'], $attrs['typography']);
-            return '<!-- wp:' . $match[1] . ' ' . json_encode($attrs, JSON_UNESCAPED_SLASHES) . ' ' . ($match[3] ? '/' : '') . '-->';
+            if ($current) unset($attrs['color'], $attrs['style'], $attrs['typography']);
+            if ($current || ($semanticIdentity && $isLink)) unset($attrs['anchor'], $attrs['anchorClassName']);
+            return '<!-- wp:' . $match[1] . ' ' . json_encode($attrs, JSON_UNESCAPED_SLASHES) . ' ' . (($match[3] ?? '') ? '/' : '') . '-->';
         }, $markup) ?? $markup;
     }
 

--- a/php-transformer/tests/contract/shared-shell-plan.php
+++ b/php-transformer/tests/contract/shared-shell-plan.php
@@ -86,4 +86,45 @@ $indexMarkup = $waveWrites['templates/index.html']['payload']['data'] ?? '';
 $assert(1 === substr_count($indexMarkup, '"slug":"header"') && str_contains($indexMarkup, 'wp:query') && str_contains($indexMarkup, 'wp:post-template') && !str_contains($indexMarkup, 'wp:post-content') && str_contains($indexMarkup, '"anchor":"wrapper"'), 'Index restores the shared wrapper context around the header part and native Query Loop.');
 foreach (array('templates/page.html', 'templates/front-page.html') as $target) $assert(1 === substr_count($waveWrites[$target]['payload']['data'] ?? '', '"slug":"header"') && 1 === substr_count($waveWrites[$target]['payload']['data'] ?? '', 'wp:post-content') && str_contains($waveWrites[$target]['payload']['data'] ?? '', '"anchor":"wrapper"'), "{$target} restores the shared wrapper context around the header part and singular post content.");
 
+$statefulWaveShell = static function (string $current, string $content, bool $color = false): string {
+    $link = static function (string $name, string $label, string $current): string {
+        $active = $name === $current;
+        return '<a class="site-link' . ($active ? ' current" id="' . $name . '-source" style="font-weight:700" aria-current="page"' : '"') . ' href="https://example.test/' . $name . '">' . $label . '</a>';
+    };
+    if ($color) $link = static function (string $name, string $label, string $current): string {
+        $active = $name === $current;
+        return '<a class="site-link' . ($active ? ' current" id="' . $name . '-source" style="color:#aa1100;font-weight:700" aria-current="page"' : '"') . ' href="https://example.test/' . $name . '">' . $label . '</a>';
+    };
+    return '<input class="nav-trigger" type="checkbox" id="navTrigger"><div id="wrapper" class="site-frame blocks-engine-source-div-a1b2c3d4-4"><div id="header-wrapper-sticky-wrapper" class="blocks-engine-source-div-a1b2c3d4-4"><div id="header-wrapper"><div class="logo">Brand</div><nav>' . $link('home', 'Home', $current) . $link('about', 'About', $current) . $link('services', 'Services', $current) . '</nav></div></div><div id="main-container"><main><h1>' . $content . '</h1></main></div></div>';
+};
+$statefulResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array(
+    'index.html' => '<style>.nav-trigger{appearance:none;border:1px solid}.current{text-decoration:underline}</style>' . $statefulWaveShell('home', 'Home', true),
+    'about.html' => '<style>.nav-trigger{appearance:none;border:1px solid}.current{text-decoration:underline}</style>' . $statefulWaveShell('about', 'About', true),
+    'services.html' => '<style>.nav-trigger{appearance:none;border:1px solid}.current{text-decoration:underline}</style>' . $statefulWaveShell('services', 'Services', true),
+    // This responsive route has no extractable nested chrome candidate and stays page-owned.
+    'contact.html' => '<div class="responsive-contact"><main><h1>Contact</h1></main></div>',
+)))->toArray();
+$statefulPlan = $statefulResult['source_reports']['wordpress_site_plan']; $statefulPages = $pages($statefulPlan);
+$statefulHeader = array_values(array_filter($statefulPlan['template_parts'], static fn(array $part): bool => 'header' === ($part['area'] ?? null)))[0] ?? array();
+$statefulDiagnostic = current(array_filter($statefulPlan['diagnostics'], static fn(array $diagnostic): bool => 'wordpress_site_plan_shell_extracted' === ($diagnostic['code'] ?? null) && 'header' === ($diagnostic['area'] ?? null)));
+$statefulMarkup = (string) ($statefulHeader['canonical_block_markup'] ?? '');
+$assert(1 === count(array_filter($statefulPlan['template_parts'], static fn(array $part): bool => 'header' === ($part['area'] ?? null))) && !str_contains($statefulPages['index.html']['canonical_block_markup'] ?? '', 'header-wrapper') && !str_contains($statefulPages['about.html']['canonical_block_markup'] ?? '', 'header-wrapper') && !str_contains($statefulPages['services.html']['canonical_block_markup'] ?? '', 'header-wrapper'), 'Nested headers differing only by route-current navigation state produce one shared header and leave page content without its shell.');
+$assert(!str_contains($statefulMarkup, 'blocks-engine-current-navigation-item') && 1 === preg_match_all('/blocks-engine-navigation-current-color-[a-f0-9]{64}/', $statefulMarkup) && str_contains($statefulMarkup, 'blocks-engine-navigation-link-color-states-0') && !str_contains($statefulMarkup, 'blocks-engine-navigation--color-') && !str_contains($statefulMarkup, '"anchor":"home-source"') && str_contains($statefulMarkup, 'site-link'), 'The emitted header keeps its navigation-root current-color and link-state carriers while removing child route state without corrupting tokens or non-state presentation.');
+$assert(str_contains($statefulPages['contact.html']['canonical_block_markup'] ?? '', 'Contact') && !str_contains($statefulPages['contact.html']['canonical_block_markup'] ?? '', 'header-wrapper') && array(array('source_path' => 'contact.html', 'reason' => 'missing')) === ($statefulDiagnostic['exclusions'] ?? null), 'A responsive route without an equivalent nested header candidate remains explicitly page-owned.');
+
+$variantShell = static function (string $current, bool $variant): string {
+    $link = static function (string $name, string $current, bool $variant): string {
+        $style = $variant && 'services' === $name ? ' style="letter-spacing:3px"' : '';
+        return '<a class="site-link' . ($name === $current ? ' current' : '') . '"' . $style . ' href="https://example.test/' . $name . '">' . ucfirst($name) . '</a>';
+    };
+    return '<div id="wrapper"><div id="header-wrapper-sticky-wrapper"><div id="header-wrapper"><nav>' . $link('home', $current, $variant) . $link('about', $current, $variant) . $link('services', $current, $variant) . '</nav></div></div><div id="main-container"><main><h1>Content</h1></main></div></div>';
+};
+$variantResult = (new ArtifactCompiler())->compile(array('entrypoint' => 'index.html', 'files' => array(
+    'index.html' => '<style>.current{text-decoration:underline}</style>' . $variantShell('home', false),
+    'about.html' => '<style>.current{text-decoration:underline}</style>' . $variantShell('about', true),
+)))->toArray();
+$variantPlan = $variantResult['source_reports']['wordpress_site_plan'];
+$variantDiagnostic = current(array_filter($variantPlan['diagnostics'], static fn(array $diagnostic): bool => 'wordpress_site_plan_shell_retained_ambiguous' === ($diagnostic['code'] ?? null) && 'header' === ($diagnostic['area'] ?? null)));
+$assert(array() === array_values(array_filter($variantPlan['template_parts'], static fn(array $part): bool => 'header' === ($part['area'] ?? null))) && 'non_equivalent' === ($variantDiagnostic['provenance']['reason'] ?? null), 'A non-current navigation presentation difference prevents false shared-header equivalence.');
+
 fwrite(STDOUT, "shared-shell-plan contract passed\n");


### PR DESCRIPTION
## Summary

- normalize complete navigation class tokens instead of substring-replacing current state
- distinguish semantic shell identity from emitted canonical template-part cleanup
- retain non-route presentation differences while canonicalizing route-current colors, anchors, styles, and geometry
- prove equivalent nested headers extract once and responsive variants remain page-owned

Closes #1082.

## Corpus evidence

The retained Cara Jane eight-route receipt produces seven nested header candidates and one explicit contact-route exclusion. All seven candidates now resolve to one 4,649-byte identity with SHA-256 `910828d9a895ffd68051b62063a4347332f9730256625fcca01a8cd355865c07`; emitted markup retains the canonical navigation-root current-color carrier.

## Verification

- `cd php-transformer && composer test`
- 280 PHP transformer parity fixtures pass
- package install proof passes
- real Cara Jane corpus identity proof passes
- regression proves non-current typography differences remain non-equivalent

## AI assistance

- **AI assistance:** Yes
- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Tracing shell extraction, analyzing the retained corpus, implementing token-safe semantic normalization, and developing regression coverage. Chris Huber reviewed the diff and remains responsible for every line.