### PR TITLE
Type Figma breakpoint collaborators

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -24,22 +24,18 @@ final class BreakpointMediaDiffBuilder
     private array $decisionTraces = array();
 
     /**
-     * @param callable(array<string, mixed>): array<int, mixed> $nodeList
      * @param callable(array<string, mixed>, string, array<string, mixed>|null, array<string, mixed>|null): array<int, string> $styleDeclarations
      * @param callable(array<string, mixed>, string, array<string, mixed>|null): mixed $supportedVectorSvg
-     * @param callable(array<string, mixed>, array<string, mixed>): bool $isFullyClippedDecorativeChild
-     * @param callable(array<string, mixed>): bool $isPaginationContainer
      * @param callable(string): string $sanitizeAttribute
      * @param callable(string): string $slug
      * @param callable(float): string $number
      */
     public function __construct(
         private readonly StickyLayoutCoordinator $stickyLayoutCoordinator,
-        private readonly mixed $nodeList,
+        private readonly StaticHtmlNodeInspector $nodeInspector,
+        private readonly VisualGeometryResolver $visualGeometryResolver,
         private readonly mixed $styleDeclarations,
         private readonly mixed $supportedVectorSvg,
-        private readonly mixed $isFullyClippedDecorativeChild,
-        private readonly mixed $isPaginationContainer,
         private readonly mixed $sanitizeAttribute,
         private readonly mixed $slug,
         private readonly mixed $number,
@@ -52,7 +48,7 @@ final class BreakpointMediaDiffBuilder
         $this->breakpointDimensionPolicy = $breakpointDimensionPolicy ?? new BreakpointDimensionPolicy($this->number);
         $this->layoutIntentClassifier = $layoutIntentClassifier ?? new LayoutIntentClassifier();
         $this->responsiveBreakpointSafetyPolicy = $responsiveBreakpointSafetyPolicy ?? new ResponsiveBreakpointSafetyPolicy(
-            $this->nodeList,
+            $this->nodeInspector,
             $this->number,
             $this->breakpointDimensionPolicy,
             $this->layoutIntentClassifier
@@ -402,7 +398,7 @@ final class BreakpointMediaDiffBuilder
         }
 
         $widths = array();
-        foreach ( ($this->nodeList)($parentNode) as $child ) {
+        foreach ( $this->nodeInspector->nodeList($parentNode) as $child ) {
             if ( ! is_array($child) || 'absolute' === ($child['layout']['positioning'] ?? null) ) {
                 continue;
             }
@@ -451,7 +447,7 @@ final class BreakpointMediaDiffBuilder
      */
     private function hasContainerChild(array $node): bool
     {
-        foreach ( ($this->nodeList)($node) as $child ) {
+        foreach ( $this->nodeInspector->nodeList($node) as $child ) {
             if ( ! is_array($child) ) {
                 continue;
             }
@@ -467,7 +463,7 @@ final class BreakpointMediaDiffBuilder
     /** @param array<string, mixed> $node */
     private function hasPositionedDirectChild(array $node): bool
     {
-        foreach ( ($this->nodeList)($node) as $child ) {
+        foreach ( $this->nodeInspector->nodeList($node) as $child ) {
             if ( ! is_array($child) ) {
                 continue;
             }
@@ -660,8 +656,8 @@ final class BreakpointMediaDiffBuilder
         }
 
         $children = array();
-        foreach ( ($this->nodeList)($node) as $child ) {
-            if ( ! is_array($child) || $this->stickyLayoutCoordinator->isSuppressedStickyGhost($child) || ($this->isFullyClippedDecorativeChild)($child, $node) ) {
+        foreach ( $this->nodeInspector->nodeList($node) as $child ) {
+            if ( ! is_array($child) || $this->stickyLayoutCoordinator->isSuppressedStickyGhost($child) || $this->visualGeometryResolver->isFullyClippedDecorativeChild($child, $node) ) {
                 continue;
             }
 
@@ -704,7 +700,7 @@ final class BreakpointMediaDiffBuilder
             $variantNode = is_array($variantStyles[$pathKey]['node'] ?? null) ? $variantStyles[$pathKey]['node'] : array();
             $baseParentNode = is_array($base['parent_node'] ?? null) ? $base['parent_node'] : null;
             $variantParentNode = is_array($variantStyles[$pathKey]['parent_node'] ?? null) ? $variantStyles[$pathKey]['parent_node'] : null;
-            $preservePaginationRow = ! empty($baseNode) && ($this->isPaginationContainer)($baseNode);
+            $preservePaginationRow = ! empty($baseNode) && $this->nodeInspector->isPaginationContainer($baseNode);
             $responsiveWidthHandledProperties = array();
             foreach ( $variantDeclarations as $declaration ) {
                 $parts = explode(':', (string) $declaration, 2);
@@ -1041,7 +1037,7 @@ final class BreakpointMediaDiffBuilder
             return false;
         }
 
-        return ! empty(($this->nodeList)($baseNode)) && ! empty(($this->nodeList)($variantNode));
+        return ! empty($this->nodeInspector->nodeList($baseNode)) && ! empty($this->nodeInspector->nodeList($variantNode));
     }
 
     /**

--- a/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
+++ b/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
@@ -10,11 +10,10 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 final class ResponsiveBreakpointSafetyPolicy
 {
     /**
-     * @param callable(array<string, mixed>): array<int, mixed> $nodeList
      * @param callable(float): string $number
      */
     public function __construct(
-        private readonly mixed $nodeList,
+        private readonly StaticHtmlNodeInspector $nodeInspector,
         private readonly mixed $number,
         private readonly BreakpointDimensionPolicy $breakpointDimensionPolicy,
         private readonly LayoutIntentClassifier $layoutIntentClassifier,
@@ -340,7 +339,7 @@ final class ResponsiveBreakpointSafetyPolicy
             && in_array($display, array('flex', 'inline-flex'), true)
             && 'row' === ($baseMap['flex-direction'] ?? null)
             && $this->hasOverwideContainerChild($node, $mobileContentWidth);
-        if ( ! $isContainer || null === $parentNode || empty(($this->nodeList)($node)) ) {
+        if ( ! $isContainer || null === $parentNode || empty($this->nodeInspector->nodeList($node)) ) {
             return array();
         }
         if ( ! $hasUnsafeFluidRow && (null === $width || $width <= min(340.0, $mobileContentWidth)) ) {
@@ -464,7 +463,7 @@ final class ResponsiveBreakpointSafetyPolicy
      */
     private function hasContainerChild(array $node): bool
     {
-        foreach ( ($this->nodeList)($node) as $child ) {
+        foreach ( $this->nodeInspector->nodeList($node) as $child ) {
             if ( ! is_array($child) ) {
                 continue;
             }
@@ -483,7 +482,7 @@ final class ResponsiveBreakpointSafetyPolicy
      */
     private function hasOverwideContainerChild(array $node, float $contentWidth): bool
     {
-        foreach ( ($this->nodeList)($node) as $child ) {
+        foreach ( $this->nodeInspector->nodeList($node) as $child ) {
             if ( ! is_array($child) ) {
                 continue;
             }
@@ -559,7 +558,7 @@ final class ResponsiveBreakpointSafetyPolicy
         $hasNewsletter = false;
         $hasBottomRow = false;
         $freeformParent = $this->isFreeformContainer($node);
-        foreach ( ($this->nodeList)($node) as $child ) {
+        foreach ( $this->nodeInspector->nodeList($node) as $child ) {
             if ( ! is_array($child) ) {
                 continue;
             }
@@ -582,7 +581,7 @@ final class ResponsiveBreakpointSafetyPolicy
     private function isFreeformContainer(array $node): bool
     {
         $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        return empty($layout['display']) && ! empty(($this->nodeList)($node));
+        return empty($layout['display']) && ! empty($this->nodeInspector->nodeList($node));
     }
 
     /**
@@ -593,7 +592,7 @@ final class ResponsiveBreakpointSafetyPolicy
         $baseHeight = $this->nodeBoxHeight($node) ?? 0.0;
         $newsletterHeight = 0.0;
         $bottomRowHeight = 0.0;
-        foreach ( ($this->nodeList)($node) as $child ) {
+        foreach ( $this->nodeInspector->nodeList($node) as $child ) {
             if ( ! is_array($child) ) {
                 continue;
             }

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -252,11 +252,10 @@ final class StaticHtmlEmitter
     {
         return $this->breakpointMediaDiffBuilder ??= new BreakpointMediaDiffBuilder(
             $this->stickyLayoutCoordinator(),
-            fn (array $node): array => $this->nodeList($node),
+            $this->nodeInspector(),
+            $this->visualGeometryResolver(),
             fn (array $node, string $type, ?array $parentNode, ?array $grandParentNode): array => $this->styleDeclarations($node, $type, $parentNode, $grandParentNode),
             fn (array $node, string $type, ?array $parentNode): mixed => $this->supportedVectorSvg($node, $type, $parentNode),
-            fn (array $child, array $parent): bool => $this->isFullyClippedDecorativeChild($child, $parent),
-            fn (array $node): bool => $this->isPaginationContainer($node),
             fn (string $value): string => $this->sanitizeAttribute($value),
             fn (string $value): string => $this->slug($value),
             fn (float $value): string => $this->number($value),
@@ -2380,24 +2379,7 @@ final class StaticHtmlEmitter
      */
     private function isPaginationContainer(array $node): bool
     {
-        $text = strtolower(' ' . preg_replace('/\s+/', ' ', trim($this->subtreePlainText($node))) . ' ');
-        if ( ! str_contains($text, ' previous ') || ! str_contains($text, ' next ') ) {
-            return false;
-        }
-
-        $numberTokens = 0;
-        foreach ( preg_split('/\s+/', trim($text)) ?: array() as $token ) {
-            if ( preg_match('/^(\d+|…|\.\.\.)$/', $token) ) {
-                ++$numberTokens;
-            }
-        }
-
-        if ( $numberTokens < 3 ) {
-            return false;
-        }
-
-        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
-        return 'flex' === ($layout['display'] ?? null) && 'row' === ($layout['flex_direction'] ?? null);
+        return $this->nodeInspector()->isPaginationContainer($node);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlNodeInspector.php
+++ b/figma-transformer/src/Html/StaticHtmlNodeInspector.php
@@ -133,4 +133,27 @@ final class StaticHtmlNodeInspector
 
         return false;
     }
+
+    /** @param array<string, mixed> $node */
+    public function isPaginationContainer(array $node): bool
+    {
+        $text = strtolower(' ' . preg_replace('/\s+/', ' ', trim($this->subtreePlainText($node))) . ' ');
+        if ( ! str_contains($text, ' previous ') || ! str_contains($text, ' next ') ) {
+            return false;
+        }
+
+        $numberTokens = 0;
+        foreach ( preg_split('/\s+/', trim($text)) ?: array() as $token ) {
+            if ( preg_match('/^(\d+|\x{2026}|\.\.\.)$/u', $token) ) {
+                ++$numberTokens;
+            }
+        }
+
+        if ( $numberTokens < 3 ) {
+            return false;
+        }
+
+        $layout = is_array($node['layout'] ?? null) ? $node['layout'] : array();
+        return 'flex' === ($layout['display'] ?? null) && 'row' === ($layout['flex_direction'] ?? null);
+    }
 }

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -376,7 +376,7 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     $assert(1 === ($responsiveQuality['summary']['fixed_width_over_desktop_uncovered_count'] ?? null), 'diagnostics-evidence-responsive-quality-uncovered-summary');
 
     $responsivePolicy = new \Automattic\BlocksEngine\FigmaTransformer\Html\ResponsiveBreakpointSafetyPolicy(
-        static fn (array $node): array => is_array($node['children'] ?? null) ? $node['children'] : array(),
+        new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlNodeInspector(),
         static fn (float $value): string => rtrim(rtrim(sprintf('%.3F', $value), '0'), '.'),
         new \Automattic\BlocksEngine\FigmaTransformer\Html\BreakpointDimensionPolicy(static fn (float $value): string => rtrim(rtrim(sprintf('%.3F', $value), '0'), '.')),
         new \Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier()

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -7196,7 +7196,7 @@ $assert(
     'breakpoint-dimension-policy-header-fluid-min-height-pairing'
 );
 $responsiveBreakpointSafetyPolicy = new Automattic\BlocksEngine\FigmaTransformer\Html\ResponsiveBreakpointSafetyPolicy(
-    static fn (array $node): array => is_array($node['children'] ?? null) ? $node['children'] : array(),
+    new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlNodeInspector(),
     fn (float $value): string => rtrim(rtrim(sprintf('%.4F', $value), '0'), '.'),
     $breakpointDimensionPolicy,
     new Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier()


### PR DESCRIPTION
## Summary
- inject normalized node inspection and visual geometry directly into `BreakpointMediaDiffBuilder`
- move pagination-container recognition into the shared node inspector
- give responsive safety policy a typed inspector instead of a traversal closure
- reduce the breakpoint builder callback bag from eight dependencies to five

Part of #1076.

## Verification
- `cd figma-transformer && composer test`
- PHP syntax checks for all changed PHP files
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map pure callback dependencies, migrate them to typed collaborators, update direct contract callers, and run compatibility verification. Chris Huber reviewed and remains responsible for the change.