### PR TITLE
Extract Figma text declaration policy

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmissionSession.php
+++ b/figma-transformer/src/Html/StaticHtmlEmissionSession.php
@@ -34,7 +34,8 @@ final class StaticHtmlEmissionSession
         $this->assetRegistry = new StaticHtmlAssetRegistry($formatter);
         $this->typographyState = new StaticHtmlTypographyState();
         $this->decisionTraceState = new StaticHtmlDecisionTraceState();
-        $this->textStyleDeclarationResolver = new TextStyleDeclarationResolver($typographyModel, $formatter, $this->typographyState);
+        $this->textSizingResolver = new StaticHtmlTextSizingResolver($nodeInspector);
+        $this->textStyleDeclarationResolver = new TextStyleDeclarationResolver($typographyModel, $formatter, $this->typographyState, $this->textSizingResolver);
         $this->paintStackResolver = new PaintStackResolver($this->assetRegistry, $formatter);
         $this->styleDeclarationBuilder = new StyleDeclarationBuilder($formatter, $this->paintStackResolver);
         $this->childLayerCompositionResolver = new ChildLayerCompositionResolver($this->assetRegistry, $formatter);
@@ -48,7 +49,6 @@ final class StaticHtmlEmissionSession
             $this->paintStackResolver,
             $this->assetRegistry,
         );
-        $this->textSizingResolver = new StaticHtmlTextSizingResolver($nodeInspector);
         $this->textWrappingResolver = new StaticHtmlTextWrappingResolver();
     }
 

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -1075,7 +1075,7 @@ final class StaticHtmlEmitter
             array_push($styles, ...$buttonLayerComposition['styles']);
         }
         $styles = $this->stickyLayoutCoordinator()->stickyAwareStyleDeclarations($node, $styles);
-        if ( 'p' === $tag && $this->hasBodyTextNameIntent(strtolower($name)) && ! $this->hasExplicitUppercaseTextCase($node) ) {
+        if ( 'p' === $tag && $this->hasBodyTextNameIntent(strtolower($name)) && ! $this->textStyleDeclarationResolver()->hasExplicitUppercaseTextCase($node) ) {
             $styles = array_values(array_filter($styles, static fn (string $style): bool => 'text-transform:uppercase' !== $style));
         }
         if ( ! empty($styles) ) {
@@ -1088,10 +1088,10 @@ final class StaticHtmlEmitter
             }
             $this->staticHtmlCssRuleSet()->rememberNodeReadableName($className, $name, $type);
         }
