### PR TITLE
Fix PHP Transformer admin-bar accommodation

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -85,6 +85,7 @@
       "php tests/unit/media-text-pattern.php",
       "php tests/unit/cover-style-resolver.php",
       "php tests/unit/css-stylesheet-transformer.php",
+      "php tests/unit/admin-bar-accommodation.php",
       "php tests/unit/css-rule-analyzer.php",
       "php tests/unit/css-selector-matcher.php",
       "php tests/unit/author-selector-semantics.php",

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -13,6 +13,7 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 use Automattic\BlocksEngine\PhpTransformer\FormatBridge\FormatBridge;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformerAnalysisCache;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\ShellLandmarkPolicy;
@@ -607,6 +608,10 @@ final class ArtifactCompiler
         $manifestAssets = $this->assetManifest($normalized['files'], $entryPath, $referenceReports['asset_references'], $html);
         $entryOwnership = is_array($entry) ? $this->fileOwnership($entry) : array('scope' => 'page', 'id' => $entryPath);
         $generatedAssets = $this->generatedAssetsForDocuments($entryBlocks['assets'], $entryOwnership, $compiledHtmlDocuments, $normalized['files']);
+        $projectedAdminBarAsset = $this->projectedAdminBarAccommodationAsset($normalized['files']);
+        if (null !== $projectedAdminBarAsset) {
+            $generatedAssets[] = $projectedAdminBarAsset;
+        }
         $beforeAuthorAssets = array_values(array_filter($generatedAssets, static fn (array $asset): bool => 'before-author' === ($asset['stylesheet_placement'] ?? '')));
         $afterAuthorAssets = array_values(array_filter($generatedAssets, static fn (array $asset): bool => 'after-author' === ($asset['stylesheet_placement'] ?? '')));
         $otherGeneratedAssets = array_values(array_filter($generatedAssets, static fn (array $asset): bool => ! in_array($asset, $beforeAuthorAssets, true) && ! in_array($asset, $afterAuthorAssets, true)));
@@ -3030,6 +3035,53 @@ final class ArtifactCompiler
             'binary'      => false,
             'content'     => $css,
             'hash'        => $hash,
+        );
+    }
+
+    /**
+     * Linked stylesheets are projected after HtmlTransformer has emitted its
+     * per-document support assets, so scan their final runtime selectors here.
+     *
+     * @param array<int, array<string, mixed>> $files
+     * @return array<string, mixed>|null
+     */
+    private function projectedAdminBarAccommodationAsset(array $files): ?array
+    {
+        $css = array();
+        $accommodation = new AdminBarAccommodation();
+        foreach ($files as $file) {
+            if ('css' !== ($file['kind'] ?? '') || 'inline-style' === ($file['source'] ?? '') || !is_string($file['content'] ?? null)) {
+                continue;
+            }
+            $supportCss = $accommodation->supportCss($file['content']);
+            if ('' !== $supportCss) {
+                $css[] = $supportCss;
+            }
+        }
+        $content = trim(implode("\n", $css));
+        if ('' === $content) {
+            return null;
+        }
+
+        $content .= "\n";
+        $hash = hash('sha256', $content);
+        $path = 'assets/css/engine-support-after-author-' . substr($hash, 0, 16) . '.css';
+        return array(
+            'source' => 'engine-support',
+            'path' => $path,
+            'target_path' => $path,
+            'kind' => 'css',
+            'role' => 'stylesheet',
+            'stylesheet_placement' => 'after-author',
+            'stylesheet_target' => 'both',
+            'mime_type' => 'text/css',
+            'media_type' => 'text/css',
+            'bytes' => strlen($content),
+            'encoding' => 'utf-8',
+            'binary' => false,
+            'content' => $content,
+            'hash' => $hash,
+            'source_hash' => $hash,
         );
     }
 

