### PR TITLE
Preserve intrinsic responsive CTA width

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -6252,6 +6252,8 @@ final class HtmlTransformer
         $style = is_array($attrs['style'] ?? null) ? $attrs['style'] : array();
         $declarations = array();
         $wrapperDeclarations = array();
+        $outerWrapperDeclarations = array();
+        $intrinsicWrapperDeclarations = array();
         foreach ( array(
             'background-color' => $style['color']['background'] ?? '',
             'color'            => $style['color']['text'] ?? '',
@@ -6277,6 +6279,20 @@ final class HtmlTransformer
         if ( $sourceControl instanceof DOMElement ) {
             $sourceDeclarations = $this->cssDeclarations($this->specificityResolvedPresentationStyle($sourceControl));
             $sourceStructuralDeclarations = $this->structuralPresentationDeclarations($sourceControl);
+            $inlineDeclarations = $this->cssDeclarations($this->attr($sourceControl, 'style'));
+            $hasAuthoredWidth = isset($inlineDeclarations['width'])
+                || array() !== $this->authorDeclaredPropertyValues($sourceControl, array( 'width' ));
+            if ( ! $hasAuthoredWidth && in_array($this->cssComparableValue((string) ($sourceDeclarations['display'] ?? '')), array( 'flex', 'inline-flex' ), true) ) {
+                // Preserve the source flex CTA's content-plus-padding contribution
+                // through the synthetic wrappers of its native button topology.
+                $outerWrapperDeclarations[] = 'width:max-content';
+                $outerWrapperDeclarations[] = 'max-width:100%';
+                $intrinsicWrapperDeclarations[] = 'width:max-content';
+                $intrinsicWrapperDeclarations[] = 'max-width:100%';
+                $declarations[] = 'box-sizing:border-box';
+                $declarations[] = 'width:max-content';
+                $declarations[] = 'max-width:100%';
+            }
             $background = $this->cssComparableValue((string) ($sourceDeclarations['background'] ?? ''));
             if ( '' === trim((string) ($style['color']['background'] ?? '')) && preg_match('/^(?:0(?:px)?(?:\s+0(?:px)?)*|none|transparent)(?:\s+none)?$/', $background) ) {
                 $declarations[] = 'background-color:transparent!important';
@@ -6312,10 +6328,16 @@ final class HtmlTransformer
             return;
         }
 
+        $outerWrapperRule = array() === $outerWrapperDeclarations
+            ? ''
+            : '.' . $marker . '.' . $marker . '.wp-block-buttons{' . implode(';', $outerWrapperDeclarations) . '}';
         $wrapperRule = array() === $wrapperDeclarations
             ? ''
             : '.' . $marker . '.' . $marker . '.wp-block-button{' . implode(';', $wrapperDeclarations) . '}';
-        $this->nativeButtonStyleRules[$marker] = $wrapperRule . '.' . $marker . '.' . $marker . '>.wp-block-button__link{' . implode(';', $declarations) . '}';
+        $intrinsicWrapperRule = array() === $intrinsicWrapperDeclarations
+            ? ''
+            : '.' . $marker . '.' . $marker . '.wp-block-button{' . implode(';', $intrinsicWrapperDeclarations) . '}';
+        $this->nativeButtonStyleRules[$marker] = $outerWrapperRule . $wrapperRule . $intrinsicWrapperRule . '.' . $marker . '.' . $marker . '>.wp-block-button__link{' . implode(';', $declarations) . '}';
     }
 
     private function sourceElementStartsHidden(DOMElement $element): bool

--- a/php-transformer/tests/fixtures/parity/html-responsive-grid-cta-intrinsic-width.json
+++ b/php-transformer/tests/fixtures/parity/html-responsive-grid-cta-intrinsic-width.json
@@ -1,0 +1,41 @@
+{
+  "schema": "blocks-engine/php-transformer/parity-fixture/v1",
+  "name": "html-responsive-grid-cta-intrinsic-width",
+  "description": "Preserves a flex CTA's content-plus-padding width through native button wrappers in a responsive source grid.",
+  "source_reference": {
+    "repo": "php-transformer",
+    "path": "tests/fixtures/parity/html-responsive-grid-cta-intrinsic-width.json",
+    "notes": "Generic deterministic regression coverage for Automattic/blocks-engine#1186. The mobile and desktop variants remain independently responsive while each promoted CTA receives intrinsic wrapper geometry."
+  },
+  "legacy_comparison": {
+    "skip": true,
+    "reason": "Native wrapper geometry support has no legacy converter equivalent."
+  },
+  "operation": "html_transformer.transform",
+  "input": {
+    "content": "<!doctype html><html><head><style>.quote-grid{display:grid;grid-template-columns:max-content}.quote-cta{display:flex;align-items:center;justify-content:center;margin:8px 0;padding:12px 24px;border-radius:50px;background:#135e96;color:#fff}.desktop-variant{display:none}@media(min-width:601px){.mobile-variant{display:none}.desktop-variant{display:grid}}</style></head><body><main><div class=\"quote-grid mobile-variant\"><a class=\"quote-cta\" href=\"/get-a-quote/\">GET A QUOTE</a></div><div class=\"quote-grid desktop-variant\"><a class=\"quote-cta\" href=\"/desktop-quote/\">REQUEST A DESKTOP QUOTE</a></div></main></body></html>"
+  },
+  "expected_blocks": [
+    { "path": "blocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0", "name": "core/buttons" },
+    { "path": "blocks.0.innerBlocks.0.innerBlocks.0.innerBlocks.0", "name": "core/button", "attrs": { "text": "GET A QUOTE", "url": "/get-a-quote/" } },
+    { "path": "blocks.0.innerBlocks.1", "name": "core/group" },
+    { "path": "blocks.0.innerBlocks.1.innerBlocks.0", "name": "core/buttons" }
+  ],
+  "expected_fallbacks": [],
+  "expect": [
+    { "path": "status", "assert": "equals", "value": "success" },
+    { "path": "source_reports.wp_block_validity.status", "assert": "equals", "value": "pass" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "style=\"margin-top:8px;margin-bottom:8px\"" },
+    { "path": "serialized_blocks", "assert": "contains", "value": "href=\"/get-a-quote/\">GET A QUOTE</a>" },
+    { "path": "assets.2.source", "assert": "equals", "value": "engine-support" },
+    { "path": "assets.2.stylesheet_placement", "assert": "equals", "value": "after-author" },
+    { "path": "assets.2.content", "assert": "contains", "value": ".wp-block-buttons{width:max-content;max-width:100%}" },
+    { "path": "assets.2.content", "assert": "contains", "value": ".wp-block-button{width:max-content;max-width:100%}" },
+    { "path": "assets.2.content", "assert": "contains", "value": "box-sizing:border-box;width:max-content;max-width:100%" },
+    { "path": "assets.1.content", "assert": "contains", "value": "padding:12px 24px;border-radius:50px" },
+    { "path": "assets.1.content", "assert": "contains", "value": "@media(min-width:601px){.mobile-variant{display:none}.desktop-variant{display:grid}}" },
+    { "path": "fallbacks", "assert": "count", "count": 0 }
+  ]
+}

--- a/php-transformer/tests/unit/engine-support-css-asset.php
+++ b/php-transformer/tests/unit/engine-support-css-asset.php
@@ -167,6 +167,7 @@ $afterFamilies = array(
     'list-navigation host' => '.wp-block-navigation.blocks-engine-list-navigation.blocks-engine-native-responsive-navigation{display:flex!important}',
     'list-navigation mobile overlay' => '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation__responsive-container.is-menu-open{background:rgba(0,0,0,.9)!important}',
     'nativeButtonStyleRules' => 'background-color:#fff!important;color:#000!important',
+    'intrinsic native button width' => '.wp-block-buttons{width:max-content;max-width:100%}',
     'directFlexButtonStyleRules' => '.wp-block-buttons){display:block!important;gap:0!important;min-width:0;width:100%!important}',
     'fullWidthButtonStyleRules' => '.wp-block-buttons){display:block!important;gap:0!important;width:100%!important}',
 );
@@ -186,6 +187,10 @@ foreach ( $afterFamilies as $family => $needle ) {
     $assert(str_contains($afterCss, $needle), 'G3: ' . $family . ' lives in after-author engine-support');
     $assert(! str_contains($authorCss, $needle), 'G3: ' . $family . ' does not leak into author-css');
 }
+$assert(
+    ! str_contains($cssFor($fullWidthButton, 'engine-support', 'after-author'), 'width:max-content'),
+    'G3: an authored button width remains authoritative over intrinsic wrapper support'
+);
 
 $orderedCssAssets = $cssAssets($authorOrder);
 $beforeIndex = null;


### PR DESCRIPTION
Closes #1186

## Summary
- preserve content-plus-padding width through synthetic `core/buttons` and `core/button` wrappers
- limit intrinsic support to flex/inline-flex controls without authored width
- keep responsive/full-width overrides, margins, chrome, destination, and valid block serialization authoritative

## Verification
- `php tests/parity/run.php` (289 fixtures)
- `php tests/contract/run.php`
- `php tests/unit/engine-support-css-asset.php` (59 assertions)
- button classifier/resolver unit contracts
- `composer validate --strict`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the native button topology, implemented and narrowed the generic producer rule, added the deterministic responsive-grid fixture, and ran the listed gates under human orchestration.