### PR TITLE
Require visual proof for inert navigation siblings

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -788,16 +788,13 @@ final class NavigationPattern implements PatternRecognizerInterface
     }
 
     /**
-     * A list-backed menu can carry direct support nodes that have no rendered
-     * menu meaning. Limit this exception to a recognized list so visible or
-     * ambiguous siblings still reject the navigation conversion.
+     * A list-backed menu can carry direct support nodes that cannot render.
+     * Attribute-only accessibility and interaction state is insufficient:
+     * authors can keep aria-hidden or inert content visible. Limit this
+     * exception to a recognized list and structural or presentation proof.
      */
     private function isInertNavigationSupportChild(DOMElement $element, ?callable $isRuntimeDomTarget, ?callable $resolvedStyle): bool
     {
-        if ( $element->hasAttribute('hidden') || $element->hasAttribute('inert') || 'true' === strtolower(trim($this->attr($element, 'aria-hidden'))) ) {
-            return true;
-        }
-
         if ( null !== $isRuntimeDomTarget
             && $isRuntimeDomTarget($element)
             && '' === trim($element->textContent ?? '')

--- a/php-transformer/tests/unit/navigation-inert-support-children.php
+++ b/php-transformer/tests/unit/navigation-inert-support-children.php
@@ -38,11 +38,23 @@ $visible = ( new HtmlTransformer() )->transform(
 $visibleMarkup = (string) ($visible['serialized_blocks'] ?? '');
 $assert(! str_contains($visibleMarkup, '<!-- wp:navigation '), 'visible non-menu siblings still reject navigation promotion', $visibleMarkup);
 
-$leadingSupport = ( new HtmlTransformer() )->transform(
-    '<nav aria-label="Primary"><span hidden>Primary navigation</span>' . $menu . '</nav>'
+$visibleAriaHidden = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary">' . $menu . '<span aria-hidden="true">Menu updated daily</span></nav>'
 )->toArray();
-$leadingSupportMarkup = (string) ($leadingSupport['serialized_blocks'] ?? '');
-$assert(! str_contains($leadingSupportMarkup, '<!-- wp:navigation '), 'support children before a recognized list do not promote navigation', $leadingSupportMarkup);
+$visibleAriaHiddenMarkup = (string) ($visibleAriaHidden['serialized_blocks'] ?? '');
+$assert(! str_contains($visibleAriaHiddenMarkup, '<!-- wp:navigation '), 'visible aria-hidden siblings still reject navigation promotion', $visibleAriaHiddenMarkup);
+
+$visibleInert = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary">' . $menu . '<span inert>Menu updated daily</span></nav>'
+)->toArray();
+$visibleInertMarkup = (string) ($visibleInert['serialized_blocks'] ?? '');
+$assert(! str_contains($visibleInertMarkup, '<!-- wp:navigation '), 'visible inert siblings still reject navigation promotion', $visibleInertMarkup);
+
+$presentationHidden = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary">' . $menu . '<span aria-hidden="true" style="display:none">Primary navigation</span><span inert style="visibility:hidden">Menu support</span></nav>'
+)->toArray();
+$presentationHiddenMarkup = (string) ($presentationHidden['serialized_blocks'] ?? '');
+$assert(1 === substr_count($presentationHiddenMarkup, '<!-- wp:navigation '), 'presentation-hidden aria and inert support children promote navigation', $presentationHiddenMarkup);
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Navigation inert support children contract: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
Fixes #1135.

## Summary
- Require structural or resolved-presentation evidence before ignoring direct support children after a list-backed menu.
- Preserve visible aria-hidden and inert siblings through the existing non-promotion path.
- Retain promotion for visually hidden support text and empty declared runtime mounts.

## Testing
- php tests/unit/navigation-inert-support-children.php
- Focused navigation unit contracts
- php php-transformer/tests/contract/run.php

AI assistance: OpenAI gpt-5.6-terra via OpenCode implemented the corrective change, regression coverage, and verification. Chris Huber reviewed and remains responsible for this change.