### PR TITLE
Fix geometry-proven provider wrapper coalescing

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4585,7 +4585,9 @@ final class HtmlTransformer
             return $this->htmlPreservationBlock($element);
         }
 
-        if ( 'div' === $tagName && null !== $this->layoutGeometryProofFor($element) ) {
+        // Geometry proof may also cover provider custom-element shells. Keep
+        // semantic HTML elements outside this reduction boundary.
+        if ( ('div' === $tagName || str_contains($tagName, '-')) && null !== $this->layoutGeometryProofFor($element) ) {
             $proofBacked = $this->proofBackedWrapperCoalescing($element, $fallbacks);
             if ( null !== $proofBacked ) {
                 return $proofBacked;

--- a/php-transformer/tests/contract/layout-geometry-proof.php
+++ b/php-transformer/tests/contract/layout-geometry-proof.php
@@ -66,4 +66,29 @@ $deepProof = array('schema' => LayoutGeometryProof::SCHEMA, 'nodes' => array(
 $deep = (new ArtifactCompiler())->compile(array('entrypoint' => 'deep.html', 'files' => array('deep.html' => $deepHtml), 'layout_geometry_proof' => $deepProof))->toArray();
 $assert(1 === count($deep['source_reports']['layout_geometry_proof'] ?? array()) && !str_contains((string) ($deep['serialized_blocks'] ?? ''), '"kind":"layout"'), 'Explicit measured reductions take precedence over a coarse captured-media layout boundary.');
 
+$providerChain = '<main>' . str_repeat('<provider-frame>', 24) . '<img src="hero.jpg" alt="Copy">' . str_repeat('</provider-frame>', 24) . '</main>';
+$providerHash = hash('sha256', $providerChain);
+$providerSelectors = array();
+$providerSelector = 'main:nth-of-type(1)';
+for ($depth = 0; $depth < 24; ++$depth) {
+    $providerSelector .= ' > provider-frame:nth-of-type(1)';
+    $providerSelectors[] = $providerSelector;
+}
+$providerNodes = array();
+$providerReductions = array();
+foreach ($providerSelectors as $depth => $selector) {
+    $providerNodes[] = array('id' => 'provider-' . $depth, 'source_path' => 'provider.html', 'source_hash' => $providerHash, 'selector' => $selector, 'boxes' => $boxes());
+    $target = $providerSelectors[$depth + 1] ?? ($selector . ' > img:nth-of-type(1)');
+    $targetId = 'provider-target-' . $depth;
+    $providerNodes[] = array('id' => $targetId, 'source_path' => 'provider.html', 'source_hash' => $providerHash, 'selector' => $target, 'boxes' => $boxes());
+    $providerReductions[] = array('wrapper' => 'provider-' . $depth, 'target' => $targetId, 'invariants' => array('selectors' => true, 'runtime' => true, 'semantics' => true, 'viewports' => true), 'corrective_css' => array('declarations' => array()));
+}
+$provider = (new ArtifactCompiler())->compile(array('entrypoint' => 'provider.html', 'files' => array('provider.html' => $providerChain), 'layout_geometry_proof' => array('schema' => LayoutGeometryProof::SCHEMA, 'nodes' => $providerNodes, 'reductions' => $providerReductions)))->toArray();
+$providerDepth = static function (array $blocks, int $depth = 0) use (&$providerDepth): int {
+    $maximum = $depth;
+    foreach ($blocks as $block) $maximum = max($maximum, $providerDepth($block['innerBlocks'] ?? array(), $depth + 1));
+    return $maximum;
+};
+$assert('core/image' === ($provider['blocks'][0]['blockName'] ?? null) && $providerDepth($provider['blocks'] ?? array()) <= 20 && array() === ($provider['fallbacks'] ?? null) && 'pass' === ((new BlockValidityValidator())->validateBlocks($provider['blocks'] ?? array())['status'] ?? ''), 'Geometry-proven provider wrapper chains reduce below the unchanged editability depth limit with valid native blocks and no fallback.');
+
 fwrite(STDOUT, "Layout geometry proof contract passed\n");


### PR DESCRIPTION
Closes #1110

## Summary
- apply existing geometry-proof coalescing to custom-element provider wrappers
- retain semantic HTML wrapper boundaries
- prove a 24-layer provider chain becomes a valid native image with no fallback and depth within the unchanged editability limit

## Tests
- `php tests/contract/layout-geometry-proof.php`
- `php tests/unit/geometry-chain-coalescing.php`
- `php php-transformer/tests/contract/run.php`

AI assistance: OpenAI gpt-5.6-terra via OpenCode implemented and verified the focused generic reduction and contract coverage. Chris Huber remains responsible for every line.