### PR TITLE
Remove duplicate glyph diagnostic compactor

### DIFF
--- a/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
+++ b/figma-transformer/src/Scenegraph/ScenegraphNormalizer.php
@@ -249,65 +249,6 @@ final class ScenegraphNormalizer
     }
 
     /**
-     * @param array<int, array<string, mixed>> $diagnostics
-     * @return array<int, array<string, mixed>>
-     */
-    private function compactGlyphCommandBlobDiagnostics(array $diagnostics): array
-    {
-        $compacted = array();
-        $count = 0;
-        $nodeIds = array();
-        $sampleGlyphs = array();
-
-        foreach ( $diagnostics as $diagnostic ) {
-            if ( ! is_array($diagnostic) || 'unsupported_text_glyph_command_blob' !== ($diagnostic['code'] ?? null) ) {
-                $compacted[] = $diagnostic;
-                continue;
-            }
-
-            $count++;
-            $context = is_array($diagnostic['context'] ?? null) ? $diagnostic['context'] : array();
-            $nodeId = isset($context['node_id']) && is_scalar($context['node_id']) ? (string) $context['node_id'] : '';
-            if ( '' !== $nodeId ) {
-                $nodeIds[$nodeId] = true;
-            }
-            if ( count($sampleGlyphs) < 10 ) {
-                $sampleGlyph = array(
-                    'node_id'     => $nodeId,
-                    'glyph_index' => isset($context['glyph_index']) && is_numeric($context['glyph_index']) ? (int) $context['glyph_index'] : null,
-                );
-                if ( isset($context['byte_length']) && is_numeric($context['byte_length']) ) {
-                    $sampleGlyph['byte_length'] = (int) $context['byte_length'];
-                }
-                if ( isset($context['reason']) && is_scalar($context['reason']) ) {
-                    $sampleGlyph['reason'] = (string) $context['reason'];
-                }
-                $sampleGlyphs[] = $sampleGlyph;
-            }
-        }
-
-        if ( 0 === $count ) {
-            return $compacted;
-        }
-
-        $sampleNodeIds = array_slice(array_keys($nodeIds), 0, 10);
-        $compacted[] = array(
-            'severity' => 'warning',
-            'code'     => 'unsupported_text_glyph_command_blob',
-            'message'  => 'Unsupported Figma text glyph command blobs were omitted from derived glyph metadata.',
-            'source'   => 'ScenegraphNormalizer',
-            'context'  => array(
-                'total_count'         => $count,
-                'affected_node_count' => count($nodeIds),
-                'sample_node_ids'     => $sampleNodeIds,
-                'sample_glyphs'       => $sampleGlyphs,
-            ),
-        );
-
-        return $compacted;
-    }
-
-    /**
      * @param array<string, array<int, string>> $childrenIndex
      * @return array<int, string>
      */


### PR DESCRIPTION
## Summary
- remove the uncalled private glyph diagnostic compactor from `ScenegraphNormalizer`
- retain the active `ScenegraphDiagnostics::compact()` implementation and public diagnostic behavior

## Verification
- `php -l figma-transformer/src/Scenegraph/ScenegraphNormalizer.php`
- `composer --working-dir=figma-transformer test`
- `git diff --check origin/trunk...HEAD`

Closes #1079
Relates to #1076

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode verified callers and active diagnostics behavior, removed the dead code, ran the package contract suite, and independently reviewed the result. Chris Huber is responsible for every line.