### PR TITLE
Preserve image URL suffixes during metadata resolution

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -16233,7 +16233,7 @@ final class HtmlTransformer
         }
 
         if ( isset($asset['url']) && is_string($asset['url']) ) {
-            $resolvedUrl = $this->safeResolvedAssetImageUrl(trim($asset['url']));
+            $resolvedUrl = $this->resolvedAssetImageUrl($url);
             if ( '' !== $resolvedUrl ) {
                 $attrs['url'] = $resolvedUrl;
             }
@@ -16254,6 +16254,12 @@ final class HtmlTransformer
         }
 
         $resolvedUrl = $this->safeResolvedAssetImageUrl(trim($asset['url']));
+        if ( '' === $resolvedUrl ) {
+            return $url;
+        }
+
+        preg_match('/^[^?#]*(.*)$/s', $url, $parts);
+        $resolvedUrl = $this->safeResolvedAssetImageUrl($resolvedUrl . ($parts[1] ?? ''));
         return '' !== $resolvedUrl ? $resolvedUrl : $url;
     }
 

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2904,6 +2904,13 @@ $assetMetadataOptions = array(
                 'id'  => 42,
                 'url' => 'https://example.test/wp-content/uploads/hero.jpg',
             ),
+            'media/root-hero.jpg' => array(
+                'id'  => 43,
+                'url' => 'https://example.test/wp-content/uploads/root-hero.jpg',
+            ),
+            'media/root-background.jpg' => array(
+                'url' => 'https://example.test/wp-content/uploads/root-background.jpg',
+            ),
         ),
     ),
 );
@@ -2914,6 +2921,17 @@ $assert('https://example.test/wp-content/uploads/hero.jpg' === ($resolvedImageAt
 $assert('Hero alt' === ($resolvedImageAttrs['alt'] ?? ''), 'HTML image transform preserves original alt text while resolving asset metadata');
 $assert(str_contains((string) ($resolvedImage['serialized_blocks'] ?? ''), 'src="https://example.test/wp-content/uploads/hero.jpg"'), 'HTML image transform serializes resolved asset URL');
 $assert(str_contains((string) ($resolvedImage['serialized_blocks'] ?? ''), 'class="wp-image-42"'), 'HTML image transform serializes resolved image id class');
+
+$resolvedRootImage = ( new HtmlTransformer() )->transform('<main><img src="/media/root-hero.jpg?size=large#hero" srcset="/media/root-hero.jpg?size=small 480w, /media/root-hero.jpg?size=large 960w" alt="Root hero"></main>', $assetMetadataOptions)->toArray();
+$resolvedRootImageAttrs = $resolvedRootImage['blocks'][0]['attrs'] ?? array();
+$assert('core/image' === ($resolvedRootImage['blocks'][0]['blockName'] ?? null), 'metadata-backed standalone responsive image remains core/image');
+$assert('https://example.test/wp-content/uploads/root-hero.jpg?size=large#hero' === ($resolvedRootImageAttrs['url'] ?? ''), 'metadata-backed root-relative image preserves its authored query and fragment suffix');
+$assert(! isset($resolvedRootImageAttrs['srcset'], $resolvedRootImageAttrs['sizes']) && ! str_contains((string) ($resolvedRootImage['serialized_blocks'] ?? ''), 'srcset=') && ! str_contains((string) ($resolvedRootImage['serialized_blocks'] ?? ''), 'sizes='), 'metadata-backed standalone responsive image does not add srcset or sizes to core/image');
+
+$resolvedRootBackground = ( new HtmlTransformer() )->transform('<main><div style="width:640px;height:320px;background-image:url(/media/root-background.jpg?crop=wide#panel)"></div></main>', $assetMetadataOptions)->toArray();
+$resolvedRootBackgroundMarkup = (string) ($resolvedRootBackground['serialized_blocks'] ?? '');
+$assert(str_contains($resolvedRootBackgroundMarkup, 'src="https://example.test/wp-content/uploads/root-background.jpg?crop=wide#panel"'), 'metadata-backed extracted root-relative background preserves its authored query and fragment suffix');
+$assert(str_contains($resolvedRootBackgroundMarkup, 'blocks-engine-background-image'), 'metadata-backed root-relative background remains an extracted editable image reference');
 
 $linkedRuntimeImage = ( new HtmlTransformer() )->transform(
     '<main><a id="productHero" class="product-detail__main-image" href="/product"><img src="assets/product.jpg" alt="Product"></a></main>'


### PR DESCRIPTION
## Summary
- preserve authored query and fragment suffixes when image metadata supplies the resolved URL
- apply the same behavior to extracted background images
- retain the intentional `core/image` lowering without `srcset` or `sizes` attributes

Closes #1167.
Unblocks Automattic/static-site-importer#1270.

## Verification
- `php tests/contract/run.php`
- `composer test`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode reviewed the retained candidate, strengthened the responsive-image contract, and ran the complete Composer suite. OpenAI GPT-5.6 Sol via OpenCode rebased the candidate onto current trunk and independently reran the focused contract. Chris Huber directed the work and is responsible for the change.