### PR TITLE
Preserve wrapped navigation gap

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -1166,19 +1166,16 @@ final class NavigationPattern implements PatternRecognizerInterface
     private function navigationContainerAttributes(DOMElement $element, callable $presentationAttributes): array
     {
         $attrs = $this->withoutCoreNavigationClasses($presentationAttributes($element));
-        if ( $this->isListNavigationSource($element) ) {
+        $list = $this->navigationListSource($element);
+        if ( $list instanceof DOMElement ) {
             $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' blocks-engine-list-navigation');
         }
         if ( '' !== (string) ($attrs['style']['spacing']['blockGap'] ?? '') ) {
             return $attrs;
         }
 
-        foreach ( $element->childNodes as $child ) {
-            if ( ! $child instanceof DOMElement || ! in_array(strtolower($child->tagName), array( 'ul', 'ol' ), true) ) {
-                continue;
-            }
-
-            $listAttrs = $this->withoutCoreNavigationClasses($presentationAttributes($child));
+        if ( $list instanceof DOMElement && ! $list->isSameNode($element) ) {
+            $listAttrs = $this->withoutCoreNavigationClasses($presentationAttributes($list));
             $listClasses = trim((string) ($listAttrs['className'] ?? ''));
             if ( '' !== $listClasses ) {
                 $attrs['className'] = implode(' ', array_values(array_unique(array_filter(preg_split('/\s+/', trim((string) ($attrs['className'] ?? '') . ' ' . $listClasses)) ?: array()))));
@@ -1188,10 +1185,9 @@ final class NavigationPattern implements PatternRecognizerInterface
             if ( '' !== $listGap ) {
                 $attrs['style']['spacing']['blockGap'] = $listGap;
             }
-            break;
         }
 
-        if ( $this->isListNavigationSource($element) && '' === (string) ($attrs['style']['spacing']['blockGap'] ?? '') ) {
+        if ( $list instanceof DOMElement && '' === (string) ($attrs['style']['spacing']['blockGap'] ?? '') ) {
             // Core navigation adds its own default gap; source lists do not.
             $attrs['style']['spacing']['blockGap'] = '0px';
         }
@@ -1201,17 +1197,29 @@ final class NavigationPattern implements PatternRecognizerInterface
 
     private function isListNavigationSource(DOMElement $element): bool
     {
+        return $this->navigationListSource($element) instanceof DOMElement;
+    }
+
+    private function navigationListSource(DOMElement $element): ?DOMElement
+    {
         if ( in_array(strtolower($element->tagName), array( 'ul', 'ol' ), true) ) {
-            return true;
+            return $element;
         }
 
         foreach ( $element->childNodes as $child ) {
             if ( $child instanceof DOMElement && in_array(strtolower($child->tagName), array( 'ul', 'ol' ), true) ) {
-                return true;
+                return $child;
+            }
+
+            if ( $child instanceof DOMElement && $this->isNavigationWrapperElement($child) ) {
+                $list = $this->navigationListSource($child);
+                if ( $list instanceof DOMElement ) {
+                    return $list;
+                }
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/php-transformer/tests/contract/run.php
+++ b/php-transformer/tests/contract/run.php
@@ -2170,6 +2170,17 @@ $assert('pass' === ($listGapNavigation['source_reports']['semantic_parity']['sta
 $assert('pass' === ($listGapNavigation['source_reports']['wp_block_validity']['status'] ?? ''), 'direct navigation list gap serializes to a valid WordPress block');
 $assert(str_contains($listGapNavigationSerialized, '<!-- wp:navigation ') && str_contains($listGapNavigationSerialized, '"blockGap":"0"'), 'direct navigation list gap uses canonical dynamic navigation serialization');
 
+$wrappedListGapNavigation = ( new HtmlTransformer() )->transform(
+    '<style>.wsite-menu-default{display:flex;gap:20px}</style><nav aria-label="Primary"><div class="nav-wrap"><ul class="wsite-menu-default"><li><a href="/one">One</a></li><li><a href="/two">Two</a></li></ul></div></nav>'
+)->toArray();
+$wrappedListGapNavigationAttrs = $wrappedListGapNavigation['blocks'][0]['attrs'] ?? array();
+$wrappedListGapNavigationSerialized = (string) ($wrappedListGapNavigation['serialized_blocks'] ?? '');
+$assert('20px' === ($wrappedListGapNavigationAttrs['style']['spacing']['blockGap'] ?? ''), '#748 wrapper-originated navigation preserves the authored list gap');
+$assert(str_contains((string) ($wrappedListGapNavigationAttrs['className'] ?? ''), 'wsite-menu-default'), '#748 wrapper-originated navigation keeps the logical source-list class');
+$assert(str_contains($wrappedListGapNavigationSerialized, '"blockGap":"20px"'), '#748 wrapper-originated navigation serializes native block spacing');
+$assert('pass' === ($wrappedListGapNavigation['source_reports']['semantic_parity']['status'] ?? ''), '#748 wrapper-originated navigation preserves semantic parity');
+$assert('pass' === ($wrappedListGapNavigation['source_reports']['wp_block_validity']['status'] ?? ''), '#748 wrapper-originated navigation stays editor-valid');
+
 $outerGapNavigation = ( new HtmlTransformer() )->transform(
     '<nav style="gap:1rem"><ul style="gap:0"><li><a href="/one">One</a></li><li><a href="/two">Two</a></li></ul></nav>'
 )->toArray();


### PR DESCRIPTION
Closes #748

## Summary
- resolve the logical source list through wrappers already accepted by navigation conversion
- carry authored list classes and native `blockGap` onto `core/navigation`
- preserve default-gap neutralization and editor-valid serialization

## Verification
- `php tests/contract/run.php`
- `composer test:parity` (288 fixtures)
- focused navigation source, direct-cluster, and brand-carrier contracts
- `composer validate --strict`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the wrapper conversion path, implemented the producer-side fix and regression, and ran the listed gates under human orchestration.