### PR TITLE
Register primitive patterns directly

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -219,16 +219,9 @@ final class HtmlTransformer
 
     private readonly LogoPattern $logoPattern;
 
-    private readonly MathPattern $mathPattern;
-
-
     private readonly TableClassificationPolicy $tableClassificationPolicy;
 
-    private readonly PlaceholderMediaPattern $placeholderMediaPattern;
-
     private readonly QuotePattern $quotePattern;
-
-    private readonly SpacerPattern $spacerPattern;
 
     private readonly PatternRecognizerRegistry $patternRecognizers;
 
@@ -591,24 +584,15 @@ final class HtmlTransformer
         $this->detailsPattern    = new DetailsPattern();
         $this->galleryPattern    = new GalleryPattern();
         $this->logoPattern       = new LogoPattern();
-        $this->mathPattern       = new MathPattern();
         $this->tableClassificationPolicy = new TableClassificationPolicy();
-        $this->placeholderMediaPattern = new PlaceholderMediaPattern();
         $this->quotePattern      = new QuotePattern();
-        $this->spacerPattern     = new SpacerPattern();
         $this->patternRecognizers = new PatternRecognizerRegistry(array(
             $this->mediaTextPattern,
             $this->coverPattern,
             $this->columnsPattern,
-            new CallbackPatternRecognizer('math', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $block = $this->mathPattern->match($element, fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement), fn (string $text): string => $this->runtime->escapeHtml($text), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block);
-            }),
+            new MathPattern(),
             new ParameterTablePattern(),
-            new CallbackPatternRecognizer('spacer', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $block = $this->spacerPattern->match($element, fn (DOMElement $sourceElement): int => $this->childElementCount($sourceElement), fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), fn (DOMElement $sourceElement, string $className): bool => $this->hasClass($sourceElement, $className), $context->presentationAttributesCallback(), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block);
-            }),
+            new SpacerPattern(),
             new CallbackPatternRecognizer('code-window', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
                 $block = $this->codeWindowPattern->match($element, $context->presentationAttributesCallback(), $context->innerHtmlCallback(), fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode), fn (DOMElement $sourceCode): string => $this->codeContent($sourceCode), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block);
@@ -617,10 +601,7 @@ final class HtmlTransformer
                 $block = $this->logoPattern->match($element, $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement), fn (DOMElement $sourceElement): string => $this->restoreSvgCasing($this->outerHtml($sourceElement)), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block);
             }),
-            new CallbackPatternRecognizer('placeholder-media', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $block = $this->placeholderMediaPattern->match($element, $context->presentationAttributesCallback(), fn (string $value): string => $this->runtime->escapeHtml($value), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block);
-            }),
+            new PlaceholderMediaPattern(),
             new CallbackPatternRecognizer('quote', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
                 $fallbacks = array();
                 $block = $this->quotePattern->matchBlockquote($element, $fallbacks, fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement), fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags), fn (string $html): string => $this->runtime->stripAllTags($html), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), fn (string $inlineTagName): bool => $this->isInlineContentElement($inlineTagName), $context->createBlockCallback());
@@ -4594,7 +4575,9 @@ final class HtmlTransformer
             fn (string $url): string => $this->resolvedAssetImageUrl($url),
             fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->mediaTextPresentationAttributes($sourceElement, $excludedGeometryProperties),
             fn (DOMElement $sourceElement): string => $this->mediaTextPresentationStyle($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->cssDeclarationString($this->structuralPresentationDeclarations($sourceElement))
+            fn (DOMElement $sourceElement): string => $this->cssDeclarationString($this->structuralPresentationDeclarations($sourceElement)),
+            fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
+            fn (string $text): string => $this->runtime->escapeHtml($text)
         );
     }
 
@@ -4622,19 +4605,20 @@ final class HtmlTransformer
     private function createProbePatternContext(): PatternContext
     {
         return new PatternContext(
-            fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-            fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
-            static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
+            presentationAttributes: fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
+            innerHtml: fn (DOMElement $sourceElement): string => $this->innerHtml($sourceElement),
+            createBlock: static fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => array(
                 'blockName'   => $name,
                 'attrs'       => $attrs,
                 'innerBlocks' => $innerBlocks,
             ),
-            null,
-            new NavigationPatternContext(
+            navigationContext: new NavigationPatternContext(
                 null,
                 fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
                 fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement))
-            )
+            ),
+            safeFallbackHtml: fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
+            escapeHtml: fn (string $text): string => $this->runtime->escapeHtml($text)
         );
     }
 
