### PR TITLE
Centralize Figma site route compilation

### DIFF
--- a/figma-transformer/src/FigmaTransformer.php
+++ b/figma-transformer/src/FigmaTransformer.php
@@ -11,7 +11,6 @@ use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigArchiveReader;
 use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter;
 use Automattic\BlocksEngine\FigmaTransformer\Parity\ParityReportBuilder;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphFrameInspector;
-use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphIndex;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphPagePlanner;
 
@@ -28,8 +27,7 @@ final class FigmaTransformer
         private readonly RenderStyleMismatchReportBuilder $renderStyleMismatchReportBuilder = new RenderStyleMismatchReportBuilder(),
         private readonly ScenegraphNormalizer $scenegraphNormalizer = new ScenegraphNormalizer(),
         private readonly ScenegraphFrameInspector $frameInspector = new ScenegraphFrameInspector(),
-        private readonly ScenegraphPagePlanner $pagePlanner = new ScenegraphPagePlanner(),
-        private readonly ScenegraphIndex $scenegraphIndex = new ScenegraphIndex()
+        private readonly ScenegraphPagePlanner $pagePlanner = new ScenegraphPagePlanner()
     ) {
     }
 
@@ -637,7 +635,6 @@ final class FigmaTransformer
             $emitOptions = $options;
             $emitOptions['implicit_route_page_plan'] = $pagePlan;
             $emitOptions['inline_css'] = false;
-            $emitOptions['link_target_paths'] = $this->linkTargetPathsFromPages($pages, $scenegraph);
             unset($emitOptions['responsive_variants'], $emitOptions['page_name']);
             $artifact = $this->htmlEmitter->emitSite($normalized, $pagePlan, $emitOptions);
             $artifact = $this->withMultiPageSourceReports($artifact, $normalized, $pagePlan, $options);
@@ -1274,138 +1271,6 @@ final class FigmaTransformer
         }
 
         return $artifactQuality;
