### PR TITLE
Strip inert resource links from inline SVG

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/DomHelpersTrait.php
@@ -534,6 +534,7 @@ trait DomHelpersTrait
         // lowercases the tag name when serializing parsed HTML).
         $html = preg_replace('@<foreignobject\b[^>]*>.*?</foreignobject>@si', '', $html) ?? $html;
         $html = preg_replace('@<foreignobject\b[^>]*/?>@si', '', $html) ?? $html;
+        $html = preg_replace('@<link\b[^>]*\/?>@si', '', $html) ?? $html;
 
         // Neutralize any residual javascript: carried in remaining attributes
         // (e.g. a style attribute), dropping the whole attribute so the shape

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -963,7 +963,7 @@ trait SvgMaterializationTrait
             // SVG asset materialization. They cannot survive into the generated
             // image document, so they must not disqualify otherwise passive,
             // self-contained artwork from the native image path.
-            if ( 'style' === strtolower($child->tagName) ) {
+            if ( in_array(strtolower($child->tagName), array('style', 'link'), true) ) {
                 continue;
             }
             if ( ! $child instanceof DOMElement || ! $this->isPassiveSvgElement($child, $allowedTags, $allowedAttributes) ) {

--- a/php-transformer/tests/unit/geometry-chain-coalescing.php
+++ b/php-transformer/tests/unit/geometry-chain-coalescing.php
@@ -28,6 +28,10 @@ for ($depth = 0; $depth < 44; ++$depth) $svgChain = '<div class="depth-' . $dept
 $deepSvg = $transform($svgChain);
 $assert('core/image' === ($deepSvg['blocks'][0]['blockName'] ?? null) && $maxDepth($deepSvg['blocks'] ?? array()) <= 20 && 1 === count(array_filter($deepSvg['assets'] ?? array(), static fn (array $asset): bool => 'svg' === ($asset['kind'] ?? null))), 'A depth-44 passive SVG image chain coalesces to one native image without losing its materialized asset.');
 
+$resourceSvg = $transform('<svg viewBox="0 0 10 10" role="presentation"><defs><link rel="stylesheet" href="assets/icon.css"></defs><path d="M0 0h10v10H0z"/></svg>');
+$resourceSvgAsset = array_values(array_filter($resourceSvg['assets'] ?? array(), static fn (array $asset): bool => 'svg' === ($asset['kind'] ?? null)))[0] ?? array();
+$assert('core/image' === ($resourceSvg['blocks'][0]['blockName'] ?? null) && !str_contains((string) ($resourceSvgAsset['content'] ?? ''), '<link') && !str_contains((string) ($resourceSvg['serialized_blocks'] ?? ''), '<!-- wp:html'), 'An inert resource link inside SVG defs is stripped before passive artwork materialization.');
+
 $wowChain = '<wow-image class="captured-media"><img src="hero.jpg" alt="Hero"></wow-image>';
 for ($depth = 0; $depth < 39; ++$depth) $wowChain = '<div class="depth-' . $depth . '">' . $wowChain . '</div>';
 $deepWow = $transform($wowChain);


### PR DESCRIPTION
## Summary
- strip inert `<link>` resource elements during inline SVG sanitization
- treat those stripped elements like stripped inline styles during passive SVG admission
- materialize drawable artwork as a native image asset instead of invalid Custom HTML

Fixes #1148.

## Verification
- `composer test:canonical`
- geometry chain coalescing contract

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced target-registry validation into SVG sanitization, implemented the resource-element handling, and ran canonical verification. Chris Huber remains responsible for the change.