### PR TITLE
Validate border color variable domains

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleAttributeMapper.php
@@ -53,9 +53,10 @@ final class StyleAttributeMapper
      * Map resolved CSS declarations to canonical block style attributes.
      *
      * @param array<string, string> $declarations
+     * @param null|callable(string): string $resolveValue
      * @return array{style: array<string, mixed>, attrs: array<string, string>, leftover: array<string, string>}
      */
-    public function map(array $declarations): array
+    public function map(array $declarations, ?callable $resolveValue = null): array
     {
         $normalized = array();
         foreach ( $declarations as $name => $value ) {
@@ -75,7 +76,7 @@ final class StyleAttributeMapper
         }
 
         $attrs = array();
-        $color = $this->color($normalized, $consumed, $attrs);
+        $color = $this->color($normalized, $consumed, $attrs, $resolveValue);
         if ( array() !== $color ) {
             $style['color'] = $color;
         }
@@ -103,7 +104,7 @@ final class StyleAttributeMapper
             $style['spacing']['blockGap'] = $blockGap;
         }
 
-        $border = $this->border($normalized, $consumed);
+        $border = $this->border($normalized, $consumed, $resolveValue);
         if ( array() !== $border ) {
             $style['border'] = $border;
         }
@@ -279,14 +280,14 @@ final class StyleAttributeMapper
      * @param array<string, bool> $consumed
      * @return array<string, string>
      */
