### PR TITLE
Fix bounded navigation author-rule collection

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -101,6 +101,7 @@
       "php tests/unit/navigation-underline-color-resolver.php",
       "php tests/unit/navigation-brand-anchor-hoist.php",
       "php tests/unit/navigation-brand-cue-carrier.php",
+      "php tests/unit/navigation-author-rule-memory.php",
       "php tests/unit/navigation-direct-cluster-parity.php",
       "php tests/unit/navigation-block-normalizer.php",
       "php tests/unit/navigation-inline-margin-carry.php",

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2061,8 +2061,12 @@ final class HtmlTransformer
 
         $rules = array();
         $order = 0;
-        $css = preg_replace('@/\*.*?\*/@s', '', $this->combinedAuthorCss) ?? $this->combinedAuthorCss;
-        $this->collectNavigationAuthorStyleRules($css, array(), $rules, $order);
+        ( new CssStylesheetTransformer() )->visitStyleRules(
+            $this->combinedAuthorCss,
+            function (string $prelude, string $body, array $conditions) use (&$rules, &$order): void {
+                $this->collectNavigationAuthorStyleRule($prelude, $body, $conditions, $rules, $order);
+            }
+        );
         return $rules;
     }
 
@@ -2070,83 +2074,40 @@ final class HtmlTransformer
      * @param list<string> $conditions
      * @param array<int, array<string, mixed>> $rules
      */
