### PR TITLE
Isolate Figma typography token state

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmissionSession.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionSession.php
@@ -12,6 +12,8 @@ final class StaticHtmlEmissionSession
     private readonly StaticHtmlPageState $pageState;
     private readonly StaticHtmlLinkState $linkState;
     private readonly StaticHtmlAssetRegistry $assetRegistry;
+    private readonly StaticHtmlTypographyState $typographyState;
+    private readonly TextStyleDeclarationResolver $textStyleDeclarationResolver;
     private readonly PaintStackResolver $paintStackResolver;
     private readonly ChildLayerCompositionResolver $childLayerCompositionResolver;
     private readonly StaticHtmlVectorEvidence $vectorEvidence;
@@ -20,10 +22,13 @@ final class StaticHtmlEmissionSession
     public function __construct(
         StaticHtmlNodeInspector $nodeInspector,
         StaticHtmlValueFormatter $formatter,
+        TypographyModel $typographyModel,
     ) {
         $this->pageState = new StaticHtmlPageState();
         $this->linkState = new StaticHtmlLinkState();
         $this->assetRegistry = new StaticHtmlAssetRegistry($formatter);
+        $this->typographyState = new StaticHtmlTypographyState();
+        $this->textStyleDeclarationResolver = new TextStyleDeclarationResolver($typographyModel, $formatter, $this->typographyState);
         $this->paintStackResolver = new PaintStackResolver($this->assetRegistry, $formatter);
         $this->childLayerCompositionResolver = new ChildLayerCompositionResolver($this->assetRegistry, $formatter);
         $this->vectorEvidence = new StaticHtmlVectorEvidence($formatter, $this->paintStackResolver);
@@ -48,6 +53,16 @@ final class StaticHtmlEmissionSession
     public function assetRegistry(): StaticHtmlAssetRegistry
     {
         return $this->assetRegistry;
+    }
+
+    public function typographyState(): StaticHtmlTypographyState
+    {
+        return $this->typographyState;
+    }
+
+    public function textStyleDeclarationResolver(): TextStyleDeclarationResolver
+    {
+        return $this->textStyleDeclarationResolver;
     }
 
     public function paintStackResolver(): PaintStackResolver

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -35,11 +35,6 @@ final class StaticHtmlEmitter
 
     private ?TypographyModel $typographyModel = null;
 
-    /**
-     * @var array<string, string> TypographyModel signature => font-size token name.
-     */
-    private array $typographyTokenVars = array();
-
     private function fontResolver(): FontResolver
     {
         return $this->fontResolver ??= new FontResolver();
@@ -53,8 +48,6 @@ final class StaticHtmlEmitter
     private ?DesignSystemExtractor $designSystemExtractor = null;
 
     private ?StyleDeclarationBuilder $styleDeclarationBuilder = null;
-
-    private ?TextStyleDeclarationResolver $textStyleDeclarationResolver = null;
 
     private ?TransformDiagnosticsBuilder $transformDiagnosticsBuilder = null;
 
@@ -119,6 +112,7 @@ final class StaticHtmlEmitter
         return new StaticHtmlEmissionSession(
             $this->nodeInspector(),
             $this->valueFormatter(),
+            $this->typographyModel(),
         );
     }
 
@@ -146,11 +140,7 @@ final class StaticHtmlEmitter
 
     private function textStyleDeclarationResolver(): TextStyleDeclarationResolver
     {
-        return $this->textStyleDeclarationResolver ??= new TextStyleDeclarationResolver(
-            $this->typographyModel(),
-            fn (float $value): string => $this->number($value),
-            fn (mixed $value, mixed $opacity = null): ?string => $this->color($value, $opacity),
-        );
+        return $this->emissionSession->textStyleDeclarationResolver();
     }
 
     private function paintStackResolver(): PaintStackResolver
@@ -374,7 +364,7 @@ final class StaticHtmlEmitter
     {
         $diagnostics = array();
         $designSystem = $this->designSystemExtractor()->extract($scenegraph);
-        $this->typographyTokenVars = is_array($designSystem['type_token_map'] ?? null) ? $designSystem['type_token_map'] : array();
+        $this->emissionSession->typographyState()->replace(is_array($designSystem['type_token_map'] ?? null) ? $designSystem['type_token_map'] : array());
         $assetFiles = $this->normalizeAssets($scenegraph['assets'] ?? array(), $diagnostics);
 
         return array(
@@ -684,7 +674,7 @@ final class StaticHtmlEmitter
                 $pageScenegraph = $scenegraph;
                 $pageScenegraph['nodes'] = array($frameNode);
                 $pageDesignSystem = $this->designSystemExtractor()->extract($pageScenegraph);
-                $this->typographyTokenVars = is_array($pageDesignSystem['type_token_map'] ?? null) ? $pageDesignSystem['type_token_map'] : array();
+                $this->emissionSession->typographyState()->replace(is_array($pageDesignSystem['type_token_map'] ?? null) ? $pageDesignSystem['type_token_map'] : array());
                 $rootClass = 'figma-node-' . $this->slug($frameId . '-' . $pageName);
                 $pageDesignSystemCss[] = (string) preg_replace('/(^|\n):root\{/m', '$1.' . $rootClass . '{', (string) ($pageDesignSystem['css'] ?? ''));
             }
@@ -9242,7 +9232,7 @@ final class StaticHtmlEmitter
      */
     private function textStyleDeclarations(array $style): array
     {
-        return $this->textStyleDeclarationResolver()->declarations($style, $this->typographyTokenVars);
+        return $this->textStyleDeclarationResolver()->declarations($style);
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlTypographyState.php
+++ b/figma-transformer/src/Html/StaticHtmlTypographyState.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Typography token variables active for the current artifact page.
+ */
+final class StaticHtmlTypographyState
+{
+    /** @var array<string, string> */
+    private array $tokenVars = array();
+
+    /** @param array<string, mixed> $tokenVars */
+    public function replace(array $tokenVars): void
+    {
+        $this->tokenVars = $tokenVars;
+    }
+
+    /** @return array<string, string> */
+    public function tokenVars(): array
+    {
+        return $this->tokenVars;
+    }
+}

--- a/figma-transformer/src/Html/TextStyleDeclarationResolver.php
+++ b/figma-transformer/src/Html/TextStyleDeclarationResolver.php
@@ -9,34 +9,25 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
  */
 final class TextStyleDeclarationResolver
 {
-    /** @var callable(float): string */
-    private $number;
-
-    /** @var callable(mixed, mixed=): ?string */
-    private $color;
-
     public function __construct(
         private readonly TypographyModel $typographyModel,
-        callable $number,
-        callable $color,
+        private readonly StaticHtmlValueFormatter $formatter,
+        private readonly StaticHtmlTypographyState $typographyState,
     ) {
-        $this->number = $number;
-        $this->color = $color;
     }
 
     /**
      * @param array<string, mixed> $style
-     * @param array<string, string> $typographyTokenVars
      * @return array<int, string>
      */
-    public function declarations(array $style, array $typographyTokenVars): array
+    public function declarations(array $style): array
     {
         $styles = array();
         $lineHeightStyles = array();
 
         $typographyStyle = $this->typographyModel->styleFromNormalizedStyle($style);
         if ( null !== $typographyStyle ) {
-            foreach ( $this->typographyModel->declarations($typographyStyle, $typographyTokenVars) as $declaration ) {
+            foreach ( $this->typographyModel->declarations($typographyStyle, $this->typographyState->tokenVars()) as $declaration ) {
                 if ( str_starts_with($declaration, 'line-height:') ) {
                     $lineHeightStyles[] = $declaration;
                     continue;
@@ -49,7 +40,7 @@ final class TextStyleDeclarationResolver
             $settings = array();
             foreach ( $style['font_variation_settings'] as $axis => $value ) {
                 if ( is_string($axis) && 1 === preg_match('/^[A-Za-z0-9 ]{4}$/', $axis) && is_numeric($value) ) {
-                    $settings[] = '"' . $axis . '" ' . ($this->number)((float) $value);
+                    $settings[] = '"' . $axis . '" ' . $this->formatter->number((float) $value);
                 }
             }
             if ( ! empty($settings) ) {
@@ -74,17 +65,17 @@ final class TextStyleDeclarationResolver
         }
 
         if ( isset($style['letter_spacing']) && is_numeric($style['letter_spacing']) ) {
-            $styles[] = 'letter-spacing:' . ($this->number)((float) $style['letter_spacing']) . 'px';
+            $styles[] = 'letter-spacing:' . $this->formatter->number((float) $style['letter_spacing']) . 'px';
         } elseif ( isset($style['letter_spacing_em']) && is_numeric($style['letter_spacing_em']) ) {
-            $styles[] = 'letter-spacing:' . ($this->number)((float) $style['letter_spacing_em']) . 'em';
+            $styles[] = 'letter-spacing:' . $this->formatter->number((float) $style['letter_spacing_em']) . 'em';
         }
 
         // Figma `paragraphIndent` maps to CSS first-line indent. Zero is implicit.
         if ( isset($style['paragraph_indent']) && is_numeric($style['paragraph_indent']) && 0.0 !== (float) $style['paragraph_indent'] ) {
-            $styles[] = 'text-indent:' . ($this->number)((float) $style['paragraph_indent']) . 'px';
+            $styles[] = 'text-indent:' . $this->formatter->number((float) $style['paragraph_indent']) . 'px';
         }
 
-        $color = ($this->color)($style['color'] ?? null);
+        $color = $this->formatter->color($style['color'] ?? null);
         if ( null !== $color ) {
             $styles[] = 'color:' . $color;
         } elseif ( isset($style['css_color']) && is_scalar($style['css_color']) ) {

--- a/figma-transformer/tests/contract/SiteGenerationContract.php
+++ b/figma-transformer/tests/contract/SiteGenerationContract.php
@@ -3352,6 +3352,7 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
                                 'height'   => 160,
                                 'children' => array(
                                     array('id' => 'token-scope:home:display', 'type' => 'TEXT', 'name' => 'Display', 'characters' => 'Display', 'fontSize' => 72, 'fontWeight' => 700),
+                                    array('id' => 'token-scope:home:subtitle', 'type' => 'TEXT', 'name' => 'Subtitle', 'characters' => 'Subtitle', 'fontSize' => 36, 'fontWeight' => 600),
                                     array('id' => 'token-scope:home:body', 'type' => 'TEXT', 'name' => 'Body', 'characters' => 'Body', 'fontSize' => 18, 'fontWeight' => 400),
                                 ),
                             ),
@@ -3384,6 +3385,8 @@ function blocks_engine_figma_transformer_run_site_generation_planning_contract(c
     $multiPageTokenScopeCss = $fileContent($multiPageTokenScopeResult, 'style.css');
     $assert(! str_contains($multiPageTokenScopeCss, ':root{--'), 'multi-page-design-tokens-not-global-root');
     $assert(str_contains($multiPageTokenScopeCss, '.figma-node-token-scope-home-home{--') && str_contains($multiPageTokenScopeCss, '.figma-node-token-scope-about-about{--'), 'multi-page-design-tokens-scoped-to-page-roots');
+    $assert(str_contains($multiPageTokenScopeCss, '.figma-node-token-scope-home-subtitle-subtitle{position:absolute;font-size:var(--font-size-heading-2)'), 'multi-page-home-text-uses-home-token-map');
+    $assert(str_contains($multiPageTokenScopeCss, '.figma-node-token-scope-about-display-display{position:absolute;font-size:var(--font-size-heading-1)') && ! str_contains($multiPageTokenScopeCss, '.figma-node-token-scope-about-display-display{position:absolute;font-size:var(--font-size-heading-2)'), 'multi-page-about-text-uses-about-token-map');
     $assert('selected_frames' === ($multiPageTransformDiagnostics['selection']['mode'] ?? null), 'multi-page-transform-diagnostics-selection-mode');
     $assert('frame:home' === ($multiPageTransformDiagnostics['selection']['selected_frames'][0]['frame_id'] ?? null), 'multi-page-transform-diagnostics-entry-frame-selection');
     $assert('about.html' === ($multiPageTransformDiagnostics['selection']['selected_frames'][1]['path'] ?? null), 'multi-page-transform-diagnostics-about-selection-path');


### PR DESCRIPTION
## Summary
- add session-owned typography token state with explicit artifact/page replacement
- make `TextStyleDeclarationResolver` session-owned so it always reads the active page token map
- replace its number and color callbacks with the typed value formatter
- remove typography token and resolver state from `StaticHtmlEmitter`
- strengthen multi-page contracts to verify text declarations consume each page's token map

Part of #1076.

## Verification
- `cd figma-transformer && composer test`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent lifecycle and compatibility review

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map typography-token lifetime, implement the typed session boundary, review multi-page lifecycle risks, and add artifact-level regression coverage. Chris Huber reviewed and remains responsible for the change.