### PR TITLE
Refactor: isolate runtime selector state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
+++ b/php-transformer/src/HtmlToBlocks/Diagnostics/FallbackEmitter.php
@@ -9,6 +9,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\CustomBlockGenerator;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\FallbackDiagnostic;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\GeneratedBlockRegistry;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RuntimeDomState;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\RuntimeSelectorState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
 use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
 use Closure;
@@ -33,7 +34,7 @@ use DOMElement;
  *  - Fallback and script accumulators stay owned by HtmlTransformer. Runtime
  *    island evidence is recorded through the per-transform RuntimeDomState.
  *  - Per-document configuration (`fallbackProvenance`, `runtimeScriptMetadata`,
- *    `runtimeCanvasSelectors`) is injected via {@see configure()} once per
+ *    `RuntimeSelectorState`) is injected via {@see configure()} once per
  *    transform.
  *  - `sourceContext()` enrichment is deeply entangled with the transformer's
  *    DOM-classification subsystem (structure signals, interactive attributes,
@@ -61,10 +62,7 @@ final class FallbackEmitter
      */
     private array $runtimeScriptMetadata = array();
 
-    /**
-     * @var array<string, bool>
-     */
-    private array $runtimeCanvasSelectors = array();
+    private RuntimeSelectorState $runtimeSelectors;
 
     /** @var array<string, string> */
     private array $sourceTagMarkers = array();
@@ -107,6 +105,7 @@ final class FallbackEmitter
     ) {
         $this->classifier     = new SubtreeClassifier();
         $this->blockGenerator = new CustomBlockGenerator();
+        $this->runtimeSelectors = new RuntimeSelectorState(array(), array(), array());
     }
 
     /**
@@ -360,14 +359,13 @@ final class FallbackEmitter
      *
      * @param array<string, string>             $fallbackProvenance
      * @param array<int, array<string, mixed>>  $runtimeScriptMetadata
-     * @param array<string, bool>               $runtimeCanvasSelectors
      * @param array<string, string>             $sourceTagMarkers
      */
-    public function configure(array $fallbackProvenance, array $runtimeScriptMetadata, array $runtimeCanvasSelectors, array $sourceTagMarkers = array()): void
+    public function configure(array $fallbackProvenance, array $runtimeScriptMetadata, RuntimeSelectorState $runtimeSelectors, array $sourceTagMarkers = array()): void
     {
         $this->fallbackProvenance     = $fallbackProvenance;
         $this->runtimeScriptMetadata  = $runtimeScriptMetadata;
-        $this->runtimeCanvasSelectors = $runtimeCanvasSelectors;
+        $this->runtimeSelectors       = $runtimeSelectors;
         $this->sourceTagMarkers       = $sourceTagMarkers;
     }
 
@@ -636,23 +634,28 @@ final class FallbackEmitter
     public function isRuntimeCanvasTarget(DOMElement $element): bool
     {
         $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && isset($this->runtimeCanvasSelectors['#' . $id]) ) {
+        if ( '' !== $id && $this->runtimeSelectors()->hasCanvas('#' . $id) ) {
             return true;
         }
 
         foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class && isset($this->runtimeCanvasSelectors['.' . $class]) ) {
+            if ( '' !== $class && $this->runtimeSelectors()->hasCanvas('.' . $class) ) {
                 return true;
             }
         }
 
