### PR TITLE
Retain bounded WordPress plan failure diagnostics

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlanView.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlanView.php
@@ -9,6 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
 final class WordPressSitePlanView
 {
     public const SCHEMA = 'blocks-engine/wordpress-site-plan-view/v1';
+    public const MAX_FAILURE_DIAGNOSTICS = 100;
 
     /** @return array<string,mixed> */
     public function fromResult(TransformerResult|array $result): array
@@ -34,17 +35,42 @@ final class WordPressSitePlanView
         $sourceReports = $data['source_reports'];
         $materializationPlan = is_array($sourceReports['materialization_plan'] ?? null) ? $sourceReports['materialization_plan'] : array();
         $theme = is_array($materializationPlan['theme'] ?? null) ? $materializationPlan['theme'] : array();
+        $wordpressSitePlan = $this->arrayValue($sourceReports, 'wordpress_site_plan');
+        $diagnostics = $this->arrayValue($sourceReports, 'wordpress_site_plan_diagnostics');
+        if ('failed' === $data['status'] && array() === $wordpressSitePlan && array() === $diagnostics) {
+            $diagnostics = $this->boundedFailureDiagnostics($data['diagnostics']);
+        }
 
         return array(
             'schema' => self::SCHEMA,
             'result_schema' => $data['schema'],
             'status' => $data['status'],
-            'wordpress_site_plan' => $this->arrayValue($sourceReports, 'wordpress_site_plan'),
+            'wordpress_site_plan' => $wordpressSitePlan,
             'gutenberg_gaps' => $this->arrayValue($sourceReports, 'gutenberg_gaps'),
             'companion_plugin_payload' => $this->arrayValue($sourceReports, 'companion_plugin_payload'),
             'font_materialization' => $this->arrayValue($theme, 'font_materialization'),
-            'diagnostics' => $this->arrayValue($sourceReports, 'wordpress_site_plan_diagnostics'),
+            'diagnostics' => $diagnostics,
         );
+    }
+
+    /** @param array<int,array<string,mixed>> $diagnostics @return array<int,array<string,mixed>> */
+    private function boundedFailureDiagnostics(array $diagnostics): array
+    {
+        $errors = array_values(array_filter($diagnostics, static fn (array $diagnostic): bool => 'error' === ($diagnostic['severity'] ?? null)));
+        if (count($errors) <= self::MAX_FAILURE_DIAGNOSTICS) {
+            return $errors;
+        }
+
+        $retainedCount = self::MAX_FAILURE_DIAGNOSTICS - 1;
+        $retained = array_slice($errors, 0, $retainedCount);
+        $retained[] = array(
+            'code' => 'wordpress_site_plan_view_diagnostics_truncated',
+            'severity' => 'warning',
+            'message' => 'Additional canonical compiler errors were omitted from the bounded WordPress site plan view.',
+            'retained_count' => $retainedCount,
+            'omitted_count' => count($errors) - $retainedCount,
+        );
+        return $retained;
     }
 
     /** @param array<string,mixed> $data @return array<mixed> */

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2927,6 +2927,27 @@ $assert(($simple['source_reports']['wordpress_site_plan'] ?? array()) === ($simp
 $assert(($boundedHandoffResult->toArray()['source_reports']['wordpress_site_plan'] ?? array()) === ($simpleObjectPlanView['wordpress_site_plan'] ?? null), 'TransformerResult handoff preserves the exact canonical plan without a compatibility projection');
 $assert(array('schema', 'result_schema', 'status', 'wordpress_site_plan', 'gutenberg_gaps', 'companion_plugin_payload', 'font_materialization', 'diagnostics') === array_keys($simplePlanView), 'WordPress site plan view has a stable bounded shape');
 $assert(!isset($simplePlanView['compiled_site'], $simplePlanView['materialization_plan'], $simplePlanView['assets'], $simplePlanView['documents'], $simplePlanView['blocks']), 'WordPress site plan view omits duplicate legacy and root projections');
+$failedPlanResult = $simple;
+$failedPlanResult['status'] = 'failed';
+unset($failedPlanResult['source_reports']['wordpress_site_plan'], $failedPlanResult['source_reports']['wordpress_site_plan_diagnostics']);
+$failedPlanResult['diagnostics'] = array(
+    array('code' => 'non_plan_warning', 'severity' => 'warning', 'message' => 'Not actionable for a failed handoff.'),
+    array('code' => 'non_plan_failure', 'severity' => 'error', 'message' => 'Canonical compiler failure.'),
+);
+$failedPlanView = (new WordPressSitePlanView())->fromResult($failedPlanResult);
+$assert(array('non_plan_failure') === array_column($failedPlanView['diagnostics'], 'code'), 'failed WordPress site plan view retains canonical compiler errors when no plan-specific diagnostic exists');
+$planSpecificDiagnostic = array('code' => 'wordpress_site_plan_invalid', 'severity' => 'error', 'message' => 'Plan-specific failure.');
+$failedPlanResult['source_reports']['wordpress_site_plan_diagnostics'] = array($planSpecificDiagnostic);
+$failedPlanView = (new WordPressSitePlanView())->fromResult($failedPlanResult);
+$assert(array($planSpecificDiagnostic) === $failedPlanView['diagnostics'], 'failed WordPress site plan view preserves existing plan-specific diagnostics exactly');
+unset($failedPlanResult['source_reports']['wordpress_site_plan_diagnostics']);
+$failedPlanResult['diagnostics'] = array_map(
+    static fn (int $index): array => array('code' => 'compiler_error_' . $index, 'severity' => 'error', 'message' => 'Compiler error.'),
+    range(1, WordPressSitePlanView::MAX_FAILURE_DIAGNOSTICS + 5)
+);
+$failedPlanView = (new WordPressSitePlanView())->fromResult($failedPlanResult);
+$truncationDiagnostic = $failedPlanView['diagnostics'][WordPressSitePlanView::MAX_FAILURE_DIAGNOSTICS - 1] ?? array();
+$assert(WordPressSitePlanView::MAX_FAILURE_DIAGNOSTICS === count($failedPlanView['diagnostics']) && 'compiler_error_1' === ($failedPlanView['diagnostics'][0]['code'] ?? '') && 'compiler_error_99' === ($failedPlanView['diagnostics'][98]['code'] ?? '') && 'wordpress_site_plan_view_diagnostics_truncated' === ($truncationDiagnostic['code'] ?? '') && 99 === ($truncationDiagnostic['retained_count'] ?? null) && 6 === ($truncationDiagnostic['omitted_count'] ?? null), 'failed WordPress site plan view deterministically bounds canonical compiler errors with explicit truncation evidence');
 $assert(ArtifactCompiler::INPUT_SCHEMA === ($simple['source_reports']['artifact']['schema'] ?? ''), 'artifact report exposes canonical site artifact schema');
 $assert(ArtifactCompiler::INPUT_SCHEMA === ($simple['source_reports']['artifact']['original_schema'] ?? ''), 'canonical site artifact input schema is accepted and preserved');
 $assert('index.html' === ($simple['source_reports']['artifact']['entry_path'] ?? ''), 'generated HTML becomes an index entry');


### PR DESCRIPTION
## Summary

- fall back to canonical compiler errors when failed results have no plan-specific diagnostics
- cap the importer-facing projection deterministically
- preserve existing successful-plan and plan-specific diagnostic behavior

Closes #1172

## Verification

- `php php-transformer/tests/contract/run.php`
- `composer validate --strict` in `php-transformer`

## AI assistance

OpenCode with OpenAI `gpt-5.6-sol` diagnosed the bounded-view information loss, implemented and reviewed the fallback projection, and reran contract and Composer validation. Chris Huber directed the work and remains responsible for the change.