### PR TITLE
Refactor direct Details pattern recognition

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -214,7 +214,6 @@ final class HtmlTransformer
 
     private readonly MediaTextPattern $mediaTextPattern;
 
-    private readonly DetailsPattern $detailsPattern;
 
     private readonly GalleryPattern $galleryPattern;
 
@@ -582,7 +581,6 @@ final class HtmlTransformer
         $this->columnsPattern    = new ColumnsPattern();
         $this->coverPattern      = new CoverPattern();
         $this->mediaTextPattern  = new MediaTextPattern();
-        $this->detailsPattern    = new DetailsPattern();
         $this->galleryPattern    = new GalleryPattern();
         $this->logoPattern       = new LogoPattern();
         $this->tableClassificationPolicy = new TableClassificationPolicy();
@@ -615,22 +613,7 @@ final class HtmlTransformer
                 $block = $this->quotePattern->matchFigureBlockquote($element, $blockquote, $fallbacks, fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement), $context->innerHtmlCallback(), fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags), fn (string $html): string => $this->runtime->stripAllTags($html), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
             }),
-            new CallbackPatternRecognizer('details', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $fallbacks = array();
-                $block = $this->detailsPattern->match($element, $fallbacks, fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
-            }),
-            new CallbackPatternRecognizer('disclosure', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $converter = $context->recursiveConverter();
-                if ( null === $converter ) {
-                    return null;
-                }
-                $fallbacks = array();
-                $block = $this->detailsPattern->matchDisclosure($element, function (DOMElement $sourceElement) use ($converter, &$fallbacks): array {
-                    return $converter->children($sourceElement, $fallbacks, true);
-                }, $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
-            }),
+            new DetailsPattern(),
             new CallbackPatternRecognizer('gallery', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
                 $block = $this->galleryPattern->match($element, fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link), fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $this->convertPictureElement($picture, $figure, $link), fn (DOMElement $figure): ?DOMElement => $this->figureLinkedMediaAnchor($figure), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block);
@@ -5159,7 +5142,7 @@ final class HtmlTransformer
         }
 
         if ( 'details' === $tagName ) {
-            return $this->recognizePatterns($element, $fallbacks, array('details'));
+            return $this->recognizePatterns($element, $fallbacks, array(DetailsPattern::class));
         }
 
         if ( 'a' === $tagName ) {
@@ -5404,7 +5387,7 @@ final class HtmlTransformer
                     return $metadataGrid;
                 }
 