-        foreach ( array_keys($this->runtimeCanvasSelectors) as $selector ) {
+        foreach ( array_keys($this->runtimeSelectors()->canvasSelectors()) as $selector ) {
             if ( $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function runtimeSelectors(): RuntimeSelectorState
+    {
+        return $this->runtimeSelectors;
     }
 
     private function elementMatchesRuntimeSelector(DOMElement $element, string $selector): bool

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -373,6 +373,11 @@ final class HtmlTransformer
         return $this->session->runtimeDomState();
     }
 
+    private function runtimeSelectors(): RuntimeSelectorState
+    {
+        return $this->session->runtimeSelectorState();
+    }
+
     /**
      * @param array<string, mixed> $options
      */
@@ -403,13 +408,15 @@ final class HtmlTransformer
         $this->staticPseudoElementStyleRules = $styleAnalysis['pseudo'];
         $this->cssCustomProperties = $styleAnalysis['custom_properties'];
         $this->resetPresentationResolutionCache();
-        $this->runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
-        $this->runtimeBehavioralSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_behavioral_selectors');
-        $this->runtimeCanvasSelectors = $this->runtimeCanvasSelectorsFromOptions($options);
+        $runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
+        $this->session->installRuntimeSelectorState(new RuntimeSelectorState(
+            $runtimeDomSelectors,
+            $this->runtimeSelectorsFromOptions($options, 'runtime_behavioral_selectors'),
+            $this->runtimeCanvasSelectorsFromOptions($options)
+        ));
         $this->session->installLayoutGeometryState(new LayoutGeometryState(
             is_array($options['layout_geometry_proof']['reductions'] ?? null) ? $options['layout_geometry_proof']['reductions'] : array()
         ));
-        $this->supersededRuntimeSelectors = array();
         $this->nextSourceProvenanceId = 1;
         $provenance               = array(
             array_merge(array(
@@ -482,7 +489,7 @@ final class HtmlTransformer
         $this->navigationBlockNormalizer->hydrateDuplicateSubmenus($body);
         $this->materializeDeclarativeCounters($body, (string) ($options['declarative_state_html'] ?? ''));
         $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
-        $this->fallbackEmitter->configure($this->fallbackProvenance, $this->runtimeScriptMetadata, $this->runtimeCanvasSelectors, $this->sourceTagMarkers);
+        $this->fallbackEmitter->configure($this->fallbackProvenance, $this->runtimeScriptMetadata, $this->runtimeSelectors(), $this->sourceTagMarkers);
         // Author-selector preparation marks source nodes for later projection.
         // General style matching begins only after those source mutations settle.
         $this->invalidateSourceSelectorMatchCache();
@@ -611,7 +618,7 @@ final class HtmlTransformer
                 ),
             ) : array(),
             'interaction_candidates' => $interactionCandidates,
-            'superseded_selectors' => array_keys($this->supersededRuntimeSelectors),
+            'superseded_selectors' => $this->runtimeSelectors()->supersededSelectors(),
             'shell_artifacts' => $shellArtifacts,
             'wp_block_validity' => $blockValidityReport,
             'semantic_parity' => $semanticParityReport,
@@ -12012,17 +12019,17 @@ final class HtmlTransformer
     private function isRuntimeDomTarget(DOMElement $element): bool
     {
         $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && isset($this->runtimeDomSelectors['#' . $id]) && ! $this->isPresentationalRuntimeSelector('#' . $id) ) {
+        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) && ! $this->isPresentationalRuntimeSelector('#' . $id) ) {
             return true;
         }
 
         foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
-            if ( '' !== $class && isset($this->runtimeDomSelectors['.' . $class]) && ! $this->isPresentationalRuntimeSelector('.' . $class) ) {
+            if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) && ! $this->isPresentationalRuntimeSelector('.' . $class) ) {
                 return true;
             }
         }
 
-        foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
+        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
             if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
@@ -12036,9 +12043,9 @@ final class HtmlTransformer
     {
         $selectors = array();
         $id = trim($this->attr($element, 'id'));
-        if ( '' !== $id && isset($this->runtimeDomSelectors['#' . $id]) ) $selectors[] = '#' . $id;
-        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) if ( '' !== $class && isset($this->runtimeDomSelectors['.' . $class]) ) $selectors[] = '.' . $class;
-        foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
+        if ( '' !== $id && $this->runtimeSelectors()->hasDom('#' . $id) ) $selectors[] = '#' . $id;
+        foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) if ( '' !== $class && $this->runtimeSelectors()->hasDom('.' . $class) ) $selectors[] = '.' . $class;
+        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
             if ( str_starts_with((string) $selector, '.') || str_starts_with((string) $selector, '#') || strtolower((string) $selector) === strtolower($element->tagName) ) continue;
             if ( ! $this->isPresentationalRuntimeSelector((string) $selector) && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) $selectors[] = (string) $selector;
         }
