### PR TITLE
fix: align direct font URL eligibility

### DIFF
--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -333,17 +333,30 @@ final class FontMaterializationPlanBuilder
                 if ( ! preg_match('/(?:^|;)\s*font-family\s*:\s*([^;{}]+)/i', $declaration, $familyMatch) || ! preg_match('/(?:^|;)\s*src\s*:\s*[^;{}]*url\(\s*(?:"([^"]+)"|\'([^\']+)\'|([^\s\)]+))\s*\)/i', $declaration, $sourceMatch) ) continue;
                 $family = $this->normalizeFamily((string) $familyMatch[1]);
                 $sourceUrl = html_entity_decode((string) (($sourceMatch[1] ?? '') ?: ($sourceMatch[2] ?? '') ?: ($sourceMatch[3] ?? '')), ENT_QUOTES | ENT_HTML5);
-                if ( '' === $family || $this->isWebSafeFontFamily($family) || $this->isInvalidFontFamily($family) || ! preg_match('~^https?://~i', $sourceUrl) ) continue;
+                if ( '' === $family || $this->isWebSafeFontFamily($family) || $this->isInvalidFontFamily($family) || ! $this->isEligibleDirectFontSourceUrl($sourceUrl) ) continue;
                 preg_match('/(?:^|;)\s*font-style\s*:\s*([^;{}]+)/i', $declaration, $styleMatch);
                 preg_match('/(?:^|;)\s*font-weight\s*:\s*([^;{}]+)/i', $declaration, $weightMatch);
                 $style = strtolower(trim((string) ($styleMatch[1] ?? 'normal')));
                 $weight = $this->typedWeight(trim((string) ($weightMatch[1] ?? '400')));
-                if ( ! in_array($style, array('normal', 'italic', 'oblique'), true) || ! preg_match('~^https?://[^\s"\']+$~i', $sourceUrl) ) continue;
+                if ( ! in_array($style, array('normal', 'italic', 'oblique'), true) ) continue;
                 $faces[] = array('family' => $family, 'style' => $style, 'weight' => $weight, 'source_url' => $sourceUrl, 'provenance' => array('source_kind' => 'css_font_face', 'source_path' => $source['source_path'], 'source_hash' => $source['source_hash'], 'selector' => 'css:@font-face(' . ($index + 1) . ')'));
             }
         }
         usort($faces, static fn (array $left, array $right): int => strcmp($left['provenance']['source_path'] . "\n" . $left['provenance']['selector'] . "\n" . $left['source_url'], $right['provenance']['source_path'] . "\n" . $right['provenance']['selector'] . "\n" . $right['source_url']));
         return $faces;
+    }
+
+    private function isEligibleDirectFontSourceUrl(string $url): bool
+    {
+        $parts = parse_url($url);
+        $path = is_array($parts) ? strtolower((string) ($parts['path'] ?? '')) : '';
+        return is_array($parts)
+            && 'https' === strtolower((string) ($parts['scheme'] ?? ''))
+            && ! empty($parts['host'])
+            && (! isset($parts['port']) || 443 === (int) $parts['port'])
+            && ! isset($parts['user'])
+            && ! isset($parts['pass'])
+            && (bool) preg_match('/\.woff2?$/', $path);
     }
 
     /** @param array<string,int|string> $weight @return array<int,int> */

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -3863,6 +3863,23 @@ $directContract = $directFacePlan['webfont_contract'] ?? array();
 $assert('direct' === ($directContract['imports'][0]['provider'] ?? null) && 'font' === ($directContract['imports'][0]['source']['format'] ?? null) && 'https://cdn.example.test/fonts/festival-display.woff2' === ($directContract['faces'][0]['sources'][0]['url'] ?? null) && 'styles/typography.css' === ($directContract['imports'][0]['provenance']['source_path'] ?? null) && 'css:@font-face(1)' === ($directContract['imports'][0]['provenance']['selector'] ?? null), 'direct font faces retain typed source URL and source provenance in the materialization contract');
 $directMaterializationPlan = ( new MaterializationPlanBuilder() )->fromCompiledSite(array('theme' => array('static_css' => $directFaceCss, 'font_css_sources' => array(array('path' => 'styles/typography.css', 'content' => $directFaceCss, 'source_hash' => str_repeat('d', 64))))));
 $assert('@font-face{font-family:"Festival Display";font-style:italic;font-weight:700;src:url("https://cdn.example.test/fonts/festival-display.woff2");}' . "\n" === ($directMaterializationPlan['theme']['font_materialization']['stylesheets'][0]['content'] ?? null), 'materialization plan carries the direct font declaration as its standalone stylesheet asset');
+$eligibleDirectFaceCss = '@font-face{font-family:Eligible Woff;src:url("https://cdn.example.test/fonts/eligible.woff?download=1")}@font-face{font-family:Eligible Woff2;src:url("https://cdn.example.test:443/fonts/eligible.WOFF2#face")}';
+$eligibleDirectFacePlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources('', $eligibleDirectFaceCss);
+$eligibleDirectFaceUrls = array_column(array_map(static fn (array $import): array => $import['source'] ?? array(), $eligibleDirectFacePlan['webfont_contract']['imports'] ?? array()), 'url');
+$expectedEligibleDirectFaceUrls = array('https://cdn.example.test/fonts/eligible.woff?download=1', 'https://cdn.example.test:443/fonts/eligible.WOFF2#face');
+sort($eligibleDirectFaceUrls, SORT_STRING); sort($expectedEligibleDirectFaceUrls, SORT_STRING);
+$assert($expectedEligibleDirectFaceUrls === $eligibleDirectFaceUrls && 2 === count($eligibleDirectFacePlan['webfont_contract']['faces'] ?? array()), 'HTTPS WOFF and WOFF2 direct faces with implicit or explicit port 443 retain the typed materialization contract');
+foreach (array(
+    'http://cdn.example.test/fonts/insecure.woff2',
+    'https://user:password@cdn.example.test/fonts/credentials.woff2',
+    'https://cdn.example.test:8443/fonts/nonstandard-port.woff2',
+    'https://cdn.example.test/fonts/not-a-font.ttf',
+    'https://',
+) as $ineligibleDirectFaceUrl) {
+    $ineligibleDirectFaceCss = '@font-face{font-family:Ineligible;src:url("' . $ineligibleDirectFaceUrl . '")}';
+    $ineligibleDirectFacePlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources('', $ineligibleDirectFaceCss);
+    $assert(array() === ($ineligibleDirectFacePlan['webfont_contract']['imports'] ?? null) && array() === ($ineligibleDirectFacePlan['webfont_contract']['faces'] ?? null), 'direct face eligibility rejects ' . $ineligibleDirectFaceUrl);
+}
 
 $rangeFontPlan = ( new FontMaterializationPlanBuilder() )->fromWebFontSources(
     '<head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300..900;1,300..900&amp;family=JetBrains+Mono:wght@400&amp;display=swap"></head>',


### PR DESCRIPTION
## Summary
- require direct font sources to meet Static Site Importer URL eligibility
- cover accepted HTTPS WOFF/WOFF2 URLs and rejected HTTP, credential, port, extension, and malformed sources

Closes #1145

## Testing
- `composer test:canonical`

## AI assistance
OpenCode using `openai/gpt-5.6-terra` implemented the direct-font URL eligibility alignment and canonical contract coverage. Chris Huber directed and reviewed the change.