### PR TITLE
fix: capture deep editable components

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -137,6 +137,7 @@
     "test:packaging": "php tests/packaging/install-proof.php"
   },
   "config": {
+    "cache-dir": "var/cache/composer",
     "platform": {
       "php": "8.1.0"
     },

--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -141,13 +141,13 @@ final class FallbackEmitter
      * @param bool                             $preserveRoot    Include the source root when it carries required semantics or styling.
      * @return array{blockName: string, attrs: array<string, mixed>}|null
      */
-    public function maybeGenerateCustomBlock(DOMElement $element, array &$generatedBlocks, string $namespace, bool $preserveRoot = false): ?array
+    public function maybeGenerateCustomBlock(DOMElement $element, array &$generatedBlocks, string $namespace, bool $preserveRoot = false, bool $confirmedComponent = false): ?array
     {
         $result = $this->classifier->classify($element, $this->classificationContext($element));
-        if ( ! $result->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK) ) {
+        if ( ! $confirmedComponent && ! $result->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK) ) {
             return null;
         }
-        if ( $result->confidence() < self::GENERATION_CONFIDENCE_THRESHOLD ) {
+        if ( ! $confirmedComponent && $result->confidence() < self::GENERATION_CONFIDENCE_THRESHOLD ) {
             return null;
         }
 
@@ -188,6 +188,70 @@ final class FallbackEmitter
             'blockName' => $namespace . '/' . $localName,
             'attrs'     => $this->blockGenerator->referenceAttributes($content),
         );
+    }
+
+    public function isRepeatableContentComponent(DOMElement $element): bool
+    {
+        if (0 < $element->getElementsByTagName('script')->length) {
+            return false;
+        }
+
+        $result = $this->classifier->classify($element, $this->classificationContext($element));
+        $signals = $result->signals();
+        $safeComponent = $result->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK)
+            && $result->confidence() >= self::GENERATION_CONFIDENCE_THRESHOLD
+            && empty($signals['inline_event_handlers']);
+        if ($safeComponent && (2 <= (int) ($signals['repeatable_children'] ?? 0) || (str_contains(strtolower($element->tagName), '-') && (!empty($signals['media_gallery']) || !empty($signals['cohesive_content_unit']))))) {
+            return true;
+        }
+        if (!str_contains(strtolower($element->tagName), '-') || !empty($signals['inline_event_handlers'])) {
+            return false;
+        }
+        foreach ($element->childNodes as $child) {
+            if (! $child instanceof DOMElement) {
+                continue;
+            }
+            $childResult = $this->classifier->classify($child, $this->classificationContext($child));
+            $childSignals = $childResult->signals();
+            if ($childResult->is(SubtreeClassifier::BUCKET_CUSTOM_BLOCK)
+                && $childResult->confidence() >= self::GENERATION_CONFIDENCE_THRESHOLD
+                && 2 <= (int) ($childSignals['repeatable_children'] ?? 0)
+                && empty($childSignals['inline_event_handlers'])
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function isSafeCustomElementHost(DOMElement $element): bool
+    {
+        if (!str_contains(strtolower($element->tagName), '-')) {
+            return false;
+        }
+        $elements = array($element);
+        foreach ($element->getElementsByTagName('*') as $descendant) {
+            if ($descendant instanceof DOMElement) {
+                $elements[] = $descendant;
+            }
+        }
+        if (4 > count($elements)) {
+            return false;
+        }
+        foreach ($elements as $candidate) {
+            if (in_array(strtolower($candidate->tagName), array('script', 'form', 'input', 'select', 'textarea', 'canvas'), true)
+                || $candidate->hasAttribute('contenteditable')
+            ) {
+                return false;
+            }
+            foreach ($candidate->attributes ?? array() as $attribute) {
+                $name = strtolower($attribute->nodeName);
+                if (str_starts_with($name, 'on') || str_starts_with($name, 'data-wp-')) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**
@@ -277,12 +341,7 @@ final class FallbackEmitter
      */
     private function sanitizeHtmlString(string $html): string
     {
-        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $html) ?? '';
-        $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
-        $html = preg_replace('/\s+(?:href|src|xlink:href)\s*=\s*("\s*javascript:[^"]*"|\'\s*javascript:[^\']*\'|javascript:[^\s>]+)/i', '', $html) ?? '';
-        $html = preg_replace('/\s+srcdoc\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
-
-        return trim($html);
+        return $this->safeFallbackHtmlString($html);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -60,6 +60,7 @@ use DOMNode;
 
 final class HtmlTransformer
 {
+    private const GENERATED_COMPONENT_MIN_SOURCE_DEPTH = 14;
     use ButtonLinkDispatchTrait;
     use DomHelpersTrait;
     use FormDispatchTrait;
@@ -823,7 +824,9 @@ final class HtmlTransformer
         $interactionCandidates = $this->interactionCandidates($body);
         $this->collectSupersededNavToggleSelectors($body);
         $shellArtifacts = !array_key_exists('extract_global_shell', $options) || !empty($options['extract_global_shell']) ? $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html')) : array();
+        $this->collectGeneratedComponentCandidates($body);
         $blocks      = $this->navigationBlockNormalizer->normalize($this->convertChildren($body, $fallbacks, true), $this->sourceProvenance, $this->sourceBaseHiddenStates);
+        $blocks = $this->compressProjectedGroupChains($blocks);
         $fallbacks = array_merge($fallbacks, $this->responsiveImageFallbacks);
         if (!$this->fallbackReductionMode) {
             $blocks = $this->reduceCoreHtmlFallbackBlocks($blocks);
@@ -1196,6 +1199,59 @@ final class HtmlTransformer
     private function reusableComponentFingerprintFor(DOMElement $element): ?string
     {
         return $this->reusableComponentFingerprints[$element->getNodePath()] ?? null;
+    }
+
+    private function collectGeneratedComponentCandidates(DOMElement $element, int $depth = 0): void
+    {
+        if (self::GENERATED_COMPONENT_MIN_SOURCE_DEPTH <= $depth
+            && ('div' === strtolower($element->tagName) || str_contains(strtolower($element->tagName), '-'))
+            && ($this->hasRepeatedDirectChildTags($element) || str_contains(strtolower($element->tagName), '-'))
+            && ($this->fallbackEmitter->isRepeatableContentComponent($element) || $this->fallbackEmitter->isSafeCustomElementHost($element))
+        ) {
+            $this->generatedComponentCandidates[$element->getNodePath()] = true;
+            return;
+        }
+
+        foreach ($element->childNodes as $child) {
+            if ($child instanceof DOMElement) {
+                $this->collectGeneratedComponentCandidates($child, $depth + 1);
+            }
+        }
+    }
+
+    private function hasRepeatedDirectChildTags(DOMElement $element): bool
+    {
+        $counts = array();
+        foreach ($element->childNodes as $child) {
+            if (! $child instanceof DOMElement) {
+                continue;
+            }
+            $tag = strtolower($child->tagName);
+            $counts[$tag] = ($counts[$tag] ?? 0) + 1;
+            if (2 <= $counts[$tag]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function isGeneratedComponentCandidate(DOMElement $element): bool
+    {
+        return isset($this->generatedComponentCandidates[$element->getNodePath()]);
+    }
+
+    /** @param array{blockName: string, attrs: array<string, mixed>} $generated @return array<string, mixed> */
+    private function generatedComponentBlock(array $generated, DOMElement $element): array
+    {
+        $block = $this->createBlock($generated['blockName'], $generated['attrs'], array(), $element);
+        foreach (array_merge(array($element), $this->descendantElements($element)) as $target) {
+            if (! $this->isRuntimeDomTarget($target)) {
+                continue;
+            }
+            $block['_editability_runtime_owned'] = true;
+            $this->recordNativeRuntimeDomPreservation($target, $generated['blockName']);
+        }
+        return $block;
     }
 
     /** @param array<string, mixed> $recognition @return array<string, mixed> */
@@ -5236,6 +5292,7 @@ final class HtmlTransformer
 
             if ( 'button' !== strtolower($this->attr($element, 'role'))
                 && ! $this->hasClass($element, 'wp-block-columns')
+                && ! $this->isGeneratedComponentCandidate($element)
                 && $this->isAuthorOwnedLayout($element)
             ) {
                 $proofBacked = $this->proofBackedWrapperCoalescing($element, $fallbacks);
@@ -5246,7 +5303,7 @@ final class HtmlTransformer
             // A direct child of an author-owned layout is itself a layout item.
             // Keep its semantic container instead of allowing a core Group to
             // contribute flow layout defaults to the author-owned parent.
-            if ( $this->isDirectChildOfAuthorOwnedLayout($element) && in_array($tagName, array( 'div', 'section', 'article', 'aside', 'header', 'footer', 'main' ), true) ) {
+            if ( ! $this->isGeneratedComponentCandidate($element) && $this->isDirectChildOfAuthorOwnedLayout($element) && in_array($tagName, array( 'div', 'section', 'article', 'aside', 'header', 'footer', 'main' ), true) ) {
                 if ( 0 === $this->childElementCount($element) && '' === trim($element->textContent) && $this->shouldPreserveEmptyVisualElement($element) ) {
                     return $this->createBlock('core/group', $this->emptyVisualElementAttributes($element), array(), $element);
                 }
@@ -5352,6 +5409,13 @@ final class HtmlTransformer
                 }
             }
 
+            if ( $this->isGeneratedComponentCandidate($element) ) {
+                $generated = $this->fallbackEmitter->maybeGenerateCustomBlock($element, $this->generatedBlocks, $this->generatedBlockNamespace, true, true);
+                if ( null !== $generated ) {
+                    return $this->generatedComponentBlock($generated, $element);
+                }
+            }
+
             $textFlow = $this->textFlowBlockFromElement($element);
             if ( null !== $textFlow ) {
                 return $textFlow;
@@ -5383,6 +5447,13 @@ final class HtmlTransformer
             return null;
         }
 
+        if ( $this->isGeneratedComponentCandidate($element) ) {
+            $generated = $this->fallbackEmitter->maybeGenerateCustomBlock($element, $this->generatedBlocks, $this->generatedBlockNamespace, true, true);
+            if ( null !== $generated ) {
+                return $this->generatedComponentBlock($generated, $element);
+            }
+        }
+
         $readableControlBlock = $this->readableFormControlBlockFromElement($element);
         if ( null !== $readableControlBlock ) {
             return $readableControlBlock;
@@ -5405,7 +5476,7 @@ final class HtmlTransformer
             // core/html. Otherwise keep the existing fallback diagnostic.
             $generated = $this->fallbackEmitter->maybeGenerateCustomBlock($element, $this->generatedBlocks, $this->generatedBlockNamespace);
             if ( null !== $generated ) {
-                return $this->createBlock($generated['blockName'], $generated['attrs'], array(), $element);
+                return $this->generatedComponentBlock($generated, $element);
             }
 
             $fallback = array(
@@ -7556,6 +7627,140 @@ final class HtmlTransformer
         return in_array($landmark, array('header', 'footer'), true) ? $landmark : null;
     }
 
+    /** @param array<int, array<string, mixed>> $blocks @return array<int, array<string, mixed>> */
+    private function compressProjectedGroupChains(array $blocks): array
+    {
+        return array_values(array_map(fn (array $block): array => $this->compressProjectedGroupBlock($block), $blocks));
+    }
+
+    /** @param array<string, mixed> $block @return array<string, mixed> */
+    private function compressProjectedGroupBlock(array $block): array
+    {
+        $chain = array();
+        $cursor = $block;
+        while ($this->isSingleGroupShellCandidate($cursor)) {
+            $descriptor = $this->groupWrapperDescriptor($cursor);
+            if (null === $descriptor) {
+                break;
+            }
+            $chain[] = array('block' => $cursor, 'descriptor' => $descriptor);
+            $cursor = $cursor['innerBlocks'][0];
+        }
+
+        $branchEndpoint = false;
+        $cursorChildren = is_array($cursor['innerBlocks'] ?? null) ? $cursor['innerBlocks'] : array();
+        if ('core/group' === ($cursor['blockName'] ?? null)
+            && 1 < count($cursorChildren)
+            && !isset($cursor['_binding_token'])
+            && !in_array(strtolower((string) ($cursor['attrs']['tagName'] ?? 'div')), array('ul', 'ol', 'li'), true)
+            && null !== ($branchDescriptor = $this->groupWrapperDescriptor($cursor))
+        ) {
+            $chain[] = array('block' => $cursor, 'descriptor' => $branchDescriptor);
+            $terminalBlocks = $this->compressProjectedGroupChains($cursorChildren);
+            $terminal = array();
+            $terminalIsShell = false;
+            $branchEndpoint = true;
+        } else {
+            $terminal = array() !== $chain ? $this->compressProjectedGroupBlock($cursor) : $cursor;
+            $terminalIsShell = $this->isLayoutShellBlock($terminal);
+            $terminalBlocks = $terminalIsShell
+                ? $terminal['innerBlocks']
+                : array($terminal);
+        }
+        $projectedCount = count(array_filter($chain, fn (array $entry): bool => $this->hasSourceProjectionClass($entry['block'])));
+        $minimumLength = $branchEndpoint ? 3 : ($projectedCount === count($chain) ? 2 : 3);
+        if ((0 < $projectedCount && $minimumLength <= count($chain)) || (1 === count($chain) && $terminalIsShell && 0 < $projectedCount)) {
+            $wrappers = array_column($chain, 'descriptor');
+            $terminalRuntimeOwned = $terminalIsShell && !empty($terminal['_editability_runtime_owned']);
+            $terminalVisualOwned = $terminalIsShell && !empty($terminal['_editability_visual_owned']);
+            if ($terminalIsShell) {
+                $wrappers = array_merge($wrappers, is_array($terminal['_layout_shell_wrappers'] ?? null) ? $terminal['_layout_shell_wrappers'] : array());
+            }
+            $opening = implode('', array_column($wrappers, 'opening'));
+            $closing = implode('', array_reverse(array_column($wrappers, 'closing')));
+            $provenanceIds = array_values(array_filter(array_map(static fn (array $entry): mixed => $entry['block']['_source_provenance_id'] ?? null, $chain), 'is_int'));
+            if ($terminalIsShell) {
+                $provenanceIds = array_merge($provenanceIds, is_array($terminal['_source_provenance_ids'] ?? null) ? $terminal['_source_provenance_ids'] : array());
+            }
+            $blockName = $this->generatedBlockNamespace . '/layout-shell';
+            if (! $this->layoutShellBlockGenerated) {
+                $this->generatedBlocks[] = (new LayoutShellBlockGenerator())->definition($blockName);
+                $this->layoutShellBlockGenerated = true;
+            }
+            return array_filter(array(
+                'blockName' => $blockName,
+                'attrs' => array('wrappers' => array_map(static fn (array $wrapper): array => array('tagName' => $wrapper['tagName'], 'attributes' => $wrapper['attributes']), $wrappers)),
+                'innerBlocks' => $terminalBlocks,
+                'innerHTML' => $opening . $closing,
+                'innerContent' => array_merge(array($opening), array_fill(0, count($terminalBlocks), null), array($closing)),
+                '_source_provenance_ids' => $provenanceIds,
+                '_layout_shell_wrappers' => $wrappers,
+                '_editability_runtime_owned' => (bool) array_filter($chain, static fn (array $entry): bool => !empty($entry['block']['_editability_runtime_owned'])) || $terminalRuntimeOwned,
+                '_editability_visual_owned' => (bool) array_filter($chain, static fn (array $entry): bool => !empty($entry['block']['_editability_visual_owned'])) || $terminalVisualOwned,
+            ), static fn (mixed $value): bool => false !== $value && array() !== $value);
+        }
+
+        if (is_array($block['innerBlocks'] ?? null)) {
+            $block['innerBlocks'] = $this->compressProjectedGroupChains($block['innerBlocks']);
+        }
+        return $block;
+    }
+
+    /** @param array<string, mixed> $block */
+    private function isLayoutShellBlock(array $block): bool
+    {
+        return str_ends_with((string) ($block['blockName'] ?? ''), '/layout-shell')
+            && 0 < count(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array());
+    }
+
+    /** @param array<string, mixed> $block */
+    private function isSingleGroupShellCandidate(array $block): bool
+    {
+        if ('core/group' !== ($block['blockName'] ?? null)
+            || 1 !== count(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array())
+            || isset($block['_binding_token'])
+            || in_array(strtolower((string) ($block['attrs']['tagName'] ?? 'div')), array('ul', 'ol', 'li'), true)
+        ) {
+            return false;
+        }
+        return true;
+    }
+
+    /** @param array<string, mixed> $block */
+    private function hasSourceProjectionClass(array $block): bool
+    {
+        return (bool) preg_match('/(?:^|\s)blocks-engine-(?:attribute|css-owned|editor-anchor|semantic|source)-/', (string) ($block['attrs']['className'] ?? ''));
+    }
+
+    /** @param array<string, mixed> $block @return array{tagName: string, attributes: array<string, string>, opening: string, closing: string}|null */
+    private function groupWrapperDescriptor(array $block): ?array
+    {
+        $content = is_array($block['innerContent'] ?? null) ? $block['innerContent'] : array();
+        $opening = is_string($content[0] ?? null) ? $content[0] : '';
+        $closing = is_string($content[array_key_last($content)] ?? null) ? $content[array_key_last($content)] : '';
+        if (! preg_match('/^<([a-z][a-z0-9-]*)\b/i', $opening, $match) || '' === $closing) {
+            return null;
+        }
+        $tagName = strtolower($match[1]);
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML('<?xml encoding="utf-8" ?><body>' . $opening . $closing . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        $element = $loaded ? $document->getElementsByTagName($tagName)->item(0) : null;
+        if (! $element instanceof DOMElement) {
+            return null;
+        }
+        $attributes = array();
+        foreach ($element->attributes ?? array() as $attribute) {
+            $attributes[strtolower($attribute->nodeName)] = (string) $attribute->nodeValue;
+        }
+        if (1 === preg_match('/!\s*important\b/i', (string) ($attributes['style'] ?? ''))) {
+            return null;
+        }
+        return array('tagName' => $tagName, 'attributes' => $attributes, 'opening' => $opening, 'closing' => $closing);
+    }
+
     /**
      * @param array<int, array<string, mixed>> $blocks
      * @return array<int, array<string, mixed>>
@@ -7575,11 +7780,15 @@ final class HtmlTransformer
     {
         foreach ( $blocks as $index => &$block ) {
             $blockPath = $path . '.' . $index;
-            $provenanceId = $block['_source_provenance_id'] ?? null;
-            if ( is_int($provenanceId) && isset($this->sourceProvenance[$provenanceId]) ) {
-                $resolved[] = array_merge(array( 'block_path' => $blockPath ), $this->sourceProvenance[$provenanceId], !empty($block['_editability_runtime_owned']) ? array('editability_runtime_owned' => true) : array(), !empty($block['_editability_visual_owned']) ? array('editability_visual_owned' => true) : array());
+            $provenanceIds = is_array($block['_source_provenance_ids'] ?? null) ? $block['_source_provenance_ids'] : array($block['_source_provenance_id'] ?? null);
+            foreach ($provenanceIds as $provenanceId) {
+                if ( is_int($provenanceId) && isset($this->sourceProvenance[$provenanceId]) ) {
+                    $resolved[] = array_merge(array( 'block_path' => $blockPath ), $this->sourceProvenance[$provenanceId], !empty($block['_editability_runtime_owned']) ? array('editability_runtime_owned' => true) : array(), !empty($block['_editability_visual_owned']) ? array('editability_visual_owned' => true) : array());
+                }
             }
             unset($block['_source_provenance_id']);
+            unset($block['_source_provenance_ids']);
+            unset($block['_layout_shell_wrappers']);
             unset($block['_binding_token']);
             unset($block['_editability_runtime_owned']);
             unset($block['_editability_visual_owned']);

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -7755,7 +7755,9 @@ final class HtmlTransformer
         foreach ($element->attributes ?? array() as $attribute) {
             $attributes[strtolower($attribute->nodeName)] = (string) $attribute->nodeValue;
         }
-        if (1 === preg_match('/!\s*important\b/i', (string) ($attributes['style'] ?? ''))) {
+        // Core serializes style declarations differently from React's save path
+        // (notably unitless zero lengths). Keep styled wrappers as core groups.
+        if ('' !== trim((string) ($attributes['style'] ?? ''))) {
             return null;
         }
         return array('tagName' => $tagName, 'attributes' => $attributes, 'opening' => $opening, 'closing' => $closing);

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -21,6 +21,7 @@ use DOMElement;
 final class HtmlTransformerSession
 {
     public array $reusableComponentFingerprints = array();
+    public array $generatedComponentCandidates = array();
     public array $formControlEchoTexts = array();
     public array $responsiveImageFallbacks = array();
     public array $responsiveImageFallbackSelectors = array();
@@ -45,6 +46,7 @@ final class HtmlTransformerSession
     public bool $authoredMarqueeBlockGenerated = false;
     public bool $emptyRuntimeTargetGenerated = false;
     public bool $capturedDialogBlockGenerated = false;
+    public bool $layoutShellBlockGenerated = false;
     public string $generatedBlockNamespace = 'custom';
     public string $generatedAssetRoot = '';
     public array $runtimeScriptMetadata = array();

--- a/php-transformer/src/HtmlToBlocks/LayoutShellBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/LayoutShellBlockGenerator.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/** Builds a bounded List View carrier for exact source wrapper chains. */
+final class LayoutShellBlockGenerator
+{
+    /** @return array<string, mixed> */
+    public function definition(string $blockName): array
+    {
+        $script = <<<'JS'
+( function( blocks, blockEditor, element ) {
+    var createElement = element.createElement;
+    var InnerBlocks = blockEditor.InnerBlocks;
+    var useBlockProps = blockEditor.useBlockProps;
+    function reactStyle( value ) {
+        var probe = document.createElement( 'div' );
+        var style = {};
+        probe.setAttribute( 'style', value || '' );
+        for ( var index = 0; index < probe.style.length; index++ ) {
+            var property = probe.style.item( index );
+            var key = property.indexOf( '--' ) === 0 ? property : property.replace( /-([a-z])/g, function( _, letter ) { return letter.toUpperCase(); } );
+            style[ key ] = probe.style.getPropertyValue( property );
+        }
+        return style;
+    }
+    function wrapperProps( attributes ) {
+        var props = {};
+        Object.keys( attributes || {} ).forEach( function( name ) {
+            var value = attributes[ name ];
+            if ( name === 'class' ) { props.className = value; }
+            else if ( name === 'style' ) { props.style = reactStyle( value ); }
+            else if ( name === 'tabindex' ) { props.tabIndex = value; }
+            else { props[ name ] = value; }
+        } );
+        return props;
+    }
+    function savedContent( wrappers ) {
+        var content = createElement( InnerBlocks.Content );
+        for ( var index = ( wrappers || [] ).length - 1; index >= 0; index-- ) {
+            content = createElement( wrappers[ index ].tagName || 'div', wrapperProps( wrappers[ index ].attributes ), content );
+        }
+        return content;
+    }
+    blocks.registerBlockType( '__BLOCK_NAME__', {
+        attributes: { wrappers: { type: 'array', default: [] } },
+        supports: { html: false, reusable: false },
+        edit: function() { return createElement( 'div', useBlockProps(), createElement( InnerBlocks ) ); },
+        save: function( props ) { return savedContent( props.attributes.wrappers ); }
+    } );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );
+JS;
+        return array(
+            'name' => 'layout-shell',
+            'block_json' => array(
+                'apiVersion' => 3,
+                'name' => $blockName,
+                'title' => 'Layout Shell',
+                'category' => 'design',
+                'editorScript' => 'file:./index.js',
+                'attributes' => array('wrappers' => array('type' => 'array', 'default' => array())),
+                'supports' => array('html' => false, 'reusable' => false),
+            ),
+            'assets' => array('index.js' => str_replace('__BLOCK_NAME__', $blockName, $script)),
+            'script_dependencies' => array('index.js' => array('wp-blocks', 'wp-block-editor', 'wp-element')),
+        );
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -214,7 +214,12 @@ trait DomHelpersTrait
 
     private function safeFallbackHtml(DOMElement $element): string
     {
-        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $this->outerHtml($element)) ?? '';
+        return $this->safeFallbackHtmlString($this->outerHtml($element));
+    }
+
+    private function safeFallbackHtmlString(string $html): string
+    {
+        $html = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $html) ?? '';
         $html = preg_replace('/\s+on[a-z]+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $html) ?? '';
         $html = preg_replace_callback(
             '/\s+([a-zA-Z_:][\w:.-]*)\s*=\s*("([^"]*)"|\'([^\']*)\'|([^\s>]+))/i',

--- a/php-transformer/tests/unit/custom-block-generator.php
+++ b/php-transformer/tests/unit/custom-block-generator.php
@@ -106,13 +106,88 @@ $galleryRepeat = ( new HtmlTransformer() )->transform($galleries)->toArray();
 $assert(array_column($galleryResult['blocks'], 'blockName') === array_column($galleryRepeat['blocks'], 'blockName'), '5: gallery content-bound identities are deterministic across runs');
 
 // ---------------------------------------------------------------------------
-// 6. Gate (negative): weak signals stay UNKNOWN -> unchanged fallback.
+// 6. Deep repeatable components use one bounded companion block after native
+//    recognizers decline, without capturing ordinary page shells.
+// ---------------------------------------------------------------------------
+$collection = '<div class="story-collection">'
+    . '<article><h3>One</h3><p>First story</p></article>'
+    . '<article><h3>Two</h3><p>Second story</p></article>'
+    . '<article><h3>Three</h3><p>Third story</p></article>'
+    . '</div>';
+$deepCollection = $collection;
+for ($depth = 0; $depth < 16; ++$depth) $deepCollection = '<div class="shell-' . $depth . '">' . $deepCollection . '</div>';
+$deepResult = ( new HtmlTransformer() )->transform($deepCollection)->toArray();
+$deepDefinitions = $deepResult['source_reports']['generated_blocks'] ?? array();
+$deepMarkup = (string) ($deepResult['serialized_blocks'] ?? '');
+$assert(1 === count($deepDefinitions), '6: one deep repeatable component produces one generated definition');
+$assert(str_contains($deepMarkup, '<!-- wp:custom/collection-') && str_contains((string) ($deepDefinitions[0]['render'] ?? ''), '<div class="story-collection">') && !str_contains((string) ($deepDefinitions[0]['render'] ?? ''), 'shell-15'), '6: capture starts at the cohesive component root rather than the surrounding page shell');
+$assert(20 >= ($deepResult['source_reports']['editability_report']['metrics']['max_nesting_depth'] ?? PHP_INT_MAX), '6: generated component keeps the resulting List View depth within policy');
+
+$shallowResult = ( new HtmlTransformer() )->transform('<div><div>' . $collection . '</div></div>')->toArray();
+$assert(array() === ($shallowResult['source_reports']['generated_blocks'] ?? array()), '6: shallow repeatable content remains native blocks');
+
+$deepSection = str_replace('<div class="story-collection">', '<section class="story-collection">', str_replace('</div>', '</section>', $collection));
+for ($depth = 0; $depth < 16; ++$depth) $deepSection = '<div>' . $deepSection . '</div>';
+$sectionResult = ( new HtmlTransformer() )->transform($deepSection)->toArray();
+$assert(array() === ($sectionResult['source_reports']['generated_blocks'] ?? array()), '6: semantic sections are not captured as opaque generated components');
+
+$unsafeCollection = str_replace('class="story-collection"', 'class="story-collection" onclick="selectStory()"', $deepCollection);
+$unsafeResult = ( new HtmlTransformer() )->transform($unsafeCollection)->toArray();
+$assert(array() === ($unsafeResult['source_reports']['generated_blocks'] ?? array()), '6: inline behavior is never removed through static generated-component capture');
+
+$customHost = '<fluid-card-grid><div><article><h3>One</h3></article><article><h3>Two</h3></article><article><h3>Three</h3></article></div></fluid-card-grid>';
+for ($depth = 0; $depth < 16; ++$depth) $customHost = '<div>' . $customHost . '</div>';
+$customHostResult = ( new HtmlTransformer() )->transform($customHost)->toArray();
+$customHostDefinitions = array_values(array_filter($customHostResult['source_reports']['generated_blocks'] ?? array(), static fn (array $definition): bool => str_contains((string) ($definition['render'] ?? ''), '<fluid-card-grid>')));
+$assert(1 === count($customHostDefinitions), '6: a deep safe custom-element host becomes one exact companion block');
+
+$unsafeHost = str_replace('<div>', '<div><input value="unsafe">', $customHost);
+$unsafeHostResult = ( new HtmlTransformer() )->transform($unsafeHost)->toArray();
+$assert(array() === array_values(array_filter($unsafeHostResult['source_reports']['generated_blocks'] ?? array(), static fn (array $definition): bool => str_contains((string) ($definition['render'] ?? ''), '<fluid-card-grid>'))), '6: custom-element hosts with data-entry controls stay on application-aware conversion paths');
+
+$unsafeUrls = '<object data="javascript:alert(1)"></object><video poster="vbscript:alert(1)"></video><a href="%6a%61vascript:alert(1)" formaction="data:text/html,unsafe">Unsafe</a><img src="safe.jpg" srcset="safe.jpg 1x, javascript:alert(1) 2x"><meta http-equiv="refresh" content="0; url=data:text/html,unsafe">';
+$unsafeDeepCollection = preg_replace('/<article>/', '<article>' . $unsafeUrls, $deepCollection, 1) ?? $deepCollection;
+$unsafeUrlResult = ( new HtmlTransformer() )->transform($unsafeDeepCollection)->toArray();
+$unsafeRenders = implode('', array_map(static fn (array $definition): string => (string) ($definition['render'] ?? ''), $unsafeUrlResult['source_reports']['generated_blocks'] ?? array()));
+$assert(!str_contains(strtolower($unsafeRenders), 'javascript:') && !str_contains(strtolower($unsafeRenders), 'vbscript:') && !str_contains(strtolower($unsafeRenders), 'data:text') && str_contains($unsafeRenders, 'src="safe.jpg"'), '6: generated component HTML uses the complete fallback URL sanitization policy');
+
+$runtimeDeepCollection = preg_replace('/<article>/', '<article id="runtime-card">', $deepCollection, 1) ?? $deepCollection;
+$runtimeComponent = ( new HtmlTransformer() )->transform($runtimeDeepCollection, array('runtime_dom_selectors' => array('#runtime-card')))->toArray();
+$runtimeContracts = $runtimeComponent['source_reports']['runtime_dom_contracts'] ?? array();
+$runtimeProvenance = $runtimeComponent['source_reports']['html']['source_provenance'] ?? array();
+$assert(in_array('#runtime-card', array_column($runtimeContracts, 'selector'), true) && array_filter($runtimeProvenance, static fn (array $entry): bool => !empty($entry['editability_runtime_owned']) && str_starts_with((string) ($entry['block_name'] ?? ''), 'custom/')), '6: descendant runtime selectors remain attributed to the generated component block');
+
+$nativeColumns = '<div class="wp-block-columns"><div class="wp-block-column"><p>One</p></div><div class="wp-block-column"><p>Two</p></div><div class="wp-block-column"><p>Three</p></div></div>';
+for ($depth = 0; $depth < 16; ++$depth) $nativeColumns = '<div>' . $nativeColumns . '</div>';
+$nativeColumnsResult = ( new HtmlTransformer() )->transform($nativeColumns)->toArray();
+$assert(array() === ($nativeColumnsResult['source_reports']['generated_blocks'] ?? array()) && str_contains((string) ($nativeColumnsResult['serialized_blocks'] ?? ''), '<!-- wp:columns'), '6: native recognizers take precedence over generated component capture');
+
+$projectedChain = '<p>Editable terminal content</p>';
+for ($depth = 0; $depth < 8; ++$depth) $projectedChain = '<div id="shell-' . $depth . '" class="shell-' . $depth . ' blocks-engine-source-div-fixture-3">' . $projectedChain . '</div>';
+$shellResult = ( new HtmlTransformer() )->transform($projectedChain)->toArray();
+$shellBlock = $shellResult['blocks'][0] ?? array();
+$shellDefinitions = array_values(array_filter($shellResult['source_reports']['generated_blocks'] ?? array(), static fn (array $definition): bool => 'Layout Shell' === ($definition['block_json']['title'] ?? null)));
+$assert(str_ends_with((string) ($shellBlock['blockName'] ?? ''), '/layout-shell') && 8 === count($shellBlock['attrs']['wrappers'] ?? array()) && 'core/paragraph' === ($shellBlock['innerBlocks'][0]['blockName'] ?? null), '6: a projected wrapper chain becomes one layout-shell block around native editable content');
+$assert(1 === count($shellDefinitions) && str_contains((string) ($shellDefinitions[0]['assets']['index.js'] ?? ''), 'InnerBlocks.Content'), '6: layout-shell emits one companion definition whose save path retains native inner blocks');
+$assert(2 === ($shellResult['source_reports']['editability_report']['metrics']['max_nesting_depth'] ?? PHP_INT_MAX) && 8 === substr_count((string) ($shellResult['serialized_blocks'] ?? ''), 'id="shell-'), '6: layout-shell collapses List View depth while preserving every rendered source wrapper');
+
+$branchShell = ( new HtmlTransformer() )->transform('<div id="branch-outer" class="blocks-engine-source-div-outer-3"><div id="branch-inner" class="blocks-engine-source-div-fixture-3"><section id="branch-section" class="blocks-engine-source-section-fixture-3"><p>First branch</p><p>Second branch</p></section></div></div>')->toArray();
+$branchBlock = $branchShell['blocks'][0] ?? array();
+$assert(str_ends_with((string) ($branchBlock['blockName'] ?? ''), '/layout-shell') && 3 === count($branchBlock['attrs']['wrappers'] ?? array()) && 2 === count($branchBlock['innerBlocks'] ?? array()), '6: layout-shell absorbs a final branching Group and exposes all ordered native children through InnerBlocks');
+$branchMarkup = (string) ($branchShell['serialized_blocks'] ?? '');
+$assert(str_contains($branchMarkup, '<section id="branch-section"') && 2 === substr_count($branchMarkup, '<!-- wp:paragraph') && strpos($branchMarkup, 'First branch') < strpos($branchMarkup, 'Second branch'), '6: branching layout-shell serialization preserves semantic wrappers and ordered native child blocks');
+
+$importantShell = ( new HtmlTransformer() )->transform('<div class="blocks-engine-source-div-outer-3" style="color:red ! important"><div class="blocks-engine-source-div-fixture-3"><p>Priority-sensitive content</p></div></div>')->toArray();
+$assert(!str_ends_with((string) ($importantShell['blocks'][0]['blockName'] ?? ''), '/layout-shell'), '6: layout-shell does not rewrite wrapper chains carrying whitespace-variant !important declarations');
+
+// ---------------------------------------------------------------------------
+// 7. Gate (negative): weak signals stay UNKNOWN -> unchanged fallback.
 // ---------------------------------------------------------------------------
 $weak = ( new HtmlTransformer() )->transform('<my-widget><span>hello there</span></my-widget>')->toArray();
-$assert(count($weak['source_reports']['generated_blocks'] ?? array()) === 0, '6: low-confidence subtree generates nothing');
-$assert(count($weak['blocks']) === 0, '6: low-confidence subtree emits no block');
-$assert(count($weak['fallbacks']) === 1, '6: existing fallback behavior is preserved');
-$assert(($weak['fallbacks'][0]['classification']['bucket'] ?? '') === 'unknown', '6: classifier verdict is unknown', json_encode($weak['fallbacks'][0]['classification'] ?? array()));
+$assert(count($weak['source_reports']['generated_blocks'] ?? array()) === 0, '7: low-confidence subtree generates nothing');
+$assert(count($weak['blocks']) === 0, '7: low-confidence subtree emits no block');
+$assert(count($weak['fallbacks']) === 1, '7: existing fallback behavior is preserved');
+$assert(($weak['fallbacks'][0]['classification']['bucket'] ?? '') === 'unknown', '7: classifier verdict is unknown', json_encode($weak['fallbacks'][0]['classification'] ?? array()));
 
 if ( $failures > 0 ) {
     fwrite(STDERR, PHP_EOL . "CustomBlockGenerator unit tests: {$passes} passed, {$failures} FAILED" . PHP_EOL);

--- a/php-transformer/tests/unit/custom-block-generator.php
+++ b/php-transformer/tests/unit/custom-block-generator.php
@@ -180,6 +180,9 @@ $assert(str_contains($branchMarkup, '<section id="branch-section"') && 2 === sub
 $importantShell = ( new HtmlTransformer() )->transform('<div class="blocks-engine-source-div-outer-3" style="color:red ! important"><div class="blocks-engine-source-div-fixture-3"><p>Priority-sensitive content</p></div></div>')->toArray();
 $assert(!str_ends_with((string) ($importantShell['blocks'][0]['blockName'] ?? ''), '/layout-shell'), '6: layout-shell does not rewrite wrapper chains carrying whitespace-variant !important declarations');
 
+$styledShell = ( new HtmlTransformer() )->transform('<div class="blocks-engine-source-div-outer-3" style="margin-top:0"><div class="blocks-engine-source-div-fixture-3"><p>Style-sensitive content</p></div></div>')->toArray();
+$assert(!str_ends_with((string) ($styledShell['blocks'][0]['blockName'] ?? ''), '/layout-shell'), '6: layout-shell leaves styled wrapper chains to core serialization');
+
 // ---------------------------------------------------------------------------
 // 7. Gate (negative): weak signals stay UNKNOWN -> unchanged fallback.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- capture only deep, safe, repeatable content components after native recognizers decline
- preserve runtime descendant contracts and source provenance on generated component references
- collapse unstyled source-projected group chains into an editable layout-shell companion while retaining wrapper DOM and ordered native children
- leave styled wrapper chains to core serialization, preventing React save normalization from invalidating blocks
- use a project-local Composer cache during Codebox transformer-overlay hydration
- apply the full fallback URL sanitization policy to generated component HTML

## Validation
- `php tests/unit/custom-block-generator.php`: 54 assertions passed
- `composer test:unit`: passed
- `composer test:canonical`: passed, including the Figma template-surface contract after #1123
- solved-only local promotion matrix: passed for 2/2 fixtures with 0 findings, valid editor blocks, and exact visual parity

## Scope
Related to #1060. Runtime plan projection is supplied by merged #1114; this PR preserves runtime descendant provenance and deep editable component capture.

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode rebased, verified, and prepared this repair for landing. Chris Huber remains responsible for every line.