### PR TITLE
Refactor: isolate layout geometry state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -49,6 +49,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SpacerPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Patterns\SocialLinksPattern;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleResolutionTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStyleAnalysis;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\LayoutGeometryState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatcher;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssSelectorMatchCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
@@ -349,6 +350,12 @@ final class HtmlTransformer
             ?? throw new \LogicException('Author styles have not been prepared for this transform.');
     }
 
+    private function layoutGeometry(): LayoutGeometryState
+    {
+        return $this->session->layoutGeometryState()
+            ?? throw new \LogicException('Layout geometry state has not been prepared for this transform.');
+    }
+
     /**
      * @param array<string, mixed> $options
      */
@@ -380,7 +387,9 @@ final class HtmlTransformer
         $this->runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
         $this->runtimeBehavioralSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_behavioral_selectors');
         $this->runtimeCanvasSelectors = $this->runtimeCanvasSelectorsFromOptions($options);
-        $this->layoutGeometryProofReductions = is_array($options['layout_geometry_proof']['reductions'] ?? null) ? $options['layout_geometry_proof']['reductions'] : array();
+        $this->session->installLayoutGeometryState(new LayoutGeometryState(
+            is_array($options['layout_geometry_proof']['reductions'] ?? null) ? $options['layout_geometry_proof']['reductions'] : array()
+        ));
         $this->supersededRuntimeSelectors = array();
         $this->nextSourceProvenanceId = 1;
         $provenance               = array(
@@ -472,7 +481,7 @@ final class HtmlTransformer
         $this->collectGeneratedComponentCandidates($body);
         $blocks      = $this->navigationBlockNormalizer->normalize($this->convertChildren($body, $fallbacks, true), $this->sourceProvenance, $this->sourceBaseHiddenStates);
         $blocks = $this->compressProjectedGroupChains($blocks);
-        if (array() !== $this->layoutGeometryProofReductions && self::MAX_NATIVE_LIST_VIEW_DEPTH < $this->blockTreeDepth($blocks)) {
+        if ($this->layoutGeometry()->hasProofReductions() && self::MAX_NATIVE_LIST_VIEW_DEPTH < $this->blockTreeDepth($blocks)) {
             $blocks = $this->compressProjectedGroupChains($blocks, true);
         }
         $fallbacks = array_merge($fallbacks, $this->responsiveImageFallbacks);
@@ -601,7 +610,7 @@ final class HtmlTransformer
                 'reusable_components' => $reusableComponentRecognition,
                 'script_metadata'      => $this->scriptMetadata,
                 'runtime_islands'      => $this->runtimeIslands,
-                'layout_geometry_proof' => $this->layoutGeometryProofProvenance,
+                'layout_geometry_proof' => $this->layoutGeometry()->proofProvenance(),
             ),
         );
         if ( array() !== $authorStylesheetProjections ) {
@@ -7903,7 +7912,7 @@ final class HtmlTransformer
             ? $this->mergeClassNames((string) ($attrs['className'] ?? ''), (string) ($childAttrs['className'] ?? ''), ...$this->classNames($element))
             : $this->mergeClassNames((string) ($childAttrs['className'] ?? ''), $this->layoutGeometryProofCarrier($proof));
         $childAttrs = array_filter($childAttrs, static fn (mixed $value): bool => ! is_string($value) || '' !== trim($value));
-        if (null !== $proof) $this->layoutGeometryProofProvenance[] = $proof;
+        if (null !== $proof) $this->layoutGeometry()->recordProof($proof);
 
         return $this->createBlock((string) $childBlock['blockName'], $childAttrs, $childBlock['innerBlocks'] ?? array(), $sourceChild);
     }