-    private function color(array $declarations, array &$consumed, array &$attrs): array
+    private function color(array $declarations, array &$consumed, array &$attrs, ?callable $resolveValue): array
     {
         $color = array();
 
         if ( isset($declarations['color']) ) {
-            $consumed['color'] = true;
-            $text = $this->cssColor($declarations['color']);
+            $text = $this->cssColor($declarations['color'], $resolveValue);
             if ( '' !== $text ) {
+                $consumed['color'] = true;
                 $preset = $this->presetColorSlug($text);
                 if ( '' !== $preset ) {
                     $attrs['textColor'] = $preset;
@@ -297,7 +298,7 @@ final class StyleAttributeMapper
         }
 
         $gradient = $this->gradient($declarations, $consumed);
-        $background = $this->backgroundColor($declarations, $consumed);
+        $background = $this->backgroundColor($declarations, $consumed, $resolveValue);
         if ( '' !== $background ) {
             $preset = $this->presetColorSlug($background);
             if ( '' !== $preset ) {
@@ -415,12 +416,15 @@ final class StyleAttributeMapper
      * @param array<string, string> $declarations
      * @param array<string, bool> $consumed
      */
-    private function backgroundColor(array $declarations, array &$consumed): string
+    private function backgroundColor(array $declarations, array &$consumed, ?callable $resolveValue): string
     {
         if ( isset($declarations['background-color']) ) {
-            $consumed['background-color'] = true;
             $color = trim($declarations['background-color']);
-            return 'transparent' === strtolower($color) ? $color : $this->cssColor($color);
+            $color = 'transparent' === strtolower($color) ? $color : $this->cssColor($color, $resolveValue);
+            if ( '' !== $color ) {
+                $consumed['background-color'] = true;
+            }
+            return $color;
         }
 
         $value = trim((string) ($declarations['background'] ?? ''));
@@ -428,9 +432,12 @@ final class StyleAttributeMapper
             return '';
         }
 
-        $consumed['background'] = true;
         $color = trim(CssValueSplitter::splitTopLevelWhitespace($value)[0] ?? '');
-        return 'transparent' === strtolower($color) ? $color : $this->cssColor($color);
+        $color = 'transparent' === strtolower($color) ? $color : $this->cssColor($color, $resolveValue);
+        if ( '' !== $color ) {
+            $consumed['background'] = true;
+        }
+        return $color;
     }
 
     /**
@@ -491,7 +498,7 @@ final class StyleAttributeMapper
      * @param array<string, bool> $consumed
      * @return array<string, string>
      */
-    private function border(array $declarations, array &$consumed): array
+    private function border(array $declarations, array &$consumed, ?callable $resolveValue): array
     {
         $border    = array();
         $positions = array_flip(array_keys($declarations));
@@ -500,15 +507,28 @@ final class StyleAttributeMapper
                 $consumed[ $name ] = true;
             }
         }
+        foreach ( $declarations as $name => $value ) {
+            if ( preg_match('/^border(?:-(?:top|right|bottom|left))?-color$/', $name)
+                && '' === $this->cssColor($value, $resolveValue)
+            ) {
+                unset($consumed[ $name ]);
+            }
+            if ( preg_match('/^border(?:-(?:top|right|bottom|left))?$/', $name)
+                && isset($this->parseBorderShorthand($value)['color'])
+                && ! isset($this->parseBorderShorthand($value, $resolveValue)['color'])
+            ) {
+                unset($consumed[ $name ]);
+            }
+        }
 
         $global = array();
         foreach ( array( 'width', 'style', 'color' ) as $component ) {
-            $global[ $component ] = $this->borderComponentCandidate($declarations, $positions, $component);
+            $global[ $component ] = $this->borderComponentCandidate($declarations, $positions, $component, '', $resolveValue);
         }
 
         $width      = trim($global['width']['value']);
         $style      = strtolower(trim($global['style']['value']));
-        $colorValue = $this->cssColor($global['color']['value']);
+        $colorValue = $this->cssColor($global['color']['value'], $resolveValue);
 
         $noBorder = 'none' === $style || ( '' !== $width && (float) $width === 0.0 && '' === $colorValue && '' === $style );
         if ( ! $noBorder ) {
@@ -533,7 +553,7 @@ final class StyleAttributeMapper
             $sideComponents = array();
             $sideDeclared   = array();
             foreach ( array( 'width', 'style', 'color' ) as $component ) {
-                $candidate = $this->borderComponentCandidate($declarations, $positions, $component, $side);
+                $candidate = $this->borderComponentCandidate($declarations, $positions, $component, $side, $resolveValue);
                 if ( $candidate['index'] > $global[ $component ]['index'] ) {
                     $sideComponents[ $component ] = $candidate['value'];
                     $sideDeclared[ $component ]   = $candidate['declared'];
@@ -542,7 +562,7 @@ final class StyleAttributeMapper
 
             $sideWidth = trim((string) ($sideComponents['width'] ?? ''));
             $sideStyle = strtolower(trim((string) ($sideComponents['style'] ?? '')));
-            $sideColor = $this->cssColor((string) ($sideComponents['color'] ?? ''));
+            $sideColor = $this->cssColor((string) ($sideComponents['color'] ?? ''), $resolveValue);
 
             $sideValues = array();
             $noSideBorder = 'none' === $sideStyle || ( '' !== $sideWidth && (float) $sideWidth === 0.0 && '' === $sideColor && '' === $sideStyle );
@@ -582,14 +602,14 @@ final class StyleAttributeMapper
      * @param array<string, int> $positions
      * @return array{value: string, index: int, declared: bool}
      */
-    private function borderComponentCandidate(array $declarations, array $positions, string $component, string $side = ''): array
+    private function borderComponentCandidate(array $declarations, array $positions, string $component, string $side = '', ?callable $resolveValue = null): array
     {
         $shorthandName = '' === $side ? 'border' : 'border-' . $side;
         $longhandName  = $shorthandName . '-' . $component;
         $candidate     = array( 'value' => '', 'index' => -1, 'declared' => false );
 
         if ( isset($declarations[ $shorthandName ]) ) {
-            $shorthand = $this->parseBorderShorthand($declarations[ $shorthandName ]);
+            $shorthand = $this->parseBorderShorthand($declarations[ $shorthandName ], $resolveValue);
             $initialValues = array(
                 'width' => 'medium',
                 'style' => 'none',
@@ -659,7 +679,7 @@ final class StyleAttributeMapper
     /**
      * @return array{width?: string, style?: string, color?: string}
      */
-    private function parseBorderShorthand(string $value): array
+    private function parseBorderShorthand(string $value, ?callable $resolveValue = null): array
     {
         $value = trim($value);
         if ( '' === $value ) {
@@ -677,7 +697,7 @@ final class StyleAttributeMapper
                 $parsed['width'] = $token;
                 continue;
             }
-            if ( '' !== $this->cssColor($token) ) {
+            if ( '' !== $this->cssColor($token, $resolveValue) ) {
                 $parsed['color'] = $token;
             }
         }
@@ -688,7 +708,7 @@ final class StyleAttributeMapper
     /**
      * Return the value when it is a usable CSS color, otherwise an empty string.
      */
-    private function cssColor(string $value): string
+    private function cssColor(string $value, ?callable $resolveValue = null): string
     {
         $value = trim($value);
         if ( '' === $value ) {
@@ -721,6 +741,15 @@ final class StyleAttributeMapper
             return $value;
         }
         if ( preg_match('/^var\s*\(\s*--[a-z0-9_-]+/i', $value) ) {
+            if ( preg_match('/^var\s*\(\s*--wp--preset--color--[a-z0-9_-]+\s*\)$/i', $value) ) {
+                return $value;
+            }
+            if ( null !== $resolveValue ) {
+                $resolved = trim((string) $resolveValue($value));
+                if ( $resolved === $value || str_contains($resolved, 'var(') || '' === $this->cssColor($resolved) ) {
+                    return '';
+                }
+            }
             return $value;
         }
         if ( 'currentcolor' === $lower ) {

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -99,21 +99,35 @@ trait StyleResolutionTrait
     /**
      * Properties carried when NO author rule declares them at all.
      *
-     * Deliberately NOT general. `box-shadow` is decorative paint with no layout
-     * or animation side effects, and it is the only unmapped property in this
-     * defect family: the four service cards are classless elements whose inline
-     * box-shadow is their only ring, so nothing else can restore it. A general
-     * "carry every leftover inline declaration" rule would also carry
-     * `animation`, `filter` and `counter-reset`, which have side effects and sit
-     * outside this defect family. Conflicting declarations do not need to be on
-     * this list — a conflict is self-evidence that the author rule would
-     * otherwise reassert the opposite value.
+     * Deliberately NOT general. Decorative paint is safe to preserve without
+     * layout or animation side effects. Color declarations also land here when
+     * their custom properties cannot be proven compatible with Gutenberg color
+     * support; carrying the authored CSS avoids activating destructive support
+     * classes without discarding the source declaration. A general "carry every
+     * leftover inline declaration" rule would also carry `animation`, `filter`
+     * and `counter-reset`, which have side effects. Conflicting declarations do
+     * not need to be on this list — a conflict is self-evidence that the author
+     * rule would otherwise reassert the opposite value.
      *
      * @return list<string>
      */
     private function inlineUnmatchedCarrierProperties(): array
     {
-        return array( 'box-shadow' );
+        return array(
+            'box-shadow',
+            'color',
+            'background-color',
+            'border-color',
+            'border',
+            'border-top',
+            'border-right',
+            'border-bottom',
+            'border-left',
+            'border-top-color',
+            'border-right-color',
+            'border-bottom-color',
+            'border-left-color',
+        );
     }
 
     /**
@@ -238,7 +252,10 @@ trait StyleResolutionTrait
             $this->presentationDeclarations($element)
         );
         $declarations = $this->classOwnedBackgroundPaintDeclarations($element, $declarations);
-        $mapped       = $this->styleAttributeMapper()->map($declarations);
+        $mapped       = $this->styleAttributeMapper()->map(
+            $declarations,
+            fn (string $value): string => $this->resolveCssVariablesInValue($value, $element)
+        );
         $forcedGeometryDeclarations = array() === $forcedGeometryProperties
             ? array()
             : $this->cssDeclarations((string) ($this->styleAttributeMapper()->serialize($mapped['style'] ?? array())['style'] ?? ''));
@@ -694,7 +711,10 @@ trait StyleResolutionTrait
         array $carried,
         array $excludedProperties
     ): array {
-        $candidates = $this->styleAttributeMapper()->map($inlineDeclarations)['leftover'] ?? array();
+        $candidates = $this->styleAttributeMapper()->map(
+            $inlineDeclarations,
+            fn (string $value): string => $this->resolveCssVariablesInValue($value, $element)
+        )['leftover'] ?? array();
         if ( isset($inlineDeclarations['box-shadow']) ) {
             $candidates['box-shadow'] = $inlineDeclarations['box-shadow'];
         }

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -1298,6 +1298,15 @@ $assert(str_contains($cssVariableButtonCss, 'border-radius:6px!important'), 'but
 $assert(! str_contains($cssVariableButtonMarkup, 'var(--amber)'), 'button fill avoids leaking source-local CSS custom properties into standalone block markup');
 $assert('pass' === ($cssVariableButton['source_reports']['wp_block_validity']['status'] ?? ''), 'CSS-variable button serialization passes generated WordPress block validity checks');
 
+$borderWidthVariableCta = ( new HtmlTransformer() )->transform(
+    '<style>:root{--corvid-border-width:var(--brw,0)}.cta{display:inline-block;width:142px;height:40px;background:#1684d6;color:#fff;border-color:var(--corvid-border-width,var(--brw,0))}</style><a class="cta" href="/more">Meer info</a>'
+)->toArray();
+$borderWidthVariableCtaMarkup = (string) ($borderWidthVariableCta['serialized_blocks'] ?? '');
+$borderWidthVariableCtaCss = implode("\n", array_column($borderWidthVariableCta['assets'] ?? array(), 'content'));
+$assert(! isset($borderWidthVariableCta['blocks'][0]['attrs']['style']['border']['color']) && ! str_contains($borderWidthVariableCtaMarkup, 'has-border-color'), 'dimension-valued custom properties do not activate Gutenberg border color support');
+$assert(str_contains($borderWidthVariableCtaMarkup, 'Meer info') && str_contains($borderWidthVariableCtaCss, 'width:142px;height:40px;background:#1684d6') && str_contains($borderWidthVariableCtaCss, 'border-color:var(--corvid-border-width,var(--brw,0))'), 'rejected CTA border color remains in authored CSS with its label, source fill, and dimensions');
+$assert('pass' === ($borderWidthVariableCta['source_reports']['wp_block_validity']['status'] ?? ''), 'dimension-valued CTA border variable preserves valid Gutenberg serialization');
+
 $plainWrappedLink = ( new HtmlTransformer() )->transform('<main><div class="card-link"><a href="/docs">Read docs</a></div></main>')->toArray();
 $assert(! str_contains((string) ($plainWrappedLink['serialized_blocks'] ?? ''), '<!-- wp:button'), 'plain single-anchor wrappers without button signals do not become buttons');
 

--- a/php-transformer/tests/unit/author-selector-semantics.php
+++ b/php-transformer/tests/unit/author-selector-semantics.php
@@ -565,14 +565,16 @@ $assert(! str_contains($geometryCustomPropertyMarkup, '--card-width:') && ! str_
 $customPropertyRoundTrip = $transform('<style>.tour-card{background:linear-gradient(135deg,var(--tone),var(--accent))}</style><div class="tour-card" style="--tone:#315b74;border-color:var(--line);border-width:1px;border-style:solid;border-radius:var(--radius);padding:1.2rem;min-height:430px;--accent:#d9b86c">Card</div>');
 $customPropertyRoundTripMarkup = (string) ($customPropertyRoundTrip['serialized_blocks'] ?? '');
 $assert(
-    str_contains($customPropertyRoundTripMarkup, 'style="border-color:var(--line);border-style:solid;border-width:1px;border-radius:var(--radius);padding-top:1.2rem;padding-right:1.2rem;padding-bottom:1.2rem;padding-left:1.2rem"')
+    str_contains($customPropertyRoundTripMarkup, 'style="border-style:solid;border-width:1px;border-radius:var(--radius);padding-top:1.2rem;padding-right:1.2rem;padding-bottom:1.2rem;padding-left:1.2rem"')
+    && ! str_contains($customPropertyRoundTripMarkup, 'has-border-color')
     && ! str_contains($customPropertyRoundTripMarkup, 'min-height:430px')
     && ! str_contains($customPropertyRoundTripMarkup, '--accent:')
     && str_contains($css($customPropertyRoundTrip), '--tone:#315b74 !important')
     && str_contains($css($customPropertyRoundTrip), '--accent:#d9b86c !important')
+    && str_contains($css($customPropertyRoundTrip), 'border-color:var(--line)')
     && str_contains($css($customPropertyRoundTrip), 'min-height:430px !important')
     && 'pass' === ($customPropertyRoundTrip['source_reports']['wp_block_validity']['status'] ?? ''),
-    'unsupported custom properties and dimensions move to generated carrier CSS while supported styles retain a valid core block round trip',
+    'unresolved color variables, custom properties, and dimensions move to generated carrier CSS while supported styles retain a valid core block round trip',
     $customPropertyRoundTripMarkup
 );
 

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -60,6 +60,28 @@ $assert(
     json_encode($uniformBorder)
 );
 
+$colorDomainMapper = new StyleAttributeMapper();
+$dimensionBorderColor = $colorDomainMapper->map(
+    array( 'border-color' => 'var(--border-width,var(--fallback-width,0))' ),
+    static fn (string $value): string => '0'
+);
+$resolvedVariableBorderColor = $colorDomainMapper->map(
+    array( 'border-color' => 'var(--border-color,#123456)' ),
+    static fn (string $value): string => '#123456'
+);
+$assert(
+    ! isset($dimensionBorderColor['style']['border']['color'])
+        && 'var(--border-width,var(--fallback-width,0))' === ($dimensionBorderColor['leftover']['border-color'] ?? ''),
+    '8c: a dimension-resolving custom property stays authored CSS instead of becoming border color support',
+    json_encode($dimensionBorderColor)
+);
+$assert(
+    'var(--border-color,#123456)' === ($resolvedVariableBorderColor['style']['border']['color'] ?? '')
+        && ! isset($resolvedVariableBorderColor['leftover']['border-color']),
+    '8d: a color-resolving custom property retains its authored token in border color support',
+    json_encode($resolvedVariableBorderColor)
+);
+
 $classBorderImage = ( new HtmlTransformer() )->transform(
     '<img class="photo" src="/photo.jpg" alt="Portrait">',
     array('static_css' => '.photo{border-top-width:12.808px;border-right-width:12.808px;border-bottom-width:12.808px;border-left-width:12.808px;border-style:solid;border-color:#fff}')
@@ -397,7 +419,7 @@ $compoundSourceProbe = ( new StaticStyleParityProbe() )->extract($compoundPaintH
 $compoundCandidateProbe = ( new StaticStyleParityProbe() )->extract(StaticStyleParityRunner::candidateHtmlFromSerializedBlocks($compoundPaintMarkup), $compoundPaintCssAsset);
 $assert(0 < (int) ($compoundSourceProbe['summary']['styled_total'] ?? 0) && 0 < (int) ($compoundCandidateProbe['summary']['styled_total'] ?? 0), '62: layered background cascade case produces nonzero source and candidate style probes', json_encode(array($compoundSourceProbe['summary'] ?? array(), $compoundCandidateProbe['summary'] ?? array())));
 
-$amberQuoteHtml = '<blockquote style="margin:0 0 1.6rem;padding-left:1.2rem;border-left:2px solid var(--secondary);font-family:var(--head);font-size:2.2rem;font-weight:700;letter-spacing:-.02em">Comfort is a result, never a method</blockquote>';
+$amberQuoteHtml = '<style>:root{--secondary:#f0ac22}</style><blockquote style="margin:0 0 1.6rem;padding-left:1.2rem;border-left:2px solid var(--secondary);font-family:var(--head);font-size:2.2rem;font-weight:700;letter-spacing:-.02em">Comfort is a result, never a method</blockquote>';
 $amberQuoteResult = ( new HtmlTransformer() )->transform($amberQuoteHtml, array())->toArray();
 $amberQuote = $amberQuoteResult['blocks'][0] ?? array();
 $amberQuoteAttrs = is_array($amberQuote['attrs'] ?? null) ? $amberQuote['attrs'] : array();
@@ -491,7 +513,7 @@ $assert(
 );
 
 $nativeBorderGroupResult = ( new HtmlTransformer() )->transform(
-    '<section style="border-left:2px solid var(--secondary)"><p>Native border</p></section>',
+    '<style>:root{--secondary:#f0ac22}</style><section style="border-left:2px solid var(--secondary)"><p>Native border</p></section>',
     array()
 )->toArray();
 $nativeBorderGroup = $nativeBorderGroupResult['blocks'][0] ?? array();


### PR DESCRIPTION
## Summary
- reject CSS variables whose resolved semantic domain is not a color
- preserve valid authored color variables while preventing invalid block border projections
- extend selector and block style support coverage

## Testing
- `php tests/unit/author-selector-semantics.php` (96 passed)
- `php tests/unit/block-style-support-conversion.php` (136 passed)

Fixes #1175

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to investigate, implement, rebase, and verify this change under human orchestration.