### PR TITLE
Guard list navigation support-child ordering

### DIFF
--- a/php-transformer/tests/unit/navigation-inert-support-children.php
+++ b/php-transformer/tests/unit/navigation-inert-support-children.php
@@ -50,6 +50,13 @@ $visibleInert = ( new HtmlTransformer() )->transform(
 $visibleInertMarkup = (string) ($visibleInert['serialized_blocks'] ?? '');
 $assert(! str_contains($visibleInertMarkup, '<!-- wp:navigation '), 'visible inert siblings still reject navigation promotion', $visibleInertMarkup);
 
+$leadingRuntime = ( new HtmlTransformer() )->transform(
+    '<nav aria-label="Primary"><div id="navigation-runtime"></div>' . $menu . '</nav>',
+    array( 'runtime_dom_selectors' => array( '#navigation-runtime' ) )
+)->toArray();
+$leadingRuntimeMarkup = (string) ($leadingRuntime['serialized_blocks'] ?? '');
+$assert(! str_contains($leadingRuntimeMarkup, '<!-- wp:navigation '), 'inert support children before a recognized list still reject navigation promotion', $leadingRuntimeMarkup);
+
 $presentationHidden = ( new HtmlTransformer() )->transform(
     '<nav aria-label="Primary">' . $menu . '<span aria-hidden="true" style="display:none">Primary navigation</span><span inert style="visibility:hidden">Menu support</span></nav>'
 )->toArray();


### PR DESCRIPTION
Closes #1109

## Summary
- retain the existing producer fix from merged PRs #1131 and #1138
- add the missing negative regression proving an inert runtime mount cannot be skipped before a real list-backed menu is recognized

## Verification
- all 10 `php-transformer/tests/unit/navigation-*.php` contracts
- `php tests/unit/navigation-inert-support-children.php` (9 assertions)
- `composer validate --strict`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode verified the live issue against current trunk, identified that production behavior had already landed, added the missing ordering regression, and ran the listed gates under human orchestration.