### PR TITLE
fix(php-transformer): suppress hidden mobile nav toggles

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -799,6 +799,7 @@ final class HtmlTransformer
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
+        $this->collectProjectedNavigationRelationships($body);
         $this->collectSupersededNavToggleSelectors($body);
         $shellArtifacts = !array_key_exists('extract_global_shell', $options) || !empty($options['extract_global_shell']) ? $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html')) : array();
         $this->collectGeneratedComponentCandidates($body);
@@ -4668,7 +4669,22 @@ final class HtmlTransformer
             return $block;
         }
 
-        if ( $this->isRedundantMenuToggleControl($element) ) {
+        $projectedNavigation = $this->projectedNavigationTargetForControl($element);
+        if ( $projectedNavigation instanceof DOMElement ) {
+            $block = $this->recognizePatterns($projectedNavigation, $fallbacks, array(NavigationPattern::class));
+            if ( null !== $block ) {
+                $controlAttrs = $this->presentationAttributes($element);
+                $block['attrs']['className'] = $this->mergeClassNames(
+                    'blocks-engine-list-navigation blocks-engine-native-responsive-navigation',
+                    (string) ($controlAttrs['className'] ?? ''),
+                    $this->sourceProjectionClassName($element)
+                );
+                $block['attrs']['overlayMenu'] = 'mobile';
+                return $block;
+            }
+        }
+
+        if ( $this->isProjectedNavigationSuppressed($element) || $this->isRedundantMenuToggleControl($element) ) {
             return null;
         }
 

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -5,6 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
 use DOMDocument;
 use DOMElement;
+use DOMNode;
 
 trait NavigationToggleSuppressionTrait
 {
@@ -334,15 +335,44 @@ trait NavigationToggleSuppressionTrait
 
     /**
      * Visible text label of a control with decorative chrome (icons, empty
-     * hamburger bars) stripped. Empty means the control shows no text label.
+     * hamburger bars) and source-hidden descendants stripped. Empty means the
+     * control shows no text label; accessible names remain separate semantics.
      */
     private function visibleMenuToggleLabel(DOMElement $element): string
     {
-        $html = $this->innerHtml($element);
-        $html = preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html;
-        $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>.*?<\/\1>/is', '', $html) ?? $html;
+        $label = '';
+        foreach ( $element->childNodes as $child ) {
+            $label .= $this->visibleMenuToggleText($child);
+        }
 
-        return trim($this->runtime->stripAllTags($html));
+        return trim($label);
+    }
+
+    private function visibleMenuToggleText(DOMNode $node): string
+    {
+        if ( XML_TEXT_NODE === $node->nodeType ) {
+            return $node->textContent ?? '';
+        }
+
+        if ( ! $node instanceof DOMElement
+            || 'svg' === strtolower($node->tagName)
+            || 'true' === strtolower($this->attr($node, 'aria-hidden'))
+            || $this->hasHiddenDisplay($node) ) {
+            return '';
+        }
+
+        $text = '';
+        foreach ( $node->childNodes as $child ) {
+            $text .= $this->visibleMenuToggleText($child);
+        }
+
+        return $text;
+    }
+
+    private function hasHiddenDisplay(DOMElement $element): bool
+    {
+        $declarations = $this->cssDeclarations($this->specificityResolvedPresentationStyle($element));
+        return 1 === preg_match('/^none(?:\s*!important)?$/i', trim((string) ($declarations['display'] ?? '')));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -9,6 +9,83 @@ use DOMNode;
 
 trait NavigationToggleSuppressionTrait
 {
+    /** @var array<string, DOMElement> */
+    private array $projectedNavigationTargetsByControlPath = array();
+
+    /** @var array<string, true> */
+    private array $projectedNavigationSuppressedPaths = array();
+
+    /**
+     * Bind a hidden dialog/menu to its source hamburger before recursive
+     * conversion. The responsive core/navigation must occupy the control's
+     * layout slot, not the hidden overlay's document position.
+     */
+    private function collectProjectedNavigationRelationships(DOMElement $root): void
+    {
+        $elementsById = array();
+        foreach ( $root->getElementsByTagName('*') as $element ) {
+            if ( $element instanceof DOMElement && '' !== trim($this->attr($element, 'id')) ) {
+                $elementsById[trim($this->attr($element, 'id'))] = $element;
+            }
+        }
+
+        foreach ( $root->getElementsByTagName('*') as $control ) {
+            if ( ! $control instanceof DOMElement || ! $this->isHamburgerMenuToggleControl($control) ) {
+                continue;
+            }
+
+            foreach ( preg_split('/\s+/', trim($this->attr($control, 'aria-controls'))) ?: array() as $controlledId ) {
+                $target = $elementsById[ltrim($controlledId, '#')] ?? null;
+                $navigation = $target instanceof DOMElement ? $this->hiddenNavigationInControlledTarget($target) : null;
+                if ( ! $navigation instanceof DOMElement || isset($this->projectedNavigationSuppressedPaths[$navigation->getNodePath()]) ) {
+                    continue;
+                }
+
+                $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] = $navigation;
+                $this->projectedNavigationSuppressedPaths[$target->getNodePath()] = true;
+                $this->projectedNavigationSuppressedPaths[$navigation->getNodePath()] = true;
+                break;
+            }
+        }
+    }
+
+    private function hiddenNavigationInControlledTarget(DOMElement $target): ?DOMElement
+    {
+        $tagName = strtolower($target->tagName);
+        $role = strtolower($this->attr($target, 'role'));
+        if ( ! $this->sourceElementStartsHidden($target)
+            || ( ! in_array($tagName, array( 'dialog', 'nav' ), true)
+                && ! in_array($role, array( 'dialog', 'alertdialog', 'navigation' ), true) ) ) {
+            return null;
+        }
+
+        $candidates = array($target);
+        foreach ( $target->getElementsByTagName('*') as $candidate ) {
+            if ( $candidate instanceof DOMElement ) {
+                $candidates[] = $candidate;
+            }
+        }
+        foreach ( $candidates as $candidate ) {
+            if ( $this->isAssociatedNavigationTarget($candidate)
+                && '' !== $this->sourceNavigationSignature($candidate)
+                && $this->convertsToCoreNavigation($candidate) ) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private function projectedNavigationTargetForControl(DOMElement $control): ?DOMElement
+    {
+        return $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] ?? null;
+    }
+
+    private function isProjectedNavigationSuppressed(DOMElement $element): bool
+    {
+        return isset($this->projectedNavigationSuppressedPaths[$element->getNodePath()]);
+    }
+
     /**
      * A JS-only hamburger menu-toggle that is redundant chrome whenever it is
      * associated with a source navigation menu — whether or not that menu
@@ -438,6 +515,14 @@ trait NavigationToggleSuppressionTrait
                 continue;
             }
 
+            $projectedTarget = $this->projectedNavigationTargetForControl($toggle);
+            if ( $projectedTarget instanceof DOMElement ) {
+                if ( $projectedTarget->isSameNode($navigation) ) {
+                    return 'mobile';
+                }
+                continue;
+            }
+
             if ( $this->elementContains($navigation, $toggle) ) {
                 return 'mobile';
             }
@@ -482,6 +567,7 @@ trait NavigationToggleSuppressionTrait
         foreach ( $document->getElementsByTagName('nav') as $candidate ) {
             if ( ! $candidate instanceof DOMElement
                 || $candidate->isSameNode($navigationRoot)
+                || $this->isProjectedNavigationSuppressed($candidate)
                 || $this->elementContains($navigationRoot, $candidate)
                 || $this->elementContains($candidate, $navigationRoot)
             ) {

--- a/php-transformer/tests/fixtures/parity/html-nav-hidden-dialog-projects-to-control.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-hidden-dialog-projects-to-control.json
@@ -1,0 +1,40 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-hidden-dialog-projects-to-control",
+  "description": "A fixed-header hamburger controls a separately positioned, source-hidden dialog containing mobile navigation links. The bounded aria-controls relationship projects one native mobile core/navigation into the control host, suppresses the hidden dialog-side conversion, and leaves the visible desktop navigation intact.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-hidden-dialog-projects-to-control.json",
+    "notes": "Models a responsive header and hidden menu dialog using semantic relationships only; no provider-specific class or ID convention participates in detection."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header class=\"fixed-header\"><a href=\"/\">Brand</a><div class=\"mobile-control-slot\"><button aria-label=\"Open Site Navigation\" aria-controls=\"mobile-menu\" aria-expanded=\"false\"><span class=\"screen-reader-label\">Open Site Navigation</span><svg aria-hidden=\"true\"><path></path></svg></button></div><nav class=\"desktop-navigation\" aria-label=\"Desktop navigation\"><a href=\"/\">HOME</a><a href=\"/about\">ABOUT</a><a href=\"/portfolio\">PORTFOLIO</a></nav></header><div id=\"mobile-menu\" role=\"dialog\" style=\"display:none\"><nav aria-label=\"Mobile navigation\"><ul><li><a href=\"/\">HOME</a></li><li><a href=\"/about\">ABOUT</a></li><li><a href=\"/portfolio\">PORTFOLIO</a></li></ul></nav></div>",
+    "options": { "static_css": ".screen-reader-label{display:none}" }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "fixed-header", "tagName": "header" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "mobile-control-slot" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation", "attrs": { "className": "blocks-engine-list-navigation blocks-engine-native-responsive-navigation", "style": { "spacing": { "blockGap": "0px" } }, "overlayMenu": "mobile" } },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "HOME", "url": "/", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "desktop-navigation", "overlayMenu": "never" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"overlayMenu\":\"mobile\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"HOME\",\"url\":\"/\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"ABOUT\",\"url\":\"/about\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"PORTFOLIO\",\"url\":\"/portfolio\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "mobile-menu" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "Open Site Navigation" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nav-visually-hidden-toggle-label-drop.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-visually-hidden-toggle-label-drop.json
@@ -1,0 +1,35 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-visually-hidden-toggle-label-drop",
+  "description": "Tianna-shaped mobile navigation: a source button has an accessible aria-label and a descendant label hidden by source display state. The hidden label is not visibly rendered, so the redundant source toggle is removed while core/navigation emits the single native responsive opener and its mobile overlay links.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-visually-hidden-toggle-label-drop.json",
+    "notes": "Covers source-resolved descendant display:none independently of vendor classes or IDs, while preserving visibly labeled controls as the conservative detection boundary."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream primitive fixture has no downstream legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header><button aria-label=\"Open Site Navigation\" aria-expanded=\"false\"><span class=\"screen-reader-label\">Open Site Navigation</span><svg aria-hidden=\"true\"><path></path></svg></button><nav aria-label=\"Main navigation\"><ul><li><a href=\"/\">HOME</a></li><li><a href=\"/about\">ABOUT</a></li><li><a href=\"/portfolio\">PORTFOLIO</a></li></ul></nav></header>",
+    "options": { "static_css": ".screen-reader-label{display:none}" }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/navigation", "attrs": { "className": "blocks-engine-list-navigation blocks-engine-native-responsive-navigation", "style": { "spacing": { "blockGap": "0px" } }, "overlayMenu": "mobile" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "HOME", "url": "/", "kind": "custom" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:button" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "Open Site Navigation" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"overlayMenu\":\"mobile\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"HOME\",\"url\":\"/\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"ABOUT\",\"url\":\"/about\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"PORTFOLIO\",\"url\":\"/portfolio\",\"kind\":\"custom\"} -->" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #1166

- Treat descendant text with source-resolved `display:none` as non-visible when classifying redundant navigation toggles.
- Project explicit `aria-controls` relationships and implicit dialog-popup relationships into the hamburger's source layout slot.
- Suppress the represented hidden dialog/navigation source paths and prevent the mapped control from promoting an unrelated visible desktop navigation.

## Root Cause

The prior relationship prepass only mapped `aria-controls`. The fresh source hamburger has `aria-label="Open Site Navigation"`, `aria-haspopup="dialog"`, and `aria-expanded="false"`, but an empty `aria-controls`. Its sibling dialog has `role="dialog"`, `aria-label="Site navigation"`, `aria-modal="true"`, and `data-visible="false"`. No map entry was created, so the dialog navigation still converted in below-fold flow and the fixed-header openers remained hidden.

## Design

For an eligible hamburger with dialog-popup semantics and no explicit target, the prepass searches outward through at most 12 enclosing chrome scopes. Within each scope it accepts exactly one hidden semantic dialog containing a link-bearing, convertible navigation. Two candidates fail closed, and no candidate leaves the standalone control unchanged. The resulting native navigation is emitted at the original control slot; the dialog and its navigation source paths are suppressed.

## Verification

- `composer test` passed canonical, unit, packaging, and 286 parity fixtures.
- `composer test:packaging` passed PHP transformer package install proof.
- `composer validate --strict`
- `php -l src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php`
- `php -l src/HtmlToBlocks/HtmlTransformer.php`
- PHP formatter/linter binaries are not configured in this package; syntax and strict Composer validation are the available checks.

## Structural Runtime Contract

The new no-`aria-controls` Tianna-shaped fixture proves a fixed-header control slot receives the one projected `overlayMenu: mobile` navigation with HOME, ABOUT, and PORTFOLIO links; the hidden dialog is absent; and visible desktop navigation remains `overlayMenu: never`. Separate fixtures prove ambiguous dialog candidates fail closed and an unrelated standalone dialog trigger is preserved.

The supplied packaged browser gate has not been rerun from this repository because it cannot materialize the imported WordPress site. The next external gate should verify one visible fixed-header opener at scroll position zero, the `is-menu-open` transition, and non-zero hit-testable links without autoscroll.

## AI Assistance

OpenCode with OpenAI GPT-5.6 Sol inspected the issue and supplied runtime evidence, implemented the generic transformer fix, added coverage, and ran the verification commands. Chris Huber reviewed and remains responsible.