@@ -7911,7 +7920,7 @@ final class HtmlTransformer
     /** @return array<string,mixed>|null */
     private function layoutGeometryProofFor(DOMElement $element): ?array
     {
-        foreach ($this->layoutGeometryProofReductions as $proof) {
+        foreach ($this->layoutGeometry()->proofReductions() as $proof) {
             // The normalizer binds the document digest. This lookup uses the
             // canonical structural selector, not a reusable author class.
             if (!is_array($proof) || $this->elementSelector($element) !== ($proof['wrapper_selector'] ?? null)) continue;
@@ -7941,7 +7950,7 @@ final class HtmlTransformer
         $childAttrs = is_array($children[0]['attrs'] ?? null) ? $children[0]['attrs'] : array();
         $childAttrs['className'] = $this->mergeClassNames((string) ($childAttrs['className'] ?? ''), $this->layoutGeometryProofCarrier($proof));
         $childAttrs = array_filter($childAttrs, static fn (mixed $value): bool => !is_string($value) || '' !== trim($value));
-        $this->layoutGeometryProofProvenance[] = $proof;
+        $this->layoutGeometry()->recordProof($proof);
         return $this->createBlock((string) $children[0]['blockName'], $childAttrs, $children[0]['innerBlocks'] ?? array(), $sourceChild);
     }
 
@@ -7954,7 +7963,7 @@ final class HtmlTransformer
         foreach ($declarations as $declaration) if (is_array($declaration)) $parts[] = $declaration['property'] . ':' . $declaration['value'];
         if (array() === $parts) return '';
         $className = 'be-layout-proof-' . substr(hash('sha256', (string) $proof['source_hash'] . "\n" . (string) $proof['wrapper_selector'] . "\n" . implode(';', $parts)), 0, 32);
-        $this->generatedGeometryRules[$className] = ':root .' . $className . '{' . implode(';', $parts) . '}';
+        $this->layoutGeometry()->registerRule($className, ':root .' . $className . '{' . implode(';', $parts) . '}');
         return $className;
     }
 
@@ -10963,7 +10972,7 @@ final class HtmlTransformer
             }
         }
 
-        $this->generatedGeometryRules[$marker] = implode("\n", $rules);
+        $this->layoutGeometry()->registerRule($marker, implode("\n", $rules));
     }
 
     private function registerTableCellGeometry(DOMElement $table): void
@@ -11007,10 +11016,7 @@ final class HtmlTransformer
         $path = $this->sourceElementIdentity($table);
         $marker = $this->sourceTableMarkers[$path] ??= $this->allocateAuthorMarker('table');
         $scopedRules = array_map(static fn (string $rule): string => '.' . $marker . '>table>' . $rule, $rules);
-        $this->generatedGeometryRules[$marker] = implode("\n", array_filter(array(
-            $this->generatedGeometryRules[$marker] ?? '',
-            implode("\n", $scopedRules),
-        )));
+        $this->layoutGeometry()->appendRule($marker, implode("\n", $scopedRules));
     }
 
     private function materializeDeclarativeCounters(DOMElement $body, string $declarativeStateHtml = ''): void
