### PR TITLE
Fix Details pattern public API compatibility

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -17,7 +17,18 @@ final class DetailsPattern implements PatternRecognizerInterface
         }
 
         $fallbacks = array();
-        if ( 'details' !== strtolower($element->tagName) ) {
+        if ( 'details' === strtolower($element->tagName) ) {
+            $block = $this->match(
+                $element,
+                $fallbacks,
+                function (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags) use ($converter): array {
+                    return $converter->childrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags);
+                },
+                $context->presentationAttributesCallback(),
+                $context->innerHtmlCallback(),
+                $context->createBlockCallback()
+            );
+        } else {
             $block = $this->matchDisclosure(
                 $element,
                 function (DOMElement $sourceElement) use ($converter, &$fallbacks): array {
@@ -27,20 +38,31 @@ final class DetailsPattern implements PatternRecognizerInterface
                 $context->innerHtmlCallback(),
                 $context->createBlockCallback()
             );
-
-            return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
         }
 
+        return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $fallbacks
+     * @param callable(DOMElement, array<int, array<string, mixed>>&, array<int, string>): array<int, array<string, mixed>> $convertChildrenWithoutTags
+     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
+     * @param callable(DOMElement): string $innerHtml
+     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
+     * @return array<string, mixed>|null
+     */
+    public function match(DOMElement $element, array &$fallbacks, callable $convertChildrenWithoutTags, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
+    {
         $summary = $this->firstChildElement($element, 'summary');
-        $children = $converter->childrenWithoutTags($element, $fallbacks, array( 'summary' ));
+        $children = $convertChildrenWithoutTags($element, $fallbacks, array( 'summary' ));
         if ( null === $summary && array() === $children ) {
             return null;
         }
 
-        return new PatternRecognitionResult($context->createBlockCallback()('core/details', array_filter(array_merge($context->presentationAttributesCallback()($element), array(
-            'summary'     => $summary instanceof DOMElement ? $context->innerHtmlCallback()($summary) : '',
+        return $createBlock('core/details', array_filter(array_merge($presentationAttributes($element), array(
+            'summary'     => $summary instanceof DOMElement ? $innerHtml($summary) : '',
             'showContent' => $element->hasAttribute('open') ? true : '',
-        )), static fn ($value): bool => '' !== $value), $children, $element), $fallbacks);
+        )), static fn ($value): bool => '' !== $value), $children, $element);
     }
 
     /**
@@ -64,7 +86,7 @@ final class DetailsPattern implements PatternRecognizerInterface
      * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<string, mixed>|null
      */
-    private function matchDisclosure(DOMElement $element, callable $convertChildren, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
+    public function matchDisclosure(DOMElement $element, callable $convertChildren, callable $presentationAttributes, callable $innerHtml, callable $createBlock): ?array
     {
         if ( $this->hasRuntimeHeavyDescendant($element) ) {
             return null;

--- a/php-transformer/tests/packaging/install-proof.php
+++ b/php-transformer/tests/packaging/install-proof.php
@@ -74,6 +74,38 @@ if (array('width' => '2px', 'style' => 'solid', 'color' => 'red') !== $quoteBord
     fwrite(STDERR, "php-transformer install proof failed WordPress 7.1 Quote border support\n");
     exit(1);
 }
+$previous = libxml_use_internal_errors(true);
+$document = new DOMDocument();
+$document->loadHTML('<details open><summary>More</summary><p>Answer.</p></details>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+$details = $document->documentElement;
+$pattern = new Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern();
+$fallbacks = array();
+$block = $pattern->match(
+    $details,
+    $fallbacks,
+    static fn (DOMElement $element, array &$sourceFallbacks, array $excludedTags): array => array(array('blockName' => 'core/paragraph')),
+    static fn (DOMElement $element): array => array(),
+    static fn (DOMElement $element): string => $element->textContent ?? '',
+    static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children)
+);
+if ('core/details' !== ($block['blockName'] ?? null) || true !== ($block['attrs']['showContent'] ?? null) || array() !== $fallbacks) {
+    fwrite(STDERR, "php-transformer install proof failed DetailsPattern public match API\n");
+    exit(1);
+}
+$document->loadHTML('<div><button aria-expanded="false" aria-controls="answer">Question?</button><div id="answer"><p>Answer.</p></div></div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+$disclosure = $pattern->matchDisclosure(
+    $document->documentElement,
+    static fn (DOMElement $element): array => array(array('blockName' => 'core/paragraph')),
+    static fn (DOMElement $element): array => array(),
+    static fn (DOMElement $element): string => $element->textContent ?? '',
+    static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array('blockName' => $name, 'attrs' => $attrs, 'innerBlocks' => $children)
+);
+libxml_clear_errors();
+libxml_use_internal_errors($previous);
+if ('core/details' !== ($disclosure['blockName'] ?? null) || 'Question?' !== ($disclosure['attrs']['summary'] ?? null)) {
+    fwrite(STDERR, "php-transformer install proof failed DetailsPattern public disclosure API\n");
+    exit(1);
+}
 PHP;
 
     run($proofRoot, array(PHP_BINARY, '-r', $smoke));

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -6,6 +6,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternConversionResult;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
@@ -41,9 +42,10 @@ $details = (new HtmlTransformer())->transform('<details><summary>More</summary><
 $assert('core/details' === ($details['blocks'][0]['blockName'] ?? null), 'Native details remains ahead of generic container lowering.');
 $assert('html_unsupported_element' === ($details['fallbacks'][0]['diagnostic_code'] ?? null), 'Details commits child fallback diagnostics through the registry result.');
 
-$overlappingDetails = (new HtmlTransformer())->transform('<details><summary><button aria-expanded="false" aria-controls="answer">Native question</button></summary><div id="answer"><p>Native answer.</p></div></details>')->toArray();
+$overlappingDetails = (new HtmlTransformer())->transform('<details open><summary><button aria-expanded="false" aria-controls="answer">Native question</button></summary><div id="answer"><p>Native answer.</p></div></details>')->toArray();
 $assert('core/details' === ($overlappingDetails['blocks'][0]['blockName'] ?? null), 'Native details wins before the overlapping ARIA disclosure shape.');
 $assert(str_contains((string) ($overlappingDetails['blocks'][0]['attrs']['summary'] ?? ''), 'Native question'), 'Native details keeps its original summary when the ARIA disclosure shape overlaps.');
+$assert(true === ($overlappingDetails['blocks'][0]['attrs']['showContent'] ?? null), 'Native details keeps its open-state attribute rather than taking the ARIA disclosure branch.');
 
 $button = (new HtmlTransformer())->transform('<a href="/go" aria-label="Open" style="display:inline-block;background:#000;color:#fff;padding:1rem">Go</a>')->toArray();
 $assert('core/html' === ($button['blocks'][0]['blockName'] ?? null), 'Button recognition remains ahead of generic anchor lowering when its accessible-name fallback wins.');
@@ -71,6 +73,13 @@ $assert('html_unsupported_element' === ($disclosure['fallbacks'][0]['diagnostic_
 $declinedDisclosure = (new HtmlTransformer())->transform('<div><button aria-expanded="false">Question?</button><p>Ordinary content.</p></div>')->toArray();
 $assert('core/details' !== ($declinedDisclosure['blocks'][0]['blockName'] ?? null), 'An ARIA toggle without a bounded panel declines disclosure lowering.');
 $assert(array() === ($declinedDisclosure['fallbacks'] ?? array()), 'A declined disclosure commits no recursive fallback diagnostics.');
+$assert('Question?' === ($declinedDisclosure['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['text'] ?? null), 'A declined disclosure retains its toggle through lower-priority button lowering.');
+$assert('Ordinary content.' === ($declinedDisclosure['blocks'][0]['innerBlocks'][1]['attrs']['content'] ?? null), 'A declined disclosure retains ordinary sibling content through lower-priority conversion.');
+
+$detailsPattern = new DetailsPattern();
+$detailsMethod = new ReflectionMethod(DetailsPattern::class, 'match');
+$disclosureMethod = new ReflectionMethod(DetailsPattern::class, 'matchDisclosure');
+$assert($detailsMethod->isPublic() && $disclosureMethod->isPublic(), 'DetailsPattern retains its released public lowering methods.');
 
 $navigationDocument = new DOMDocument();
 $previous = libxml_use_internal_errors(true);


### PR DESCRIPTION
## Summary
- preserve the released `DetailsPattern::match()` and `matchDisclosure()` APIs
- use those methods as the canonical lowering path behind direct registry recognition
- strengthen native-details precedence, decline/no-effect, and package API coverage

## Related

Follow-up to #1170 and #1171. Relates to #242.

## Verification

- `composer --working-dir=php-transformer test`
- focused staged-registry and package API coverage
- PHP syntax checks
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reviewed the merged direct-recognizer change, identified the released API regression, prepared the compatibility-preserving canonical lowering fix, and verified the full transformer suite. Chris Huber owns decisions and is responsible for the change.