@@ -4720,7 +4704,7 @@ final class HtmlTransformer
             return null;
         }
 
-        $mathBlock = $this->recognizePatterns($element, $fallbacks, array('math'));
+        $mathBlock = $this->recognizePatterns($element, $fallbacks, array(MathPattern::class));
         if ( null !== $mathBlock ) {
             return $mathBlock;
         }
@@ -5307,14 +5291,7 @@ final class HtmlTransformer
 
             $this->captureDivBasedPseudoFormFallback($element, $fallbacks);
 
-            $spacer = $this->spacerPattern->match(
-                $element,
-                fn (DOMElement $sourceElement): int => $this->childElementCount($sourceElement),
-                fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
-                fn (DOMElement $sourceElement, string $className): bool => $this->hasClass($sourceElement, $className),
-                fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->presentationAttributes($sourceElement, $excludedGeometryProperties),
-                fn (string $name, array $attrs = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null): array => $this->createBlock($name, $attrs, $innerBlocks, $sourceElement)
-            );
+            $spacer = $this->recognizePatterns($element, $fallbacks, array(SpacerPattern::class));
             if ( null !== $spacer ) {
                 return $spacer;
             }
@@ -5388,7 +5365,7 @@ final class HtmlTransformer
                 return $logo;
             }
 
-            $spacer = $this->recognizePatterns($element, $fallbacks, array('spacer'));
+            $spacer = $this->recognizePatterns($element, $fallbacks, array(SpacerPattern::class));
             if ( null !== $spacer ) {
                 return $spacer;
             }
@@ -5673,7 +5650,7 @@ final class HtmlTransformer
      */
     private function convertMediaDispatchElement(DOMElement $element, string $tagName, array &$fallbacks): array
     {
-        $placeholderMedia = $this->recognizePatterns($element, $fallbacks, array('placeholder-media'));
+        $placeholderMedia = $this->recognizePatterns($element, $fallbacks, array(PlaceholderMediaPattern::class));
         if ( null !== $placeholderMedia ) {
             return array( 'handled' => true, 'block' => $placeholderMedia );
         }
@@ -8893,7 +8870,7 @@ final class HtmlTransformer
                 return null;
             }
 
-            $height = $this->spacerPattern->heightFromStyle($this->attr($flank, 'style'));
+            $height = SpacerPattern::heightFromStyle($this->attr($flank, 'style'));
             if ( '' === $height || ! $this->isPositiveCssLength($this->resolveCssVariablesInValue($height, $flank)) ) {
                 return null;
             }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -5365,11 +5365,6 @@ final class HtmlTransformer
                 return $logo;
             }
 
