### PR TITLE
Extract quote pattern recognizers from HtmlTransformer

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -26,6 +26,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPatte
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\FigureQuotePattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\GalleryPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
@@ -41,6 +42,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecogniz
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecursiveConverter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\QuotePatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SocialLinksPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionTrait;
@@ -222,8 +224,6 @@ final class HtmlTransformer
     private readonly LogoPattern $logoPattern;
 
     private readonly TableClassificationPolicy $tableClassificationPolicy;
-
-    private readonly QuotePattern $quotePattern;
 
     private readonly PatternRecognizerRegistry $patternRecognizers;
 
@@ -588,7 +588,7 @@ final class HtmlTransformer
         $this->galleryPattern    = new GalleryPattern();
         $this->logoPattern       = new LogoPattern();
         $this->tableClassificationPolicy = new TableClassificationPolicy();
-        $this->quotePattern      = new QuotePattern();
+        $quotePattern            = new QuotePattern();
         $this->patternRecognizers = new PatternRecognizerRegistry(array(
             $this->mediaTextPattern,
             $this->coverPattern,
@@ -605,18 +605,8 @@ final class HtmlTransformer
                 return null === $block ? null : new PatternRecognitionResult($block);
             }),
             new PlaceholderMediaPattern(),
-            new CallbackPatternRecognizer('quote', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $fallbacks = array();
-                $block = $this->quotePattern->matchBlockquote($element, $fallbacks, fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement), fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags), fn (string $html): string => $this->runtime->stripAllTags($html), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), fn (string $inlineTagName): bool => $this->isInlineContentElement($inlineTagName), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
-            }),
-            new CallbackPatternRecognizer('figure-quote', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
-                $blockquote = $this->firstChildElement($element, 'blockquote');
-                if (! $blockquote instanceof DOMElement) return null;
-                $fallbacks = array();
-                $block = $this->quotePattern->matchFigureBlockquote($element, $blockquote, $fallbacks, fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement), $context->innerHtmlCallback(), fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags), fn (string $html): string => $this->runtime->stripAllTags($html), $context->presentationAttributesCallback(), fn (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags): array => $this->convertChildrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags), $context->createBlockCallback());
-                return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);
-            }),
+            $quotePattern,
+            new FigureQuotePattern($quotePattern),
             new DetailsPattern(),
             new CallbackPatternRecognizer('gallery', function (DOMElement $element, PatternContext $context): ?PatternRecognitionResult {
                 $block = $this->galleryPattern->match($element, fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $this->convertImageElement($image, $figure, $picture, $link), fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $this->convertPictureElement($picture, $figure, $link), fn (DOMElement $figure): ?DOMElement => $this->figureLinkedMediaAnchor($figure), $context->presentationAttributesCallback(), $context->innerHtmlCallback(), $context->createBlockCallback());
@@ -4642,6 +4632,12 @@ final class HtmlTransformer
                     $this->htmlPreservationBlock($anchor),
                     array(FallbackDiagnostic::build(array('type' => 'html', 'reason' => 'stylable_button_accessible_name_requires_typed_companion', 'diagnostic_code' => 'html_stylable_button_accessible_name_fallback', 'source_format' => 'html', 'tag' => 'a', 'html' => $this->safeFallbackHtml($anchor)), $this->fallbackProvenance))
                 )
+            ),
+            new QuotePatternContext(
+                fn (DOMElement $sourceElement): string => $this->citationFromElement($sourceElement),
+                fn (DOMElement $sourceElement, array $excludedTags): string => $this->innerHtmlWithoutTags($sourceElement, $excludedTags),
+                fn (string $html): string => $this->runtime->stripAllTags($html),
+                fn (string $inlineTagName): bool => $this->isInlineContentElement($inlineTagName)
             )
         );
     }