-    }
-
-    /**
-     * Map planned frame ids to their generated page paths so per-page emission can resolve NODE/prototype links to slugs.
-     *
-     * @param array<int, mixed> $pages
-     * @return array<string, string>
-     */
-    private function linkTargetPathsFromPages(array $pages, array $scenegraph): array
-    {
-        $map = array();
-        $descendantRootPaths = array();
-        foreach ( $pages as $page ) {
-            if ( ! is_array($page) ) {
-                continue;
-            }
-
-            $frameId = isset($page['frame_id']) && is_scalar($page['frame_id']) ? (string) $page['frame_id'] : '';
-            $path = isset($page['path']) && is_scalar($page['path']) && '' !== (string) $page['path']
-                ? (string) $page['path']
-                : (true === ($page['entrypoint'] ?? false) ? 'index.html' : (string) ($page['slug'] ?? $frameId) . '.html');
-            if ( '' === $frameId || '' === $path ) {
-                continue;
-            }
-
-            $map[$frameId] = $path;
-            $descendantRootPaths[$frameId] = $path;
-
-            foreach ( is_array($page['variants'] ?? null) ? $page['variants'] : array() as $variant ) {
-                if ( ! is_array($variant) || ! isset($variant['frame_id']) || ! is_scalar($variant['frame_id']) ) {
-                    continue;
-                }
-
-                $variantFrameId = (string) $variant['frame_id'];
-                if ( '' === $variantFrameId ) {
-                    continue;
-                }
-
-                $map[$variantFrameId] = $path;
-                $descendantRootPaths[$variantFrameId] = $path;
-            }
-        }
-
-        if ( empty($descendantRootPaths) ) {
-            return $map;
-        }
-
-        $index = $this->scenegraphIndex->build($scenegraph);
-        $nodes = is_array($index['nodes'] ?? null) ? $index['nodes'] : array();
-        $childrenIndex = is_array($index['children_index'] ?? null) ? $index['children_index'] : array();
-        foreach ( $descendantRootPaths as $rootId => $path ) {
-            $this->mapDescendantLinkTargets((string) $rootId, (string) $path, $childrenIndex, $nodes, $map);
-        }
-
-        return $map;
-    }
-
-    /**
-     * Map every node below a planned page frame to that page's generated path.
-     * Figma prototype links often target a section/text/control inside a frame
-     * instead of the page frame itself; static HTML can only navigate to the
-     * generated page path, so descendants inherit their containing page target.
-     *
-     * @param array<string, array<int, string>>  $childrenIndex
-     * @param array<string, array<string, mixed>> $nodes
-     * @param array<string, string>              $map
-     */
-    private function mapDescendantLinkTargets(string $rootId, string $path, array $childrenIndex, array $nodes, array &$map): void
-    {
-        $stack = is_array($childrenIndex[$rootId] ?? null) ? $childrenIndex[$rootId] : array();
-        $visited = array($rootId => true);
-        $guard = 0;
-
-        while ( array() !== $stack && $guard < 200000 ) {
-            ++$guard;
-            $nodeId = array_pop($stack);
-            if ( ! is_string($nodeId) || isset($visited[$nodeId]) ) {
-                continue;
-            }
-
-            $visited[$nodeId] = true;
-            $map[$nodeId] = $this->descendantLinkTargetPath($path, is_array($nodes[$nodeId] ?? null) ? $nodes[$nodeId] : array());
-
-            foreach ( is_array($childrenIndex[$nodeId] ?? null) ? $childrenIndex[$nodeId] : array() as $childId ) {
-                if ( is_string($childId) && ! isset($visited[$childId]) ) {
-                    $stack[] = $childId;
-                }
-            }
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $node
-     */
-    private function descendantLinkTargetPath(string $path, array $node): string
-    {
-        if ( 'TEXT' !== strtoupper((string) ($node['type'] ?? '')) ) {
-            return $path;
-        }
-
-        $name = strtolower((string) ($node['name'] ?? ''));
-        $fontSize = isset($node['fontSize']) && is_numeric($node['fontSize']) ? (float) $node['fontSize'] : null;
-        if ( null !== $fontSize && $fontSize < 24.0 ) {
-            return $path;
-        }
-        if ( null === $fontSize && ! str_contains($name, 'heading') && ! str_contains($name, 'title') ) {
-            return $path;
-        }
-
-        $text = trim((string) ($node['characters'] ?? $node['text'] ?? $node['name'] ?? ''));
-        if ( '' === $text ) {
-            return $path;
-        }
-
-        return $this->linkHrefWithHash($path, $this->slug($text));
-    }
-
-    private function linkHrefWithHash(string $href, string $hash): string
-    {
-        if ( '' === $hash || str_contains($href, '#') ) {
-            return $href;
-        }
-
-        return $href . '#' . $hash;
-    }
-
-    private function slug(string $value): string
-    {
-        $slug = strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', $value) ?? '');
-        $slug = trim($slug, '-');
-
-        return '' === $slug ? 'node' : $slug;
     }
 
     /**

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3546,6 +3546,7 @@ final class StaticHtmlEmitter
      */
     private function siteLinkTargetPaths(array $pagePlan, array $scenegraph, array $options): array
     {
+        $explicitPaths = $this->normalizeLinkTargetPaths($options);
         $map = $this->linkTargetPathsFromPagePlan($pagePlan, $options);
         $nodeMap = $this->nodeMap($scenegraph);
         foreach ( $this->plannedPages($pagePlan) as $index => $page ) {
@@ -3561,9 +3562,11 @@ final class StaticHtmlEmitter
                 }
             }
             foreach ( array_values(array_unique(array_filter($frameIds))) as $frameId ) {
-                $map[$frameId] = $path;
+                if ( ! isset($explicitPaths[$frameId]) ) {
+                    $map[$frameId] = $path;
+                }
                 if ( isset($nodeMap[$frameId]) && is_array($nodeMap[$frameId]) ) {
-                    $this->mapDescendantLinkTargets($nodeMap[$frameId], $path, $map, array($frameId => true));
+                    $this->mapDescendantLinkTargets($nodeMap[$frameId], $path, $map, $explicitPaths);
                 }
             }
         }
@@ -3574,11 +3577,17 @@ final class StaticHtmlEmitter
     /**
      * @param array<string, mixed> $node
      * @param array<string, string> $map
-     * @param array<string, bool> $visited
+     * @param array<string, string> $explicitPaths
      */
-    private function mapDescendantLinkTargets(array $node, string $path, array &$map, array $visited): void
+    private function mapDescendantLinkTargets(array $node, string $path, array &$map, array $explicitPaths): void
     {
-        foreach ( $this->nodeList($node) as $child ) {
+        $rootId = (string) ($node['id'] ?? '');
+        $stack = $this->nodeList($node);
+        $visited = '' === $rootId ? array() : array($rootId => true);
+        $guard = 0;
+        while ( array() !== $stack && $guard < 200000 ) {
+            ++$guard;
+            $child = array_pop($stack);
             if ( ! is_array($child) ) {
                 continue;
             }
@@ -3587,8 +3596,14 @@ final class StaticHtmlEmitter
                 continue;
             }
             $visited[$id] = true;
-            $map[$id] = $this->descendantLinkTargetPath($path, $child);
-            $this->mapDescendantLinkTargets($child, $path, $map, $visited);
+            if ( ! isset($explicitPaths[$id]) ) {
+                $map[$id] = $this->descendantLinkTargetPath($path, $child);
+            }
+            foreach ( $this->nodeList($child) as $grandchild ) {
+                if ( is_array($grandchild) ) {
+                    $stack[] = $grandchild;
+                }
+            }
         }
     }
 
@@ -3604,7 +3619,7 @@ final class StaticHtmlEmitter
             return $path;
         }
         $text = trim((string) ($node['characters'] ?? $node['text'] ?? $node['name'] ?? ''));
