### PR TITLE
Fix list navigation promotion with inert support children

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -105,6 +105,7 @@
       "php tests/unit/navigation-inline-margin-carry.php",
       "php tests/unit/navigation-source-provenance.php",
       "php tests/unit/navigation-dropped-anchors.php",
+      "php tests/unit/navigation-inert-support-children.php",
       "php tests/unit/button-signal-classifier.php",
       "php tests/unit/button-style-resolver.php",
       "php tests/unit/button-font-family-carry.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -5210,7 +5210,7 @@ final class HtmlTransformer
         }
 
         if ( 'nav' === $tagName ) {
-            $navigation = $this->recognizePatterns($element, $fallbacks, array(AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class), false);
+            $navigation = $this->recognizePatterns($element, $fallbacks, array(AccordionPattern::class, SocialLinksPattern::class, NavigationPattern::class));
             if ( null !== $navigation ) {
                 return $this->rememberAccordionDisclosureRoot($navigation, $element);
             }

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -703,6 +703,7 @@ final class NavigationPattern implements PatternRecognizerInterface
     private function navigationBlocks(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock, ?callable $isRuntimeDomTarget = null, bool $allowsDescriptiveChrome = false, ?callable $navigationUnderlineColor = null, bool $itemsAreVouched = false, ?callable $resolvedStyle = null, ?callable $navigationColorInteractionStates = null): array
     {
         $blocks = array();
+        $hasListBackedMenu = false;
         $allowsDescriptiveChrome = $allowsDescriptiveChrome || $this->hasSubmenuSignal($element);
         // A caller that has already established structurally that this element IS
         // the nav's link cluster vouches for its direct anchors. The class
@@ -720,6 +721,10 @@ final class NavigationPattern implements PatternRecognizerInterface
             }
 
             if ( XML_TEXT_NODE === $child->nodeType && '' === trim($child->textContent ?? '') ) {
+                continue;
+            }
+
+            if ( $child instanceof DOMElement && $hasListBackedMenu && $this->isInertNavigationSupportChild($child, $isRuntimeDomTarget, $resolvedStyle) ) {
                 continue;
             }
 
@@ -748,6 +753,7 @@ final class NavigationPattern implements PatternRecognizerInterface
                     return array();
                 }
                 $blocks = array_merge($blocks, $listBlocks);
+                $hasListBackedMenu = true;
                 continue;
             }
 
@@ -779,6 +785,38 @@ final class NavigationPattern implements PatternRecognizerInterface
         }
 
         return $blocks;
+    }
+
+    /**
+     * A list-backed menu can carry direct support nodes that have no rendered
+     * menu meaning. Limit this exception to a recognized list so visible or
+     * ambiguous siblings still reject the navigation conversion.
+     */
+    private function isInertNavigationSupportChild(DOMElement $element, ?callable $isRuntimeDomTarget, ?callable $resolvedStyle): bool
+    {
+        if ( $element->hasAttribute('hidden') || $element->hasAttribute('inert') || 'true' === strtolower(trim($this->attr($element, 'aria-hidden'))) ) {
+            return true;
+        }
+
+        if ( null !== $isRuntimeDomTarget
+            && $isRuntimeDomTarget($element)
+            && '' === trim($element->textContent ?? '')
+            && 0 === $element->childElementCount
+        ) {
+            return true;
+        }
+
+        if ( null === $resolvedStyle ) {
+            return false;
+        }
+
+        $style = strtolower((string) $resolvedStyle($element));
+        return 1 === preg_match('/(?:^|;)\s*(?:display\s*:\s*none|visibility\s*:\s*hidden)\s*(?:!important)?\s*(?:;|$)/', $style)
+            || (
+                1 === preg_match('/(?:^|;)\s*position\s*:\s*(?:absolute|fixed)\s*(?:!important)?\s*(?:;|$)/', $style)
+                && 1 === preg_match('/(?:^|;)\s*overflow\s*:\s*hidden\s*(?:!important)?\s*(?:;|$)/', $style)
+                && 1 === preg_match('/(?:^|;)\s*clip(?:-path)?\s*:/', $style)
+            );
     }
 
     /**

--- a/php-transformer/tests/unit/navigation-inert-support-children.php
+++ b/php-transformer/tests/unit/navigation-inert-support-children.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$failures = 0;
+$passes = 0;
+
+$assert = static function (bool $condition, string $message, string $detail = ''): void {
+    global $failures, $passes;
+    if ( $condition ) {
+        ++$passes;
+        return;
+    }
+
+    ++$failures;
+    fwrite(STDERR, 'FAIL: ' . $message . ('' !== $detail ? ' - ' . $detail : '') . PHP_EOL);
+};
+
+$menu = '<ul><li><a href="/about">About</a></li><li><a href="/contact">Contact</a></li></ul>';
+$result = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary">' . $menu
+    . '<span style="position:absolute;overflow:hidden;clip:rect(0 0 0 0)">Primary navigation</span><div id="navigation-runtime"></div></nav>',
+    array( 'runtime_dom_selectors' => array( '#navigation-runtime' ) )
+)->toArray();
+$markup = (string) ($result['serialized_blocks'] ?? '');
+
+$assert(1 === substr_count($markup, '<!-- wp:navigation '), 'a recognized list menu promotes to one core/navigation block', $markup);
+$assert(str_contains($markup, '"url":"/about"') && str_contains($markup, '"url":"/contact"'), 'promoted navigation retains every list destination', $markup);
+$assert('pass' === ($result['source_reports']['semantic_parity']['status'] ?? ''), 'inert support children retain semantic navigation parity', json_encode($result['source_reports']['semantic_parity'] ?? array()));
+$assert('pass' === ($result['source_reports']['wp_block_validity']['status'] ?? ''), 'promoted navigation remains Gutenberg-valid', json_encode($result['source_reports']['wp_block_validity'] ?? array()));
+
+$visible = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary">' . $menu . '<span>Menu updated daily</span></nav>'
+)->toArray();
+$visibleMarkup = (string) ($visible['serialized_blocks'] ?? '');
+$assert(! str_contains($visibleMarkup, '<!-- wp:navigation '), 'visible non-menu siblings still reject navigation promotion', $visibleMarkup);
+
+$leadingSupport = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary"><span hidden>Primary navigation</span>' . $menu . '</nav>'
+)->toArray();
+$leadingSupportMarkup = (string) ($leadingSupport['serialized_blocks'] ?? '');
+$assert(! str_contains($leadingSupportMarkup, '<!-- wp:navigation '), 'support children before a recognized list do not promote navigation', $leadingSupportMarkup);
+
+if ( $failures > 0 ) {
+    fwrite(STDERR, "Navigation inert support children contract: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+
+echo "Navigation inert support children contract passed: {$passes} assertions\n";


### PR DESCRIPTION
## Summary
- Promote a recognized list-backed navigation past direct, provably inert support children.
- Retain rejection for visible siblings and support nodes that precede the menu.
- Preserve navigation semantic-parity and Gutenberg-validity evidence.

## Testing
- php tests/unit/navigation-inert-support-children.php
- Focused navigation unit contracts
- php php-transformer/tests/contract/run.php

AI assistance: OpenAI gpt-5.6-sol via OpenCode implemented the fix, regression tests, and verification. Chris Huber reviewed and remains responsible for this change.