### PR TITLE
Group pattern capabilities into typed contexts

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -24,6 +24,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CoverPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\DetailsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\FigureQuotePattern;
@@ -31,7 +32,9 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\GalleryPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\GalleryPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\LogoPatternContext;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MarkupPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MediaPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MediaTextPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\NavigationPatternContext;
@@ -4597,14 +4600,20 @@ final class HtmlTransformer
                 fn (DOMElement $sourceElement): array => $this->navigationColorInteractionStates($sourceElement),
                 fn (DOMElement $sourceElement): string => $this->navigationOverlayMenu($sourceElement)
             ),
-            fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
-            fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
-            fn (string $url): string => $this->resolvedAssetImageUrl($url),
-            fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->mediaTextPresentationAttributes($sourceElement, $excludedGeometryProperties),
-            fn (DOMElement $sourceElement): string => $this->mediaTextPresentationStyle($sourceElement),
-            fn (DOMElement $sourceElement): string => $this->cssDeclarationString($this->structuralPresentationDeclarations($sourceElement)),
-            fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
-            fn (string $text): string => $this->runtime->escapeHtml($text),
+            new MediaPatternContext(
+                fn (DOMElement $sourceElement): string => $this->mergedPresentationStyle($sourceElement),
+                fn (DOMElement $sourceElement): array => $this->htmlAttributes($sourceElement),
+                fn (string $url): string => $this->resolvedAssetImageUrl($url),
+                fn (DOMElement $sourceElement, array $excludedGeometryProperties = array()): array => $this->mediaTextPresentationAttributes($sourceElement, $excludedGeometryProperties),
+                fn (DOMElement $sourceElement): string => $this->mediaTextPresentationStyle($sourceElement)
+            ),
+            new ColumnsPatternContext(
+                fn (DOMElement $sourceElement): string => $this->cssDeclarationString($this->structuralPresentationDeclarations($sourceElement))
+            ),
+            new MarkupPatternContext(
+                fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
+                fn (string $text): string => $this->runtime->escapeHtml($text)
+            ),
             new ButtonPatternContext(
                 fn (DOMElement $anchor): ?array => $this->fileBlockFromAnchor($anchor),
                 fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->mergedPresentationStyle($sourceElement)),
@@ -4676,8 +4685,10 @@ final class HtmlTransformer
                 fn (DOMElement $item, DOMElement $anchor): string => $this->navigationUnderlineColor($item, $anchor),
                 fn (DOMElement $sourceElement): string => $this->resolveCssVariablesInValue($this->specificityResolvedPresentationStyle($sourceElement))
             ),
