### PR TITLE
Make projected mobile navigation presentation-safe

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -1401,6 +1401,22 @@ final class HtmlTransformer
             if ( str_contains($serializedBlocks, 'blocks-engine-native-responsive-navigation') ) {
                 $afterAuthorCssParts[] = '.wp-block-navigation.blocks-engine-list-navigation.blocks-engine-native-responsive-navigation{display:flex!important}';
             }
+            if ( str_contains($serializedBlocks, 'blocks-engine-projected-dialog-navigation') ) {
+                $mobileOverlayBackground = $this->sourceMobileNavigationOverlayBackground();
+                $fallbackTextColor = '';
+                if ( '' === $mobileOverlayBackground ) {
+                    $mobileOverlayBackground = '#fff';
+                    $fallbackTextColor = 'color:#111!important;';
+                }
+                $projectedOpenMenu = '.wp-block-navigation.blocks-engine-projected-dialog-navigation .wp-block-navigation__responsive-container.is-menu-open';
+                $afterAuthorCssParts[] = $projectedOpenMenu . '{background:' . $mobileOverlayBackground . '!important;' . $fallbackTextColor . 'position:fixed!important;inset:0!important;padding:clamp(4rem,12vh,7rem) clamp(1.5rem,6vw,4rem) 2rem!important;overflow-y:auto!important;z-index:99998!important}'
+                    . "\n" . $projectedOpenMenu . ' .wp-block-navigation__responsive-container-content{align-items:flex-start!important;justify-content:flex-start!important;gap:1rem!important;width:100%!important}'
+                    . "\n" . $projectedOpenMenu . ' .wp-block-navigation__container{align-items:flex-start!important;gap:.75rem!important;width:100%!important}'
+                    . "\n" . $projectedOpenMenu . ' .wp-block-navigation-item__content{' . $fallbackTextColor . 'font-size:clamp(1.125rem,4vw,1.5rem)!important;line-height:1.4!important;padding:.5rem 0!important}'
+                    . "\n" . $projectedOpenMenu . ' .wp-block-navigation__responsive-container-close{background:#fff!important;color:#111!important;position:fixed!important;top:1rem!important;right:1rem!important;padding:.75rem!important;z-index:1!important}'
+                    . "\n" . 'body.admin-bar ' . $projectedOpenMenu . '{top:var(--wp-admin--admin-bar--height,32px)!important}'
+                    . "\n" . 'body.admin-bar ' . $projectedOpenMenu . ' .wp-block-navigation__responsive-container-close{top:calc(1rem + var(--wp-admin--admin-bar--height,32px))!important}';
+            }
             // Size a carried menu to its content when it sits inside a brand
             // carrier. The carrier renders <nav> and core/navigation renders
             // another <nav> inside it, so an authored `header nav` rule matches