@@ -15261,7 +15267,7 @@ final class HtmlTransformer
     private function hasLayoutGeometryProofInSubtree(DOMElement $element): bool
     {
         $prefix = $this->elementSelector($element) . ' > ';
-        foreach ( $this->layoutGeometryProofReductions as $proof ) {
+        foreach ( $this->layoutGeometry()->proofReductions() as $proof ) {
             if ( is_array($proof) && str_starts_with((string) ($proof['wrapper_selector'] ?? ''), $prefix) ) {
                 return true;
             }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -5,7 +5,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStyleAnalysis;
-use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\LayoutGeometryState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\PresentationResolutionCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\SourceStyleResolutionState;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
@@ -100,11 +100,7 @@ final class HtmlTransformerSession
     public bool $fallbackReductionMode = false;
     public readonly PresentationResolutionCache $presentationResolutionCache;
     public readonly SourceStyleResolutionState $sourceStyleResolutionState;
-    public array $generatedGeometryRules = array();
-    public ?GeometryCarrierClassAllocator $geometryCarrierClassAllocator = null;
-    /** @var array<int,array<string,mixed>> */
-    public array $layoutGeometryProofReductions = array();
-    public array $layoutGeometryProofProvenance = array();
+    private ?LayoutGeometryState $layoutGeometryState = null;
     public readonly FallbackEmitter $fallbackEmitter;
 
     /** @param Closure(DOMElement): array<string, mixed> $sourceContextResolver */
@@ -123,5 +119,15 @@ final class HtmlTransformerSession
     public function authorStyleAnalysis(): ?AuthorStyleAnalysis
     {
         return $this->authorStyleAnalysis;
+    }
+
+    public function installLayoutGeometryState(LayoutGeometryState $state): void
+    {
+        $this->layoutGeometryState = $state;
+    }
+
+    public function layoutGeometryState(): ?LayoutGeometryState
+    {
+        return $this->layoutGeometryState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/LayoutGeometryState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/LayoutGeometryState.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/** Per-transform geometry proof and generated carrier state. */
+final class LayoutGeometryState
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $proofProvenance = array();
+
+    /** @var array<string, string> */
+    private array $rules = array();
+
+    private readonly GeometryCarrierClassAllocator $carrierClassAllocator;
+
+    /** @param array<int, array<string, mixed>> $proofReductions */
+    public function __construct(private readonly array $proofReductions = array())
+    {
+        $this->carrierClassAllocator = new GeometryCarrierClassAllocator();
+    }
+
+    public function hasProofReductions(): bool
+    {
+        return array() !== $this->proofReductions;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function proofReductions(): array
+    {
+        return $this->proofReductions;
+    }
+
+    /** @param array<string, mixed> $proof */
+    public function recordProof(array $proof): void
+    {
+        $this->proofProvenance[] = $proof;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function proofProvenance(): array
+    {
+        return $this->proofProvenance;
+    }
+
+    public function allocateCarrier(string $signature): string
+    {
+        return $this->carrierClassAllocator->allocate($signature);
+    }
+
+    public function registerRule(string $className, string $rule): void
+    {
+        $this->rules[$className] = $rule;
+    }
+
+    public function appendRule(string $className, string $rule): void
+    {
+        $this->rules[$className] = implode("\n", array_filter(array(
+            $this->rules[$className] ?? '',
+            $rule,
+        )));
+    }
+
+    public function cssForSerializedBlocks(string $serializedBlocks): string
+    {
+        $usedRules = array();
+        foreach ($this->rules as $className => $rule) {
+            if (preg_match('/(?:^|[^a-zA-Z0-9_-])' . preg_quote($className, '/') . '(?:$|[^a-zA-Z0-9_-])/', $serializedBlocks)) {
+                $usedRules[] = $rule;
+            }
+        }
+
+        return implode("\n", $usedRules);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -543,7 +543,7 @@ trait StyleResolutionTrait
             $importantDeclarations[] = $property . ':' . $value . ' !important';
         }
         $signature = implode(';', array_merge($normalPriorityDeclarations, $importantDeclarations));
-        $className = ($this->geometryCarrierClassAllocator ??= new GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $signature);
+        $className = $this->layoutGeometry()->allocateCarrier($this->geometryStructuralPath($element) . "\n" . $signature);
         $rules = array();
         if ( array() !== $normalPriorityDeclarations ) {
             $rules[] = ':root .' . $className . '{' . implode(';', $normalPriorityDeclarations) . '}';
@@ -551,7 +551,7 @@ trait StyleResolutionTrait
         if ( array() !== $importantDeclarations ) {
             $rules[] = '.' . $className . '{' . implode(';', $importantDeclarations) . '}';
         }
-        $this->generatedGeometryRules[$className] = implode("\n", $rules);
+        $this->layoutGeometry()->registerRule($className, implode("\n", $rules));
 
         return $className;
     }
@@ -973,8 +973,8 @@ trait StyleResolutionTrait
         }
 
         $rule = 'height:100% !important';
-        $className = ($this->geometryCarrierClassAllocator ??= new GeometryCarrierClassAllocator())->allocate('figure-height' . "\n" . $this->geometryStructuralPath($image) . "\n" . $rule);
-        $this->generatedGeometryRules[$className] = '.' . $className . '{' . $rule . '}';
+        $className = $this->layoutGeometry()->allocateCarrier('figure-height' . "\n" . $this->geometryStructuralPath($image) . "\n" . $rule);
+        $this->layoutGeometry()->registerRule($className, '.' . $className . '{' . $rule . '}');
 
         return $className;
     }
@@ -1172,14 +1172,7 @@ trait StyleResolutionTrait
 
     private function generatedGeometryCss(string $serializedBlocks): string
     {
-        $rules = array();
-        foreach ($this->generatedGeometryRules as $className => $rule) {
-            if (preg_match('/(?:^|[^a-zA-Z0-9_-])' . preg_quote($className, '/') . '(?:$|[^a-zA-Z0-9_-])/', $serializedBlocks)) {
-                $rules[] = $rule;
-            }
-        }
-
-        return implode("\n", $rules);
+        return $this->layoutGeometry()->cssForSerializedBlocks($serializedBlocks);
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -167,8 +167,8 @@ trait SvgMaterializationTrait
             // rule wins without forcing intrinsic media outside this explicit
             // parent-fill path.
             $imgRule = '>img{width:100%;height:100%;-o-object-fit:' . $objectFit . ';object-fit:' . $objectFit . '}';
-            $fillClass = ($this->geometryCarrierClassAllocator ??= new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
-            $this->generatedGeometryRules[$fillClass] = '.' . $fillClass . $figureRule . '.wp-block-image.' . $fillClass . $imgRule;
+            $fillClass = $this->layoutGeometry()->allocateCarrier($this->geometryStructuralPath($element) . "\n" . $figureRule . $imgRule);
+            $this->layoutGeometry()->registerRule($fillClass, '.' . $fillClass . $figureRule . '.wp-block-image.' . $fillClass . $imgRule);
             $attrs = array(
                 'url'       => $url,
                 'alt'       => $this->svgImageAlt($element),
@@ -189,14 +189,14 @@ trait SvgMaterializationTrait
                 }
             }
             $rule = ($richTextImage ? '' : '>img') . '{display:' . $imageDisplay . ($preserveInlineGeometry ? ';vertical-align:baseline' : '') . $mediaBox . '}';
-            $geometryClass = ($this->geometryCarrierClassAllocator ??= new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $rule);
-            $this->generatedGeometryRules[$geometryClass] = ($preserveBlockDisplay ? '.' . $geometryClass . '{line-height:0}' : '') . '.' . $geometryClass . $rule;
+            $geometryClass = $this->layoutGeometry()->allocateCarrier($this->geometryStructuralPath($element) . "\n" . $rule);
+            $this->layoutGeometry()->registerRule($geometryClass, ($preserveBlockDisplay ? '.' . $geometryClass . '{line-height:0}' : '') . '.' . $geometryClass . $rule);
         } elseif ( ! $richTextImage ) {
             // Core/image rejects typography.lineHeight. A standalone SVG still
             // needs its source line box removed when it becomes a figure.
             $rule = '{line-height:0}';
-            $geometryClass = ($this->geometryCarrierClassAllocator ??= new \Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeometryCarrierClassAllocator())->allocate($this->geometryStructuralPath($element) . "\n" . $rule);
-            $this->generatedGeometryRules[$geometryClass] = '.' . $geometryClass . $rule;
+            $geometryClass = $this->layoutGeometry()->allocateCarrier($this->geometryStructuralPath($element) . "\n" . $rule);
+            $this->layoutGeometry()->registerRule($geometryClass, '.' . $geometryClass . $rule);
         }
         $attrs = array_filter(array_merge(array(
             'url'          => $url,


### PR DESCRIPTION
## Summary

- add a per-transform `LayoutGeometryState` for proof inputs, applied-proof provenance, carrier allocation, and generated geometry rules
- remove four layout-geometry fields from `HtmlTransformerSession` magic forwarding
- preserve geometry decisions and byte-level output while giving the transformer and its traits one typed state boundary

Part of #242.

## Verification

- `composer test`
- 289 parity fixtures
- layout geometry proof contract
- block style support conversion: 136 assertions
- reused-transformer session equivalence
- packaging install proof
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode profiled the remaining transformer session state, implemented the layout-geometry state extraction, and ran the focused and full verification suites. Chris Huber directed the work and reviewed the resulting boundary.