### PR TITLE
Refactor Figma node rendering around one layout plan

### DIFF
--- a/figma-transformer/src/Html/CanvasShellResolver.php
+++ b/figma-transformer/src/Html/CanvasShellResolver.php
@@ -10,17 +10,12 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 final class CanvasShellResolver
 {
     /**
-     * @param callable(array<string, mixed>): bool $isFreeformContainer
      * @param callable(array<string, mixed>): bool $freeformContainerShouldUseFlow
-     * @param callable(array<string, mixed>): bool $hasAbsoluteChild
-     * @param callable(array<string, mixed>): bool $hasDecorativeFlexUnderlayChild
      */
     public function __construct(
         private readonly LayoutFrameRoleClassifier $layoutFrameRoleClassifier,
-        private readonly mixed $isFreeformContainer,
+        private readonly LayoutIntentClassifier $layoutIntentClassifier,
         private readonly mixed $freeformContainerShouldUseFlow,
-        private readonly mixed $hasAbsoluteChild,
-        private readonly mixed $hasDecorativeFlexUnderlayChild,
         private readonly VisualGeometryResolver $visualGeometryResolver,
         private readonly ?BreakpointDimensionPolicy $breakpointDimensionPolicy = null,
     ) {
@@ -218,7 +213,7 @@ final class CanvasShellResolver
      */
     private function isFreeformContainer(array $node): bool
     {
-        return ($this->isFreeformContainer)($node);
+        return $this->layoutIntentClassifier->isFreeformContainer($node);
     }
 
     /**
@@ -234,7 +229,7 @@ final class CanvasShellResolver
      */
     private function hasAbsoluteChild(array $node): bool
     {
-        return ($this->hasAbsoluteChild)($node);
+        return $this->layoutIntentClassifier->hasAbsoluteChild($node);
     }
 
     /**
@@ -242,6 +237,6 @@ final class CanvasShellResolver
      */
     private function hasDecorativeFlexUnderlayChild(array $node): bool
     {
-        return ($this->hasDecorativeFlexUnderlayChild)($node);
+        return $this->layoutIntentClassifier->hasDecorativeFlexUnderlayChild($node);
     }
 }

--- a/figma-transformer/src/Html/NodeRenderPlan.php
+++ b/figma-transformer/src/Html/NodeRenderPlan.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Immutable layout facts shared by node HTML and CSS emission.
+ */
+final class NodeRenderPlan
+{
+    /**
+     * @param array<int, mixed> $children
+     * @param array<string, mixed>|null $layoutIntent
+     * @param array<string, mixed> $stackingContext
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly array $children,
+        public readonly ?array $layoutIntent,
+        public readonly CanvasShellDecision $canvasShell,
+        public readonly array $stackingContext,
+        public readonly bool $parentIsFreeform,
+        public readonly bool $parentFreeformUsesFlow,
+        public readonly bool $decorativeFlexUnderlay,
+        public readonly bool $parentHasDecorativeFlexUnderlay,
+    ) {
+    }
+}

--- a/figma-transformer/src/Html/PositioningStyleResolver.php
+++ b/figma-transformer/src/Html/PositioningStyleResolver.php
@@ -9,20 +9,9 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
  */
 final class PositioningStyleResolver
 {
-    /**
-     * @param callable(array<string, mixed>): bool $isFreeformContainer
-     * @param callable(array<string, mixed>): bool $freeformContainerShouldUseFlow
-     * @param callable(array<string, mixed>, array<string, mixed>): bool $isDecorativeFlexUnderlay
-     * @param callable(array<string, mixed>): bool $hasDecorativeFlexUnderlayChild
-     */
     public function __construct(
-        private readonly LayoutIntentClassifier $layoutIntentClassifier,
         private readonly CssPositioningResolver $cssPositioningResolver,
         private readonly CanvasShellResolver $canvasShellResolver,
-        private readonly mixed $isFreeformContainer,
-        private readonly mixed $freeformContainerShouldUseFlow,
-        private readonly mixed $isDecorativeFlexUnderlay,
-        private readonly mixed $hasDecorativeFlexUnderlayChild,
     ) {
     }
 
@@ -33,21 +22,21 @@ final class PositioningStyleResolver
      * @param array<string, mixed>|null $parentNode
      * @param array<int, string> $declaredStyles
      */
-    public function resolve(array $node, string $type, ?array $parentNode, array $box, array $layout, CanvasShellDecision $canvasShell, array $declaredStyles): PositioningStyleDecision
+    public function resolve(array $node, ?array $parentNode, array $box, array $layout, NodeRenderPlan $plan, array $declaredStyles): PositioningStyleDecision
     {
         $styles = array();
-        $isDecorativeFlexUnderlay = null !== $parentNode && $this->isDecorativeFlexUnderlay($node, $parentNode);
-        $parentFreeformUsesFlow = null !== $parentNode && $this->freeformContainerShouldUseFlow($parentNode);
-        $willPositionAbsolute = (null !== $parentNode && $this->isFreeformContainer($parentNode) && ! $parentFreeformUsesFlow) || ('absolute' === ($layout['positioning'] ?? null) && ! $parentFreeformUsesFlow) || $isDecorativeFlexUnderlay;
-        $stackingContextPlan = $this->layoutIntentClassifier->stackingContextPlan($node, $parentNode);
+        $isDecorativeFlexUnderlay = $plan->decorativeFlexUnderlay;
+        $parentFreeformUsesFlow = $plan->parentFreeformUsesFlow;
+        $willPositionAbsolute = ($plan->parentIsFreeform && ! $parentFreeformUsesFlow) || ('absolute' === ($layout['positioning'] ?? null) && ! $parentFreeformUsesFlow) || $isDecorativeFlexUnderlay;
+        $stackingContextPlan = $plan->stackingContext;
         $effectiveZIndex = isset($stackingContextPlan['z_index']) && is_int($stackingContextPlan['z_index']) ? $stackingContextPlan['z_index'] : null;
         $zIndexReason = isset($stackingContextPlan['z_index_reason']) && is_string($stackingContextPlan['z_index_reason']) ? $stackingContextPlan['z_index_reason'] : null;
 
-        if ( $canvasShell->responsiveCenteredFlowShell && ! $willPositionAbsolute ) {
+        if ( $plan->canvasShell->responsiveCenteredFlowShell && ! $willPositionAbsolute ) {
             $styles[] = 'margin-left:auto';
             $styles[] = 'margin-right:auto';
         }
-        if ( ! $willPositionAbsolute && (true === ($stackingContextPlan['manages_local_stacking'] ?? false) || ($parentFreeformUsesFlow && 'FRAME' === $type)) ) {
+        if ( ! $willPositionAbsolute && (true === ($stackingContextPlan['manages_local_stacking'] ?? false) || ($parentFreeformUsesFlow && 'FRAME' === $plan->type)) ) {
             $styles[] = 'position:relative';
         }
 
@@ -55,7 +44,7 @@ final class PositioningStyleResolver
             $styles[] = 'isolation:isolate';
         }
 
-        $absolutePositioningDecision = $this->absolutePositioningDecision($node, $parentNode, $box, $layout, $canvasShell, $isDecorativeFlexUnderlay, $parentFreeformUsesFlow);
+        $absolutePositioningDecision = $this->absolutePositioningDecision($node, $parentNode, $box, $layout, $plan->canvasShell, $isDecorativeFlexUnderlay, $parentFreeformUsesFlow, $plan->parentIsFreeform);
         if ( null !== $absolutePositioningDecision ) {
             foreach ( $absolutePositioningDecision->declarations as $style ) {
                 $styles[] = $style;
@@ -69,7 +58,7 @@ final class PositioningStyleResolver
             $styles[] = 'pointer-events:none';
         }
 
-        if ( null !== $parentNode && ! $willPositionAbsolute && null === $effectiveZIndex && $this->hasDecorativeFlexUnderlayChild($parentNode) ) {
+        if ( null !== $parentNode && ! $willPositionAbsolute && null === $effectiveZIndex && $plan->parentHasDecorativeFlexUnderlay ) {
             $styles[] = 'position:relative';
             $styles[] = 'z-index:1';
         }
@@ -91,12 +80,12 @@ final class PositioningStyleResolver
      * @param array<string, mixed> $box
      * @param array<string, mixed> $layout
      */
-    private function absolutePositioningDecision(array $node, ?array $parentNode, array $box, array $layout, CanvasShellDecision $canvasShell, bool $isDecorativeFlexUnderlay, bool $parentFreeformUsesFlow): ?AbsolutePositioningDecision
+    private function absolutePositioningDecision(array $node, ?array $parentNode, array $box, array $layout, CanvasShellDecision $canvasShell, bool $isDecorativeFlexUnderlay, bool $parentFreeformUsesFlow, bool $parentIsFreeform): ?AbsolutePositioningDecision
     {
         $reasonCode = '';
         if ( $isDecorativeFlexUnderlay ) {
             $reasonCode = 'decorative_flex_underlay_absolute';
-        } elseif ( null !== $parentNode && $this->isFreeformContainer($parentNode) && ! $parentFreeformUsesFlow ) {
+        } elseif ( null !== $parentNode && $parentIsFreeform && ! $parentFreeformUsesFlow ) {
             $reasonCode = 'freeform_parent_absolute_child';
         } elseif ( 'absolute' === ($layout['positioning'] ?? null) && ! $parentFreeformUsesFlow ) {
             $reasonCode = 'explicit_absolute_positioning';
@@ -142,36 +131,4 @@ final class PositioningStyleResolver
         return str_starts_with($style, 'left:') || str_starts_with($style, 'right:') || str_starts_with($style, 'margin-left:') || str_starts_with($style, 'margin-right:');
     }
 
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function isFreeformContainer(array $node): bool
-    {
-        return ($this->isFreeformContainer)($node);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function freeformContainerShouldUseFlow(array $node): bool
-    {
-        return ($this->freeformContainerShouldUseFlow)($node);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     * @param array<string, mixed> $parentNode
-     */
-    private function isDecorativeFlexUnderlay(array $node, array $parentNode): bool
-    {
-        return ($this->isDecorativeFlexUnderlay)($node, $parentNode);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function hasDecorativeFlexUnderlayChild(array $node): bool
-    {
-        return ($this->hasDecorativeFlexUnderlayChild)($node);
-    }
 }

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -107,6 +107,8 @@ final class StaticHtmlEmitter
 
     private ?SourceGeometryFlexGapResolver $sourceGeometryFlexGapResolver = null;
 
+    private ?LayoutIntentClassifier $layoutIntentClassifier = null;
+
     public function __construct(?LayoutGapResolver $layoutGapResolver = null)
     {
         $this->layoutGapResolver = $layoutGapResolver ?? new LayoutGapResolver();
@@ -215,10 +217,8 @@ final class StaticHtmlEmitter
     {
         return $this->canvasShellResolver ??= new CanvasShellResolver(
             $this->layoutFrameRoleClassifier(),
-            fn (array $node): bool => $this->isFreeformContainer($node),
+            $this->layoutIntentClassifier(),
             fn (array $node): bool => $this->freeformContainerShouldUseFlow($node),
-            fn (array $node): bool => $this->hasAbsoluteChild($node),
-            fn (array $node): bool => $this->hasDecorativeFlexUnderlayChild($node),
             $this->visualGeometryResolver(),
             $this->breakpointDimensionPolicy(),
         );
@@ -227,13 +227,8 @@ final class StaticHtmlEmitter
     private function positioningStyleResolver(): PositioningStyleResolver
     {
         return $this->positioningStyleResolver ??= new PositioningStyleResolver(
-            $this->layoutIntentClassifier(),
             $this->cssPositioningResolver(),
             $this->canvasShellResolver(),
-            fn (array $node): bool => $this->isFreeformContainer($node),
-            fn (array $node): bool => $this->freeformContainerShouldUseFlow($node),
-            fn (array $node, array $parentNode): bool => $this->isDecorativeFlexUnderlay($node, $parentNode),
-            fn (array $node): bool => $this->hasDecorativeFlexUnderlayChild($node),
         );
     }
 
@@ -289,7 +284,7 @@ final class StaticHtmlEmitter
 
     private function layoutIntentClassifier(): LayoutIntentClassifier
     {
-        return new LayoutIntentClassifier($this->assetsById);
+        return $this->layoutIntentClassifier ??= new LayoutIntentClassifier($this->assetsById);
     }
 
     private function layoutFrameRoleClassifier(): LayoutFrameRoleClassifier
@@ -418,6 +413,11 @@ final class StaticHtmlEmitter
         $this->breakpointMediaDiffBuilder()->resetDecisionTraces();
         $this->stickyLayoutCoordinator()->reset();
         $this->cssPositioningResolver = null;
+        $this->layoutIntentClassifier = null;
+        $this->sourceGeometryFlexGapResolver = null;
+        $this->canvasShellResolver = null;
+        $this->positioningStyleResolver = null;
+        $this->staticHtmlSemanticClassifier = null;
     }
 
     /**
@@ -853,6 +853,33 @@ final class StaticHtmlEmitter
     }
 
     /**
+     * Resolve layout and stacking facts once for both markup and CSS emission.
+     *
+     * @param array<string, mixed> $node
+     * @param array<string, mixed>|null $parentNode
+     * @param array<string, mixed>|null $grandParentNode
+     */
+    private function nodeRenderPlan(array $node, ?array $parentNode, ?array $grandParentNode): NodeRenderPlan
+    {
+        $layoutIntentClassifier = $this->layoutIntentClassifier();
+        $layoutIntent = $layoutIntentClassifier->layoutIntent($node, $parentNode);
+        $parentIsFreeform = null !== $parentNode && $layoutIntentClassifier->isFreeformContainer($parentNode);
+        $parentFreeformUsesFlow = null !== $parentNode && $this->freeformContainerShouldUseFlow($parentNode);
+
+        return new NodeRenderPlan(
+            strtoupper((string) ($node['type'] ?? 'FRAME')),
+            $this->childrenInEmissionOrder($node, $layoutIntentClassifier->layoutIntent($node)),
+            $layoutIntent,
+            $this->canvasShellResolver()->resolve($node, $parentNode, $grandParentNode),
+            $layoutIntentClassifier->stackingContextPlan($node, $parentNode),
+            $parentIsFreeform,
+            $parentFreeformUsesFlow,
+            null !== $parentNode && $layoutIntentClassifier->isDecorativeFlexUnderlay($node, $parentNode),
+            null !== $parentNode && $layoutIntentClassifier->hasDecorativeFlexUnderlayChild($parentNode),
+        );
+    }
+
+    /**
      * @param array<string, mixed> $node
      * @param array<int, string>                 $cssRules
      * @param array<int, array<string, mixed>>   $diagnostics
@@ -896,7 +923,8 @@ final class StaticHtmlEmitter
         $id = $this->sanitizeAttribute((string) ($node['id'] ?? ''));
         $name = (string) ($node['name'] ?? '');
         $attributeName = $this->sanitizeAttribute($name);
-        $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
+        $plan = $this->nodeRenderPlan($node, $parentNode, $grandParentNode);
+        $type = $plan->type;
         if ( 'TEXT' === $type ) {
             $text = $this->textGlyphSvg($node);
             if ( null === $text ) {
@@ -925,7 +953,7 @@ final class StaticHtmlEmitter
                 'page_path' => $this->currentPagePath,
             );
         }
-        $children = $this->childrenInEmissionOrder($node);
+        $children = $plan->children;
         $imageElement = $this->imageElementMetadata($node, $type, $children);
         if ( null !== $imageElement ) {
             $tag = 'img';
@@ -1042,7 +1070,7 @@ final class StaticHtmlEmitter
         }
 
         $rendersInlineVectorSvg = null !== $vectorSvgMarkup && '' !== trim($vectorSvgMarkup);
-        $styles = $this->styleDeclarations($node, $type, $parentNode, $grandParentNode, $rendersInlineVectorSvg);
+        $styles = $this->styleDeclarations($node, $type, $parentNode, $grandParentNode, $rendersInlineVectorSvg, $plan);
         if ( ! empty($buttonLayerComposition['styles']) ) {
             array_push($styles, ...$buttonLayerComposition['styles']);
         }
@@ -1083,7 +1111,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node, $parentNode);
+        $layoutIntent = $plan->layoutIntent;
         $elementClassName = null === $imageElement ? $className : $className . ' figma-image-asset';
         $attributes = sprintf(' class="%1$s" data-figma-node-id="%2$s" data-figma-node-name="%3$s"', $elementClassName, $id, $attributeName);
         $attributes .= ' data-source-node-type="' . $this->sanitizeAttribute($type) . '"';
@@ -6470,14 +6498,16 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $node
      * @return array<int, string>
      */
-    private function styleDeclarations(array $node, string $type, ?array $parentNode, ?array $grandParentNode, bool $rendersInlineVectorSvg = false): array
+    private function styleDeclarations(array $node, string $type, ?array $parentNode, ?array $grandParentNode, bool $rendersInlineVectorSvg = false, ?NodeRenderPlan $plan = null): array
     {
         $styles = array();
+
+        $plan ??= $this->nodeRenderPlan($node, $parentNode, $grandParentNode);
 
         $box = is_array($node['box'] ?? null) ? $node['box'] : array();
         $layoutBox = $box;
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        $canvasShell = $this->canvasShellResolver()->resolve($node, $parentNode, $grandParentNode);
+        $canvasShell = $plan->canvasShell;
         $canvasWidthDecision = null;
         $zeroHeightVectorFallbackHeight = $this->zeroHeightVectorFallbackHeight($node, $type);
         foreach ( array('width', 'height') as $dimension ) {
@@ -6593,7 +6623,7 @@ final class StaticHtmlEmitter
             $styles[] = $style;
         }
 
-        $positioningStyleDecision = $this->positioningStyleResolver()->resolve($node, $type, $parentNode, $box, $layout, $canvasShell, $styles);
+        $positioningStyleDecision = $this->positioningStyleResolver()->resolve($node, $parentNode, $box, $layout, $plan, $styles);
         foreach ( $positioningStyleDecision->styles as $style ) {
             $styles[] = $style;
         }
@@ -6669,7 +6699,7 @@ final class StaticHtmlEmitter
             $styles[] = $style;
         }
 
-        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node, $parentNode);
+        $layoutIntent = $plan->layoutIntent;
         $freeformFlowIntent = empty($layout['display'] ?? null) ? $this->freeformContainerFlowIntent($node) : null;
         if ( null !== $freeformFlowIntent ) {
             $layoutIntent = $freeformFlowIntent;
@@ -6825,11 +6855,11 @@ final class StaticHtmlEmitter
      * @param array<string, mixed> $node
      * @return array<int, mixed>
      */
-    private function childrenInEmissionOrder(array $node): array
+    private function childrenInEmissionOrder(array $node, ?array $layoutIntent = null): array
     {
         $children = $this->nodeList($node);
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        $layoutIntent = $this->layoutIntentClassifier()->layoutIntent($node);
+        $layoutIntent ??= $this->layoutIntentClassifier()->layoutIntent($node);
         if (
             ! empty($layout['display'] ?? null)
             || ! is_array($layoutIntent)

--- a/figma-transformer/tests/contract/LayoutFrameRoleContract.php
+++ b/figma-transformer/tests/contract/LayoutFrameRoleContract.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\FigmaTransformer\Html\CanvasShellDecision;
 use Automattic\BlocksEngine\FigmaTransformer\Html\CssPositioningResolver;
 use Automattic\BlocksEngine\FigmaTransformer\Html\LayoutFrameRoleClassifier;
 use Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier;
+use Automattic\BlocksEngine\FigmaTransformer\Html\NodeRenderPlan;
 use Automattic\BlocksEngine\FigmaTransformer\Html\PositioningStyleResolver;
 use Automattic\BlocksEngine\FigmaTransformer\Html\VisualGeometryResolver;
 
@@ -102,17 +103,8 @@ function blocks_engine_figma_transformer_run_layout_frame_role_contract(callable
 
     $resolver = new CanvasShellResolver(
         $classifier,
-        static fn (array $node): bool => true === (($node['layout']['freeform'] ?? false)),
+        new LayoutIntentClassifier(),
         static fn (array $node): bool => true === (($node['layout']['freeform_uses_flow'] ?? false)),
-        static function (array $node): bool {
-            foreach ( is_array($node['children'] ?? null) ? $node['children'] : array() as $child ) {
-                if ( is_array($child) && 'absolute' === (($child['layout']['positioning'] ?? null)) ) {
-                    return true;
-                }
-            }
-            return false;
-        },
-        static fn (array $node): bool => true === (($node['layout']['has_decorative_underlay'] ?? false)),
         $visualGeometry,
     );
     $freeformBand = $band;
@@ -127,15 +119,21 @@ function blocks_engine_figma_transformer_run_layout_frame_role_contract(callable
 
     $positioningIntent = new LayoutIntentClassifier();
     $positioningResolver = new PositioningStyleResolver(
-        $positioningIntent,
         new CssPositioningResolver($positioningIntent, static fn (float $value): string => 0.0 === fmod($value, 1.0) ? (string) (int) $value : rtrim(rtrim(sprintf('%.3F', $value), '0'), '.')),
         $resolver,
-        static fn (array $node): bool => true === (($node['layout']['freeform'] ?? false)),
-        static fn (array $node): bool => true === (($node['layout']['freeform_uses_flow'] ?? false)),
-        static fn (array $node, array $parentNode): bool => false,
-        static fn (array $node): bool => false,
     );
-    $positioningDecision = $positioningResolver->resolve($backgroundNode, 'FRAME', $freeformBand, $backgroundBox, $backgroundLayout, $backgroundDecision, array('width:100vw'));
+    $backgroundPlan = new NodeRenderPlan(
+        'FRAME',
+        array(),
+        $positioningIntent->layoutIntent($backgroundNode, $freeformBand),
+        $backgroundDecision,
+        $positioningIntent->stackingContextPlan($backgroundNode, $freeformBand),
+        true,
+        false,
+        false,
+        false,
+    );
+    $positioningDecision = $positioningResolver->resolve($backgroundNode, $freeformBand, $backgroundBox, $backgroundLayout, $backgroundPlan, array('width:100vw'));
     $assert(null !== $positioningDecision->absolutePositioningDecision, 'positioning-decision-records-absolute-boundary');
     $assert('freeform_parent_absolute_child' === ($positioningDecision->absolutePositioningDecision->reasonCode ?? null), 'positioning-decision-reason-freeform-parent');
     $assert(array('position:absolute', 'top:0px', 'left:50%', 'margin-left:-50vw') === ($positioningDecision->absolutePositioningDecision->declarations ?? array()), 'positioning-decision-declarations-filter-local-and-append-viewport');


### PR DESCRIPTION
## Summary
- introduce an immutable `NodeRenderPlan` shared by markup and CSS emission
- compute child order, layout intent, canvas-shell classification, stacking, and parent flow facts once per node
- remove seven callback dependencies from canvas and positioning resolvers
- scope asset-dependent classifiers and resolver graphs to one public emission so emitter reuse cannot retain prior transform state

## Verification
- `php -l src/Html/NodeRenderPlan.php`
- `php -l src/Html/CanvasShellResolver.php`
- `php -l src/Html/PositioningStyleResolver.php`
- `php -l src/Html/StaticHtmlEmitter.php`
- `composer test`
- `git diff --check`

Relates to #1076.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode mapped the emitter callback and recomputation boundaries, implemented the node render-plan redesign, updated focused contracts, and ran the complete figma-transformer contract suite. Chris Huber is responsible for every line.