### PR TITLE
Isolate Figma decision trace state

### DIFF
--- a/figma-transformer/src/Html/DecisionTraceBuilder.php
+++ b/figma-transformer/src/Html/DecisionTraceBuilder.php
@@ -14,9 +14,8 @@ final class DecisionTraceBuilder
      * @param array<string, mixed> $node
      * @param array<string, mixed>|null $parentNode
      * @param array<string, mixed> $evidence
-     * @param callable(array<string, mixed>): string|null $classResolver
      */
-    public static function recordEmitterTrace(array &$traces, string $domain, string $reasonCode, array $node, string $decision, ?array $parentNode, array $evidence, string $currentPagePath, ?callable $classResolver = null): void
+    public static function recordEmitterTrace(array &$traces, string $domain, string $reasonCode, array $node, string $decision, ?array $parentNode, array $evidence, string $currentPagePath, ?string $class = null): void
     {
         if ( '' === $reasonCode ) {
             $reasonCode = 'unknown';
@@ -29,11 +28,6 @@ final class DecisionTraceBuilder
         if ( isset($traces[$key]) ) {
             $traces[$key]['count'] = (int) ($traces[$key]['count'] ?? 1) + 1;
             return;
-        }
-
-        $class = null;
-        if ( null !== $classResolver && ('' !== $nodeId || ! empty($node['name'] ?? '')) ) {
-            $class = $classResolver($node);
         }
 
         $traces[$key] = array_filter(array(

--- a/figma-transformer/src/Html/StaticHtmlDecisionTraceState.php
+++ b/figma-transformer/src/Html/StaticHtmlDecisionTraceState.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Deduplicated emitter decision traces for one public emission.
+ */
+final class StaticHtmlDecisionTraceState
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $traces = array();
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed>|null $parentNode
+     * @param array<string, mixed> $evidence
+     */
+    public function record(string $domain, string $reasonCode, array $node, string $decision, ?array $parentNode, array $evidence, string $currentPagePath, ?string $class): void
+    {
+        DecisionTraceBuilder::recordEmitterTrace(
+            $this->traces,
+            $domain,
+            $reasonCode,
+            $node,
+            $decision,
+            $parentNode,
+            $evidence,
+            $currentPagePath,
+            $class
+        );
+    }
+
+    public function count(): int
+    {
+        return count($this->traces);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function slice(int $offset): array
+    {
+        return array_slice($this->traces, $offset);
+    }
+
+    /** @return array<string, mixed> */
+    public function summary(): array
+    {
+        return DecisionTraceBuilder::summary($this->traces);
+    }
+
+}

--- a/figma-transformer/src/Html/StaticHtmlEmissionSession.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionSession.php
@@ -13,6 +13,7 @@ final class StaticHtmlEmissionSession
     private readonly StaticHtmlLinkState $linkState;
     private readonly StaticHtmlAssetRegistry $assetRegistry;
     private readonly StaticHtmlTypographyState $typographyState;
+    private readonly StaticHtmlDecisionTraceState $decisionTraceState;
     private readonly TextStyleDeclarationResolver $textStyleDeclarationResolver;
     private readonly PaintStackResolver $paintStackResolver;
     private readonly ChildLayerCompositionResolver $childLayerCompositionResolver;
@@ -28,6 +29,7 @@ final class StaticHtmlEmissionSession
         $this->linkState = new StaticHtmlLinkState();
         $this->assetRegistry = new StaticHtmlAssetRegistry($formatter);
         $this->typographyState = new StaticHtmlTypographyState();
+        $this->decisionTraceState = new StaticHtmlDecisionTraceState();
         $this->textStyleDeclarationResolver = new TextStyleDeclarationResolver($typographyModel, $formatter, $this->typographyState);
         $this->paintStackResolver = new PaintStackResolver($this->assetRegistry, $formatter);
         $this->childLayerCompositionResolver = new ChildLayerCompositionResolver($this->assetRegistry, $formatter);
@@ -63,6 +65,11 @@ final class StaticHtmlEmissionSession
     public function textStyleDeclarationResolver(): TextStyleDeclarationResolver
     {
         return $this->textStyleDeclarationResolver;
+    }
+
+    public function decisionTraceState(): StaticHtmlDecisionTraceState
+    {
+        return $this->decisionTraceState;
     }
 
     public function paintStackResolver(): PaintStackResolver

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -305,14 +305,6 @@ final class StaticHtmlEmitter
     private array $suppressedVisualNodeIds = array();
 
     /**
-     * Stable reason traces for behavior decisions that suppress, re-route, or
-     * normalize source nodes without changing the emitted artifact contract.
-     *
-     * @var array<string, array<string, mixed>>
-     */
-    private array $decisionTraces = array();
-
-    /**
      * Reset state whose lifetime is one public emission call.
      *
      * @param array<string, mixed> $options
@@ -329,7 +321,6 @@ final class StaticHtmlEmitter
         $this->staticHtmlCssRuleSet()->resetReadableNames();
         $this->emittedNodeMetadata = array();
         $this->suppressedVisualNodeIds = array();
-        $this->decisionTraces = array();
         $this->archiveAssetContentResolver = is_callable($options['archive_asset_content_resolver'] ?? null) ? $options['archive_asset_content_resolver'] : null;
         $this->breakpointMediaDiffBuilder()->resetDecisionTraces();
         $this->stickyLayoutCoordinator()->reset();
@@ -682,7 +673,7 @@ final class StaticHtmlEmitter
             $pageCssRuleOffset = count($emission['css_rules']);
             $pageDiagnosticOffset = count($diagnostics);
             $pageStyleDiagnosticOffset = count($nodeStyleDiagnostics);
-            $pageDecisionTraceOffset = count($this->decisionTraces);
+            $pageDecisionTraceOffset = $this->emissionSession->decisionTraceState()->count();
             $pageResponsiveTraceOffset = count($this->breakpointMediaDiffBuilder()->decisionTraces());
             $pageLinkDiagnosticsBefore = $this->linkState->diagnostics();
             $pageDocument = $this->emitPageDocument(array($frameNode), $path, $this->sanitizeText($pageName), $pageName, is_scalar($page['page_type'] ?? null) ? (string) $page['page_type'] : '', is_scalar($page['slug'] ?? null) ? (string) $page['slug'] : $this->templateSlugFromPath($path), 1, $emission['css_rules'], $diagnostics, $nodeStyleDiagnostics, $options);
@@ -724,7 +715,7 @@ final class StaticHtmlEmitter
             $pageMediaBlocks = $this->breakpointMediaDiffBuilder()->buildMediaBlocks($page, $frameNode, $nodeMap);
             $pageEmissionReports[$path]['media_blocks'] = $pageMediaBlocks;
             $pageEmissionReports[$path]['decision_traces'] = array_merge(
-                array_slice($this->decisionTraces, $pageDecisionTraceOffset),
+                $this->emissionSession->decisionTraceState()->slice($pageDecisionTraceOffset),
                 array_slice($this->breakpointMediaDiffBuilder()->decisionTraces(), $pageResponsiveTraceOffset)
             );
             $pageEmissionReports[$path]['links'] = $this->linkDiagnosticsDelta($pageLinkDiagnosticsBefore, $this->linkState->diagnostics());
@@ -4312,7 +4303,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        return DecisionTraceBuilder::summary($this->decisionTraces);
+        return $this->emissionSession->decisionTraceState()->summary();
     }
 
     /**
@@ -4330,8 +4321,9 @@ final class StaticHtmlEmitter
      */
     private function recordDecisionTrace(string $domain, string $reasonCode, array $node, string $decision, ?array $parentNode = null, array $evidence = array()): void
     {
-        DecisionTraceBuilder::recordEmitterTrace(
-            $this->decisionTraces,
+        $nodeId = (string) ($node['id'] ?? '');
+        $class = '' !== $nodeId || ! empty($node['name'] ?? '') ? $this->nodeDiagnosticClass($node) : null;
+        $this->emissionSession->decisionTraceState()->record(
             $domain,
             $reasonCode,
             $node,
@@ -4339,7 +4331,7 @@ final class StaticHtmlEmitter
             $parentNode,
             $evidence,
             $this->pageState->path,
-            fn (array $traceNode): string => $this->nodeDiagnosticClass($traceNode)
+            $class
         );
     }
 

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -991,6 +991,11 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
     $assert(1 === ($multiPageReports[1]['diagnostic_codes']['unsupported_vector_node_placeholder'] ?? null), 'diagnostics-evidence-multi-page-about-diagnostic-code-page-scoped');
     $assert(1 === ($multiPageReports[0]['transform_diagnostics']['images']['node_refs'] ?? null), 'diagnostics-evidence-multi-page-home-image-diagnostics-page-scoped');
     $assert(1 === ($multiPageReports[1]['transform_diagnostics']['vectors']['placeholders'] ?? null), 'diagnostics-evidence-multi-page-about-vector-diagnostics-page-scoped');
+    $homePageDecisionTraceSamples = $multiPageReports[0]['transform_diagnostics']['decision_traces']['samples'] ?? array();
+    $aboutPageDecisionTraceSamples = $multiPageReports[1]['transform_diagnostics']['decision_traces']['samples'] ?? array();
+    $assert(! empty($homePageDecisionTraceSamples) && array() === array_values(array_filter($homePageDecisionTraceSamples, static fn (array $trace): bool => 'index.html' !== ($trace['page_path'] ?? null))), 'diagnostics-evidence-multi-page-home-decision-traces-page-scoped');
+    $assert(! empty($aboutPageDecisionTraceSamples) && array() === array_values(array_filter($aboutPageDecisionTraceSamples, static fn (array $trace): bool => 'aggregation-about.html' !== ($trace['page_path'] ?? null))), 'diagnostics-evidence-multi-page-about-decision-traces-page-scoped');
+    $assert(isset($homePageDecisionTraceSamples[0]['class']) && str_starts_with((string) $homePageDecisionTraceSamples[0]['class'], 'figma-node-'), 'diagnostics-evidence-multi-page-decision-trace-class-preserved');
     $assert(0 === ($multiPageDiagnostics['artifact_quality']['summary']['empty_decoded_text_nodes'] ?? null), 'diagnostics-evidence-multi-page-empty-text-count-aggregated');
     $assert(0 === ($multiPageDiagnostics['artifact_quality']['summary']['missing_emitted_text_nodes'] ?? null), 'diagnostics-evidence-multi-page-missing-text-count-aggregated');
     blocks_engine_figma_transformer_contract_assert_diagnostic_value($assert, $multiPageDiagnostics, array('decision_traces', 'schema'), 'blocks-engine/figma-transformer/decision-traces/v1', 'diagnostics-evidence-multi-page-decision-traces-schema');

--- a/figma-transformer/tests/contract/VisualNodeMapContract.php
+++ b/figma-transformer/tests/contract/VisualNodeMapContract.php
@@ -1261,10 +1261,19 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     blocks_engine_figma_transformer_contract_assert_node_rect($assert, $staleNestedInstanceImage, array('x' => 112.0, 'y' => 198.0, 'width' => 376.0, 'height' => 282.0), 'visual-map-nested-instance-stale-definition-transform-rect-parent-local');
 
     $reusedEmitter = new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter();
-    $reusedEmitter->emit(array(
+    $reusedPriorResult = $reusedEmitter->emit(array(
         'name' => 'Prior emission',
-        'nodes' => array(array('id' => 'reuse:prior', 'type' => 'FRAME', 'name' => 'Prior root', 'width' => 320, 'height' => 160)),
+        'nodes' => array(array(
+            'id' => 'reuse:prior',
+            'type' => 'FRAME',
+            'name' => 'Prior root',
+            'width' => 320,
+            'height' => 160,
+            'children' => array(array('id' => 'reuse:prior:vector', 'type' => 'VECTOR', 'name' => 'Prior unsupported vector', 'width' => 24, 'height' => 24)),
+        )),
     ));
+    $reusedPriorDiagnostics = is_array($reusedPriorResult['source_report']['transform_diagnostics'] ?? null) ? $reusedPriorResult['source_report']['transform_diagnostics'] : array();
+    $assert(1 === ($reusedPriorDiagnostics['decision_traces']['reason_counts']['non_renderable_unsupported_vector_suppressed'] ?? null), 'visual-map-emitter-reuse-prior-decision-trace-recorded');
     $reusedSite = $reusedEmitter->emitSite(array(
         'name' => 'Reused emitter site',
         'nodes' => array(
@@ -1290,8 +1299,10 @@ function blocks_engine_figma_transformer_run_visual_node_map_contract(callable $
     ), array('static_site_page_path' => 'single.html'));
     $reusedSingleCss = blocks_engine_figma_transformer_contract_file_content($reusedSinglePage, 'style.css');
     $reusedSingleHtml = blocks_engine_figma_transformer_contract_file_content($reusedSinglePage, 'index.html');
+    $reusedSingleDiagnostics = is_array($reusedSinglePage['source_report']['transform_diagnostics'] ?? null) ? $reusedSinglePage['source_report']['transform_diagnostics'] : array();
     $assert(! str_contains($reusedSingleCss, 'figma-node-reuse-home-home') && ! str_contains($reusedSingleCss, 'figma-node-reuse-about-about'), 'visual-map-emitter-reuse-clears-prior-site-css');
     $assert(str_contains($reusedSingleHtml, 'data-page-path="single.html"') && null === blocks_engine_figma_transformer_contract_find_visual_node_in_map($reusedSinglePage['source_report']['visual_node_map'] ?? array(), 'reuse:home'), 'visual-map-emitter-reuse-clears-prior-site-page-state');
+    $assert(! isset($reusedSingleDiagnostics['decision_traces']['reason_counts']['non_renderable_unsupported_vector_suppressed']), 'visual-map-emitter-reuse-clears-prior-decision-traces');
 
     $inlineSite = (new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter())->emitSite(array(
         'name' => 'Inline diagnostics site',


### PR DESCRIPTION
## Summary
- add session-owned deduplicated emitter decision trace state with explicit count, slice, record, and summary operations
- remove the raw trace map from `StaticHtmlEmitter` while preserving artifact-wide accumulation and per-page slices
- replace `DecisionTraceBuilder`'s class-resolver callback with precomputed scalar class evidence
- retain the responsive builder's separate trace map and existing final merge behavior
- add contracts for page-scoped trace paths, class evidence, and reused-emitter trace isolation

Part of #1076.

## Verification
- `cd figma-transformer && composer test`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent lifecycle and compatibility review

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map decision-trace lifetime, implement the typed state boundary, review deduplication and page-slicing compatibility, and add artifact-level regression coverage. Chris Huber reviewed and remains responsible for the change.