@@ -4665,8 +4681,12 @@ final class HtmlTransformer
             $block = $this->recognizePatterns($projectedNavigation, $fallbacks, array(NavigationPattern::class));
             if ( null !== $block ) {
                 $controlAttrs = $this->presentationAttributes($element);
+                $nativeClassNames = 'blocks-engine-list-navigation blocks-engine-native-responsive-navigation';
+                if ( $this->isImplicitDialogNavigationControl($element) ) {
+                    $nativeClassNames .= ' blocks-engine-projected-dialog-navigation';
+                }
                 $block['attrs']['className'] = $this->mergeClassNames(
-                    'blocks-engine-list-navigation blocks-engine-native-responsive-navigation',
+                    $nativeClassNames,
                     (string) ($controlAttrs['className'] ?? ''),
                     $this->sourceProjectionClassName($element)
                 );

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -15,6 +15,9 @@ trait NavigationToggleSuppressionTrait
     /** @var array<string, true> */
     private array $projectedNavigationSuppressedPaths = array();
 
+    /** @var array<string, true> */
+    private array $implicitDialogNavigationControlPaths = array();
+
     /**
      * Bind a hidden dialog/menu to its source hamburger before recursive
      * conversion. The responsive core/navigation must occupy the control's
@@ -51,6 +54,7 @@ trait NavigationToggleSuppressionTrait
 
             $relationship = $this->implicitHiddenNavigationRelationship($control);
             if ( null !== $relationship ) {
+                $this->implicitDialogNavigationControlPaths[$control->getNodePath()] = true;
                 $this->recordProjectedNavigationRelationship($control, $relationship['target'], $relationship['navigation']);
             }
         }
@@ -147,6 +151,11 @@ trait NavigationToggleSuppressionTrait
     private function projectedNavigationTargetForControl(DOMElement $control): ?DOMElement
     {
         return $this->projectedNavigationTargetsByControlPath[$control->getNodePath()] ?? null;
+    }
+
+    private function isImplicitDialogNavigationControl(DOMElement $control): bool
+    {
+        return isset($this->implicitDialogNavigationControlPaths[$control->getNodePath()]);
     }
 
     private function isProjectedNavigationSuppressed(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-projects-to-control.json
+++ b/php-transformer/tests/fixtures/parity/html-nav-implicit-dialog-projects-to-control.json
@@ -17,7 +17,7 @@
     { "path": "blocks.0", "name": "core/group", "attrs": { "className": "chrome-shell" } },
     { "path": "blocks.0.innerBlocks.0", "name": "core/group", "attrs": { "className": "fixed-header", "tagName": "header" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1", "name": "core/group", "attrs": { "className": "mobile-control-slot" } },
-    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation", "attrs": { "className": "blocks-engine-list-navigation blocks-engine-native-responsive-navigation", "style": { "spacing": { "blockGap": "0px" } }, "overlayMenu": "mobile" } },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0", "name": "core/navigation", "attrs": { "className": "blocks-engine-list-navigation blocks-engine-native-responsive-navigation blocks-engine-projected-dialog-navigation", "style": { "spacing": { "blockGap": "0px" } }, "overlayMenu": "mobile" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.1.innerBlocks.0.innerBlocks.0", "name": "core/navigation-link", "attrs": { "label": "HOME", "url": "/", "kind": "custom" } },
     { "path": "blocks.0.innerBlocks.0.innerBlocks.2", "name": "core/navigation", "attrs": { "className": "desktop-navigation", "overlayMenu": "never" } }
   ],
@@ -31,6 +31,13 @@
     { "path": "serialized_blocks", "assert": "contains", "value": "\"overlayMenu\":\"mobile\"" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"ABOUT\",\"url\":\"/about\",\"kind\":\"custom\"} -->" },
     { "path": "serialized_blocks", "assert": "contains", "value": "<!-- wp:navigation-link {\"label\":\"PORTFOLIO\",\"url\":\"/portfolio\",\"kind\":\"custom\"} -->" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "blocks-engine-projected-dialog-navigation" },
+    { "path": "assets.2.content", "assert": "contains", "value": ".wp-block-navigation.blocks-engine-projected-dialog-navigation .wp-block-navigation__responsive-container.is-menu-open{background:#fff!important;color:#111!important;position:fixed!important;inset:0!important" },
+    { "path": "assets.2.content", "assert": "contains", "value": ".wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container{align-items:flex-start!important;gap:.75rem!important;width:100%!important}" },
+    { "path": "assets.2.content", "assert": "contains", "value": ".wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation-item__content{color:#111!important;font-size:clamp(1.125rem,4vw,1.5rem)!important;line-height:1.4!important;padding:.5rem 0!important}" },
+    { "path": "assets.2.content", "assert": "contains", "value": ".wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-close{background:#fff!important;color:#111!important;position:fixed!important;top:1rem!important;right:1rem!important;padding:.75rem!important" },
+    { "path": "assets.2.content", "assert": "contains", "value": "body.admin-bar .wp-block-navigation.blocks-engine-projected-dialog-navigation .wp-block-navigation__responsive-container.is-menu-open{top:var(--wp-admin--admin-bar--height,32px)!important}" },
+    { "path": "assets.2.content", "assert": "not_contains", "value": ".wp-block-navigation.blocks-engine-projected-dialog-navigation{background:" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "mobile-menu" },
     { "path": "serialized_blocks", "assert": "not_contains", "value": "Open menu" }
   ]


### PR DESCRIPTION
## Summary
Give implicitly projected mobile navigation a coherent full-screen open state when source dialog styling cannot be transferred.

## What changed
- Tag only implicit-dialog projections with a dedicated class.
- Emit bounded fallback overlay, link, close-control, and admin-bar CSS for that class.
- Extend the existing Tianna-shaped parity fixture with serialized-block and CSS assertions.

## How to test
1. Run `php -l php-transformer/src/HtmlToBlocks/HtmlTransformer.php && php -l php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php`; expect passes as recorded by Homeboy's deterministic gate.

## Compatibility
Bounded to implicit-dialog projections; desktop navigation, explicit menus, authored overlay backgrounds, and ambiguous dialogs retain existing behavior.

## Evidence
- Base advanced after verification: verified trunk at ef4f426855dfc6fb23b041a853cfbf466be25891; publication observed 9863196c7b45a41814fc7586c3fba9cf133fe885. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/blocks-engine/issues/1185
- Verified finalization base: trunk at ef4f426855dfc6fb23b041a853cfbf466be25891
- manual-verify: passed (php -l php-transformer/src/HtmlToBlocks/HtmlTransformer.php && php -l php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** traced the projected navigation path, implemented bounded open-state styling, added parity assertions, and ran deterministic verification

## Source relationships
- Closes Automattic/blocks-engine#1185
