### PR TITLE
Fix false disclosure matching content loss

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -71,7 +71,7 @@ final class DetailsPattern
         }
 
         $header = $this->headerForToggle($element, $toggle);
-        if ( ! $header instanceof DOMElement ) {
+        if ( ! $header instanceof DOMElement || ! $this->isBoundedDisclosureHeader($header, $toggle) ) {
             return null;
         }
 
@@ -149,12 +149,17 @@ final class DetailsPattern
         }
 
         for ( $node = $header->nextSibling; null !== $node; $node = $node->nextSibling ) {
-            if ( $node instanceof DOMElement ) {
+            if ( $node instanceof DOMElement && $this->isCollapsibleRegion($node) ) {
                 return $node;
             }
         }
 
         return null;
+    }
+
+    private function isCollapsibleRegion(DOMElement $element): bool
+    {
+        return $element->hasAttribute('hidden') || 'region' === strtolower($this->trimmedAttribute($element, 'role'));
     }
 
     /**
@@ -171,6 +176,22 @@ final class DetailsPattern
         }
 
         return null;
+    }
+
+    /**
+     * A disclosure header may wrap its toggle (for example in a heading), but
+     * must not also contain unrelated page-content branches that would be lost
+     * when the widget is folded into one details block.
+     */
+    private function isBoundedDisclosureHeader(DOMElement $header, DOMElement $toggle): bool
+    {
+        foreach ( $header->getElementsByTagName('*') as $candidate ) {
+            if ( $candidate instanceof DOMElement && ! $this->containsNode($candidate, $toggle) && ! $this->containsNode($toggle, $candidate) ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function isNavigationLandmark(DOMElement $element): bool

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -596,6 +596,15 @@ $headingDisclosureResult = ( new HtmlTransformer() )->transform('<div class="ite
 $assert('core/details' === (($headingDisclosureResult['blocks'][0] ?? array())['blockName'] ?? null), 'a heading-wrapped disclosure toggle converts to core/details');
 $assert('Shipping times?' === (($headingDisclosureResult['blocks'][0] ?? array())['attrs']['summary'] ?? null), 'heading-wrapped disclosure toggle text maps to the details summary');
 
+// A nested navigation toggle cannot consume its page-container ancestor as a
+// disclosure header and discard the sibling page content.
+$pageShellDisclosureResult = ( new HtmlTransformer() )->transform('<div id="master-page"><div id="site-pages"><header><button aria-expanded="false">Open site navigation</button></header><main><h1>Portfolio heading</h1><p>Substantive page content.</p><img src="portrait.jpg" alt="Portrait"></main></div><div class="navigation-overlay"><nav><a href="/about">About</a></nav></div></div>')->toArray();
+$pageShellDisclosureMarkup = (string) ($pageShellDisclosureResult['serialized_blocks'] ?? '');
+$assert(! str_contains($pageShellDisclosureMarkup, '<!-- wp:details'), 'a page shell with a nested navigation toggle is not converted to core/details');
+$assert(str_contains($pageShellDisclosureMarkup, 'Portfolio heading'), 'a false disclosure preserves the substantive page heading');
+$assert(str_contains($pageShellDisclosureMarkup, 'Substantive page content.'), 'a false disclosure preserves the substantive page paragraph');
+$assert(str_contains($pageShellDisclosureMarkup, '<!-- wp:image'), 'a false disclosure preserves the substantive page image');
+
 // Negative guard: a plain heading followed by text is NOT a disclosure (no
 // toggle control, aria-expanded, or aria-controls) and must stay as a heading +
 // paragraph rather than being forced into core/details.


### PR DESCRIPTION
## Summary
- require inferred disclosure headers to contain only the toggle branch
- require unreferenced sibling panels to carry a collapsible-region signal
- preserve substantive heading, paragraph, and image content in the reported page shell

## Verification
- `composer test`
- `composer run test:packaging`
- `git diff --check`

Closes #1153

## AI assistance
OpenCode with OpenAI GPT-5.6 Terra diagnosed, implemented, and verified this fix. The supplied issue trace was prepared with OpenCode and OpenAI GPT-5.6 Sol. Chris Huber reviewed and remains responsible for the change.