### PR TITLE
fix: capture deep media layout boundaries

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -68,6 +68,7 @@ final class HtmlTransformer
     use SvgMaterializationTrait;
 
     private const MAX_INTERACTION_CANDIDATES = 100;
+    private const MAX_CAPTURED_LAYOUT_SOURCE_NESTING = 20;
 
     /**
      * Core blocks this transformer can produce, keyed by the contract that
@@ -5176,6 +5177,11 @@ final class HtmlTransformer
             $flankedSeparator = $this->flankedSeparatorBlockFromElement($element);
             if ( null !== $flankedSeparator ) {
                 return $flankedSeparator;
+            }
+
+            $capturedMediaLayout = $this->capturedMediaLayoutBoundaryBlock($element);
+            if ( null !== $capturedMediaLayout ) {
+                return $capturedMediaLayout;
             }
 
             // A gallery can only contain native image blocks. Preserve the
@@ -14857,10 +14863,63 @@ final class HtmlTransformer
 
         return $this->createBlock(
             $this->generatedBlockNamespace . '/' . ResponsiveMediaBlockGenerator::LOCAL_NAME,
-            array( 'content' => $this->safeFallbackHtml($element) ),
+            array( 'content' => $this->safeFallbackHtml($element), 'kind' => 'media' ),
             array(),
             $element
         );
+    }
+
+    /** @return array<string, mixed>|null */
+    private function capturedMediaLayoutBoundaryBlock(DOMElement $element): ?array
+    {
+        if ( 'main' !== strtolower($element->tagName)
+            || $this->isRuntimeDomTarget($element)
+            || $this->hasRuntimeTargetInSubtree($element)
+            || $this->sourceElementNestingDepth($element) <= self::MAX_CAPTURED_LAYOUT_SOURCE_NESTING
+            || ! $this->hasCapturedMediaContent($element)
+        ) {
+            return null;
+        }
+
+        if ( ! $this->responsiveMediaBlockGenerated ) {
+            $this->generatedBlocks[] = ( new ResponsiveMediaBlockGenerator() )->definition($this->generatedBlockNamespace);
+            $this->responsiveMediaBlockGenerated = true;
+        }
+
+        return $this->createBlock(
+            $this->generatedBlockNamespace . '/' . ResponsiveMediaBlockGenerator::LOCAL_NAME,
+            array( 'content' => $this->safeFallbackHtml($element), 'kind' => 'layout' ),
+            array(),
+            $element
+        );
+    }
+
+    private function hasCapturedMediaContent(DOMElement $element): bool
+    {
+        return 0 < $element->getElementsByTagName('img')->length
+            || 0 < $element->getElementsByTagName('svg')->length
+            || 0 < $element->getElementsByTagName('video')->length;
+    }
+
+    private function hasRuntimeTargetInSubtree(DOMElement $element): bool
+    {
+        foreach ( $element->getElementsByTagName('*') as $descendant ) {
+            if ( $descendant instanceof DOMElement && $this->isRuntimeDomTarget($descendant) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function sourceElementNestingDepth(DOMElement $element): int
+    {
+        $depth = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                $depth = max($depth, 1 + $this->sourceElementNestingDepth($child));
+            }
+        }
+        return $depth;
     }
 
     /** @return array<string, mixed>|null */

--- a/php-transformer/src/HtmlToBlocks/ResponsiveMediaBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/ResponsiveMediaBlockGenerator.php
@@ -17,10 +17,11 @@ final class ResponsiveMediaBlockGenerator
             'name' => $namespace . '/' . self::LOCAL_NAME,
             'title' => 'Responsive Media',
             'category' => 'media',
-            'description' => 'An editable responsive or linked image.',
+            'description' => 'An editable captured media or layout boundary.',
             'editorScript' => 'file:./index.js',
             'attributes' => array(
                 'content' => array( 'type' => 'string', 'default' => '', 'role' => 'content' ),
+                'kind' => array( 'type' => 'string', 'default' => 'media' ),
             ),
             'supports' => array( 'html' => false ),
         );
