### PR TITLE
perf(php-transformer): deduplicate shared reductions

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
+++ b/php-transformer/src/ArtifactCompiler/ArtifactCompiler.php
@@ -174,7 +174,7 @@ final class ArtifactCompiler
             'compiler_options' => $this->receiptCompilerOptions(),
         );
         $plan['shared_reduction'] = array(
-            'files' => $sharedArtifact['files'],
+            'files_source' => 'artifact',
             'component_facts' => $this->collectComponentFacts($sharedArtifact['files']),
         );
         $plan['shared_reduction_digest'] = $this->planDigest($plan['shared_reduction']);
@@ -318,7 +318,7 @@ final class ArtifactCompiler
         $this->assertSharedPlan($sharedPlan);
         $this->assertPagePlan($pagePlan, $sharedPlan);
         $sharedArtifact = isset($sharedPlan['shared_reduction'])
-            ? array_merge($sharedPlan['artifact'], array('files' => $sharedPlan['shared_reduction']['files']))
+            ? array_merge($sharedPlan['artifact'], array('files' => $this->sharedReductionFiles($sharedPlan, $payloadReader)))
             : $this->materializePlanArtifact($sharedPlan['artifact'], $payloadReader);
         $pageArtifact = $this->materializePlanArtifact($pagePlan['artifact'], $payloadReader);
         $files = self::sortedByPath(array_merge($sharedArtifact['files'], $pageArtifact['files']));
@@ -473,7 +473,7 @@ final class ArtifactCompiler
         $hasReceipts = false;
         foreach ($pagePlans as $candidate) if ($this->isTerminalReceiptSchema($candidate['receipt_schema'] ?? null)) { $hasReceipts = true; break; }
         $sharedArtifact = $hasReceipts
-            ? array_merge($sharedPlan['artifact'], array('files' => array()))
+            ? array_merge($sharedPlan['artifact'], array('files' => $this->sharedReductionFiles($sharedPlan, $payloadReader)))
             : $this->materializePlanArtifact($sharedPlan['artifact'], $payloadReader);
         $files = $sharedArtifact['files'];
         $seen = array();
@@ -867,7 +867,7 @@ final class ArtifactCompiler
     private function reduceCompiledReceipts(array $sharedPlan, array $sharedArtifact, array $reductions, array $compiledDocuments): array
     {
         $sharedReduction = $sharedPlan['shared_reduction'];
-        $files = $sharedReduction['files'];
+        $files = $sharedArtifact['files'];
         $sharedArtifact['files'] = $files;
         $documents = array('documents' => array(), 'components' => array(), 'diagnostics' => array());
         $componentFacts = array($sharedReduction['component_facts']);
@@ -1503,6 +1503,15 @@ final class ArtifactCompiler
         return $artifact;
     }
 
