### PR TITLE
Expose editability evidence in the bounded site plan view

### DIFF
--- a/php-transformer/src/WordPressSitePlan/WordPressSitePlanView.php
+++ b/php-transformer/src/WordPressSitePlan/WordPressSitePlanView.php
@@ -49,6 +49,7 @@ final class WordPressSitePlanView
             'gutenberg_gaps' => $this->arrayValue($sourceReports, 'gutenberg_gaps'),
             'companion_plugin_payload' => $this->arrayValue($sourceReports, 'companion_plugin_payload'),
             'font_materialization' => $this->arrayValue($theme, 'font_materialization'),
+            'editability_report' => $this->arrayValue($sourceReports, 'editability_report'),
             'diagnostics' => $diagnostics,
         );
     }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\Contract\TransformerResult;
+use Automattic\BlocksEngine\PhpTransformer\Contract\EditabilityReport;
 use Automattic\BlocksEngine\PhpTransformer\Contract\VisualParityReportContract;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactNormalizer;
@@ -2946,7 +2947,14 @@ $assert(WordPressSitePlanView::SCHEMA === ($simplePlanView['schema'] ?? ''), 'Wo
 $assert(WordPressSitePlanView::SCHEMA === ($simpleObjectPlanView['schema'] ?? ''), 'Transformer result exposes the bounded WordPress site plan view directly');
 $assert(($simple['source_reports']['wordpress_site_plan'] ?? array()) === ($simplePlanView['wordpress_site_plan'] ?? null), 'WordPress site plan view preserves the exact canonical plan');
 $assert(($boundedHandoffResult->toArray()['source_reports']['wordpress_site_plan'] ?? array()) === ($simpleObjectPlanView['wordpress_site_plan'] ?? null), 'TransformerResult handoff preserves the exact canonical plan without a compatibility projection');
-$assert(array('schema', 'result_schema', 'status', 'wordpress_site_plan', 'gutenberg_gaps', 'companion_plugin_payload', 'font_materialization', 'diagnostics') === array_keys($simplePlanView), 'WordPress site plan view has a stable bounded shape');
+$assert(($simple['source_reports']['editability_report'] ?? null) === ($simplePlanView['editability_report'] ?? null), 'WordPress site plan view preserves the producer-owned editability report exactly');
+$assert(array('schema', 'metrics', 'block_types', 'documents', 'signals', 'signal_totals') === array_keys($simplePlanView['editability_report'] ?? array()) && EditabilityReport::SCHEMA === ($simplePlanView['editability_report']['schema'] ?? null), 'WordPress site plan view exposes the current versioned editability report shape');
+$boundedEditabilityReport = (new EditabilityReport())->fromDocuments(array('large.html' => array('blocks' => array_fill(0, 101, array('blockName' => 'core/group', 'attrs' => array(), 'innerBlocks' => array(), 'innerHTML' => '')))));
+$boundedPlanResult = $simple;
+$boundedPlanResult['source_reports']['editability_report'] = $boundedEditabilityReport;
+$boundedPlanView = (new WordPressSitePlanView())->fromResult($boundedPlanResult);
+$assert($boundedEditabilityReport === ($boundedPlanView['editability_report'] ?? null) && 101 === ($boundedPlanView['editability_report']['signal_totals']['observed'] ?? null) && 100 === ($boundedPlanView['editability_report']['signal_totals']['reported'] ?? null) && 1 === ($boundedPlanView['editability_report']['signal_totals']['omitted'] ?? null) && true === ($boundedPlanView['editability_report']['signal_totals']['truncated'] ?? null) && 100 === count($boundedPlanView['editability_report']['signals'] ?? array()), 'WordPress site plan view preserves bounded editability evidence without reprojecting it');
+$assert(array('schema', 'result_schema', 'status', 'wordpress_site_plan', 'gutenberg_gaps', 'companion_plugin_payload', 'font_materialization', 'editability_report', 'diagnostics') === array_keys($simplePlanView), 'WordPress site plan view has a stable bounded shape');
 $assert(!isset($simplePlanView['compiled_site'], $simplePlanView['materialization_plan'], $simplePlanView['assets'], $simplePlanView['documents'], $simplePlanView['blocks']), 'WordPress site plan view omits duplicate legacy and root projections');
 $failedPlanResult = $simple;
 $failedPlanResult['status'] = 'failed';


### PR DESCRIPTION
## Summary
- expose the producer-owned `editability_report` in `WordPressSitePlanView`
- preserve the canonical versioned report without reprojecting or moving mutation ownership
- verify exact shape and bounded signal evidence, including truncation totals

Closes #1168.
Unblocks Automattic/static-site-importer#1270.

## Verification
- `php tests/unit/editability-report.php`
- `php tests/contract/run.php`
- `composer test`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode traced report ownership, implemented the bounded view exposure, and added exact-shape coverage. OpenAI GPT-5.6 Sol via OpenCode rebased the candidate onto current trunk, reviewed it, and ran the complete Composer suite. Chris Huber directed the work and is responsible for the change.