@@ -34,13 +35,13 @@ final class ResponsiveMediaBlockGenerator
     var createElement = element.createElement;
     function edit( props ) {
         return createElement( 'div', blockEditor.useBlockProps(), createElement( components.TextareaControl, {
-            label: 'Responsive media HTML',
+            label: 'Captured media or layout HTML',
             value: props.attributes.content || '',
             onChange: function( content ) { props.setAttributes( { content: content } ); }
         } ) );
     }
     blocks.registerBlockType( '__BLOCK_NAME__', {
-        attributes: { content: { type: 'string', default: '', role: 'content' } },
+        attributes: { content: { type: 'string', default: '', role: 'content' }, kind: { type: 'string', default: 'media' } },
         supports: { html: false },
         edit: edit,
         save: function() { return null; }

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -420,4 +420,18 @@ $deepMediaStaged = $deepMediaCompiler->compose($deepMediaShared, array_reverse($
 $assert('passed' === ($deepMediaWhole['source_reports']['editability_policy']['status'] ?? null) && 20 >= ($deepMediaWhole['source_reports']['editability_report']['metrics']['max_nesting_depth'] ?? PHP_INT_MAX), 'Depth-44 SVG and depth-39 custom media routes satisfy the unchanged editability nesting policy.');
 $assert($canonical($deepMediaWhole) === $canonical($deepMediaStaged), 'Deep media wrapper coalescing preserves direct and staged canonical equivalence.');
 
+$layoutBoundary = '<main class="story">';
+for ($depth = 0; $depth < 24; ++$depth) $layoutBoundary .= '<div class="layer-' . $depth . '">';
+$layoutBoundary .= '<a href="/story" aria-label="Story"><img src="story.jpg" alt="Story"></a>';
+for ($depth = 0; $depth < 24; ++$depth) $layoutBoundary .= '</div>';
+$layoutBoundary .= '</main>';
+$layoutArtifact = array('entrypoint' => 'index.html', 'files' => array(array('path' => 'index.html', 'content' => $layoutBoundary)));
+$layoutCompiler = new ArtifactCompiler();
+$layoutWhole = $layoutCompiler->compile($layoutArtifact)->toArray();
+$layoutShared = $layoutCompiler->prepareShared($layoutArtifact);
+$layoutStaged = $layoutCompiler->compose($layoutShared, array($layoutCompiler->compilePage($layoutArtifact, $layoutShared, 'index.html')))->toArray();
+$layoutPage = $layoutWhole['source_reports']['compiled_site']['pages'][0] ?? array();
+$assert('passed' === ($layoutWhole['source_reports']['editability_policy']['status'] ?? null) && str_contains((string) ($layoutPage['block_markup'] ?? ''), '"kind":"layout"'), 'A deep semantic media main compiles as one typed layout boundary under the unchanged editability policy.');
+$assert($canonical($layoutWhole) === $canonical($layoutStaged), 'Typed captured layout boundaries preserve direct and staged canonical equivalence.');
+
 fwrite(STDOUT, "Staged artifact compilation contract passed\n");

--- a/php-transformer/tests/unit/responsive-media-block.php
+++ b/php-transformer/tests/unit/responsive-media-block.php
@@ -40,6 +40,7 @@ JS;
 $editorAttributes = json_decode((string) shell_exec('node -e ' . escapeshellarg($editorSchemaRunner) . ' ' . escapeshellarg(base64_encode($editor))), true);
 $assert(($definition['block_json']['attributes'] ?? null) === $editorAttributes, 'the editor registration attribute schema exactly matches generated block metadata');
 $assert('content' === ($editorAttributes['content']['role'] ?? null), 'the editor registration marks responsive media HTML as Gutenberg content');
+$assert('media' === ($editorAttributes['kind']['default'] ?? null), 'the editor registration carries the typed captured-boundary kind');
 
 $source = '<a class="social" href="/profile" target="_blank" rel="noopener" aria-label="Profile"><picture class="hero"><source media="(min-width: 800px)" type="image/webp" srcset="hero,wide.webp 1200w, hero.webp 600w" sizes="100vw"><img class="avatar" src="hero.jpg" srcset="hero.jpg 1x, hero-2x.jpg 2x" sizes="100vw" width="44" height="44" alt="Profile"></picture></a>';
 $result = ( new HtmlTransformer() )->transform($source)->toArray();
@@ -65,5 +66,27 @@ $assert(str_contains($nestedWrappedContent, '<div class="crop"') && str_contains
 
 $labeledWrapper = ( new HtmlTransformer() )->transform('<a href="/profile"><div><wow-image><img src="profile.png" alt="Profile"></wow-image><span>Profile</span></div></a>')->toArray();
 $assert('custom/responsive-media' !== ($labeledWrapper['blocks'][0]['blockName'] ?? null), 'a linked image wrapper with authored label content is not collapsed into responsive media');
+
+$layoutHtml = '<main class="story"><div class="shell">';
+for ($depth = 0; $depth < 21; ++$depth) $layoutHtml .= '<div class="layer-' . $depth . '">';
+$layoutHtml .= '<a href="/story" aria-label="Story"><img src="story.jpg" alt="Story"></a>';
+for ($depth = 0; $depth < 21; ++$depth) $layoutHtml .= '</div>';
+$layoutHtml .= '</div></main>';
+$layout = ( new HtmlTransformer() )->transform($layoutHtml)->toArray();
+$layoutBlock = $layout['blocks'][0] ?? array();
+$assert('custom/responsive-media' === ($layoutBlock['blockName'] ?? null) && 'layout' === ($layoutBlock['attrs']['kind'] ?? null), 'A deep semantic media main uses the existing companion as a typed layout boundary.');
+$assert(str_contains((string) ($layoutBlock['attrs']['content'] ?? ''), 'href="/story"') && str_contains((string) ($layoutBlock['attrs']['content'] ?? ''), 'aria-label="Story"') && str_contains((string) ($layoutBlock['attrs']['content'] ?? ''), 'layer-20'), 'A captured layout boundary retains links, accessibility, and authored selector identity.');
+$assert('pass' === ($layout['source_reports']['wp_block_validity']['status'] ?? null), 'A captured layout boundary remains valid Gutenberg block markup.');
+$layoutPayload = ( new CompanionPluginPayload() )->fromBlockTypes(array(), array(), array(), $layout['source_reports']['generated_blocks'] ?? array());
+$assert(array( 'content', 'kind' ) === array_keys($layoutPayload['blocks'][0]['block_json']['attributes'] ?? array()) && ResponsiveMediaBlockGenerator::RENDERER === ($layoutPayload['blocks'][0]['renderer'] ?? null) && ! isset($layoutPayload['blocks'][0]['render']), 'The companion payload preserves the bounded typed layout schema and audited renderer only.');
+
+$shallow = ( new HtmlTransformer() )->transform('<main><div><img src="story.jpg" alt="Story"></div></main>')->toArray();
+$assert('custom/responsive-media' !== ($shallow['blocks'][0]['blockName'] ?? null), 'A shallow media main remains on native conversion paths.');
+
+$runtimeLayout = ( new HtmlTransformer() )->transform($layoutHtml, array('runtime_dom_selectors' => array('.story')))->toArray();
+$assert('custom/responsive-media' !== ($runtimeLayout['blocks'][0]['blockName'] ?? null), 'A declared runtime layout boundary remains addressable instead of being captured.');
+
+$nestedRuntimeLayout = ( new HtmlTransformer() )->transform($layoutHtml, array('runtime_dom_selectors' => array('.layer-20')))->toArray();
+$assert('custom/responsive-media' !== ($nestedRuntimeLayout['blocks'][0]['blockName'] ?? null), 'A declared runtime descendant remains addressable instead of being captured.');
 
 fwrite(STDOUT, "Responsive media companion tests passed\n");


### PR DESCRIPTION
## Summary
- Extend the existing responsive-media companion with a typed `layout` boundary.
- Capture only deeply nested semantic `main` content containing media when no declared runtime target is present.
- Preserve the complete bounded source subtree for SSI rendering, including authored CSS selectors, responsive markup, links, accessibility attributes, and passive metadata.

Closes #1039

## Verification
- `composer test`
- `composer test:parity`
- `composer test:wordpress-integration` (skipped: `WP_TESTS_DIR` unavailable)
- `composer test:packaging`
- Exact reduced artifact: homepage max depth `19`; post max depth `19`; editability policy passed.

## AI assistance
OpenAI GPT-5.6-terra via OpenCode investigated the artifact, implemented the typed captured-layout extension, and ran verification. Chris Huber remains responsible for every line.