### PR TITLE
Fix bounded typography font discovery

### DIFF
--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -63,6 +63,7 @@
     ],
     "test:unit": [
       "php tests/unit/runtime-declarations-streaming-hash.php",
+      "php tests/unit/font-family-declaration-memory.php",
       "php tests/unit/asset-reference-canonicalizer-memory.php",
       "php tests/unit/srcset-parser.php",
        "php tests/unit/responsive-media-block.php",

--- a/php-transformer/src/HtmlToBlocks/TypographyParityAnalyzer.php
+++ b/php-transformer/src/HtmlToBlocks/TypographyParityAnalyzer.php
@@ -63,9 +63,8 @@ final class TypographyParityAnalyzer
             );
         }
 
-        $typographyCss = $this->planBuilder->resolveCssVariables(trim($this->styleBlockCss($html) . "\n" . $css));
         $headingDeclarations = array_merge(
-            $this->headingFamiliesFromCss($typographyCss),
+            $this->headingFamiliesFromCssSources(array($this->styleBlockCss($html), $css)),
             $this->normalizeInlineHeadingDeclarations($inlineHeadingDeclarations)
         );
 
@@ -158,26 +157,23 @@ final class TypographyParityAnalyzer
      *
      * @return array<int,array{family:string,role:string,selector:string,source_snippet:string}>
      */
