### PR TITLE
Add typed Figma emission session

### DIFF
--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -25,7 +25,6 @@ final class BreakpointMediaDiffBuilder
 
     /**
      * @param callable(array<string, mixed>, string, array<string, mixed>|null, array<string, mixed>|null): array<int, string> $styleDeclarations
-     * @param callable(array<string, mixed>, string, array<string, mixed>|null): mixed $supportedVectorSvg
      * @param callable(string): string $sanitizeAttribute
      * @param callable(string): string $slug
      * @param callable(float): string $number
@@ -34,8 +33,8 @@ final class BreakpointMediaDiffBuilder
         private readonly StickyLayoutCoordinator $stickyLayoutCoordinator,
         private readonly StaticHtmlNodeInspector $nodeInspector,
         private readonly VisualGeometryResolver $visualGeometryResolver,
+        private readonly VectorSvgRenderer $vectorSvgRenderer,
         private readonly mixed $styleDeclarations,
-        private readonly mixed $supportedVectorSvg,
         private readonly mixed $sanitizeAttribute,
         private readonly mixed $slug,
         private readonly mixed $number,
@@ -650,7 +649,7 @@ final class BreakpointMediaDiffBuilder
             'path_key'        => $pathKey,
         );
 
-        $vectorSvg = ($this->supportedVectorSvg)($node, $type, $parentNode);
+        $vectorSvg = $this->vectorSvgRenderer->supportedVectorSvg($node, $type, $parentNode);
         if ( 'BOOLEAN_OPERATION' === $type && null !== $vectorSvg ) {
             return;
         }

--- a/figma-transformer/src/Html/PaintStackResolver.php
+++ b/figma-transformer/src/Html/PaintStackResolver.php
@@ -11,13 +11,10 @@ final class PaintStackResolver
 {
     /**
      * @param callable(array<string, mixed>): ?string $resolveAndMarkPaintAssetPath
-     * @param callable(float): string $numberFormatter
-     * @param callable(mixed, mixed=): ?string $color
      */
     public function __construct(
         private readonly mixed $resolveAndMarkPaintAssetPath,
-        private readonly mixed $numberFormatter,
-        private readonly mixed $color,
+        private readonly StaticHtmlValueFormatter $formatter,
     ) {
     }
 