-            $spacer = $this->recognizePatterns($element, $fallbacks, array(SpacerPattern::class));
-            if ( null !== $spacer ) {
-                return $spacer;
-            }
-
             $navigationSection = $this->navigationSectionBlockFromElement($element);
             if ( null !== $navigationSection ) {
                 return $navigationSection;

--- a/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
+/** @internal Pattern recognizers are implementation details of HtmlTransformer. */
 final class MathPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;

--- a/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
@@ -5,59 +5,48 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
-final class MathPattern
+final class MathPattern implements PatternRecognizerInterface
 {
-    /**
-     * @param callable(DOMElement, string): string $attr
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(DOMElement): string $safeFallbackHtml
-     * @param callable(string): string $escapeHtml
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, callable $attr, callable $presentationAttributes, callable $innerHtml, callable $safeFallbackHtml, callable $escapeHtml, callable $createBlock): ?array
+    use PatternDomHelpersTrait;
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        if ( ! $this->isMathElement($element, $attr) ) {
+        $safeFallbackHtml = $context->safeFallbackHtmlCallback();
+        $escapeHtml = $context->escapeHtmlCallback();
+        if ( null === $safeFallbackHtml || null === $escapeHtml || ! $this->isMathElement($element) ) {
             return null;
         }
 
         $tagName = strtolower($element->tagName);
-        $content = 'math' === $tagName ? $safeFallbackHtml($element) : $this->mathExpressionContent($element, $innerHtml, $escapeHtml);
+        $content = 'math' === $tagName ? $safeFallbackHtml($element) : $this->mathExpressionContent($element, $context->innerHtmlCallback(), $escapeHtml);
         if ( '' === trim($content) ) {
             return null;
         }
 
-        return $createBlock('core/math', array_merge($presentationAttributes($element), array( 'content' => $content )), array(), $element);
+        return new PatternRecognitionResult($context->createBlockCallback()('core/math', array_merge($context->presentationAttributesCallback()($element), array( 'content' => $content )), array(), $element));
     }
 
-    /**
-     * @param callable(DOMElement, string): string $attr
-     */
-    private function isMathElement(DOMElement $element, callable $attr): bool
+    private function isMathElement(DOMElement $element): bool
     {
         if ( 'math' === strtolower($element->tagName) ) {
             return true;
         }
 
-        if ( $this->hasMathSignal($element, $attr) ) {
+        if ( $this->hasMathSignal($element) ) {
             return true;
         }
 
         return in_array(strtolower($element->tagName), array( 'div', 'p', 'span' ), true) && $this->isTeXDelimitedText(trim($element->textContent ?? ''));
     }
 
-    /**
-     * @param callable(DOMElement, string): string $attr
-     */
-    private function hasMathSignal(DOMElement $element, callable $attr): bool
+    private function hasMathSignal(DOMElement $element): bool
     {
         $signals = strtolower(trim(implode(' ', array(
-            $attr($element, 'class'),
-            $attr($element, 'id'),
-            $attr($element, 'data-math'),
-            $attr($element, 'data-latex'),
-            $attr($element, 'data-tex'),
+            $this->attr($element, 'class'),
+            $this->attr($element, 'id'),
+            $this->attr($element, 'data-math'),
+            $this->attr($element, 'data-latex'),
+            $this->attr($element, 'data-tex'),
         ))));
 
         return (bool) preg_match('/(?:^|[\s_-])(?:math|latex|tex|katex|mathjax)(?:$|[\s_-])/', $signals);

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -19,6 +19,8 @@ final class PatternContext
      * @param callable(DOMElement, array<int, string>): array<string, mixed>|null $mediaTextPresentationAttributes
      * @param callable(DOMElement): string|null $mediaTextPresentationStyle
      * @param callable(DOMElement): string|null $structuralPresentationStyle
+     * @param callable(DOMElement): string|null $safeFallbackHtml
+     * @param callable(string): string|null $escapeHtml
      */
     public function __construct(
         private readonly mixed $presentationAttributes,
@@ -31,7 +33,9 @@ final class PatternContext
         private readonly mixed $resolveAssetImageUrl = null,
         private readonly mixed $mediaTextPresentationAttributes = null,
         private readonly mixed $mediaTextPresentationStyle = null,
-        private readonly mixed $structuralPresentationStyle = null
+        private readonly mixed $structuralPresentationStyle = null,
+        private readonly mixed $safeFallbackHtml = null,
+        private readonly mixed $escapeHtml = null
     ) {
     }
 
@@ -67,4 +71,6 @@ final class PatternContext
     public function mediaTextPresentationAttributesCallback(): ?callable { return is_callable($this->mediaTextPresentationAttributes) ? $this->mediaTextPresentationAttributes : null; }
     public function mediaTextPresentationStyleCallback(): ?callable { return is_callable($this->mediaTextPresentationStyle) ? $this->mediaTextPresentationStyle : null; }
     public function structuralPresentationStyleCallback(): ?callable { return is_callable($this->structuralPresentationStyle) ? $this->structuralPresentationStyle : null; }
+    public function safeFallbackHtmlCallback(): ?callable { return is_callable($this->safeFallbackHtml) ? $this->safeFallbackHtml : null; }
+    public function escapeHtmlCallback(): ?callable { return is_callable($this->escapeHtml) ? $this->escapeHtml : null; }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
@@ -5,23 +5,17 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
-final class PlaceholderMediaPattern
+final class PlaceholderMediaPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
 
-    /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(string): string $escapeHtml
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, callable $presentationAttributes, callable $escapeHtml, callable $createBlock): ?array
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         if ( ! $this->isPlaceholderMediaElement($element) ) {
             return null;
         }
 
-        $attrs = $presentationAttributes($element);
+        $attrs = $context->presentationAttributesCallback()($element);
         // The aspect ratio rides on the preserved placeholder/ratio classNames and
         // companion-plugin CSS; a raw inline `style` string would invalidate the
         // core/group block, so it is intentionally not emitted here (#261).
@@ -29,9 +23,13 @@ final class PlaceholderMediaPattern
         unset($attrs['style']);
 
         $label = $this->placeholderLabel($element);
-        $children = '' !== $label ? array( $createBlock('core/paragraph', array( 'content' => $escapeHtml($label) ), array(), null) ) : array();
+        $escapeHtml = $context->escapeHtmlCallback();
+        if ( null === $escapeHtml ) {
+            return null;
+        }
+        $children = '' !== $label ? array( $context->createBlockCallback()('core/paragraph', array( 'content' => $escapeHtml($label) ), array(), null) ) : array();
 
-        return $createBlock('core/group', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $children, $element);
+        return new PatternRecognitionResult($context->createBlockCallback()('core/group', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $children, $element));
     }
 
     private function isPlaceholderMediaElement(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
+/** @internal Pattern recognizers are implementation details of HtmlTransformer. */
 final class PlaceholderMediaPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
@@ -12,6 +13,11 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         if ( ! $this->isPlaceholderMediaElement($element) ) {
+            return null;
+        }
+
+        $escapeHtml = $context->escapeHtmlCallback();
+        if ( null === $escapeHtml ) {
             return null;
         }
 
@@ -23,10 +29,6 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
         unset($attrs['style']);
 
         $label = $this->placeholderLabel($element);
-        $escapeHtml = $context->escapeHtmlCallback();
-        if ( null === $escapeHtml ) {
-            return null;
-        }
         $children = '' !== $label ? array( $context->createBlockCallback()('core/paragraph', array( 'content' => $escapeHtml($label) ), array(), null) ) : array();
 
         return new PatternRecognitionResult($context->createBlockCallback()('core/group', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $children, $element));

--- a/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
+/** @internal Pattern recognizers are implementation details of HtmlTransformer. */
 final class SpacerPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;

--- a/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
@@ -5,41 +5,47 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
-final class SpacerPattern
+final class SpacerPattern implements PatternRecognizerInterface
 {
-    /**
-     * @param callable(DOMElement): int $childElementCount
-     * @param callable(DOMElement, string): string $attr
-     * @param callable(DOMElement, string): bool $hasClass
-     * @param callable(DOMElement, array<int, string>): array<string, mixed> $presentationAttributes
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, callable $childElementCount, callable $attr, callable $hasClass, callable $presentationAttributes, callable $createBlock): ?array
+    use PatternDomHelpersTrait;
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        if ( '' !== trim($element->textContent ?? '') || 0 !== $childElementCount($element) ) {
+        if ( '' !== trim($element->textContent ?? '') || 0 !== $this->childElementCount($element) ) {
             return null;
         }
 
-        $height = $this->heightFromStyle($attr($element, 'style'));
+        $height = self::heightFromStyle($this->attr($element, 'style'));
         if ( '' === $height ) {
             return null;
         }
 
-        if ( ! $hasClass($element, 'wp-block-spacer') && ! $hasClass($element, 'spacer') && ! $hasClass($element, 'wsite-spacer') ) {
+        if ( ! $this->hasClass($element, 'wp-block-spacer') && ! $this->hasClass($element, 'spacer') && ! $this->hasClass($element, 'wsite-spacer') ) {
             return null;
         }
 
         // core/spacer serializes height itself. Preserve all remaining geometry
         // through the generated stylesheet rather than removing the whole carrier.
-        $attrs = $presentationAttributes($element, array( 'height' ));
+        $attrs = $context->presentationAttributesCallback()($element, array( 'height' ));
         $attrs['height'] = $height;
         unset($attrs['style']);
 
-        return $createBlock('core/spacer', $attrs, array(), $element);
+        return new PatternRecognitionResult($context->createBlockCallback()('core/spacer', $attrs, array(), $element));
     }
 
-    public function heightFromStyle(string $style): string
+    private function childElementCount(DOMElement $element): int
+    {
+        $count = 0;
+        foreach ( $element->childNodes as $child ) {
+            if ( $child instanceof DOMElement ) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    public static function heightFromStyle(string $style): string
     {
         if ( ! preg_match('/(?:^|;)\s*height\s*:\s*([^;]+)/i', $style, $matches) ) {
             return '';

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -127,7 +127,24 @@ $missingSafeFallback = new PatternContext(static fn (DOMElement $source): array 
 $missingEscapeHtml = new PatternContext(static fn (DOMElement $source): array => array(), $innerHtml, $createBlock, safeFallbackHtml: static fn (DOMElement $source): string => 'safe');
 $assertSame(null, ( new MathPattern() )->recognize($elementFromHtml('<math><mi>x</mi></math>'), $missingSafeFallback), 'Math declines without its safe-fallback context dependency.');
 $assertSame(null, ( new MathPattern() )->recognize($elementFromHtml('<math><mi>x</mi></math>'), $missingEscapeHtml), 'Math declines without its HTML-escaping context dependency.');
-$assertSame(null, ( new PlaceholderMediaPattern() )->recognize($elementFromHtml('<div class="placeholder media" style="aspect-ratio: 16 / 9">Label</div>'), $missingEscapeHtml), 'Placeholder media declines without its HTML-escaping context dependency.');
+$placeholderState = new ArrayObject();
+$missingPlaceholderEscapeHtml = new PatternContext(
+    static function (DOMElement $source) use ($placeholderState): array {
+        $placeholderState[] = 'presentation';
+        return array();
+    },
+    static function (DOMElement $source) use ($placeholderState): string {
+        $placeholderState[] = 'inner-html';
+        return '';
+    },
+    static function (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null) use ($placeholderState): array {
+        $placeholderState[] = 'create-block';
+        return array();
+    },
+    safeFallbackHtml: static fn (DOMElement $source): string => 'safe'
+);
+$assertSame(null, ( new PlaceholderMediaPattern() )->recognize($elementFromHtml('<div class="placeholder media" style="aspect-ratio: 16 / 9">Label</div>'), $missingPlaceholderEscapeHtml), 'Placeholder media declines without its HTML-escaping context dependency.');
+$assertSame(array(), $placeholderState->getArrayCopy(), 'Placeholder media validates missing dependencies before invoking stateful context callbacks.');
 
 echo "pattern recognizer registry ok\n";
 exit(0 === $failures ? 0 : 1);

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -7,6 +7,9 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognitionResult;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerInterface;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
 
 $failures = 0;
 $assertSame = static function (mixed $expected, mixed $actual, string $message) use (&$failures): void {
@@ -65,6 +68,66 @@ $result = ( new PatternRecognizerRegistry( array( $declined, $first, $second ) )
 $assertSame('first', $result?->block()['blockName'] ?? null, 'First matching recognizer wins.');
 $assertSame(array( array( 'type' => 'fallback' ) ), $result?->fallbacks(), 'Result keeps fallbacks with its block.');
 $assertSame(array( 'declined', 'first' ), $calls->getArrayCopy(), 'Declined recognizers contribute no result and dispatch stops after the winner.');
+
+$elementFromHtml = static function (string $html): DOMElement {
+    $document = new DOMDocument();
+    $previous = libxml_use_internal_errors(true);
+    $document->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+    if ( ! $document->documentElement instanceof DOMElement ) {
+        throw new RuntimeException('Fixture did not produce a DOM element.');
+    }
+
+    return $document->documentElement;
+};
+$innerHtml = static function (DOMElement $source): string {
+    $html = '';
+    foreach ( $source->childNodes as $child ) {
+        $html .= $source->ownerDocument?->saveHTML($child) ?: '';
+    }
+
+    return trim($html);
+};
+$createBlock = static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children );
+$directContext = new PatternContext(
+    static fn (DOMElement $source, array $excluded = array()): array => array(),
+    $innerHtml,
+    $createBlock,
+    safeFallbackHtml: static fn (DOMElement $source): string => $source->ownerDocument?->saveHTML($source) ?: '',
+    escapeHtml: static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+);
+$overlap = ( new PatternRecognizerRegistry( array( new MathPattern(), new PlaceholderMediaPattern() ) ) )->firstMatch($elementFromHtml('<div class="placeholder media math" style="aspect-ratio: 16 / 9">$x$</div>'), $directContext);
+$assertSame('core/math', $overlap?->block()['blockName'] ?? null, 'Math wins direct ordered-registry competition with placeholder media.');
+$assertSame('$x$', $overlap?->block()['attrs']['content'] ?? null, 'Direct ordered-registry winner preserves math content.');
+
+$state = new ArrayObject();
+$lower = new class($state) implements PatternRecognizerInterface {
+    public function __construct(private readonly ArrayObject $state) {}
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $this->state[] = 'lower';
+        return new PatternRecognitionResult(array( 'blockName' => 'lower' ));
+    }
+};
+$declinedSpacerContext = new PatternContext(
+    static function (DOMElement $source, array $excluded = array()) use ($state): array {
+        $state[] = 'presentation';
+        return array();
+    },
+    $innerHtml,
+    $createBlock
+);
+$declinedSpacer = ( new PatternRecognizerRegistry( array( new SpacerPattern(), $lower ) ) )->firstMatch($elementFromHtml('<div class="spacer" style="height: 24px">Visible content</div>'), $declinedSpacerContext);
+$assertSame('lower', $declinedSpacer?->block()['blockName'] ?? null, 'A declined direct spacer leaves lower recognizers available.');
+$assertSame(array( 'lower' ), $state->getArrayCopy(), 'A declined direct spacer does not invoke context callbacks or mutate recognizer state.');
+
+$missingSafeFallback = new PatternContext(static fn (DOMElement $source): array => array(), $innerHtml, $createBlock, escapeHtml: static fn (string $text): string => $text);
+$missingEscapeHtml = new PatternContext(static fn (DOMElement $source): array => array(), $innerHtml, $createBlock, safeFallbackHtml: static fn (DOMElement $source): string => 'safe');
+$assertSame(null, ( new MathPattern() )->recognize($elementFromHtml('<math><mi>x</mi></math>'), $missingSafeFallback), 'Math declines without its safe-fallback context dependency.');
+$assertSame(null, ( new MathPattern() )->recognize($elementFromHtml('<math><mi>x</mi></math>'), $missingEscapeHtml), 'Math declines without its HTML-escaping context dependency.');
+$assertSame(null, ( new PlaceholderMediaPattern() )->recognize($elementFromHtml('<div class="placeholder media" style="aspect-ratio: 16 / 9">Label</div>'), $missingEscapeHtml), 'Placeholder media declines without its HTML-escaping context dependency.');
 
 echo "pattern recognizer registry ok\n";
 exit(0 === $failures ? 0 : 1);

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -24,6 +24,14 @@ $button = (new HtmlTransformer())->transform('<a href="/go" aria-label="Open" st
 $assert('core/html' === ($button['blocks'][0]['blockName'] ?? null), 'Button recognition remains ahead of generic anchor lowering when its accessible-name fallback wins.');
 $assert('html_stylable_button_accessible_name_fallback' === ($button['fallbacks'][0]['diagnostic_code'] ?? null), 'Button fallback is committed by the staged registry dispatcher.');
 
+$mathOverPlaceholder = (new HtmlTransformer())->transform('<div class="placeholder media math" style="aspect-ratio: 16 / 9">$x$</div>')->toArray();
+$assert('core/math' === ($mathOverPlaceholder['blocks'][0]['blockName'] ?? null), 'Math remains ahead of the overlapping placeholder-media recognizer.');
+$assert('$x$' === ($mathOverPlaceholder['blocks'][0]['attrs']['content'] ?? null), 'The higher-precedence math recognizer preserves its exact content.');
+
+$declinedSpacer = (new HtmlTransformer())->transform('<div class="spacer" style="height: 24px">Visible content</div>')->toArray();
+$assert('core/paragraph' === ($declinedSpacer['blocks'][0]['blockName'] ?? null), 'A spacer candidate with visible content declines to normal element lowering.');
+$assert('Visible content' === ($declinedSpacer['blocks'][0]['attrs']['content'] ?? null), 'Declining spacer recognition preserves the lower-priority conversion output.');
+
 $quoteWithNavigation = (new HtmlTransformer())->transform('<blockquote><nav><a href="/one">One</a><a href="/two">Two</a></nav></blockquote>')->toArray();
 $assert('core/quote' === ($quoteWithNavigation['blocks'][0]['blockName'] ?? null), 'Quote child lowering does not re-enter unrelated registry recognizers through the navigation probe.');
 


### PR DESCRIPTION
Closes #1157
Relates to #242

## Summary
- register math, spacer, and placeholder-media as direct ordered recognizers
- remove their `HtmlTransformer` callback wrappers and the duplicate spacer probe
- make missing recognizer context dependencies decline without invoking stateful callbacks
- add real ordered-competition and declined-no-effect registry contracts

These pattern classes are internal implementation details under the package API policy documented in `php-transformer/README.md` and `docs/pr-review-guide.md`; no compatibility wrappers are retained.

## Deletion
- production: 76 additions, 101 deletions
- net production deletion: 25 lines

## Verification
- `composer --working-dir=php-transformer test`
- 281 parity fixtures
- WordPress site-plan contract
- focused recognizer registry and staged-dispatch contracts
- changed-file PHP syntax checks
- `git diff origin/trunk...HEAD --check`

The optional WordPress integration harness was unavailable because `WP_TESTS_DIR` is not configured; the non-optional site-plan contract passed.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the registry architecture, implemented the direct recognizers, ran independent regression reviews, corrected no-effect behavior, and executed the deterministic verification. Chris Huber directed and reviewed the work and is responsible for the change.