-        if ( $this->isSemanticListItemBodyText($node, $parentNode, $grandParentNode) && $this->textContainsLowercase($this->rawDecodedText($node)) && ! $this->hasExplicitUppercaseTextCase($node) ) {
+        if ( $this->isSemanticListItemBodyText($node, $parentNode, $grandParentNode) && $this->textStyleDeclarationResolver()->containsLowercase($this->rawDecodedText($node)) && ! $this->textStyleDeclarationResolver()->hasExplicitUppercaseTextCase($node) ) {
             $parentClassName = 'figma-node-' . $this->slug((string) ($parentNode['id'] ?? '') . '-' . (string) ($parentNode['name'] ?? 'Node'));
             $cssRules[] = '.' . $parentClassName . '>.' . $className . '{text-transform:none}';
-        } elseif ( 'p' === $tag && $this->hasBodyTextNameIntent(strtolower($name)) && ! $this->hasExplicitUppercaseTextCase($node) ) {
+        } elseif ( 'p' === $tag && $this->hasBodyTextNameIntent(strtolower($name)) && ! $this->textStyleDeclarationResolver()->hasExplicitUppercaseTextCase($node) ) {
             $cssRules[] = 'ol .' . $className . ',ul .' . $className . '{text-transform:none}';
         }
         if ( in_array($tag, array('ol', 'ul'), true) && $this->listShouldRenderMarkers($node, null !== $sourceTextList) && ! $this->isChromeListContext($node, $parentNode, $grandParentNode) ) {
@@ -8635,35 +8635,20 @@ final class StaticHtmlEmitter
     {
         $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
         $style = is_array($text['style'] ?? null) ? $text['style'] : array();
-        if ( $this->isSemanticListItemBodyText($node, $parentNode, $grandParentNode) && $this->textStyleHasUnprovenUppercaseTransform($node, $style) ) {
-            unset($style['text_transform']);
-        }
+        $fallbackColor = null;
         if ( ! isset($style['color']) ) {
             $paints = is_array($node['figma_paints']['fills'] ?? null) ? $node['figma_paints']['fills'] : array();
-            $color = $this->firstSolidPaint($paints);
-            if ( null !== $color ) {
-                $style['css_color'] = $color;
-            }
+            $fallbackColor = $this->firstSolidPaint($paints);
         }
 
-        $styles = $this->textStyleDeclarations($style);
-        $derivedLineHeight = $this->emissionSession->textSizingResolver()->derivedBaselineLineHeight($text);
-        if ( null !== $derivedLineHeight && 0.0 < $derivedLineHeight ) {
-            $styles = array_values(array_filter(
-                $styles,
-                static fn (string $style): bool => ! str_starts_with($style, 'line-height:')
-            ));
-            $styles[] = 'line-height:' . $this->number($derivedLineHeight) . 'px';
-        }
-        if ( $this->textShouldPreserveChromeSpacing($node, $parentNode, $grandParentNode) ) {
-            $styles[] = 'white-space:pre-wrap';
-        } elseif ( $this->textHasLineBreaks($node) && ! $this->shouldSplitParagraphs($node) ) {
-            $styles[] = 'white-space:pre-line';
-        } elseif ( $this->textIsAtomicSingleLineLabel($node, $text) ) {
-            $styles[] = 'white-space:nowrap';
-        }
-
-        return $styles;
+        return $this->textStyleDeclarationResolver()->nodeDeclarations(
+            $node,
+            $fallbackColor,
+            $this->isSemanticListItemBodyText($node, $parentNode, $grandParentNode),
+            $this->textShouldPreserveChromeSpacing($node, $parentNode, $grandParentNode),
+            $this->shouldSplitParagraphs($node),
+            $this->textIsAtomicSingleLineLabel($node, $text),
+        );
     }
 
     /**
@@ -8694,41 +8679,6 @@ final class StaticHtmlEmitter
         return isset($node['characters']) && is_scalar($node['characters']) && '' !== trim((string) $node['characters']);
     }
 
-    /**
-     * @param array<string, mixed> $node
-     * @param array<string, mixed> $style
-     */
-    private function textStyleHasUnprovenUppercaseTransform(array $node, array $style): bool
-    {
-        if ( 'uppercase' !== strtolower((string) ($style['text_transform'] ?? '')) ) {
-            return false;
-        }
-
-        if ( ! $this->textContainsLowercase($this->rawDecodedText($node)) ) {
-            return false;
-        }
-
-        return ! $this->hasExplicitUppercaseTextCase($node);
-    }
-
-    /** @param array<string, mixed> $source */
-    private function hasExplicitUppercaseTextCase(array $source): bool
-    {
-        foreach ( array('textCase', 'text_case') as $key ) {
-            if ( isset($source[$key]) && is_scalar($source[$key]) && 'UPPER' === strtoupper((string) $source[$key]) ) {
-                return true;
-            }
-        }
-
-        foreach ( array('style', 'textData', 'derivedTextData') as $key ) {
-            if ( is_array($source[$key] ?? null) && $this->hasExplicitUppercaseTextCase($source[$key]) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private function hasBodyTextNameIntent(string $lowerName): bool
     {
         foreach ( array('paragraph', 'body', 'supporting text', 'caption', 'description', 'excerpt', 'copy') as $needle ) {
@@ -8738,11 +8688,6 @@ final class StaticHtmlEmitter
         }
 
         return false;
-    }
-
-    private function textContainsLowercase(string $text): bool
-    {
-        return 1 === preg_match('/\p{Ll}/u', $text);
     }
 
     /**

--- a/figma-transformer/src/Html/TextStyleDeclarationResolver.php
+++ b/figma-transformer/src/Html/TextStyleDeclarationResolver.php
@@ -13,7 +13,107 @@ final class TextStyleDeclarationResolver
         private readonly TypographyModel $typographyModel,
         private readonly StaticHtmlValueFormatter $formatter,
         private readonly StaticHtmlTypographyState $typographyState,
+        private readonly StaticHtmlTextSizingResolver $textSizingResolver,
     ) {
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @return array<int, string>
+     */
+    public function nodeDeclarations(
+        array $node,
+        ?string $fallbackColor,
+        bool $semanticListItemBodyText,
+        bool $preserveChromeSpacing,
+        bool $splitParagraphs,
+        bool $atomicSingleLineLabel
+    ): array {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $style = is_array($text['style'] ?? null) ? $text['style'] : array();
+        if ( $semanticListItemBodyText && $this->hasUnprovenUppercaseTransform($node, $style) ) {
+            unset($style['text_transform']);
+        }
+        if ( ! isset($style['color']) && null !== $fallbackColor ) {
+            $style['css_color'] = $fallbackColor;
+        }
+
+        $styles = $this->declarations($style);
+        $derivedLineHeight = $this->textSizingResolver->derivedBaselineLineHeight($text);
+        if ( null !== $derivedLineHeight && 0.0 < $derivedLineHeight ) {
+            $styles = array_values(array_filter(
+                $styles,
+                static fn (string $style): bool => ! str_starts_with($style, 'line-height:')
+            ));
+            $styles[] = 'line-height:' . $this->formatter->number($derivedLineHeight) . 'px';
+        }
+        if ( $preserveChromeSpacing ) {
+            $styles[] = 'white-space:pre-wrap';
+        } elseif ( $this->textSizingResolver->hasLineBreaks($node) && ! $splitParagraphs ) {
+            $styles[] = 'white-space:pre-line';
+        } elseif ( $atomicSingleLineLabel ) {
+            $styles[] = 'white-space:nowrap';
+        }
+
+        return $styles;
+    }
+
+    /** @param array<string, mixed> $source */
+    public function hasExplicitUppercaseTextCase(array $source): bool
+    {
+        foreach ( array('textCase', 'text_case') as $key ) {
+            if ( isset($source[$key]) && is_scalar($source[$key]) && 'UPPER' === strtoupper((string) $source[$key]) ) {
+                return true;
+            }
+        }
+
+        foreach ( array('style', 'textData', 'derivedTextData') as $key ) {
+            if ( is_array($source[$key] ?? null) && $this->hasExplicitUppercaseTextCase($source[$key]) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function containsLowercase(string $text): bool
+    {
+        return 1 === preg_match('/\p{Ll}/u', $text);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $style
+     */
+    private function hasUnprovenUppercaseTransform(array $node, array $style): bool
+    {
+        return 'uppercase' === strtolower((string) ($style['text_transform'] ?? ''))
+            && $this->containsLowercase($this->rawDecodedText($node))
+            && ! $this->hasExplicitUppercaseTextCase($node);
+    }
+
+    /** @param array<string, mixed> $node */
+    private function rawDecodedText(array $node): string
+    {
+        $text = is_array($node['figma_text'] ?? null) ? $node['figma_text'] : array();
+        $segments = is_array($text['segments'] ?? null) ? $text['segments'] : array();
+        if ( ! empty($segments) ) {
+            $content = '';
+            foreach ( $segments as $segment ) {
+                if ( is_array($segment) && isset($segment['characters']) && is_scalar($segment['characters']) ) {
+                    $content .= (string) $segment['characters'];
+                }
+            }
+            if ( '' !== $content ) {
+                return $content;
+            }
+        }
+
+        if ( isset($text['characters']) && is_scalar($text['characters']) ) {
+            return (string) $text['characters'];
+        }
+
+        return (string) ($node['characters'] ?? $node['text'] ?? '');
     }
 
     /**


### PR DESCRIPTION
## Summary
- extend the session-owned text declaration resolver with node-level typography classification
- centralize fallback fill color, uppercase evidence, derived line-height replacement, and white-space precedence
- retain semantic list, footer chrome, paragraph splitting, and atomic-label facts as explicit typed inputs
- keep inline segment declarations on the existing normalized-style path
- remove 70 lines of declaration policy from `StaticHtmlEmitter` without adding callbacks

Part of #1076.

## Verification
- `cd figma-transformer && composer test`
- `composer validate --no-check-publish`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent declaration-order, uppercase, lifecycle, and coverage review

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map the typography dependency boundary, implement the resolver extraction, review behavior and architecture compatibility, and run verification. Chris Huber reviewed and remains responsible for the change.