-            safeFallbackHtml: fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
-            escapeHtml: fn (string $text): string => $this->runtime->escapeHtml($text),
+            markupContext: new MarkupPatternContext(
+                fn (DOMElement $sourceElement): string => $this->safeFallbackHtml($sourceElement),
+                fn (string $text): string => $this->runtime->escapeHtml($text)
+            ),
             codeWindowContext: new CodeWindowPatternContext(
                 fn (DOMElement $sourcePre, DOMElement $sourceCode): array => $this->codePresentationAttributes($sourcePre, $sourceCode),
                 fn (DOMElement $sourceCode): string => $this->codeContent($sourceCode)

--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPattern.php
@@ -33,8 +33,8 @@ final class ColumnsPattern implements PatternRecognizerInterface
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         $converter = $context->recursiveConverter();
-        $style     = $context->structuralPresentationStyleCallback();
-        if ( null === $converter || null === $style ) {
+        $columns = $context->columnsContext();
+        if ( null === $converter || null === $columns ) {
             return null;
         }
 
@@ -45,7 +45,7 @@ final class ColumnsPattern implements PatternRecognizerInterface
             array($converter, 'children'),
             array($converter, 'element'),
             $context->presentationAttributes(...),
-            $style,
+            $columns->structuralStyle(...),
             $context->createBlock(...)
         );
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/ColumnsPatternContext.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Closure;
+use DOMElement;
+
+final class ColumnsPatternContext
+{
+    /** @param Closure(DOMElement): string $structuralStyle */
+    public function __construct(private readonly Closure $structuralStyle)
+    {
+    }
+
+    public function structuralStyle(DOMElement $element): string { return ($this->structuralStyle)($element); }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/CoverPattern.php
@@ -43,10 +43,8 @@ final class CoverPattern implements PatternRecognizerInterface
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         $converter = $context->recursiveConverter();
-        $style     = $context->mergedPresentationStyleCallback();
-        $attrs     = $context->htmlAttributesCallback();
-        $url       = $context->resolveAssetImageUrlCallback();
-        if ( null === $converter || null === $style || null === $attrs || null === $url ) {
+        $media = $context->mediaContext();
+        if ( null === $converter || null === $media ) {
             return null;
         }
 
@@ -56,9 +54,9 @@ final class CoverPattern implements PatternRecognizerInterface
             $fallbacks,
             array($converter, 'children'),
             $context->presentationAttributes(...),
-            $style,
-            $attrs,
-            $url,
+            $media->coverStyle(...),
+            $media->htmlAttributes(...),
+            $media->resolveImageUrl(...),
             $context->createBlock(...)
         );
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/MarkupPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MarkupPatternContext.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Closure;
+use DOMElement;
+
+final class MarkupPatternContext
+{
+    /**
+     * @param Closure(DOMElement): string $safeFallbackHtml
+     * @param Closure(string): string $escapeHtml
+     */
+    public function __construct(
+        private readonly Closure $safeFallbackHtml,
+        private readonly Closure $escapeHtml
+    ) {
+    }
+
+    public function safeFallbackHtml(DOMElement $element): string { return ($this->safeFallbackHtml)($element); }
+    public function escapeHtml(string $text): string { return ($this->escapeHtml)($text); }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MathPattern.php
@@ -12,14 +12,13 @@ final class MathPattern implements PatternRecognizerInterface
 
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
-        $safeFallbackHtml = $context->safeFallbackHtmlCallback();
-        $escapeHtml = $context->escapeHtmlCallback();
-        if ( null === $safeFallbackHtml || null === $escapeHtml || ! $this->isMathElement($element) ) {
+        $markup = $context->markupContext();
+        if ( null === $markup || ! $this->isMathElement($element) ) {
             return null;
         }
 
         $tagName = strtolower($element->tagName);
-        $content = 'math' === $tagName ? $safeFallbackHtml($element) : $this->mathExpressionContent($element, $context->innerHtml(...), $escapeHtml);
+        $content = 'math' === $tagName ? $markup->safeFallbackHtml($element) : $this->mathExpressionContent($element, $context->innerHtml(...), $markup->escapeHtml(...));
         if ( '' === trim($content) ) {
             return null;
         }

--- a/php-transformer/src/HtmlToBlocks/Patterns/MediaPatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MediaPatternContext.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns;
+
+use Closure;
+use DOMElement;
+
+final class MediaPatternContext
+{
+    /**
+     * @param Closure(DOMElement): string $coverStyle
+     * @param Closure(DOMElement): array<string, string> $htmlAttributes
+     * @param Closure(string): string $resolveImageUrl
+     * @param Closure(DOMElement, array<int, string>): array<string, mixed> $mediaTextAttributes
+     * @param Closure(DOMElement): string $mediaTextStyle
+     */
+    public function __construct(
+        private readonly Closure $coverStyle,
+        private readonly Closure $htmlAttributes,
+        private readonly Closure $resolveImageUrl,
+        private readonly Closure $mediaTextAttributes,
+        private readonly Closure $mediaTextStyle
+    ) {
+    }
+
+    public function coverStyle(DOMElement $element): string { return ($this->coverStyle)($element); }
+    /** @return array<string, string> */
+    public function htmlAttributes(DOMElement $element): array { return ($this->htmlAttributes)($element); }
+    public function resolveImageUrl(string $url): string { return ($this->resolveImageUrl)($url); }
+    /** @param array<int, string> $excludedGeometryProperties
+     * @return array<string, mixed>
+     */
+    public function mediaTextAttributes(DOMElement $element, array $excludedGeometryProperties = array()): array { return ($this->mediaTextAttributes)($element, $excludedGeometryProperties); }
+    public function mediaTextStyle(DOMElement $element): string { return ($this->mediaTextStyle)($element); }
+}

--- a/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/MediaTextPattern.php
@@ -30,11 +30,8 @@ final class MediaTextPattern implements PatternRecognizerInterface
     public function recognize(DOMElement $element, PatternContext $context): ?PatternRecognitionResult
     {
         $converter = $context->recursiveConverter();
-        $attrs     = $context->mediaTextPresentationAttributesCallback();
-        $style     = $context->mediaTextPresentationStyleCallback();
-        $html      = $context->htmlAttributesCallback();
-        $url       = $context->resolveAssetImageUrlCallback();
-        if ( null === $converter || null === $attrs || null === $style || null === $html || null === $url ) {
+        $media = $context->mediaContext();
+        if ( null === $converter || null === $media ) {
             return null;
         }
 
@@ -44,10 +41,10 @@ final class MediaTextPattern implements PatternRecognizerInterface
             $fallbacks,
             array($converter, 'children'),
             array($converter, 'element'),
-            $attrs,
-            $style,
-            $html,
-            $url,
+            $media->mediaTextAttributes(...),
+            $media->mediaTextStyle(...),
+            $media->htmlAttributes(...),
+            $media->resolveImageUrl(...),
             $context->createBlock(...)
         );
 

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternContext.php
@@ -14,14 +14,9 @@ final class PatternContext
      * @param Closure(string, array<string, mixed>, array<int, array<string, mixed>>, DOMElement|null, DOMElement|null): array<string, mixed> $createBlock
      * @param PatternRecursiveConverter|null $recursiveConverter
      * @param NavigationPatternContext|null $navigationContext
-     * @param Closure(DOMElement): string|null $mergedPresentationStyle
-     * @param Closure(DOMElement): array<string, string>|null $htmlAttributes
-     * @param Closure(string): string|null $resolveAssetImageUrl
-     * @param Closure(DOMElement, array<int, string>): array<string, mixed>|null $mediaTextPresentationAttributes
-     * @param Closure(DOMElement): string|null $mediaTextPresentationStyle
-     * @param Closure(DOMElement): string|null $structuralPresentationStyle
-     * @param Closure(DOMElement): string|null $safeFallbackHtml
-     * @param Closure(string): string|null $escapeHtml
+     * @param MediaPatternContext|null $mediaContext
+     * @param ColumnsPatternContext|null $columnsContext
+     * @param MarkupPatternContext|null $markupContext
      * @param ButtonPatternContext|null $buttonContext
      * @param QuotePatternContext|null $quoteContext
      * @param CodeWindowPatternContext|null $codeWindowContext
@@ -34,14 +29,9 @@ final class PatternContext
         private readonly Closure $createBlock,
         private readonly ?PatternRecursiveConverter $recursiveConverter = null,
         private readonly ?NavigationPatternContext $navigationContext = null,
-        private readonly ?Closure $mergedPresentationStyle = null,
-        private readonly ?Closure $htmlAttributes = null,
-        private readonly ?Closure $resolveAssetImageUrl = null,
-        private readonly ?Closure $mediaTextPresentationAttributes = null,
-        private readonly ?Closure $mediaTextPresentationStyle = null,
-        private readonly ?Closure $structuralPresentationStyle = null,
-        private readonly ?Closure $safeFallbackHtml = null,
-        private readonly ?Closure $escapeHtml = null,
+        private readonly ?MediaPatternContext $mediaContext = null,
+        private readonly ?ColumnsPatternContext $columnsContext = null,
+        private readonly ?MarkupPatternContext $markupContext = null,
         private readonly ?ButtonPatternContext $buttonContext = null,
         private readonly ?QuotePatternContext $quoteContext = null,
         private readonly ?CodeWindowPatternContext $codeWindowContext = null,
@@ -76,14 +66,9 @@ final class PatternContext
 
     public function recursiveConverter(): ?PatternRecursiveConverter { return $this->recursiveConverter; }
     public function navigationContext(): ?NavigationPatternContext { return $this->navigationContext; }
-    public function mergedPresentationStyleCallback(): ?Closure { return $this->mergedPresentationStyle; }
-    public function htmlAttributesCallback(): ?Closure { return $this->htmlAttributes; }
-    public function resolveAssetImageUrlCallback(): ?Closure { return $this->resolveAssetImageUrl; }
-    public function mediaTextPresentationAttributesCallback(): ?Closure { return $this->mediaTextPresentationAttributes; }
-    public function mediaTextPresentationStyleCallback(): ?Closure { return $this->mediaTextPresentationStyle; }
-    public function structuralPresentationStyleCallback(): ?Closure { return $this->structuralPresentationStyle; }
-    public function safeFallbackHtmlCallback(): ?Closure { return $this->safeFallbackHtml; }
-    public function escapeHtmlCallback(): ?Closure { return $this->escapeHtml; }
+    public function mediaContext(): ?MediaPatternContext { return $this->mediaContext; }
+    public function columnsContext(): ?ColumnsPatternContext { return $this->columnsContext; }
+    public function markupContext(): ?MarkupPatternContext { return $this->markupContext; }
     public function buttonContext(): ?ButtonPatternContext { return $this->buttonContext; }
     public function quoteContext(): ?QuotePatternContext { return $this->quoteContext; }
     public function codeWindowContext(): ?CodeWindowPatternContext { return $this->codeWindowContext; }

--- a/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PlaceholderMediaPattern.php
@@ -16,8 +16,8 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
             return null;
         }
 
-        $escapeHtml = $context->escapeHtmlCallback();
-        if ( null === $escapeHtml ) {
+        $markup = $context->markupContext();
+        if ( null === $markup ) {
             return null;
         }
 
@@ -29,7 +29,7 @@ final class PlaceholderMediaPattern implements PatternRecognizerInterface
         unset($attrs['style']);
 
         $label = $this->placeholderLabel($element);
-        $children = '' !== $label ? array( $context->createBlock('core/paragraph', array( 'content' => $escapeHtml($label) )) ) : array();
+        $children = '' !== $label ? array( $context->createBlock('core/paragraph', array( 'content' => $markup->escapeHtml($label) )) ) : array();
 
         return new PatternRecognitionResult($context->createBlock('core/group', array_filter($attrs, static fn ($value): bool => is_array($value) ? array() !== $value : '' !== trim((string) $value)), $children, $element));
     }

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognit
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerInterface;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PatternRecognizerRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MathPattern;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\MarkupPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\PlaceholderMediaPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
 
@@ -102,8 +103,10 @@ $directContext = new PatternContext(
     static fn (DOMElement $source, array $excluded = array()): array => array(),
     $innerHtml,
     $createBlock,
-    safeFallbackHtml: static fn (DOMElement $source): string => $source->ownerDocument?->saveHTML($source) ?: '',
-    escapeHtml: static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+    markupContext: new MarkupPatternContext(
+        static fn (DOMElement $source): string => $source->ownerDocument?->saveHTML($source) ?: '',
+        static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+    )
 );
 $overlap = ( new PatternRecognizerRegistry( array( new MathPattern(), new PlaceholderMediaPattern() ) ) )->firstMatch($elementFromHtml('<div class="placeholder media math" style="aspect-ratio: 16 / 9">$x$</div>'), $directContext);
 $assertSame('core/math', $overlap?->block()['blockName'] ?? null, 'Math wins direct ordered-registry competition with placeholder media.');
@@ -131,12 +134,10 @@ $declinedSpacer = ( new PatternRecognizerRegistry( array( new SpacerPattern(), $
 $assertSame('lower', $declinedSpacer?->block()['blockName'] ?? null, 'A declined direct spacer leaves lower recognizers available.');
 $assertSame(array( 'lower' ), $state->getArrayCopy(), 'A declined direct spacer does not invoke context callbacks or mutate recognizer state.');
 
-$missingSafeFallback = new PatternContext(static fn (DOMElement $source): array => array(), $innerHtml, $createBlock, escapeHtml: static fn (string $text): string => $text);
-$missingEscapeHtml = new PatternContext(static fn (DOMElement $source): array => array(), $innerHtml, $createBlock, safeFallbackHtml: static fn (DOMElement $source): string => 'safe');
-$assertSame(null, ( new MathPattern() )->recognize($elementFromHtml('<math><mi>x</mi></math>'), $missingSafeFallback), 'Math declines without its safe-fallback context dependency.');
-$assertSame(null, ( new MathPattern() )->recognize($elementFromHtml('<math><mi>x</mi></math>'), $missingEscapeHtml), 'Math declines without its HTML-escaping context dependency.');
+$missingMarkup = new PatternContext(static fn (DOMElement $source): array => array(), $innerHtml, $createBlock);
+$assertSame(null, ( new MathPattern() )->recognize($elementFromHtml('<math><mi>x</mi></math>'), $missingMarkup), 'Math declines without its atomic markup capability.');
 $placeholderState = new ArrayObject();
-$missingPlaceholderEscapeHtml = new PatternContext(
+$missingPlaceholderMarkup = new PatternContext(
     static function (DOMElement $source) use ($placeholderState): array {
         $placeholderState[] = 'presentation';
         return array();
@@ -148,10 +149,9 @@ $missingPlaceholderEscapeHtml = new PatternContext(
     static function (string $name, array $attrs = array(), array $children = array(), ?DOMElement $source = null) use ($placeholderState): array {
         $placeholderState[] = 'create-block';
         return array();
-    },
-    safeFallbackHtml: static fn (DOMElement $source): string => 'safe'
+    }
 );
-$assertSame(null, ( new PlaceholderMediaPattern() )->recognize($elementFromHtml('<div class="placeholder media" style="aspect-ratio: 16 / 9">Label</div>'), $missingPlaceholderEscapeHtml), 'Placeholder media declines without its HTML-escaping context dependency.');
+$assertSame(null, ( new PlaceholderMediaPattern() )->recognize($elementFromHtml('<div class="placeholder media" style="aspect-ratio: 16 / 9">Label</div>'), $missingPlaceholderMarkup), 'Placeholder media declines without its atomic markup capability.');
 $assertSame(array(), $placeholderState->getArrayCopy(), 'Placeholder media validates missing dependencies before invoking stateful context callbacks.');
 
 echo "pattern recognizer registry ok\n";


### PR DESCRIPTION
## Summary

- replace the eight remaining optional closure fields in `PatternContext` with media, markup, and columns capability contexts
- give cover, media-text, columns, math, and placeholder recognizers direct semantic capability APIs
- make markup safety atomic instead of permitting partially configured safe-HTML and escaping dependencies
- keep probe contexts intentionally limited to markup capabilities while normal contexts receive all three groups

Part of #1211. Follows #1218.

## Verification

- `composer --working-dir=php-transformer test`
- 289 PHP Transformer parity fixtures passed
- staged registry dispatch passed with 45 assertions
- packaging install proof passed

## Compatibility

Registry order, capability availability, side-effect-free declines, emitted blocks, fallback transactions, parity fixtures, and transformer result contracts are unchanged. Released matcher callback signatures remain available; only registry orchestration now uses the typed contexts.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode mapped the remaining optional capability groups, implemented the typed media, markup, and columns contexts, migrated recognizers and context construction, updated focused decline coverage, and ran the complete PHP Transformer verification suite. Chris Huber directed the work and is responsible for the engineering decisions and review.