### PR TITLE
Type Figma style resolution dependencies

### DIFF
--- a/figma-transformer/src/Html/BreakpointDimensionPolicy.php
+++ b/figma-transformer/src/Html/BreakpointDimensionPolicy.php
@@ -6,14 +6,13 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
 /**
  * Resolves responsive breakpoint width policy into CSS declarations.
+ *
+ * @internal
  */
 final class BreakpointDimensionPolicy
 {
-    /**
-     * @param callable(float): string|null $number
-     */
     public function __construct(
-        private readonly mixed $number = null,
+        private readonly ?StaticHtmlValueFormatter $formatter = null,
     ) {
     }
 
@@ -164,7 +163,7 @@ final class BreakpointDimensionPolicy
     {
         $declarations = array('width:100%', 'max-width:100%', 'height:auto', 'display:flex', 'flex-direction:column', 'align-items:stretch', 'justify-content:flex-start');
         if ( null !== $sourceHeight && $sourceHeight > 0.0 ) {
-            $declarations[] = 'min-height:' . ($this->number)($sourceHeight) . 'px';
+            $declarations[] = 'min-height:' . $this->formatNumber($sourceHeight) . 'px';
         }
 
         return $declarations;
@@ -298,8 +297,8 @@ final class BreakpointDimensionPolicy
 
     private function formatNumber(float $value): string
     {
-        if ( is_callable($this->number) ) {
-            return ($this->number)($value);
+        if ( null !== $this->formatter ) {
+            return $this->formatter->number($value);
         }
 
         return rtrim(rtrim(sprintf('%.4F', $value), '0'), '.');

--- a/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
+++ b/figma-transformer/src/Html/BreakpointMediaDiffBuilder.php
@@ -6,6 +6,8 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
 /**
  * Builds responsive media-query overrides from planned breakpoint variants.
+ *
+ * @internal
  */
 final class BreakpointMediaDiffBuilder
 {
@@ -25,9 +27,6 @@ final class BreakpointMediaDiffBuilder
 
     /**
      * @param callable(array<string, mixed>, string, array<string, mixed>|null, array<string, mixed>|null): array<int, string> $styleDeclarations
-     * @param callable(string): string $sanitizeAttribute
-     * @param callable(string): string $slug
-     * @param callable(float): string $number
      */
     public function __construct(
         private readonly StickyLayoutCoordinator $stickyLayoutCoordinator,
@@ -35,20 +34,18 @@ final class BreakpointMediaDiffBuilder
         private readonly VisualGeometryResolver $visualGeometryResolver,
         private readonly VectorSvgRenderer $vectorSvgRenderer,
         private readonly mixed $styleDeclarations,
-        private readonly mixed $sanitizeAttribute,
-        private readonly mixed $slug,
-        private readonly mixed $number,
+        private readonly StaticHtmlValueFormatter $formatter,
         ?ResponsiveNodeMatcher $responsiveNodeMatcher = null,
         ?BreakpointDimensionPolicy $breakpointDimensionPolicy = null,
         ?LayoutIntentClassifier $layoutIntentClassifier = null,
         ?ResponsiveBreakpointSafetyPolicy $responsiveBreakpointSafetyPolicy = null,
     ) {
-        $this->responsiveNodeMatcher = $responsiveNodeMatcher ?? new ResponsiveNodeMatcher($this->slug);
-        $this->breakpointDimensionPolicy = $breakpointDimensionPolicy ?? new BreakpointDimensionPolicy($this->number);
+        $this->responsiveNodeMatcher = $responsiveNodeMatcher ?? new ResponsiveNodeMatcher($this->formatter);
+        $this->breakpointDimensionPolicy = $breakpointDimensionPolicy ?? new BreakpointDimensionPolicy($this->formatter);
         $this->layoutIntentClassifier = $layoutIntentClassifier ?? new LayoutIntentClassifier();
         $this->responsiveBreakpointSafetyPolicy = $responsiveBreakpointSafetyPolicy ?? new ResponsiveBreakpointSafetyPolicy(
             $this->nodeInspector,
-            $this->number,
+            $this->formatter,
             $this->breakpointDimensionPolicy,
             $this->layoutIntentClassifier
         );
@@ -237,14 +234,14 @@ final class BreakpointMediaDiffBuilder
                 // container child can re-establish flow height.
                 $isCanvasContainer = ! in_array($display, array('flex', 'inline-flex', 'grid', 'inline-grid'), true);
                 if ( $isCanvasContainer || $isInferredGrid || ( ! $wrapsRow && ! $this->hasContainerChild($node) ) ) {
-                    $declarations[] = 'min-height:' . ($this->number)(min($height, 720.0)) . 'px';
+                    $declarations[] = 'min-height:' . $this->formatter->number(min($height, 720.0)) . 'px';
                 }
             }
             if ( null !== $minHeight && $minHeight > 720.0 && in_array($display, array('flex', 'inline-flex', 'grid', 'inline-grid'), true) && $this->hasContainerChild($node) ) {
                 // A stacked row turns its normal children into vertical flow; their
                 // desktop equal-height floors would otherwise become blank space.
                 $declarations[] = $isInferredGrid
-                    ? 'min-height:' . ($this->number)($minHeight) . 'px'
+                    ? 'min-height:' . $this->formatter->number($minHeight) . 'px'
                     : 'min-height:0';
             }
             if ( $mobile && $wrapsRow ) {
@@ -316,7 +313,7 @@ final class BreakpointMediaDiffBuilder
                         continue;
                     }
                     $minimum = max(14.0, $sourceValue * 0.55);
-                    $declarations[] = $property . ':clamp(' . ($this->number)($minimum) . 'px,' . ($this->number)($sourceValue / $sourceViewportWidth * 100.0) . 'vw,' . ($this->number)($sourceValue) . 'px)';
+                    $declarations[] = $property . ':clamp(' . $this->formatter->number($minimum) . 'px,' . $this->formatter->number($sourceValue / $sourceViewportWidth * 100.0) . 'vw,' . $this->formatter->number($sourceValue) . 'px)';
                 }
             }
         }
@@ -332,7 +329,7 @@ final class BreakpointMediaDiffBuilder
             }
             if ( null !== $height && $height > 0.0 ) {
                 $declarations[] = 'height:auto';
-                $declarations[] = 'aspect-ratio:' . ($this->number)($width) . ' / ' . ($this->number)($height);
+                $declarations[] = 'aspect-ratio:' . $this->formatter->number($width) . ' / ' . $this->formatter->number($height);
             }
             if ( isset($baseMap['background-size']) && ! in_array($baseMap['background-size'], array('cover', 'contain'), true) ) {
                 $declarations[] = 'background-size:cover';
@@ -374,8 +371,8 @@ final class BreakpointMediaDiffBuilder
         }
 
         return array(
-            'width' => ($this->number)(min(100.0, $width / $parentWidth * 100.0)) . '%',
-            'left'  => ($this->number)(max(0.0, (float) $box['x'] / $parentWidth * 100.0)) . '%',
+            'width' => $this->formatter->number(min(100.0, $width / $parentWidth * 100.0)) . '%',
+            'left'  => $this->formatter->number(max(0.0, (float) $box['x'] / $parentWidth * 100.0)) . '%',
         );
     }
 
