### PR TITLE
Fix projected empty group depth

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -7657,6 +7657,7 @@ final class HtmlTransformer
         }
 
         $branchEndpoint = false;
+        $emptyEndpoint = false;
         $cursorChildren = is_array($cursor['innerBlocks'] ?? null) ? $cursor['innerBlocks'] : array();
         if ('core/group' === ($cursor['blockName'] ?? null)
             && 1 < count($cursorChildren)
@@ -7669,6 +7670,17 @@ final class HtmlTransformer
             $terminal = array();
             $terminalIsShell = false;
             $branchEndpoint = true;
+        } elseif ('core/group' === ($cursor['blockName'] ?? null)
+            && array() === $cursorChildren
+            && !isset($cursor['_binding_token'])
+            && !in_array(strtolower((string) ($cursor['attrs']['tagName'] ?? 'div')), array('ul', 'ol', 'li'), true)
+            && null !== ($emptyDescriptor = $this->groupWrapperDescriptor($cursor))
+        ) {
+            $chain[] = array('block' => $cursor, 'descriptor' => $emptyDescriptor);
+            $terminalBlocks = array();
+            $terminal = array();
+            $terminalIsShell = false;
+            $emptyEndpoint = true;
         } else {
             $terminal = array() !== $chain ? $this->compressProjectedGroupBlock($cursor) : $cursor;
             $terminalIsShell = $this->isLayoutShellBlock($terminal);
@@ -7677,7 +7689,7 @@ final class HtmlTransformer
                 : array($terminal);
         }
         $projectedCount = count(array_filter($chain, fn (array $entry): bool => $this->hasSourceProjectionClass($entry['block'])));
-        $minimumLength = $branchEndpoint ? 3 : ($projectedCount === count($chain) ? 2 : 3);
+        $minimumLength = $branchEndpoint ? 3 : ($emptyEndpoint ? 2 : ($projectedCount === count($chain) ? 2 : 3));
         if ((0 < $projectedCount && $minimumLength <= count($chain)) || (1 === count($chain) && $terminalIsShell && 0 < $projectedCount)) {
             $wrappers = array_column($chain, 'descriptor');
             $terminalRuntimeOwned = $terminalIsShell && !empty($terminal['_editability_runtime_owned']);

--- a/php-transformer/tests/unit/custom-block-generator.php
+++ b/php-transformer/tests/unit/custom-block-generator.php
@@ -171,6 +171,11 @@ $assert(str_ends_with((string) ($shellBlock['blockName'] ?? ''), '/layout-shell'
 $assert(1 === count($shellDefinitions) && str_contains((string) ($shellDefinitions[0]['assets']['index.js'] ?? ''), 'InnerBlocks.Content'), '6: layout-shell emits one companion definition whose save path retains native inner blocks');
 $assert(2 === ($shellResult['source_reports']['editability_report']['metrics']['max_nesting_depth'] ?? PHP_INT_MAX) && 8 === substr_count((string) ($shellResult['serialized_blocks'] ?? ''), 'id="shell-'), '6: layout-shell collapses List View depth while preserving every rendered source wrapper');
 
+$emptyShellResult = ( new HtmlTransformer() )->transform('<div id="empty-outer" class="blocks-engine-source-div-outer-3"><div id="empty-inner" class="blocks-engine-source-div-inner-3"></div></div>')->toArray();
+$emptyShellBlock = $emptyShellResult['blocks'][0] ?? array();
+$assert(str_ends_with((string) ($emptyShellBlock['blockName'] ?? ''), '/layout-shell') && 2 === count($emptyShellBlock['attrs']['wrappers'] ?? array()) && empty($emptyShellBlock['innerBlocks']), '6: layout-shell absorbs a projected empty Group endpoint without adding List View depth');
+$assert(1 === ($emptyShellResult['source_reports']['editability_report']['metrics']['max_nesting_depth'] ?? PHP_INT_MAX) && str_contains((string) ($emptyShellResult['serialized_blocks'] ?? ''), 'id="empty-outer"') && str_contains((string) ($emptyShellResult['serialized_blocks'] ?? ''), 'id="empty-inner"'), '6: empty layout-shell serialization preserves both source wrappers exactly');
+
 $branchShell = ( new HtmlTransformer() )->transform('<div id="branch-outer" class="blocks-engine-source-div-outer-3"><div id="branch-inner" class="blocks-engine-source-div-fixture-3"><section id="branch-section" class="blocks-engine-source-section-fixture-3"><p>First branch</p><p>Second branch</p></section></div></div>')->toArray();
 $branchBlock = $branchShell['blocks'][0] ?? array();
 $assert(str_ends_with((string) ($branchBlock['blockName'] ?? ''), '/layout-shell') && 3 === count($branchBlock['attrs']['wrappers'] ?? array()) && 2 === count($branchBlock['innerBlocks'] ?? array()), '6: layout-shell absorbs a final branching Group and exposes all ordered native children through InnerBlocks');


### PR DESCRIPTION
## Summary
- absorb a projected empty Group endpoint into the existing exact-DOM layout shell
- preserve both source wrappers while removing one unnecessary List View level
- cover empty terminal chains alongside existing linear and branching shell cases

Fixes #1133.

## Verification
- `composer test:canonical`
- Greek Corner catering route: all 15 geometry reductions applied, max nesting reduced from 21 to 20, unchanged editability policy passes
- Greek Corner home route: max nesting 19, unchanged editability policy passes

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced the proof-backed source selectors into generated Gutenberg block paths, identified the terminal Group compression gap, implemented the fix, and ran canonical and route-level verification. Chris Huber remains responsible for the change.