### PR TITLE
Refactor: isolate runtime DOM evidence state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -8,6 +8,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Classification\SubtreeCl
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\CustomBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\GeneratedBlockRegistry;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RuntimeDomState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
@@ -29,10 +30,8 @@ use DOMElement;
  * byte-identical to the inline implementation.
  *
  * Decoupling notes:
- *  - The accumulators (`$fallbacks`, `$runtimeIslands`, `$scriptMetadata`) stay
- *    owned by HtmlTransformer (they are read at output time and from
- *    non-fallback code such as `isPreservedRuntimeIslandElement`); the emitter
- *    receives them by reference rather than reaching into transformer state.
+ *  - Fallback and script accumulators stay owned by HtmlTransformer. Runtime
+ *    island evidence is recorded through the per-transform RuntimeDomState.
  *  - Per-document configuration (`fallbackProvenance`, `runtimeScriptMetadata`,
  *    `runtimeCanvasSelectors`) is injected via {@see configure()} once per
  *    transform.
@@ -69,15 +68,6 @@ final class FallbackEmitter
 
     /** @var array<string, string> */
     private array $sourceTagMarkers = array();
-
-    /**
-     * DOM identity for each emitted runtime island, kept aligned by index with
-     * the transformer's accumulator so nested findings can be compared without
-     * exposing implementation-only node paths in diagnostics.
-     *
-     * @var array<int, array{document: int, path: string}>
-     */
-    private array $runtimeIslandOrigins = array();
 
     private readonly SubtreeClassifier $classifier;
 
@@ -379,7 +369,6 @@ final class FallbackEmitter
         $this->runtimeScriptMetadata  = $runtimeScriptMetadata;
         $this->runtimeCanvasSelectors = $runtimeCanvasSelectors;
         $this->sourceTagMarkers       = $sourceTagMarkers;
-        $this->runtimeIslandOrigins   = array();
     }
 
     /**
@@ -413,9 +402,8 @@ final class FallbackEmitter
 
     /**
      * @param array<int, array<string, mixed>> $fallbacks
-     * @param array<int, array<string, mixed>> $runtimeIslands
      */