-                $disclosure = $this->recognizePatterns($element, $fallbacks, array('disclosure'));
+                $disclosure = $this->recognizePatterns($element, $fallbacks, array(DetailsPattern::class));
                 if ( null !== $disclosure ) {
                     $this->nativeDisclosureRootIds[ $element->getNodePath() ?? '' ] = true;
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -5,30 +5,42 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
 use DOMElement;
 
-final class DetailsPattern
+final class DetailsPattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
 
-    /**
-     * @param array<int, array<string, mixed>> $fallbacks
-     * @param callable(DOMElement, array<int, array<string, mixed>>&, array<int, string>): array<int, array<string, mixed>> $convertChildrenWithoutTags
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function match(DOMElement $element, array &$fallbacks, callable $convertChildrenWithoutTags, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
+        $converter = $context->recursiveConverter();
+        if ( ! $converter instanceof PatternRecursiveConverter ) {
+            return null;
+        }
+
+        $fallbacks = array();
+        if ( 'details' !== strtolower($element->tagName) ) {
+            $block = $this->matchDisclosure(
+                $element,
+                function (DOMElement $sourceElement) use ($converter, &$fallbacks): array {
+                    return $converter->children($sourceElement, $fallbacks, true);
+                },
+                $context->presentationAttributesCallback(),
+                $context->innerHtmlCallback(),
+                $context->createBlockCallback()
+            );
+
+            return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
+        }
+
         $summary = $this->firstChildElement($element, 'summary');
-        $children = $convertChildrenWithoutTags($element, $fallbacks, array( 'summary' ));
+        $children = $converter->childrenWithoutTags($element, $fallbacks, array( 'summary' ));
         if ( null === $summary && array() === $children ) {
             return null;
         }
 
-        return $createBlock('core/details', array_filter(array_merge($presentationAttributes($element), array(
-            'summary'     => $summary instanceof DOMElement ? $innerHtml($summary) : '',
+        return new PatternRecognitionResult($context->createBlockCallback()('core/details', array_filter(array_merge($context->presentationAttributesCallback()($element), array(
+            'summary'     => $summary instanceof DOMElement ? $context->innerHtmlCallback()($summary) : '',
             'showContent' => $element->hasAttribute('open') ? true : '',
-        )), static fn ($value): bool => '' !== $value), $children, $element);
+        )), static fn ($value): bool => '' !== $value), $children, $element), $fallbacks);
     }
 
     /**
@@ -52,7 +64,7 @@ final class DetailsPattern
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>|null
      */
-    public function matchDisclosure(DOMElement $element, callable $convertChildren, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
+    private function matchDisclosure(DOMElement $element, callable $convertChildren, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
     {
         if ( $this->hasRuntimeHeavyDescendant($element) ) {
             return null;

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -41,6 +41,10 @@ $details = (new HtmlTransformer())->transform('<details><summary>More</summary><
 $assert('core/details' === ($details['blocks'][0]['blockName'] ?? null), 'Native details remains ahead of generic container lowering.');
 $assert('html_unsupported_element' === ($details['fallbacks'][0]['diagnostic_code'] ?? null), 'Details commits child fallback diagnostics through the registry result.');
 
+$overlappingDetails = (new HtmlTransformer())->transform('<details><summary><button aria-expanded="false" aria-controls="answer">Native question</button></summary><div id="answer"><p>Native answer.</p></div></details>')->toArray();
+$assert('core/details' === ($overlappingDetails['blocks'][0]['blockName'] ?? null), 'Native details wins before the overlapping ARIA disclosure shape.');
+$assert(str_contains((string) ($overlappingDetails['blocks'][0]['attrs']['summary'] ?? ''), 'Native question'), 'Native details keeps its original summary when the ARIA disclosure shape overlaps.');
+
 $button = (new HtmlTransformer())->transform('<a href="/go" aria-label="Open" style="display:inline-block;background:#000;color:#fff;padding:1rem">Go</a>')->toArray();
 $assert('core/html' === ($button['blocks'][0]['blockName'] ?? null), 'Button recognition remains ahead of generic anchor lowering when its accessible-name fallback wins.');
 $assert('html_stylable_button_accessible_name_fallback' === ($button['fallbacks'][0]['diagnostic_code'] ?? null), 'Button fallback is committed by the staged registry dispatcher.');
@@ -63,6 +67,10 @@ $assert('html_unsupported_element' === ($accordion['fallbacks'][0]['diagnostic_c
 $disclosure = (new HtmlTransformer())->transform('<div><button aria-expanded="false" aria-controls="answer">Question?</button><div id="answer"><p>Answer.</p><object data="/answer.pdf"></object></div></div>')->toArray();
 $assert('core/details' === ($disclosure['blocks'][0]['blockName'] ?? null), 'Disclosure recognition survives an unsupported panel child.');
 $assert('html_unsupported_element' === ($disclosure['fallbacks'][0]['diagnostic_code'] ?? null), 'Disclosure commits recursive panel diagnostics through its winning result.');
+
+$declinedDisclosure = (new HtmlTransformer())->transform('<div><button aria-expanded="false">Question?</button><p>Ordinary content.</p></div>')->toArray();
+$assert('core/details' !== ($declinedDisclosure['blocks'][0]['blockName'] ?? null), 'An ARIA toggle without a bounded panel declines disclosure lowering.');
+$assert(array() === ($declinedDisclosure['fallbacks'] ?? array()), 'A declined disclosure commits no recursive fallback diagnostics.');
 
 $navigationDocument = new DOMDocument();
 $previous = libxml_use_internal_errors(true);


### PR DESCRIPTION
Closes #1170
Relates to #242

## Summary

- register `DetailsPattern` directly for native details and bounded ARIA disclosure lowering
- replace callback-only `details` and `disclosure` allow-list names with `DetailsPattern::class`
- keep recursive child diagnostics transactional: they are committed only when DetailsPattern wins
- add end-to-end overlapping native-details, declined-disclosure no-effect, and existing winning fallback coverage

## Design

`DetailsPattern` takes the existing typed `PatternContext` inputs: `PatternRecursiveConverter`, presentation attributes, inner HTML, and block construction. It emits one `PatternRecognitionResult` for either native details or an ARIA disclosure. No context fields, compatibility adapter, or package contract were added.

## Deletion

- production: 30 additions, 35 deletions
- net production deletion: 5 lines
- removed transformer-owned DetailsPattern instance and both callback registrations

## Verification

- `composer --working-dir=php-transformer test`
  - canonical contracts
  - 283 PHP Transformer parity fixtures
  - package install proof
- `php -l php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php`
- `php tests/unit/pattern-registry-staged-dispatch.php`
- `php tests/unit/pattern-recognizer-registry.php`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode audited trunk and GitHub history, selected and implemented this bounded direct-recognizer simplification, wrote regression coverage, ran verification, and independently reviewed the diff. Chris Huber owns the engineering decisions and review.