-        return '' === $text ? $path : $path . '#' . $this->slug($text);
+        return '' === $text ? $path : $this->linkHrefWithHash($path, $this->slug($text));
     }
 
     /** @param array<string, mixed> $pagePlan */

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -3619,7 +3619,7 @@ final class StaticHtmlEmitter
             return $path;
         }
         $text = trim((string) ($node['characters'] ?? $node['text'] ?? $node['name'] ?? ''));
-        return '' === $text ? $path : $this->linkHrefWithHash($path, $this->slug($text));
+        return '' === $text || str_contains($path, '#') ? $path : $this->linkHrefWithHash($path, $this->slug($text));
     }
 
     /** @param array<string, mixed> $pagePlan */

--- a/figma-transformer/src/Html/StaticHtmlEmitter.php
+++ b/figma-transformer/src/Html/StaticHtmlEmitter.php
@@ -577,7 +577,7 @@ final class StaticHtmlEmitter
         $implicitRoutePagePlan = is_array($options['implicit_route_page_plan'] ?? null) ? $options['implicit_route_page_plan'] : $pagePlan;
         $implicitRouteData = $this->implicitRouteDataFromPagePlan($implicitRoutePagePlan, $scenegraph);
         $this->linkState->resetForSite(
-            $this->linkTargetPathsFromPagePlan($pagePlan, $options),
+            $this->siteLinkTargetPaths($pagePlan, $scenegraph, $options),
             $this->entrypointPathFromPagePlan($implicitRoutePagePlan),
             $implicitRouteData['paths'],
             $implicitRouteData['targets']
@@ -3532,6 +3532,79 @@ final class StaticHtmlEmitter
         }
 
         return $map;
