### PR TITLE
Refactor: isolate asset materialization state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/AssetMaterializationState.php
+++ b/php-transformer/src/HtmlToBlocks/AssetMaterializationState.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/** Per-transform source metadata and generated asset state. */
+final class AssetMaterializationState
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $generated = array();
+
+    /** @param array<string, array<string, mixed>> $metadata */
+    public function __construct(
+        private readonly string $root,
+        private readonly array $metadata
+    ) {
+    }
+
+    public function rootedPath(string $path): string
+    {
+        return ('' !== $this->root ? $this->root . '/' : '') . ltrim($path, '/');
+    }
+
+    /** @param array<string, mixed> $asset */
+    public function register(string $path, array $asset): void
+    {
+        $this->generated[$path] = $asset;
+    }
+
+    /**
+     * @param array<string, mixed> $asset
+     * @param array<string, mixed> $occurrence
+     */
+    public function registerInlineSvg(string $path, array $asset, array $occurrence, string $visualPayload): void
+    {
+        if (!isset($this->generated[$path])) {
+            if (is_string($occurrence['fingerprint'] ?? null)) {
+                $asset['component_occurrence_counts'] = array($occurrence['fingerprint'] => 1);
+            }
+            $asset['component_occurrences_omitted'] = 0;
+            $this->generated[$path] = $asset;
+            return;
+        }
+
+        $existing = $this->generated[$path];
+        // Shared visual identity must not retain instance accessibility metadata.
+        $existing['content'] = (string) ($existing['visual_payload'] ?? $visualPayload . "\n");
+        $existing['bytes'] = strlen($existing['content']);
+        $existing['hash'] = hash('sha256', $existing['content']);
+        $existing['source_hash'] = $existing['hash'];
+        $occurrences = is_array($existing['component_occurrences'] ?? null) ? $existing['component_occurrences'] : array();
+        $counts = is_array($existing['component_occurrence_counts'] ?? null) ? $existing['component_occurrence_counts'] : array();
+        if (is_string($occurrence['fingerprint'] ?? null)) {
+            $counts[$occurrence['fingerprint']] = (int) ($counts[$occurrence['fingerprint']] ?? 0) + 1;
+        }
+        if (count($occurrences) < 8 && !in_array($occurrence, $occurrences, true)) {
+            $occurrences[] = $occurrence;
+        } elseif (!in_array($occurrence, $occurrences, true)) {
+            $existing['component_occurrences_omitted'] = (int) ($existing['component_occurrences_omitted'] ?? 0) + 1;
+        }
+        $existing['component_occurrences'] = $occurrences;
+        $existing['component_occurrence_counts'] = $counts;
+        $existing['selector'] = $occurrences[0]['selector'] ?? $existing['selector'];
+        $this->generated[$path] = $existing;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function assets(): array
+    {
+        return array_values($this->generated);
+    }
+
+    /** @return array<string, array<string, mixed>> */
+    public function checkpoint(): array
+    {
+        return $this->generated;
+    }
+
+    /** @param array<string, array<string, mixed>> $checkpoint */
+    public function restore(array $checkpoint): void
+    {
+        $this->generated = $checkpoint;
+    }
+
+    public function hasInlineSvgSource(string $source): bool
+    {
+        if (isset($this->generated[$source]) && 'inline-svg' === ($this->generated[$source]['source'] ?? '')) {
+            return true;
+        }
+        foreach ($this->generated as $asset) {
+            if ('inline-svg' === ($asset['source'] ?? '') && $source === ($asset['source_url'] ?? null)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** @return array<string, mixed>|null */
+    public function metadataForUrl(string $url): ?array
+    {
+        foreach ($this->metadataLookupKeys($url) as $key) {
+            if (isset($this->metadata[$key])) {
+                return $this->metadata[$key];
+            }
+        }
+        return null;
+    }
+
+    /** @return array<int, string> */
+    private function metadataLookupKeys(string $url): array
+    {
+        $keys = array();
+        // Root-relative URLs cannot traverse out of their website root.
+        if (str_starts_with(trim($url), '/') && preg_match('~(?:^|/)\.\.(?:/|$)~', parse_url($url, PHP_URL_PATH) ?: '')) {
+            return array(trim($url));
+        }
+        foreach (array(trim($url), ltrim(trim($url), '/')) as $key) {
+            if ('' !== $key && !in_array($key, $keys, true)) {
+                $keys[] = $key;
+            }
+        }
+        $path = parse_url($url, PHP_URL_PATH);
+        if (is_string($path)) {
+            foreach (array($path, ltrim($path, '/')) as $key) {
+                if ('' !== $key && !in_array($key, $keys, true)) {
+                    $keys[] = $key;
+                }
+            }
+        }
+        return $keys;
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -362,6 +362,12 @@ final class HtmlTransformer
             ?? throw new \LogicException('Generated block registry has not been prepared for this transform.');
     }
 
+    private function materializedAssets(): AssetMaterializationState
+    {
+        return $this->session->assetMaterializationState()
+            ?? throw new \LogicException('Asset materialization state has not been prepared for this transform.');
+    }
+
     /**
      * @param array<string, mixed> $options
      */
@@ -375,11 +381,13 @@ final class HtmlTransformer
         $startedAt = hrtime(true);
         $this->fallbackProvenance = TransformationOptions::provenance($options);
         $this->session->installGeneratedBlockRegistry(new GeneratedBlockRegistry($this->generatedBlockNamespaceFromOptions($options)));
-        $this->generatedAssetRoot = trim((string) ($options['generated_asset_root'] ?? ''), '/');
+        $this->session->installAssetMaterializationState(new AssetMaterializationState(
+            trim((string) ($options['generated_asset_root'] ?? ''), '/'),
+            $this->assetMetadataFromOptions($options)
+        ));
         $this->preserveShellLandmarks = !empty($options['extract_global_shell']);
         $this->fallbackReductionMode = !empty($options['fallback_reduction_mode']);
         $this->runtimeScriptMetadata = $this->runtimeScriptMetadataFromOptions($options);
-        $this->assetMetadata = $this->assetMetadataFromOptions($options);
         $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $staticCss = (string) ($options['static_css'] ?? '');
         $styleAnalysis = $this->composedStyleAnalysis($this->stylesheetPayloads($html, $staticCss, $options));
@@ -628,7 +636,7 @@ final class HtmlTransformer
             status: $this->statusForFallbacks($fallbacks, $context),
             blocks: $blocks,
             serializedBlocks: $serializedBlocks,
-            assets: array_values($this->generatedAssets),
+            assets: $this->materializedAssets()->assets(),
             diagnostics: $diagnostics,
             fallbacks: $fallbacks,
             provenance: $provenance,
@@ -651,7 +659,7 @@ final class HtmlTransformer
     private function engineSupportCss(): string
     {
         $css = array();
-        foreach ($this->generatedAssets as $asset) if ('engine-support' === ($asset['source'] ?? '') && 'css' === ($asset['kind'] ?? '') && is_string($asset['content'] ?? null)) $css[] = $asset['content'];
+        foreach ($this->materializedAssets()->assets() as $asset) if ('engine-support' === ($asset['source'] ?? '') && 'css' === ($asset['kind'] ?? '') && is_string($asset['content'] ?? null)) $css[] = $asset['content'];
         return implode("\n", $css);
     }
 
@@ -921,7 +929,7 @@ final class HtmlTransformer
     private function finalizeReusableComponentRecognition(array $recognition): array
     {
         $assetOccurrences = array();
-        foreach ($this->generatedAssets as $asset) {
+        foreach ($this->materializedAssets()->assets() as $asset) {
             if (!is_array($asset) || 'inline-svg' !== ($asset['source'] ?? null)) continue;
             foreach (is_array($asset['component_occurrence_counts'] ?? null) ? $asset['component_occurrence_counts'] : array() as $fingerprint => $count) if (is_string($fingerprint) && is_int($count)) $assetOccurrences[$fingerprint] = (int) ($assetOccurrences[$fingerprint] ?? 0) + $count;
         }
@@ -1246,7 +1254,7 @@ final class HtmlTransformer
         $hash = hash('sha256', $content);
         $path = 'assets/css/' . $pathPrefix . '-' . substr($hash, 0, 16) . '.css';
 
-        $this->generatedAssets[$path] = array(
+        $this->materializedAssets()->register($path, array(
             'source'      => $source,
             'source_path' => '',
             'path'        => $path,
@@ -1263,7 +1271,7 @@ final class HtmlTransformer
             'binary'      => false,
             'hash'        => $hash,
             'source_hash' => $hash,
-        );
+        ));
     }
 
     private function materializeEditorStaticStateStylesheet(): void
@@ -8856,7 +8864,7 @@ final class HtmlTransformer
         }
 
         $textRun = '';
-        $generatedAssets = $this->generatedAssets;
+        $generatedAssets = $this->materializedAssets()->checkpoint();
         foreach ( $element->childNodes as $child ) {
             if ( XML_TEXT_NODE === $child->nodeType ) {
                 $textRun .= htmlspecialchars($child->textContent ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
@@ -8864,7 +8872,7 @@ final class HtmlTransformer
             }
 
             if ( ! $child instanceof DOMElement ) {
-                $this->generatedAssets = $generatedAssets;
+                $this->materializedAssets()->restore($generatedAssets);
                 return null;
             }
 
@@ -8875,7 +8883,7 @@ final class HtmlTransformer
 
             $image = $this->inlineSvgRichTextImageMarkup($child);
             if ( null === $image ) {
-                $this->generatedAssets = $generatedAssets;
+                $this->materializedAssets()->restore($generatedAssets);
                 return null;
             }
 
@@ -8884,7 +8892,7 @@ final class HtmlTransformer
 
         $content = trim($textRun);
         if ( '' === trim($this->runtime->stripAllTags($content)) || $this->richTextRequiresHtmlFallbackWithoutNativeSvgImageObjects($content) ) {
-            $this->generatedAssets = $generatedAssets;
+            $this->materializedAssets()->restore($generatedAssets);
             return null;
         }
 
@@ -8897,21 +8905,21 @@ final class HtmlTransformer
             return $content;
         }
 
-        $generatedAssets = $this->generatedAssets;
+        $generatedAssets = $this->materializedAssets()->checkpoint();
         foreach ( $element->getElementsByTagName('svg') as $svg ) {
             if ( ! $svg instanceof DOMElement ) {
                 continue;
             }
             $image = $this->inlineSvgRichTextImageMarkup($svg, false);
             if ( null === $image ) {
-                $this->generatedAssets = $generatedAssets;
+                $this->materializedAssets()->restore($generatedAssets);
                 return null;
             }
             // RichText preparation may normalize SVG casing (viewBox -> viewbox),
             // so the DOM serialization is not a stable replacement key.
             $replaced = preg_replace('@<svg\b[^>]*>.*?</svg>@is', $image, $content, 1);
             if ( ! is_string($replaced) || $replaced === $content ) {
-                $this->generatedAssets = $generatedAssets;
+                $this->materializedAssets()->restore($generatedAssets);
                 return null;
             }
             $content = $replaced;
@@ -8957,9 +8965,7 @@ final class HtmlTransformer
 
     private function isGeneratedInlineSvgSource(string $source): bool
     {
-        if (isset($this->generatedAssets[$source]) && 'inline-svg' === ($this->generatedAssets[$source]['source'] ?? '')) return true;
-        foreach ($this->generatedAssets as $asset) if (is_array($asset) && 'inline-svg' === ($asset['source'] ?? '') && $source === ($asset['source_url'] ?? null)) return true;
-        return false;
+        return $this->materializedAssets()->hasInlineSvgSource($source);
     }
 
     private function stripDecorativeSvgFromRichText(string $content): string
@@ -16085,40 +16091,7 @@ final class HtmlTransformer
      */
     private function assetMetadataForUrl(string $url): ?array
     {
-        foreach ( $this->assetMetadataLookupKeys($url) as $key ) {
-            if ( isset($this->assetMetadata[$key]) ) {
-                return $this->assetMetadata[$key];
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function assetMetadataLookupKeys(string $url): array
-    {
-        $keys = array();
-        // Root-relative URLs cannot traverse out of their website root. Keep
-        // their original spelling so they cannot match a relative asset key.
-        if (str_starts_with(trim($url), '/') && preg_match('~(?:^|/)\.\.(?:/|$)~', parse_url($url, PHP_URL_PATH) ?: '')) return array(trim($url));
-        foreach ( array( trim($url), ltrim(trim($url), '/') ) as $key ) {
-            if ( '' !== $key && ! in_array($key, $keys, true) ) {
-                $keys[] = $key;
-            }
-        }
-
-        $path = parse_url($url, PHP_URL_PATH);
-        if ( is_string($path) ) {
-            foreach ( array( $path, ltrim($path, '/') ) as $key ) {
-                if ( '' !== $key && ! in_array($key, $keys, true) ) {
-                    $keys[] = $key;
-                }
-            }
-        }
-
-        return $keys;
+        return $this->materializedAssets()->metadataForUrl($url);
     }
 
     private function safeResolvedAssetImageUrl(string $url): string

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -40,10 +40,8 @@ final class HtmlTransformerSession
     public array $nativeDisclosureRootIds = array();
     private ?GeneratedBlockRegistry $generatedBlockRegistry = null;
     public bool $emptyRuntimeTargetGenerated = false;
-    public string $generatedAssetRoot = '';
     public array $runtimeScriptMetadata = array();
-    public array $assetMetadata = array();
-    public array $generatedAssets = array();
+    private ?AssetMaterializationState $assetMaterializationState = null;
     public array $nativeSearchTriggerCssRules = array();
     public array $nativeButtonStyleRules = array();
     public array $syntheticHeaderAnchorStyleRules = array();
@@ -129,5 +127,15 @@ final class HtmlTransformerSession
     public function generatedBlockRegistry(): ?GeneratedBlockRegistry
     {
         return $this->generatedBlockRegistry;
+    }
+
+    public function installAssetMaterializationState(AssetMaterializationState $state): void
+    {
+        $this->assetMaterializationState = $state;
+    }
+
+    public function assetMaterializationState(): ?AssetMaterializationState
+    {
+        return $this->assetMaterializationState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -110,29 +110,7 @@ trait SvgMaterializationTrait
             'visual_payload' => $visualPayload . "\n",
         );
         if (array() !== $occurrence) $asset['component_occurrences'] = array($occurrence);
-        if (isset($this->generatedAssets[$path])) {
-            $existing = $this->generatedAssets[$path];
-            // A shared path represents visual identity. Once more than one
-            // instance uses it, discard instance accessibility metadata from
-            // the payload; core/image owns that metadata per block via alt.
-            $existing['content'] = (string) ($existing['visual_payload'] ?? $visualPayload . "\n");
-            $existing['bytes'] = strlen($existing['content']);
-            $existing['hash'] = hash('sha256', $existing['content']);
-            $existing['source_hash'] = $existing['hash'];
-            $occurrences = is_array($existing['component_occurrences'] ?? null) ? $existing['component_occurrences'] : array();
-            $counts = is_array($existing['component_occurrence_counts'] ?? null) ? $existing['component_occurrence_counts'] : array();
-            if (is_string($occurrence['fingerprint'] ?? null)) $counts[$occurrence['fingerprint']] = (int) ($counts[$occurrence['fingerprint']] ?? 0) + 1;
-            if (count($occurrences) < 8 && !in_array($occurrence, $occurrences, true)) $occurrences[] = $occurrence;
-            elseif (!in_array($occurrence, $occurrences, true)) $existing['component_occurrences_omitted'] = (int) ($existing['component_occurrences_omitted'] ?? 0) + 1;
-            $existing['component_occurrences'] = $occurrences;
-            $existing['component_occurrence_counts'] = $counts;
-            $existing['selector'] = $occurrences[0]['selector'] ?? $existing['selector'];
-            $this->generatedAssets[$path] = $existing;
-        } else {
-            if (is_string($occurrence['fingerprint'] ?? null)) $asset['component_occurrence_counts'] = array($occurrence['fingerprint'] => 1);
-            $asset['component_occurrences_omitted'] = 0;
-            $this->generatedAssets[$path] = $asset;
-        }
+        $this->materializedAssets()->registerInlineSvg($path, $asset, $occurrence, $visualPayload);
 
         $dimensions = $this->cssOwnsMediaBox($element) ? array() : $this->svgImageDimensions($element, $html);
         $presentation = $this->presentationDeclarations($element);
@@ -620,7 +598,7 @@ trait SvgMaterializationTrait
         // selector. A content address lets every compatible instance share one
         // core/image asset while retaining its own alt text and presentation.
         $filename = 'inline-svg-' . substr(hash('sha256', $html), 0, 16) . '.svg';
-        return ('' !== $this->generatedAssetRoot ? $this->generatedAssetRoot . '/' : '') . 'assets/materialized-svg/' . $filename;
+        return $this->materializedAssets()->rootedPath('assets/materialized-svg/' . $filename);
     }
 
     private function sourceRelativeMaterializedSvgPath(string $path): string


### PR DESCRIPTION
## Summary

- add per-transform `AssetMaterializationState` ownership for source metadata, generated paths, and assets
- centralize inline-SVG visual-identity merging and explicit rollback checkpoints
- remove asset root, metadata, and generated asset arrays from `HtmlTransformerSession` magic forwarding

Part of #242.

## Verification

- `composer test`
- 289 parity fixtures
- canonical HTML-to-blocks contract
- reusable component recognition
- author selector semantics: 96 assertions
- artifact author stylesheet projection
- reused-transformer session equivalence
- packaging install proof
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode profiled asset mutation and rollback paths, implemented the typed materialization state, and ran focused and full verification. Chris Huber directed the work and reviewed the resulting boundary.