### PR TITLE
Centralize default recognizer composition

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -16,11 +16,8 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\DiagnosticsC
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\SemanticParityReporter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\AccordionPattern;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonAnchorPattern;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsContainerPattern;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ButtonsPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\CodeWindowPatternContext;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\ColumnsPattern;
@@ -214,13 +211,6 @@ final class HtmlTransformer
     private readonly BlockFactory $blockFactory;
 
     private readonly BackgroundImageExtractor $backgroundImageExtractor;
-
-    private readonly ColumnsPattern $columnsPattern;
-
-    private readonly CoverPattern $coverPattern;
-
-    private readonly MediaTextPattern $mediaTextPattern;
-
 
     private readonly TableClassificationPolicy $tableClassificationPolicy;
 
@@ -579,33 +569,8 @@ final class HtmlTransformer
         );
         $this->blockFactory      = new BlockFactory();
         $this->backgroundImageExtractor = new BackgroundImageExtractor();
-        $buttonsPattern         = new ButtonsPattern();
-        $this->columnsPattern    = new ColumnsPattern();
-        $this->coverPattern      = new CoverPattern();
-        $this->mediaTextPattern  = new MediaTextPattern();
         $this->tableClassificationPolicy = new TableClassificationPolicy();
-        $quotePattern            = new QuotePattern();
-        $this->patternRecognizers = new PatternRecognizerRegistry(array(
-            $this->mediaTextPattern,
-            $this->coverPattern,
-            $this->columnsPattern,
-            new MathPattern(),
-            new ParameterTablePattern(),
-            new SpacerPattern(),
-            new CodeWindowPattern(),
-            new LogoPattern(),
-            new PlaceholderMediaPattern(),
-            $quotePattern,
-            new FigureQuotePattern($quotePattern),
-            new DetailsPattern(),
-            new GalleryPattern(),
-            new ButtonsContainerPattern($buttonsPattern),
-            new ButtonAnchorPattern($buttonsPattern),
-            new ButtonPattern($buttonsPattern),
-            new AccordionPattern(),
-            new SocialLinksPattern(),
-            new NavigationPattern(),
-        ));
+        $this->patternRecognizers = PatternRecognizerRegistry::createDefault();
         $this->navigationUnderlineColorResolver = new NavigationUnderlineColorResolver();
         $this->navigationBlockNormalizer = new NavigationBlockNormalizer(fn (string $label): string => $this->normalizedNavigationLabel($label));
         $this->diagnosticsCollector = new DiagnosticsCollector();

--- a/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
+++ b/php-transformer/src/HtmlToBlocks/Patterns/PatternRecognizerRegistry.php
@@ -7,6 +7,35 @@ use DOMElement;
 
 final class PatternRecognizerRegistry
 {
+    /** Canonical production composition; array order defines recognizer precedence. */
+    public static function createDefault(): self
+    {
+        $buttons = new ButtonsPattern();
+        $quote = new QuotePattern();
+
+        return new self(array(
+            new MediaTextPattern(),
+            new CoverPattern(),
+            new ColumnsPattern(),
+            new MathPattern(),
+            new ParameterTablePattern(),
+            new SpacerPattern(),
+            new CodeWindowPattern(),
+            new LogoPattern(),
+            new PlaceholderMediaPattern(),
+            $quote,
+            new FigureQuotePattern($quote),
+            new DetailsPattern(),
+            new GalleryPattern(),
+            new ButtonsContainerPattern($buttons),
+            new ButtonAnchorPattern($buttons),
+            new ButtonPattern($buttons),
+            new AccordionPattern(),
+            new SocialLinksPattern(),
+            new NavigationPattern(),
+        ));
+    }
+
     /**
      * @param array<int, PatternRecognizerInterface> $recognizers
      */

--- a/php-transformer/tests/unit/pattern-recognizer-registry.php
+++ b/php-transformer/tests/unit/pattern-recognizer-registry.php
@@ -108,8 +108,8 @@ $directContext = new PatternContext(
         static fn (string $text): string => htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
     )
 );
-$overlap = ( new PatternRecognizerRegistry( array( new MathPattern(), new PlaceholderMediaPattern() ) ) )->firstMatch($elementFromHtml('<div class="placeholder media math" style="aspect-ratio: 16 / 9">$x$</div>'), $directContext);
-$assertSame('core/math', $overlap?->block()['blockName'] ?? null, 'Math wins direct ordered-registry competition with placeholder media.');
+$overlap = PatternRecognizerRegistry::createDefault()->firstMatch($elementFromHtml('<div class="placeholder media math" style="aspect-ratio: 16 / 9">$x$</div>'), $directContext);
+$assertSame('core/math', $overlap?->block()['blockName'] ?? null, 'Math wins the default ordered-registry competition with placeholder media.');
 $assertSame('$x$', $overlap?->block()['attrs']['content'] ?? null, 'Direct ordered-registry winner preserves math content.');
 
 $state = new ArrayObject();


### PR DESCRIPTION
## Summary

- make `PatternRecognizerRegistry` the canonical owner of production recognizer composition and precedence
- retain constructor-injected custom registries for focused tests
- remove three transformer-owned pattern instances and the full recognizer construction graph from `HtmlTransformer`
- exercise overlapping math and placeholder precedence through the actual default registry

Part of #1211. Follows #1219.

## Verification

- `composer --working-dir=php-transformer test`
- 289 PHP Transformer parity fixtures passed
- staged registry dispatch passed with 45 assertions
- packaging install proof passed

## Compatibility

The canonical recognizer order, shared quote and button matcher identities, emitted blocks, fallback transactions, and transformer result contracts are unchanged. Custom registry construction remains available.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced recognizer ownership on merged trunk, moved the exact production composition graph into the registry, removed dead transformer ownership, updated default-order coverage, and ran the complete PHP Transformer verification suite. Chris Huber directed the work and is responsible for the engineering decisions and review.