@@ -5075,7 +5071,7 @@ final class HtmlTransformer
         }
 
         if ( 'blockquote' === $tagName ) {
-            return $this->recognizePatterns($element, $fallbacks, array('quote'));
+            return $this->recognizePatterns($element, $fallbacks, array(QuotePattern::class));
         }
 
         if ( 'figure' === $tagName ) {
@@ -5114,7 +5110,7 @@ final class HtmlTransformer
 
             $blockquote = $this->firstChildElement($element, 'blockquote');
             if ( $blockquote instanceof DOMElement ) {
-                return $this->recognizePatterns($element, $fallbacks, array('figure-quote'));
+                return $this->recognizePatterns($element, $fallbacks, array(FigureQuotePattern::class));
             }
 
             return $this->convertFigureGeneric($element, $fallbacks);

--- a/php-transformer/src/HtmlToBlocks/Patterns/FigureQuotePattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/FigureQuotePattern.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use DOMElement;
+
+final class FigureQuotePattern implements PatternRecognizerInterface
+{
+    use PatternDomHelpersTrait;
+
+    public function __construct(private readonly QuotePattern $quotes) {}
+
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $blockquote = $this->firstChildElement($element, 'blockquote');
+        return $blockquote instanceof DOMElement ? $this->quotes->matchFigureBlockquote($element, $blockquote, $context) : null;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -22,6 +22,7 @@ final class PatternContext
      * @param callable(DOMElement): string|null $safeFallbackHtml
      * @param callable(string): string|null $escapeHtml
      * @param ButtonPatternContext|null $buttonContext
+     * @param QuotePatternContext|null $quoteContext
      */
     public function __construct(
         private readonly mixed $presentationAttributes,
@@ -37,7 +38,8 @@ final class PatternContext
         private readonly mixed $structuralPresentationStyle = null,
         private readonly mixed $safeFallbackHtml = null,
         private readonly mixed $escapeHtml = null,
-        private readonly ?ButtonPatternContext $buttonContext = null
+        private readonly ?ButtonPatternContext $buttonContext = null,
+        private readonly ?QuotePatternContext $quoteContext = null
     ) {
     }
 
@@ -76,4 +78,5 @@ final class PatternContext
     public function safeFallbackHtmlCallback(): ?callable { return is_callable($this->safeFallbackHtml) ? $this->safeFallbackHtml : null; }
     public function escapeHtmlCallback(): ?callable { return is_callable($this->escapeHtml) ? $this->escapeHtml : null; }
     public function buttonContext(): ?ButtonPatternContext { return $this->buttonContext; }
+    public function quoteContext(): ?QuotePatternContext { return $this->quoteContext; }
 }

--- a/php-transformer/src/HtmlToBlocks/Patterns/QuotePattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/QuotePattern.php
@@ -7,129 +7,106 @@ use DOMElement;
 
 use const XML_TEXT_NODE;
 
-final class QuotePattern
+final class QuotePattern implements PatternRecognizerInterface
 {
     use PatternDomHelpersTrait;
 
-    /**
-     * Inline blockquote entry point (convertElement blockquote-tag branch).
-     *
-     * @param array<int, array<string, mixed>> $fallbacks
-     * @param callable(DOMElement): string $citationFromElement
-     * @param callable(DOMElement, array<int, string>): string $innerHtmlWithoutTags
-     * @param callable(string): string $stripAllTags
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement, array<int, array<string, mixed>>&, array<int, string>): array<int, array<string, mixed>> $convertChildrenWithoutTags
-     * @param callable(string): bool $isInlineContentElement
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function matchBlockquote(
-        DOMElement $element,
-        array &$fallbacks,
-        callable $citationFromElement,
-        callable $innerHtmlWithoutTags,
-        callable $stripAllTags,
-        callable $presentationAttributes,
-        callable $convertChildrenWithoutTags,
-        callable $isInlineContentElement,
-        callable $createBlock
-    ): ?array {
-        $citation = $citationFromElement($element);
-        $value = $innerHtmlWithoutTags($element, array( 'cite', 'footer' ));
-        if ( '' === trim($stripAllTags($value)) ) {
+    public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        return $this->matchBlockquote($element, $context);
+    }
+
+    public function matchBlockquote(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
+    {
+        $quotes = $context->quoteContext();
+        $converter = $context->recursiveConverter();
+        if ( null === $quotes || null === $converter ) {
             return null;
         }
 
-        if ( $this->hasClass($element, 'wp-block-pullquote') ) {
-            return $createBlock('core/pullquote', array_filter(array_merge($presentationAttributes($element), array(
-                'value'    => $value,
-                'citation' => $citation,
-            )), static fn ($value): bool => '' !== $value), array(), $element);
+        $citation = $quotes->citationFromElement($element);
+        $value = $quotes->innerHtmlWithoutTags($element, array( 'cite', 'footer' ));
+        if ( '' === trim($quotes->stripAllTags($value)) ) {
+            return null;
         }
 
-        $innerBlocks = $this->phrasingQuoteChildren($element, $value, $isInlineContentElement, $createBlock);
+        $createBlock = $context->createBlockCallback();
+        if ( $this->hasClass($element, 'wp-block-pullquote') ) {
+            return new PatternRecognitionResult($createBlock('core/pullquote', array_filter(array_merge($context->presentationAttributesCallback()($element), array(
+                'value'    => $value,
+                'citation' => $citation,
+            )), static fn ($value): bool => '' !== $value), array(), $element));
+        }
+
+        $fallbacks = array();
+        $innerBlocks = $this->phrasingQuoteChildren($element, $value, $context, $quotes);
         if ( array() === $innerBlocks ) {
-            $innerBlocks = $convertChildrenWithoutTags($element, $fallbacks, array( 'cite', 'footer' ));
+            $innerBlocks = $converter->childrenWithoutTags($element, $fallbacks, array( 'cite', 'footer' ));
         }
         if ( array() === $innerBlocks ) {
             $innerBlocks[] = $createBlock('core/paragraph', array( 'content' => $value ));
         }
 
-        return $createBlock('core/quote', array_filter(array_merge($presentationAttributes($element), array( 'citation' => $citation )), static fn ($value): bool => '' !== $value), $innerBlocks, $element);
+        return new PatternRecognitionResult(
+            $createBlock('core/quote', array_filter(array_merge($context->presentationAttributesCallback()($element), array( 'citation' => $citation )), static fn ($value): bool => '' !== $value), $innerBlocks, $element),
+            $fallbacks
+        );
     }
 
-    /**
-     * figure>blockquote entry point (convertElement figure-tag branch).
-     *
-     * @param array<int, array<string, mixed>> $fallbacks
-     * @param callable(DOMElement): string $citationFromElement
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(DOMElement, array<int, string>): string $innerHtmlWithoutTags
-     * @param callable(string): string $stripAllTags
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement, array<int, array<string, mixed>>&, array<int, string>): array<int, array<string, mixed>> $convertChildrenWithoutTags
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
-     * @return array<string, mixed>|null
-     */
-    public function matchFigureBlockquote(
-        DOMElement $figure,
-        DOMElement $blockquote,
-        array &$fallbacks,
-        callable $citationFromElement,
-        callable $innerHtml,
-        callable $innerHtmlWithoutTags,
-        callable $stripAllTags,
-        callable $presentationAttributes,
-        callable $convertChildrenWithoutTags,
-        callable $createBlock
-    ): ?array {
-        $citation = $citationFromElement($blockquote);
+    public function matchFigureBlockquote(DOMElement $figure, DOMElement $blockquote, PatternContext $context): ?PatternRecognitionResult
+    {
+        $quotes = $context->quoteContext();
+        $converter = $context->recursiveConverter();
+        if ( null === $quotes || null === $converter ) {
+            return null;
+        }
+
+        $citation = $quotes->citationFromElement($blockquote);
         $caption = $this->firstChildElement($figure, 'figcaption');
         if ( '' === $citation && $caption instanceof DOMElement ) {
-            $citation = $innerHtml($caption);
+            $citation = $context->innerHtmlCallback()($caption);
             $captionClass = trim($this->attr($caption, 'class'));
             if ( '' !== $captionClass ) {
                 $citation = '<span class="' . htmlspecialchars($captionClass, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '">' . $citation . '</span>';
             }
         }
 
-        $value = $innerHtmlWithoutTags($blockquote, array( 'cite', 'footer' ));
-        if ( '' === trim($stripAllTags($value)) ) {
+        $value = $quotes->innerHtmlWithoutTags($blockquote, array( 'cite', 'footer' ));
+        if ( '' === trim($quotes->stripAllTags($value)) ) {
             return null;
         }
 
-        $attrs = array_filter(array_merge($presentationAttributes($figure), array( 'citation' => $citation )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value);
+        $createBlock = $context->createBlockCallback();
+        $attrs = array_filter(array_merge($context->presentationAttributesCallback()($figure), array( 'citation' => $citation )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value);
 
         if ( $this->hasClass($figure, 'wp-block-pullquote') || $this->hasClass($blockquote, 'wp-block-pullquote') ) {
-            return $createBlock('core/pullquote', array_merge($attrs, array( 'value' => $value )), array(), $figure);
+            return new PatternRecognitionResult($createBlock('core/pullquote', array_merge($attrs, array( 'value' => $value )), array(), $figure));
         }
 
+        $fallbacks = array();
         $innerBlocks = array();
         foreach ( $figure->childNodes as $child ) {
             if ( ! $child instanceof DOMElement || $child->isSameNode($blockquote) || $child->isSameNode($caption) ) {
                 continue;
             }
-            $content = $innerHtml($child);
-            if ( 'true' !== strtolower(trim($this->attr($child, 'aria-hidden'))) || '' === trim($stripAllTags($content)) ) {
+            $content = $context->innerHtmlCallback()($child);
+            if ( 'true' !== strtolower(trim($this->attr($child, 'aria-hidden'))) || '' === trim($quotes->stripAllTags($content)) ) {
                 continue;
             }
-            $innerBlocks[] = $createBlock('core/paragraph', array_merge($presentationAttributes($child), array( 'content' => $content )), array(), $child);
+            $innerBlocks[] = $createBlock('core/paragraph', array_merge($context->presentationAttributesCallback()($child), array( 'content' => $content )), array(), $child);
         }
-        $innerBlocks = array_merge($innerBlocks, $convertChildrenWithoutTags($blockquote, $fallbacks, array( 'cite', 'footer' )));
+        $innerBlocks = array_merge($innerBlocks, $converter->childrenWithoutTags($blockquote, $fallbacks, array( 'cite', 'footer' )));
         if ( array() === $innerBlocks ) {
             $innerBlocks[] = $createBlock('core/paragraph', array( 'content' => $value ));
         }
 
-        return $createBlock('core/quote', $attrs, $innerBlocks, $figure);
+        return new PatternRecognitionResult($createBlock('core/quote', $attrs, $innerBlocks, $figure), $fallbacks);
     }
 
     /**
-     * @param callable(string): bool $isInlineContentElement
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null): array<string, mixed> $createBlock
      * @return array<int, array<string, mixed>>
      */
-    private function phrasingQuoteChildren(DOMElement $element, string $value, callable $isInlineContentElement, callable $createBlock): array
+    private function phrasingQuoteChildren(DOMElement $element, string $value, PatternContext $context, QuotePatternContext $quotes): array
     {
         // A blockquote may be wrapped in phrasing elements while still carrying
         // structural descendants. Send that shape through child lowering so the
@@ -152,14 +129,14 @@ final class QuotePattern
                 continue;
             }
             $isDirectText = false;
-            if ( 'br' === $tagName || $isInlineContentElement($tagName) ) {
+            if ( 'br' === $tagName || $quotes->isInlineContentElement($tagName) ) {
                 continue;
             }
 
             return array();
         }
 
-        return array( $createBlock('core/paragraph', array_filter(array(
+        return array( $context->createBlockCallback()('core/paragraph', array_filter(array(
             'content'   => $value,
             'className' => $isDirectText ? 'blocks-engine-synthetic-paragraph' : '',
         ), static fn (string $value): bool => '' !== $value)) );

--- a/php-transformer/src/HtmlToBlocks/Patterns/QuotePatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/QuotePatternContext.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Closure;
+use DOMElement;
+
+final class QuotePatternContext
+{
+    /**
+     * @param Closure(DOMElement): string $citationFromElement
+     * @param Closure(DOMElement, array<int, string>): string $innerHtmlWithoutTags
+     * @param Closure(string): string $stripAllTags
+     * @param Closure(string): bool $isInlineContentElement
+     */
+    public function __construct(
+        private readonly Closure $citationFromElement,
+        private readonly Closure $innerHtmlWithoutTags,
+        private readonly Closure $stripAllTags,
+        private readonly Closure $isInlineContentElement
+    ) {
+    }
+
+    public function citationFromElement(DOMElement $element): string { return ($this->citationFromElement)($element); }
+    /** @param array<int, string> $excludedTags */
+    public function innerHtmlWithoutTags(DOMElement $element, array $excludedTags): string { return ($this->innerHtmlWithoutTags)($element, $excludedTags); }
+    public function stripAllTags(string $html): string { return ($this->stripAllTags)($html); }
+    public function isInlineContentElement(string $tagName): bool { return ($this->isInlineContentElement)($tagName); }
+}

--- a/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
+++ b/php-transformer/tests/unit/pattern-registry-staged-dispatch.php
@@ -70,6 +70,15 @@ $assert('Visible content' === ($declinedSpacer['blocks'][0]['attrs']['content'] 
 $quoteWithNavigation = (new HtmlTransformer())->transform('<blockquote><nav><a href="/one">One</a><a href="/two">Two</a></nav></blockquote>')->toArray();
 $assert('core/quote' === ($quoteWithNavigation['blocks'][0]['blockName'] ?? null), 'Quote child lowering does not re-enter unrelated registry recognizers through the navigation probe.');
 
+$figureQuote = (new HtmlTransformer())->transform('<figure><blockquote><p>Quoted.</p><object data="/quote.pdf"></object></blockquote><figcaption class="credit">Ada</figcaption></figure>')->toArray();
+$assert('core/quote' === ($figureQuote['blocks'][0]['blockName'] ?? null), 'A figure quote wins before generic figure lowering.');
+$assert('<span class="credit">Ada</span>' === ($figureQuote['blocks'][0]['attrs']['citation'] ?? null), 'The direct figure-quote recognizer preserves caption citation markup.');
+$assert('html_unsupported_element' === ($figureQuote['fallbacks'][0]['diagnostic_code'] ?? null), 'A winning figure quote commits recursive child fallback diagnostics.');
+
+$declinedQuote = (new HtmlTransformer())->transform('<blockquote><cite>Ada</cite></blockquote>')->toArray();
+$assert(array() === ($declinedQuote['blocks'] ?? array()), 'A quote without visible quoted content declines normal lowering.');
+$assert(array() === ($declinedQuote['fallbacks'] ?? array()), 'A declined quote commits no recursive fallback diagnostics.');
+
 $accordion = (new HtmlTransformer())->transform('<section class="faq"><div class="faq-item"><button aria-controls="a">A?</button><div id="a"><p>A.</p><object data="/a.pdf"></object></div></div><div class="faq-item"><button aria-controls="b">B?</button><div id="b"><p>B.</p></div></div></section>')->toArray();
 $assert('core/accordion' === ($accordion['blocks'][0]['blockName'] ?? null), 'Accordion recognition survives an unsupported panel child.');
 $assert('html_unsupported_element' === ($accordion['fallbacks'][0]['diagnostic_code'] ?? null), 'Accordion commits recursive panel diagnostics through its winning result.');


### PR DESCRIPTION
## Summary

- make `QuotePattern` the direct ordered blockquote recognizer
- add a direct `FigureQuotePattern` at the existing figure precedence position
- replace transformer callback wiring with a typed quote context and the existing recursive converter
- preserve child fallback diagnostics only when quote recognition wins

Part of #1211. Follows #1214.

## Verification

- `composer --working-dir=php-transformer test`
- 289 PHP Transformer parity fixtures passed
- staged registry dispatch passed with 37 assertions
- packaging install proof passed

## Compatibility

Registry order, emitted quote and pullquote blocks, caption citation markup, recursive fallback diagnostics, and transformer result contracts are unchanged. Three unrelated callback recognizers remain for later #1211 slices.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the merged recognizer architecture, implemented the direct quote-family slice, added behavior-level precedence and side-effect coverage, and ran the complete PHP Transformer verification suite. Chris Huber directed the work and is responsible for the engineering decisions and review.