### PR TITLE
fix: emit authored marquee as a static companion

### DIFF
--- a/php-transformer/src/HtmlToBlocks/AuthoredMarqueeBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthoredMarqueeBlockGenerator.php
@@ -24,7 +24,7 @@ final class AuthoredMarqueeBlockGenerator
                 'duration' => array( 'type' => 'number', 'default' => 40 ),
             ),
             'supports' => array( 'html' => false ),
-            'render' => 'file:./render.php',
+            'style' => 'file:./style.css',
         );
     }
 
@@ -34,11 +34,14 @@ final class AuthoredMarqueeBlockGenerator
         $script = <<<'JS'
 ( function( blocks, blockEditor, element ) {
     var createElement = element.createElement;
+    var RichText = blockEditor.RichText;
+    function duration( value ) { value = Number( value ); return Math.min( 600, Math.max( 1, Number.isFinite( value ) ? value : 40 ) ); }
     function edit( props ) {
-        return createElement( 'div', blockEditor.useBlockProps(), createElement( blockEditor.RichText, {
+        return createElement( 'div', blockEditor.useBlockProps(), createElement( RichText, {
             tagName: 'p',
             value: props.attributes.content || '',
             onChange: function( content ) { props.setAttributes( { content: content } ); },
+            allowedFormats: [],
             placeholder: 'Animated text'
         } ) );
     }
@@ -46,29 +49,30 @@ final class AuthoredMarqueeBlockGenerator
         attributes: { content: { type: 'string', default: '' }, direction: { type: 'string', default: 'left' }, duration: { type: 'number', default: 40 } },
         supports: { html: false },
         edit: edit,
-        save: function() { return null; }
+        save: function( props ) {
+            var attributes = props.attributes;
+            var direction = 'right' === attributes.direction ? 'right' : 'left';
+            var content = attributes.content || '';
+            var contentProps = { tagName: 'span', className: 'blocks-engine-authored-marquee__content', value: content };
+            return createElement( 'div', { className: 'blocks-engine-authored-marquee', style: { '--blocks-engine-marquee-duration': duration( attributes.duration ) + 's' }, 'data-direction': direction }, createElement( 'div', { className: 'blocks-engine-authored-marquee__viewport' }, createElement( 'div', { className: 'blocks-engine-authored-marquee__track' }, createElement( RichText.Content, contentProps ), createElement( RichText.Content, Object.assign( {}, contentProps, { 'aria-hidden': true, inert: '' } ) ) ) );
+        }
     } );
 } )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
 JS;
 
-        $render = <<<'PHP'
-<?php
-$content = isset( $attributes['content'] ) ? wp_kses_post( (string) $attributes['content'] ) : '';
-$direction = 'right' === ( $attributes['direction'] ?? '' ) ? 'right' : 'left';
-$duration = isset( $attributes['duration'] ) ? (float) $attributes['duration'] : 40;
-$duration = min( 600, max( 1, $duration ) );
-?>
-<div <?php echo get_block_wrapper_attributes( array( 'class' => 'blocks-engine-authored-marquee', 'style' => '--blocks-engine-marquee-duration:' . esc_attr( $duration ) . 's' ) ); ?> data-direction="<?php echo esc_attr( $direction ); ?>">
-    <div class="blocks-engine-authored-marquee__viewport">
-        <div class="blocks-engine-authored-marquee__track"><span class="blocks-engine-authored-marquee__content"><?php echo $content; ?></span><span class="blocks-engine-authored-marquee__content" aria-hidden="true"><?php echo $content; ?></span></div>
-    </div>
-</div>
-<style>
-.blocks-engine-authored-marquee{max-width:100%;min-width:0}.blocks-engine-authored-marquee__viewport{max-width:100%;overflow-x:clip}@supports not (overflow:clip){.blocks-engine-authored-marquee__viewport{overflow:hidden}}.blocks-engine-authored-marquee__track{display:flex;width:max-content;min-width:100%;animation:blocks-engine-authored-marquee var(--blocks-engine-marquee-duration,40s) linear infinite}.blocks-engine-authored-marquee[data-direction="right"] .blocks-engine-authored-marquee__track{animation-direction:reverse}.blocks-engine-authored-marquee__content{flex:none;padding-inline-end:1rem}.blocks-engine-authored-marquee__content[aria-hidden="true"]{user-select:none}@keyframes blocks-engine-authored-marquee{to{transform:translateX(-50%)}}@media (prefers-reduced-motion:reduce){.blocks-engine-authored-marquee__track{width:auto;white-space:normal;animation:none;transform:none}.blocks-engine-authored-marquee__content[aria-hidden="true"]{display:none}}
-</style>
-PHP;
+        $style = '.blocks-engine-authored-marquee{max-width:100%;min-width:0}.blocks-engine-authored-marquee__viewport{max-width:100%;overflow-x:clip}@supports not (overflow:clip){.blocks-engine-authored-marquee__viewport{overflow:hidden}}.blocks-engine-authored-marquee__track{display:flex;width:max-content;min-width:100%;animation:blocks-engine-authored-marquee var(--blocks-engine-marquee-duration,40s) linear infinite}.blocks-engine-authored-marquee[data-direction="right"] .blocks-engine-authored-marquee__track{animation-direction:reverse}.blocks-engine-authored-marquee__content{flex:none;padding-inline-end:1rem}.blocks-engine-authored-marquee__content[aria-hidden="true"]{user-select:none}@keyframes blocks-engine-authored-marquee{to{transform:translateX(-50%)}}@media (prefers-reduced-motion:reduce){.blocks-engine-authored-marquee__track{width:auto;white-space:normal;animation:none;transform:none}.blocks-engine-authored-marquee__content[aria-hidden="true"]{display:none}}';
 
-        return array( 'index.js' => str_replace('__BLOCK_NAME__', $blockName, $script), 'render.php' => $render );
+        return array( 'index.js' => str_replace('__BLOCK_NAME__', $blockName, $script), 'style.css' => $style );
+    }
+
+    /** @param array<string, mixed> $attributes */
+    public function markup(array $attributes): string
+    {
+        $content = (string) ($attributes['content'] ?? '');
+        $direction = 'right' === ($attributes['direction'] ?? '') ? 'right' : 'left';
+        $duration = min(600, max(1, (float) ($attributes['duration'] ?? 40)));
+
+        return '<div class="blocks-engine-authored-marquee" style="--blocks-engine-marquee-duration:' . $duration . 's" data-direction="' . $direction . '"><div class="blocks-engine-authored-marquee__viewport"><div class="blocks-engine-authored-marquee__track"><span class="blocks-engine-authored-marquee__content">' . $content . '</span><span class="blocks-engine-authored-marquee__content" aria-hidden="true" inert="">' . $content . '</span></div></div></div>';
     }
 
     /** @return array<string, mixed> */

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -14896,11 +14896,20 @@ final class HtmlTransformer
             }
         }
 