@@ -345,12 +342,12 @@ final class PaintStackResolver
 
     private function number(float $value): string
     {
-        return ($this->numberFormatter)($value);
+        return $this->formatter->number($value);
     }
 
     private function color(mixed $value, mixed $opacity = null): ?string
     {
-        return ($this->color)($value, $opacity);
+        return $this->formatter->color($value, $opacity);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmissionSession.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionSession.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Typed state and render services shared by one emitter execution context.
+ */
+final class StaticHtmlEmissionSession
+{
+    private readonly StaticHtmlPageState $pageState;
+    private readonly StaticHtmlLinkState $linkState;
+    private readonly VectorSvgRenderer $vectorSvgRenderer;
+
+    public function __construct(
+        StaticHtmlNodeInspector $nodeInspector,
+        StaticHtmlValueFormatter $formatter,
+        private readonly StaticHtmlVectorEvidence $vectorEvidence,
+    ) {
+        $this->pageState = new StaticHtmlPageState();
+        $this->linkState = new StaticHtmlLinkState();
+        $this->vectorSvgRenderer = new VectorSvgRenderer($nodeInspector, $formatter, $this->vectorEvidence);
+    }
+
+    public function pageState(): StaticHtmlPageState
+    {
+        return $this->pageState;
+    }
+
+    public function linkState(): StaticHtmlLinkState
+    {
+        return $this->linkState;
+    }
+
+    public function vectorSvgRenderer(): VectorSvgRenderer
+    {
+        return $this->vectorSvgRenderer;
+    }
+
+    public function vectorEvidence(): StaticHtmlVectorEvidence
+    {
+        return $this->vectorEvidence;
+    }
+
+}

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -67,8 +67,6 @@ final class StaticHtmlEmitter
 
     private ?DesignSystemExtractor $designSystemExtractor = null;
 
-    private ?VectorSvgRenderer $vectorSvgRenderer = null;
-
     private ?StyleDeclarationBuilder $styleDeclarationBuilder = null;
 
     private ?TextStyleDeclarationResolver $textStyleDeclarationResolver = null;
@@ -109,11 +107,16 @@ final class StaticHtmlEmitter
 
     private ?StaticHtmlNodeInspector $nodeInspector = null;
 
+    private ?StaticHtmlValueFormatter $valueFormatter = null;
+
+    private StaticHtmlEmissionSession $emissionSession;
+
     public function __construct(?LayoutGapResolver $layoutGapResolver = null)
     {
         $this->layoutGapResolver = $layoutGapResolver ?? new LayoutGapResolver();
-        $this->linkState = new StaticHtmlLinkState();
-        $this->pageState = new StaticHtmlPageState();
+        $this->emissionSession = $this->newEmissionSession();
+        $this->linkState = $this->emissionSession->linkState();
+        $this->pageState = $this->emissionSession->pageState();
     }
 
     private ?LayoutFrameRoleClassifier $layoutFrameRoleClassifier = null;
@@ -127,14 +130,15 @@ final class StaticHtmlEmitter
 
     private function vectorSvgRenderer(): VectorSvgRenderer
     {
-        return $this->vectorSvgRenderer ??= new VectorSvgRenderer(
-            fn (array $node): array => $this->nodeList($node),
-            fn (float $value): string => $this->number($value),
-            fn (string $value): string => $this->sanitizeAttribute($value),
-            fn (array $paints): ?string => $this->firstSolidPaint($paints),
-            fn (array $node): ?string => $this->backgroundColor($node),
-            fn (array $node): array => $this->nodeImagePaints($node),
-            fn (array $node): array => $this->explicitNodeAssetReferences($node),
+        return $this->emissionSession->vectorSvgRenderer();
+    }
+
+    private function newEmissionSession(): StaticHtmlEmissionSession
+    {
+        return new StaticHtmlEmissionSession(
+            $this->nodeInspector(),
+            $this->valueFormatter(),
+            new StaticHtmlVectorEvidence($this->valueFormatter(), $this->paintStackResolver()),
         );
     }
 
@@ -173,8 +177,7 @@ final class StaticHtmlEmitter
     {
         return $this->paintStackResolver ??= new PaintStackResolver(
             fn (array $paint): ?string => $this->resolveAndMarkPaintAssetPath($paint),
-            fn (float $value): string => $this->number($value),
-            fn (mixed $value, mixed $opacity = null): ?string => $this->color($value, $opacity),
+            $this->valueFormatter(),
         );
     }
 
@@ -254,8 +257,8 @@ final class StaticHtmlEmitter
             $this->stickyLayoutCoordinator(),
             $this->nodeInspector(),
             $this->visualGeometryResolver(),
+            $this->emissionSession->vectorSvgRenderer(),
             fn (array $node, string $type, ?array $parentNode, ?array $grandParentNode): array => $this->styleDeclarations($node, $type, $parentNode, $grandParentNode),
-            fn (array $node, string $type, ?array $parentNode): mixed => $this->supportedVectorSvg($node, $type, $parentNode),
             fn (string $value): string => $this->sanitizeAttribute($value),
             fn (string $value): string => $this->slug($value),
             fn (float $value): string => $this->number($value),
@@ -290,6 +293,11 @@ final class StaticHtmlEmitter
     private function nodeInspector(): StaticHtmlNodeInspector
     {
         return $this->nodeInspector ??= new StaticHtmlNodeInspector();
+    }
+
+    private function valueFormatter(): StaticHtmlValueFormatter
+    {
+        return $this->valueFormatter ??= new StaticHtmlValueFormatter();
     }
 
     private function layoutFrameRoleClassifier(): LayoutFrameRoleClassifier
@@ -347,6 +355,10 @@ final class StaticHtmlEmitter
      */
     private function beginEmission(array $options): void
     {
+        $this->emissionSession = $this->newEmissionSession();
+        $this->linkState = $this->emissionSession->linkState();
+        $this->pageState = $this->emissionSession->pageState();
+        $this->breakpointMediaDiffBuilder = null;
         $this->renderTextGlyphPaths = true === ($options['render_text_glyph_paths'] ?? false);
         $this->usedAssetPaths = array();
         $this->generatedAssetFiles = array();
@@ -6354,17 +6366,7 @@ final class StaticHtmlEmitter
      */
     private function explicitNodeAssetReferences(array $node): array
     {
-        $references = array();
-        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
-            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
-                $references[] = (string) $node[$key];
-            }
-        }
-        if ( is_array($node['image'] ?? null) ) {
-            $references = array_merge($references, $this->imageAssetReferences($node['image']));
-        }
-
-        return array_values(array_unique($references));
+        return $this->emissionSession->vectorEvidence()->explicitNodeAssetReferences($node);
     }
 
     /**
@@ -9743,7 +9745,7 @@ final class StaticHtmlEmitter
      */
     private function nodeImagePaints(array $node): array
     {
-        return VisualLayerEvidence::imagePaints($node);
+        return $this->emissionSession->vectorEvidence()->nodeImagePaints($node);
     }
 
     /**
@@ -9866,24 +9868,7 @@ final class StaticHtmlEmitter
      */
     private function paintAssetReferences(array $paint): array
     {
-        $references = array();
-        foreach ( array('ref', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref') as $key ) {
-            if ( isset($paint[$key]) && is_scalar($paint[$key]) && '' !== (string) $paint[$key] ) {
-                $references[] = (string) $paint[$key];
-            }
-        }
-
-        if ( is_array($paint['assetRef'] ?? null) ) {
-            $references = array_merge($references, $this->assetRefReferences($paint['assetRef']));
-        }
-
-        foreach ( array('image', 'thumbnail', 'imageThumbnail', 'sourceImage') as $imageKey ) {
-            if ( is_array($paint[$imageKey] ?? null) ) {
-                $references = array_merge($references, $this->imageAssetReferences($paint[$imageKey]));
-            }
-        }
-
-        return array_values(array_unique($references));
+        return VisualLayerEvidence::paintAssetReferences($paint);
     }
 
     /**
@@ -9892,21 +9877,7 @@ final class StaticHtmlEmitter
      */
     private function imageAssetReferences(array $image): array
     {
-        $references = array();
-        foreach ( array('hash', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref', 'ref', 'source_id', 'node_id', 'nodeId', 'name', 'fileName', 'filename') as $key ) {
-            if ( isset($image[$key]) && is_scalar($image[$key]) && '' !== (string) $image[$key] ) {
-                $references[] = (string) $image[$key];
-            }
-        }
-
-        if ( is_array($image['assetRef'] ?? null) ) {
-            $references = array_merge($references, $this->assetRefReferences($image['assetRef']));
-        }
-        if ( is_array($image['sourceImage'] ?? null) ) {
-            $references = array_merge($references, $this->imageAssetReferences($image['sourceImage']));
-        }
-
-        return array_values(array_unique($references));
+        return VisualLayerEvidence::imageAssetReferences($image);
     }
 
     /**
@@ -9915,19 +9886,7 @@ final class StaticHtmlEmitter
      */
     private function assetRefReferences(array $assetRef): array
     {
-        $references = array();
-        foreach ( array('id', 'key', 'nodeID', 'fileKey', 'libraryKey', 'publishID', 'sourceLibraryKey') as $key ) {
-            if ( isset($assetRef[$key]) && is_scalar($assetRef[$key]) && '' !== (string) $assetRef[$key] ) {
-                $references[] = (string) $assetRef[$key];
-            }
-        }
-        if ( is_array($assetRef['guid'] ?? null) && isset($assetRef['guid']['sessionID'], $assetRef['guid']['localID']) ) {
-            $references[] = (string) $assetRef['guid']['sessionID'] . ':' . (string) $assetRef['guid']['localID'];
-        } elseif ( isset($assetRef['guid']) && is_scalar($assetRef['guid']) && '' !== (string) $assetRef['guid'] ) {
-            $references[] = (string) $assetRef['guid'];
-        }
-
-        return array_values(array_unique($references));
+        return VisualLayerEvidence::assetRefReferences($assetRef);
     }
 
     private function isUnsupportedVectorType(string $type): bool
@@ -10098,28 +10057,7 @@ final class StaticHtmlEmitter
      */
     private function backgroundColor(array $node): ?string
     {
-        $paints = is_array($node['figma_paints']['fills'] ?? null) ? $node['figma_paints']['fills'] : array();
-        $paint = $this->firstBackgroundPaint($paints);
-        if ( null !== $paint ) {
-            return $paint;
-        }
-
-        $paints = is_array($node['figma_paints']['background'] ?? null) ? $node['figma_paints']['background'] : array();
-        $paint = $this->firstBackgroundPaint($paints);
-        if ( null !== $paint ) {
-            return $paint;
-        }
-
-        return $this->color($node['background'] ?? $node['backgroundColor'] ?? $node['fill'] ?? $node['fills'][0]['color'] ?? $node['fillPaints'][0]['color'] ?? $node['paints']['fills'][0]['color'] ?? $node['paints'][0]['color'] ?? $node['paints'][0][0]['color'] ?? null);
-    }
-
-    /**
-     * @param array<int, mixed> $paints
-     */
-    private function firstBackgroundPaint(array $paints): ?string
-    {
-        $paint = $this->firstCssPaint($paints);
-        return is_array($paint) ? $paint['css'] : null;
+        return $this->emissionSession->vectorEvidence()->backgroundColor($node);
     }
 
     /**
@@ -10136,18 +10074,7 @@ final class StaticHtmlEmitter
      */
     private function firstSolidPaint(array $paints): ?string
     {
-        foreach ( $paints as $paint ) {
-            if ( ! is_array($paint) || 'SOLID' !== ($paint['type'] ?? null) ) {
-                continue;
-            }
-
-            $color = $this->color($paint['color'] ?? null, $paint['opacity'] ?? null);
-            if ( null !== $color ) {
-                return $color;
-            }
-        }
-
-        return null;
+        return $this->emissionSession->vectorEvidence()->firstSolidPaint($paints);
     }
 
     /**
@@ -10329,45 +10256,7 @@ final class StaticHtmlEmitter
 
     private function color(mixed $value, mixed $opacity = null): ?string
     {
-        if ( is_string($value) && preg_match('/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/', $value) ) {
-            return strtolower($value);
-        }
-
-        if ( ! is_array($value) ) {
-            return null;
-        }
-
-        $red = $this->colorChannel($value['r'] ?? $value['red'] ?? null);
-        $green = $this->colorChannel($value['g'] ?? $value['green'] ?? null);
-        $blue = $this->colorChannel($value['b'] ?? $value['blue'] ?? null);
-        if ( null === $red || null === $green || null === $blue ) {
-            return null;
-        }
-
-        $alpha = $opacity;
-        if ( null === $alpha && isset($value['a']) ) {
-            $alpha = $value['a'];
-        }
-
-        if ( is_numeric($alpha) && (float) $alpha < 1 ) {
-            return sprintf('rgba(%d,%d,%d,%s)', $red, $green, $blue, $this->number(max(0, (float) $alpha)));
-        }
-
-        return sprintf('#%02x%02x%02x', $red, $green, $blue);
-    }
-
-    private function colorChannel(mixed $value): ?int
-    {
-        if ( ! is_numeric($value) ) {
-            return null;
-        }
-
-        $channel = (float) $value;
-        if ( $channel <= 1 ) {
-            $channel *= 255;
-        }
-
-        return max(0, min(255, (int) round($channel)));
+        return $this->valueFormatter()->color($value, $opacity);
     }
 
     private function extensionForMimeType(string $mimeType): string
@@ -10692,11 +10581,7 @@ final class StaticHtmlEmitter
 
     private function number(float $value): string
     {
-        if ( ! is_finite($value) ) {
-            return '0';
-        }
-
-        return rtrim(rtrim(sprintf('%.3F', $value), '0'), '.');
+        return $this->valueFormatter()->number($value);
     }
 
     /**
@@ -10727,6 +10612,6 @@ final class StaticHtmlEmitter
 
     private function sanitizeAttribute(string $text): string
     {
-        return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        return $this->valueFormatter()->sanitizeAttribute($text);
     }
 }

--- a/figma-transformer/src/Html/StaticHtmlValueFormatter.php
+++ b/figma-transformer/src/Html/StaticHtmlValueFormatter.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Canonical scalar formatting for emitted HTML, CSS, and SVG values.
+ */
+final class StaticHtmlValueFormatter
+{
+    public function number(float $value): string
+    {
+        if ( ! is_finite($value) ) {
+            return '0';
+        }
+
+        return rtrim(rtrim(sprintf('%.3F', $value), '0'), '.');
+    }
+
+    public function color(mixed $value, mixed $opacity = null): ?string
+    {
+        if ( is_string($value) && preg_match('/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/', $value) ) {
+            return strtolower($value);
+        }
+
+        if ( ! is_array($value) ) {
+            return null;
+        }
+
+        $red = $this->colorChannel($value['r'] ?? $value['red'] ?? null);
+        $green = $this->colorChannel($value['g'] ?? $value['green'] ?? null);
+        $blue = $this->colorChannel($value['b'] ?? $value['blue'] ?? null);
+        if ( null === $red || null === $green || null === $blue ) {
+            return null;
+        }
+
+        $alpha = $opacity;
+        if ( null === $alpha && isset($value['a']) ) {
+            $alpha = $value['a'];
+        }
+
+        if ( is_numeric($alpha) && (float) $alpha < 1 ) {
+            return sprintf('rgba(%d,%d,%d,%s)', $red, $green, $blue, $this->number(max(0, (float) $alpha)));
+        }
+
+        return sprintf('#%02x%02x%02x', $red, $green, $blue);
+    }
+
+    public function sanitizeAttribute(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    private function colorChannel(mixed $value): ?int
+    {
+        if ( ! is_numeric($value) ) {
+            return null;
+        }
+
+        $channel = (float) $value;
+        if ( $channel <= 1 ) {
+            $channel *= 255;
+        }
+
+        return max(0, min(255, (int) round($channel)));
+    }
+}

--- a/figma-transformer/src/Html/StaticHtmlVectorEvidence.php
+++ b/figma-transformer/src/Html/StaticHtmlVectorEvidence.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Pure paint and asset-reference evidence used while resolving vector SVG.
+ */
+final class StaticHtmlVectorEvidence
+{
+    public function __construct(
+        private readonly StaticHtmlValueFormatter $formatter,
+        private readonly PaintStackResolver $paintStackResolver,
+    ) {
+    }
+
+    /** @param array<int, mixed> $paints */
+    public function firstSolidPaint(array $paints): ?string
+    {
+        foreach ( $paints as $paint ) {
+            if ( ! is_array($paint) || 'SOLID' !== ($paint['type'] ?? null) ) {
+                continue;
+            }
+
+            $color = $this->formatter->color($paint['color'] ?? null, $paint['opacity'] ?? null);
+            if ( null !== $color ) {
+                return $color;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $node */
+    public function backgroundColor(array $node): ?string
+    {
+        foreach ( array('fills', 'background') as $key ) {
+            $paints = is_array($node['figma_paints'][$key] ?? null) ? $node['figma_paints'][$key] : array();
+            $paint = $this->paintStackResolver->firstCssPaint($paints);
+            if ( is_array($paint) ) {
+                return $paint['css'];
+            }
+        }
+
+        return $this->formatter->color($node['background'] ?? $node['backgroundColor'] ?? $node['fill'] ?? $node['fills'][0]['color'] ?? $node['fillPaints'][0]['color'] ?? $node['paints']['fills'][0]['color'] ?? $node['paints'][0]['color'] ?? $node['paints'][0][0]['color'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, array<string, mixed>>
+     */
+    public function nodeImagePaints(array $node): array
+    {
+        return VisualLayerEvidence::imagePaints($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    public function explicitNodeAssetReferences(array $node): array
+    {
+        return VisualLayerEvidence::explicitNodeAssetReferences($node);
+    }
+}

--- a/figma-transformer/src/Html/VectorSvgRenderer.php
+++ b/figma-transformer/src/Html/VectorSvgRenderer.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
-use Closure;
-
 /**
  * Renders normalized Figma vector geometry as inline SVG markup.
  */
@@ -16,30 +14,11 @@ final class VectorSvgRenderer
     private const VECTOR_PRIMITIVE_TYPES = array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'RECTANGLE', 'ROUNDED_RECTANGLE', 'STAR', 'POLYGON', 'REGULAR_POLYGON');
     private const VECTOR_CONTAINER_TYPES = array('GROUP', 'FRAME', 'COMPONENT', 'INSTANCE');
 
-    private Closure $nodeList;
-    private Closure $number;
-    private Closure $sanitizeAttribute;
-    private Closure $firstSolidPaint;
-    private Closure $backgroundColor;
-    private Closure $nodeImagePaints;
-    private Closure $explicitNodeAssetReferences;
-
     public function __construct(
-        callable $nodeList,
-        callable $number,
-        callable $sanitizeAttribute,
-        callable $firstSolidPaint,
-        callable $backgroundColor,
-        callable $nodeImagePaints,
-        callable $explicitNodeAssetReferences
+        private readonly StaticHtmlNodeInspector $nodeInspector,
+        private readonly StaticHtmlValueFormatter $formatter,
+        private readonly StaticHtmlVectorEvidence $vectorEvidence,
     ) {
-        $this->nodeList = $nodeList instanceof Closure ? $nodeList : Closure::fromCallable($nodeList);
-        $this->number = $number instanceof Closure ? $number : Closure::fromCallable($number);
-        $this->sanitizeAttribute = $sanitizeAttribute instanceof Closure ? $sanitizeAttribute : Closure::fromCallable($sanitizeAttribute);
-        $this->firstSolidPaint = $firstSolidPaint instanceof Closure ? $firstSolidPaint : Closure::fromCallable($firstSolidPaint);
-        $this->backgroundColor = $backgroundColor instanceof Closure ? $backgroundColor : Closure::fromCallable($backgroundColor);
-        $this->nodeImagePaints = $nodeImagePaints instanceof Closure ? $nodeImagePaints : Closure::fromCallable($nodeImagePaints);
-        $this->explicitNodeAssetReferences = $explicitNodeAssetReferences instanceof Closure ? $explicitNodeAssetReferences : Closure::fromCallable($explicitNodeAssetReferences);
     }
 
     /**
@@ -1439,17 +1418,17 @@ final class VectorSvgRenderer
      */
     private function nodeList(array $node): array
     {
-        return ($this->nodeList)($node);
+        return $this->nodeInspector->nodeList($node);
     }
 
     private function number(float $value): string
     {
-        return ($this->number)($value);
+        return $this->formatter->number($value);
     }
 
     private function sanitizeAttribute(string $value): string
     {
-        return ($this->sanitizeAttribute)($value);
+        return $this->formatter->sanitizeAttribute($value);
     }
 
     /**
@@ -1457,7 +1436,7 @@ final class VectorSvgRenderer
      */
     private function firstSolidPaint(array $paints): ?string
     {
-        return ($this->firstSolidPaint)($paints);
+        return $this->vectorEvidence->firstSolidPaint($paints);
     }
 
     /**
@@ -1465,7 +1444,7 @@ final class VectorSvgRenderer
      */
     private function backgroundColor(array $node): ?string
     {
-        return ($this->backgroundColor)($node);
+        return $this->vectorEvidence->backgroundColor($node);
     }
 
     /**
@@ -1474,7 +1453,7 @@ final class VectorSvgRenderer
      */
     private function nodeImagePaints(array $node): array
     {
-        return ($this->nodeImagePaints)($node);
+        return $this->vectorEvidence->nodeImagePaints($node);
     }
 
     /**
@@ -1483,6 +1462,6 @@ final class VectorSvgRenderer
      */
     private function explicitNodeAssetReferences(array $node): array
     {
-        return ($this->explicitNodeAssetReferences)($node);
+        return $this->vectorEvidence->explicitNodeAssetReferences($node);
     }
 }

--- a/figma-transformer/src/Html/VisualLayerEvidence.php
+++ b/figma-transformer/src/Html/VisualLayerEvidence.php
@@ -59,4 +59,93 @@ final class VisualLayerEvidence
     {
         return null !== self::firstImagePaint($node);
     }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    public static function explicitNodeAssetReferences(array $node): array
+    {
+        $references = array();
+        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
+                $references[] = (string) $node[$key];
+            }
+        }
+        if ( is_array($node['image'] ?? null) ) {
+            $references = array_merge($references, self::imageAssetReferences($node['image']));
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    /**
+     * @param array<string, mixed> $image
+     * @return array<int, string>
+     */
+    public static function imageAssetReferences(array $image): array
+    {
+        $references = array();
+        foreach ( array('hash', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref', 'ref', 'source_id', 'node_id', 'nodeId', 'name', 'fileName', 'filename') as $key ) {
+            if ( isset($image[$key]) && is_scalar($image[$key]) && '' !== (string) $image[$key] ) {
+                $references[] = (string) $image[$key];
+            }
+        }
+
+        if ( is_array($image['assetRef'] ?? null) ) {
+            $references = array_merge($references, self::assetRefReferences($image['assetRef']));
+        }
+        if ( is_array($image['sourceImage'] ?? null) ) {
+            $references = array_merge($references, self::imageAssetReferences($image['sourceImage']));
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    /**
+     * @param array<string, mixed> $paint
+     * @param array<int, string>|null $referenceKeys
+     * @return array<int, string>
+     */
+    public static function paintAssetReferences(array $paint, ?array $referenceKeys = null): array
+    {
+        $references = array();
+        foreach ( $referenceKeys ?? array('ref', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref') as $key ) {
+            if ( isset($paint[$key]) && is_scalar($paint[$key]) && '' !== (string) $paint[$key] ) {
+                $references[] = (string) $paint[$key];
+            }
+        }
+
+        if ( is_array($paint['assetRef'] ?? null) ) {
+            $references = array_merge($references, self::assetRefReferences($paint['assetRef']));
+        }
+        foreach ( array('image', 'thumbnail', 'imageThumbnail', 'sourceImage') as $imageKey ) {
+            if ( is_array($paint[$imageKey] ?? null) ) {
+                $references = array_merge($references, self::imageAssetReferences($paint[$imageKey]));
+            }
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    /**
+     * @param array<string, mixed> $assetRef
+     * @return array<int, string>
+     */
+    public static function assetRefReferences(array $assetRef): array
+    {
+        $references = array();
+        foreach ( array('id', 'key', 'nodeID', 'fileKey', 'libraryKey', 'publishID', 'sourceLibraryKey') as $key ) {
+            if ( isset($assetRef[$key]) && is_scalar($assetRef[$key]) && '' !== (string) $assetRef[$key] ) {
+                $references[] = (string) $assetRef[$key];
+            }
+        }
+        if ( is_array($assetRef['guid'] ?? null) && isset($assetRef['guid']['sessionID'], $assetRef['guid']['localID']) ) {
+            $references[] = (string) $assetRef['guid']['sessionID'] . ':' . (string) $assetRef['guid']['localID'];
+        } elseif ( isset($assetRef['guid']) && is_scalar($assetRef['guid']) && '' !== (string) $assetRef['guid'] ) {
+            $references[] = (string) $assetRef['guid'];
+        }
+
+        return array_values(array_unique($references));
+    }
 }

--- a/figma-transformer/src/Html/VisualNodeMapBuilder.php
+++ b/figma-transformer/src/Html/VisualNodeMapBuilder.php
@@ -542,16 +542,7 @@ final class VisualNodeMapBuilder
 
     private function explicitNodeAssetReferences(array $node): array
     {
-        $references = array();
-        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref') as $key ) {
-            if ( isset($node[$key]) && is_scalar($node[$key]) && '' !== (string) $node[$key] ) {
-                $references[] = (string) $node[$key];
-            }
-        }
-        if ( is_array($node['image'] ?? null) ) {
-            $references = array_merge($references, $this->imageAssetReferences($node['image']));
-        }
-        return array_values(array_unique($references));
+        return VisualLayerEvidence::explicitNodeAssetReferences($node);
     }
 
     private function resolveAssetPath(string $assetId): ?string
@@ -570,21 +561,7 @@ final class VisualNodeMapBuilder
      */
     private function paintAssetReferences(array $paint): array
     {
-        $references = array();
-        foreach ( array('imageRef', 'imageHash', 'ref', 'asset_id', 'assetId', 'image_ref') as $key ) {
-            if ( isset($paint[$key]) && is_scalar($paint[$key]) && '' !== (string) $paint[$key] ) {
-                $references[] = (string) $paint[$key];
-            }
-        }
-        if ( is_array($paint['assetRef'] ?? null) ) {
-            $references = array_merge($references, $this->assetRefReferences($paint['assetRef']));
-        }
-        foreach ( array('image', 'thumbnail', 'imageThumbnail', 'sourceImage') as $imageKey ) {
-            if ( is_array($paint[$imageKey] ?? null) ) {
-                $references = array_merge($references, $this->imageAssetReferences($paint[$imageKey]));
-            }
-        }
-        return array_values(array_unique($references));
+        return VisualLayerEvidence::paintAssetReferences($paint, array('imageRef', 'imageHash', 'ref', 'asset_id', 'assetId', 'image_ref'));
     }
 
     /**
@@ -593,39 +570,7 @@ final class VisualNodeMapBuilder
      */
     private function imageAssetReferences(array $image): array
     {
-        $references = array();
-        foreach ( array('hash', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref', 'ref', 'source_id', 'node_id', 'nodeId', 'name', 'fileName', 'filename') as $key ) {
-            if ( isset($image[$key]) && is_scalar($image[$key]) && '' !== (string) $image[$key] ) {
-                $references[] = (string) $image[$key];
-            }
-        }
-        if ( is_array($image['assetRef'] ?? null) ) {
-            $references = array_merge($references, $this->assetRefReferences($image['assetRef']));
-        }
-        if ( is_array($image['sourceImage'] ?? null) ) {
-            $references = array_merge($references, $this->imageAssetReferences($image['sourceImage']));
-        }
-        return array_values(array_unique($references));
-    }
-
-    /**
-     * @param array<string, mixed> $assetRef
-     * @return array<int, string>
-     */
-    private function assetRefReferences(array $assetRef): array
-    {
-        $references = array();
-        foreach ( array('id', 'key', 'nodeID', 'fileKey', 'libraryKey', 'publishID', 'sourceLibraryKey') as $key ) {
-            if ( isset($assetRef[$key]) && is_scalar($assetRef[$key]) && '' !== (string) $assetRef[$key] ) {
-                $references[] = (string) $assetRef[$key];
-            }
-        }
-        if ( is_array($assetRef['guid'] ?? null) && isset($assetRef['guid']['sessionID'], $assetRef['guid']['localID']) ) {
-            $references[] = (string) $assetRef['guid']['sessionID'] . ':' . (string) $assetRef['guid']['localID'];
-        } elseif ( isset($assetRef['guid']) && is_scalar($assetRef['guid']) && '' !== (string) $assetRef['guid'] ) {
-            $references[] = (string) $assetRef['guid'];
-        }
-        return array_values(array_unique($references));
+        return VisualLayerEvidence::imageAssetReferences($image);
     }
 
     private function nodeImagePaints(array $node): array


### PR DESCRIPTION
## Summary
- create a fresh `StaticHtmlEmissionSession` for every public emission and make it own page state, link state, and vector rendering services
- replace `VectorSvgRenderer`'s seven closures with typed node inspection, value formatting, and vector evidence collaborators
- pass the typed renderer directly into responsive breakpoint comparison, reducing its remaining callback bag from five to four
- centralize number, color, HTML attribute, image paint, and nested asset-reference evidence shared by emission and visual-map paths
- preserve caller-specific asset-reference ordering while removing duplicate traversal implementations

Part of #1076. Style resolution remains the next intentionally stateful callback boundary because it also owns asset usage, typography tokens, and decision traces.

## Verification
- `cd figma-transformer && composer test`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent architecture review of lifecycle, cache invalidation, and output compatibility

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map transitive emitter state, design and implement the typed session boundary, review lifecycle and compatibility risks, and run verification. Chris Huber reviewed and remains responsible for the change.