### PR TITLE
Project implicit dialog navigation into mobile headers

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -37,23 +37,77 @@ trait NavigationToggleSuppressionTrait
             foreach ( preg_split('/\s+/', trim($this->attr($control, 'aria-controls'))) ?: array() as $controlledId ) {
                 $target = $elementsById[ltrim($controlledId, '#')] ?? null;
                 $navigation = $target instanceof DOMElement ? $this->hiddenNavigationInControlledTarget($target) : null;
-                if ( ! $navigation instanceof DOMElement || isset($this->projectedNavigationSuppressedPaths[$navigation->getNodePath()]) ) {
+                if ( ! $target instanceof DOMElement || ! $navigation instanceof DOMElement ) {
+                    continue;
+                }
+                $this->recordProjectedNavigationRelationship($control, $target, $navigation);
+                break;
+            }
+
+            if ( isset($this->projectedNavigationTargetsByControlPath[$control->getNodePath()])
+                || ! $this->hasDialogPopupSemantics($control) ) {
+                continue;
+            }
+
+            $relationship = $this->implicitHiddenNavigationRelationship($control);
+            if ( null !== $relationship ) {
+                $this->recordProjectedNavigationRelationship($control, $relationship['target'], $relationship['navigation']);
+            }
+        }
+    }
+
+    private function recordProjectedNavigationRelationship(DOMElement $control, DOMElement $target, DOMElement $navigation): void
+    {
+        if ( isset($this->projectedNavigationSuppressedPaths[$navigation->getNodePath()]) ) {
+            return;
+        }
+
+        $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] = $navigation;
+        $this->projectedNavigationSuppressedPaths[$target->getNodePath()] = true;
+        $this->projectedNavigationSuppressedPaths[$navigation->getNodePath()] = true;
+    }
+
+    private function hasDialogPopupSemantics(DOMElement $control): bool
+    {
+        return in_array('dialog', preg_split('/\s+/', strtolower(trim($this->attr($control, 'aria-haspopup')))) ?: array(), true)
+            && $control->hasAttribute('aria-expanded');
+    }
+
+    /**
+     * @return array{target: DOMElement, navigation: DOMElement}|null
+     */
+    private function implicitHiddenNavigationRelationship(DOMElement $control): ?array
+    {
+        $depth = 0;
+        for ( $scope = $this->menuToggleScope($control); $scope instanceof DOMElement && $depth < 12; $scope = $scope->parentNode, ++$depth ) {
+            $candidates = array();
+            foreach ( $scope->getElementsByTagName('*') as $candidate ) {
+                if ( ! $candidate instanceof DOMElement || $candidate->isSameNode($control) || ! $this->isSemanticDialog($candidate) ) {
                     continue;
                 }
 
-                $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] = $navigation;
-                $this->projectedNavigationSuppressedPaths[$target->getNodePath()] = true;
-                $this->projectedNavigationSuppressedPaths[$navigation->getNodePath()] = true;
-                break;
+                $navigation = $this->hiddenNavigationInControlledTarget($candidate);
+                if ( $navigation instanceof DOMElement ) {
+                    $candidates[] = array('target' => $candidate, 'navigation' => $navigation);
+                }
+            }
+
+            if ( 1 === count($candidates) ) {
+                return $candidates[0];
+            }
+            if ( 1 < count($candidates) ) {
+                return null;
             }
         }