--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -3050,7 +3050,7 @@ final class ArtifactCompiler
         $css = array();
         $accommodation = new AdminBarAccommodation();
         foreach ($files as $file) {
-            if ('css' !== ($file['kind'] ?? '') || 'inline-style' === ($file['source'] ?? '') || !is_string($file['content'] ?? null)) {
+            if ('css' !== ($file['kind'] ?? '') || !is_string($file['content'] ?? null)) {
                 continue;
             }
             $supportCss = $accommodation->supportCss($file['content']);

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -43,6 +43,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionTra
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
@@ -1423,6 +1424,10 @@ final class HtmlTransformer
         }
         if ( '' !== trim($authorCss) ) {
             $authorCssParts[] = $authorCss;
+            $adminBarAccommodation = (new AdminBarAccommodation())->supportCss($authorCss);
+            if ( '' !== $adminBarAccommodation ) {
+                $afterAuthorCssParts[] = $adminBarAccommodation;
+            }
         }
         if ( str_contains($serializedBlocks, 'blocks-engine-list-navigation') ) {
             // Keep only source-responsive navigation hosts visible. Ordinary

--- a/php-transformer/src/HtmlToBlocks/Style/AdminBarAccommodation.php
+++ b/php-transformer/src/HtmlToBlocks/Style/AdminBarAccommodation.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/** Builds logged-in-only offsets for authored viewport-anchored layers. */
+final class AdminBarAccommodation
+{
+    private const MAX_RULES = 100;
+
+    public function supportCss(string $stylesheet): string
+    {
+        $rules = array();
+        (new CssStylesheetTransformer())->visitStyleRules($stylesheet, static function (string $prelude, string $body, array $ancestors) use (&$rules): void {
+            if (count($rules) >= self::MAX_RULES) {
+                return;
+            }
+
+            $declarations = CssRuleAnalyzer::declarations($body, array('position', 'top'));
+            $values = array();
+            foreach ($declarations as $declaration) {
+                $important = self::isImportant($declaration['value']);
+                if (!isset($values[$declaration['name']]) || $important || !$values[$declaration['name']]['important']) {
+                    $values[$declaration['name']] = array('value' => self::withoutImportant($declaration['value']), 'important' => $important);
+                }
+            }
+            if (!in_array(strtolower($values['position']['value'] ?? ''), array('fixed', 'sticky'), true)) {
+                return;
+            }
+
+            $top = trim($values['top']['value'] ?? '');
+            if ('' === $top || 'auto' === strtolower($top)) {
+                return;
+            }
+
+            $selectors = CssStylesheetTransformer::splitSelectorList($prelude);
+            if (null === $selectors) {
+                return;
+            }
+            foreach ($selectors as $selector) {
+                $selector = trim($selector);
+                $key = implode("\0", $ancestors) . "\0" . $selector . "\0" . $top;
+                if ('' === $selector || isset($rules[$key])) {
+                    continue;
+                }
+                $rules[$key] = array('selector' => $selector, 'top' => $top, 'ancestors' => $ancestors);
+                if (count($rules) >= self::MAX_RULES) {
+                    break;
+                }
+            }
+        });
+
+        $css = array();
+        foreach ($rules as $rule) {
+            $top = '0' === trim($rule['top']) || '+0' === trim($rule['top']) || '-0' === trim($rule['top']) ? '0px' : $rule['top'];
+            $ruleCss = 'body.admin-bar ' . $rule['selector'] . '{top:calc((' . $top . ') + var(--wp-admin--admin-bar--height, 32px))!important}';
+            foreach (array_reverse($rule['ancestors']) as $ancestor) {
+                $ruleCss = $ancestor . '{' . $ruleCss . '}';
+            }
+            $css[] = $ruleCss;
+        }
+
+        return implode("\n", $css);
+    }
+
+    private static function withoutImportant(string $value): string
+    {
+        return trim((string) preg_replace('/\s*!important\s*$/i', '', $value));
+    }
+
+    private static function isImportant(string $value): bool
+    {
+        return 1 === preg_match('/\s*!important\s*$/i', $value);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/CssStylesheetTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/Style/CssStylesheetTransformer.php
@@ -48,6 +48,19 @@ final class CssStylesheetTransformer
     }
 
     /**
+     * Visit every style rule with its enclosing safe-to-walk at-rules.
+     *
+     * @param callable(string, string, list<string>): void $visitStyleRule
+     */
+    public function visitStyleRules(string $stylesheet, callable $visitStyleRule): void
+    {
+        if ( ! $this->isWellFormedStylesheet($stylesheet) ) {
+            return;
+        }
+        $this->visitRules($stylesheet, $visitStyleRule, array());
+    }
+
+    /**
      * @return array{preamble: string, stylesheet: string}
      */
     public function splitLeadingAtRulePreamble(string $stylesheet): array
@@ -161,6 +174,34 @@ final class CssStylesheetTransformer
         }
 
         return $output;
+    }
+
+    /** @param callable(string, string, list<string>): void $visitStyleRule @param list<string> $ancestors */
+    private function visitRules(string $css, callable $visitStyleRule, array $ancestors): void
+    {
+        $offset = 0;
+        $length = strlen($css);
+        while ($offset < $length) {
+            $boundary = $this->nextRuleBoundary($css, $offset);
+            if (null === $boundary || ';' === $css[$boundary]) {
+                $offset = null === $boundary ? $length : $boundary + 1;
+                continue;
+            }
+            $blockEnd = $this->matchingBrace($css, $boundary);
+            if (null === $blockEnd) {
+                return;
+            }
+            $prelude = substr($css, $offset, $boundary - $offset);
+            $body = substr($css, $boundary + 1, $blockEnd - $boundary - 1);
+            if ($this->isAtRule($prelude) && $this->walksNestedRules($prelude)) {
+                $nested = $ancestors;
+                $nested[] = trim($prelude);
+                $this->visitRules($body, $visitStyleRule, $nested);
+            } elseif ($this->isStylePrelude($prelude)) {
+                $visitStyleRule($prelude, $body, $ancestors);
+            }
+            $offset = $blockEnd + 1;
+        }
     }
 
     private function nextRuleBoundary(string $css, int $offset): ?int

--- a/php-transformer/tests/unit/admin-bar-accommodation.php
+++ b/php-transformer/tests/unit/admin-bar-accommodation.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
+
+$failures = 0;
+$passes = 0;
+$assert = static function (bool $condition, string $message) use (&$failures, &$passes): void {
+    if ($condition) { ++$passes; return; }
+    ++$failures;
+    fwrite(STDERR, "FAIL: {$message}\n");
+};
+
+$build = static fn (string $css): string => (new AdminBarAccommodation())->supportCss($css);
+$fixed = $build('.opaque-shell{position:fixed;top:0}');
+$assert('body.admin-bar .opaque-shell{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}' === $fixed, 'fixed opaque selector receives a logged-in offset');
+
+$sticky = $build('.toc{position:sticky;top:calc(var(--header-height) + 1rem)}');
+$assert('body.admin-bar .toc{top:calc((calc(var(--header-height) + 1rem)) + var(--wp-admin--admin-bar--height, 32px))!important}' === $sticky, 'sticky calc top expression is preserved');
+
+$complex = $build('@media (max-width: 700px){:is(.header, [data-layer="a,b"]){position:fixed;top:12px!important;content:";{}"}}');
+$assert(str_contains($complex, 'body.admin-bar :is(.header, [data-layer="a,b"]){top:calc((12px) + var(--wp-admin--admin-bar--height, 32px))!important}'), 'nested syntax and opaque selector bytes remain usable');
+
+$ordinary = $build('.card{position:relative;top:12px}.overlay{position:fixed;bottom:0}.auto{position:sticky;top:auto}');
+$assert('' === $ordinary, 'ordinary, bottom-anchored, and auto-top rules remain unaffected');
+
+$duplicates = $build('.x{position:fixed;top:0}.x{position:fixed;top:0}');
+$assert(1 === substr_count($duplicates, 'body.admin-bar .x{'), 'duplicate authored rules emit one bounded override');
+
+$many = '';
+for ($index = 0; $index < 101; ++$index) $many .= '.x' . $index . '{position:fixed;top:0}';
+$assert(100 === substr_count($build($many), 'body.admin-bar .x'), 'accommodation caps generated overrides');
+
+if ($failures > 0) {
+    fwrite(STDERR, "Admin bar accommodation unit tests: {$failures} failed, {$passes} passed\n");
+    exit(1);
+}
+fwrite(STDOUT, "Admin bar accommodation unit tests: {$passes} passed\n");

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -6,6 +6,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use Automattic\BlocksEngine\PhpTransformer\VisualParity\StaticCssCascade;
 use Automattic\BlocksEngine\PhpTransformer\VisualParity\StaticStyleParityProbe;
 use Automattic\BlocksEngine\PhpTransformer\VisualParity\StaticStyleParityRunner;
 
@@ -50,8 +51,8 @@ $assert(str_contains((string) ($assetsByPath['a.occurrence-2-generated-1.css']['
 
 $projectedPinnedLayer = ( new ArtifactCompiler() )->compile(array(
     'files' => array(
-        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="site.css"><main><div class="data-liberation-mobile-document"><div id="projected-pinned-layer">Header</div></div></main>' ),
-        array( 'path' => 'site.css', 'kind' => 'css', 'content' => '#projected-pinned-layer{position:fixed;top:0}@media (max-width:700px){:where(.data-liberation-mobile-document) #projected-pinned-layer{position:fixed;top:0}}' ),
+        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<style>#projected-pinned-layer{position:fixed;top:0}</style><link rel="stylesheet" href="site.css"><main><div class="data-liberation-mobile-document"><div id="projected-pinned-layer">Header</div><div id="projected-mobile-pinned-layer">Mobile header</div></div></main>' ),
+        array( 'path' => 'site.css', 'kind' => 'css', 'content' => '@media (max-width:700px){:where(.data-liberation-mobile-document) #projected-mobile-pinned-layer{position:fixed;top:0}}' ),
     ),
 ) )->toArray();
 $projectedPinnedAssets = $projectedPinnedLayer['assets'] ?? array();
@@ -65,7 +66,15 @@ foreach ($projectedPinnedAssets as $index => $asset) {
 }
 $projectedPinnedSupport = is_int($projectedPinnedSupportIndex) ? (string) ($projectedPinnedAssets[$projectedPinnedSupportIndex]['content'] ?? '') : '';
 $assert(is_int($projectedPinnedAuthorIndex) && is_int($projectedPinnedSupportIndex) && $projectedPinnedAuthorIndex < $projectedPinnedSupportIndex, 'projected linked stylesheet loads before its post-author admin-bar support asset');
-$assert(str_contains($projectedPinnedSupport, 'body.admin-bar #projected-pinned-layer{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}') && str_contains($projectedPinnedSupport, '@media (max-width:700px){body.admin-bar :where(.data-liberation-mobile-document) #projected-pinned-layer{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}}'), 'projected fixed runtime selector and nested mobile selector receive admin-bar offsets');
+$assert(str_contains($projectedPinnedSupport, 'body.admin-bar #projected-pinned-layer{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}') && str_contains($projectedPinnedSupport, '@media (max-width:700px){body.admin-bar :where(.data-liberation-mobile-document) #projected-mobile-pinned-layer{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}}'), 'projected inline fixed runtime selector and nested linked mobile selector receive admin-bar offsets');
+$projectedPinnedCss = implode("\n", array_map(static fn (array $asset): string => (string) ($asset['content'] ?? ''), $projectedPinnedAssets));
+$projectedPinnedDocument = new DOMDocument();
+$projectedPinnedDocument->loadHTML('<html><body class="admin-bar"><div id="projected-pinned-layer">Header</div></body></html>');
+$projectedPinnedElement = $projectedPinnedDocument->getElementById('projected-pinned-layer');
+$projectedPinnedTop = $projectedPinnedElement instanceof DOMElement
+    ? (new StaticCssCascade($projectedPinnedDocument, $projectedPinnedCss))->resolve($projectedPinnedElement, array('top'), array())['top'] ?? ''
+    : '';
+$assert('calc((0px) + 32px)' === $projectedPinnedTop, 'authenticated desktop cascade resolves the projected pinned layer top through post-author support CSS');
 
 $richText = ( new ArtifactCompiler() )->compile(array(
     'files' => array(

--- a/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
+++ b/php-transformer/tests/unit/artifact-author-stylesheet-projection.php
@@ -48,6 +48,25 @@ $assert(! str_contains((string) ($assetsByPath['a.css']['content'] ?? ''), 'a.ct
 $assert(hash('sha256', '.hero p{color:green}') === ($assetsByPath['index.inline-2.css']['source_hash'] ?? null) && ! str_contains((string) ($assetsByPath['index.inline-2.css']['content'] ?? ''), '.hero p') && str_contains((string) ($assetsByPath['index.inline-2.css']['content'] ?? ''), ':where(.blocks-engine-source-p-'), 'inline CSS is rewritten in place with original source provenance');
 $assert(str_contains((string) ($assetsByPath['a.occurrence-2-generated-1.css']['content'] ?? ''), '> :where(.wp-block-button__link):hover') && '.authored-collision{color:purple}' === ($assetsByPath['a.occurrence-2.css']['content'] ?? ''), 'allocated occurrence alias is referenced while authored collision CSS remains a deterministic orphan asset');
 
+$projectedPinnedLayer = ( new ArtifactCompiler() )->compile(array(
+    'files' => array(
+        array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<link rel="stylesheet" href="site.css"><main><div class="data-liberation-mobile-document"><div id="projected-pinned-layer">Header</div></div></main>' ),
+        array( 'path' => 'site.css', 'kind' => 'css', 'content' => '#projected-pinned-layer{position:fixed;top:0}@media (max-width:700px){:where(.data-liberation-mobile-document) #projected-pinned-layer{position:fixed;top:0}}' ),
+    ),
+) )->toArray();
+$projectedPinnedAssets = $projectedPinnedLayer['assets'] ?? array();
+$projectedPinnedAuthorIndex = array_search('site.css', array_column($projectedPinnedAssets, 'path'), true);
+$projectedPinnedSupportIndex = null;
+foreach ($projectedPinnedAssets as $index => $asset) {
+    if ('engine-support' === ($asset['source'] ?? '') && 'after-author' === ($asset['stylesheet_placement'] ?? '')) {
+        $projectedPinnedSupportIndex = $index;
+        break;
+    }
+}
+$projectedPinnedSupport = is_int($projectedPinnedSupportIndex) ? (string) ($projectedPinnedAssets[$projectedPinnedSupportIndex]['content'] ?? '') : '';
+$assert(is_int($projectedPinnedAuthorIndex) && is_int($projectedPinnedSupportIndex) && $projectedPinnedAuthorIndex < $projectedPinnedSupportIndex, 'projected linked stylesheet loads before its post-author admin-bar support asset');
+$assert(str_contains($projectedPinnedSupport, 'body.admin-bar #projected-pinned-layer{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}') && str_contains($projectedPinnedSupport, '@media (max-width:700px){body.admin-bar :where(.data-liberation-mobile-document) #projected-pinned-layer{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}}'), 'projected fixed runtime selector and nested mobile selector receive admin-bar offsets');
+
 $richText = ( new ArtifactCompiler() )->compile(array(
     'files' => array(
         array( 'path' => 'index.html', 'kind' => 'html', 'content' => '<!doctype html><html><head><link rel="stylesheet" href="a.css"><link rel="stylesheet" href="b.css"></head><body><p><span class="quote-mark">&quot;</span>Testimonial</p></body></html>' ),

--- a/php-transformer/tests/unit/engine-support-css-asset.php
+++ b/php-transformer/tests/unit/engine-support-css-asset.php
@@ -115,6 +115,10 @@ $fullWidthButton = ( new HtmlTransformer() )->transform(
 $syntheticImageFigure = ( new HtmlTransformer() )->transform(
     '<main><img src="portrait.jpg" alt="Portrait"><figure class="authored-figure"><img src="work.jpg" alt="Work"></figure></main>'
 )->toArray();
+$adminBar = ( new HtmlTransformer() )->transform(
+    '<style>.fixed-shell{position:fixed;top:0}.sticky-toc{position:sticky;top:calc(var(--header-h) + 1rem)}.ordinary{position:relative;top:1rem}</style>'
+        . '<header class="fixed-shell">Header</header><aside class="sticky-toc">Contents</aside><main class="ordinary">Content</main>'
+)->toArray();
 
 $results = array(
     $authorOrder,
@@ -255,6 +259,12 @@ $assert(
     'G6: richtext-marker mark defers neutral background and color to engine support CSS'
 );
 $assert(str_contains($beforeCss, ':where(mark)[style*="--blocks-engine-richtext-marker:"]{background-color:transparent;color:inherit}'), 'G6: richTextMarkerResetCss remains in engine-support');
+
+$adminBarAuthorCss = $cssFor($adminBar, 'author-css');
+$adminBarSupportCss = $cssFor($adminBar, 'engine-support', 'after-author');
+$assert(str_contains($adminBarAuthorCss, '.fixed-shell{position:fixed;top:0}') && ! str_contains($adminBarAuthorCss, 'body.admin-bar'), 'G7: authored fixed CSS remains logged-out source CSS');
+$assert(str_contains($adminBarSupportCss, 'body.admin-bar .fixed-shell{top:calc((0px) + var(--wp-admin--admin-bar--height, 32px))!important}') && str_contains($adminBarSupportCss, 'body.admin-bar .sticky-toc{top:calc((calc(var(--header-h) + 1rem)) + var(--wp-admin--admin-bar--height, 32px))!important}'), 'G7: post-author support offsets fixed and sticky layers');
+$assert(! str_contains($adminBarSupportCss, '.ordinary'), 'G7: ordinary positioned rules do not receive admin-bar support CSS');
 
 if ( $failures > 0 ) {
     fwrite(STDERR, "Engine support CSS asset contract: {$failures} failed, {$passes} passed\n");


### PR DESCRIPTION
## Summary
- add a bounded, selector-agnostic post-author support-CSS pass for authored fixed/sticky rules with explicit usable `top` values
- preserve authored CSS and logged-out geometry; generated `body.admin-bar` rules compose the original top with `var(--wp-admin--admin-bar--height, 32px)`
- reuse the CSS syntax scanner to visit nested safe at-rules and preserve selector/expression syntax, including opaque selectors

## Tianna evidence
Issue #1162 records the Tianna Wolfson import reproduction: its generated stylesheet retains a fixed header shell at `top: 0`, while generated output contains no `body.admin-bar` offset. This change emits the post-author logged-in override without vendor-specific selector rules.

## Verification
- `composer test`
- `composer test:packaging`
- `php -l src/HtmlToBlocks/Style/AdminBarAccommodation.php && php -l src/HtmlToBlocks/Style/CssStylesheetTransformer.php && php -l src/HtmlToBlocks/HtmlTransformer.php && php -l tests/unit/admin-bar-accommodation.php && php -l tests/unit/engine-support-css-asset.php`
- `composer validate --no-check-publish`
- `git diff --check`

The TypeScript package check was attempted but the package manager stopped before typechecking because this environment requires approval for ignored dependency build scripts. No TypeScript files changed.

Closes #1162

## AI assistance
OpenCode using OpenAI GPT-5.6 Sol implemented the PHP support-CSS pass, tests, and verification. Chris Huber reviewed and remains responsible.