+    }
+
+    /**
+     * Build the complete site route map alongside the page-emission lifecycle.
+     * Prototype links can target descendants, while static HTML routes target
+     * the page containing that descendant.
+     *
+     * @param array<string, mixed> $pagePlan
+     * @param array<string, mixed> $scenegraph
+     * @param array<string, mixed> $options
+     * @return array<string, string>
+     */
+    private function siteLinkTargetPaths(array $pagePlan, array $scenegraph, array $options): array
+    {
+        $map = $this->linkTargetPathsFromPagePlan($pagePlan, $options);
+        $nodeMap = $this->nodeMap($scenegraph);
+        foreach ( $this->plannedPages($pagePlan) as $index => $page ) {
+            if ( ! is_array($page) ) {
+                continue;
+            }
+
+            $path = $this->pagePath($page, (string) ($page['name'] ?? 'Page'), is_int($index) ? $index : 0);
+            $frameIds = array((string) ($page['frame_id'] ?? ''));
+            foreach ( is_array($page['variants'] ?? null) ? $page['variants'] : array() as $variant ) {
+                if ( is_array($variant) ) {
+                    $frameIds[] = (string) ($variant['frame_id'] ?? '');
+                }
+            }
+            foreach ( array_values(array_unique(array_filter($frameIds))) as $frameId ) {
+                $map[$frameId] = $path;
+                if ( isset($nodeMap[$frameId]) && is_array($nodeMap[$frameId]) ) {
+                    $this->mapDescendantLinkTargets($nodeMap[$frameId], $path, $map, array($frameId => true));
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, string> $map
+     * @param array<string, bool> $visited
+     */
+    private function mapDescendantLinkTargets(array $node, string $path, array &$map, array $visited): void
+    {
+        foreach ( $this->nodeList($node) as $child ) {
+            if ( ! is_array($child) ) {
+                continue;
+            }
+            $id = (string) ($child['id'] ?? '');
+            if ( '' === $id || isset($visited[$id]) ) {
+                continue;
+            }
+            $visited[$id] = true;
+            $map[$id] = $this->descendantLinkTargetPath($path, $child);
+            $this->mapDescendantLinkTargets($child, $path, $map, $visited);
+        }
+    }
+
+    /** @param array<string, mixed> $node */
+    private function descendantLinkTargetPath(string $path, array $node): string
+    {
+        if ( 'TEXT' !== strtoupper((string) ($node['type'] ?? '')) ) {
+            return $path;
+        }
+        $name = strtolower((string) ($node['name'] ?? ''));
+        $fontSize = isset($node['fontSize']) && is_numeric($node['fontSize']) ? (float) $node['fontSize'] : null;
+        if ( (null !== $fontSize && $fontSize < 24.0) || (null === $fontSize && ! str_contains($name, 'heading') && ! str_contains($name, 'title')) ) {
+            return $path;
+        }
+        $text = trim((string) ($node['characters'] ?? $node['text'] ?? $node['name'] ?? ''));
+        return '' === $text ? $path : $path . '#' . $this->slug($text);
     }
 
     /** @param array<string, mixed> $pagePlan */

--- a/figma-transformer/tests/contract/LinkContract.php
+++ b/figma-transformer/tests/contract/LinkContract.php
@@ -165,7 +165,7 @@ function blocks_engine_figma_transformer_run_link_contract(callable $assert, cal
         ),
     ));
     $preFragmentHomeHtml = $fileContent($preFragmentResult, 'index.html');
-    $assert(str_contains($preFragmentHomeHtml, 'href="about.html#about-us" data-figma-link-type="node"') && ! str_contains($preFragmentHomeHtml, 'about.html#provided#'), 'pre-fragmented-page-path-emits-one-generated-fragment');
+    $assert(str_contains($preFragmentHomeHtml, 'href="about.html#provided" data-figma-link-type="node"') && ! str_contains($preFragmentHomeHtml, 'about.html#provided#'), 'pre-fragmented-page-path-retains-supplied-fragment');
     
     // Real anchor tags: an unresolved NODE link is counted in the diagnostic without inventing href="#".
     $unresolvedResult = blocks_engine_figma_transformer_transform_scenegraph(array(

--- a/figma-transformer/tests/contract/LinkContract.php
+++ b/figma-transformer/tests/contract/LinkContract.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Automattic\BlocksEngine\FigmaTransformer\FigFile\FigKiwiDecoder;
+use Automattic\BlocksEngine\FigmaTransformer\Html\StaticHtmlEmitter;
 use Automattic\BlocksEngine\FigmaTransformer\Scenegraph\ScenegraphNormalizer;
 
 /**
@@ -89,6 +90,12 @@ function blocks_engine_figma_transformer_run_link_contract(callable $assert, cal
     $navHomeHtml = $fileContent($navResult, 'index.html');
     $assert(str_contains($navHomeHtml, '<a class="figma-link" href="about.html" data-figma-link-type="node">'), 'node-hyperlink-resolves-to-slug');
     $assert(2 === substr_count($navHomeHtml, 'href="about.html"'), 'node-and-prototype-links-both-resolve');
+    $navOverrideResult = blocks_engine_figma_transformer_transform_scenegraph($navScenegraph, array(
+        'include_all_pages' => true,
+        'entry_frame_id' => 'nav:home',
+        'link_target_paths' => array('nav:about' => 'custom-root.html'),
+    ));
+    $assert(str_contains($fileContent($navOverrideResult, 'index.html'), 'href="custom-root.html" data-figma-link-type="node"'), 'explicit-root-link-target-path-is-preserved');
     $navPagePaths = array_values(array_map(
         static fn (array $page): string => (string) ($page['path'] ?? ''),
         array_filter($navResult['source_reports']['figma']['html']['pages'] ?? array(), 'is_array')
@@ -130,7 +137,7 @@ function blocks_engine_figma_transformer_run_link_contract(callable $assert, cal
                 'width'    => 1280,
                 'height'   => 900,
                 'children' => array(
-                    array('id' => 'desc:about:title', 'type' => 'TEXT', 'name' => 'About title', 'characters' => 'About us'),
+                    array('id' => 'desc:about:title', 'type' => 'TEXT', 'name' => 'About title', 'characters' => 'About us', 'fontSize' => 32),
                 ),
             ),
         ),
@@ -140,6 +147,25 @@ function blocks_engine_figma_transformer_run_link_contract(callable $assert, cal
     $descendantTargetLinks = $descendantTargetResult['source_reports']['figma']['html']['transform_diagnostics']['links'] ?? array();
     $assert(str_contains($descendantTargetHomeHtml, '<a class="figma-link" href="about.html#about-us" data-figma-link-type="node">'), 'descendant-prototype-target-resolves-to-containing-page');
     $assert(0 === ($descendantTargetLinks['unresolved'] ?? null) && ($descendantTargetLinks['node_links'] ?? 0) >= 1, 'descendant-prototype-target-link-coverage-resolved');
+    $descendantOverrideResult = blocks_engine_figma_transformer_transform_scenegraph($descendantTargetScenegraph, array(
+        'include_all_pages' => true,
+        'entry_frame_id' => 'desc:home',
+        'link_target_paths' => array('desc:about:title' => 'custom-descendant.html#provided'),
+    ));
+    $descendantOverrideHtml = $fileContent($descendantOverrideResult, 'index.html');
+    $assert(str_contains($descendantOverrideHtml, 'href="custom-descendant.html#provided" data-figma-link-type="node"'), 'explicit-descendant-link-target-path-is-preserved');
+    $preFragmentScenegraph = (new ScenegraphNormalizer())->normalize($descendantTargetScenegraph, array(
+        'render_document' => true,
+        'document_frame_ids' => array('desc:home', 'desc:about'),
+    ));
+    $preFragmentResult = (new StaticHtmlEmitter())->emitSite($preFragmentScenegraph, array(
+        'pages' => array(
+            array('frame_id' => 'desc:home', 'name' => 'Home', 'path' => 'index.html', 'entrypoint' => true),
+            array('frame_id' => 'desc:about', 'name' => 'About', 'path' => 'about.html#provided', 'entrypoint' => false),
+        ),
+    ));
+    $preFragmentHomeHtml = $fileContent($preFragmentResult, 'index.html');
+    $assert(str_contains($preFragmentHomeHtml, 'href="about.html#about-us" data-figma-link-type="node"') && ! str_contains($preFragmentHomeHtml, 'about.html#provided#'), 'pre-fragmented-page-path-emits-one-generated-fragment');
     
     // Real anchor tags: an unresolved NODE link is counted in the diagnostic without inventing href="#".
     $unresolvedResult = blocks_engine_figma_transformer_transform_scenegraph(array(

--- a/figma-transformer/tests/contract/LinkContract.php
+++ b/figma-transformer/tests/contract/LinkContract.php
@@ -89,6 +89,15 @@ function blocks_engine_figma_transformer_run_link_contract(callable $assert, cal
     $navHomeHtml = $fileContent($navResult, 'index.html');
     $assert(str_contains($navHomeHtml, '<a class="figma-link" href="about.html" data-figma-link-type="node">'), 'node-hyperlink-resolves-to-slug');
     $assert(2 === substr_count($navHomeHtml, 'href="about.html"'), 'node-and-prototype-links-both-resolve');
+    $navPagePaths = array_values(array_map(
+        static fn (array $page): string => (string) ($page['path'] ?? ''),
+        array_filter($navResult['source_reports']['figma']['html']['pages'] ?? array(), 'is_array')
+    ));
+    $navHtmlPaths = array_values(array_map(
+        static fn (array $file): string => (string) ($file['path'] ?? ''),
+        array_filter($navResult['files'] ?? array(), static fn (array $file): bool => 'text/html' === ($file['mime_type'] ?? null))
+    ));
+    $assert($navHtmlPaths === $navPagePaths, 'multi-page-routes-and-source-reports-remain-in-emission-order');
     
     // Prototype links may target a descendant inside a planned page frame rather than the frame itself.
     $descendantTargetScenegraph = array(


### PR DESCRIPTION
Closes #1156
Relates to #1076

## Summary
- move planned-page and descendant route-map ownership into the unified `StaticHtmlEmitter::emitSite()` lifecycle
- remove the parallel `FigmaTransformer` scenegraph-index traversal and route helpers
- preserve explicit root and descendant target overrides
- preserve caller-provided fragments and bounded cycle-safe traversal
- prove emitted page order remains aligned with source reports

## Deletion
- production: 90 additions, 137 deletions
- net production deletion: 47 lines

## Verification
- `composer --working-dir=figma-transformer test`
- `composer --working-dir=figma-transformer validate --strict`
- changed-file PHP syntax checks
- `git diff origin/trunk...HEAD --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the parallel route compilers, implemented the ownership move, ran independent regression reviews, corrected override and fragment semantics, and executed the full contract suite. Chris Huber directed and reviewed the work and is responsible for the change.