### PR TITLE
Preserve styled custom video hosts

### DIFF
--- a/php-transformer/.gitignore
+++ b/php-transformer/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /vendor/
+/var/

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4738,9 +4738,11 @@ final class HtmlTransformer
             );
         }
 
-        $customVideo = $this->videoOnlyCustomElement($element);
+        $customVideo = $this->customVideoElement($element);
         if ( $customVideo instanceof DOMElement ) {
-            return $this->convertMediaElement($customVideo);
+            return $this->hasTransparentCustomVideoHostPresentation($element)
+                ? $this->convertMediaElement($customVideo)
+                : $this->responsiveMediaBlock($element);
         }
 
         $mediaDispatch = $this->convertMediaDispatchElement($element, $tagName, $fallbacks);
@@ -15210,7 +15212,7 @@ final class HtmlTransformer
         return $images->item(0);
     }
 
-    private function videoOnlyCustomElement(DOMElement $element): ?DOMElement
+    private function customVideoElement(DOMElement $element): ?DOMElement
     {
         if ( ! str_contains($element->tagName, '-') || '' !== trim($element->textContent ?? '') || ! $this->isSafeTransparentCustomElement($element) ) {
             return null;
@@ -15228,6 +15230,24 @@ final class HtmlTransformer
         }
 
         return $videos->item(0);
+    }
+
+    private function hasTransparentCustomVideoHostPresentation(DOMElement $element): bool
+    {
+        // Flattening the host drops its box. A class, id, inline declaration, or
+        // matched author rule means that box may carry presentation we cannot
+        // faithfully move onto core/video.
+        if ( '' !== $this->attr($element, 'class') || '' !== $this->attr($element, 'id') || '' !== $this->attr($element, 'style') || array() !== $this->structuralPresentationDeclarations($element) ) {
+            return false;
+        }
+
+        foreach ( $this->styleRuleCandidates($element, 'static-conditional') as $rule ) {
+            if ( $this->matchesCssSelector($element, $rule['selector']) && array() !== ($rule['declarations'] ?? array()) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /** @return array<int, array<string, mixed>> */

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -79,14 +79,21 @@ $assert(
     str_contains($videoResult['blocks'][0]['innerHTML'] ?? '', '<video src="hero.mp4" autoplay="autoplay" loop="loop" muted="muted" playsinline="playsinline"></video>'),
     'video playback attributes should be preserved in native save markup'
 );
-$customVideoResult = ( new HtmlTransformer() )->transform('<wix-video><video src="hero.mp4" poster="hero.jpg" controls autoplay loop muted playsinline><track kind="captions" src="captions.vtt" srclang="en" label="English" default></video></wix-video>')->toArray();
+$coffeeFestivalVideoResult = ( new HtmlTransformer() )->transform('<wix-video><video src="hero.mp4" poster="hero.jpg" controls autoplay loop muted playsinline><track kind="captions" src="captions.vtt" srclang="en" label="English" default></video></wix-video>')->toArray();
 $assert(
-    'core/video' === ($customVideoResult['blocks'][0]['blockName'] ?? null)
-        && 'hero.jpg' === ($customVideoResult['blocks'][0]['attrs']['poster'] ?? null)
-        && array(array( 'kind' => 'captions', 'src' => 'captions.vtt', 'srcLang' => 'en', 'label' => 'English', 'default' => true )) === ($customVideoResult['blocks'][0]['attrs']['tracks'] ?? null)
-        && str_contains((string) ($customVideoResult['serialized_blocks'] ?? ''), '<track kind="captions" src="captions.vtt" srclang="en" label="English" default="default">')
-        && array() === ($customVideoResult['fallbacks'] ?? array()),
-    'custom media hosts with one native video lower to editable core/video markup'
+    'core/video' === ($coffeeFestivalVideoResult['blocks'][0]['blockName'] ?? null)
+        && 'hero.jpg' === ($coffeeFestivalVideoResult['blocks'][0]['attrs']['poster'] ?? null)
+        && array(array( 'kind' => 'captions', 'src' => 'captions.vtt', 'srcLang' => 'en', 'label' => 'English', 'default' => true )) === ($coffeeFestivalVideoResult['blocks'][0]['attrs']['tracks'] ?? null)
+        && str_contains((string) ($coffeeFestivalVideoResult['serialized_blocks'] ?? ''), '<track kind="captions" src="captions.vtt" srclang="en" label="English" default="default">')
+        && array() === ($coffeeFestivalVideoResult['fallbacks'] ?? array()),
+    'the presentation-transparent Coffee Festival custom video lowers to editable core/video markup'
+);
+$styledCustomVideoResult = ( new HtmlTransformer() )->transform('<wix-video style="display:block;width:320px;overflow:hidden;transform:scale(.9);border:1px solid red"><video src="hero.mp4"></video></wix-video>')->toArray();
+$assert(
+    'custom/responsive-media' === ($styledCustomVideoResult['blocks'][0]['blockName'] ?? null)
+        && str_contains((string) ($styledCustomVideoResult['blocks'][0]['attrs']['content'] ?? ''), 'style="display:block;width:320px;overflow:hidden;transform:scale(.9);border:1px solid red"')
+        && ! str_contains((string) ($styledCustomVideoResult['serialized_blocks'] ?? ''), '<!-- wp:html'),
+    'styled custom video hosts preserve presentation in a typed gap instead of lowering to core/video'
 );
 $ambiguousCustomVideoResult = ( new HtmlTransformer() )->transform('<wix-video><video src="hero.mp4"></video><video src="trailer.mp4"></video></wix-video>')->toArray();
 $assert(


### PR DESCRIPTION
## Summary
- lower only presentation-transparent custom video hosts to `core/video`
- preserve styled hosts in the editable typed responsive-media companion
- add Coffee Festival and styled-host regression coverage

Closes #1136
Follow-up to #1107 and merged PR #1128.

## Tests
- `composer test:canonical`

AI assistance: OpenAI gpt-5.6-terra via OpenCode implemented the transformer change and contract coverage; Chris Huber remains responsible for the change.