### PR TITLE
Extract button pattern recognizers from HtmlTransformer

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -16,6 +16,10 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsC
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\SemanticParityReporter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\AccordionPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonAnchorPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonPatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsContainerPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CallbackPatternRecognizer;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPattern;
@@ -203,8 +207,6 @@ final class HtmlTransformer
     private readonly BlockFactory $blockFactory;
 
     private readonly BackgroundImageExtractor $backgroundImageExtractor;
-
-    private readonly ButtonsPattern $buttonsPattern;
 
     private readonly CodeWindowPattern $codeWindowPattern;
 
@@ -578,7 +580,7 @@ final class HtmlTransformer
         );
         $this->blockFactory      = new BlockFactory();
         $this->backgroundImageExtractor = new BackgroundImageExtractor();
-        $this->buttonsPattern    = new ButtonsPattern();
+        $buttonsPattern         = new ButtonsPattern();
         $this->codeWindowPattern = new CodeWindowPattern();
         $this->columnsPattern    = new ColumnsPattern();
         $this->coverPattern      = new CoverPattern();
@@ -620,22 +622,9 @@ final class HtmlTransformer
                 $block = $this->galleryPattern->match($element, fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link), fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $this->convertPictureElement($picture, $figure, $link), fn (DOMElement $figure): ?DOMElement => $this->figureLinkedMediaAnchor($figure), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
                 return null === $block ? null : new PatternRecognitionResult($block);
             }),
-            new CallbackPatternRecognizer('buttons-container', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $block = $this->buttonsPattern->matchContainer($element, $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)), $context->innerHtmlCallback(), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block);
-            }),
-            new CallbackPatternRecognizer('button-anchor', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $fallbacks = array();
-                $block = $this->buttonsPattern->matchAnchor($element, fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)), fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name), $context->createBlockCallback(), function (DOMElement $anchor) use (&$fallbacks): array {
-                    $fallbacks[] = FallbackDiagnostic::build(array('type' => 'html', 'reason' => 'stylable_button_accessible_name_requires_typed_companion', 'diagnostic_code' => 'html_stylable_button_accessible_name_fallback', 'source_format' => 'html', 'tag' => 'a', 'html' => $this->safeFallbackHtml($anchor)), $this->fallbackProvenance);
-                    return $this->htmlPreservationBlock($anchor);
-                });
-                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
-            }),
-            new CallbackPatternRecognizer('button', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $block = $this->buttonsPattern->matchButton($element, $context->presentationAttributesCallback(), fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)), fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement), fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content), fn (DOMElement $sourceElement): bool => $sourceElement->parentNode instanceof DOMElement && in_array($this->authoredDisplay($sourceElement->parentNode), array('grid', 'inline-grid'), true), $context->createBlockCallback());
-                return new PatternRecognitionResult($block);
-            }),
+            new ButtonsContainerPattern($buttonsPattern),
+            new ButtonAnchorPattern($buttonsPattern),
+            new ButtonPattern($buttonsPattern),
             new AccordionPattern(),
             new SocialLinksPattern(),
             new NavigationPattern(),
@@ -4641,7 +4630,19 @@ final class HtmlTransformer
             fn (DOMElement $sourceElement): string => $this->mediaTextPresentationStyle($sourceElement),
             fn (DOMElement $sourceElement): string => $this->cssDeclarationString($this->structuralPresentationDeclarations($sourceElement)),
             fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
-            fn (string $text): string => $this->runtime->escapeHtml($text)
+            fn (string $text): string => $this->runtime->escapeHtml($text),
+            new ButtonPatternContext(
+                fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
+                fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)),
+                fn (DOMElement $sourceElement): string => $this->richTextContentWithMaterializedInlineStyles($sourceElement),
+                fn (DOMElement $sourceElement, string $content): ?string => $this->richTextContentWithMaterializedSvgImages($sourceElement, $content),
+                fn (DOMElement $sourceElement, string $name): string => $this->attr($sourceElement, $name),
+                fn (DOMElement $sourceElement): bool => $sourceElement->parentNode instanceof DOMElement && in_array($this->authoredDisplay($sourceElement->parentNode), array('grid', 'inline-grid'), true),
+                fn (DOMElement $anchor): PatternRecognitionResult => new PatternRecognitionResult(
+                    $this->htmlPreservationBlock($anchor),
+                    array(FallbackDiagnostic::build(array('type' => 'html', 'reason' => 'stylable_button_accessible_name_requires_typed_companion', 'diagnostic_code' => 'html_stylable_button_accessible_name_fallback', 'source_format' => 'html', 'tag' => 'a', 'html' => $this->safeFallbackHtml($anchor)), $this->fallbackProvenance))
+                )
+            )
         );
     }
 
