### PR TITLE
Extract Figma reserve-height geometry

### DIFF
--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -6510,7 +6510,7 @@ final class StaticHtmlEmitter
             }
         }
 
-        $absoluteChildReserveHeightDecision = $this->absoluteChildReserveHeightDecision($node);
+        $absoluteChildReserveHeightDecision = $this->visualGeometryResolver()->absoluteChildReserveHeightDecision($node);
         $absoluteChildReserveHeight = is_array($absoluteChildReserveHeightDecision) && isset($absoluteChildReserveHeightDecision['height']) && is_numeric($absoluteChildReserveHeightDecision['height']) ? (float) $absoluteChildReserveHeightDecision['height'] : null;
         if ( null !== $absoluteChildReserveHeight && ! $this->stylesDeclareProperty($styles, 'min-height') ) {
             $layoutMinHeight = isset($layout['min_height']) && is_numeric($layout['min_height']) ? (float) $layout['min_height'] : null;
@@ -7343,78 +7343,6 @@ final class StaticHtmlEmitter
     /**
      * @param array<string, mixed> $node
      */
-    private function absoluteChildReserveHeightDecision(array $node): ?array
-    {
-        $children = $this->nodeList($node);
-        if ( empty($children) || (! $this->isFreeformContainer($node) && ! $this->hasAbsoluteChild($node) && ! $this->hasDecorativeFlexUnderlayChild($node)) ) {
-            return null;
-        }
-
-        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
-        $parentHeight = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
-        $maxBottom = null;
-        $contributingChildren = 0;
-        $childEvidence = array();
-        foreach ( $children as $child ) {
-            if ( ! is_array($child) ) {
-                continue;
-            }
-
-            $layout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
-            if ( ! $this->isFreeformContainer($node) && 'absolute' !== ($layout['positioning'] ?? null) && ! $this->isDecorativeFlexUnderlay($child, $node) ) {
-                continue;
-            }
-
-            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
-            if ( ! isset($childBox['height']) || ! is_numeric($childBox['height']) ) {
-                continue;
-            }
-
-            $top = $this->positionOffset($childBox, $box, 'y');
-            if ( null === $top ) {
-                continue;
-            }
-            if ( $top < -0.5 ) {
-                return null;
-            }
-
-            $visualBoundsEvidence = $this->visualGeometryResolver()->childVisualBoundsEvidenceInParent($child, $node);
-            $visualBounds = is_array($visualBoundsEvidence['transformed_visual_box'] ?? null) ? $visualBoundsEvidence['transformed_visual_box'] : array();
-            if ( isset($visualBounds['y'], $visualBounds['height']) && is_numeric($visualBounds['y']) && is_numeric($visualBounds['height']) ) {
-                $top = (float) $visualBounds['y'];
-                $bottom = $top + (float) $visualBounds['height'];
-            } else {
-                $bottom = $top + (float) $childBox['height'];
-            }
-            if ( $top < -0.5 ) {
-                return null;
-            }
-            if ( null !== $parentHeight && $bottom > $parentHeight + 0.5 && ! $this->isFooterChromeNode($node, null, 1) ) {
-                return null;
-            }
-            $maxBottom = null === $maxBottom ? $bottom : max($maxBottom, $bottom);
-            $contributingChildren++;
-            $visualBoundsEvidence['reserve_top'] = $top;
-            $visualBoundsEvidence['reserve_bottom'] = $bottom;
-            $childEvidence[] = $visualBoundsEvidence;
-        }
-
-        if ( $contributingChildren <= 1 || null === $maxBottom || $maxBottom <= 0.0 ) {
-            return null;
-        }
-        if ( null !== $parentHeight && abs($parentHeight - $maxBottom) > 0.5 && ! $this->isFooterChromeNode($node, null, 1) ) {
-            return null;
-        }
-
-        return array(
-            'height' => $maxBottom,
-            'children' => $childEvidence,
-        );
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
     private function isNearZeroHeightContainer(array $node, string $type): bool
     {
         if ( ! in_array($type, array('FRAME', 'GROUP', 'COMPONENT', 'INSTANCE'), true) || empty($this->nodeList($node)) ) {
@@ -7441,14 +7369,6 @@ final class StaticHtmlEmitter
     private function positionOffset(array $box, array $parentBox, string $dimension, ?array $parentNode = null): ?float
     {
         return $this->layoutIntentClassifier()->positionOffset($box, $parentBox, $dimension, $parentNode);
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function hasAbsoluteChild(array $node): bool
-    {
-        return $this->layoutIntentClassifier()->hasAbsoluteChild($node);
     }
 
     /**

--- a/figma-transformer/src/Html/VisualGeometryResolver.php
+++ b/figma-transformer/src/Html/VisualGeometryResolver.php
@@ -131,6 +131,88 @@ final class VisualGeometryResolver
 
     /**
      * @param array<string, mixed> $node
+     * @return array{height: float, children: array<int, array<string, mixed>>}|null
+     */
+    public function absoluteChildReserveHeightDecision(array $node): ?array
+    {
+        $children = is_array($node['nodes'] ?? null)
+            ? array_values($node['nodes'])
+            : (is_array($node['children'] ?? null) ? array_values($node['children']) : array());
+        $isFreeform = $this->layoutIntentClassifier->isFreeformContainer($node);
+        if ( empty($children) || (! $isFreeform && ! $this->layoutIntentClassifier->hasAbsoluteChild($node) && ! $this->layoutIntentClassifier->hasDecorativeFlexUnderlayChild($node)) ) {
+            return null;
+        }
+
+        $box = is_array($node['box'] ?? null) ? $node['box'] : array();
+        $parentHeight = isset($box['height']) && is_numeric($box['height']) ? (float) $box['height'] : null;
+        $maxBottom = null;
+        $contributingChildren = 0;
+        $childEvidence = array();
+        foreach ( $children as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+
+            $layout = is_array($child['layout'] ?? null) ? $child['layout'] : array();
+            if ( ! $isFreeform && 'absolute' !== ($layout['positioning'] ?? null) && ! $this->layoutIntentClassifier->isDecorativeFlexUnderlay($child, $node) ) {
+                continue;
+            }
+
+            $childBox = is_array($child['box'] ?? null) ? $child['box'] : array();
+            if ( ! isset($childBox['height']) || ! is_numeric($childBox['height']) ) {
+                continue;
+            }
+
+            $top = $this->layoutIntentClassifier->positionOffset($childBox, $box, 'y');
+            if ( null === $top ) {
+                continue;
+            }
+            if ( $top < -0.5 ) {
+                return null;
+            }
+
+            $visualBoundsEvidence = $this->childVisualBoundsEvidenceInParent($child, $node);
+            $visualBounds = is_array($visualBoundsEvidence['transformed_visual_box'] ?? null) ? $visualBoundsEvidence['transformed_visual_box'] : array();
+            if ( isset($visualBounds['y'], $visualBounds['height']) && is_numeric($visualBounds['y']) && is_numeric($visualBounds['height']) ) {
+                $top = (float) $visualBounds['y'];
+                $bottom = $top + (float) $visualBounds['height'];
+            } else {
+                $bottom = $top + (float) $childBox['height'];
+            }
+            if ( $top < -0.5 ) {
+                return null;
+            }
+            if ( null !== $parentHeight && $bottom > $parentHeight + 0.5 && ! $this->isFooterChromeNode($node) ) {
+                return null;
+            }
+            $maxBottom = null === $maxBottom ? $bottom : max($maxBottom, $bottom);
+            ++$contributingChildren;
+            $visualBoundsEvidence['reserve_top'] = $top;
+            $visualBoundsEvidence['reserve_bottom'] = $bottom;
+            $childEvidence[] = $visualBoundsEvidence;
+        }
+
+        if ( $contributingChildren <= 1 || null === $maxBottom || $maxBottom <= 0.0 ) {
+            return null;
+        }
+        if ( null !== $parentHeight && abs($parentHeight - $maxBottom) > 0.5 && ! $this->isFooterChromeNode($node) ) {
+            return null;
+        }
+
+        return array(
+            'height' => $maxBottom,
+            'children' => $childEvidence,
+        );
+    }
+
+    /** @param array<string, mixed> $node */
+    private function isFooterChromeNode(array $node): bool
+    {
+        return LayoutIntentClassifier::CHROME_GROUP_ROLE_FOOTER === $this->layoutIntentClassifier->chromeGroupRole($node, null, 1);
+    }
+
+    /**
+     * @param array<string, mixed> $node
      */
     public function isHorizontallyReflected(array $node): bool
     {


### PR DESCRIPTION
## Summary
- move absolute-child reserve-height inference into `VisualGeometryResolver`
- keep transformed visual bounds, source offsets, clipping tolerances, footer exceptions, and child evidence in one typed geometry domain
- retain emission and decision tracing as consumers of the resolver decision
- remove the obsolete emitter proxy and 81 lines from `StaticHtmlEmitter`
- add no callbacks or constructor dependencies

Part of #1076.

## Verification
- `cd figma-transformer && composer test`
- `composer validate --no-check-publish`
- PHP syntax checks for every changed PHP file
- `git diff --check`
- independent geometry, tolerance, evidence, trace, and architecture review

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to map the geometry boundary, implement the typed resolver extraction, review behavior and evidence compatibility, and run verification. Chris Huber reviewed and remains responsible for the change.