### PR TITLE
Pair masks with unsupported runtime media

### DIFF
--- a/php-transformer/src/Contract/ConversionReportProjection.php
+++ b/php-transformer/src/Contract/ConversionReportProjection.php
@@ -174,6 +174,7 @@ final class ConversionReportProjection
                     'events'                 => $fallback['events'] ?? array(),
                     'script_dependency_hint' => $fallback['script_dependency_hint'] ?? '',
                     'readable_blocks'        => $fallback['readable_blocks'] ?? array(),
+                    'dependent_losses'       => $fallback['dependent_losses'] ?? array(),
                     'html_bytes'             => $fallback['html_bytes'] ?? (isset($fallback['html']) && is_string($fallback['html']) ? strlen($fallback['html']) : null),
                     'html_truncated'         => $fallback['html_truncated'] ?? null,
                 ),

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -4483,6 +4483,8 @@ final class HtmlTransformer
     private function convertChildren(DOMNode $parent, array &$fallbacks, bool $captureUnsupported = false): array
     {
         $blocks = array();
+        $unsupportedRuntimeMediaOwner = null;
+        $ownerFallbackIndex = null;
 
         foreach ( $parent->childNodes as $child ) {
             if ( XML_TEXT_NODE === $child->nodeType ) {
@@ -4497,13 +4499,97 @@ final class HtmlTransformer
                 continue;
             }
 
+            if ( $unsupportedRuntimeMediaOwner instanceof DOMElement
+                && 'svg' === strtolower($child->tagName)
+                && $this->isDependentRuntimeMediaMask($child)
+                && is_int($ownerFallbackIndex)
+            ) {
+                $this->recordDependentRuntimeMediaMaskLoss($unsupportedRuntimeMediaOwner, $child, $fallbacks, $ownerFallbackIndex);
+                $unsupportedRuntimeMediaOwner = null;
+                $ownerFallbackIndex = null;
+                continue;
+            }
+
+            // Pairing is deliberately bounded to adjacent element siblings.
+            $unsupportedRuntimeMediaOwner = null;
+            $ownerFallbackIndex = null;
+            $fallbackOffset = count($fallbacks);
             $block = $this->convertElement($child, $fallbacks, $captureUnsupported);
             if ( null !== $block ) {
                 $blocks[] = $block;
+            } elseif ( $this->isRuntimeMediaSurfaceElement($child) ) {
+                $ownerSelector = $this->elementSelector($child);
+                for ( $index = $fallbackOffset; $index < count($fallbacks); ++$index ) {
+                    if ( $ownerSelector === ($fallbacks[$index]['selector'] ?? null)
+                        && in_array((string) ($fallbacks[$index]['diagnostic_code'] ?? ''), array( 'html_iframe_embed_fallback', 'html_unsupported_element' ), true)
+                    ) {
+                        $unsupportedRuntimeMediaOwner = $child;
+                        $ownerFallbackIndex = $index;
+                        break;
+                    }
+                }
             }
         }
 
         return $blocks;
+    }
+
+    private function isRuntimeMediaSurfaceElement(DOMElement $element): bool
+    {
+        $tagName = strtolower($element->tagName);
+        if ( in_array($tagName, array( 'iframe', 'canvas', 'embed', 'object' ), true) ) {
+            return true;
+        }
+
+        return str_contains($tagName, '-')
+            && 1 === preg_match('/(?:^|-)(?:audio|carousel|gallery|iframe|media|player|slideshow|video)(?:-|$)/', $tagName);
+    }
+
+    private function isDependentRuntimeMediaMask(DOMElement $element): bool
+    {
+        if ( '' !== trim($this->attr($element, 'aria-label'))
+            || in_array(strtolower(trim($this->attr($element, 'role'))), array( 'img', 'graphics-document', 'graphics-symbol' ), true)
+            || 0 < $element->getElementsByTagName('title')->length
+            || 0 < $element->getElementsByTagName('desc')->length
+        ) {
+            return false;
+        }
+
+        $identity = strtolower(implode(' ', array(
+            $this->attr($element, 'id'),
+            $this->attr($element, 'class'),
+            $this->attr($element, 'data-role'),
+        )));
+        if ( 1 === preg_match('/\b(?:clip|mask|overlay)\b/', $identity) ) {
+            return true;
+        }
+
+        $paths = $element->getElementsByTagName('path');
+        $path = 1 === $paths->length ? $paths->item(0) : null;
+        return $path instanceof DOMElement
+            && 1 === $element->getElementsByTagName('*')->length
+            && '' !== trim($this->attr($path, 'd'))
+            && '' === trim($this->attr($element, 'fill'))
+            && '' === trim($this->attr($element, 'stroke'))
+            && '' === trim($this->attr($path, 'fill'))
+            && '' === trim($this->attr($path, 'stroke'));
+    }
+
+    /** @param array<int, array<string, mixed>> $fallbacks */
+    private function recordDependentRuntimeMediaMaskLoss(DOMElement $owner, DOMElement $mask, array &$fallbacks, int $fallbackIndex): void
+    {
+        $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($mask));
+        $fallbacks[$fallbackIndex]['dependent_losses'][] = array(
+            'relationship' => 'runtime_media_mask',
+            'disposition' => 'omitted',
+            'reason' => 'owner_surface_unsupported',
+            'owner_selector' => $this->elementSelector($owner),
+            'selector' => $this->elementSelector($mask),
+            'tag' => 'svg',
+            'html' => $boundedHtml['html'],
+            'html_bytes' => $boundedHtml['bytes'],
+            'html_truncated' => $boundedHtml['truncated'],
+        );
     }
 
     private function patternContext(bool $includeRuntimeDomTarget = true): PatternContext

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -103,6 +103,32 @@ $assert(
     'ambiguous custom media hosts remain typed gaps rather than raw HTML'
 );
 
