### PR TITLE
refactor: type presentation resolution cache

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\PresentationResolutionCache;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
 use DOMElement;
@@ -112,10 +113,7 @@ final class HtmlTransformerSession
     public int $nextSourceProvenanceId = 1;
     public bool $preserveShellLandmarks = false;
     public bool $fallbackReductionMode = false;
-    public array $presentationAttributesCache = array();
-    public array $presentationDeclarationsCache = array();
-    public array $mergedPresentationStyleCache = array();
-    public array $mediaTextPresentationStyleCache = array();
+    public readonly PresentationResolutionCache $presentationResolutionCache;
     public array $generatedGeometryRules = array();
     public ?GeometryCarrierClassAllocator $geometryCarrierClassAllocator = null;
     public ?CssSelectorMatchCache $sourceSelectorMatchCache = null;
@@ -127,5 +125,6 @@ final class HtmlTransformerSession
     public function __construct(Runtime $runtime, Closure $sourceContextResolver)
     {
         $this->fallbackEmitter = new FallbackEmitter($runtime, $sourceContextResolver);
+        $this->presentationResolutionCache = new PresentationResolutionCache();
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/PresentationResolutionCache.php
+++ b/php-transformer/src/HtmlToBlocks/Style/PresentationResolutionCache.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/** Per-transform memoized presentation results. */
+final class PresentationResolutionCache
+{
+    /** @var array<string, array<string, mixed>> */
+    public array $attributes = array();
+
+    /** @var array<string, array<string, string>> */
+    public array $declarations = array();
+
+    /** @var array<string, string> */
+    public array $mergedStyles = array();
+
+    /** @var array<string, string> */
+    public array $mediaTextStyles = array();
+}

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -228,8 +228,9 @@ trait StyleResolutionTrait
             . ':' . implode(',', $excludedGeometryProperties)
             . ':' . implode(',', $forcedGeometryProperties)
             . ':' . ($carrierOwnsInlineGeometry ? 'carrier' : 'inline');
-        if ( isset($this->presentationAttributesCache[$cacheKey]) ) {
-            return $this->presentationAttributesCache[$cacheKey];
+        $cache = $this->session->presentationResolutionCache;
+        if ( isset($cache->attributes[$cacheKey]) ) {
+            return $cache->attributes[$cacheKey];
         }
 
         $declarations = $this->classOwnedResponsiveDeclarations(
@@ -260,7 +261,7 @@ trait StyleResolutionTrait
             'layout'    => $this->layoutAttribute($element, $this->cssDeclarationString($declarations)),
         )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value));
 
-        $this->presentationAttributesCache[$cacheKey] = $attrs;
+        $cache->attributes[$cacheKey] = $attrs;
 
         return $attrs;
     }