-    private function collectNavigationAuthorStyleRules(string $css, array $conditions, array &$rules, int &$order): void
+    private function collectNavigationAuthorStyleRule(string $prelude, string $body, array $conditions, array &$rules, int &$order): void
     {
-        $directCss = $css;
-        $events = array();
-        for ( $offset = 0, $length = strlen($css); $offset < $length; ++$offset ) {
-            if ( '@' !== $css[$offset] ) {
-                continue;
-            }
-            $blockStart = $this->findCssToken($css, '{', $offset);
-            $statementEnd = $this->findCssToken($css, ';', $offset);
-            if ( null === $blockStart || (null !== $statementEnd && $statementEnd < $blockStart) ) {
-                continue;
-            }
-            $end = $this->findMatchingCssBrace($css, $blockStart);
-            if ( null === $end ) {
-                continue;
-            }
-            $prelude = trim(substr($css, $offset, $blockStart - $offset));
-            $directCss = substr_replace($directCss, str_repeat(' ', $end - $offset + 1), $offset, $end - $offset + 1);
-            if ( preg_match('/^@(media|container|supports|layer|scope|starting-style)\b/i', $prelude) ) {
-                $events[] = array(
-                    'offset' => $offset,
-                    'css' => substr($css, $blockStart + 1, $end - $blockStart - 1),
-                    'conditions' => array_merge($conditions, array( $prelude )),
-                );
-            }
-            $offset = $end;
+        if ( str_starts_with(ltrim($prelude), '@') ) {
+            return;
         }
-
-        if ( preg_match_all('/([^{}]+)\{([^{}]+)\}/', $directCss, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE) ) {
-            foreach ( $matches as $match ) {
-                $events[] = array(
-                    'offset' => $match[0][1],
-                    'prelude' => $match[1][0],
-                    'body' => $match[2][0],
-                    'conditions' => $conditions,
-                );
-            }
+        $declarations = $this->safeVisualDeclarations($this->cssDeclarations($body));
+        if ( array() === $declarations ) {
+            return;
         }
-
-        usort($events, static fn (array $left, array $right): int => $left['offset'] <=> $right['offset']);
-        foreach ( $events as $event ) {
-            if ( isset($event['css']) ) {
-                $this->collectNavigationAuthorStyleRules($event['css'], $event['conditions'], $rules, $order);
+        $ruleId = $order++;
+        foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
+            $selector = trim($selector);
+            if ( '' === $selector || str_starts_with($selector, '@') ) {
                 continue;
             }
-
-            $declarations = $this->safeVisualDeclarations($this->cssDeclarations((string) $event['body']));
-            if ( array() === $declarations ) {
+            $parsed = $this->parsedCssSelector($selector);
+            if ( ! ($parsed['supported'] ?? false) ) {
                 continue;
             }
-            $ruleId = $order++;
-            foreach ( CssStylesheetTransformer::splitSelectorList((string) $event['prelude']) ?? array() as $selector ) {
-                $selector = trim($selector);
-                if ( '' === $selector || str_starts_with($selector, '@') ) {
-                    continue;
-                }
-                $parsed = $this->parsedCssSelector($selector);
-                if ( ! ($parsed['supported'] ?? false) ) {
-                    continue;
-                }
-                $pseudo = '';
-                $pseudoSpan = $parsed['pseudo_state_suffix_span'] ?? null;
-                if ( is_array($pseudoSpan) ) {
-                    $pseudo = strtolower(substr($selector, $pseudoSpan['start'], $pseudoSpan['end'] - $pseudoSpan['start']));
-                }
-                $rules[] = array(
-                    'id' => $ruleId,
-                    'selector' => $selector,
-                    'parsed' => $parsed,
-                    'declarations' => $declarations,
-                    'conditions' => $event['conditions'],
-                    'pseudo' => $pseudo,
-                    'specificity' => $this->navigationSelectorSpecificity($parsed, $pseudo),
-                    'order' => $ruleId,
-                );
+            $pseudo = '';
+            $pseudoSpan = $parsed['pseudo_state_suffix_span'] ?? null;
+            if ( is_array($pseudoSpan) ) {
+                $pseudo = strtolower(substr($selector, $pseudoSpan['start'], $pseudoSpan['end'] - $pseudoSpan['start']));
             }
+            $rules[] = array(
+                'id' => $ruleId,
+                'selector' => $selector,
+                'parsed' => $parsed,
+                'declarations' => $declarations,
+                'conditions' => $conditions,
+                'pseudo' => $pseudo,
+                'specificity' => $this->navigationSelectorSpecificity($parsed, $pseudo),
+                'order' => $ruleId,
+            );
         }
     }
 

--- a/php-transformer/tests/unit/navigation-author-rule-memory.php
+++ b/php-transformer/tests/unit/navigation-author-rule-memory.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+ini_set('memory_limit', '96M');
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\HtmlTransformer;
+
+$transformer = new HtmlTransformer();
+$reflection = new ReflectionClass($transformer);
+$transformer->combinedAuthorCss = '@keyframes inert{' . str_repeat('x', 32 * 1024 * 1024) . '}'
+    . '@media (min-width:1px){.menu li a:hover{color:#123456}}';
+
+$collect = $reflection->getMethod('navigationAuthorStyleRules');
+$rules = $collect->invoke($transformer);
+$rule = is_array($rules) ? ($rules[0] ?? array()) : array();
+
+$valid = 1 === count($rules)
+    && '.menu li a:hover' === ($rule['selector'] ?? null)
+    && array( 'color' => '#123456' ) === ($rule['declarations'] ?? null)
+    && array( '@media (min-width:1px)' ) === ($rule['conditions'] ?? null)
+    && array( 0, 2, 2 ) === ($rule['specificity'] ?? null)
+    && 0 === ($rule['order'] ?? null);
+
+if ( ! $valid ) {
+    fwrite(STDERR, 'Navigation author-rule memory contract failed: ' . json_encode($rules) . PHP_EOL);
+    exit(1);
+}
+
+fwrite(STDOUT, "Navigation author-rule memory contract passed\n");


### PR DESCRIPTION
## Summary

- replace full-stylesheet navigation rule copies with the shared syntax-aware incremental visitor
- preserve rule order, selector specificity, conditional ancestry, and authored declarations
- reject inert at-rule bodies before declaration parsing
- add a 32 MB stylesheet regression under a 96 MB PHP memory cap

Fixes #1197.

## Verification

- `composer test`
- 286 PHP transformer parity fixtures
- 41 navigation brand/cascade assertions
- new navigation author-rule memory contract under 96 MB

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the 512 MB corpus failure, implemented the incremental visitor integration, and ran the test suite. Chris Huber directed the work and remains responsible for the change.