### PR TITLE
refactor: register parameter tables directly

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -220,7 +220,6 @@ final class HtmlTransformer
 
     private readonly MathPattern $mathPattern;
 
-    private readonly ParameterTablePattern $parameterTablePattern;
 
     private readonly TableClassificationPolicy $tableClassificationPolicy;
 
@@ -592,7 +591,6 @@ final class HtmlTransformer
         $this->galleryPattern    = new GalleryPattern();
         $this->logoPattern       = new LogoPattern();
         $this->mathPattern       = new MathPattern();
-        $this->parameterTablePattern = new ParameterTablePattern();
         $this->tableClassificationPolicy = new TableClassificationPolicy();
         $this->placeholderMediaPattern = new PlaceholderMediaPattern();
         $this->quotePattern      = new QuotePattern();
@@ -605,10 +603,7 @@ final class HtmlTransformer
                 $block = $this->mathPattern->match($element, fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement), fn (string $text): string => $this->runtime->escapeHtml($text), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block);
             }),
-            new CallbackPatternRecognizer('parameter-table', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $block = $this->parameterTablePattern->match($element, $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block);
-            }),
+            new ParameterTablePattern(),
             new CallbackPatternRecognizer('spacer', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
                 $block = $this->spacerPattern->match($element, fn (DOMElement $sourceElement): int => $this->childElementCount($sourceElement), fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), fn (DOMElement $sourceElement, string $className): bool => $this->hasClass($sourceElement, $className), $context->presentationAttributesCallback(), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block);
@@ -5076,7 +5071,7 @@ final class HtmlTransformer
             return $this->createBlock('core/table', array_merge($this->presentationAttributes($element), $this->tableAttributes($element)), array(), $element);
         }
 
-        $parameterTable = $this->recognizePatterns($element, $fallbacks, array('parameter-table'));
+        $parameterTable = $this->recognizePatterns($element, $fallbacks, array(ParameterTablePattern::class));
         if ( null !== $parameterTable ) {
             return $parameterTable;
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/ParameterTablePattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ParameterTablePattern.php
@@ -5,18 +5,14 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
-final class ParameterTablePattern
+final class ParameterTablePattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
 
-    /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
+        $innerHtml = $context->innerHtmlCallback();
+
         if ( ! $this->hasClass($element, 'param-table') ) {
             return null;
         }
@@ -49,14 +45,14 @@ final class ParameterTablePattern
             return null;
         }
 
-        return $createBlock('core/table', array_merge($presentationAttributes($element), array(
+        return new PatternRecognitionResult($context->createBlockCallback()('core/table', array_merge($context->presentationAttributesCallback()($element), array(
             'head' => array( array( 'cells' => array(
                 array( 'content' => 'Parameter', 'tag' => 'th' ),
                 array( 'content' => 'Type', 'tag' => 'th' ),
                 array( 'content' => 'Description', 'tag' => 'th' ),
             ) ) ),
             'body' => $rows,
-        )), array(), $element);
+        )), array(), $element));
     }
 
     private function firstDirectChildWithClass(DOMElement $element, string $className): ?DOMElement


### PR DESCRIPTION
## Summary
- make `ParameterTablePattern` a direct ordered `PatternRecognizerInterface`
- remove its redundant `HtmlTransformer` callback wrapper
- preserve the parameter-table-only probe using the direct recognizer class

Closes #1137
Relates to #242

## Testing
- `php php-transformer/tests/unit/pattern-recognizer-registry.php`
- `composer --working-dir=php-transformer test`
- `php -l php-transformer/src/HtmlToBlocks/Patterns/ParameterTablePattern.php`
- `php -l php-transformer/src/HtmlToBlocks/HtmlTransformer.php`
- `git diff --check origin/trunk...HEAD`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode assisted with inspecting the fresh worktree, implementing the behavior-preserving direct recognizer, and running verification. Chris Huber directed the work and remains responsible for this pull request.