### PR TITLE
Preserve authored input whitespace in save markup

### DIFF
--- a/php-transformer/src/HtmlToBlocks/AuthoredInputBlockGenerator.php
+++ b/php-transformer/src/HtmlToBlocks/AuthoredInputBlockGenerator.php
@@ -67,7 +67,7 @@ JS;
         $escape = static fn (mixed $value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $markup = '<input';
         foreach ( array( 'type', 'id', 'name', 'value', 'placeholder', 'ariaLabel', 'className', 'style', 'min', 'max', 'step' ) as $key ) {
-            $value = trim((string) ($attrs[$key] ?? ''));
+            $value = (string) ($attrs[$key] ?? '');
             if ( '' !== $value ) {
                 $markup .= ' ' . ( 'className' === $key ? 'class' : ( 'ariaLabel' === $key ? 'aria-label' : $key ) ) . '="' . $escape($value) . '"';
             }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1358,6 +1358,13 @@ $assert(str_contains($styledInputMarkup, '<input type="email" id="newsletter" na
 $assert(! str_contains($styledInputMarkup, '<!-- wp:html') || str_contains($styledInputMarkup, '<input class="js-filter"'), 'styled static input never uses core/html while runtime input remains compatible');
 $assert('pass' === ($styledInputs['source_reports']['wp_block_validity']['status'] ?? ''), 'compact input serialization passes canonical Gutenberg validity');
 
+$whitespaceInput = ( new HtmlTransformer() )->transform(
+    '<input class="authored-input" type="text" name="expected-# of people " placeholder=" ">',
+    array('static_css' => '.authored-input{border:1px solid;padding:1rem}')
+)->toArray();
+$whitespaceInputBlock = $whitespaceInput['blocks'][0] ?? array();
+$assert('expected-# of people ' === ($whitespaceInputBlock['attrs']['name'] ?? null) && ' ' === ($whitespaceInputBlock['attrs']['placeholder'] ?? null) && str_contains((string) ($whitespaceInput['serialized_blocks'] ?? ''), 'name="expected-# of people " placeholder=" "'), 'compact input PHP markup preserves the same safe whitespace-bearing attributes as its companion save function');
+
 $unstyledSelect = ( new HtmlTransformer() )->transform(
     '<main><select id="plain-sort" class="catalog-sort" name="products" aria-label="Sort products"><option selected>Featured</option><option>Price</option></select></main>'
 )->toArray();


### PR DESCRIPTION
## Summary
- preserve safe whitespace-bearing input attributes in PHP markup
- align emitted inner HTML with companion editor save output
- cover whitespace-only placeholders and trailing name whitespace

Fixes #1149.

## Verification
- `composer test:canonical`
- HTML-to-blocks contract

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced target-registry input validation to PHP/JS serialization divergence, implemented the fix, and ran canonical verification. Chris Huber remains responsible for the change.