### PR TITLE
Extract Figma visual style resolution

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmissionSession.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionSession.php
@@ -20,6 +20,7 @@ final class StaticHtmlEmissionSession
     private readonly ChildLayerCompositionResolver $childLayerCompositionResolver;
     private readonly StaticHtmlVectorEvidence $vectorEvidence;
     private readonly VectorSvgRenderer $vectorSvgRenderer;
+    private readonly StaticHtmlVisualStyleResolver $visualStyleResolver;
 
     public function __construct(
         StaticHtmlNodeInspector $nodeInspector,
@@ -37,6 +38,14 @@ final class StaticHtmlEmissionSession
         $this->childLayerCompositionResolver = new ChildLayerCompositionResolver($this->assetRegistry, $formatter);
         $this->vectorEvidence = new StaticHtmlVectorEvidence($formatter, $this->paintStackResolver);
         $this->vectorSvgRenderer = new VectorSvgRenderer($nodeInspector, $formatter, $this->vectorEvidence);
+        $this->visualStyleResolver = new StaticHtmlVisualStyleResolver(
+            $formatter,
+            $this->vectorEvidence,
+            $this->vectorSvgRenderer,
+            $this->styleDeclarationBuilder,
+            $this->paintStackResolver,
+            $this->assetRegistry,
+        );
     }
 
     public function pageState(): StaticHtmlPageState
@@ -92,6 +101,11 @@ final class StaticHtmlEmissionSession
     public function vectorEvidence(): StaticHtmlVectorEvidence
     {
         return $this->vectorEvidence;
+    }
+
+    public function visualStyleResolver(): StaticHtmlVisualStyleResolver
+    {
+        return $this->visualStyleResolver;
     }
 
 }

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -6546,25 +6546,9 @@ final class StaticHtmlEmitter
         }
         $fullBleedBreakoutDecision = $this->canvasShellResolver()->fullBleedViewportBreakoutDecision($canvasShell);
 
-        if ( $this->nodeShouldEmitCssBackground($type, $zeroHeightVectorFallbackHeight, $rendersInlineVectorSvg) ) {
-            $background = $this->backgroundColor($node);
-            if ( null !== $background ) {
-                $styles[] = 'background:' . $background;
-            }
-        }
+        array_push($styles, ...$this->emissionSession->visualStyleResolver()->backgroundDeclarations($node, $type, $zeroHeightVectorFallbackHeight, $rendersInlineVectorSvg));
 
         $box = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
