### PR TITLE
Give PatternContext a typed semantic API

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/AccordionPattern.php
@@ -11,10 +11,10 @@ final class AccordionPattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        $createBlock = $context->createBlockCallback();
+        $createBlock = $context->createBlock(...);
         $converter = $context->recursiveConverter();
-        $presentationAttributes = $context->presentationAttributesCallback();
-        $innerHtml = $context->innerHtmlCallback();
+        $presentationAttributes = $context->presentationAttributes(...);
+        $innerHtml = $context->innerHtml(...);
 
         if ( null === $converter || ! $this->hasAccordionSignal($element) || $this->hasRuntimeHeavyDescendant($element) ) {
             return null;

--- a/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ButtonsPattern.php
@@ -39,19 +39,19 @@ final class ButtonsPattern
             return null;
         }
 
-        $text = $this->buttonText($anchor, $context->innerHtmlCallback()($anchor), $buttons);
+        $text = $this->buttonText($anchor, $context->innerHtml($anchor), $buttons);
         if ( $this->hasMateriallyDifferentAccessibleLabel($anchor, $text) ) {
             return $buttons->accessibleNameFallback($anchor);
         }
 
-        $block = $context->createBlockCallback()('core/buttons', $this->buttonWrapperAttributes($anchor, $context, $buttons), array( $this->buttonBlockFromAnchor($anchor, $context, $buttons) ), $anchor);
+        $block = $context->createBlock('core/buttons', $this->buttonWrapperAttributes($anchor, $context, $buttons), array( $this->buttonBlockFromAnchor($anchor, $context, $buttons) ), $anchor);
         return new PatternRecognitionResult($block);
     }
 
     /** @return array<string, mixed> */
     public function matchButton(DOMElement $button, PatternContext $context, ButtonPatternContext $buttons): array
     {
-        $createBlock = $context->createBlockCallback();
+        $createBlock = $context->createBlock(...);
         $resolvedButtonStyle = trim($buttons->resolvedStyle($button));
         $attrs = $this->buttonPresentationAttributes($button, $context, $buttons);
         if ( $buttons->isGridItem($button) ) {
@@ -80,7 +80,7 @@ final class ButtonsPattern
     {
         $wrappedAnchor = $this->singleSimpleAnchorChild($element);
         if ( null !== $wrappedAnchor && $this->hasWrapperButtonSignal($element, $buttons->resolvedStyle($element)) ) {
-            return $context->createBlockCallback()('core/buttons', $this->buttonWrapperAttributes($element, $context, $buttons), array( $this->buttonBlockFromAnchor($wrappedAnchor, $context, $buttons, $element) ), $element);
+            return $context->createBlock('core/buttons', $this->buttonWrapperAttributes($element, $context, $buttons), array( $this->buttonBlockFromAnchor($wrappedAnchor, $context, $buttons, $element) ), $element);
         }
 
         $buttonBlocks = array();
@@ -94,7 +94,7 @@ final class ButtonsPattern
             return null;
         }
 
-        return $context->createBlockCallback()('core/buttons', $context->presentationAttributesCallback()($element), $buttonBlocks, $element);
+        return $context->createBlock('core/buttons', $context->presentationAttributes($element), $buttonBlocks, $element);
     }
 
     /** @return array<string, mixed> */
@@ -117,9 +117,9 @@ final class ButtonsPattern
         if ( $hasAuthoredStyleRules && ($presentationElement === $anchor || $presentationElement->parentNode === $anchor) ) {
             $this->removeSourceControlClasses($attrs, $presentationElement);
         }
-        $text = $this->buttonText($anchor, $context->innerHtmlCallback()($anchor), $buttons);
+        $text = $this->buttonText($anchor, $context->innerHtml($anchor), $buttons);
 
-        return $context->createBlockCallback()('core/button', array_filter(array_merge($attrs, array(
+        return $context->createBlock('core/button', array_filter(array_merge($attrs, array(
             'text'       => $text,
             'url'        => $buttons->attribute($anchor, 'href'),
             'title'      => $this->buttonTitleForAnchor($anchor, $text),
@@ -135,7 +135,7 @@ final class ButtonsPattern
      */
     private function buttonWrapperAttributes(DOMElement $element, PatternContext $context, ButtonPatternContext $buttons): array
     {
-        $presentation = $context->presentationAttributesCallback()($element);
+        $presentation = $context->presentationAttributes($element);
         $attrs = array();
         $margin = $presentation['style']['spacing']['margin'] ?? null;
         if ( is_array($margin) && array() !== $margin ) {
@@ -320,7 +320,7 @@ final class ButtonsPattern
         if ( '' !== trim((string) ($native['style']['shadow'] ?? '')) ) {
             $excludedGeometry[] = 'box-shadow';
         }
-        $attrs = $context->presentationAttributesCallback()($element, $excludedGeometry);
+        $attrs = $context->presentationAttributes($element, $excludedGeometry);
         // Buttons resolve styling from the raw merged CSS string, not the canonical
         // block style object, so the (now object-shaped) presentation `style` is
         // dropped and re-derived via ButtonStyleResolver below.

--- a/php-transformer/src/HtmlToBlocks/Patterns/CodeWindowPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CodeWindowPattern.php
@@ -18,11 +18,11 @@ final class CodeWindowPattern implements PatternRecognizerInterface
 
         $block = $this->match(
             $element,
-            $context->presentationAttributesCallback(),
-            $context->innerHtmlCallback(),
+            $context->presentationAttributes(...),
+            $context->innerHtml(...),
             fn (DOMElement $pre, DOMElement $code): array => $codeWindow->presentationAttributes($pre, $code),
             fn (DOMElement $code): string => $codeWindow->content($code),
-            $context->createBlockCallback()
+            $context->createBlock(...)
         );
 
         return null === $block ? null : new PatternRecognitionResult($block);

--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -44,9 +44,9 @@ final class ColumnsPattern implements PatternRecognizerInterface
             $fallbacks,
             array($converter, 'children'),
             array($converter, 'element'),
-            $context->presentationAttributesCallback(),
+            $context->presentationAttributes(...),
             $style,
-            $context->createBlockCallback()
+            $context->createBlock(...)
         );
 
         return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -55,11 +55,11 @@ final class CoverPattern implements PatternRecognizerInterface
             $element,
             $fallbacks,
             array($converter, 'children'),
-            $context->presentationAttributesCallback(),
+            $context->presentationAttributes(...),
             $style,
             $attrs,
             $url,
-            $context->createBlockCallback()
+            $context->createBlock(...)
         );
 
         return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);

--- a/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/DetailsPattern.php
@@ -24,9 +24,9 @@ final class DetailsPattern implements PatternRecognizerInterface
                 function (DOMElement $sourceElement, array &$sourceFallbacks, array $excludedTags) use ($converter): array {
                     return $converter->childrenWithoutTags($sourceElement, $sourceFallbacks, $excludedTags);
                 },
-                $context->presentationAttributesCallback(),
-                $context->innerHtmlCallback(),
-                $context->createBlockCallback()
+                $context->presentationAttributes(...),
+                $context->innerHtml(...),
+                $context->createBlock(...)
             );
         } else {
             $block = $this->matchDisclosure(
@@ -34,9 +34,9 @@ final class DetailsPattern implements PatternRecognizerInterface
                 function (DOMElement $sourceElement) use ($converter, &$fallbacks): array {
                     return $converter->children($sourceElement, $fallbacks, true);
                 },
-                $context->presentationAttributesCallback(),
-                $context->innerHtmlCallback(),
-                $context->createBlockCallback()
+                $context->presentationAttributes(...),
+                $context->innerHtml(...),
+                $context->createBlock(...)
             );
         }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/GalleryPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/GalleryPattern.php
@@ -23,9 +23,9 @@ final class GalleryPattern implements PatternRecognizerInterface
             fn (DOMElement $image, ?DOMElement $figure = null, ?DOMElement $picture = null, ?DOMElement $link = null): ?array => $gallery->convertImage($image, $figure, $picture, $link),
             fn (DOMElement $picture, ?DOMElement $figure = null, ?DOMElement $link = null): ?array => $gallery->convertPicture($picture, $figure, $link),
             fn (DOMElement $figure): ?DOMElement => $gallery->linkedMediaAnchor($figure),
-            $context->presentationAttributesCallback(),
-            $context->innerHtmlCallback(),
-            $context->createBlockCallback()
+            $context->presentationAttributes(...),
+            $context->innerHtml(...),
+            $context->createBlock(...)
         );
 
         return null === $block ? null : new PatternRecognitionResult($block);

--- a/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/LogoPattern.php
@@ -18,11 +18,11 @@ final class LogoPattern implements PatternRecognizerInterface
 
         $block = $this->match(
             $element,
-            $context->presentationAttributesCallback(),
+            $context->presentationAttributes(...),
             fn (DOMElement $source): string => $logo->richText($source),
             fn (DOMElement $source): string => $logo->outerHtml($source),
             fn (DOMElement $source, string $content): ?string => $logo->materializeSvgImages($source, $content),
-            $context->createBlockCallback()
+            $context->createBlock(...)
         );
 
         return null === $block ? null : new PatternRecognitionResult($block);

--- a/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
@@ -19,12 +19,12 @@ final class MathPattern implements PatternRecognizerInterface
         }
 
         $tagName = strtolower($element->tagName);
-        $content = 'math' === $tagName ? $safeFallbackHtml($element) : $this->mathExpressionContent($element, $context->innerHtmlCallback(), $escapeHtml);
+        $content = 'math' === $tagName ? $safeFallbackHtml($element) : $this->mathExpressionContent($element, $context->innerHtml(...), $escapeHtml);
         if ( '' === trim($content) ) {
             return null;
         }
 
-        return new PatternRecognitionResult($context->createBlockCallback()('core/math', array_merge($context->presentationAttributesCallback()($element), array( 'content' => $content )), array(), $element));
+        return new PatternRecognitionResult($context->createBlock('core/math', array_merge($context->presentationAttributes($element), array( 'content' => $content )), array(), $element));
     }
 
     private function isMathElement(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
@@ -48,7 +48,7 @@ final class MediaTextPattern implements PatternRecognizerInterface
             $style,
             $html,
             $url,
-            $context->createBlockCallback()
+            $context->createBlock(...)
         );
 
         return null === $block ? null : new PatternRecognitionResult($block, $fallbacks);

--- a/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/NavigationPattern.php
@@ -30,9 +30,9 @@ final class NavigationPattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        $presentationAttributes = $context->presentationAttributesCallback();
-        $innerHtml = $context->innerHtmlCallback();
-        $createBlock = $context->createBlockCallback();
+        $presentationAttributes = $context->presentationAttributes(...);
+        $innerHtml = $context->innerHtml(...);
+        $createBlock = $context->createBlock(...);
         $navigationContext = $context->navigationContext();
         $isRuntimeDomTarget = $navigationContext?->runtimeDomTargetCallback();
         $navigationUnderlineColor = $navigationContext?->underlineColorCallback();

--- a/php-transformer/src/HtmlToBlocks/Patterns/ParameterTablePattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ParameterTablePattern.php
@@ -11,7 +11,7 @@ final class ParameterTablePattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        $innerHtml = $context->innerHtmlCallback();
+        $innerHtml = $context->innerHtml(...);
 
         if ( ! $this->hasClass($element, 'param-table') ) {
             return null;
@@ -45,7 +45,7 @@ final class ParameterTablePattern implements PatternRecognizerInterface
             return null;
         }
 
-        return new PatternRecognitionResult($context->createBlockCallback()('core/table', array_merge($context->presentationAttributesCallback()($element), array(
+        return new PatternRecognitionResult($context->createBlock('core/table', array_merge($context->presentationAttributes($element), array(
             'head' => array( array( 'cells' => array(
                 array( 'content' => 'Parameter', 'tag' => 'th' ),
                 array( 'content' => 'Type', 'tag' => 'th' ),

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -3,24 +3,25 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
 
+use Closure;
 use DOMElement;
 
 final class PatternContext
 {
     /**
-     * @param callable(DOMElement): array<string, mixed> $presentationAttributes
-     * @param callable(DOMElement): string $innerHtml
-     * @param callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
+     * @param Closure(DOMElement, array<int, string>): array<string, mixed> $presentationAttributes
+     * @param Closure(DOMElement): string $innerHtml
+     * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
      * @param PatternRecursiveConverter|null $recursiveConverter
      * @param NavigationPatternContext|null $navigationContext
-     * @param callable(DOMElement): string|null $mergedPresentationStyle
-     * @param callable(DOMElement): array<string, string>|null $htmlAttributes
-     * @param callable(string): string|null $resolveAssetImageUrl
-     * @param callable(DOMElement, array<int, string>): array<string, mixed>|null $mediaTextPresentationAttributes
-     * @param callable(DOMElement): string|null $mediaTextPresentationStyle
-     * @param callable(DOMElement): string|null $structuralPresentationStyle
-     * @param callable(DOMElement): string|null $safeFallbackHtml
-     * @param callable(string): string|null $escapeHtml
+     * @param Closure(DOMElement): string|null $mergedPresentationStyle
+     * @param Closure(DOMElement): array<string, string>|null $htmlAttributes
+     * @param Closure(string): string|null $resolveAssetImageUrl
+     * @param Closure(DOMElement, array<int, string>): array<string, mixed>|null $mediaTextPresentationAttributes
+     * @param Closure(DOMElement): string|null $mediaTextPresentationStyle
+     * @param Closure(DOMElement): string|null $structuralPresentationStyle
+     * @param Closure(DOMElement): string|null $safeFallbackHtml
+     * @param Closure(string): string|null $escapeHtml
      * @param ButtonPatternContext|null $buttonContext
      * @param QuotePatternContext|null $quoteContext
      * @param CodeWindowPatternContext|null $codeWindowContext
@@ -28,19 +29,19 @@ final class PatternContext
      * @param GalleryPatternContext|null $galleryContext
      */
     public function __construct(
-        private readonly mixed $presentationAttributes,
-        private readonly mixed $innerHtml,
-        private readonly mixed $createBlock,
+        private readonly Closure $presentationAttributes,
+        private readonly Closure $innerHtml,
+        private readonly Closure $createBlock,
         private readonly ?PatternRecursiveConverter $recursiveConverter = null,
         private readonly ?NavigationPatternContext $navigationContext = null,
-        private readonly mixed $mergedPresentationStyle = null,
-        private readonly mixed $htmlAttributes = null,
-        private readonly mixed $resolveAssetImageUrl = null,
-        private readonly mixed $mediaTextPresentationAttributes = null,
-        private readonly mixed $mediaTextPresentationStyle = null,
-        private readonly mixed $structuralPresentationStyle = null,
-        private readonly mixed $safeFallbackHtml = null,
-        private readonly mixed $escapeHtml = null,
+        private readonly ?Closure $mergedPresentationStyle = null,
+        private readonly ?Closure $htmlAttributes = null,
+        private readonly ?Closure $resolveAssetImageUrl = null,
+        private readonly ?Closure $mediaTextPresentationAttributes = null,
+        private readonly ?Closure $mediaTextPresentationStyle = null,
+        private readonly ?Closure $structuralPresentationStyle = null,
+        private readonly ?Closure $safeFallbackHtml = null,
+        private readonly ?Closure $escapeHtml = null,
         private readonly ?ButtonPatternContext $buttonContext = null,
         private readonly ?QuotePatternContext $quoteContext = null,
         private readonly ?CodeWindowPatternContext $codeWindowContext = null,
@@ -50,39 +51,39 @@ final class PatternContext
     }
 
     /**
-     * @return callable(DOMElement): array<string, mixed>
+     * @param array<int, string> $excludedGeometryProperties
+     * @return array<string, mixed>
      */
-    public function presentationAttributesCallback(): callable
+    public function presentationAttributes(DOMElement $element, array $excludedGeometryProperties = array()): array
     {
-        return $this->presentationAttributes;
+        return ($this->presentationAttributes)($element, $excludedGeometryProperties);
+    }
+
+    public function innerHtml(DOMElement $element): string
+    {
+        return ($this->innerHtml)($element);
     }
 
     /**
-     * @return callable(DOMElement): string
+     * @param array<string, mixed> $attributes
+     * @param array<int, array<string, mixed>> $innerBlocks
+     * @return array<string, mixed>
      */
-    public function innerHtmlCallback(): callable
+    public function createBlock(string $name, array $attributes = array(), array $innerBlocks = array(), ?DOMElement $sourceElement = null, ?DOMElement $logicalSourceElement = null): array
     {
-        return $this->innerHtml;
-    }
-
-    /**
-     * @return callable(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed>
-     */
-    public function createBlockCallback(): callable
-    {
-        return $this->createBlock;
+        return ($this->createBlock)($name, $attributes, $innerBlocks, $sourceElement, $logicalSourceElement);
     }
 
     public function recursiveConverter(): ?PatternRecursiveConverter { return $this->recursiveConverter; }
     public function navigationContext(): ?NavigationPatternContext { return $this->navigationContext; }
-    public function mergedPresentationStyleCallback(): ?callable { return is_callable($this->mergedPresentationStyle) ? $this->mergedPresentationStyle : null; }
-    public function htmlAttributesCallback(): ?callable { return is_callable($this->htmlAttributes) ? $this->htmlAttributes : null; }
-    public function resolveAssetImageUrlCallback(): ?callable { return is_callable($this->resolveAssetImageUrl) ? $this->resolveAssetImageUrl : null; }
-    public function mediaTextPresentationAttributesCallback(): ?callable { return is_callable($this->mediaTextPresentationAttributes) ? $this->mediaTextPresentationAttributes : null; }
-    public function mediaTextPresentationStyleCallback(): ?callable { return is_callable($this->mediaTextPresentationStyle) ? $this->mediaTextPresentationStyle : null; }
-    public function structuralPresentationStyleCallback(): ?callable { return is_callable($this->structuralPresentationStyle) ? $this->structuralPresentationStyle : null; }
-    public function safeFallbackHtmlCallback(): ?callable { return is_callable($this->safeFallbackHtml) ? $this->safeFallbackHtml : null; }
-    public function escapeHtmlCallback(): ?callable { return is_callable($this->escapeHtml) ? $this->escapeHtml : null; }
+    public function mergedPresentationStyleCallback(): ?Closure { return $this->mergedPresentationStyle; }
+    public function htmlAttributesCallback(): ?Closure { return $this->htmlAttributes; }
+    public function resolveAssetImageUrlCallback(): ?Closure { return $this->resolveAssetImageUrl; }
+    public function mediaTextPresentationAttributesCallback(): ?Closure { return $this->mediaTextPresentationAttributes; }
+    public function mediaTextPresentationStyleCallback(): ?Closure { return $this->mediaTextPresentationStyle; }
+    public function structuralPresentationStyleCallback(): ?Closure { return $this->structuralPresentationStyle; }
+    public function safeFallbackHtmlCallback(): ?Closure { return $this->safeFallbackHtml; }
+    public function escapeHtmlCallback(): ?Closure { return $this->escapeHtml; }
     public function buttonContext(): ?ButtonPatternContext { return $this->buttonContext; }
     public function quoteContext(): ?QuotePatternContext { return $this->quoteContext; }
     public function codeWindowContext(): ?CodeWindowPatternContext { return $this->codeWindowContext; }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
@@ -21,7 +21,7 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $attrs = $context->presentationAttributesCallback()($element);
+        $attrs = $context->presentationAttributes($element);
         // The aspect ratio rides on the preserved placeholder/ratio classNames and
         // companion-plugin CSS; a raw inline `style` string would invalidate the
         // core/group block, so it is intentionally not emitted here (#261).
@@ -29,9 +29,9 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
         unset($attrs['style']);
 
         $label = $this->placeholderLabel($element);
-        $children = '' !== $label ? array( $context->createBlockCallback()('core/paragraph', array( 'content' => $escapeHtml($label) ), array(), null) ) : array();
+        $children = '' !== $label ? array( $context->createBlock('core/paragraph', array( 'content' => $escapeHtml($label) )) ) : array();
 
-        return new PatternRecognitionResult($context->createBlockCallback()('core/group', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $children, $element));
+        return new PatternRecognitionResult($context->createBlock('core/group', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $children, $element));
     }
 
     private function isPlaceholderMediaElement(DOMElement $element): bool

--- a/php-transformer/src/HtmlToBlocks/Patterns/QuotePattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/QuotePattern.php
@@ -30,9 +30,9 @@ final class QuotePattern implements PatternRecognizerInterface
             return null;
         }
 
-        $createBlock = $context->createBlockCallback();
+        $createBlock = $context->createBlock(...);
         if ( $this->hasClass($element, 'wp-block-pullquote') ) {
-            return new PatternRecognitionResult($createBlock('core/pullquote', array_filter(array_merge($context->presentationAttributesCallback()($element), array(
+            return new PatternRecognitionResult($createBlock('core/pullquote', array_filter(array_merge($context->presentationAttributes($element), array(
                 'value'    => $value,
                 'citation' => $citation,
             )), static fn ($value): bool => '' !== $value), array(), $element));
@@ -48,7 +48,7 @@ final class QuotePattern implements PatternRecognizerInterface
         }
 
         return new PatternRecognitionResult(
-            $createBlock('core/quote', array_filter(array_merge($context->presentationAttributesCallback()($element), array( 'citation' => $citation )), static fn ($value): bool => '' !== $value), $innerBlocks, $element),
+            $createBlock('core/quote', array_filter(array_merge($context->presentationAttributes($element), array( 'citation' => $citation )), static fn ($value): bool => '' !== $value), $innerBlocks, $element),
             $fallbacks
         );
     }
@@ -64,7 +64,7 @@ final class QuotePattern implements PatternRecognizerInterface
         $citation = $quotes->citationFromElement($blockquote);
         $caption = $this->firstChildElement($figure, 'figcaption');
         if ( '' === $citation && $caption instanceof DOMElement ) {
-            $citation = $context->innerHtmlCallback()($caption);
+            $citation = $context->innerHtml($caption);
             $captionClass = trim($this->attr($caption, 'class'));
             if ( '' !== $captionClass ) {
                 $citation = '<span class="' . htmlspecialchars($captionClass, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '">' . $citation . '</span>';
@@ -76,8 +76,8 @@ final class QuotePattern implements PatternRecognizerInterface
             return null;
         }
 
-        $createBlock = $context->createBlockCallback();
-        $attrs = array_filter(array_merge($context->presentationAttributesCallback()($figure), array( 'citation' => $citation )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value);
+        $createBlock = $context->createBlock(...);
+        $attrs = array_filter(array_merge($context->presentationAttributes($figure), array( 'citation' => $citation )), static fn ($value): bool => is_array($value) ? array() !== $value : '' !== $value);
 
         if ( $this->hasClass($figure, 'wp-block-pullquote') || $this->hasClass($blockquote, 'wp-block-pullquote') ) {
             return new PatternRecognitionResult($createBlock('core/pullquote', array_merge($attrs, array( 'value' => $value )), array(), $figure));
@@ -89,11 +89,11 @@ final class QuotePattern implements PatternRecognizerInterface
             if ( ! $child instanceof DOMElement || $child->isSameNode($blockquote) || $child->isSameNode($caption) ) {
                 continue;
             }
-            $content = $context->innerHtmlCallback()($child);
+            $content = $context->innerHtml($child);
             if ( 'true' !== strtolower(trim($this->attr($child, 'aria-hidden'))) || '' === trim($quotes->stripAllTags($content)) ) {
                 continue;
             }
-            $innerBlocks[] = $createBlock('core/paragraph', array_merge($context->presentationAttributesCallback()($child), array( 'content' => $content )), array(), $child);
+            $innerBlocks[] = $createBlock('core/paragraph', array_merge($context->presentationAttributes($child), array( 'content' => $content )), array(), $child);
         }
         $innerBlocks = array_merge($innerBlocks, $converter->childrenWithoutTags($blockquote, $fallbacks, array( 'cite', 'footer' )));
         if ( array() === $innerBlocks ) {
@@ -136,7 +136,7 @@ final class QuotePattern implements PatternRecognizerInterface
             return array();
         }
 
-        return array( $context->createBlockCallback()('core/paragraph', array_filter(array(
+        return array( $context->createBlock('core/paragraph', array_filter(array(
             'content'   => $value,
             'className' => $isDirectText ? 'blocks-engine-synthetic-paragraph' : '',
         ), static fn (string $value): bool => '' !== $value)) );

--- a/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SocialLinksPattern.php
@@ -58,8 +58,8 @@ final class SocialLinksPattern implements PatternRecognizerInterface
             $iconOnly = $iconOnly && '' === $text && $this->hasIcon($anchor);
             $sourceElement = $this->structuralItem($anchor, $element);
             $structuralItems = $structuralItems && ! $sourceElement->isSameNode($anchor);
-            $links[] = $context->createBlockCallback()('core/social-link', array_merge(
-                $context->presentationAttributesCallback()($sourceElement),
+            $links[] = $context->createBlock('core/social-link', array_merge(
+                $context->presentationAttributes($sourceElement),
                 array_filter(array(
                 'url' => $url,
                 'service' => $this->service($url) ?? 'chain',
@@ -68,7 +68,7 @@ final class SocialLinksPattern implements PatternRecognizerInterface
             ), array(), $sourceElement);
         }
 
-        $attrs = $context->presentationAttributesCallback()($element);
+        $attrs = $context->presentationAttributes($element);
         if ( $showLabels ) {
             $attrs['showLabels'] = true;
         }
@@ -83,7 +83,7 @@ final class SocialLinksPattern implements PatternRecognizerInterface
             $attrs['className'] = trim((string) ($attrs['className'] ?? '') . ' blocks-engine-source-social-item-spacing');
         }
         return new PatternRecognitionResult(
-            $context->createBlockCallback()('core/social-links', $attrs, $links, $element)
+            $context->createBlock('core/social-links', $attrs, $links, $element)
         );
     }
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/SpacerPattern.php
@@ -27,11 +27,11 @@ final class SpacerPattern implements PatternRecognizerInterface
 
         // core/spacer serializes height itself. Preserve all remaining geometry
         // through the generated stylesheet rather than removing the whole carrier.
-        $attrs = $context->presentationAttributesCallback()($element, array( 'height' ));
+        $attrs = $context->presentationAttributes($element, array( 'height' ));
         $attrs['height'] = $height;
         unset($attrs['style']);
 
-        return new PatternRecognitionResult($context->createBlockCallback()('core/spacer', $attrs, array(), $element));
+        return new PatternRecognitionResult($context->createBlock('core/spacer', $attrs, array(), $element));
     }
 
     private function childElementCount(DOMElement $element): int

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -32,6 +32,14 @@ $context = new PatternContext(
     static fn (DOMElement $source): string => '',
     static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null): array => array( 'blockName' => $name )
 );
+$semanticContext = new PatternContext(
+    static fn (DOMElement $source, array $excluded = array()): array => array( 'excluded' => $excluded ),
+    static fn (DOMElement $source): string => '<span>content</span>',
+    static fn (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null, ?DOMElement $logicalSource = null): array => array( 'blockName' => $name, 'logicalTag' => $logicalSource?->tagName )
+);
+$assertSame(array( 'excluded' => array( 'width' ) ), $semanticContext->presentationAttributes($element, array( 'width' )), 'Pattern context forwards presentation exclusions through its semantic API.');
+$assertSame('<span>content</span>', $semanticContext->innerHtml($element), 'Pattern context exposes inner HTML as a direct operation.');
+$assertSame(array( 'blockName' => 'core/group', 'logicalTag' => 'div' ), $semanticContext->createBlock('core/group', logicalSourceElement: $element), 'Pattern context forwards logical block provenance through its semantic API.');
 $calls = new ArrayObject();
 $declined = new class($calls) implements PatternRecognizerInterface {
     public function __construct(private readonly ArrayObject $calls) {}


### PR DESCRIPTION
## Summary

- replace all eleven `mixed` callable fields in `PatternContext` with explicit `Closure` types
- expose presentation attributes, inner HTML, and block creation as direct semantic operations
- remove the three ubiquitous callback-returning accessors and simplify all seventeen recognizer consumers
- retain first-class callable bridges only where released matcher APIs still accept callbacks

Part of #1211. Follows #1217.

## Verification

- `composer --working-dir=php-transformer test`
- 289 PHP Transformer parity fixtures passed
- staged registry dispatch passed with 45 assertions
- packaging install proof passed

## Compatibility

All in-repository context construction already supplies closures. Registry order, recognition behavior, fallback transactions, emitted blocks, parity fixtures, and transformer result contracts are unchanged. `HtmlTransformer` requires no new wiring for this refactor.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode mapped every pattern-context dependency, implemented the typed semantic facade, migrated recognizer call sites, added focused forwarding coverage, and ran the complete PHP Transformer verification suite. Chris Huber directed the work and is responsible for the engineering decisions and review.