@@ -618,7 +615,7 @@ final class BreakpointMediaDiffBuilder
      */
     private function mediaBlock(string $feature, int $breakpointPx, array $rules): string
     {
-        return '@media (' . $feature . ':' . ($this->number)((float) $breakpointPx) . 'px){'
+        return '@media (' . $feature . ':' . $this->formatter->number((float) $breakpointPx) . 'px){'
             . "\n" . implode("\n", $rules) . "\n}";
     }
 
@@ -632,10 +629,10 @@ final class BreakpointMediaDiffBuilder
             return;
         }
 
-        $id = ($this->sanitizeAttribute)((string) ($node['id'] ?? ''));
+        $id = $this->formatter->sanitizeAttribute((string) ($node['id'] ?? ''));
         $name = (string) ($node['name'] ?? '');
         $type = strtoupper((string) ($node['type'] ?? 'FRAME'));
-        $className = 'figma-node-' . ($this->slug)($id . '-' . $name);
+        $className = 'figma-node-' . $this->formatter->slug($id . '-' . $name);
         $styles = $this->stickyLayoutCoordinator->stickyAwareStyleDeclarations($node, ($this->styleDeclarations)($node, $type, $parentNode, $grandParentNode));
 
         $map[$pathKey] = array(

--- a/figma-transformer/src/Html/CssPositioningResolver.php
+++ b/figma-transformer/src/Html/CssPositioningResolver.php
@@ -6,15 +6,14 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
 /**
  * Resolves CSS declarations for nodes that leave normal flow.
+ *
+ * @internal
  */
 final class CssPositioningResolver
 {
-    /**
-     * @param callable(float): string $numberFormatter
-     */
     public function __construct(
         private readonly LayoutIntentClassifier $layoutIntentClassifier,
-        private readonly mixed $numberFormatter,
+        private readonly StaticHtmlValueFormatter $formatter,
     ) {
     }
 
@@ -471,7 +470,7 @@ final class CssPositioningResolver
 
     private function number(float $value): string
     {
-        return ($this->numberFormatter)($value);
+        return $this->formatter->number($value);
     }
 
     /**

--- a/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
+++ b/figma-transformer/src/Html/ResponsiveBreakpointSafetyPolicy.php
@@ -6,15 +6,14 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
 /**
  * Resolves class-scoped responsive fallback decisions when breakpoint nodes cannot be matched directly.
+ *
+ * @internal
  */
 final class ResponsiveBreakpointSafetyPolicy
 {
-    /**
-     * @param callable(float): string $number
-     */
     public function __construct(
         private readonly StaticHtmlNodeInspector $nodeInspector,
-        private readonly mixed $number,
+        private readonly StaticHtmlValueFormatter $formatter,
         private readonly BreakpointDimensionPolicy $breakpointDimensionPolicy,
         private readonly LayoutIntentClassifier $layoutIntentClassifier,
     ) {
@@ -118,7 +117,7 @@ final class ResponsiveBreakpointSafetyPolicy
         }
 
         if ( $hasBackgroundImage && null !== $height && $height > 0.0 ) {
-            $declarations = array('width:100%', 'max-width:100%', 'height:auto', 'aspect-ratio:' . ($this->number)($width) . ' / ' . ($this->number)($height));
+            $declarations = array('width:100%', 'max-width:100%', 'height:auto', 'aspect-ratio:' . $this->formatter->number($width) . ' / ' . $this->formatter->number($height));
             if ( isset($baseMap['background-size']) && ! in_array($baseMap['background-size'], array('cover', 'contain'), true) ) {
                 $declarations[] = 'background-size:cover';
             }
@@ -135,7 +134,7 @@ final class ResponsiveBreakpointSafetyPolicy
         if ( null !== $height && $height > 240.0 ) {
             $declarations[] = 'height:auto';
             if ( ! $wrapsRow ) {
-                $declarations[] = 'min-height:' . ($this->number)(min($height, 720.0)) . 'px';
+                $declarations[] = 'min-height:' . $this->formatter->number(min($height, 720.0)) . 'px';
             }
         }
 
@@ -241,7 +240,7 @@ final class ResponsiveBreakpointSafetyPolicy
     private function namedResponsiveShellDecision(array $node, ?array $parentNode, array $baseMap, string $name, string $parentName, bool $isContainer, ?float $width, string $positioning, string $display, ?string $chromeRole, float $viewportWidth): array
     {
         if ( 'footer' === $name && $isContainer && $this->hasFooterResponsiveShell($node) ) {
-            return array('reason_code' => 'responsive_footer_shell_safety', 'declarations' => array('height:auto', 'min-height:' . ($this->number)($this->footerResponsiveMinHeight($node)) . 'px'));
+            return array('reason_code' => 'responsive_footer_shell_safety', 'declarations' => array('height:auto', 'min-height:' . $this->formatter->number($this->footerResponsiveMinHeight($node)) . 'px'));
         }
 
         if ( (LayoutIntentClassifier::CHROME_GROUP_ROLE_NAVIGATION === $chromeRole || 'navigation' === $name) && $isContainer ) {
@@ -319,7 +318,7 @@ final class ResponsiveBreakpointSafetyPolicy
         $mobileContentWidth = max(1.0, $viewportWidth - 48.0);
         return array(
             'width:calc(100% - 48px)',
-            'max-width:' . ($this->number)(min($width, $mobileContentWidth)) . 'px',
+            'max-width:' . $this->formatter->number(min($width, $mobileContentWidth)) . 'px',
             'left:24px',
             'right:auto',
         );
@@ -640,7 +639,7 @@ final class ResponsiveBreakpointSafetyPolicy
         $declarations = array('width:100%', 'max-width:100%', 'height:auto', 'display:flex', 'flex-direction:column', 'align-items:stretch', 'justify-content:flex-start');
         $minHeight = $this->responsiveHeaderMinHeight($node, $baseMap, $variantNode);
         if ( null !== $minHeight && $minHeight > 0.0 ) {
-            $declarations[] = 'min-height:' . ($this->number)($minHeight) . 'px';
+            $declarations[] = 'min-height:' . $this->formatter->number($minHeight) . 'px';
         }
 
         return $declarations;

--- a/figma-transformer/src/Html/ResponsiveNodeMatcher.php
+++ b/figma-transformer/src/Html/ResponsiveNodeMatcher.php
@@ -6,6 +6,8 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
 /**
  * Builds stable node match keys for responsive breakpoint diffs.
+ *
+ * @internal
  */
 final class ResponsiveNodeMatcher
 {
@@ -13,11 +15,8 @@ final class ResponsiveNodeMatcher
     private const VIEWPORT_SIZE_PATTERN = '/\b\d{3,4}\s*x\s*\d{3,5}\b/';
     private const VIEWPORT_WIDTH_PATTERN = '/\b(320|375|390|393|414|428|768|834|1024|1280|1366|1440|1512|1728|1920)\b/';
 
-    /**
-     * @param callable(string): string $slug
-     */
     public function __construct(
-        private readonly mixed $slug,
+        private readonly StaticHtmlValueFormatter $formatter,
     ) {
     }
 
@@ -49,7 +48,7 @@ final class ResponsiveNodeMatcher
         $counts = array();
         foreach ( $siblings as $sibling ) {
             foreach ( $this->sourceIdentities($sibling) as $sourceId ) {
-                $key = ($this->slug)($sourceId);
+                $key = $this->formatter->slug($sourceId);
                 $counts[$key] = ($counts[$key] ?? 0) + 1;
             }
         }
@@ -67,7 +66,7 @@ final class ResponsiveNodeMatcher
         $keys = array();
 
         foreach ( $this->sourceIdentities($node) as $sourceId ) {
-            $sourceKey = ($this->slug)($sourceId);
+            $sourceKey = $this->formatter->slug($sourceId);
             if ( 1 === ($siblingSourceIdentityCounts[$sourceKey] ?? 1) ) {
                 $keys[] = 'source:' . $sourceKey;
             }

--- a/figma-transformer/src/Html/StaticHtmlEmissionSession.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionSession.php
@@ -16,6 +16,7 @@ final class StaticHtmlEmissionSession
     private readonly StaticHtmlDecisionTraceState $decisionTraceState;
     private readonly TextStyleDeclarationResolver $textStyleDeclarationResolver;
     private readonly PaintStackResolver $paintStackResolver;
+    private readonly StyleDeclarationBuilder $styleDeclarationBuilder;
     private readonly ChildLayerCompositionResolver $childLayerCompositionResolver;
     private readonly StaticHtmlVectorEvidence $vectorEvidence;
     private readonly VectorSvgRenderer $vectorSvgRenderer;
@@ -32,6 +33,7 @@ final class StaticHtmlEmissionSession
         $this->decisionTraceState = new StaticHtmlDecisionTraceState();
         $this->textStyleDeclarationResolver = new TextStyleDeclarationResolver($typographyModel, $formatter, $this->typographyState);
         $this->paintStackResolver = new PaintStackResolver($this->assetRegistry, $formatter);
+        $this->styleDeclarationBuilder = new StyleDeclarationBuilder($formatter, $this->paintStackResolver);
         $this->childLayerCompositionResolver = new ChildLayerCompositionResolver($this->assetRegistry, $formatter);
         $this->vectorEvidence = new StaticHtmlVectorEvidence($formatter, $this->paintStackResolver);
         $this->vectorSvgRenderer = new VectorSvgRenderer($nodeInspector, $formatter, $this->vectorEvidence);
@@ -75,6 +77,11 @@ final class StaticHtmlEmissionSession
     public function paintStackResolver(): PaintStackResolver
     {
         return $this->paintStackResolver;
+    }
+
+    public function styleDeclarationBuilder(): StyleDeclarationBuilder
+    {
+        return $this->styleDeclarationBuilder;
     }
 
     public function childLayerCompositionResolver(): ChildLayerCompositionResolver

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -47,8 +47,6 @@ final class StaticHtmlEmitter
 
     private ?DesignSystemExtractor $designSystemExtractor = null;
 
-    private ?StyleDeclarationBuilder $styleDeclarationBuilder = null;
-
     private ?TransformDiagnosticsBuilder $transformDiagnosticsBuilder = null;
 
     private ?StaticHtmlEmissionDiagnostics $staticHtmlEmissionDiagnostics = null;
@@ -118,11 +116,7 @@ final class StaticHtmlEmitter
 
     private function styleDeclarationBuilder(): StyleDeclarationBuilder
     {
-        return $this->styleDeclarationBuilder ??= new StyleDeclarationBuilder(
-            fn (float $value): string => $this->number($value),
-            fn (array $paints): ?array => $this->firstCssPaint($paints),
-            fn (mixed $value, mixed $opacity = null): ?string => $this->color($value, $opacity),
-        );
+        return $this->emissionSession->styleDeclarationBuilder();
     }
 
     private function staticHtmlCssRuleSet(): StaticHtmlCssRuleSet
@@ -180,7 +174,7 @@ final class StaticHtmlEmitter
     {
         return $this->cssPositioningResolver ??= new CssPositioningResolver(
             $this->layoutIntentClassifier(),
-            fn (float $value): string => $this->number($value),
+            $this->valueFormatter(),
         );
     }
 
@@ -226,9 +220,7 @@ final class StaticHtmlEmitter
             $this->visualGeometryResolver(),
             $this->emissionSession->vectorSvgRenderer(),
             fn (array $node, string $type, ?array $parentNode, ?array $grandParentNode): array => $this->styleDeclarations($node, $type, $parentNode, $grandParentNode),
-            fn (string $value): string => $this->sanitizeAttribute($value),
-            fn (string $value): string => $this->slug($value),
-            fn (float $value): string => $this->number($value),
+            $this->valueFormatter(),
             null,
             $this->breakpointDimensionPolicy(),
         );
@@ -236,7 +228,7 @@ final class StaticHtmlEmitter
 
     private function breakpointDimensionPolicy(): BreakpointDimensionPolicy
     {
-        return $this->breakpointDimensionPolicy ??= new BreakpointDimensionPolicy(fn (float $value): string => $this->number($value));
+        return $this->breakpointDimensionPolicy ??= new BreakpointDimensionPolicy($this->valueFormatter());
     }
 
     private function childLayerCompositionResolver(): ChildLayerCompositionResolver

--- a/figma-transformer/src/Html/StyleDeclarationBuilder.php
+++ b/figma-transformer/src/Html/StyleDeclarationBuilder.php
@@ -6,18 +6,14 @@ namespace Automattic\BlocksEngine\FigmaTransformer\Html;
 
 /**
  * Builds focused CSS declaration groups for emitted Figma nodes.
+ *
+ * @internal
  */
 final class StyleDeclarationBuilder
 {
-    /**
-     * @param callable(float): string $numberFormatter
-     * @param callable(array<int, mixed>): array{css: string, gradient: bool}|null $firstCssPaint
-     * @param callable(mixed, mixed=): ?string $color
-     */
     public function __construct(
-        private readonly mixed $numberFormatter,
-        private readonly mixed $firstCssPaint,
-        private readonly mixed $color,
+        private readonly StaticHtmlValueFormatter $formatter,
+        private readonly PaintStackResolver $paintStackResolver,
     ) {
     }
 
@@ -319,16 +315,16 @@ final class StyleDeclarationBuilder
      */
     private function firstCssPaint(array $paints): ?array
     {
-        return ($this->firstCssPaint)($paints);
+        return $this->paintStackResolver->firstCssPaint($paints);
     }
 
     private function color(mixed $value, mixed $opacity = null): ?string
     {
-        return ($this->color)($value, $opacity);
+        return $this->formatter->color($value, $opacity);
     }
 
     private function number(float $value): string
     {
-        return ($this->numberFormatter)($value);
+        return $this->formatter->number($value);
     }
 }

--- a/figma-transformer/tests/contract/ComponentCloneEmissionContract.php
+++ b/figma-transformer/tests/contract/ComponentCloneEmissionContract.php
@@ -48,7 +48,7 @@ function blocks_engine_figma_transformer_run_component_clone_emission_contract(c
 
     $scalarPositioning = new Automattic\BlocksEngine\FigmaTransformer\Html\CssPositioningResolver(
         new Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier(),
-        static fn (float $value): string => 0.0 === fmod($value, 1.0) ? (string) (int) $value : rtrim(rtrim(sprintf('%.3F', $value), '0'), '.')
+        new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter()
     );
     $scalarStyles = $scalarPositioning->styles(
         array('x' => 1774, 'y' => 2387, 'width' => 225, 'height' => 48, 'coordinate_space' => 'local', 'local_origin' => 'page'),
@@ -67,7 +67,7 @@ function blocks_engine_figma_transformer_run_component_clone_emission_contract(c
 
     $headerChromePositioning = new Automattic\BlocksEngine\FigmaTransformer\Html\CssPositioningResolver(
         new Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier(),
-        static fn (float $value): string => 0.0 === fmod($value, 1.0) ? (string) (int) $value : rtrim(rtrim(sprintf('%.3F', $value), '0'), '.')
+        new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter()
     );
     $headerChromeCtaStyles = $headerChromePositioning->styles(
         array('x' => 1180, 'y' => 72, 'width' => 225, 'height' => 48),

--- a/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
+++ b/figma-transformer/tests/contract/DiagnosticsEvidenceContract.php
@@ -377,8 +377,8 @@ function blocks_engine_figma_transformer_run_diagnostics_evidence_contract(calla
 
     $responsivePolicy = new \Automattic\BlocksEngine\FigmaTransformer\Html\ResponsiveBreakpointSafetyPolicy(
         new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlNodeInspector(),
-        static fn (float $value): string => rtrim(rtrim(sprintf('%.3F', $value), '0'), '.'),
-        new \Automattic\BlocksEngine\FigmaTransformer\Html\BreakpointDimensionPolicy(static fn (float $value): string => rtrim(rtrim(sprintf('%.3F', $value), '0'), '.')),
+        new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter(),
+        new \Automattic\BlocksEngine\FigmaTransformer\Html\BreakpointDimensionPolicy(new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter()),
         new \Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier()
     );
     $responsiveDecision = $responsivePolicy->responsiveSafetyDecision(

--- a/figma-transformer/tests/contract/LayoutFrameRoleContract.php
+++ b/figma-transformer/tests/contract/LayoutFrameRoleContract.php
@@ -119,7 +119,7 @@ function blocks_engine_figma_transformer_run_layout_frame_role_contract(callable
 
     $positioningIntent = new LayoutIntentClassifier();
     $positioningResolver = new PositioningStyleResolver(
-        new CssPositioningResolver($positioningIntent, static fn (float $value): string => 0.0 === fmod($value, 1.0) ? (string) (int) $value : rtrim(rtrim(sprintf('%.3F', $value), '0'), '.')),
+        new CssPositioningResolver($positioningIntent, new \Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter()),
         $resolver,
     );
     $backgroundPlan = new NodeRenderPlan(

--- a/figma-transformer/tests/contract/run.php
+++ b/figma-transformer/tests/contract/run.php
@@ -7169,8 +7169,8 @@ $assert(str_contains($ulResetSiteCss, 'ul,ol{margin:0;padding:0;list-style:none}
 // PARITY FIX 3 — Responsive breakpoint keyed at midpoint, not variant width.
 // Two-variant case: desktop=1440, mobile=390 → midpoint = 915 (not 390).
 // ──────────────────────────────────────────────────────────────────────────────
-$breakpointDimensionPolicy = new Automattic\BlocksEngine\FigmaTransformer\Html\BreakpointDimensionPolicy(fn (float $value): string => rtrim(rtrim(sprintf('%.4F', $value), '0'), '.'));
-$responsiveNodeMatcher = new Automattic\BlocksEngine\FigmaTransformer\Html\ResponsiveNodeMatcher(fn (string $value): string => strtolower(preg_replace('/[^a-z0-9]+/i', '-', trim($value, '-')) ?? $value));
+$breakpointDimensionPolicy = new Automattic\BlocksEngine\FigmaTransformer\Html\BreakpointDimensionPolicy(new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter());
+$responsiveNodeMatcher = new Automattic\BlocksEngine\FigmaTransformer\Html\ResponsiveNodeMatcher(new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter());
 $assert('header' === $responsiveNodeMatcher->responsiveIdentity('Header Desktop 1440'), 'responsive-node-matcher-strips-desktop-width-qualifiers');
 $assert('hero-card' === $responsiveNodeMatcher->responsiveIdentity('Hero Card / Mobile 390 x 844'), 'responsive-node-matcher-strips-mobile-viewport-size');
 $responsiveNodeMatcherDesktopCounts = $responsiveNodeMatcher->siblingSignatureCounts(array(array('type' => 'FRAME', 'name' => 'Header Desktop')));
@@ -7197,7 +7197,7 @@ $assert(
 );
 $responsiveBreakpointSafetyPolicy = new Automattic\BlocksEngine\FigmaTransformer\Html\ResponsiveBreakpointSafetyPolicy(
     new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlNodeInspector(),
-    fn (float $value): string => rtrim(rtrim(sprintf('%.4F', $value), '0'), '.'),
+    new Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlValueFormatter(),
     $breakpointDimensionPolicy,
     new Automattic\BlocksEngine\FigmaTransformer\Html\LayoutIntentClassifier()
 );


### PR DESCRIPTION
## Summary
- replace formatting and paint callbacks across style declaration, positioning, breakpoint dimension, responsive matching, and responsive safety helpers with typed collaborators
- make `StyleDeclarationBuilder` session-owned alongside its paint stack and asset registry
- reduce `BreakpointMediaDiffBuilder` to one remaining callback: style declaration orchestration
- align responsive slugging, escaping, and number formatting with normal emission
- mark implementation helpers `@internal` consistently with the documented package API

Part of #1076. This is the prerequisite for moving `styleDeclarations()` without hiding emitter callbacks in the new resolver.

## Verification
- `cd figma-transformer && composer test`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent output, lifecycle, and package-boundary review

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map style dependency callbacks, implement typed collaborators, audit the documented public API boundary, and run compatibility verification. Chris Huber reviewed and remains responsible for the change.