-        if ( $this->isFiniteNumeric($box['opacity'] ?? null) ) {
-            $styles[] = 'opacity:' . $this->number((float) $box['opacity']);
-        }
-
-        if ( isset($box['blend_mode']) && is_scalar($box['blend_mode']) ) {
-            $blendMode = $this->blendModeCss((string) $box['blend_mode']);
-            if ( null !== $blendMode ) {
-                $styles[] = 'mix-blend-mode:' . $blendMode;
-            }
-        }
-
         $transform = $this->isNearZeroHeightContainer($node, $type) || $this->hasAbsoluteVisualBounds($node) ? null : $this->transformStyle($box);
         if ( null !== $transform ) {
             $styles[] = 'transform:' . $transform;
@@ -6578,22 +6562,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        foreach ( $this->radiusStyles($box) as $style ) {
-            $styles[] = $style;
-        }
-
-        if ( ! $this->rendersStrokeInsideInlineSvg($node, $type, $parentNode) ) {
-            foreach ( $this->strokeStyles($node) as $style ) {
-                $styles[] = $style;
-            }
-        }
-
-        foreach ( $this->composedImageBackgroundStyles($node) as $style ) {
-            $styles[] = $style;
-        }
-        if ( $canvasShell->fullBleedCanvasChild ) {
-            $styles = $this->scaleFullBleedImageCropStyles($styles, $layoutBox);
-        }
+        array_push($styles, ...$this->emissionSession->visualStyleResolver()->decorationDeclarations($node, $type, $parentNode, $canvasShell->fullBleedCanvasChild, $layoutBox));
 
         if ( 'TEXT' === $type ) {
             foreach ( $this->textStyles($node, $parentNode, $grandParentNode) as $style ) {
@@ -6612,9 +6581,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        foreach ( $this->effectStyles($node, $type) as $style ) {
-            $styles[] = $style;
-        }
+        array_push($styles, ...$this->emissionSession->visualStyleResolver()->effectDeclarations($node, $type));
 
         $layoutIntent = $plan->layoutIntent;
         $freeformFlowIntent = empty($layout['display'] ?? null) ? $this->freeformContainerFlowIntent($node) : null;
@@ -6686,35 +6653,6 @@ final class StaticHtmlEmitter
         $this->recordGeometryDecisionDiagnostics($node, $type, $parentNode, $layoutBox, $box, $layout, $canvasShell, $canvasWidthDecision, $fullBleedBreakoutDecision, $positioningStyleDecision, $styles, $transform);
 
         return $styles;
-    }
-
-    /**
-     * @param array<int, string> $styles
-     * @param array<string, mixed> $box
-     * @return array<int, string>
-     */
-    private function scaleFullBleedImageCropStyles(array $styles, array $box): array
-    {
-        if ( ! isset($box['width']) || ! is_numeric($box['width']) || (float) $box['width'] <= 0.0 ) {
-            return $styles;
-        }
-
-        $sourceWidth = (float) $box['width'];
-        $scaled = array();
-        foreach ( $styles as $style ) {
-            if ( str_starts_with($style, 'background-size:') ) {
-                $scaled[] = $this->scaleFullBleedImageCropDeclaration($style, $sourceWidth, 'size');
-                continue;
-            }
-            if ( str_starts_with($style, 'background-position:') ) {
-                $scaled[] = $this->scaleFullBleedImageCropDeclaration($style, $sourceWidth, 'position');
-                continue;
-            }
-
-            $scaled[] = $style;
-        }
-
-        return $scaled;
     }
 
     /**
@@ -6927,40 +6865,6 @@ final class StaticHtmlEmitter
         return $attributes;
     }
 
-    private function scaleFullBleedImageCropDeclaration(string $style, float $sourceWidth, string $kind): string
-    {
-        $parts = explode(':', $style, 2);
-        if ( 2 !== count($parts) ) {
-            return $style;
-        }
-
-        $layers = explode(',', $parts[1]);
-        $scaledLayers = array();
-        foreach ( $layers as $layer ) {
-            $tokens = preg_split('/\s+/', trim($layer));
-            if ( ! is_array($tokens) || 2 !== count($tokens) ) {
-                return $style;
-            }
-
-            $scaledTokens = array();
-            foreach ( $tokens as $token ) {
-                if ( 1 !== preg_match('/^-?\d+(?:\.\d+)?px$/', $token) ) {
-                    return $style;
-                }
-
-                $value = (float) substr($token, 0, -2);
-                if ( 'size' === $kind && $value <= 0.0 ) {
-                    return $style;
-                }
-                $scaledTokens[] = 'calc(100vw * ' . $this->number($value / $sourceWidth) . ')';
-            }
-
-            $scaledLayers[] = implode(' ', $scaledTokens);
-        }
-
-        return $parts[0] . ':' . implode(',', $scaledLayers);
-    }
-
     /**
      * @param array<string, mixed> $node
      * @param array<string, mixed>|null $parentNode
@@ -7171,15 +7075,6 @@ final class StaticHtmlEmitter
             '-webkit-mask-repeat:no-repeat',
             'mask-repeat:no-repeat',
         );
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     * @return array<int, string>
-     */
-    private function composedImageBackgroundStyles(array $node): array
-    {
-        return $this->paintStackResolver()->composedImageBackgroundStyles($node, $this->nodeAssetPaths($node));
     }
 
     /**
@@ -9238,38 +9133,6 @@ final class StaticHtmlEmitter
     }
 
     /**
-     * @param array<string, mixed> $node
-     */
-    private function rendersStrokeInsideInlineSvg(array $node, string $type, ?array $parentNode): bool
-    {
-        if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON'), true) ) {
-            return false;
-        }
-
-        $strokeStyles = $this->strokeStyles($node);
-        if ( empty($strokeStyles) ) {
-            return false;
-        }
-
-        foreach ( $strokeStyles as $style ) {
-            if ( str_starts_with($style, 'border-image:') ) {
-                return false;
-            }
-        }
-
-        return null !== $this->supportedVectorSvg($node, $type, $parentNode);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     * @return array<int, string>
-     */
-    private function effectStyles(array $node, string $type): array
-    {
-        return $this->styleDeclarationBuilder()->effectStyles($node, $type);
-    }
-
-    /**
      * @param mixed $assets
      * @param array<int, array<string, mixed>> $diagnostics
      * @return array<int, array<string, mixed>>
@@ -9455,33 +9318,6 @@ final class StaticHtmlEmitter
     private function nodeAssetPath(array $node): ?string
     {
         return $this->emissionSession->assetRegistry()->resolveAndMarkNode($node);
-    }
-
-    /**
-     * Return all image-fill asset paths for a node ordered top→bottom (Figma's
-     * topmost paint first), matching CSS background-image layer stacking order.
-     * Figma stores fills bottom→top in the array, so fills are reversed before
-     * resolution. Paints with `visible === false` are skipped. Every resolved
-     * path is marked used so its blob is emitted.
-     *
-     * When a node carries no fill-based image paints the method falls back to
-     * the legacy node-level reference (same as {@see nodeAssetPath()}) so that
-     * simple `asset_id` nodes continue to work unchanged.
-     *
-     * @param array<string, mixed> $node
-     * @return array<int, string>
-     */
-    private function nodeAssetPaths(array $node): array
-    {
-        $layers = $this->nodeImagePaintLayers($node);
-        if ( ! empty($layers) ) {
-            return array_map(static fn (array $layer): string => (string) $layer['path'], $layers);
-        }
-
-        // Fallback: node-level asset reference (e.g. explicit `asset_id` key
-        // not expressed as a fill paint).
-        $fallbackPath = $this->nodeAssetPath($node);
-        return null !== $fallbackPath ? array($fallbackPath) : array();
     }
 
     /**
@@ -10046,34 +9882,6 @@ final class StaticHtmlEmitter
     private function numericOrNull(mixed $value): ?float
     {
         return is_numeric($value) ? (float) $value : null;
-    }
-
-    /**
-     * Map a Figma node-level blendMode enum to the equivalent CSS
-     * `mix-blend-mode` keyword. Returns null for the default compositing
-     * modes (NORMAL / PASS_THROUGH) and any unrecognized value so no CSS
-     * is emitted in those cases.
-     */
-    private function blendModeCss(string $blendMode): ?string
-    {
-        return match ( strtoupper($blendMode) ) {
-            'MULTIPLY' => 'multiply',
-            'SCREEN' => 'screen',
-            'OVERLAY' => 'overlay',
-            'DARKEN' => 'darken',
-            'LIGHTEN' => 'lighten',
-            'COLOR_DODGE' => 'color-dodge',
-            'COLOR_BURN' => 'color-burn',
-            'HARD_LIGHT' => 'hard-light',
-            'SOFT_LIGHT' => 'soft-light',
-            'DIFFERENCE' => 'difference',
-            'EXCLUSION' => 'exclusion',
-            'HUE' => 'hue',
-            'SATURATION' => 'saturation',
-            'COLOR' => 'color',
-            'LUMINOSITY' => 'luminosity',
-            default => null,
-        };
     }
 
     private function color(mixed $value, mixed $opacity = null): ?string

--- a/figma-transformer/src/Html/StaticHtmlVisualStyleResolver.php
+++ b/figma-transformer/src/Html/StaticHtmlVisualStyleResolver.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\FigmaTransformer\Html;
+
+/**
+ * Resolves visual paint, stroke, image, and effect declarations.
+ *
+ * @internal
+ */
+final class StaticHtmlVisualStyleResolver
+{
+    public function __construct(
+        private readonly StaticHtmlValueFormatter $formatter,
+        private readonly StaticHtmlVectorEvidence $vectorEvidence,
+        private readonly VectorSvgRenderer $vectorSvgRenderer,
+        private readonly StyleDeclarationBuilder $styleDeclarationBuilder,
+        private readonly PaintStackResolver $paintStackResolver,
+        private readonly StaticHtmlAssetRegistry $assetRegistry,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    public function backgroundDeclarations(array $node, string $type, ?float $zeroHeightVectorFallbackHeight, bool $rendersInlineVectorSvg): array
+    {
+        $styles = array();
+        if ( $this->nodeShouldEmitCssBackground($type, $zeroHeightVectorFallbackHeight, $rendersInlineVectorSvg) ) {
+            $background = $this->vectorEvidence->backgroundColor($node);
+            if ( null !== $background ) {
+                $styles[] = 'background:' . $background;
+            }
+        }
+
+        $figmaBox = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        if ( isset($figmaBox['opacity']) && is_numeric($figmaBox['opacity']) && is_finite((float) $figmaBox['opacity']) ) {
+            $styles[] = 'opacity:' . $this->formatter->number((float) $figmaBox['opacity']);
+        }
+
+        if ( isset($figmaBox['blend_mode']) && is_scalar($figmaBox['blend_mode']) ) {
+            $blendMode = $this->blendModeCss((string) $figmaBox['blend_mode']);
+            if ( null !== $blendMode ) {
+                $styles[] = 'mix-blend-mode:' . $blendMode;
+            }
+        }
+
+        return $styles;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed>|null $parentNode
+     * @param array<string, mixed> $layoutBox
+     * @return array<int, string>
+     */
+    public function decorationDeclarations(array $node, string $type, ?array $parentNode, bool $fullBleedCanvasChild, array $layoutBox): array
+    {
+        $figmaBox = is_array($node['figma_box'] ?? null) ? $node['figma_box'] : array();
+        $styles = $this->styleDeclarationBuilder->radiusStyles($figmaBox);
+        if ( ! $this->rendersStrokeInsideInlineSvg($node, $type, $parentNode) ) {
+            array_push($styles, ...$this->styleDeclarationBuilder->strokeStyles($node));
+        }
+
+        array_push($styles, ...$this->composedImageBackgroundStyles($node));
+        return $fullBleedCanvasChild ? $this->scaleFullBleedImageCropStyles($styles, $layoutBox) : $styles;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    public function effectDeclarations(array $node, string $type): array
+    {
+        return $this->styleDeclarationBuilder->effectStyles($node, $type);
+    }
+
+    private function nodeShouldEmitCssBackground(string $type, ?float $zeroHeightVectorFallbackHeight, bool $rendersInlineVectorSvg): bool
+    {
+        if ( 'TEXT' === $type || ('LINE' === $type && $rendersInlineVectorSvg) ) {
+            return false;
+        }
+
+        if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE'), true) ) {
+            return true;
+        }
+
+        return ! $rendersInlineVectorSvg || null !== $zeroHeightVectorFallbackHeight;
+    }
+
+    /** @param array<string, mixed> $node */
+    private function rendersStrokeInsideInlineSvg(array $node, string $type, ?array $parentNode): bool
+    {
+        if ( ! in_array($type, array('VECTOR', 'BOOLEAN_OPERATION', 'LINE', 'ELLIPSE', 'STAR', 'POLYGON', 'REGULAR_POLYGON'), true) ) {
+            return false;
+        }
+
+        $strokeStyles = $this->styleDeclarationBuilder->strokeStyles($node);
+        if ( empty($strokeStyles) ) {
+            return false;
+        }
+
+        foreach ( $strokeStyles as $style ) {
+            if ( str_starts_with($style, 'border-image:') ) {
+                return false;
+            }
+        }
+
+        return null !== $this->vectorSvgRenderer->supportedVectorSvg($node, $type, $parentNode);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    private function composedImageBackgroundStyles(array $node): array
+    {
+        $imageLayers = $this->paintStackResolver->nodeImagePaintLayers($node);
+        $fallbackPaths = ! empty($imageLayers)
+            ? array_map(static fn (array $layer): string => (string) $layer['path'], $imageLayers)
+            : array_values(array_filter(array($this->assetRegistry->resolveAndMarkNode($node))));
+
+        return $this->paintStackResolver->composedImageBackgroundStyles($node, $fallbackPaths);
+    }
+
+    /**
+     * @param array<int, string> $styles
+     * @param array<string, mixed> $box
+     * @return array<int, string>
+     */
+    private function scaleFullBleedImageCropStyles(array $styles, array $box): array
+    {
+        if ( ! isset($box['width']) || ! is_numeric($box['width']) || (float) $box['width'] <= 0.0 ) {
+            return $styles;
+        }
+
+        $sourceWidth = (float) $box['width'];
+        $scaled = array();
+        foreach ( $styles as $style ) {
+            if ( str_starts_with($style, 'background-size:') ) {
+                $scaled[] = $this->scaleFullBleedImageCropDeclaration($style, $sourceWidth, 'size');
+            } elseif ( str_starts_with($style, 'background-position:') ) {
+                $scaled[] = $this->scaleFullBleedImageCropDeclaration($style, $sourceWidth, 'position');
+            } else {
+                $scaled[] = $style;
+            }
+        }
+
+        return $scaled;
+    }
+
+    private function scaleFullBleedImageCropDeclaration(string $style, float $sourceWidth, string $kind): string
+    {
+        $parts = explode(':', $style, 2);
+        if ( 2 !== count($parts) ) {
+            return $style;
+        }
+
+        $scaledLayers = array();
+        foreach ( explode(',', $parts[1]) as $layer ) {
+            $tokens = preg_split('/\s+/', trim($layer));
+            if ( ! is_array($tokens) || 2 !== count($tokens) ) {
+                return $style;
+            }
+
+            $scaledTokens = array();
+            foreach ( $tokens as $token ) {
+                if ( 1 !== preg_match('/^-?\d+(?:\.\d+)?px$/', $token) ) {
+                    return $style;
+                }
+                $value = (float) substr($token, 0, -2);
+                if ( 'size' === $kind && $value <= 0.0 ) {
+                    return $style;
+                }
+                $scaledTokens[] = 'calc(100vw * ' . $this->formatter->number($value / $sourceWidth) . ')';
+            }
+            $scaledLayers[] = implode(' ', $scaledTokens);
+        }
+
+        return $parts[0] . ':' . implode(',', $scaledLayers);
+    }
+
+    private function blendModeCss(string $blendMode): ?string
+    {
+        return match ( strtoupper($blendMode) ) {
+            'MULTIPLY' => 'multiply',
+            'SCREEN' => 'screen',
+            'OVERLAY' => 'overlay',
+            'DARKEN' => 'darken',
+            'LIGHTEN' => 'lighten',
+            'COLOR_DODGE' => 'color-dodge',
+            'COLOR_BURN' => 'color-burn',
+            'HARD_LIGHT' => 'hard-light',
+            'SOFT_LIGHT' => 'soft-light',
+            'DIFFERENCE' => 'difference',
+            'EXCLUSION' => 'exclusion',
+            'HUE' => 'hue',
+            'SATURATION' => 'saturation',
+            'COLOR' => 'color',
+            'LUMINOSITY' => 'luminosity',
+            default => null,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add a session-owned typed `StaticHtmlVisualStyleResolver` for background, opacity, blend, radius, stroke, image paint, full-bleed crop, and effect declarations
- preserve declaration insertion order around transforms and text styles
- reuse the session's vector renderer, paint stack, asset registry, formatter, and focused declaration builder
- remove the corresponding visual policy and helper implementations from `StaticHtmlEmitter`, reducing it by 195 lines

Part of #1076. This is the first complete domain moved out of `styleDeclarations()`; layout geometry and text flow remain the next domains.

## Verification
- `cd figma-transformer && composer test`
- `composer validate --no-check-publish`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent CSS ordering, asset, vector, lifecycle, and compatibility review

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map the visual declaration domain, implement the typed resolver, audit CSS ordering and asset/vector behavior, and run compatibility verification. Chris Huber reviewed and remains responsible for the change.