### PR TITLE
perf(php-transformer): reuse stylesheet discovery per page

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -55,6 +55,9 @@ final class ArtifactCompiler
     /** Observational only: excludes receipt cache hits. */
     private int $htmlDocumentTransformCount = 0;
 
+    /** Observational only: counts source stylesheet discovery passes. */
+    private int $stylesheetAssetDiscoveryCount = 0;
+
     public function __construct(private readonly bool $cacheHtmlAnalysis = true)
     {
     }
@@ -76,6 +79,7 @@ final class ArtifactCompiler
             'author_hits' => $cache->authorSelectorHits,
             'author_evictions' => $cache->authorSelectorEvictions,
             'author_bytes' => $cache->authorSelectorBytes,
+            'stylesheet_asset_discoveries' => $this->stylesheetAssetDiscoveryCount,
         );
     }
 
@@ -1968,7 +1972,8 @@ final class ArtifactCompiler
             );
         }
 
-        $stylesheetPayloads = $this->linkedStylesheetPayloads($html, $sourcePath, $files);
+        $stylesheetAssets = $this->stylesheetAssetsForSource($html, $sourcePath, $files);
+        $stylesheetPayloads = $this->linkedStylesheetPayloads($stylesheetAssets, $sourcePath, $files);
         $analysisCache = $this->cacheHtmlAnalysis
             ? $this->htmlTransformerAnalysisCache ??= new HtmlTransformerAnalysisCache()
             : new HtmlTransformerAnalysisCache();
@@ -1977,9 +1982,9 @@ final class ArtifactCompiler
             'source'                    => $sourcePath,
             'source_scope'              => $sourceScope,
             'declarative_state_html'    => $html,
-            'static_css'                => $this->linkedStylesheetCss($html, $sourcePath, $files),
+            'static_css'                => trim(implode("\n", array_column($stylesheetPayloads, 'content'))),
             'stylesheet_payloads'       => $stylesheetPayloads,
-            'author_stylesheet_assets'  => $this->stylesheetAssetsForSource($html, $sourcePath, $files),
+            'author_stylesheet_assets'  => $stylesheetAssets,
             'skip_author_stylesheet_materialization' => true,
             'asset_metadata'            => $this->assetMetadataForSource($sourcePath, $files),
             'runtime_script_metadata'   => $this->runtimeScriptMetadataForSource($html, $sourcePath, $files),
@@ -2376,23 +2381,16 @@ final class ArtifactCompiler
     }
 
     /**
-     * @param array<int, array<string, mixed>> $files
-     */
-    private function linkedStylesheetCss(string $html, string $sourcePath, array $files): string
-    {
-        return trim(implode("\n", array_column($this->linkedStylesheetPayloads($html, $sourcePath, $files), 'content')));
-    }
-
-    /**
      * Keep source stylesheet boundaries intact for payload-addressed analysis.
      *
+     * @param list<array{path: string, content: string, source_hash: string}> $stylesheets
      * @param array<int, array<string, mixed>> $files
      * @return list<array{content: string, source_hash: string}>
      */
-    private function linkedStylesheetPayloads(string $html, string $sourcePath, array $files): array
+    private function linkedStylesheetPayloads(array $stylesheets, string $sourcePath, array $files): array
     {
         $payloads = array();
-        foreach ( $this->stylesheetAssetsForSource($html, $sourcePath, $files) as $stylesheet ) {
+        foreach ( $stylesheets as $stylesheet ) {
             $content = (string) ($stylesheet['content'] ?? '');
             if ( '' !== trim($content) ) {
                 $payloads[] = array(
@@ -2414,6 +2412,7 @@ final class ArtifactCompiler
      */
     private function stylesheetAssetsForSource(string $html, string $sourcePath, array $files): array
     {
+        ++$this->stylesheetAssetDiscoveryCount;
         $byPath = array();
         $inline = array();
         $occurrencePaths = array();

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -96,6 +96,7 @@ $assert(array() !== $cachedSitePlan && array() !== $isolatedSitePlan, 'The repea
 $assert($withoutDurations($isolatedSitePlan) === $withoutDurations($cachedSitePlan), 'A 54-page artifact must produce the same canonical WordPress site plan with cached and isolated stylesheet analysis.');
 $artifactMetrics = $cachedCompiler->htmlAnalysisCacheMetrics();
 $assert(($artifactMetrics['style_builds'] ?? 0) === 55 && ($artifactMetrics['style_hits'] ?? 0) >= 53 && ($artifactMetrics['style_bytes'] ?? 0) > 0, 'Artifact compiler exposes bounded source-payload cache build, hit, and byte counters.');
+$assert(55 === ($artifactMetrics['stylesheet_asset_discoveries'] ?? null), 'A 54-page repeated-CSS artifact discovers each document stylesheet set once, plus one canonical site-ordering pass.');
 
 $byteBudgetCache = new HtmlTransformerAnalysisCache();
 $byteBudgetPayloads = array();


### PR DESCRIPTION
## Summary

- discover each HTML document stylesheet set once and share that immutable result across static CSS, payload analysis, and author projection inputs
- expose an observational stylesheet discovery counter without changing canonical result envelopes
- extend the representative 54-page repeated-CSS regression to require one discovery per page plus canonical site ordering
- keep Blocks Engine generic and leave bounded cache sizing unchanged

Relates to #1044.

## Performance Evidence

The deterministic 54-page repeated-CSS artifact previously performed 163 stylesheet discovery passes: three per document plus one canonical site-ordering pass. It now performs 55, reducing repeated discovery work by 108 passes (66.3%). The same regression compares cached and isolated compilation and requires byte-equivalent canonical WordPress site plans.

## Verification

- `php tests/unit/html-transformer-shared-analysis-cache.php`
- `composer validate --strict`
- `composer test`
- `php tests/contract/production-acceptance-matrix.php`
- `git diff --check`

The required WordPress integration suite uses the CI-provisioned WordPress test runtime and will be verified by this draft PR's checks.

## AI Assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** Reading issue and source context, implementing the generic stylesheet-discovery ownership change, adding deterministic performance instrumentation and regression coverage, running verification, and drafting this PR. Chris Huber reviewed and remains responsible for the change.