+
+        return null;
     }
 
     private function hiddenNavigationInControlledTarget(DOMElement $target): ?DOMElement
     {
         $tagName = strtolower($target->tagName);
         $role = strtolower($this->attr($target, 'role'));
-        if ( ! $this->sourceElementStartsHidden($target)
+        if ( ! $this->sourceElementIsHidden($target)
             || ( ! in_array($tagName, array( 'dialog', 'nav' ), true)
                 && ! in_array($role, array( 'dialog', 'alertdialog', 'navigation' ), true) ) ) {
             return null;
@@ -74,6 +128,20 @@ trait NavigationToggleSuppressionTrait
         }
 
         return null;
+    }
+
+    private function isSemanticDialog(DOMElement $element): bool
+    {
+        return 'dialog' === strtolower($element->tagName)
+            || in_array(strtolower($this->attr($element, 'role')), array( 'dialog', 'alertdialog' ), true);
+    }
+
+    private function sourceElementIsHidden(DOMElement $element): bool
+    {
+        return $this->sourceElementStartsHidden($element)
+            || $element->hasAttribute('hidden')
+            || 'true' === strtolower($this->attr($element, 'aria-hidden'))
+            || 'false' === strtolower($this->attr($element, 'data-visible'));
     }
 
     private function projectedNavigationTargetForControl(DOMElement $control): ?DOMElement

--- a/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-ambiguous-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-ambiguous-preserved.json
@@ -1,0 +1,23 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-implicit-dialog-ambiguous-preserved",
+  "description": "A dialog-popup hamburger shares its chrome scope with two hidden, link-bearing navigation dialogs. The implicit relationship is ambiguous, so neither target is projected or suppressed and the standalone control remains content.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-implicit-dialog-ambiguous-preserved.json",
+    "notes": "Fail-closed guard for implicit dialog pairing." 
+  },
+  "legacy_comparison": { "skip": true, "reason": "This upstream primitive fixture has no downstream legacy comparison." },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header><button aria-label=\"Open menu\" aria-haspopup=\"dialog\" aria-expanded=\"false\"><span class=\"screen-reader-label\">Open menu</span><svg aria-hidden=\"true\"><path></path></svg></button></header><div role=\"dialog\" aria-label=\"Site navigation\" data-visible=\"false\"><nav><a href=\"/\">HOME</a><a href=\"/about\">ABOUT</a></nav></div><div role=\"dialog\" aria-label=\"Account navigation\" data-visible=\"false\"><nav><a href=\"/account\">ACCOUNT</a><a href=\"/logout\">LOG OUT</a></nav></div>",
+    "options": { "static_css": ".screen-reader-label{display:none}" }
+  },
+  "expected_blocks": [],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Open menu" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "\"overlayMenu\":\"mobile\"" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-projects-to-control.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-projects-to-control.json
@@ -1,0 +1,37 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-implicit-dialog-projects-to-control",
+  "description": "Tianna-shaped responsive navigation: an icon-only hamburger exposes dialog semantics through aria-haspopup and aria-expanded but has no aria-controls. Its nearest shared chrome scope contains exactly one source-hidden dialog with link-bearing navigation, so that navigation is projected into the fixed-header control slot and the dialog source is suppressed.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-implicit-dialog-projects-to-control.json",
+    "notes": "Uses only generic ARIA dialog state, source-hidden data-visible state, and semantic navigation structure."
+  },
+  "legacy_comparison": { "skip": true, "reason": "This upstream primitive fixture has no downstream legacy comparison." },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<div class=\"chrome-shell\"><header class=\"fixed-header\"><a href=\"/\">Brand</a><div class=\"mobile-control-slot\"><button aria-label=\"Open menu\" aria-haspopup=\"dialog\" aria-expanded=\"false\"><span class=\"screen-reader-label\">Open menu</span><svg aria-hidden=\"true\"><path></path></svg></button></div><nav class=\"desktop-navigation\" aria-label=\"Desktop navigation\"><a href=\"/\">HOME</a><a href=\"/about\">ABOUT</a><a href=\"/portfolio\">PORTFOLIO</a></nav></header><div id=\"mobile-menu\" role=\"dialog\" aria-modal=\"true\" aria-label=\"Site navigation\" data-visible=\"false\"><nav aria-label=\"Mobile navigation\"><ul><li><a href=\"/\">HOME</a></li><li><a href=\"/about\">ABOUT</a></li><li><a href=\"/portfolio\">PORTFOLIO</a></li></ul></nav></div></div>",
+    "options": { "static_css": ".screen-reader-label{display:none}" }
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group", "attrs": { "className": "chrome-shell" } },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "fixed-header", "tagName": "header" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "mobile-control-slot" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation", "attrs": { "className": "blocks-engine-list-navigation blocks-engine-native-responsive-navigation", "style": { "spacing": { "blockGap": "0px" } }, "overlayMenu": "mobile" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "HOME", "url": "/", "kind": "custom" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "desktop-navigation", "overlayMenu": "never" } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks.0.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks", "assert": "count", "count": 1 },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks", "assert": "count", "count": 3 },
+    { "path": "serialized_blocks", "assert": "contains", "value": "\"overlayMenu\":\"mobile\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"ABOUT\",\"url\":\"/about\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"PORTFOLIO\",\"url\":\"/portfolio\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "mobile-menu" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "Open menu" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-standalone-preserved.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-standalone-preserved.json
@@ -1,0 +1,23 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-nav-implicit-dialog-standalone-preserved",
+  "description": "An icon-only dialog-popup control with no eligible hidden navigation target remains an ordinary source control; popup semantics alone never cause navigation projection or suppression.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-nav-implicit-dialog-standalone-preserved.json",
+    "notes": "Negative guard for unrelated standalone dialog triggers." 
+  },
+  "legacy_comparison": { "skip": true, "reason": "This upstream primitive fixture has no downstream legacy comparison." },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<header><button aria-label=\"Open menu\" aria-haspopup=\"dialog\" aria-expanded=\"false\"><span class=\"screen-reader-label\">Open menu</span><svg aria-hidden=\"true\"><path></path></svg></button></header>",
+    "options": { "static_css": ".screen-reader-label{display:none}" }
+  },
+  "expected_blocks": [],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "Open menu" },
+    { "path": "serialized_blocks", "assert": "not_contains", "value": "<!-- wp:navigation" }
+  ]
+}


### PR DESCRIPTION
## Summary

Completes #1166 after PR #1169 handled explicit dialog relationships.

- Resolves an implicit hamburger-to-dialog navigation relationship when `aria-haspopup="dialog"` is present without `aria-controls`.
- Projects the hidden dialog's native navigation into the original fixed-header control slot.
- Fails closed when the enclosing chrome scope contains ambiguous eligible dialogs.
- Preserves standalone controls and visible desktop navigation.

## Runtime Evidence

The combined Tianna import passed the external WordPress browser gate at `http://localhost:8925/`:

- 11/11 routes returned HTTP 200.
- Mobile anonymous: one fixed, hit-testable opener at `347.5,17.5`, `24x24`; opening it leaves `scrollY=0` and exposes the native navigation.
- Mobile authenticated: opener at `347.5,63.5`, below the 46px admin bar; same no-scroll interaction result.
- 22/22 homepage images loaded; 2,835 blocks; zero `core/html` fallback blocks.

Evidence: `/Users/chubes/Studio/tianna-1154-1163-final-20260824-144156/VALIDATION.md`.

## Verification

- `composer test`
- `composer test:packaging`
- `composer validate --strict`
- `git diff --check`

## AI Assistance

OpenCode with OpenAI GPT-5.6 Sol traced the packaged WordPress mobile runtime, implemented the bounded implicit-dialog relationship projection, added deterministic fixtures, and ran the listed verification. Chris Huber directed the work and remains responsible for review.