@@ -5523,7 +5524,7 @@ final class HtmlTransformer
                 return $standaloneSearch;
             }
 
-            $buttons = $this->recognizePatterns($element, $fallbacks, array('buttons-container'));
+            $buttons = $this->recognizePatterns($element, $fallbacks, array(ButtonsContainerPattern::class));
             if ( null !== $buttons ) {
                 return $buttons;
             }

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonAnchorPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonAnchorPattern.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+final class ButtonAnchorPattern implements PatternRecognizerInterface
+{
+    public function __construct(private readonly ButtonsPattern $buttons) {}
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $buttonContext = $context->buttonContext();
+        return null === $buttonContext ? null : $this->buttons->matchAnchor($element, $context, $buttonContext);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonPattern.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+final class ButtonPattern implements PatternRecognizerInterface
+{
+    public function __construct(private readonly ButtonsPattern $buttons) {}
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $buttonContext = $context->buttonContext();
+        return null === $buttonContext ? null : new PatternRecognitionResult($this->buttons->matchButton($element, $context, $buttonContext));
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonPatternContext.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Closure;
+use DOMElement;
+
+final class ButtonPatternContext
+{
+    /**
+     * @param Closure(DOMElement): ?array<string, mixed> $fileBlockFromAnchor
+     * @param Closure(DOMElement): string $resolvedStyle
+     * @param Closure(DOMElement): string $richText
+     * @param Closure(DOMElement, string): ?string $materializeSvgImages
+     * @param Closure(DOMElement, string): string $attribute
+     * @param Closure(DOMElement): bool $isGridItem
+     * @param Closure(DOMElement): PatternRecognitionResult $accessibleNameFallback
+     */
+    public function __construct(
+        private readonly Closure $fileBlockFromAnchor,
+        private readonly Closure $resolvedStyle,
+        private readonly Closure $richText,
+        private readonly Closure $materializeSvgImages,
+        private readonly Closure $attribute,
+        private readonly Closure $isGridItem,
+        private readonly Closure $accessibleNameFallback
+    ) {
+    }
+
+    public function fileBlockFromAnchor(DOMElement $anchor): ?array { return ($this->fileBlockFromAnchor)($anchor); }
+    public function resolvedStyle(DOMElement $element): string { return ($this->resolvedStyle)($element); }
+    public function richText(DOMElement $element): string { return ($this->richText)($element); }
+    public function materializeSvgImages(DOMElement $element, string $content): ?string { return ($this->materializeSvgImages)($element, $content); }
+    public function attribute(DOMElement $element, string $name): string { return ($this->attribute)($element, $name); }
+    public function isGridItem(DOMElement $element): bool { return ($this->isGridItem)($element); }
+    public function accessibleNameFallback(DOMElement $anchor): PatternRecognitionResult { return ($this->accessibleNameFallback)($anchor); }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsContainerPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsContainerPattern.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+final class ButtonsContainerPattern implements PatternRecognizerInterface
+{
+    public function __construct(private readonly ButtonsPattern $buttons) {}
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $buttonContext = $context->buttonContext();
+        if ( null === $buttonContext ) return null;
+        $block = $this->buttons->matchContainer($element, $context, $buttonContext);
+        return null === $block ? null : new PatternRecognitionResult($block);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -18,22 +18,11 @@ final class ButtonsPattern
         $this->signalClassifier = new ButtonSignalClassifier();
     }
 
-    /**
-     * @param callable(DOMElement): array<string, mixed>|null $fileBlockFromAnchor
-     * @param callable(DOMElement, array<int, string>): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $resolvedStyle
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(DOMElement, string): ?string $materializeSvgImages
-     * @param callable(DOMElement, string): string $attr
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
-     * @param callable(DOMElement): array<string, mixed> $accessibleNameFallback
-     * @return array<string, mixed>|null
-     */
-    public function matchAnchor(DOMElement $anchor, callable $fileBlockFromAnchor, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $materializeSvgImages, callable $attr, callable $createBlock, callable $accessibleNameFallback): ?array
+    public function matchAnchor(DOMElement $anchor, PatternContext $context, ButtonPatternContext $buttons): ?PatternRecognitionResult
     {
-        $fileBlock = $fileBlockFromAnchor($anchor);
+        $fileBlock = $buttons->fileBlockFromAnchor($anchor);
         if ( null !== $fileBlock ) {
-            return $fileBlock;
+            return new PatternRecognitionResult($fileBlock);
         }
 
         // A native button cannot faithfully retain nested controls or runtime
@@ -42,45 +31,38 @@ final class ButtonsPattern
             return null;
         }
 
-        if ( $this->isPositionedFragmentNavigation($anchor, (string) $resolvedStyle($anchor)) ) {
+        if ( $this->isPositionedFragmentNavigation($anchor, $buttons->resolvedStyle($anchor)) ) {
             return null;
         }
 
-        $surface = $this->buttonSurfaceElement($anchor);
-        if ( ! $this->hasButtonSignal($anchor, (string) $resolvedStyle($anchor), null !== $surface ? (string) $resolvedStyle($surface) : '', $resolvedStyle) ) {
+        if ( ! $this->hasButtonSignal($anchor, $buttons) ) {
             return null;
         }
 
-        $text = $this->buttonText($anchor, $innerHtml($anchor), $materializeSvgImages);
+        $text = $this->buttonText($anchor, $context->innerHtmlCallback()($anchor), $buttons);
         if ( $this->hasMateriallyDifferentAccessibleLabel($anchor, $text) ) {
-            return $accessibleNameFallback($anchor);
+            return $buttons->accessibleNameFallback($anchor);
         }
 
-        return $createBlock('core/buttons', $this->buttonWrapperAttributes($anchor, $presentationAttributes, $resolvedStyle), array( $this->buttonBlockFromAnchor($anchor, $presentationAttributes, $resolvedStyle, $innerHtml, $materializeSvgImages, $attr, $createBlock) ), $anchor);
+        $block = $context->createBlockCallback()('core/buttons', $this->buttonWrapperAttributes($anchor, $context, $buttons), array( $this->buttonBlockFromAnchor($anchor, $context, $buttons) ), $anchor);
+        return new PatternRecognitionResult($block);
     }
 
-    /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $resolvedStyle
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(DOMElement, string): ?string $materializeSvgImages
-     * @param callable(DOMElement): bool $isGridItem
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>
-     */
-    public function matchButton(DOMElement $button, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $materializeSvgImages, callable $isGridItem, callable $createBlock): array
+    /** @return array<string, mixed> */
+    public function matchButton(DOMElement $button, PatternContext $context, ButtonPatternContext $buttons): array
     {
-        $resolvedButtonStyle = trim((string) $resolvedStyle($button));
-        $attrs = $this->buttonPresentationAttributes($button, $presentationAttributes, $resolvedStyle);
-        if ( $isGridItem($button) ) {
+        $createBlock = $context->createBlockCallback();
+        $resolvedButtonStyle = trim($buttons->resolvedStyle($button));
+        $attrs = $this->buttonPresentationAttributes($button, $context, $buttons);
+        if ( $buttons->isGridItem($button) ) {
             $attrs['width'] = 100;
         }
         if ( 100 === (int) ($attrs['width'] ?? 0) && $resolvedButtonStyle !== trim($button->getAttribute('style')) ) {
             $this->removeSourceControlClasses($attrs, $button);
         }
-        $text = $this->buttonText($button, $innerHtml($button), $materializeSvgImages);
+        $text = $this->buttonText($button, $buttons->richText($button), $buttons);
 
-        return $createBlock('core/buttons', $this->buttonWrapperAttributes($button, $presentationAttributes, $resolvedStyle), array(
+        return $createBlock('core/buttons', $this->buttonWrapperAttributes($button, $context, $buttons), array(
             $createBlock('core/button', array_filter(array_merge(
                 $attrs,
                 $this->buttonRuntimeAttributes($button),
@@ -93,54 +75,37 @@ final class ButtonsPattern
         ), $button);
     }
 
-    /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $resolvedStyle
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(DOMElement, string): ?string $materializeSvgImages
-     * @param callable(DOMElement, string): string $attr
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function matchContainer(DOMElement $element, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $materializeSvgImages, callable $attr, callable $createBlock): ?array
+    /** @return array<string, mixed>|null */
+    public function matchContainer(DOMElement $element, PatternContext $context, ButtonPatternContext $buttons): ?array
     {
         $wrappedAnchor = $this->singleSimpleAnchorChild($element);
-        if ( null !== $wrappedAnchor && $this->hasWrapperButtonSignal($element, (string) $resolvedStyle($element)) ) {
-            return $createBlock('core/buttons', $this->buttonWrapperAttributes($element, $presentationAttributes, $resolvedStyle), array( $this->buttonBlockFromAnchor($wrappedAnchor, $presentationAttributes, $resolvedStyle, $innerHtml, $materializeSvgImages, $attr, $createBlock, $element) ), $element);
+        if ( null !== $wrappedAnchor && $this->hasWrapperButtonSignal($element, $buttons->resolvedStyle($element)) ) {
+            return $context->createBlockCallback()('core/buttons', $this->buttonWrapperAttributes($element, $context, $buttons), array( $this->buttonBlockFromAnchor($wrappedAnchor, $context, $buttons, $element) ), $element);
         }
 
-        $buttons = array();
+        $buttonBlocks = array();
         foreach ( $element->childNodes as $child ) {
-            $surface = $child instanceof DOMElement ? $this->buttonSurfaceElement($child) : null;
-            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') && ! $this->isPositionedFragmentNavigation($child, (string) $resolvedStyle($child)) && $this->hasButtonSignal($child, (string) $resolvedStyle($child), null !== $surface ? (string) $resolvedStyle($surface) : '', $resolvedStyle) ) {
-                $buttons[] = $this->buttonBlockFromAnchor($child, $presentationAttributes, $resolvedStyle, $innerHtml, $materializeSvgImages, $attr, $createBlock);
+            if ( $child instanceof DOMElement && 'a' === strtolower($child->tagName) && '' !== trim($child->textContent ?? '') && ! $this->isPositionedFragmentNavigation($child, $buttons->resolvedStyle($child)) && $this->hasButtonSignal($child, $buttons) ) {
+                $buttonBlocks[] = $this->buttonBlockFromAnchor($child, $context, $buttons);
             }
         }
 
-        if ( count($buttons) <= 1 ) {
+        if ( count($buttonBlocks) <= 1 ) {
             return null;
         }
 
-        return $createBlock('core/buttons', $presentationAttributes($element), $buttons, $element);
+        return $context->createBlockCallback()('core/buttons', $context->presentationAttributesCallback()($element), $buttonBlocks, $element);
     }
 
-    /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $resolvedStyle
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(DOMElement, string): ?string $materializeSvgImages
-     * @param callable(DOMElement, string): string $attr
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>
-     */
-    private function buttonBlockFromAnchor(DOMElement $anchor, callable $presentationAttributes, callable $resolvedStyle, callable $innerHtml, callable $materializeSvgImages, callable $attr, callable $createBlock, ?DOMElement $presentationElement = null): array
+    /** @return array<string, mixed> */
+    private function buttonBlockFromAnchor(DOMElement $anchor, PatternContext $context, ButtonPatternContext $buttons, ?DOMElement $presentationElement = null): array
     {
         $presentationElement ??= $this->buttonSurfaceElement($anchor) ?? $anchor;
-        $resolvedPresentation = trim((string) $resolvedStyle($presentationElement));
+        $resolvedPresentation = trim($buttons->resolvedStyle($presentationElement));
         $hasAuthoredStyleRules = $resolvedPresentation !== trim($presentationElement->getAttribute('style'));
-        $attrs = $this->buttonPresentationAttributes($presentationElement, $presentationAttributes, $resolvedStyle);
+        $attrs = $this->buttonPresentationAttributes($presentationElement, $context, $buttons);
         if ( $presentationElement !== $anchor ) {
-            $anchorStyle = (string) $resolvedStyle($anchor);
+            $anchorStyle = $buttons->resolvedStyle($anchor);
             if ( preg_match('/(?:^|;)\s*border\s*:\s*(?!0(?:;|$)|none(?:;|$))[^;]+/i', $anchorStyle)
                 && ! preg_match('/(?:^|;)\s*border-radius\s*:/i', $anchorStyle)
             ) {
@@ -152,36 +117,34 @@ final class ButtonsPattern
         if ( $hasAuthoredStyleRules && ($presentationElement === $anchor || $presentationElement->parentNode === $anchor) ) {
             $this->removeSourceControlClasses($attrs, $presentationElement);
         }
-        $text = $this->buttonText($anchor, $innerHtml($anchor), $materializeSvgImages);
+        $text = $this->buttonText($anchor, $context->innerHtmlCallback()($anchor), $buttons);
 
-        return $createBlock('core/button', array_filter(array_merge($attrs, array(
+        return $context->createBlockCallback()('core/button', array_filter(array_merge($attrs, array(
             'text'       => $text,
-            'url'        => $attr($anchor, 'href'),
+            'url'        => $buttons->attribute($anchor, 'href'),
             'title'      => $this->buttonTitleForAnchor($anchor, $text),
-            'linkTarget' => $attr($anchor, 'target'),
-            'rel'        => $attr($anchor, 'rel'),
+            'linkTarget' => $buttons->attribute($anchor, 'target'),
+            'rel'        => $buttons->attribute($anchor, 'rel'),
         )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value), array(), $presentationElement, $anchor);
     }
 
     /**
      * External spacing belongs to the core/buttons flex item, not its child link.
      *
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $resolvedStyle
      * @return array<string, mixed>
      */
-    private function buttonWrapperAttributes(DOMElement $element, callable $presentationAttributes, callable $resolvedStyle): array
+    private function buttonWrapperAttributes(DOMElement $element, PatternContext $context, ButtonPatternContext $buttons): array
     {
-        $presentation = $presentationAttributes($element);
+        $presentation = $context->presentationAttributesCallback()($element);
         $attrs = array();
         $margin = $presentation['style']['spacing']['margin'] ?? null;
         if ( is_array($margin) && array() !== $margin ) {
             $attrs['style']['spacing']['margin'] = $margin;
         }
 
-        $alignment = $this->textAlignment((string) $resolvedStyle($element));
+        $alignment = $this->textAlignment($buttons->resolvedStyle($element));
         if ( '' === $alignment && $element->parentNode instanceof DOMElement ) {
-            $alignment = $this->textAlignment((string) $resolvedStyle($element->parentNode));
+            $alignment = $this->textAlignment($buttons->resolvedStyle($element->parentNode));
         }
         if ( in_array($alignment, array( 'left', 'center', 'right' ), true) ) {
             $attrs['layout'] = array(
@@ -223,12 +186,11 @@ final class ButtonsPattern
             : null;
     }
 
-    /** @param callable(DOMElement, string): ?string $materializeSvgImages */
-    private function buttonText(DOMElement $element, string $html, callable $materializeSvgImages): string
+    private function buttonText(DOMElement $element, string $html, ButtonPatternContext $buttons): string
     {
         $html = preg_replace('/<img\b[^>]*\balt\s*=\s*(["\'])(.*?)\1[^>]*>/is', '$2', $html) ?? $html;
         $html = preg_replace('/<img\b[^>]*>/is', '', $html) ?? $html;
-        $html = $materializeSvgImages($element, $html) ?? (preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html);
+        $html = $buttons->materializeSvgImages($element, $html) ?? (preg_replace('/<svg\b[^>]*>.*?<\/svg>/is', '', $html) ?? $html);
         $html = preg_replace('/<([a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*(["\'])?true\2[^>]*>\s*<\/\1>/i', '', $html) ?? $html;
         $html = preg_replace('/<\/?(?:' . self::BLOCK_LEVEL_LABEL_TAGS . ')\b[^>]*>/i', '', $html) ?? $html;
         $html = $this->unwrapPresentationalSpan(trim($html));
@@ -323,13 +285,11 @@ final class ButtonsPattern
     }
 
     /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $resolvedStyle
      * @return array<string, mixed>
      */
-    private function buttonPresentationAttributes(DOMElement $element, callable $presentationAttributes, callable $resolvedStyle): array
+    private function buttonPresentationAttributes(DOMElement $element, PatternContext $context, ButtonPatternContext $buttons): array
     {
-        $resolvedStyle = (string) $resolvedStyle($element);
+        $resolvedStyle = $buttons->resolvedStyle($element);
         $width = $this->buttonWidth($resolvedStyle);
         // Resolve native paint before classifying an outline: a generic reset such
         // as `button { background: none }` can precede a filled button variant.
@@ -360,7 +320,7 @@ final class ButtonsPattern
         if ( '' !== trim((string) ($native['style']['shadow'] ?? '')) ) {
             $excludedGeometry[] = 'box-shadow';
         }
-        $attrs = $presentationAttributes($element, $excludedGeometry);
+        $attrs = $context->presentationAttributesCallback()($element, $excludedGeometry);
         // Buttons resolve styling from the raw merged CSS string, not the canonical
         // block style object, so the (now object-shaped) presentation `style` is
         // dropped and re-derived via ButtonStyleResolver below.
@@ -494,16 +454,16 @@ final class ButtonsPattern
         return preg_match('/^(?:transparent|none|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))\s*$/i', trim((string) ($matches[1] ?? ''))) === 1;
     }
 
-    /** @param callable(DOMElement): string $resolvedStyle */
-    private function hasButtonSignal(DOMElement $anchor, string $resolvedStyle = '', string $surfaceStyle = '', ?callable $resolvedStyleForElement = null): bool
+    private function hasButtonSignal(DOMElement $anchor, ButtonPatternContext $buttons): bool
     {
+        $resolvedStyle = $buttons->resolvedStyle($anchor);
         $hasNestedLabelAndSvg = $this->hasNestedLabelAndSvg($anchor);
         if ( $this->signalClassifier->hasTransformSignal($anchor, $resolvedStyle) || ( $hasNestedLabelAndSvg && $this->signalClassifier->hasClassSignal($anchor) ) ) {
             return true;
         }
 
         $surface = $this->buttonSurfaceElement($anchor);
-        if ( null !== $surface && $this->signalClassifier->hasStyleSignal($surface, $surfaceStyle) ) {
+        if ( null !== $surface && $this->signalClassifier->hasStyleSignal($surface, $buttons->resolvedStyle($surface)) ) {
             return true;
         }
 
@@ -512,7 +472,7 @@ final class ButtonsPattern
         // above intentionally rejects that topology, so inspect safe phrasing
         // descendants without treating arbitrary nested content as a button.
         foreach ( $anchor->getElementsByTagName('span') as $label ) {
-            if ( $label instanceof DOMElement && ( ( $hasNestedLabelAndSvg && $this->signalClassifier->hasClassSignal($label) ) || ( null !== $resolvedStyleForElement && $this->signalClassifier->hasTransformSignal($label, (string) $resolvedStyleForElement($label)) ) ) ) {
+            if ( $label instanceof DOMElement && ( ( $hasNestedLabelAndSvg && $this->signalClassifier->hasClassSignal($label) ) || $this->signalClassifier->hasTransformSignal($label, $buttons->resolvedStyle($label)) ) ) {
                 return true;
             }
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -21,6 +21,7 @@ final class PatternContext
      * @param callable(DOMElement): string|null $structuralPresentationStyle
      * @param callable(DOMElement): string|null $safeFallbackHtml
      * @param callable(string): string|null $escapeHtml
+     * @param ButtonPatternContext|null $buttonContext
      */
     public function __construct(
         private readonly mixed $presentationAttributes,
@@ -35,7 +36,8 @@ final class PatternContext
         private readonly mixed $mediaTextPresentationStyle = null,
         private readonly mixed $structuralPresentationStyle = null,
         private readonly mixed $safeFallbackHtml = null,
-        private readonly mixed $escapeHtml = null
+        private readonly mixed $escapeHtml = null,
+        private readonly ?ButtonPatternContext $buttonContext = null
     ) {
     }
 
@@ -73,4 +75,5 @@ final class PatternContext
     public function structuralPresentationStyleCallback(): ?callable { return is_callable($this->structuralPresentationStyle) ? $this->structuralPresentationStyle : null; }
     public function safeFallbackHtmlCallback(): ?callable { return is_callable($this->safeFallbackHtml) ? $this->safeFallbackHtml : null; }
     public function escapeHtmlCallback(): ?callable { return is_callable($this->escapeHtml) ? $this->escapeHtml : null; }
+    public function buttonContext(): ?ButtonPatternContext { return $this->buttonContext; }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/ButtonLinkDispatchTrait.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support;
 
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonAnchorPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonPattern;
 use DOMElement;
 
 trait ButtonLinkDispatchTrait
@@ -22,7 +24,7 @@ trait ButtonLinkDispatchTrait
             return $linkedLogo;
         }
 
-        $button = $this->recognizePatterns($element, $fallbacks, array('button-anchor'));
+        $button = $this->recognizePatterns($element, $fallbacks, array(ButtonAnchorPattern::class));
         if ( null !== $button ) {
             return $button;
         }
@@ -111,6 +113,6 @@ trait ButtonLinkDispatchTrait
         }
 
         $fallbacks = array();
-        return $this->recognizePatterns($element, $fallbacks, array('button'));
+        return $this->recognizePatterns($element, $fallbacks, array(ButtonPattern::class));
     }
 }

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -51,6 +51,14 @@ $button = (new HtmlTransformer())->transform('<a href="/go" aria-label="Open" st
 $assert('core/html' === ($button['blocks'][0]['blockName'] ?? null), 'Button recognition remains ahead of generic anchor lowering when its accessible-name fallback wins.');
 $assert('html_stylable_button_accessible_name_fallback' === ($button['fallbacks'][0]['diagnostic_code'] ?? null), 'Button fallback is committed by the staged registry dispatcher.');
 
+$buttonContainer = (new HtmlTransformer())->transform('<div><a class="button" style="display:inline-block;background:#000;color:#fff;padding:1rem" href="/one">One</a><a class="button" style="display:inline-block;background:#000;color:#fff;padding:1rem" href="/two">Two</a></div>')->toArray();
+$assert('core/buttons' === ($buttonContainer['blocks'][0]['blockName'] ?? null), 'A multi-button container wins before generic inline-wrapper lowering.');
+$assert(2 === count($buttonContainer['blocks'][0]['innerBlocks'] ?? array()), 'The direct container recognizer preserves both button children.');
+
+$declinedButtonAnchor = (new HtmlTransformer())->transform('<a href="/ordinary">Ordinary link</a>')->toArray();
+$assert('core/paragraph' === ($declinedButtonAnchor['blocks'][0]['blockName'] ?? null), 'An anchor without a button signal declines to ordinary link lowering.');
+$assert(array() === ($declinedButtonAnchor['fallbacks'] ?? array()), 'A declined button anchor commits no accessible-name fallback diagnostics.');
+
 $mathOverPlaceholder = (new HtmlTransformer())->transform('<div class="placeholder media math" style="aspect-ratio: 16 / 9">$x$</div>')->toArray();
 $assert('core/math' === ($mathOverPlaceholder['blocks'][0]['blockName'] ?? null), 'Math remains ahead of the overlapping placeholder-media recognizer.');
 $assert('$x$' === ($mathOverPlaceholder['blocks'][0]['attrs']['content'] ?? null), 'The higher-precedence math recognizer preserves its exact content.');


### PR DESCRIPTION
## Summary

- replace the buttons-container, button-anchor, and button callback registrations with direct ordered recognizers
- introduce one typed button lowering context instead of threading transformer callbacks through each registry entry
- preserve accessible-name fallback ownership until the anchor recognizer wins
- cover container precedence and side-effect-free anchor decline behavior

Part of #1211.

## Verification

- `composer --working-dir=php-transformer test`
- 289 PHP Transformer parity fixtures passed
- staged registry dispatch passed with 32 assertions
- packaging install proof passed

## Compatibility

The registry order, emitted block shapes, fallback diagnostics, and public transformer result contracts are unchanged. Five unrelated callback recognizers remain for later #1211 slices.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the recognizer architecture, implemented the direct button recognizer slice, added behavior-level coverage, and ran the complete PHP Transformer verification suite. Chris Huber directed the work and is responsible for the engineering decisions and review.