-    public function captureCanvasFallback(DOMElement $element, array &$fallbacks, array &$runtimeIslands): void
+    public function captureCanvasFallback(DOMElement $element, array &$fallbacks, RuntimeDomState $runtimeDom): void
     {
         if ( ! $this->isRuntimeCanvasTarget($element) ) {
             return;
@@ -428,7 +416,7 @@ final class FallbackEmitter
                 ? 'Scripts may target #' . $id . ' and call canvas APIs such as getContext(); replacing it with a wrapper block changes runtime behavior.'
                 : 'Scripts may target this canvas by selector and call canvas APIs such as getContext(); replacing it with a wrapper block changes runtime behavior.',
             'required_scripts' => $this->requiredScriptsForElement($element),
-        ), $runtimeIslands);
+        ), $runtimeDom);
 
         $fallbacks[] = FallbackDiagnostic::build(array_filter(array(
             'type'            => 'html',
@@ -455,9 +443,8 @@ final class FallbackEmitter
 
     /**
      * @param array<int, array<string, mixed>> $fallbacks
-     * @param array<int, array<string, mixed>> $runtimeIslands
      */
-    public function captureScriptFallback(DOMElement $element, array &$fallbacks, array &$runtimeIslands): void
+    public function captureScriptFallback(DOMElement $element, array &$fallbacks, RuntimeDomState $runtimeDom): void
     {
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
         $boundedBody = $this->boundedFallbackText(trim($element->textContent ?? ''));
@@ -478,7 +465,7 @@ final class FallbackEmitter
             $scriptIslandMetadata['body_bytes']     = $boundedBody['bytes'];
             $scriptIslandMetadata['body_truncated'] = $boundedBody['truncated'];
         }
-        $this->recordRuntimeIsland($element, 'script', 'script_requires_runtime', 'client_script_execution', $scriptIslandMetadata, $runtimeIslands);
+        $this->recordRuntimeIsland($element, 'script', 'script_requires_runtime', 'client_script_execution', $scriptIslandMetadata, $runtimeDom);
         $fallbacks[] = FallbackDiagnostic::build(array(
             'type'            => 'html',
             'reason'          => 'script_requires_runtime',
@@ -542,9 +529,8 @@ final class FallbackEmitter
 
     /**
      * @param array<int, array<string, mixed>> $fallbacks
-     * @param array<int, array<string, mixed>> $runtimeIslands
      */
-    public function captureTemplateFallback(DOMElement $element, array &$fallbacks, array &$runtimeIslands): void
+    public function captureTemplateFallback(DOMElement $element, array &$fallbacks, RuntimeDomState $runtimeDom): void
     {
         $runtimeTemplate = $this->templateRequiresRuntimePreservation($element);
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
@@ -559,7 +545,7 @@ final class FallbackEmitter
                 'body_bytes'      => $boundedBody['bytes'],
                 'body_truncated'  => $boundedBody['truncated'],
                 'required_scripts' => $this->requiredScriptsForElement($element),
-            ), $runtimeIslands);
+            ), $runtimeDom);
         }
 
         $fallbacks[] = FallbackDiagnostic::build(array_filter(array(
@@ -589,9 +575,8 @@ final class FallbackEmitter
 
     /**
      * @param array<string, mixed> $metadata
-     * @param array<int, array<string, mixed>> $runtimeIslands
      */
-    public function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata, array &$runtimeIslands): void
+    public function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata, RuntimeDomState $runtimeDom): void
     {
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
         $island = FallbackDiagnostic::withGenericFindingMetadata(array_filter(array_merge(array(
@@ -613,51 +598,11 @@ final class FallbackEmitter
             'required_scripts'    => array(),
         ), $metadata), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value));
 
-        $key = json_encode(array(
-            'kind'     => $island['kind'] ?? '',
-            'selector' => $island['selector'] ?? '',
-            'snippet'  => $island['source_snippet'] ?? '',
-        ), JSON_UNESCAPED_SLASHES);
-        $origin = array(
-            'document' => $element->ownerDocument instanceof DOMDocument ? spl_object_id($element->ownerDocument) : 0,
-            'path'     => $element->getNodePath() ?? '',
+        $runtimeDom->recordIsland(
+            $island,
+            $element->ownerDocument instanceof DOMDocument ? spl_object_id($element->ownerDocument) : 0,
+            $element->getNodePath() ?? ''
         );
-        $nestedIslandIndexes = array();
-        foreach ( $runtimeIslands as $index => $existing ) {
-            $existingKey = json_encode(array(
-                'kind'     => $existing['kind'] ?? '',
-                'selector' => $existing['selector'] ?? '',
-                'snippet'  => $existing['source_snippet'] ?? '',
-            ), JSON_UNESCAPED_SLASHES);
-            if ( $key === $existingKey ) {
-                return;
-            }
-
-            $existingOrigin = $this->runtimeIslandOrigins[$index] ?? null;
-            if ( ! is_array($existingOrigin)
-                || 0 === $origin['document']
-                || $origin['document'] !== ($existingOrigin['document'] ?? 0)
-                || '' === $origin['path']
-                || '' === ($existingOrigin['path'] ?? '')
-            ) {
-                continue;
-            }
-
-            $existingPath = (string) $existingOrigin['path'];
-            if ( str_starts_with($origin['path'], $existingPath . '/') ) {
-                return;
-            }
-            if ( str_starts_with($existingPath, $origin['path'] . '/') ) {
-                $nestedIslandIndexes[] = $index;
-            }
-        }
-
-        foreach ( array_reverse($nestedIslandIndexes) as $index ) {
-            array_splice($runtimeIslands, $index, 1);
-            array_splice($this->runtimeIslandOrigins, $index, 1);
-        }
-        $runtimeIslands[] = $island;
-        $this->runtimeIslandOrigins[] = $origin;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -368,6 +368,11 @@ final class HtmlTransformer
             ?? throw new \LogicException('Asset materialization state has not been prepared for this transform.');
     }
 
+    private function runtimeDom(): RuntimeDomState
+    {
+        return $this->session->runtimeDomState();
+    }
+
     /**
      * @param array<string, mixed> $options
      */
@@ -526,9 +531,9 @@ final class HtmlTransformer
             self::class,
             $this->scriptMetadata,
             $fallbacks,
-            $this->runtimeIslands,
-            array_values($this->runtimeDomPreservations),
-            array_values($this->runtimeDomFallbacks),
+            $this->runtimeDom()->islands(),
+            $this->runtimeDom()->preservations(),
+            $this->runtimeDom()->fallbacks(),
             $blockValidityReport,
             $semanticParityReport,
             $contentRoundTripReport
@@ -591,9 +596,9 @@ final class HtmlTransformer
             'available_core_blocks' => $nativeTargetBlocks,
             'core_block_capabilities' => $capabilityMatrix,
             'head_metadata' => $headMetadata,
-            'runtime_islands' => $this->runtimeIslands,
-            'runtime_dom_contracts' => array_values($this->runtimeDomPreservations),
-            'runtime_dom_fallbacks' => array_values($this->runtimeDomFallbacks),
+            'runtime_islands' => $this->runtimeDom()->islands(),
+            'runtime_dom_contracts' => $this->runtimeDom()->preservations(),
+            'runtime_dom_fallbacks' => $this->runtimeDom()->fallbacks(),
             'generated_blocks' => $this->generatedBlocks()->definitions(),
             'gutenberg_gaps' => $this->generatedBlocks()->has(DescriptionListBlockGenerator::class) ? array(
                 array(
@@ -623,7 +628,7 @@ final class HtmlTransformer
                 'structure_signals'    => $this->structureProvenance,
                 'reusable_components' => $reusableComponentRecognition,
                 'script_metadata'      => $this->scriptMetadata,
-                'runtime_islands'      => $this->runtimeIslands,
+                'runtime_islands'      => $this->runtimeDom()->islands(),
                 'layout_geometry_proof' => $this->layoutGeometry()->proofProvenance(),
             ),
         );
@@ -10620,13 +10625,7 @@ final class HtmlTransformer
     private function isPreservedRuntimeIslandElement(DOMElement $element): bool
     {
         $selector = $this->runtimeIslandSelector($element);
-        foreach ( $this->runtimeIslands as $island ) {
-            if ( is_array($island) && ($island['selector'] ?? null) === $selector ) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->runtimeDom()->hasIslandSelector($selector);
     }
 
     /**
@@ -11993,7 +11992,7 @@ final class HtmlTransformer
      */
     private function captureCanvasFallback(DOMElement $element, array &$fallbacks): void
     {
-        $this->fallbackEmitter->captureCanvasFallback($element, $fallbacks, $this->runtimeIslands);
+        $this->fallbackEmitter->captureCanvasFallback($element, $fallbacks, $this->runtimeDom());
     }
 
     private function isRuntimeCanvasTarget(DOMElement $element): bool
@@ -12365,7 +12364,7 @@ final class HtmlTransformer
      */
     private function recordRuntimeIsland(DOMElement $element, string $kind, string $reason, string $runtimeRequirement, array $metadata = array()): void
     {
-        $this->fallbackEmitter->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeIslands);
+        $this->fallbackEmitter->recordRuntimeIsland($element, $kind, $reason, $runtimeRequirement, $metadata, $this->runtimeDom());
     }
 
     private function recordNativeRuntimeDomPreservation(DOMElement $element, string $blockName, bool $includeRichTextDescendants = false): void
@@ -12380,15 +12379,7 @@ final class HtmlTransformer
         }
         foreach ($elements as $target) {
             foreach ($this->runtimeDomSelectorsForElement($target) as $selector) {
-                $key = $blockName . "\n" . $selector;
-                if (isset($this->runtimeDomPreservations[$key])) {
-                    continue;
-                }
-                $this->runtimeDomPreservations[$key] = array(
-                    'block_name' => $blockName,
-                    'tag' => strtolower($target->tagName),
-                    'selector' => $selector,
-                );
+                $this->runtimeDom()->recordPreservation($blockName, strtolower($target->tagName), $selector);
             }
         }
     }
@@ -12396,15 +12387,7 @@ final class HtmlTransformer
     private function recordRuntimeDomFallback(DOMElement $element, string $blockName): void
     {
         foreach ($this->runtimeDomSelectorsForElement($element) as $selector) {
-            $key = $blockName . "\n" . $selector;
-            if (isset($this->runtimeDomFallbacks[$key])) {
-                continue;
-            }
-            $this->runtimeDomFallbacks[$key] = array(
-                'block_name' => $blockName,
-                'tag' => strtolower($element->tagName),
-                'selector' => $selector,
-            );
+            $this->runtimeDom()->recordFallback($blockName, strtolower($element->tagName), $selector);
         }
     }
 
@@ -12506,7 +12489,7 @@ final class HtmlTransformer
      */
     private function captureScriptFallback(DOMElement $element, array &$fallbacks): void
     {
-        $this->fallbackEmitter->captureScriptFallback($element, $fallbacks, $this->runtimeIslands);
+        $this->fallbackEmitter->captureScriptFallback($element, $fallbacks, $this->runtimeDom());
     }
 
     private function captureStaticScriptMetadata(DOMElement $element): bool
@@ -12557,7 +12540,7 @@ final class HtmlTransformer
      */
     private function captureTemplateFallback(DOMElement $element, array &$fallbacks): void
     {
-        $this->fallbackEmitter->captureTemplateFallback($element, $fallbacks, $this->runtimeIslands);
+        $this->fallbackEmitter->captureTemplateFallback($element, $fallbacks, $this->runtimeDom());
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -34,9 +34,7 @@ final class HtmlTransformerSession
     public array $formControlSlotPaths = array();
     public array $structureProvenance = array();
     public array $scriptMetadata = array();
-    public array $runtimeIslands = array();
-    public array $runtimeDomPreservations = array();
-    public array $runtimeDomFallbacks = array();
+    private readonly RuntimeDomState $runtimeDomState;
     public array $nativeDisclosureRootIds = array();
     private ?GeneratedBlockRegistry $generatedBlockRegistry = null;
     public bool $emptyRuntimeTargetGenerated = false;
@@ -97,6 +95,7 @@ final class HtmlTransformerSession
         $this->fallbackEmitter = new FallbackEmitter($runtime, $sourceContextResolver);
         $this->presentationResolutionCache = new PresentationResolutionCache();
         $this->sourceStyleResolutionState = new SourceStyleResolutionState();
+        $this->runtimeDomState = new RuntimeDomState();
     }
 
     public function installAuthorStyleAnalysis(AuthorStyleAnalysis $analysis): void
@@ -137,5 +136,10 @@ final class HtmlTransformerSession
     public function assetMaterializationState(): ?AssetMaterializationState
     {
         return $this->assetMaterializationState;
+    }
+
+    public function runtimeDomState(): RuntimeDomState
+    {
+        return $this->runtimeDomState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/RuntimeDomState.php
+++ b/php-transformer/src/HtmlToBlocks/RuntimeDomState.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/** Per-transform runtime island and retained DOM contract evidence. */
+final class RuntimeDomState
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $islands = array();
+
+    /** @var array<int, array{document: int, path: string}> */
+    private array $islandOrigins = array();
+
+    /** @var array<string, array<string, string>> */
+    private array $preservations = array();
+
+    /** @var array<string, array<string, string>> */
+    private array $fallbacks = array();
+
+    /** @param array<string, mixed> $island */
+    public function recordIsland(array $island, int $document, string $path): void
+    {
+        $key = $this->islandKey($island);
+        $nestedIslandIndexes = array();
+        foreach ($this->islands as $index => $existing) {
+            if ($key === $this->islandKey($existing)) {
+                return;
+            }
+
+            $existingOrigin = $this->islandOrigins[$index] ?? null;
+            if (!is_array($existingOrigin)
+                || 0 === $document
+                || $document !== ($existingOrigin['document'] ?? 0)
+                || '' === $path
+                || '' === ($existingOrigin['path'] ?? '')
+            ) {
+                continue;
+            }
+
+            $existingPath = (string) $existingOrigin['path'];
+            if (str_starts_with($path, $existingPath . '/')) {
+                return;
+            }
+            if (str_starts_with($existingPath, $path . '/')) {
+                $nestedIslandIndexes[] = $index;
+            }
+        }
+
+        foreach (array_reverse($nestedIslandIndexes) as $index) {
+            array_splice($this->islands, $index, 1);
+            array_splice($this->islandOrigins, $index, 1);
+        }
+        $this->islands[] = $island;
+        $this->islandOrigins[] = array('document' => $document, 'path' => $path);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function islands(): array
+    {
+        return $this->islands;
+    }
+
+    public function hasIslandSelector(string $selector): bool
+    {
+        foreach ($this->islands as $island) {
+            if (($island['selector'] ?? null) === $selector) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function recordPreservation(string $blockName, string $tag, string $selector): void
+    {
+        $key = $blockName . "\n" . $selector;
+        if (isset($this->preservations[$key])) {
+            return;
+        }
+        $this->preservations[$key] = array(
+            'block_name' => $blockName,
+            'tag' => $tag,
+            'selector' => $selector,
+        );
+    }
+
+    /** @return array<int, array<string, string>> */
+    public function preservations(): array
+    {
+        return array_values($this->preservations);
+    }
+
+    public function recordFallback(string $blockName, string $tag, string $selector): void
+    {
+        $key = $blockName . "\n" . $selector;
+        if (isset($this->fallbacks[$key])) {
+            return;
+        }
+        $this->fallbacks[$key] = array(
+            'block_name' => $blockName,
+            'tag' => $tag,
+            'selector' => $selector,
+        );
+    }
+
+    /** @return array<int, array<string, string>> */
+    public function fallbacks(): array
+    {
+        return array_values($this->fallbacks);
+    }
+
+    /** @param array<string, mixed> $island */
+    private function islandKey(array $island): string|false
+    {
+        return json_encode(array(
+            'kind' => $island['kind'] ?? '',
+            'selector' => $island['selector'] ?? '',
+            'snippet' => $island['source_snippet'] ?? '',
+        ), JSON_UNESCAPED_SLASHES);
+    }
+}


### PR DESCRIPTION
## Summary

- add per-transform `RuntimeDomState` ownership for runtime islands and retained/fallback DOM contracts
- centralize duplicate and nested-island suppression with its private DOM-origin evidence
- remove three runtime evidence arrays from `HtmlTransformerSession` and parallel origin state from `FallbackEmitter`

Part of #242.

## Verification

- `composer test`
- 289 parity fixtures
- canonical HTML-to-blocks runtime-island matrix
- WordPress site-plan contract
- custom block generator: 58 assertions
- inert capture scaffolding: 11 assertions
- reused-transformer session equivalence
- packaging install proof
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced runtime-island and DOM-contract state across the transformer and fallback emitter, implemented the typed owner, and ran focused and full verification. Chris Huber directed the work and reviewed the resulting boundary.