### PR TITLE
Combine top-level stylesheet analysis passes

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2875,12 +2875,13 @@ final class HtmlTransformer
             $analysis = $this->analysisCache->style($key);
             if ( null === $analysis ) {
                 ++$this->analysisCache->styleBuilds;
+                $topLevel = $this->topLevelStyleAnalysis($payload);
                 $analysis = array(
-                    'static' => $this->staticStyleRules('', $payload),
+                    'static' => $topLevel['static'],
                     'conditional' => $this->conditionalStyleRules('', $payload),
-                    'navigation_state' => $this->navigationStateStyleRules('', $payload),
+                    'navigation_state' => $topLevel['navigation_state'],
                     'image_shape' => $this->imageShapeStyleRules('', $payload),
-                    'pseudo' => $this->staticPseudoElementStyleRules('', $payload),
+                    'pseudo' => $topLevel['pseudo'],
                     'custom_properties' => $this->cssCustomPropertyAnalysis($payload),
                 );
                 $this->analysisCache->rememberStyle($key, $analysis);

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -1980,30 +1980,33 @@ trait StyleResolutionTrait
     }
 
     /**
-     * @return array<int, array{selector: string, declarations: array<string, string>, mediaTextDeclarations: list<array{property: string, value: string, important: bool}>, mediaTextSpecificity: array{int, int, int}}>
+     * Build immutable resting, interaction, and pseudo-element rule streams
+     * together so each payload is scanned and parsed once.
+     *
+     * @return array{
+     *     static: list<array{selector: string, declarations: array<string, string>, mediaTextDeclarations: list<array{property: string, value: string, important: bool}>, mediaTextSpecificity: array{int, int, int}}>,
+     *     navigation_state: list<array{selector: string, base_selector: string, state: string, declarations: array<string, string>}>,
+     *     pseudo: list<array{selector: string, pseudo: string, declarations: array<string, string>}>
+     * }
      */
-    private function staticStyleRules(string $html, string $linkedCss): array
+    private function topLevelStyleAnalysis(string $css): array
     {
-        $css = trim($linkedCss);
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map('trim', $matches[1]));
-        }
-
+        $analysis = array('static' => array(), 'navigation_state' => array(), 'pseudo' => array());
         if ( '' === trim($css) ) {
-            return array();
+            return $analysis;
         }
 
         $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
         $css = $this->topLevelCssRules($css);
-        $rules = array();
         if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
