### PR TITLE
Bound captured-dialog staged evidence

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -555,7 +555,10 @@ final class ArtifactCompiler
         return $this->finalizeArtifact($artifact, array(
             'normalized' => $normalized,
             'inline_compilation' => true,
-            'captured_dialogs' => $capturedDialogs,
+            'captured_dialogs' => array(
+                'diagnostics' => $capturedDialogs['diagnostics'],
+                'projected_count' => $capturedDialogs['projected_count'],
+            ),
         ));
     }
 
@@ -1036,7 +1039,10 @@ final class ArtifactCompiler
             'canonical_provenance_hashes' => $canonicalProvenanceHashes,
             'canonical_diagnostics' => array_merge($normalized['diagnostics'], $capturedDialogs['diagnostics']),
             'canonical_rejected_count' => $normalized['rejected_count'],
-            'captured_dialogs' => $capturedDialogs,
+            'captured_dialogs' => array(
+                'diagnostics' => $capturedDialogs['diagnostics'],
+                'projected_count' => $capturedDialogs['projected_count'],
+            ),
         );
     }
 

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -31,6 +31,7 @@ $artifact['runtime_declarations'] = array(array('kind' => 'entity_collection', '
 $compiler = new ArtifactCompiler();
 $shared = $compiler->prepareShared($artifact);
 $assert('blocks-engine/php-transformer/staged-shared-plan/v1' === $shared['schema'] && 2 === $shared['summary']['file_count'] && preg_match('/^[a-f0-9]{64}$/', $shared['digest']), 'Shared preparation preserves the published v1 plan envelope and digest.');
+$assert(array('diagnostics', 'projected_count') === array_keys($shared['analysis']['captured_dialogs']), 'Shared preparation persists bounded captured-dialog evidence without duplicating projected artifact files.');
 // Inline assets expanded out of an unannotated page follow that page, not the
 // immutable shared plan: parking page-varying content in the shared plan would
 // invalidate every page plan on a page edit.


### PR DESCRIPTION
## Summary

- retain only captured-dialog diagnostics and projected count in staged shared analysis
- keep projected files in their existing shared/page ownership records without duplicating them under analysis
- assert the bounded serialized evidence shape while preserving staged and whole compilation parity

Fixes #1192.

## Verification

- `composer test`
- `php tests/contract/staged-artifact-compilation.php`
- `php tests/unit/artifact-normalizer-source-budget.php`
- PHP syntax checks for changed files
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode measured the 225 MB staged plan, traced 209.7 MB to duplicated captured-dialog files, implemented the bounded evidence shape, and ran the full Composer test suite. Chris Huber directed the work and remains responsible.