-        return $this->createBlock($this->generatedBlockNamespace . '/' . AuthoredMarqueeBlockGenerator::LOCAL_NAME, array(
+        $attributes = array(
             'content' => $content,
             'direction' => $this->attr($track, 'data-marquee-animation'),
             'duration' => min(600, max(1, $duration)),
-        ), array(), $element);
+        );
+        $markup = ( new AuthoredMarqueeBlockGenerator() )->markup($attributes);
+
+        return array(
+            'blockName' => $this->generatedBlockNamespace . '/' . AuthoredMarqueeBlockGenerator::LOCAL_NAME,
+            'attrs' => $attributes,
+            'innerBlocks' => array(),
+            'innerHTML' => $markup,
+            'innerContent' => array( $markup ),
+        );
     }
 
     /**

--- a/php-transformer/tests/unit/authored-marquee-block.php
+++ b/php-transformer/tests/unit/authored-marquee-block.php
@@ -5,6 +5,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\AuthoredMarqueeBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\CompanionPluginPayload;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 
 $assert = static function (bool $condition, string $message): void {
@@ -22,12 +23,41 @@ $assert('Protecting what matters' === ($block['attrs']['content'] ?? null), 'the
 $assert('left' === ($block['attrs']['direction'] ?? null) && 17.5 === ($block['attrs']['duration'] ?? null), 'direction and timing intent are preserved');
 $assert(!str_contains((string) ($result['serialized_blocks'] ?? ''), '<!-- wp:html'), 'marquee content emits no raw HTML block');
 $definition = $result['source_reports']['generated_blocks'][0] ?? array();
-$render = (string) ($definition['assets']['render.php'] ?? '');
 $editor = (string) ($definition['assets']['index.js'] ?? '');
-$assert(str_contains($editor, 'RichText') && !str_contains($editor, 'RawHTML'), 'the companion edits one text value without duplicating editor content');
-$assert(str_contains($render, 'overflow-x:clip') && str_contains($render, 'max-width:100%') && str_contains($render, 'aria-hidden="true"'), 'the runtime contract clips duplicate tracks inside a bounded viewport');
-$assert(str_contains($render, 'prefers-reduced-motion:reduce') && str_contains($render, 'animation:none') && str_contains($render, 'display:none'), 'reduced motion leaves one readable static track');
+$style = (string) ($definition['assets']['style.css'] ?? '');
+$assert(str_contains($editor, 'RichText') && 1 === substr_count($editor, 'createElement( RichText,') && str_contains($editor, 'allowedFormats: []'), 'the companion edits one plain-text value without duplicating editor content');
+$assert(!str_contains($editor, 'RawHTML') && str_contains($editor, 'RichText.Content') && str_contains($editor, "'aria-hidden': true") && str_contains($editor, "inert: ''"), 'the static save shape escapes RichText content and makes the continuous-motion duplicate inert and hidden');
+$assert(str_contains($style, 'overflow-x:clip') && str_contains($style, 'max-width:100%'), 'the static stylesheet clips the duplicate track in narrow viewports');
+$assert(str_contains($style, 'prefers-reduced-motion:reduce') && str_contains($style, 'animation:none') && str_contains($style, 'display:none'), 'reduced motion leaves one readable static track');
+$assert(str_contains((string) ($result['serialized_blocks'] ?? ''), '--blocks-engine-marquee-duration:17.5s') && str_contains((string) ($result['serialized_blocks'] ?? ''), 'data-direction="left"'), 'static block markup preserves bounded duration and authored direction');
+$assert('pass' === ($result['source_reports']['wp_block_validity']['status'] ?? null), 'static marquee serialization is editor-valid');
 $serialized = ( new Runtime() )->serializeBlocks(array($block));
 $assert('custom/authored-marquee' === (new Runtime())->parseBlocks($serialized)[0]['blockName'], 'the companion reference persists through parse and serialize');
+$escaped = ( new HtmlTransformer() )->transform('<div style="--marquee-duration: 0s"><p><span data-marquee-animation="left"><span>Tom &amp; Jerry &lt; 3</span></span></p></div>')->toArray();
+$escapedMarkup = (string) (($escaped['blocks'][0]['innerHTML'] ?? ''));
+$assert(str_contains($escapedMarkup, 'Tom &amp; Jerry &lt; 3') && !str_contains($escapedMarkup, 'Tom & Jerry < 3') && str_contains($escapedMarkup, 'data-direction="left"') && str_contains($escapedMarkup, '--blocks-engine-marquee-duration:1s'), 'source text is escaped while duration is deterministically bounded');
+$maximumMarkup = ( new AuthoredMarqueeBlockGenerator() )->markup(array( 'content' => 'Bounded', 'direction' => 'right', 'duration' => 900 ));
+$invalidDirectionMarkup = ( new AuthoredMarqueeBlockGenerator() )->markup(array( 'content' => 'Bounded', 'direction' => 'up', 'duration' => 40 ));
+$assert(str_contains($maximumMarkup, 'data-direction="right"') && str_contains($maximumMarkup, '--blocks-engine-marquee-duration:600s') && str_contains($maximumMarkup, 'aria-hidden="true" inert=""') && str_contains($invalidDirectionMarkup, 'data-direction="left"'), 'the frontend markup bounds direction and duration and keeps duplicate content inaccessible');
+
+$payload = ( new CompanionPluginPayload() )->fromBlockTypes(array(), array(), array(), array( $definition ));
+$payloadBlock = $payload['blocks'][0] ?? array();
+$assets = $payloadBlock['assets'] ?? array();
+$isSafeCompanionAsset = static function (mixed $path, mixed $content): bool {
+    if ( ! is_string($path) || ! is_scalar($content) || '' === $path || str_starts_with($path, '/') || str_contains($path, '\\') || str_contains($path, '../') || str_contains($path, './') ) {
+        return false;
+    }
+    foreach ( explode('/', $path) as $segment ) {
+        if ( '' === $segment || '.' === $segment || '..' === $segment || 1 !== preg_match('/^[A-Za-z0-9._-]+$/', $segment) ) {
+            return false;
+        }
+    }
+    $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+    return in_array($extension, array( 'js', 'mjs', 'css', 'json', 'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'ico', 'woff', 'woff2', 'ttf', 'otf', 'eot' ), true)
+        && ! preg_match('/<\\?(?:php|=|[[:space:]])/i', (string) $content);
+};
+$assert(CompanionPluginPayload::SCHEMA === ($payload['schema'] ?? null) && array( 'index.js', 'style.css' ) === array_keys($assets), 'the complete companion payload contains the established static asset shape');
+$assert(array_reduce(array_keys($assets), static fn (bool $safe, string $path): bool => $safe && $isSafeCompanionAsset($path, $assets[$path]), true), 'every generated marquee asset passes SSI static path and content constraints');
+$assert(!isset($payloadBlock['render'], $payloadBlock['renderer'], $payloadBlock['block_json']['render']) && !array_filter(array_keys($assets), static fn (string $path): bool => 'php' === strtolower((string) pathinfo($path, PATHINFO_EXTENSION))), 'the generated marquee payload emits no executable PHP asset or renderer');
 
 fwrite(STDOUT, "Authored marquee companion tests passed\n");


### PR DESCRIPTION
Closes #1041

## Summary
- Replace the authored marquee dynamic `render.php` companion with deterministic static block markup and registered `style.css`.
- Preserve bounded duration and direction, escaped source text, reduced-motion behavior, and one visible accessible track; the duplicate animation track is `aria-hidden` and inert.
- Cover static editor/save shape, parse/serialize validity, CSS registration, SSI-safe companion assets, and no executable PHP assets.

## SSI Rejection Root Cause
The generated marquee block declared `render.php`, whose executable PHP content was included in the companion asset map. Static Site Importer validates companion assets as static-only and rejects content containing server-code tags. The generated block now contains only `index.js` and `style.css`, with metadata registering the stylesheet and no render asset or renderer.

## Verification
- `php php-transformer/tests/unit/authored-marquee-block.php`
  - Passed.
- `composer test` (from `php-transformer`)
  - Passed: canonical, unit, parity (280 fixtures), and packaging suites.
- `composer test:wordpress-integration` (from `php-transformer`)
  - Skipped cleanly because `WP_TESTS_DIR` is unavailable in this worktree.

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode reviewed the existing candidate, merged current `origin/trunk`, implemented and tested the static companion conversion. Chris Huber remains responsible for every line.