+$runtimeMediaMaskFixture = file_get_contents(dirname(__DIR__) . '/fixtures/unsupported-runtime-media-mask.html');
+$runtimeMediaMaskResult = ( new HtmlTransformer() )->transform((string) $runtimeMediaMaskFixture)->toArray();
+$runtimeMediaMaskMarkup = (string) ($runtimeMediaMaskResult['serialized_blocks'] ?? '');
+$runtimeMediaMaskFallback = $runtimeMediaMaskResult['fallbacks'][0] ?? array();
+$runtimeMediaMaskReportFallback = $runtimeMediaMaskResult['source_reports']['conversion_report']['fallback_diagnostics'][0] ?? array();
+$assert(
+    'runtime-slideshow' === ($runtimeMediaMaskFallback['tag'] ?? null)
+        && 'runtime_media_mask' === ($runtimeMediaMaskFallback['dependent_losses'][0]['relationship'] ?? null)
+        && 'omitted' === ($runtimeMediaMaskFallback['dependent_losses'][0]['disposition'] ?? null)
+        && ($runtimeMediaMaskFallback['dependent_losses'] ?? null) === ($runtimeMediaMaskReportFallback['dependent_losses'] ?? null),
+    'unsupported runtime media records its adjacent decorative mask as an explicit dependent loss'
+);
+$assert(
+    ! str_contains($runtimeMediaMaskMarkup, '334.611')
+        && str_contains($runtimeMediaMaskMarkup, 'Quality one')
+        && str_contains($runtimeMediaMaskMarkup, 'Quality two')
+        && str_contains($runtimeMediaMaskMarkup, 'Quality three'),
+    'a dependent mask is omitted without discarding independent sibling labels'
+);
+$assert(
+    1 === count(array_filter($runtimeMediaMaskResult['assets'] ?? array(), static fn (array $asset): bool => 'inline-svg' === ($asset['source'] ?? null)))
+        && str_contains($runtimeMediaMaskMarkup, '<img src="assets/materialized-svg/')
+        && str_contains(implode("\n", array_column($runtimeMediaMaskResult['assets'] ?? array(), 'content')), 'Independent mark'),
+    'an independent labeled SVG still follows the normal native image materialization path'
+);
+
 $responsiveImageResult = ( new HtmlTransformer() )->transform('<img src="hero.jpg" srcset="hero.jpg 1x, hero-2x.jpg 2x" sizes="100vw" alt="Hero">')->toArray();
 $assert(
     'core/image' === ($responsiveImageResult['blocks'][0]['blockName'] ?? null)

--- a/php-transformer/tests/fixtures/unsupported-runtime-media-mask.html
+++ b/php-transformer/tests/fixtures/unsupported-runtime-media-mask.html
@@ -1,0 +1,10 @@
+<section class="feature-surface">
+  <runtime-slideshow data-source="featured-projects"></runtime-slideshow>
+  <svg viewBox="0 0 334.611 266.893"><path d="M226.09 266.893H0L108.521 0h226.09L226.09 266.893z"></path></svg>
+  <div class="quality-labels">
+    <a href="/quality/one">Quality one</a>
+    <a href="/quality/two">Quality two</a>
+    <a href="/quality/three">Quality three</a>
+  </div>
+</section>
+<svg viewBox="0 0 20 20" role="img" aria-label="Independent mark"><path fill="#2271b1" d="M2 2h16v16H2z"></path></svg>


### PR DESCRIPTION
## Summary
- retain decorative masks when their media surface must fall back at runtime
- project the relationship into conversion diagnostics instead of orphaning the mask
- add a contract fixture for unsupported masked media

## Testing
- `php tests/contract/run.php`

Fixes #1177

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to investigate, implement, rebase, and verify this change under human orchestration.