@@ -1152,8 +1153,9 @@ trait StyleResolutionTrait
     private function presentationDeclarations(DOMElement $element): array
     {
         $cacheKey = $this->presentationCacheKey($element);
-        if ( isset($this->presentationDeclarationsCache[$cacheKey]) ) {
-            return $this->presentationDeclarationsCache[$cacheKey];
+        $cache = $this->session->presentationResolutionCache;
+        if ( isset($cache->declarations[$cacheKey]) ) {
+            return $cache->declarations[$cacheKey];
         }
 
         $style = $this->mergedPresentationStyle($element);
@@ -1164,9 +1166,9 @@ trait StyleResolutionTrait
         if ( $this->isCssAllResetValue((string) ($declarations['all'] ?? '')) ) {
             unset($declarations['all']);
         }
-        $this->presentationDeclarationsCache[$cacheKey] = $declarations;
+        $cache->declarations[$cacheKey] = $declarations;
 
-        return $this->presentationDeclarationsCache[$cacheKey];
+        return $cache->declarations[$cacheKey];
     }
 
     /**
@@ -1520,13 +1522,14 @@ trait StyleResolutionTrait
     private function mediaTextPresentationStyle(DOMElement $element): string
     {
         $cacheKey = $this->presentationCacheKey($element);
-        if ( isset($this->mediaTextPresentationStyleCache[$cacheKey]) ) {
-            return $this->mediaTextPresentationStyleCache[$cacheKey];
+        $cache = $this->session->presentationResolutionCache;
+        if ( isset($cache->mediaTextStyles[$cacheKey]) ) {
+            return $cache->mediaTextStyles[$cacheKey];
         }
 
-        $this->mediaTextPresentationStyleCache[$cacheKey] = $this->cssDeclarationString($this->mediaTextPresentationDeclarations($element));
+        $cache->mediaTextStyles[$cacheKey] = $this->cssDeclarationString($this->mediaTextPresentationDeclarations($element));
 
-        return $this->mediaTextPresentationStyleCache[$cacheKey];
+        return $cache->mediaTextStyles[$cacheKey];
     }
 
     /**
@@ -1675,13 +1678,14 @@ trait StyleResolutionTrait
     private function mergedPresentationStyle(DOMElement $element): string
     {
         $cacheKey = $this->presentationCacheKey($element);
-        if ( isset($this->mergedPresentationStyleCache[$cacheKey]) ) {
-            return $this->mergedPresentationStyleCache[$cacheKey];
+        $cache = $this->session->presentationResolutionCache;
+        if ( isset($cache->mergedStyles[$cacheKey]) ) {
+            return $cache->mergedStyles[$cacheKey];
         }
 
         $inlineStyle = $this->attr($element, 'style');
         if ( array() === $this->staticStyleRules || (! $this->isHighValueStyledElement($element) && ! $this->hasGenericRecognitionDemand($element)) ) {
-            $this->mergedPresentationStyleCache[$cacheKey] = $inlineStyle;
+            $cache->mergedStyles[$cacheKey] = $inlineStyle;
             return $inlineStyle;
         }
 
@@ -1693,14 +1697,14 @@ trait StyleResolutionTrait
         }
 
         if ( array() === $declarations ) {
-            $this->mergedPresentationStyleCache[$cacheKey] = $inlineStyle;
+            $cache->mergedStyles[$cacheKey] = $inlineStyle;
             return $inlineStyle;
         }
 
         $declarations = $this->mergeCssDeclarationMaps($declarations, $this->cssDeclarations($inlineStyle));
-        $this->mergedPresentationStyleCache[$cacheKey] = $this->cssDeclarationString($declarations);
+        $cache->mergedStyles[$cacheKey] = $this->cssDeclarationString($declarations);
 
-        return $this->mergedPresentationStyleCache[$cacheKey];
+        return $cache->mergedStyles[$cacheKey];
     }
 
     /**

--- a/php-transformer/tests/unit/media-text-pattern.php
+++ b/php-transformer/tests/unit/media-text-pattern.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerSession;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MediaTextPattern;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
@@ -950,11 +949,10 @@ $memoizedElement = $elementFromHtml('<section style="display:flex"><img src="mem
 $mediaStyleMethod = new ReflectionMethod(HtmlTransformer::class, 'mediaTextPresentationStyle');
 $presentationKeyMethod = new ReflectionMethod(HtmlTransformer::class, 'presentationCacheKey');
 $sessionProperty = new ReflectionProperty(HtmlTransformer::class, 'session');
-$mediaStyleCacheProperty = new ReflectionProperty(HtmlTransformerSession::class, 'mediaTextPresentationStyleCache');
 $firstMediaStyle = $mediaStyleMethod->invoke($memoizedTransformer, $memoizedElement);
 $memoizedElement->setAttribute('style', 'display:grid');
 $secondMediaStyle = $mediaStyleMethod->invoke($memoizedTransformer, $memoizedElement);
-$mediaStyleCache = $mediaStyleCacheProperty->getValue($sessionProperty->getValue($memoizedTransformer));
+$mediaStyleCache = $sessionProperty->getValue($memoizedTransformer)->presentationResolutionCache->mediaTextStyles;
 $presentationKey = $presentationKeyMethod->invoke($memoizedTransformer, $memoizedElement);
 $assertSame('display:flex', $firstMediaStyle, 'Media-text presentation style resolves initial authored style.');
 $assertSame($firstMediaStyle, $secondMediaStyle, 'Media-text presentation style reuses cached value for same DOM node.');


### PR DESCRIPTION
## Summary

- group four presentation memoization maps into session-owned `PresentationResolutionCache`
- replace magic-forwarded cache access with explicit typed state in `StyleResolutionTrait`
- reduce the flat `HtmlTransformerSession` from 104 properties to 101

This is the first bounded per-run state slice from #242. It changes cache ownership only; style inputs, selector state, geometry output, and transformation contracts remain unchanged.

## Stability and performance proof

- media-text memoization retains the shared presentation cache key
- reused transformer instances remain equivalent to fresh instances
- shared analysis cache metrics remain unchanged
- 134 block-style support assertions pass
- alternating benchmark medians were effectively identical: 2208.9 ms baseline versus 2212.5 ms candidate (0.16%, within system noise)

## Verification

- `composer test`
- 280 parity fixtures
- package install proof

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to identify the bounded presentation-cache ownership seam, replace magic forwarding with explicit typed state, update cache behavior coverage, benchmark for regression, and run verification. Chris Huber is responsible for every line.