### PR TITLE
Preserve valid core/file labels

### DIFF
--- a/packages/blocks-engine/src/wp/__tests__/file-save-validity.test.ts
+++ b/packages/blocks-engine/src/wp/__tests__/file-save-validity.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { setupDomGlobals } from '../dom-globals.js';
+
+const require = createRequire(import.meta.url);
+
+type ParsedBlock = { attributes: { fileName?: { toString(): string } } };
+type ParityFixture = { expect: Array<{ path: string; assert: string; value?: unknown }> };
+
+type WpRuntime = {
+  registerCoreBlocks(): void;
+  parse(markup: string): ParsedBlock[];
+  validateBlock(block: unknown): [boolean, unknown[]];
+};
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL(
+      '../../../../../php-transformer/tests/fixtures/parity/html-file-rich-text-label.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+) as ParityFixture;
+
+const serializedBlocks = fixture.expect.find(
+  ({ path, assert }) => path === 'serialized_blocks' && assert === 'equals',
+)?.value;
+
+describe('WordPress 7.1 core/file save validity', () => {
+  let wp: WpRuntime;
+
+  beforeAll(() => {
+    setupDomGlobals();
+    wp = require('@wordpress/blocks') as WpRuntime;
+    const library = require('@wordpress/block-library') as Pick<WpRuntime, 'registerCoreBlocks'>;
+    library.registerCoreBlocks();
+  });
+
+  it('reproduces the invalid nested-span serialization', () => {
+    const markup = '<!-- wp:file {"href":"/docs/privacy.pdf","text":"<span class=\\"pdf-label\\">Privacy policy</span>"} --><div class="wp-block-file"><a href="/docs/privacy.pdf"><span class="pdf-label">Privacy policy</span></a></div><!-- /wp:file -->';
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const blocks = wp.parse(markup);
+
+    expect(blocks).toHaveLength(1);
+    expect(wp.validateBlock(blocks[0])[0]).toBe(false);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
+  it('accepts the transformer fixture output as sourced RichText', () => {
+    expect(typeof serializedBlocks).toBe('string');
+    const blocks = wp.parse(serializedBlocks as string);
+
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].attributes.fileName?.toString()).toBe('<mark class="pdf-label" style="--blocks-engine-richtext-marker:label-1"><strong>Privacy</strong> policy</mark>');
+    expect(blocks.map((block) => wp.validateBlock(block)[0])).toEqual([true, true, true]);
+  });
+});

--- a/php-transformer/src/HtmlToBlocks/BlockFactory.php
+++ b/php-transformer/src/HtmlToBlocks/BlockFactory.php
@@ -834,9 +834,10 @@ final class BlockFactory
     private function fileHtml(array $attrs): string
     {
         $href = (string) ($attrs['href'] ?? $attrs['url'] ?? '');
-        $text = (string) ($attrs['text'] ?? ($href !== '' ? basename(parse_url($href, PHP_URL_PATH) ?: $href) : ''));
+        $textLinkHref = (string) ($attrs['textLinkHref'] ?? $href);
+        $fileName = (string) ($attrs['fileName'] ?? ($href !== '' ? basename(parse_url($href, PHP_URL_PATH) ?: $href) : ''));
         $linkAttrs = array(
-            'href' => $href,
+            'href' => $textLinkHref,
         );
 
         $downloadButton = '';
@@ -844,7 +845,7 @@ final class BlockFactory
             $downloadButton = '<a class="wp-block-file__button wp-element-button" href="' . htmlspecialchars($href, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '" download>Download</a>';
         }
 
-        return '<div' . $this->blockSupportAttrs($attrs, 'wp-block-file') . '><a' . $this->htmlAttrs($linkAttrs) . '>' . $this->preserveRichTextPunctuation($text) . '</a>' . $downloadButton . '</div>';
+        return '<div' . $this->blockSupportAttrs($attrs, 'wp-block-file') . '><a' . $this->htmlAttrs($linkAttrs) . '>' . $this->preserveRichTextPunctuation($fileName) . '</a>' . $downloadButton . '</div>';
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -7095,13 +7095,12 @@ final class HtmlTransformer
     }
 
     /**
-     * Lift class/style styling hooks out of a paragraph/heading/list-item's
-     * RichText `content` so the stored block round-trips through RichText
-     * unchanged.
+     * Lift class/style styling hooks out of a block's RichText source so the
+     * stored block round-trips through RichText unchanged.
      *
-     * core/paragraph, core/heading, and core/list-item store `content` as
-     * RichText, which only preserves a fixed set of inline formats (a, strong,
-     * em, br, …). A `<span class="…">` / `<span style="…">` is not a format, so
+     * Core text blocks store `content`, and core/file stores `fileName`, as
+     * RichText. RichText only preserves a fixed set of inline formats (a,
+     * strong, em, br, …). A `<span class="…">` / `<span style="…">` is not a format, so
      * RichText drops its attributes on parse: the saved markup no longer matches
      * the re-serialized block ("unexpected or invalid content"), and the class —
      * a styling hook the materialized CSS targets — would be silently lost.
@@ -7130,11 +7129,12 @@ final class HtmlTransformer
      */
     private function hoistContentWrappingSpans(string $name, array $attrs): array
     {
-        if ( ! in_array($name, array( 'core/paragraph', 'core/heading', 'core/list-item' ), true) ) {
+        $richTextAttribute = 'core/file' === $name ? 'fileName' : 'content';
+        if ( ! in_array($name, array( 'core/file', 'core/paragraph', 'core/heading', 'core/list-item' ), true) ) {
             return $attrs;
         }
 
-        $content = (string) ($attrs['content'] ?? '');
+        $content = (string) ($attrs[$richTextAttribute] ?? '');
         if ( '' === $content || ! preg_match('/<(?:span|font|a|em|i|strong|b|mark|small|sub|sup)\b/i', $content) ) {
             return $attrs;
         }
@@ -7195,7 +7195,7 @@ final class HtmlTransformer
             return $attrs;
         }
 
-        $attrs['content'] = $newContent;
+        $attrs[$richTextAttribute] = $newContent;
 
         if ( '' !== $hoistedClasses ) {
             $promoted = $this->promotedClassName($hoistedClasses);
@@ -14927,10 +14927,10 @@ final class HtmlTransformer
 
         $attrs = array_filter(array_merge($this->presentationAttributes($anchor), array(
             'href'               => $href,
-            'url'                => $href,
-            'text'               => $this->innerHtml($anchor),
+            'fileName'           => $this->richTextContentWithMaterializedInlineStyles($anchor),
+            'textLinkHref'       => $href,
             'showDownloadButton' => $anchor->hasAttribute('download'),
-        )), static fn (mixed $value): bool => is_bool($value) ? $value : '' !== $value);
+        )), static fn (mixed $value): bool => is_bool($value) ? true : '' !== $value);
 
         return $this->createBlock('core/file', $attrs, array(), $anchor);
     }