-            return array();
+            return $analysis;
         }
 
         foreach ( $matches as $match ) {
-            $declarations = $this->safeVisualDeclarations($this->cssDeclarations((string) $match[2]));
+            $body = (string) $match[2];
+            $declarations = $this->safeVisualDeclarations($this->cssDeclarations($body));
             $mediaTextDeclarations = array_values(array_filter(
-                $this->mediaTextInlineDeclarationEntries((string) $match[2]),
+                $this->mediaTextInlineDeclarationEntries($body),
                 static fn (array $entry): bool => in_array($entry['property'], array(
                     'align-items',
                     'direction',
@@ -2017,83 +2020,49 @@ trait StyleResolutionTrait
                     'width',
                 ), true)
             ));
-            if ( array() === $declarations && array() === $mediaTextDeclarations ) {
-                continue;
-            }
             foreach ( explode(',', (string) $match[1]) as $selector ) {
                 $selector = trim($selector);
-                if ( '' !== $selector && ! $this->selectorCarriesPseudoState($selector) && $this->isSupportedCssSelector($selector) ) {
-                    $rules[] = array(
+                if ( ( array() !== $declarations || array() !== $mediaTextDeclarations )
+                    && '' !== $selector
+                    && ! $this->selectorCarriesPseudoState($selector)
+                    && $this->isSupportedCssSelector($selector)
+                ) {
+                    $analysis['static'][] = array(
                         'selector' => $selector,
                         'declarations' => $declarations,
                         'mediaTextDeclarations' => $mediaTextDeclarations,
                         'mediaTextSpecificity' => $this->mediaTextSelectorSpecificity($selector),
                     );
                 }
-            }
-        }
-
-        return $rules;
-    }
-
-    /**
-     * Keep top-level interaction rules separate from resting-style resolution.
-     * Navigation conversion uses these to yield a resting colour only for
-     * states where an authored colour replacement exists, and to re-point
-     * anchor-class selectors after core moves that class onto the item.
-     *
-     * Multi-state selectors fail closed. Treating `:hover:focus` as either
-     * independent state would remove the resting colour too broadly.
-     *
-     * @return list<array{selector: string, base_selector: string, state: string, declarations: array<string, string>}>
-     */
-    private function navigationStateStyleRules(string $html, string $linkedCss): array
-    {
-        $css = trim($linkedCss);
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            $css .= ('' === $css ? '' : "\n") . implode("\n", array_map('trim', $matches[1]));
-        }
-        if ( '' === trim($css) ) {
-            return array();
-        }
-
-        $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
-        $css = $this->topLevelCssRules($css);
-        if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
-            return array();
-        }
-
-        $rules = array();
-        foreach ( $matches as $match ) {
-            $declarations = $this->safeVisualDeclarations($this->cssDeclarations((string) $match[2]));
-            if ( array() === $declarations ) {
-                continue;
-            }
-            foreach ( explode(',', (string) $match[1]) as $selector ) {
-                $selector = trim($selector);
-                if ( '' === $selector
-                    || 1 !== preg_match_all('/:(hover|focus-visible|focus|active)\b/i', $selector, $stateMatches, PREG_OFFSET_CAPTURE)
+                if ( array() !== $declarations
+                    && 1 === preg_match_all('/:(hover|focus-visible|focus|active)\b/i', $selector, $stateMatches, PREG_OFFSET_CAPTURE)
                 ) {
-                    continue;
+                    $state = strtolower((string) $stateMatches[1][0][0]);
+                    $offset = (int) $stateMatches[0][0][1];
+                    $baseSelector = trim(substr_replace($selector, '', $offset, strlen((string) $stateMatches[0][0][0])));
+                    if ( '' !== $baseSelector && ! $this->selectorCarriesPseudoState($baseSelector) && $this->isSupportedCssSelector($baseSelector) ) {
+                        $analysis['navigation_state'][] = array(
+                            'selector' => $selector,
+                            'base_selector' => $baseSelector,
+                            'state' => $state,
+                            'declarations' => $declarations,
+                        );
+                    }
                 }
-
-                $state = strtolower((string) $stateMatches[1][0][0]);
-                $offset = (int) $stateMatches[0][0][1];
-                $baseSelector = trim(substr_replace($selector, '', $offset, strlen((string) $stateMatches[0][0][0])));
-                if ( '' === $baseSelector || $this->selectorCarriesPseudoState($baseSelector) || ! $this->isSupportedCssSelector($baseSelector) ) {
-                    continue;
+                if ( array() !== $declarations && preg_match('/::?(before|after)\b/i', $selector, $pseudoMatch) ) {
+                    $baseSelector = trim((string) preg_replace('/::?(?:before|after)\b/i', '', $selector));
+                    if ( '' !== $baseSelector && ! $this->selectorCarriesPseudoState($baseSelector) && $this->isSupportedCssSelector($baseSelector) ) {
+                        $analysis['pseudo'][] = array(
+                            'selector' => $baseSelector,
+                            'pseudo' => strtolower($pseudoMatch[1]),
+                            'declarations' => $declarations,
+                        );
+                    }
                 }
-
-                $rules[] = array(
-                    'selector' => $selector,
-                    'base_selector' => $baseSelector,
-                    'state' => $state,
-                    'declarations' => $declarations,
-                );
             }
         }
 
-        return $rules;
+        return $analysis;
     }
 
     /**
@@ -2301,53 +2270,6 @@ trait StyleResolutionTrait
         }
 
         return null;
-    }
-
-    /**
-     * @return array<int, array{selector: string, pseudo: string, declarations: array<string, string>}>
-     */
-    private function staticPseudoElementStyleRules(string $html, string $linkedCss): array
-    {
-        $css = trim($linkedCss);
-        if ( preg_match_all('@<style\b[^>]*>(.*?)</style>@is', $html, $matches) ) {
-            $css .= ( '' === $css ? '' : "\n" ) . implode("\n", array_map('trim', $matches[1]));
-        }
-
-        if ( '' === trim($css) ) {
-            return array();
-        }
-
-        $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
-        $css = $this->topLevelCssRules($css);
-        $rules = array();
-        if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
-            return array();
-        }
-
-        foreach ( $matches as $match ) {
-            $declarations = $this->safeVisualDeclarations($this->cssDeclarations((string) $match[2]));
-            if ( array() === $declarations ) {
-                continue;
-            }
-
-            foreach ( explode(',', (string) $match[1]) as $selector ) {
-                $selector = trim($selector);
-                if ( ! preg_match('/::?(before|after)\b/i', $selector, $pseudoMatch) ) {
-                    continue;
-                }
-
-                $baseSelector = trim((string) preg_replace('/::?(?:before|after)\b/i', '', $selector));
-                if ( '' !== $baseSelector && ! $this->selectorCarriesPseudoState($baseSelector) && $this->isSupportedCssSelector($baseSelector) ) {
-                    $rules[] = array(
-                        'selector'     => $baseSelector,
-                        'pseudo'       => strtolower($pseudoMatch[1]),
-                        'declarations' => $declarations,
-                    );
-                }
-            }
-        }
-
-        return $rules;
     }
 
     private function topLevelCssRules(string $css): string