-    private function headingFamiliesFromCss(string $css): array
+    private function headingFamiliesFromCssSources(array $stylesheets): array
     {
-        if ( '' === trim($css) || ! preg_match_all('/([^{}]+)\{([^{}]*)\}/s', $css, $rules, PREG_SET_ORDER) ) {
-            return array();
-        }
-
         $declarations = array();
-        foreach ( $rules as $rule ) {
-            if ( ! preg_match('/font-family\s*:\s*([^;{}]+)/i', (string) $rule[2], $declaration) ) {
-                continue;
-            }
-            $family = $this->primaryFamily((string) $declaration[1]);
-            if ( '' === $family ) {
-                continue;
-            }
-
-            foreach ( array_map('trim', explode(',', (string) $rule[1])) as $selector ) {
-                if ( '' === $selector ) {
+        $variables = $this->planBuilder->cssVariableValues($stylesheets);
+        foreach ( $stylesheets as $css ) {
+            $offset = 0;
+            while ( preg_match('/([^{}]+)\{([^{}]*)\}/s', $css, $rule, PREG_OFFSET_CAPTURE, $offset) ) {
+                $offset = $rule[0][1] + strlen($rule[0][0]);
+                if ( ! preg_match('/font-family\s*:\s*([^;{}]+)/i', (string) $rule[2][0], $fontFamily) ) {
                     continue;
                 }
+                $value = $this->planBuilder->resolveCssVariableValue((string) $fontFamily[1], $variables);
+                $family = $this->primaryFamily($value);
+                if ( '' === $family ) {
+                    continue;
+                }
+                foreach ( array_map('trim', explode(',', (string) $rule[1][0])) as $selector ) {
                 $role = $this->roleForSelector($selector);
                 if ( '' === $role ) {
                     continue;
@@ -186,8 +182,9 @@ final class TypographyParityAnalyzer
                     'family'         => $family,
                     'role'           => $role,
                     'selector'       => $selector,
-                    'source_snippet' => $this->boundSnippet(trim((string) $rule[0])),
+                    'source_snippet' => $this->boundSnippet(trim((string) $rule[0][0])),
                 );
+                }
             }
         }
 

--- a/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
+++ b/php-transformer/src/StaticSite/FontMaterialization/FontMaterializationPlanBuilder.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
 use InvalidArgumentException;
 
 final class FontMaterializationPlanBuilder
@@ -56,8 +57,6 @@ final class FontMaterializationPlanBuilder
         // their concrete typefaces before parsing so the plan captures the real
         // family — never a literal `var(--font-body)` token, which would corrupt
         // the materialized Google Fonts request and the body role.
-        $resolvedCss = $this->resolveCssVariables($css);
-
         $imports = $this->webFontImports($css, $cssSources);
         $directFaces = $this->directFontFaces($css, $cssSources);
         foreach ( $directFaces as $directFace ) {
@@ -77,7 +76,7 @@ final class FontMaterializationPlanBuilder
             $this->fontUsageFromLinkedStylesheets($html),
             ...array_column(array_filter($imports, static fn (array $import): bool => 'google_fonts' === $import['provider']), 'font_usage')
         );
-        $roles = $this->fontRolesFromCss($resolvedCss);
+        $roles = $this->fontRolesFromCss($css);
 
         // A CSS family name alone does not prove that Google hosts the font.
         // Materialize only families backed by a Google import/link or a direct face.
@@ -495,31 +494,16 @@ final class FontMaterializationPlanBuilder
      */
     public function fontRolesFromCss(string $css): array
     {
-        if ( '' === $css || ! preg_match('/\S/', $css) ) {
-            return array();
-        }
-
         $heading = '';
         $body = '';
-        $offset = 0;
-        while ( preg_match('/([^{}]+)\{([^{}]*)\}/s', $css, $rule, PREG_OFFSET_CAPTURE, $offset) ) {
-            $offset = $rule[0][1] + strlen($rule[0][0]);
-            if ( ! preg_match('/font-family\s*:\s*([^;{}]+)/i', (string) $rule[2][0], $declaration) ) {
-                continue;
+        foreach ( $this->fontFamilyDeclarationsFromCssSources(array($css)) as $declaration ) {
+            $selector = $declaration['selector'];
+            $family = $declaration['family'];
+            if ( '' === $heading && preg_match('/(^|[\s>+~])h[1-6]\b/i', $selector) ) {
+                $heading = $family;
             }
-            $family = $this->primaryFamily((string) $declaration[1]);
-            if ( '' === $family ) {
-                continue;
-            }
-
-            $selectors = array_map('trim', explode(',', (string) $rule[1][0]));
-            foreach ( $selectors as $selector ) {
-                if ( '' === $heading && preg_match('/(^|[\s>+~])h[1-6]\b/i', $selector) ) {
-                    $heading = $family;
-                }
-                if ( '' === $body && preg_match('/(^|[\s>+~])(body|html|:root|\*)\b/i', $selector) ) {
-                    $body = $family;
-                }
+            if ( '' === $body && preg_match('/(^|[\s>+~])(body|html|:root|\*)\b/i', $selector) ) {
+                $body = $family;
             }
             if ( '' !== $heading && '' !== $body ) {
                 break;
@@ -527,6 +511,58 @@ final class FontMaterializationPlanBuilder
         }
 
         return array_filter(array('heading' => $heading, 'body' => $body), static fn (string $value): bool => '' !== $value);
+    }
+
+    /**
+     * @param list<string> $stylesheets
+     * @return list<array{family:string,selector:string,source_snippet:string}>
+     */
+    public function fontFamilyDeclarationsFromCssSources(array $stylesheets): array
+    {
+        $variables = $this->cssVariableValues($stylesheets);
+        $visitor = new CssStylesheetTransformer();
+        $declarations = array();
+        foreach ( $stylesheets as $css ) {
+            $visitor->visitStyleRules($css, function (string $prelude, string $body) use (&$declarations, $variables): void {
+                if ( str_starts_with(ltrim($prelude), '@') || ! preg_match('/font-family\s*:\s*([^;{}]+)/i', $body, $match) ) {
+                    return;
+                }
+                $value = $this->resolveCssVariableValue((string) $match[1], $variables);
+                $family = $this->primaryFamily($value);
+                if ( '' === $family ) {
+                    return;
+                }
+                foreach ( CssStylesheetTransformer::splitSelectorList($prelude) ?? array() as $selector ) {
+                    $selector = trim($selector);
+                    if ( '' !== $selector ) {
+                        $declarations[] = array(
+                            'family' => $family,
+                            'selector' => $selector,
+                            'source_snippet' => trim($prelude) . '{font-family:' . trim((string) $match[1]) . '}',
+                        );
+                    }
+                }
+            });
+        }
+        return $declarations;
+    }
+
+    /** @param list<string> $stylesheets @return array<string,string> */
+    public function cssVariableValues(array $stylesheets): array
+    {
+        $variables = array();
+        $visitor = new CssStylesheetTransformer();
+        foreach ( $stylesheets as $css ) {
+            $visitor->visitStyleRules($css, static function (string $prelude, string $body) use (&$variables): void {
+                if ( str_starts_with(ltrim($prelude), '@') || ! preg_match_all('/(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+)/', $body, $matches, PREG_SET_ORDER) ) {
+                    return;
+                }
+                foreach ( $matches as $match ) {
+                    $variables[(string) $match[1]] = trim((string) $match[2]);
+                }
+            });
+        }
+        return $variables;
     }
 
     /**
@@ -641,6 +677,29 @@ final class FontMaterializationPlanBuilder
         }
 
         return $css;
+    }
+
+    /** @param array<string,string> $variables */
+    public function resolveCssVariableValue(string $value, array $variables): string
+    {
+        for ( $pass = 0; $pass < 5; $pass++ ) {
+            $expanded = preg_replace_callback(
+                '/var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,\s*([^()]*))?\)/',
+                static function (array $match) use ($variables): string {
+                    $name = (string) $match[1];
+                    if ( isset($variables[$name]) && '' !== $variables[$name] ) {
+                        return $variables[$name];
+                    }
+                    return isset($match[2]) && '' !== trim((string) $match[2]) ? trim((string) $match[2]) : (string) $match[0];
+                },
+                $value
+            );
+            if ( ! is_string($expanded) || $expanded === $value ) {
+                break;
+            }
+            $value = $expanded;
+        }
+        return $value;
     }
 
     /**

--- a/php-transformer/tests/unit/font-family-declaration-memory.php
+++ b/php-transformer/tests/unit/font-family-declaration-memory.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+ini_set('memory_limit', '96M');
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder;
+
+$css = '@keyframes inert{' . str_repeat('x', 32 * 1024 * 1024) . '}'
+    . ':root{--heading:"Playfair Display",serif;--body:"Lora",serif}'
+    . 'body{font-family:var(--body)}h1{font-family:var(--heading)}';
+$roles = ( new FontMaterializationPlanBuilder() )->fontRolesFromCss($css);
+
+if ( array( 'heading' => 'Playfair Display', 'body' => 'Lora' ) !== $roles ) {
+    fwrite(STDERR, 'Font-family declaration memory contract failed: ' . json_encode($roles) . PHP_EOL);
+    exit(1);
+}
+
+fwrite(STDOUT, "Font-family declaration memory contract passed\n");


### PR DESCRIPTION
## Summary

- stop expanding complete author stylesheets to resolve font custom properties
- collect custom-property and `font-family` facts incrementally through the shared stylesheet visitor
- resolve only retained font-family values while preserving cross-source variables
- keep typography parity diagnostic behavior unchanged with an incremental legacy-selector scan
- add a 32 MB stylesheet regression under a 96 MB PHP memory cap

Fixes #1199.

## Verification

- `composer test`
- 286 PHP transformer parity fixtures
- package install proof
- new font-family declaration memory contract under 96 MB

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the 512 MB typography failure, implemented bounded font discovery, and ran the full suite. Chris Huber directed the work and remains responsible for the change.