### PR TITLE
Require PHP 8.2 and test through PHP 8.5

### DIFF
--- a/.github/workflows/figma-transformer.yml
+++ b/.github/workflows/figma-transformer.yml
@@ -14,8 +14,12 @@ on:
 
 jobs:
   validate:
-    name: Composer validate and test
+    name: Composer validate and test (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["8.2", "8.3", "8.4", "8.5"]
 
     defaults:
       run:
@@ -28,7 +32,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
 

--- a/.github/workflows/php-transformer.yml
+++ b/.github/workflows/php-transformer.yml
@@ -18,8 +18,12 @@ on:
 
 jobs:
   validate:
-    name: Composer validate and test
+    name: Composer validate and test (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["8.2", "8.3", "8.4", "8.5"]
 
     defaults:
       run:
@@ -32,7 +36,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
 
@@ -76,8 +80,12 @@ jobs:
         run: npm test
 
   wordpress-site-plan:
-    name: WordPress site plan integration
+    name: WordPress site plan integration (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["8.2", "8.3", "8.4", "8.5"]
     services:
       mysql:
         image: mysql:8.0.36
@@ -95,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php-version }}
           extensions: mysqli
           tools: composer:v2
       - name: Install package dependencies

--- a/.github/workflows/solved-fixture-regression.yml
+++ b/.github/workflows/solved-fixture-regression.yml
@@ -18,8 +18,8 @@ permissions:
 
 jobs:
   solved-site-promotion:
-    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@a4f469d6b5646dfec387e0e3ea80b1215bd24e7f
+    uses: Automattic/static-site-importer/.github/workflows/solved-site-promotion.yml@dbdf5413d34d8c55c034ee28a271c3ec8f53adf8
     with:
-      static-site-importer-sha: a4f469d6b5646dfec387e0e3ea80b1215bd24e7f
+      static-site-importer-sha: dbdf5413d34d8c55c034ee28a271c3ec8f53adf8
       blocks-engine-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       blocks-engine-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/figma-transformer/composer.json
+++ b/figma-transformer/composer.json
@@ -30,7 +30,7 @@
     }
   },
   "require": {
-    "php": ">=8.1"
+    "php": ">=8.2"
   },
   "suggest": {
     "ext-zstd": "Decode zstd-compressed canvas.fig chunks when inspecting .fig archives.",
@@ -48,7 +48,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.1.0"
+      "php": "8.2.0"
     },
     "sort-packages": true
   },

--- a/figma-transformer/composer.lock
+++ b/figma-transformer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "573cf2c999c8bddf48bef60dd13169b8",
+    "content-hash": "80f3c4326532d2b2b2f1c2ecef8e34fa",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -13,11 +13,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.0"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/figma-transformer/figma-transformer.php
+++ b/figma-transformer/figma-transformer.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/Automattic/blocks-engine/tree/trunk/figma-transformer
  * Description: PHP primitives for transforming Figma designs into static HTML website artifacts.
  * Version: 0.1.3
- * Requires PHP: 8.1
+ * Requires PHP: 8.2
  * Author: Automattic
  * License: GPL-3.0-or-later
  * Text Domain: blocks-engine-figma-transformer

--- a/figma-transformer/vendor/composer/platform_check.php
+++ b/figma-transformer/vendor/composer/platform_check.php
@@ -4,8 +4,8 @@
 
 $issues = array();
 
-if (!(PHP_VERSION_ID >= 80100)) {
-    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.1.0". You are running ' . PHP_VERSION . '.';
+if (!(PHP_VERSION_ID >= 80200)) {
+    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.2.0". You are running ' . PHP_VERSION . '.';
 }
 
 if ($issues) {

--- a/php-transformer/README.md
+++ b/php-transformer/README.md
@@ -197,7 +197,7 @@ If the first release is only available as a Blocks Engine monorepo archive, down
           }
         },
         "require": {
-          "php": ">=8.1",
+          "php": ">=8.2",
           "league/commonmark": "^2.5",
           "league/html-to-markdown": "^5.1"
         }

--- a/php-transformer/composer.json
+++ b/php-transformer/composer.json
@@ -32,7 +32,7 @@
   "require": {
     "league/commonmark": "^2.5",
     "league/html-to-markdown": "^5.1",
-    "php": ">=8.1"
+    "php": ">=8.2"
   },
   "scripts": {
     "parity": "@test:parity",
@@ -143,7 +143,7 @@
   "config": {
     "cache-dir": "var/cache/composer",
     "platform": {
-      "php": "8.1.0"
+      "php": "8.2.0"
     },
     "sort-packages": true
   },

--- a/php-transformer/composer.lock
+++ b/php-transformer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "476b850b6b0510a27a9a00aceb422d79",
+    "content-hash": "c1ba98deec0dd648a36a4162ecfd4c98",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -2572,11 +2572,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.0"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/php-transformer/docs/consumer-prs/html-to-blocks-converter.md
+++ b/php-transformer/docs/consumer-prs/html-to-blocks-converter.md
@@ -180,7 +180,7 @@ php tests/core-block-coverage-docs-smoke.php
 git diff --check
 ```
 
-If the downstream PR adds a Composer script for the existing smoke/unit matrix, prefer that script and keep the explicit smoke commands in the PR body as the reviewer-facing evidence list. The GitHub workflow runs `homeboy test` across PHP 8.1, 8.2, 8.3, and 8.4.
+If the downstream PR adds a Composer script for the existing smoke/unit matrix, prefer that script and keep the explicit smoke commands in the PR body as the reviewer-facing evidence list. The GitHub workflow runs `homeboy test` across PHP 8.2, 8.3, 8.4, and 8.5.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

- raise the PHP transformer and Figma transformer Composer floors from PHP 8.1 to 8.2
- update the Figma plugin header and vendored Composer platform check
- test both packages across PHP 8.2, 8.3, 8.4, and 8.5
- run WordPress site-plan integration across the same matrix
- update producer and consumer documentation

This is the producer-side companion to Automattic/static-site-importer#1319. PHP 8.1 has reached end of life.

## Verification

- `composer validate --strict && composer test` in `php-transformer/`
- 286 PHP transformer parity fixtures passed
- PHP transformer package-install proof passed
- `composer validate --strict && composer test` in `figma-transformer/`
- Figma transformer contract tests passed
- `git diff --check`
- `actionlint` parsed both changed workflows and reported only the pre-existing ShellCheck info at unchanged `php-transformer.yml:116`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode audited the producer runtime contract, updated both package constraints and workflow matrices, regenerated Composer metadata, and ran the package verification. Chris Huber selected the PHP 8.2 support floor and remains responsible.