--- a/php-transformer/tests/unit/block-style-support-conversion.php
+++ b/php-transformer/tests/unit/block-style-support-conversion.php
@@ -362,8 +362,8 @@ $assert('pricing-card' === ($paintAttrs['className'] ?? ''), '39: high-value car
 $assert(! isset($paintAttrs['style']['box-shadow']), '40: class-owned box-shadow is not stored as an unsupported block style attr', json_encode($paintAttrs['style'] ?? array()));
 $assert(! isset($paintAttrs['style']['background-position']) && ! isset($paintAttrs['style']['background-size']), '41: background layer controls stay out of block style attrs', json_encode($paintAttrs['style'] ?? array()));
 
-$rulesMethod = new ReflectionMethod(HtmlTransformer::class, 'staticStyleRules');
-$paintRules = $rulesMethod->invoke(new HtmlTransformer(), '', $paintCss);
+$rulesMethod = new ReflectionMethod(HtmlTransformer::class, 'topLevelStyleAnalysis');
+$paintRules = $rulesMethod->invoke(new HtmlTransformer(), $paintCss)['static'];
 $paintDeclarations = $paintRules[0]['declarations'] ?? array();
 
 $assert(($paintDeclarations['background'] ?? '') === 'radial-gradient(circle at 20% 10%,rgba(255,255,255,.9),rgba(255,255,255,0) 38%),linear-gradient(180deg,#fff,#f5efe4)', '42: radial and layered backgrounds survive safe CSS resolution', json_encode($paintDeclarations));


### PR DESCRIPTION
## Summary

- collect resting, navigation-state, and pseudo-element rules from one top-level stylesheet scan
- parse safe visual declarations once per rule body and share the immutable result across all three outputs
- remove the three duplicate analysis methods and update the direct rule-stream contract

Related to #1044.

## Evidence

A 2,002-rule synthetic payload produced byte-identical cached analysis before and after this change: SHA-256 `469977f54454207fe8c1031d9b2d4d6962513bd92ee205bd1176ffc72017919b`, 476,258 serialized bytes.

Five direct benchmark runs measured the owning primitive rather than noisy whole-transform wall time:

- trunk, three passes: 56.8, 46.7, 45.9, 51.4, 49.7 ms
- branch, one pass: 44.1, 28.9, 26.9, 24.6, 26.0 ms
- median: 49.7 ms to 26.9 ms, 45.9% lower

This is a bounded stylesheet-analysis simplification, not a claim that corpus compilation is now complete.

## Verification

- `composer validate --strict`
- `composer test`
- 289 PHP transformer parity fixtures
- PHP package install proof
- targeted author selector, navigation rule, stylesheet projection, engine support, and block style support contracts
- `git diff --check`

## AI Assistance

GPT-5.6-sol was used through OpenCode to trace duplicate stylesheet analysis passes, benchmark rejected and accepted approaches, implement the one-pass primitive, and run repository verification. Chris Huber reviewed and directed the work.