### PR TITLE
perf(php-transformer): deduplicate terminal receipts

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -36,6 +36,7 @@ final class ArtifactCompiler
     public const PAGE_PLAN_SCHEMA = 'blocks-engine/php-transformer/staged-page-plan/v1';
     public const PAGE_RECEIPT_SCHEMA = 'blocks-engine/php-transformer/compiled-page-receipt/v1';
     public const COMPILED_RECEIPT_SCHEMA = 'blocks-engine/php-transformer/compiled-page-receipt/v2';
+    public const COMPACT_RECEIPT_SCHEMA = 'blocks-engine/php-transformer/compiled-page-receipt/v3';
 
     /**
      * Tag-only script selectors whose native DOM shape can be behavior-bearing.
@@ -374,7 +375,10 @@ final class ArtifactCompiler
         }
         // A receipt owns every page-derived input required by final reduction.
         // Text is hydrated here; binary references deliberately stay portable.
-        $pagePlan['receipt_schema'] = isset($sharedPlan['shared_reduction']) ? self::COMPILED_RECEIPT_SCHEMA : self::PAGE_RECEIPT_SCHEMA;
+        $pagePlan['receipt_schema'] = isset($sharedPlan['shared_reduction'])
+            ? ($pagePlan['compiler_options']['compiled_page_schema'] ?? self::COMPACT_RECEIPT_SCHEMA)
+            : self::PAGE_RECEIPT_SCHEMA;
+        if (self::COMPACT_RECEIPT_SCHEMA === $pagePlan['receipt_schema']) $pagePlan['artifact'] = $pageArtifact;
         $pagePlan['compiled_documents'] = $compiledDocuments;
         $pagePlan['owned_document_paths'] = array_keys($compiledDocuments);
         if (!isset($sharedPlan['shared_reduction'])) {
@@ -398,6 +402,9 @@ final class ArtifactCompiler
             $files,
             $entryPath
         );
+        if (self::COMPACT_RECEIPT_SCHEMA === $pagePlan['receipt_schema']) {
+            unset($pagePlan['terminal_reduction']['files'], $pagePlan['terminal_reduction']['entry_blocks']);
+        }
         /*
          * Observational work data is deliberately excluded from the receipt
          * digest so independently resumed work has stable canonical identity.
@@ -464,7 +471,7 @@ final class ArtifactCompiler
         $this->htmlDocumentTransformCount = 0;
         $this->assertSharedPlan($sharedPlan);
         $hasReceipts = false;
-        foreach ($pagePlans as $candidate) if (($candidate['receipt_schema'] ?? null) === self::COMPILED_RECEIPT_SCHEMA) { $hasReceipts = true; break; }
+        foreach ($pagePlans as $candidate) if ($this->isTerminalReceiptSchema($candidate['receipt_schema'] ?? null)) { $hasReceipts = true; break; }
         $sharedArtifact = $hasReceipts
             ? array_merge($sharedPlan['artifact'], array('files' => array()))
             : $this->materializePlanArtifact($sharedPlan['artifact'], $payloadReader);
@@ -479,19 +486,21 @@ final class ArtifactCompiler
                 throw new \InvalidArgumentException(sprintf('Composition received more than one staged page plan for page id "%s".', $pagePlan['page_id']));
             }
             $seen[$pagePlan['page_id']] = true;
-            $isReceipt = ($pagePlan['receipt_schema'] ?? null) === self::COMPILED_RECEIPT_SCHEMA;
+            $isReceipt = $this->isTerminalReceiptSchema($pagePlan['receipt_schema'] ?? null);
             if (!$isReceipt) {
                 if ($hasReceipts) throw new \InvalidArgumentException('Composition requires a compiled receipt for every page plan.');
                 $pageArtifact = $this->materializePlanArtifact($pagePlan['artifact'], $payloadReader);
                 $files = array_merge($files, $pageArtifact['files']);
                 continue;
             }
-            if (!isset($sharedPlan['shared_reduction'])) throw new \InvalidArgumentException('Compiled v2 receipts require the digest-bound shared reduction supplied by their shared plan.');
+            if (!isset($sharedPlan['shared_reduction'])) throw new \InvalidArgumentException('Compiled terminal receipts require the digest-bound shared reduction supplied by their shared plan.');
             $reduction = $pagePlan['terminal_reduction'] ?? null;
-            if (!is_array($reduction) || !is_array($reduction['files'] ?? null) || !is_array($reduction['source_documents'] ?? null) || !is_array($reduction['component_facts'] ?? null)) throw new \InvalidArgumentException('A compiled page receipt requires a complete terminal reduction.');
+            $isCompactReceipt = self::COMPACT_RECEIPT_SCHEMA === ($pagePlan['receipt_schema'] ?? null);
+            $pageFiles = $isCompactReceipt ? ($pagePlan['artifact']['files'] ?? null) : ($reduction['files'] ?? null);
+            if (!is_array($reduction) || !is_array($pageFiles) || !is_array($reduction['source_documents'] ?? null) || !is_array($reduction['component_facts'] ?? null)) throw new \InvalidArgumentException('A compiled page receipt requires a complete terminal reduction.');
             if (($pagePlan['shared_reduction_digest'] ?? null) !== ($sharedPlan['shared_reduction_digest'] ?? null)) throw new \InvalidArgumentException('A compiled page receipt is bound to another shared reduction.');
-            $pageArtifact = array('files' => $reduction['files']);
-            $files = array_merge($files, $reduction['files']);
+            $pageArtifact = array('files' => $pageFiles);
+            $files = array_merge($files, $pageFiles);
             $expected = $this->ownedHtmlPaths($pageArtifact['files'], (string) $pagePlan['page_id']);
             if ($expected !== array_keys($pagePlan['compiled_documents']) || $expected !== ($pagePlan['owned_document_paths'] ?? null)) throw new \InvalidArgumentException('A compiled page receipt does not exactly cover its owned HTML documents.');
             $expectedTransformable = $this->ownedTransformablePaths($pageArtifact['files'], (string) $pagePlan['page_id']);
@@ -505,6 +514,11 @@ final class ArtifactCompiler
                     throw new \InvalidArgumentException('A compiled page plan contains invalid or duplicate document output.');
                 }
                 $compiledDocuments[$path] = $document;
+            }
+            if ($isCompactReceipt) {
+                $reduction['files'] = $pageFiles;
+                $entryPath = (string) ($sharedPlan['analysis']['entry_path'] ?? '');
+                $reduction['entry_blocks'] = $pagePlan['compiled_documents'][$entryPath] ?? null;
             }
             $reductions[] = $reduction;
         }
@@ -1553,7 +1567,7 @@ final class ArtifactCompiler
         if (!$this->compatibleReceiptOptions($pagePlan['compiler_options'] ?? null) || ($pagePlan['output_schema'] ?? null) !== TransformerResult::SCHEMA) {
             throw new \InvalidArgumentException('A staged page plan was prepared with incompatible compiler options or output schema.');
         }
-        if (isset($pagePlan['compiled_documents']) && !in_array(($pagePlan['receipt_schema'] ?? null), array(self::PAGE_RECEIPT_SCHEMA, self::COMPILED_RECEIPT_SCHEMA), true)) {
+        if (isset($pagePlan['compiled_documents']) && !in_array(($pagePlan['receipt_schema'] ?? null), array(self::PAGE_RECEIPT_SCHEMA, self::COMPILED_RECEIPT_SCHEMA, self::COMPACT_RECEIPT_SCHEMA), true)) {
             throw new \InvalidArgumentException('A compiled page plan requires the compiled page receipt schema.');
         }
         $this->assertPlanDigest(
@@ -1572,7 +1586,7 @@ final class ArtifactCompiler
             $input['compiled_documents'] = $pagePlan['compiled_documents'];
             $input['owned_document_paths'] = $pagePlan['owned_document_paths'] ?? null;
             $input['shared_reduction_digest'] = $pagePlan['shared_reduction_digest'] ?? null;
-            if (($pagePlan['receipt_schema'] ?? null) === self::COMPILED_RECEIPT_SCHEMA) $input['terminal_reduction'] = $pagePlan['terminal_reduction'] ?? null;
+            if ($this->isTerminalReceiptSchema($pagePlan['receipt_schema'] ?? null)) $input['terminal_reduction'] = $pagePlan['terminal_reduction'] ?? null;
         }
         $input['compiler_options'] = $pagePlan['compiler_options'] ?? null;
         $input['output_schema'] = $pagePlan['output_schema'] ?? null;
@@ -1596,7 +1610,7 @@ final class ArtifactCompiler
     private function receiptCompilerOptions(): array
     {
         return array(
-            'compiled_page_schema' => self::COMPILED_RECEIPT_SCHEMA,
+            'compiled_page_schema' => self::COMPACT_RECEIPT_SCHEMA,
             'output_schema' => TransformerResult::SCHEMA,
         );
     }
@@ -1604,10 +1618,14 @@ final class ArtifactCompiler
     /** @param mixed $options */
     private function compatibleReceiptOptions(mixed $options): bool
     {
-        return $options === $this->receiptCompilerOptions() || $options === array(
-            'compiled_page_schema' => self::PAGE_RECEIPT_SCHEMA,
-            'output_schema' => TransformerResult::SCHEMA,
-        );
+        return $options === $this->receiptCompilerOptions()
+            || $options === array('compiled_page_schema' => self::COMPILED_RECEIPT_SCHEMA, 'output_schema' => TransformerResult::SCHEMA)
+            || $options === array('compiled_page_schema' => self::PAGE_RECEIPT_SCHEMA, 'output_schema' => TransformerResult::SCHEMA);
+    }
+
+    private function isTerminalReceiptSchema(mixed $schema): bool
+    {
+        return in_array($schema, array(self::COMPILED_RECEIPT_SCHEMA, self::COMPACT_RECEIPT_SCHEMA), true);
     }
 
     /** @param array<string,mixed> $normalized @return array<string,mixed> */

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -50,7 +50,8 @@ $assert(array('about.html', 'contact.html', 'index.html') === array_keys($batchP
 
 $compiledPages = array();
 foreach ($pageIds as $pageId) $compiledPages[$pageId] = $compiler->compilePage($artifact, $shared, $pageId);
-$assert(1 === ($compiledPages['about.html']['work']['compiled_document_count'] ?? null) && isset($compiledPages['about.html']['compiled_documents']['about.html']), 'A compiled page plan persists only its bounded page-owned document receipt.');
+$assert(ArtifactCompiler::COMPACT_RECEIPT_SCHEMA === ($compiledPages['about.html']['receipt_schema'] ?? null) && 1 === ($compiledPages['about.html']['work']['compiled_document_count'] ?? null) && isset($compiledPages['about.html']['compiled_documents']['about.html']), 'A compiled page plan persists only its bounded page-owned document receipt.');
+$assert(!array_key_exists('files', $compiledPages['about.html']['terminal_reduction']) && !array_key_exists('entry_blocks', $compiledPages['index.html']['terminal_reduction']), 'Compact receipts reference canonical page files and compiled entry output instead of serializing duplicate terminal payloads.');
 $compiledBatch = $compiler->compilePreparedPages($shared, $pages);
 foreach ($compiledBatch as &$compiledBatchPage) unset($compiledBatchPage['work']['compile_duration_ms']);
 unset($compiledBatchPage);
@@ -93,6 +94,15 @@ unset($initialWorker, $manyArtifact, $preparedPages);
 $resumedWorker = new ArtifactCompiler();
 $manyReceipts = array_merge($manyReceipts, array_values($resumedWorker->compilePreparedPages($serializedShared, array_slice($serializedPages, 25, null, true))));
 $serializedReceipts = json_decode(json_encode($manyReceipts, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+$expandedReceipts = $serializedReceipts;
+foreach ($expandedReceipts as &$expandedReceipt) {
+    $expandedReceipt['terminal_reduction']['files'] = $expandedReceipt['artifact']['files'];
+    $expandedReceipt['terminal_reduction']['entry_blocks'] = $expandedReceipt['compiled_documents']['index.html'] ?? null;
+}
+unset($expandedReceipt);
+$compactReceiptBytes = strlen(json_encode($serializedReceipts, JSON_THROW_ON_ERROR));
+$expandedReceiptBytes = strlen(json_encode($expandedReceipts, JSON_THROW_ON_ERROR));
+$assert($compactReceiptBytes < $expandedReceiptBytes, sprintf('Fifty compact receipts serialize fewer bytes than equivalent duplicate terminal payloads (%d compact bytes versus %d expanded bytes).', $compactReceiptBytes, $expandedReceiptBytes));
 $terminalWorker = new ArtifactCompiler();
 $manyStaged = $terminalWorker->compose($serializedShared, array_reverse($serializedReceipts))->toArray();
 $canonical = static function (mixed $value) use (&$canonical): mixed {
@@ -108,6 +118,15 @@ $assert($canonical($manyInline['source_reports']['wordpress_site_plan'] ?? array
 $assert($canonical($manyInline) === $canonical($manyStaged), 'Fifty-page arbitrary-order resume preserves the complete canonical transformer result after observational fields are excluded.');
 $manyPageComponent = current(array_filter($manyStaged['components'], static fn(array $component): bool => 'page' === ($component['name'] ?? null)));
 $assert(50 === ($manyPageComponent['occurrences'] ?? null), 'A class occurring once per page is qualified from the globally summed uncapped component facts.');
+$largeReceiptArtifact = array('entrypoint' => 'index.html', 'files' => array(array('path' => 'index.html', 'content' => '<main><p>' . str_repeat('receipt-payload ', 32768) . '</p></main>')));
+$largeReceiptShared = $compiler->prepareShared($largeReceiptArtifact);
+$largeReceipt = $compiler->compilePage($largeReceiptArtifact, $largeReceiptShared, 'index.html');
+$largeExpandedReceipt = $largeReceipt;
+$largeExpandedReceipt['terminal_reduction']['files'] = $largeExpandedReceipt['artifact']['files'];
+$largeExpandedReceipt['terminal_reduction']['entry_blocks'] = $largeExpandedReceipt['compiled_documents']['index.html'];
+$largeCompactBytes = strlen(json_encode($largeReceipt, JSON_THROW_ON_ERROR));
+$largeExpandedBytes = strlen(json_encode($largeExpandedReceipt, JSON_THROW_ON_ERROR));
+$assert($largeCompactBytes < (int) ($largeExpandedBytes * 0.7), sprintf('A large compiled page receipt is at least thirty percent smaller without duplicate source and entry output (%d compact bytes versus %d expanded bytes).', $largeCompactBytes, $largeExpandedBytes));
 $pageScopedScriptArtifact = array('entrypoint' => 'index.html', 'files' => array(
     array('path' => 'index.html', 'content' => '<main id="home-target"><script src="js/home.js"></script><h1>Home</h1></main>'),
     array('path' => 'about.html', 'content' => '<main id="about-target"><script src="js/about.js"></script><h1>About</h1></main>'),
@@ -212,6 +231,19 @@ $reductionMismatch['shared_reduction']['component_facts']['classes']['corrupt'] 
 $throws(static fn() => $compiler->compose($reductionMismatch, array()), 'Composition rejects a shared reduction whose immutable digest no longer matches.');
 
 $throws(static fn() => $compiler->compose($shared, array($pages['index.html'], $pages['index.html'])), 'Composition rejects more than one page plan for the same page id.');
+
+$v2Shared = $shared;
+$v2Shared['compiler_options']['compiled_page_schema'] = ArtifactCompiler::COMPILED_RECEIPT_SCHEMA;
+$v2Shared['digest'] = RuntimeDeclarations::hash(array('artifact' => $v2Shared['artifact'], 'analysis' => $v2Shared['analysis'], 'shared_reduction' => $v2Shared['shared_reduction'], 'shared_reduction_digest' => $v2Shared['shared_reduction_digest'], 'compiler_options' => $v2Shared['compiler_options']));
+$v2Receipts = array();
+foreach ($pageIds as $pageId) {
+    $v2Page = $compiler->preparePage($artifact, $v2Shared, $pageId);
+    $v2Page['compiler_options']['compiled_page_schema'] = ArtifactCompiler::COMPILED_RECEIPT_SCHEMA;
+    $v2Page['digest'] = RuntimeDeclarations::hash(array('shared_digest' => $v2Page['shared_digest'], 'page_id' => $v2Page['page_id'], 'artifact' => $v2Page['artifact'], 'compiler_options' => $v2Page['compiler_options'], 'output_schema' => $v2Page['output_schema']));
+    $v2Receipts[] = $compiler->compilePreparedPage($v2Shared, $v2Page);
+}
+$v2Result = $compiler->compose($v2Shared, array_reverse($v2Receipts))->toArray();
+$assert(array_key_exists('files', $v2Receipts[0]['terminal_reduction']) && array_key_exists('entry_blocks', $v2Receipts[0]['terminal_reduction']) && $whole['blocks'] === $v2Result['blocks'] && ($whole['source_reports']['wordpress_site_plan'] ?? array()) === ($v2Result['source_reports']['wordpress_site_plan'] ?? array()), 'Persisted v2 duplicate-payload receipts retain canonical composition compatibility.');
 
 $legacyShared = $shared;
 unset($legacyShared['shared_reduction'], $legacyShared['shared_reduction_digest']);
@@ -449,4 +481,4 @@ $layoutPage = $layoutWhole['source_reports']['compiled_site']['pages'][0] ?? arr
 $assert('passed' === ($layoutWhole['source_reports']['editability_policy']['status'] ?? null) && str_contains((string) ($layoutPage['block_markup'] ?? ''), '<!-- wp:custom/responsive-layout {"content":'), 'A deep semantic media main compiles as one dedicated typed layout boundary under the unchanged editability policy.');
 $assert($canonical($layoutWhole) === $canonical($layoutStaged), 'Typed captured layout boundaries preserve direct and staged canonical equivalence.');
 
-fwrite(STDOUT, "Staged artifact compilation contract passed\n");
+fwrite(STDOUT, sprintf("Staged artifact compilation contract passed (50-page receipts: %d compact / %d expanded bytes; large receipt: %d compact / %d expanded bytes)\n", $compactReceiptBytes, $expandedReceiptBytes, $largeCompactBytes, $largeExpandedBytes));


### PR DESCRIPTION
## Summary

- introduce `compiled-page-receipt/v3`, which stores hydrated page files only in `artifact.files` and compiled entry output only in `compiled_documents`
- derive transient terminal reduction inputs from those canonical fields during composition instead of serializing duplicate `terminal_reduction.files` and `terminal_reduction.entry_blocks`
- retain canonical composition support for persisted v1 and v2 receipts
- preserve reference-backed worker isolation and terminal zero-read behavior

Relates to #1044.

## Size Evidence

- 50-page deterministic fixture: 379,000 expanded bytes -> 348,150 compact bytes
- payload-dominant compiled receipt: 5,252,837 expanded bytes -> 2,627,211 compact bytes (49.99% reduction)
- direct, arbitrary-order staged, persisted v2, and reference-backed composition remain canonically equivalent

## Verification

- `composer validate --strict`
- `composer test` (canonical, 289 parity fixtures, packaging)
- `php tests/contract/staged-artifact-compilation.php`
- `php tests/contract/production-acceptance-matrix.php`
- `git diff --check`

Local `homeboy review lint` could not select a provider because the local `blocks-engine` component has no configured extension; repository-native lint/static analysis and CI remain authoritative.

## AI Assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** Tracing receipt ownership and terminal composition, implementing the versioned compact contract and persisted-receipt compatibility, adding deterministic size and parity coverage, running verification, and drafting this PR. Chris Huber reviewed and remains responsible for the change.