### PR TITLE
Keep media-forward heroes on the native block path

### DIFF
--- a/packages/blocks-engine/src/theme/__tests__/strategy-seam.test.ts
+++ b/packages/blocks-engine/src/theme/__tests__/strategy-seam.test.ts
@@ -326,4 +326,52 @@ describe('structuredStrategy — interpretive theme-styled reconstruction (no-CS
     // and it genuinely differs from the default preserve-dom output (regression guard).
     expect(structuredBody).not.toEqual(defaultedBody);
   });
+
+  it('keeps a textless media-forward hero native and reports unrepresentable social controls', () => {
+    // Generic reduction of issue #1070's Eggchasers evidence: three localized large
+    // images, a linked CTA, and four icon-only controls with no heading/body copy.
+    const hero = sectionSpec({
+      interactionModel: 'color-block-grid',
+      height: 760,
+      images: [
+        sectionImage('/wp-content/uploads/2026/hero-main.jpg', { width: 1440, height: 900 }),
+        sectionImage('/wp-content/uploads/2026/hero-left.jpg', { width: 900, height: 900 }),
+        sectionImage('/wp-content/uploads/2026/hero-right.jpg', { width: 900, height: 900 }),
+      ],
+      buttons: [{ label: 'TICKETS', href: '/tickets/' }],
+      icons: Array.from({ length: 4 }, () => ({
+        kind: 'glyph' as const,
+        glyph: 'social',
+        width: 24,
+        height: 24,
+      })),
+      layout: {
+        containerWidth: 1440,
+        padding: '0',
+        childLayout: 'grid',
+        columnCount: 3,
+        gap: '24px',
+      },
+      sectionHtml:
+        '<section class="media-hero"><img src="/wp-content/uploads/2026/hero-main.jpg"><img src="/wp-content/uploads/2026/hero-left.jpg"><img src="/wp-content/uploads/2026/hero-right.jpg"><a href="/tickets/">TICKETS</a></section>',
+    });
+
+    const aggregate = reconstructNativeAggregate([hero], { strategy: structuredStrategy });
+    const body = aggregate.sectionMarkup.join('\n');
+
+    expect(aggregate.sections[0]).toMatchObject({
+      decision: 'native',
+      coverage: { lost: false, textCoverage: 1, missingImages: [] },
+    });
+    expect(body).toContain('wp:gallery');
+    expect(body).toContain('wp:button');
+    expect(body).toContain('href="/tickets/"');
+    expect(body).not.toContain('wp:html');
+    expect(body).not.toContain('wp:social-links');
+    expect(body).not.toMatch(/(?:min-)?width:1440px|min-width:980px|!important/);
+    expect(aggregate.fallbackDiagnostics).toEqual([]);
+    expect(aggregate.provenanceFlags).toContain(
+      'gutenberg-gap#0: 4 icon-only control(s) lack service/destination semantics — social links not emitted',
+    );
+  });
 });

--- a/packages/blocks-engine/src/theme/native-renderers-section.ts
+++ b/packages/blocks-engine/src/theme/native-renderers-section.ts
@@ -5,6 +5,7 @@ import {
   emptyNativeRenderOut,
   headingBlock,
   paragraphBlock,
+  sectionButtons,
   wrapSection,
 } from './native-block-builders.js';
 import { centerOf, isDarkSection, isTintedSection, sectionPad } from './native-layout.js';
@@ -115,6 +116,19 @@ export function renderImageRow(section: SectionSpec, ctx?: NativeRenderCtx): Nat
   );
   const gallery = galleryBlock(section.images, out, { sectionHeight: section.height }, ctx);
   if (gallery) parts.push(gallery);
+  const largeImages = section.images.filter((image) => Math.min(image.width || 0, image.height || 0) >= 200);
+  const mediaForwardControlHero =
+    section.headings.length === 0 &&
+    section.bodyText.length === 0 &&
+    largeImages.length >= 2 &&
+    section.icons.length > 0 &&
+    ((section.buttons?.length ?? 0) > 0 || section.buttonLabels.length > 0);
+  if (mediaForwardControlHero && ctx) parts.push(...sectionButtons(section, out, ctx));
+  if (mediaForwardControlHero) {
+    out.flags.push(
+      `gutenberg-gap#${section.sectionIndex}: ${section.icons.length} icon-only control(s) lack service/destination semantics — social links not emitted`,
+    );
+  }
   out.markup = wrapSection(parts.filter(Boolean), {
     wide: '1100px',
     raised: isTintedSection(section),


### PR DESCRIPTION
## Summary

- keep textless media-forward hero sections on the native gallery path
- emit captured CTA buttons alongside the gallery
- report icon-only controls as an explicit Gutenberg gap when service and destination semantics are unavailable
- add provider-neutral regression coverage derived from the Eggchasers capture

Closes #1070.

## Verification

- `pnpm exec vitest run src/theme/__tests__/strategy-seam.test.ts` (7 passed)
- `pnpm run typecheck`

The package-wide Vitest run is baseline-red outside this change: 90 test files / 466 tests passed in the first run, while worker-pool/E2E timeouts, a missing prebuilt WP runtime bundle, and an unrelated documentation assertion failed. The changed strategy seam test passes independently.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the imported-site failure, implemented the renderer and regression test, and assisted with verification and PR preparation. Chris Huber reviewed the diff and remains responsible for every line.