### PR TITLE
Isolate Figma emission asset state

### DIFF
--- a/figma-transformer/src/Html/ChildLayerCompositionResolver.php
+++ b/figma-transformer/src/Html/ChildLayerCompositionResolver.php
@@ -4,28 +4,16 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
-use Closure;
-
 /**
  * Resolves sibling-layer compositions that should be expressed on a target child
  * instead of emitted as separate visible DOM layers.
  */
 final class ChildLayerCompositionResolver
 {
-    /** @var Closure(array<string, mixed>): ?string */
-    private Closure $nodeAssetPath;
-
-    /** @var Closure(float): string */
-    private Closure $number;
-
-    /**
-     * @param Closure(array<string, mixed>): ?string $nodeAssetPath
-     * @param Closure(float): string $number
-     */
-    public function __construct(Closure $nodeAssetPath, Closure $number)
-    {
-        $this->nodeAssetPath = $nodeAssetPath;
-        $this->number = $number;
+    public function __construct(
+        private readonly StaticHtmlAssetRegistry $assetRegistry,
+        private readonly StaticHtmlValueFormatter $formatter,
+    ) {
     }
 
     /**
@@ -112,7 +100,7 @@ final class ChildLayerCompositionResolver
             }
 
             $nodeId = isset($node['id']) && is_scalar($node['id']) ? (string) $node['id'] : '';
-            if ( '' === $nodeId || null !== ($this->nodeAssetPath)($node) || ! $this->hasVisibleSolidFill($node) ) {
+            if ( '' === $nodeId || null !== $this->assetRegistry->resolveAndMarkNode($node) || ! $this->hasVisibleSolidFill($node) ) {
                 continue;
             }
 
@@ -121,7 +109,7 @@ final class ChildLayerCompositionResolver
                     continue;
                 }
 
-                $assetPath = ($this->nodeAssetPath)($candidate);
+                $assetPath = $this->assetRegistry->resolveAndMarkNode($candidate);
                 if ( null !== $assetPath && $this->isSameBoxNode($node, $candidate) && $this->isIconRecolorMaskComposition($node, $candidate, $assetPath) ) {
                     $maskPaths[$nodeId] = $assetPath;
                     $sourceId = isset($candidate['id']) && is_scalar($candidate['id']) ? (string) $candidate['id'] : '';
@@ -226,7 +214,7 @@ final class ChildLayerCompositionResolver
         }
 
         return array(
-            'key' => $type . '|width:' . ($this->number)(round($box['width'], 1)) . '|height:' . ($this->number)(round($box['height'], 1)) . '|' . $pathSignature,
+            'key' => $type . '|width:' . $this->formatter->number(round($box['width'], 1)) . '|height:' . $this->formatter->number(round($box['height'], 1)) . '|' . $pathSignature,
             'box' => $box,
         );
     }
@@ -419,17 +407,17 @@ final class ChildLayerCompositionResolver
         $relativeTop = $maskTop - $targetTop;
 
         if ( 'ELLIPSE' === $maskType ) {
-            return 'ellipse(' . ($this->number)($maskWidth / 2.0) . 'px ' . ($this->number)($maskHeight / 2.0) . 'px at ' . ($this->number)($relativeLeft + ($maskWidth / 2.0)) . 'px ' . ($this->number)($relativeTop + ($maskHeight / 2.0)) . 'px)';
+            return 'ellipse(' . $this->formatter->number($maskWidth / 2.0) . 'px ' . $this->formatter->number($maskHeight / 2.0) . 'px at ' . $this->formatter->number($relativeLeft + ($maskWidth / 2.0)) . 'px ' . $this->formatter->number($relativeTop + ($maskHeight / 2.0)) . 'px)';
         }
 
         $clip = 'inset('
-            . ($this->number)($relativeTop) . 'px '
-            . ($this->number)($targetWidth - ($relativeLeft + $maskWidth)) . 'px '
-            . ($this->number)($targetHeight - ($relativeTop + $maskHeight)) . 'px '
-            . ($this->number)($relativeLeft) . 'px';
+            . $this->formatter->number($relativeTop) . 'px '
+            . $this->formatter->number($targetWidth - ($relativeLeft + $maskWidth)) . 'px '
+            . $this->formatter->number($targetHeight - ($relativeTop + $maskHeight)) . 'px '
+            . $this->formatter->number($relativeLeft) . 'px';
         $radius = $this->simpleMaskRadius($maskNode);
         if ( null !== $radius && $radius > 0.0 ) {
-            $clip .= ' round ' . ($this->number)($radius) . 'px';
+            $clip .= ' round ' . $this->formatter->number($radius) . 'px';
         }
 
         return $clip . ')';

--- a/figma-transformer/src/Html/PaintStackResolver.php
+++ b/figma-transformer/src/Html/PaintStackResolver.php
@@ -9,11 +9,8 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
  */
 final class PaintStackResolver
 {
-    /**
-     * @param callable(array<string, mixed>): ?string $resolveAndMarkPaintAssetPath
-     */
     public function __construct(
-        private readonly mixed $resolveAndMarkPaintAssetPath,
+        private readonly StaticHtmlAssetRegistry $assetRegistry,
         private readonly StaticHtmlValueFormatter $formatter,
     ) {
     }
@@ -337,7 +334,7 @@ final class PaintStackResolver
 
     private function resolveAndMarkPaintAssetPath(array $paint): ?string
     {
-        return ($this->resolveAndMarkPaintAssetPath)($paint);
+        return $this->assetRegistry->resolveAndMarkPaint($paint);
     }
 
     private function number(float $value): string

--- a/figma-transformer/src/Html/StaticHtmlAssetRegistry.php
+++ b/figma-transformer/src/Html/StaticHtmlAssetRegistry.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Per-emission asset aliases, availability evidence, and usage tracking.
+ */
+final class StaticHtmlAssetRegistry
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $assetsById = array();
+
+    /** @var array<string, string> */
+    private array $unavailableReasonsById = array();
+
+    /** @var array<string, bool> */
+    private array $usedPaths = array();
+
+    public function __construct(private readonly StaticHtmlValueFormatter $formatter)
+    {
+    }
+
+    public function reset(): void
+    {
+        $this->assetsById = array();
+        $this->unavailableReasonsById = array();
+        $this->usedPaths = array();
+    }
+
+    /**
+     * @param array<string, mixed> $asset
+     * @return array<int, string>
+     */
+    public function aliases(array $asset, string $id): array
+    {
+        $aliases = array($id);
+        foreach ( array('hash', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref', 'source_id', 'node_id', 'nodeId', 'name', 'fileName', 'filename', 'key', 'fileKey', 'libraryKey', 'publishID', 'sourceLibraryKey') as $key ) {
+            if ( isset($asset[$key]) && is_scalar($asset[$key]) ) {
+                $aliases[] = (string) $asset[$key];
+            }
+        }
+
+        foreach ( $aliases as $alias ) {
+            $aliases[] = $this->formatter->slug($alias);
+        }
+
+        if ( isset($asset['path']) && is_scalar($asset['path']) ) {
+            $path = (string) $asset['path'];
+            $aliases[] = $path;
+            $aliases[] = basename($path);
+            $aliases[] = pathinfo($path, PATHINFO_FILENAME);
+        }
+
+        return array_values(array_unique(array_filter($aliases, static fn (string $alias): bool => '' !== $alias)));
+    }
+
+    /**
+     * @param array<int, string> $aliases
+     * @param array<string, mixed> $file
+     */
+    public function register(array $aliases, array $file): void
+    {
+        foreach ( $aliases as $alias ) {
+            $this->assetsById[$alias] = $file;
+        }
+    }
+
+    /** @param array<int, string> $aliases */
+    public function markUnavailable(array $aliases, string $reason): void
+    {
+        foreach ( $aliases as $alias ) {
+            $this->unavailableReasonsById[$alias] = $reason;
+        }
+    }
+
+    /** @return array<string, array<string, mixed>> */
+    public function index(): array
+    {
+        return $this->assetsById;
+    }
+
+    /** @param array<string, mixed> $node */
+    public function resolveAndMarkNode(array $node): ?string
+    {
+        return $this->resolveAndMarkReferences($this->nodeReferences($node));
+    }
+
+    /** @param array<string, mixed> $paint */
+    public function resolveAndMarkPaint(array $paint): ?string
+    {
+        return $this->resolveAndMarkReferences(VisualLayerEvidence::paintAssetReferences($paint));
+    }
+
+    /**
+     * @param array<int, string> $references
+     */
+    public function unavailableReason(array $references): ?string
+    {
+        foreach ( $references as $reference ) {
+            if ( isset($this->unavailableReasonsById[$reference]) ) {
+                return $this->unavailableReasonsById[$reference];
+            }
+
+            $slugged = $this->formatter->slug($reference);
+            if ( isset($this->unavailableReasonsById[$slugged]) ) {
+                return $this->unavailableReasonsById[$slugged];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assetFiles
+     * @return array<int, array<string, mixed>>
+     */
+    public function referencedFiles(array $assetFiles): array
+    {
+        if ( empty($this->usedPaths) ) {
+            return array();
+        }
+
+        return array_values(array_filter(
+            $assetFiles,
+            fn (array $file): bool => isset($this->usedPaths[(string) ($file['path'] ?? '')])
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    public function nodeReferences(array $node): array
+    {
+        $references = array();
+        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref', 'id', 'name') as $key ) {
+            if ( isset($node[$key]) && is_scalar($node[$key]) ) {
+                $references[] = (string) $node[$key];
+            }
+        }
+
+        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
+            $paintCollections = array();
+            if ( is_array($node[$paintKey] ?? null) ) {
+                $paintCollections[] = $node[$paintKey];
+            }
+            if ( is_array($node['figma_paints'][$paintKey] ?? null) ) {
+                $paintCollections[] = $node['figma_paints'][$paintKey];
+            }
+
+            foreach ( $paintCollections as $paints ) {
+                foreach ( $paints as $paint ) {
+                    if ( is_array($paint) && 'IMAGE' === strtoupper((string) ($paint['type'] ?? '')) ) {
+                        $references = array_merge($references, VisualLayerEvidence::paintAssetReferences($paint));
+                    }
+                }
+            }
+        }
+
+        foreach ( $references as $reference ) {
+            $references[] = $this->formatter->slug($reference);
+        }
+
+        return array_values(array_unique($references));
+    }
+
+    /** @param array<int, string> $references */
+    private function resolveAndMarkReferences(array $references): ?string
+    {
+        foreach ( $references as $assetId ) {
+            $path = $this->resolvePath($assetId);
+            if ( null !== $path ) {
+                $this->usedPaths[$path] = true;
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolvePath(string $assetId): ?string
+    {
+        if ( isset($this->assetsById[$assetId]) ) {
+            return (string) $this->assetsById[$assetId]['path'];
+        }
+
+        $slugged = $this->formatter->slug($assetId);
+        return isset($this->assetsById[$slugged]) ? (string) $this->assetsById[$slugged]['path'] : null;
+    }
+}

--- a/figma-transformer/src/Html/StaticHtmlEmissionSession.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionSession.php
@@ -11,15 +11,22 @@ final class StaticHtmlEmissionSession
 {
     private readonly StaticHtmlPageState $pageState;
     private readonly StaticHtmlLinkState $linkState;
+    private readonly StaticHtmlAssetRegistry $assetRegistry;
+    private readonly PaintStackResolver $paintStackResolver;
+    private readonly ChildLayerCompositionResolver $childLayerCompositionResolver;
+    private readonly StaticHtmlVectorEvidence $vectorEvidence;
     private readonly VectorSvgRenderer $vectorSvgRenderer;
 
     public function __construct(
         StaticHtmlNodeInspector $nodeInspector,
         StaticHtmlValueFormatter $formatter,
-        private readonly StaticHtmlVectorEvidence $vectorEvidence,
     ) {
         $this->pageState = new StaticHtmlPageState();
         $this->linkState = new StaticHtmlLinkState();
+        $this->assetRegistry = new StaticHtmlAssetRegistry($formatter);
+        $this->paintStackResolver = new PaintStackResolver($this->assetRegistry, $formatter);
+        $this->childLayerCompositionResolver = new ChildLayerCompositionResolver($this->assetRegistry, $formatter);
+        $this->vectorEvidence = new StaticHtmlVectorEvidence($formatter, $this->paintStackResolver);
         $this->vectorSvgRenderer = new VectorSvgRenderer($nodeInspector, $formatter, $this->vectorEvidence);
     }
 
@@ -36,6 +43,21 @@ final class StaticHtmlEmissionSession
     public function vectorSvgRenderer(): VectorSvgRenderer
     {
         return $this->vectorSvgRenderer;
+    }
+
+    public function assetRegistry(): StaticHtmlAssetRegistry
+    {
+        return $this->assetRegistry;
+    }
+
+    public function paintStackResolver(): PaintStackResolver
+    {
+        return $this->paintStackResolver;
+    }
+
+    public function childLayerCompositionResolver(): ChildLayerCompositionResolver
+    {
+        return $this->childLayerCompositionResolver;
     }
 
     public function vectorEvidence(): StaticHtmlVectorEvidence

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -15,24 +15,9 @@ final class StaticHtmlEmitter
     private LayoutGapResolver $layoutGapResolver;
 
     /**
-     * @var array<string, array<string, mixed>>
-     */
-    private array $assetsById = array();
-
-    /**
-     * @var array<string, string>
-     */
-    private array $assetUnavailableReasonsById = array();
-
-    /**
      * @var callable|null
      */
     private mixed $archiveAssetContentResolver = null;
-
-    /**
-     * @var array<string, bool>
-     */
-    private array $usedAssetPaths = array();
 
     /**
      * @var array<string, array<string, mixed>>
@@ -71,8 +56,6 @@ final class StaticHtmlEmitter
 
     private ?TextStyleDeclarationResolver $textStyleDeclarationResolver = null;
 
-    private ?PaintStackResolver $paintStackResolver = null;
-
     private ?TransformDiagnosticsBuilder $transformDiagnosticsBuilder = null;
 
     private ?StaticHtmlEmissionDiagnostics $staticHtmlEmissionDiagnostics = null;
@@ -94,8 +77,6 @@ final class StaticHtmlEmitter
     private ?BreakpointMediaDiffBuilder $breakpointMediaDiffBuilder = null;
 
     private ?BreakpointDimensionPolicy $breakpointDimensionPolicy = null;
-
-    private ?ChildLayerCompositionResolver $childLayerCompositionResolver = null;
 
     private ?LocalBorderShellClusterResolver $localBorderShellClusterResolver = null;
 
@@ -138,7 +119,6 @@ final class StaticHtmlEmitter
         return new StaticHtmlEmissionSession(
             $this->nodeInspector(),
             $this->valueFormatter(),
-            new StaticHtmlVectorEvidence($this->valueFormatter(), $this->paintStackResolver()),
         );
     }
 
@@ -175,10 +155,7 @@ final class StaticHtmlEmitter
 
     private function paintStackResolver(): PaintStackResolver
     {
-        return $this->paintStackResolver ??= new PaintStackResolver(
-            fn (array $paint): ?string => $this->resolveAndMarkPaintAssetPath($paint),
-            $this->valueFormatter(),
-        );
+        return $this->emissionSession->paintStackResolver();
     }
 
     private function transformDiagnosticsBuilder(): TransformDiagnosticsBuilder
@@ -274,10 +251,7 @@ final class StaticHtmlEmitter
 
     private function childLayerCompositionResolver(): ChildLayerCompositionResolver
     {
-        return $this->childLayerCompositionResolver ??= new ChildLayerCompositionResolver(
-            fn (array $node): ?string => $this->nodeAssetPath($node),
-            fn (float $value): string => $this->number($value),
-        );
+        return $this->emissionSession->childLayerCompositionResolver();
     }
 
     private function localBorderShellClusterResolver(): LocalBorderShellClusterResolver
@@ -287,7 +261,7 @@ final class StaticHtmlEmitter
 
     private function layoutIntentClassifier(): LayoutIntentClassifier
     {
-        return $this->layoutIntentClassifier ??= new LayoutIntentClassifier($this->assetsById);
+        return $this->layoutIntentClassifier ??= new LayoutIntentClassifier($this->emissionSession->assetRegistry()->index());
     }
 
     private function nodeInspector(): StaticHtmlNodeInspector
@@ -360,7 +334,6 @@ final class StaticHtmlEmitter
         $this->pageState = $this->emissionSession->pageState();
         $this->breakpointMediaDiffBuilder = null;
         $this->renderTextGlyphPaths = true === ($options['render_text_glyph_paths'] ?? false);
-        $this->usedAssetPaths = array();
         $this->generatedAssetFiles = array();
         $this->generatedVectorSvgPathsByHash = array();
         $this->staticHtmlCssRuleSet()->resetReadableNames();
@@ -4063,7 +4036,7 @@ final class StaticHtmlEmitter
      */
     private function visualNodeMap(array $nodes): array
     {
-        return (new VisualNodeMapBuilder($this->assetsById, $this->renderTextGlyphPaths, $this->emittedNodeMetadata))->build($this->withoutSuppressedVisualNodes($nodes));
+        return (new VisualNodeMapBuilder($this->emissionSession->assetRegistry()->index(), $this->renderTextGlyphPaths, $this->emittedNodeMetadata))->build($this->withoutSuppressedVisualNodes($nodes));
     }
 
     /**
@@ -9329,8 +9302,8 @@ final class StaticHtmlEmitter
      */
     private function normalizeAssets(mixed $assets, array &$diagnostics): array
     {
-        $this->assetsById = array();
-        $this->assetUnavailableReasonsById = array();
+        $assetRegistry = $this->emissionSession->assetRegistry();
+        $assetRegistry->reset();
         $this->staticHtmlSemanticClassifier = null;
         if ( ! is_array($assets) ) {
             return array();
@@ -9373,9 +9346,7 @@ final class StaticHtmlEmitter
                 }
 
                 $reason = true === ($asset['content_omitted'] ?? false) ? 'archive_asset_content_omitted' : 'asset_content_unavailable';
-                foreach ( $this->assetAliases($asset, $id) as $alias ) {
-                    $this->assetUnavailableReasonsById[$alias] = $reason;
-                }
+                $assetRegistry->markUnavailable($assetRegistry->aliases($asset, $id), $reason);
                 continue;
             }
 
@@ -9389,9 +9360,7 @@ final class StaticHtmlEmitter
             );
 
             $files[] = $file;
-            foreach ( $this->assetAliases($asset, $id) as $alias ) {
-                $this->assetsById[$alias] = $file;
-            }
+            $assetRegistry->register($assetRegistry->aliases($asset, $id), $file);
         }
 
         usort(
@@ -9511,15 +9480,7 @@ final class StaticHtmlEmitter
      */
     private function nodeAssetPath(array $node): ?string
     {
-        foreach ( $this->nodeAssetReferences($node) as $assetId ) {
-            $path = $this->resolveAssetPath($assetId);
-            if ( null !== $path ) {
-                $this->usedAssetPaths[$path] = true;
-                return $path;
-            }
-        }
-
-        return null;
+        return $this->emissionSession->assetRegistry()->resolveAndMarkNode($node);
     }
 
     /**
@@ -9568,14 +9529,7 @@ final class StaticHtmlEmitter
      */
     private function referencedAssetFiles(array $assetFiles): array
     {
-        if ( empty($this->usedAssetPaths) ) {
-            return array();
-        }
-
-        return array_values(array_filter(
-            $assetFiles,
-            fn (array $file): bool => isset($this->usedAssetPaths[(string) ($file['path'] ?? '')])
-        ));
+        return $this->emissionSession->assetRegistry()->referencedFiles($assetFiles);
     }
 
     /**
@@ -9749,117 +9703,11 @@ final class StaticHtmlEmitter
     }
 
     /**
-     * @param array<string, mixed> $asset
-     * @return array<int, string>
-     */
-    private function assetAliases(array $asset, string $id): array
-    {
-        $aliases = array($id);
-        foreach ( array('hash', 'imageRef', 'imageHash', 'asset_id', 'assetId', 'image_ref', 'source_id', 'node_id', 'nodeId', 'name', 'fileName', 'filename', 'key', 'fileKey', 'libraryKey', 'publishID', 'sourceLibraryKey') as $key ) {
-            if ( isset($asset[$key]) && is_scalar($asset[$key]) ) {
-                $aliases[] = (string) $asset[$key];
-            }
-        }
-
-        foreach ( $aliases as $alias ) {
-            $aliases[] = $this->slug($alias);
-        }
-
-        if ( isset($asset['path']) && is_scalar($asset['path']) ) {
-            $path = (string) $asset['path'];
-            $aliases[] = $path;
-            $aliases[] = basename($path);
-            $aliases[] = pathinfo($path, PATHINFO_FILENAME);
-        }
-
-        return array_values(array_unique(array_filter($aliases, static fn (string $alias): bool => '' !== $alias)));
-    }
-
-    /**
      * @param array<int, string> $references
      */
     private function assetUnavailableReasonForReferences(array $references): ?string
     {
-        foreach ( $references as $reference ) {
-            if ( isset($this->assetUnavailableReasonsById[$reference]) ) {
-                return $this->assetUnavailableReasonsById[$reference];
-            }
-
-            $slugged = $this->slug($reference);
-            if ( isset($this->assetUnavailableReasonsById[$slugged]) ) {
-                return $this->assetUnavailableReasonsById[$slugged];
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     * @return array<int, string>
-     */
-    private function nodeAssetReferences(array $node): array
-    {
-        $references = array();
-        foreach ( array('asset_id', 'assetId', 'image_ref', 'imageRef', 'imageHash', 'ref', 'id', 'name') as $key ) {
-            if ( isset($node[$key]) && is_scalar($node[$key]) ) {
-                $references[] = (string) $node[$key];
-            }
-        }
-
-        foreach ( array('fills', 'strokes', 'background') as $paintKey ) {
-            $paintCollections = array();
-            if ( is_array($node[$paintKey] ?? null) ) {
-                $paintCollections[] = $node[$paintKey];
-            }
-            if ( is_array($node['figma_paints'][$paintKey] ?? null) ) {
-                $paintCollections[] = $node['figma_paints'][$paintKey];
-            }
-
-            foreach ( $paintCollections as $paints ) {
-                foreach ( $paints as $paint ) {
-                    if ( ! is_array($paint) || 'IMAGE' !== strtoupper((string) ($paint['type'] ?? '')) ) {
-                        continue;
-                    }
-
-                    $references = array_merge($references, $this->paintAssetReferences($paint));
-                }
-            }
-        }
-
-        foreach ( $references as $reference ) {
-            $references[] = $this->slug($reference);
-        }
-
-        return array_values(array_unique($references));
-    }
-
-    private function resolveAssetPath(string $assetId): ?string
-    {
-        if ( isset($this->assetsById[$assetId]) ) {
-            return (string) $this->assetsById[$assetId]['path'];
-        }
-
-        $slugged = $this->slug($assetId);
-        return isset($this->assetsById[$slugged]) ? (string) $this->assetsById[$slugged]['path'] : null;
-    }
-
-    /**
-     * @param array<string, mixed> $paint
-     */
-    private function resolveAndMarkPaintAssetPath(array $paint): ?string
-    {
-        foreach ( $this->paintAssetReferences($paint) as $assetId ) {
-            $path = $this->resolveAssetPath($assetId);
-            if ( null === $path ) {
-                continue;
-            }
-
-            $this->usedAssetPaths[$path] = true;
-            return $path;
-        }
-
-        return null;
+        return $this->emissionSession->assetRegistry()->unavailableReason($references);
     }
 
     /**
@@ -10518,10 +10366,7 @@ final class StaticHtmlEmitter
 
     private function slug(string $value): string
     {
-        $slug = strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', $value) ?? '');
-        $slug = trim($slug, '-');
-
-        return '' === $slug ? 'node' : $slug;
+        return $this->valueFormatter()->slug($value);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlValueFormatter.php
+++ b/figma-transformer/src/Html/StaticHtmlValueFormatter.php
@@ -52,6 +52,14 @@ final class StaticHtmlValueFormatter
         return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 
+    public function slug(string $value): string
+    {
+        $slug = strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', $value) ?? '');
+        $slug = trim($slug, '-');
+
+        return '' === $slug ? 'node' : $slug;
+    }
+
     private function colorChannel(mixed $value): ?int
     {
         if ( ! is_numeric($value) ) {

--- a/figma-transformer/tests/contract/ImagePaintContract.php
+++ b/figma-transformer/tests/contract/ImagePaintContract.php
@@ -420,6 +420,89 @@ function blocks_engine_figma_transformer_run_image_paint_contract(callable $asse
     $assert(in_array('assets/used-image.png', $unusedAssetPaths, true), 'unused-asset-keeps-referenced');
     $assert(! in_array('assets/unused-image.png', $unusedAssetPaths, true), 'unused-asset-omits-unreferenced');
 
+    $responsiveAssetResult = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter())->emitSite(array(
+        'name'   => 'Responsive Asset Fixture',
+        'assets' => array(
+            'desktop-image' => array('mime_type' => 'image/png', 'content' => 'desktop image'),
+            'mobile-image' => array('mime_type' => 'image/png', 'content' => 'mobile image'),
+            'responsive-unused-image' => array('mime_type' => 'image/png', 'content' => 'unused image'),
+        ),
+        'nodes' => array(
+            array(
+                'id' => 'responsive-assets:desktop',
+                'type' => 'FRAME',
+                'name' => 'Responsive Assets Desktop',
+                'box' => array('width' => 1440, 'height' => 800),
+                'children' => array(array(
+                    'id' => 'responsive-assets:desktop:image',
+                    'type' => 'RECTANGLE',
+                    'name' => 'Hero image',
+                    'box' => array('width' => 1200, 'height' => 600),
+                    'figma_paints' => array('fills' => array(array('type' => 'IMAGE', 'imageRef' => 'desktop-image'))),
+                )),
+            ),
+            array(
+                'id' => 'responsive-assets:mobile',
+                'type' => 'FRAME',
+                'name' => 'Responsive Assets Mobile',
+                'box' => array('width' => 390, 'height' => 800),
+                'children' => array(array(
+                    'id' => 'responsive-assets:mobile:image',
+                    'type' => 'RECTANGLE',
+                    'name' => 'Hero image',
+                    'box' => array('width' => 342, 'height' => 400),
+                    'figma_paints' => array('fills' => array(array('type' => 'IMAGE', 'imageRef' => 'mobile-image'))),
+                )),
+            ),
+        ),
+    ), array('pages' => array(array(
+        'frame_id' => 'responsive-assets:desktop',
+        'name' => 'Responsive Assets',
+        'path' => 'index.html',
+        'entrypoint' => true,
+        'responsive' => true,
+        'breakpoint_count' => 2,
+        'variants' => array(
+            array('frame_id' => 'responsive-assets:desktop', 'device_hint' => 'desktop', 'viewport_width' => 1440, 'primary' => true, 'order' => 0),
+            array('frame_id' => 'responsive-assets:mobile', 'device_hint' => 'mobile', 'viewport_width' => 390, 'primary' => false, 'order' => 1),
+        ),
+    ))));
+    $responsiveAssetCss = $fileContent($responsiveAssetResult, 'style.css');
+    $responsiveAssetPaths = array_map(static fn (array $asset): string => (string) ($asset['path'] ?? ''), $responsiveAssetResult['assets'] ?? array());
+    $responsiveAssetFilePaths = array_map(static fn (array $file): string => (string) ($file['path'] ?? ''), $responsiveAssetResult['files'] ?? array());
+    $assert(str_contains($responsiveAssetCss, '@media') && str_contains($responsiveAssetCss, 'url("assets/mobile-image.png")'), 'responsive-only-asset-emits-media-css');
+    $assert(in_array('assets/mobile-image.png', $responsiveAssetPaths, true) && in_array('assets/mobile-image.png', $responsiveAssetFilePaths, true), 'responsive-only-asset-retained-in-report-and-files');
+    $assert(2 === ($responsiveAssetResult['metrics']['asset_count'] ?? null), 'responsive-only-asset-counted');
+    $assert(! in_array('assets/responsive-unused-image.png', $responsiveAssetPaths, true), 'responsive-unused-asset-omitted');
+
+    $assetReuseEmitter = new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter();
+    $assetReuseEmitter->emit(array(
+        'name' => 'Prior Asset Emission',
+        'assets' => array('prior-image' => array('mime_type' => 'image/png', 'content' => 'prior image')),
+        'nodes' => array(array(
+            'id' => 'asset-reuse:prior',
+            'type' => 'RECTANGLE',
+            'name' => 'Prior image',
+            'box' => array('width' => 10, 'height' => 10),
+            'figma_paints' => array('fills' => array(array('type' => 'IMAGE', 'imageRef' => 'prior-image'))),
+        )),
+    ));
+    $assetReuseResult = $assetReuseEmitter->emit(array(
+        'name' => 'Current Asset Emission',
+        'assets' => array('current-image' => array('mime_type' => 'image/png', 'content' => 'current image')),
+        'nodes' => array(array(
+            'id' => 'asset-reuse:current',
+            'type' => 'RECTANGLE',
+            'name' => 'Current image',
+            'box' => array('width' => 10, 'height' => 10),
+            'figma_paints' => array('fills' => array(array('type' => 'IMAGE', 'imageRef' => 'current-image'))),
+        )),
+    ));
+    $assetReusePaths = array_map(static fn (array $file): string => (string) ($file['path'] ?? ''), $assetReuseResult['files'] ?? array());
+    $assert(in_array('assets/current-image.png', $assetReusePaths, true), 'asset-registry-reuse-keeps-current-file');
+    $assert(! in_array('assets/prior-image.png', $assetReusePaths, true), 'asset-registry-reuse-clears-prior-file');
+    $assert(1 === ($assetReuseResult['metrics']['asset_count'] ?? null), 'asset-registry-reuse-resets-count');
+
     $backgroundPaintsResult = blocks_engine_figma_transformer_transform_scenegraph(array(
         'name'  => 'Background Paints Fixture',
         'nodes' => array(


### PR DESCRIPTION
## Summary
- add a per-emission `StaticHtmlAssetRegistry` for aliases, unavailable reasons, path resolution, usage marking, and referenced-file retention
- make the emission session own the registry plus its paint-stack and child-layer consumers
- replace emitter callbacks in `PaintStackResolver` and `ChildLayerCompositionResolver` with typed registry and formatter dependencies
- reduce `StaticHtmlEmitter` asset methods to delegation while preserving reference order, slug fallback, responsive marking, and public artifact schemas
- add artifact-level contracts for responsive-only asset retention and reused-emitter asset isolation

Part of #1076. Typography-token state and decision-trace state remain separate follow-up boundaries with different lifetimes.

## Verification
- `cd figma-transformer && composer test`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent architecture and compatibility review

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map style-resolution state, design and implement the typed asset registry, review lifecycle and compatibility risks, and add artifact-level regression coverage. Chris Huber reviewed and remains responsible for the change.