--- a/php-transformer/tests/fixtures/parity/html-file-rich-text-label.json
+++ b/php-transformer/tests/fixtures/parity/html-file-rich-text-label.json
@@ -1,0 +1,30 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-file-rich-text-label",
+  "description": "Serializes document labels through core/file RichText semantics without changing plain labels or explicit download buttons.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-file-rich-text-label.json",
+    "notes": "Regression coverage for blocks-engine issue 1176."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "This upstream core/file validity fixture has no legacy comparison."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<a class=\"download-link\" href=\"/docs/privacy.pdf\"><span class=\"pdf-label\" data-blocks-engine-richtext-marker=\"label-1\"><strong>Privacy</strong> policy</span></a><a href=\"/docs/plain.pdf\">Plain PDF</a><a href=\"/docs/download.pdf\" download>Download PDF</a>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/file", "attrs": { "className": "download-link", "href": "/docs/privacy.pdf", "fileName": "<mark class=\"pdf-label\" style=\"--blocks-engine-richtext-marker:label-1\"><strong>Privacy</strong> policy</mark>", "textLinkHref": "/docs/privacy.pdf", "showDownloadButton": false } },
+    { "path": "blocks.1", "name": "core/file", "attrs": { "href": "/docs/plain.pdf", "fileName": "Plain PDF", "textLinkHref": "/docs/plain.pdf", "showDownloadButton": false } },
+    { "path": "blocks.2", "name": "core/file", "attrs": { "href": "/docs/download.pdf", "fileName": "Download PDF", "textLinkHref": "/docs/download.pdf", "showDownloadButton": true } }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "blocks", "assert": "count", "count": 3 },
+    { "path": "fallbacks", "assert": "count", "count": 0 },
+    { "path": "serialized_blocks", "assert": "equals", "value": "<!-- wp:file {\"className\":\"download-link\",\"href\":\"/docs/privacy.pdf\",\"showDownloadButton\":false} --><div class=\"wp-block-file download-link\"><a href=\"/docs/privacy.pdf\"><mark class=\"pdf-label\" style=\"--blocks-engine-richtext-marker:label-1\"><strong>Privacy</strong> policy</mark></a></div><!-- /wp:file --><!-- wp:file {\"href\":\"/docs/plain.pdf\",\"showDownloadButton\":false} --><div class=\"wp-block-file\"><a href=\"/docs/plain.pdf\">Plain PDF</a></div><!-- /wp:file --><!-- wp:file {\"href\":\"/docs/download.pdf\",\"showDownloadButton\":true} --><div class=\"wp-block-file\"><a href=\"/docs/download.pdf\">Download PDF</a><a class=\"wp-block-file__button wp-element-button\" href=\"/docs/download.pdf\" download>Download</a></div><!-- /wp:file -->" }
+  ]
+}

--- a/php-transformer/tests/fixtures/parity/html-layout-media-file-primitives.json
+++ b/php-transformer/tests/fixtures/parity/html-layout-media-file-primitives.json
@@ -22,7 +22,7 @@
     { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/separator", "attrs": { "className": "is-style-wide" } },
     { "path": "blocks.1", "name": "core/video", "attrs": { "src": "/movie.mp4", "poster": "/poster.jpg", "width": "640", "controls": true } },
     { "path": "blocks.2", "name": "core/audio", "attrs": { "src": "/clip.mp3", "controls": true } },
-    { "path": "blocks.3", "name": "core/file", "attrs": { "href": "/docs/menu.pdf", "url": "/docs/menu.pdf", "text": "Menu PDF", "showDownloadButton": true } }
+    { "path": "blocks.3", "name": "core/file", "attrs": { "href": "/docs/menu.pdf", "fileName": "Menu PDF", "textLinkHref": "/docs/menu.pdf", "showDownloadButton": true } }
   ],
   "expected_fallbacks": [],
   "expect": [


### PR DESCRIPTION
## Summary
- serialize document link labels through valid `core/file` rich-text content
- preserve authored labels without introducing invalid nested markup
- add PHP parity fixtures and WordPress save-validity coverage

## Testing
- `php tests/contract/run.php`
- `src/wp/__tests__/file-save-validity.test.ts` (2 passed)

Fixes #1176

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to investigate, implement, rebase, and verify this change under human orchestration.