@@ -12047,7 +12054,7 @@ final class HtmlTransformer
 
     private function shouldPreserveRuntimeAppShell(DOMElement $element): bool
     {
-        if ( array() === $this->runtimeDomSelectors && array() === $this->runtimeCanvasSelectors ) {
+        if ( ! $this->runtimeSelectors()->hasRuntimeTargets() ) {
             return false;
         }
 
@@ -12305,7 +12312,7 @@ final class HtmlTransformer
             return false;
         }
 
-        foreach ( array_keys($this->runtimeDomSelectors) as $selector ) {
+        foreach ( array_keys($this->runtimeSelectors()->domSelectors()) as $selector ) {
             if ( str_contains((string) $selector, '[') && $this->elementMatchesRuntimeSelector($element, (string) $selector) ) {
                 return true;
             }
@@ -12340,7 +12347,7 @@ final class HtmlTransformer
 
     private function isPresentationalRuntimeSelector(string $selector): bool
     {
-        return $this->isPresentationalAnimationSelector($selector) && ! isset($this->runtimeBehavioralSelectors[$selector]);
+        return $this->isPresentationalAnimationSelector($selector) && ! $this->runtimeSelectors()->hasBehavioral($selector);
     }
 
     private function elementMatchesRuntimeSelector(DOMElement $element, string $selector): bool
@@ -12506,7 +12513,7 @@ final class HtmlTransformer
     {
         $id = trim($this->attr($element, 'id'));
         $type = strtolower(trim($this->attr($element, 'type')));
-        if ( '' === $id || ! in_array($type, array('application/json', 'application/ld+json'), true) || ! isset($this->runtimeDomSelectors['#' . $id]) ) {
+        if ( '' === $id || ! in_array($type, array('application/json', 'application/ld+json'), true) || ! $this->runtimeSelectors()->hasDom('#' . $id) ) {
             return false;
         }
 
@@ -15265,7 +15272,7 @@ final class HtmlTransformer
 
     private function isDeclaredRuntimeDomTarget(DOMElement $element): bool
     {
-        foreach (array_keys($this->runtimeDomSelectors) as $selector) {
+        foreach (array_keys($this->runtimeSelectors()->domSelectors()) as $selector) {
             if (str_starts_with((string) $selector, '#') && substr((string) $selector, 1) === $this->attr($element, 'id')) {
                 return true;
             }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -57,10 +57,7 @@ final class HtmlTransformerSession
     public array $buttonWrapperSpacingFallbacks = array();
     public array $imageShapeStyleRules = array();
     public array $staticPseudoElementStyleRules = array();
-    public array $runtimeDomSelectors = array();
-    public array $runtimeBehavioralSelectors = array();
-    public array $runtimeCanvasSelectors = array();
-    public array $supersededRuntimeSelectors = array();
+    private RuntimeSelectorState $runtimeSelectorState;
     public array $sourceTagMarkers = array();
     public array $sourceControlMarkers = array();
     public array $directFlexButtonStyleRules = array();
@@ -96,6 +93,7 @@ final class HtmlTransformerSession
         $this->presentationResolutionCache = new PresentationResolutionCache();
         $this->sourceStyleResolutionState = new SourceStyleResolutionState();
         $this->runtimeDomState = new RuntimeDomState();
+        $this->runtimeSelectorState = new RuntimeSelectorState(array(), array(), array());
     }
 
     public function installAuthorStyleAnalysis(AuthorStyleAnalysis $analysis): void
@@ -141,5 +139,15 @@ final class HtmlTransformerSession
     public function runtimeDomState(): RuntimeDomState
     {
         return $this->runtimeDomState;
+    }
+
+    public function installRuntimeSelectorState(RuntimeSelectorState $state): void
+    {
+        $this->runtimeSelectorState = $state;
+    }
+
+    public function runtimeSelectorState(): RuntimeSelectorState
+    {
+        return $this->runtimeSelectorState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/RuntimeSelectorState.php
+++ b/php-transformer/src/HtmlToBlocks/RuntimeSelectorState.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/** Per-transform declared and superseded runtime selectors. */
+final class RuntimeSelectorState
+{
+    /** @var array<string, true> */
+    private array $superseded = array();
+
+    /**
+     * @param array<string, bool> $dom
+     * @param array<string, bool> $behavioral
+     * @param array<string, bool> $canvas
+     */
+    public function __construct(
+        private readonly array $dom,
+        private readonly array $behavioral,
+        private readonly array $canvas
+    ) {
+    }
+
+    /** @return array<string, bool> */
+    public function domSelectors(): array
+    {
+        return $this->dom;
+    }
+
+    /** @return array<string, bool> */
+    public function canvasSelectors(): array
+    {
+        return $this->canvas;
+    }
+
+    public function hasDom(string $selector): bool
+    {
+        return isset($this->dom[$selector]);
+    }
+
+    public function hasBehavioral(string $selector): bool
+    {
+        return isset($this->behavioral[$selector]);
+    }
+
+    public function hasCanvas(string $selector): bool
+    {
+        return isset($this->canvas[$selector]);
+    }
+
+    public function hasRuntimeTargets(): bool
+    {
+        return array() !== $this->dom || array() !== $this->canvas;
+    }
+
+    public function supersede(string $selector): void
+    {
+        $this->superseded[$selector] = true;
+    }
+
+    /** @return array<int, string> */
+    public function supersededSelectors(): array
+    {
+        return array_keys($this->superseded);
+    }
+}

--- a/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/NavigationToggleSuppressionTrait.php
@@ -230,7 +230,7 @@ trait NavigationToggleSuppressionTrait
                 continue;
             }
 
-            $this->supersededRuntimeSelectors['#' . $controlledId] = true;
+            $this->runtimeSelectors()->supersede('#' . $controlledId);
 
             $target = $this->elementWithId($toggle, $controlledId);
             if ( $target instanceof DOMElement && ! $target->isSameNode($toggle) ) {
@@ -303,12 +303,12 @@ trait NavigationToggleSuppressionTrait
     {
         $id = trim($this->attr($element, 'id'));
         if ( '' !== $id ) {
-            $this->supersededRuntimeSelectors['#' . $id] = true;
+            $this->runtimeSelectors()->supersede('#' . $id);
         }
 
         foreach ( preg_split('/\s+/', trim($this->attr($element, 'class'))) ?: array() as $class ) {
             if ( '' !== $class ) {
-                $this->supersededRuntimeSelectors['.' . $class] = true;
+                $this->runtimeSelectors()->supersede('.' . $class);
             }
         }
     }


### PR DESCRIPTION
## Summary

- add per-transform `RuntimeSelectorState` ownership for DOM, behavioral, canvas, and superseded selectors
- route navigation suppression and runtime target queries through the typed selector owner
- remove four selector arrays from `HtmlTransformerSession` and the duplicated canvas-selector array from `FallbackEmitter`

Part of #242.

## Verification

- `composer test`
- 289 parity fixtures
- canonical HTML-to-blocks runtime selector matrix
- standalone core HTML fallback reduction: 9 assertions
- WordPress site-plan contract
- navigation inert/direct-cluster contracts
- reused-transformer session equivalence
- packaging install proof
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced runtime selector inputs and supersession across the transformer, navigation suppression, and fallback emitter; implemented the typed owner; and ran focused and full verification. Chris Huber directed the work and reviewed the resulting boundary.