+    /** @return array<int,array<string,mixed>> */
+    private function sharedReductionFiles(array $sharedPlan, ?PayloadReader $payloadReader): array
+    {
+        if (is_array($sharedPlan['shared_reduction']['files'] ?? null)) {
+            return $sharedPlan['shared_reduction']['files'];
+        }
+        return $this->materializePlanArtifact($sharedPlan['artifact'], $payloadReader)['files'];
+    }
+
     /** @param array<string,mixed> $file */
     private function isReferenceBackedBinary(array $file): bool
     {
@@ -1529,7 +1538,9 @@ final class ArtifactCompiler
             throw new \InvalidArgumentException('A staged shared plan requires its serialized artifact payload.');
         }
         if (isset($sharedPlan['shared_reduction'])) {
-            if (!is_array($sharedPlan['shared_reduction']['files'] ?? null) || !is_array($sharedPlan['shared_reduction']['component_facts'] ?? null) || !is_string($sharedPlan['shared_reduction_digest'] ?? null) || !hash_equals($this->planDigest($sharedPlan['shared_reduction']), $sharedPlan['shared_reduction_digest'])) {
+            $filesSource = $sharedPlan['shared_reduction']['files_source'] ?? null;
+            $hasFiles = is_array($sharedPlan['shared_reduction']['files'] ?? null) || 'artifact' === $filesSource;
+            if (!$hasFiles || !is_array($sharedPlan['shared_reduction']['component_facts'] ?? null) || !is_string($sharedPlan['shared_reduction_digest'] ?? null) || !hash_equals($this->planDigest($sharedPlan['shared_reduction']), $sharedPlan['shared_reduction_digest'])) {
                 throw new \InvalidArgumentException('A staged shared plan contains an invalid shared reduction digest.');
             }
         }

--- a/php-transformer/tests/contract/staged-artifact-compilation.php
+++ b/php-transformer/tests/contract/staged-artifact-compilation.php
@@ -31,6 +31,7 @@ $artifact['runtime_declarations'] = array(array('kind' => 'entity_collection', '
 $compiler = new ArtifactCompiler();
 $shared = $compiler->prepareShared($artifact);
 $assert('blocks-engine/php-transformer/staged-shared-plan/v1' === $shared['schema'] && 2 === $shared['summary']['file_count'] && preg_match('/^[a-f0-9]{64}$/', $shared['digest']), 'Shared preparation preserves the published v1 plan envelope and digest.');
+$assert('artifact' === ($shared['shared_reduction']['files_source'] ?? null) && !array_key_exists('files', $shared['shared_reduction']), 'Inline shared reductions reference their digest-bound artifact files instead of serializing a duplicate payload.');
 $assert(array('diagnostics', 'projected_count') === array_keys($shared['analysis']['captured_dialogs']), 'Shared preparation persists bounded captured-dialog evidence without duplicating projected artifact files.');
 // Inline assets expanded out of an unannotated page follow that page, not the
 // immutable shared plan: parking page-varying content in the shared plan would
@@ -127,6 +128,17 @@ $largeExpandedReceipt['terminal_reduction']['entry_blocks'] = $largeExpandedRece
 $largeCompactBytes = strlen(json_encode($largeReceipt, JSON_THROW_ON_ERROR));
 $largeExpandedBytes = strlen(json_encode($largeExpandedReceipt, JSON_THROW_ON_ERROR));
 $assert($largeCompactBytes < (int) ($largeExpandedBytes * 0.7), sprintf('A large compiled page receipt is at least thirty percent smaller without duplicate source and entry output (%d compact bytes versus %d expanded bytes).', $largeCompactBytes, $largeExpandedBytes));
+$largeSharedArtifact = array('entrypoint' => 'index.html', 'files' => array(
+    array('path' => 'index.html', 'content' => '<main>Shared reduction size</main>'),
+    array('path' => 'assets/shared.bin', 'content_base64' => base64_encode(str_repeat('shared-payload', 32768)), 'mime_type' => 'application/octet-stream', 'metadata' => array('compilation' => array('scope' => 'shared'))),
+));
+$largeSharedPlan = $compiler->prepareShared($largeSharedArtifact);
+$largeExpandedSharedPlan = $largeSharedPlan;
+$largeExpandedSharedPlan['shared_reduction']['files'] = $largeExpandedSharedPlan['artifact']['files'];
+unset($largeExpandedSharedPlan['shared_reduction']['files_source']);
+$largeSharedBytes = strlen(json_encode($largeSharedPlan, JSON_THROW_ON_ERROR));
+$largeExpandedSharedBytes = strlen(json_encode($largeExpandedSharedPlan, JSON_THROW_ON_ERROR));
+$assert($largeSharedBytes < (int) ($largeExpandedSharedBytes * 0.7), sprintf('A large shared plan is at least thirty percent smaller when its reduction references the digest-bound artifact files (%d compact bytes versus %d expanded bytes).', $largeSharedBytes, $largeExpandedSharedBytes));
 $pageScopedScriptArtifact = array('entrypoint' => 'index.html', 'files' => array(
     array('path' => 'index.html', 'content' => '<main id="home-target"><script src="js/home.js"></script><h1>Home</h1></main>'),
     array('path' => 'about.html', 'content' => '<main id="about-target"><script src="js/about.js"></script><h1>About</h1></main>'),


### PR DESCRIPTION
## Summary

- retain inline shared files once in the digest-bound staged artifact
- make the shared reduction reference those artifact files instead of serializing a duplicate payload
- preserve legacy and reference-backed reduction compatibility
- add a large-plan contract proving at least 30% serialization reduction with canonical staged parity intact

Refs #1044.

## Corpus evidence

Measured against a retained 68.4 MB, 19-page artifact:

- full shared plan: 252,505,739 expanded bytes to 126,322,219 compact bytes
- retained shared checkpoint after existing file sharding: 138,684 bytes
- duplicate bytes removed: 126,183,520
- `prepareShared()`: 21.11 seconds
- `preparePages()`: 14.56 seconds for all 19 page plans
- peak memory: 414,433,280 bytes

The broader 58-page cold whole-artifact acceptance in #1044 remains separate from this bounded staged-state repair.

## Verification

- `composer test`
- 289 PHP transformer parity fixtures
- staged 50-page arbitrary-order resume contract
- package install proof
- `git diff --check`

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode inspected staged compiler ownership and reduction paths, implemented the compact shared-reduction contract, added size and parity coverage, ran the full suite, and measured the retained corpus. Chris Huber directed the repair and remains responsible for the change.