### PR TITLE
Refactor source style resolution state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -57,6 +57,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodat
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\SourceStyleResolutionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\ButtonLinkDispatchTrait;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\DomHelpersTrait;
@@ -378,6 +379,11 @@ final class HtmlTransformer
         return $this->session->runtimeSelectorState();
     }
 
+    private function sourceStyles(): SourceStyleResolutionState
+    {
+        return $this->session->sourceStyleResolutionState();
+    }
+
     /**
      * @param array<string, mixed> $options
      */
@@ -398,15 +404,9 @@ final class HtmlTransformer
         $this->preserveShellLandmarks = !empty($options['extract_global_shell']);
         $this->fallbackReductionMode = !empty($options['fallback_reduction_mode']);
         $this->runtimeScriptMetadata = $this->runtimeScriptMetadataFromOptions($options);
-        $this->staticClassPromotions = $this->detectStaticClassPromotions($html);
         $staticCss = (string) ($options['static_css'] ?? '');
         $styleAnalysis = $this->composedStyleAnalysis($this->stylesheetPayloads($html, $staticCss, $options));
-        $this->staticStyleRules = $styleAnalysis['static'];
-        $this->conditionalStyleRules = $styleAnalysis['conditional'];
-        $this->navigationStateStyleRules = $styleAnalysis['navigation_state'];
-        $this->imageShapeStyleRules = $styleAnalysis['image_shape'];
-        $this->staticPseudoElementStyleRules = $styleAnalysis['pseudo'];
-        $this->cssCustomProperties = $styleAnalysis['custom_properties'];
+        $this->sourceStyles()->installStylesheetAnalysis($this->detectStaticClassPromotions($html), $styleAnalysis);
         $this->resetPresentationResolutionCache();
         $runtimeDomSelectors = $this->runtimeSelectorsFromOptions($options, 'runtime_dom_selectors');
         $this->session->installRuntimeSelectorState(new RuntimeSelectorState(
@@ -859,7 +859,7 @@ final class HtmlTransformer
      */
     private function metrics(string $input, array $blocks, string $output, array $fallbacks, array $diagnostics, int $startedAt): array
     {
-        $selectorCache = $this->session->sourceStyleResolutionState->selectorMatchCache;
+        $selectorCache = $this->sourceStyles()->selectorMatchCache;
         return array(
             'input_bytes'           => strlen($input),
             'block_count'           => $this->countBlocks($blocks),
@@ -1402,7 +1402,7 @@ final class HtmlTransformer
         }
 
         $rules = array();
-        foreach ( array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule ) {
+        foreach ( array_merge($this->sourceStyles()->staticRules(), $this->sourceStyles()->conditionalRules()) as $rule ) {
             $selector = trim((string) ($rule['selector'] ?? ''));
             if ( 1 !== preg_match('/^\.([A-Za-z_][A-Za-z0-9_-]*)$/', $selector, $match) ) {
                 continue;
@@ -2197,7 +2197,7 @@ final class HtmlTransformer
     private function navigationColorInteractionStates(DOMElement $element): array
     {
         $matched = array();
-        foreach ( $this->navigationStateStyleRules as $rule ) {
+        foreach ( $this->sourceStyles()->navigationStateRules() as $rule ) {
             if ( ! isset($rule['declarations']['color'])
                 || ! $this->matchesCssSelector($element, $rule['base_selector'])
             ) {
@@ -2494,7 +2494,7 @@ final class HtmlTransformer
     private function sourceMobileNavigationOverlayBackground(): string
     {
         $background = '';
-        foreach ( array_merge($this->staticStyleRules, $this->conditionalStyleRules) as $rule ) {
+        foreach ( array_merge($this->sourceStyles()->staticRules(), $this->sourceStyles()->conditionalRules()) as $rule ) {
             $selector = strtolower((string) ($rule['selector'] ?? ''));
             if ( ! str_contains($selector, 'nav') || ! preg_match('/(?:^|[^a-z0-9])(?:mobile|drawer|offcanvas|overlay|menu-panel|nav-panel)(?:[^a-z0-9]|$)/', $selector) ) {
                 continue;
@@ -2527,7 +2527,7 @@ final class HtmlTransformer
             ? $this->combinedAuthorStylesheet($html, $staticCss)
             : implode("\n\n", array_column($stylesheetAssets, 'content'));
         $this->session->installAuthorStyleAnalysis(new AuthorStyleAnalysis($html, $combinedAuthorCss, $stylesheetAssets, $sourceBody));
-        $this->formLayoutCss = $combinedAuthorCss;
+        $this->sourceStyles()->setFormLayoutCss($combinedAuthorCss);
 
         if ( '' === $combinedAuthorCss ) {
             return;
@@ -3625,7 +3625,7 @@ final class HtmlTransformer
     /** @return array<string, mixed> */
     private function parsedCssSelector(string $selector): array
     {
-        return $this->parsedCssSelectors[$selector] ??= CssSelectorMatcher::parse($selector);
+        return $this->sourceStyles()->parsedSelector($selector);
     }
 
     /** @param array<string, mixed> $parsed @return list<DOMElement> */
@@ -4374,7 +4374,7 @@ final class HtmlTransformer
             $item,
             $anchor,
             fn (DOMElement $element): array => $this->presentationDeclarations($element),
-            $this->staticPseudoElementStyleRules,
+            $this->sourceStyles()->pseudoElementRules(),
             fn (DOMElement $element, string $selector): bool => $this->matchesCssSelector($element, $selector)
         );
     }
@@ -6304,7 +6304,7 @@ final class HtmlTransformer
                 $parsed = $selector['direct_child_parsed'];
                 $last = count($parsed['compounds'] ?? array()) - 1;
                 if ( $parsed['supported'] && $last >= 1 && '>' === ($parsed['combinators'][$last - 1] ?? '')
-                    && ($this->session->sourceStyleResolutionState->selectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $parsed, true)['matches'] ) {
+                    && ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $parsed, true)['matches'] ) {
                     return true;
                 }
             }
@@ -7826,13 +7826,13 @@ final class HtmlTransformer
 
     private function promotedClassName(string $className): string
     {
-        if ( '' === trim($className) || array() === $this->staticClassPromotions ) {
+        if ( '' === trim($className) || ! $this->sourceStyles()->hasClassPromotions() ) {
             return $this->presentationClassName($className);
         }
 
         $classes = preg_split('/\s+/', trim($className)) ?: array();
         foreach ( $classes as $class ) {
-            foreach ( $this->staticClassPromotions[$class] ?? array() as $terminalClass ) {
+            foreach ( $this->sourceStyles()->classPromotions($class) as $terminalClass ) {
                 if ( ! in_array($terminalClass, $classes, true) ) {
                     $classes[] = $terminalClass;
                 }
@@ -8118,7 +8118,7 @@ final class HtmlTransformer
             if ( isset($matchedRules[$ruleOrder])
                 || ! ($candidate['parsed']['supported'] ?? false)
                 || null !== ($candidate['parsed']['pseudo_state_suffix_span'] ?? null)
-                || ! ($this->session->sourceStyleResolutionState->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $candidate['selector'], $candidate['parsed'])['matches']
+                || ! ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $candidate['selector'], $candidate['parsed'])['matches']
             ) {
                 continue;
             }
@@ -8250,7 +8250,7 @@ final class HtmlTransformer
             if ( isset($matchedRules[$ruleOrder]) || ! $selector['parsed']['supported'] ) {
                 continue;
             }
-            if ( ($this->session->sourceStyleResolutionState->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $selector['selector'], $selector['parsed'], true)['matches'] ) {
+            if ( ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $selector['selector'], $selector['parsed'], true)['matches'] ) {
                 $matchedRules[$ruleOrder] = true;
                 $declarations = $this->mergeCssDeclarationMaps($declarations, $selector['declarations']);
             }
@@ -8262,7 +8262,7 @@ final class HtmlTransformer
     private function authorStyleRuleCandidates(DOMElement $element): array
     {
         $index = $this->authorStyles()->styleRuleCandidateIndex();
-        return ($this->session->sourceStyleResolutionState->selectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, 'author-rules', $index);
+        return ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, 'author-rules', $index);
     }
 
     private function selectorMatchingSurvivesWrapperCoalescing(DOMElement $element, DOMElement $child, bool $exact = false): bool
@@ -8294,7 +8294,7 @@ final class HtmlTransformer
         foreach ( $beforeCandidates as $selector ) {
             $matchesBefore[$selector['key']] = $selector['parsed']['supported'] && (bool) array_filter(
                 $chain,
-                fn (DOMElement $node): bool => ($this->session->sourceStyleResolutionState->selectorMatchCache ??= new CssSelectorMatchCache())->matches($node, $selector['selector'], $selector['parsed'], true)['matches']
+                fn (DOMElement $node): bool => ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($node, $selector['selector'], $selector['parsed'], true)['matches']
             );
         }
 
@@ -8315,7 +8315,7 @@ final class HtmlTransformer
         }
         foreach ( $candidates as $key => $selector ) {
             $matchesAfter = $selector['parsed']['supported']
-                && ($this->session->sourceStyleResolutionState->selectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $selector['parsed'], true)['matches'];
+                && ($this->sourceStyles()->selectorMatchCache ??= new CssSelectorMatchCache())->matches($child, $selector['selector'], $selector['parsed'], true)['matches'];
             if ( ($matchesBefore[$key] ?? false) !== $matchesAfter && ($exact || ! $this->hasOnlyRenderNeutralDeclarations($selector['declarations'])) ) {
                 $survives = false;
                 break;
@@ -8426,7 +8426,7 @@ final class HtmlTransformer
 
     private function hasStaticPseudoElementRule(DOMElement $element): bool
     {
-        foreach ( $this->staticPseudoElementStyleRules as $rule ) {
+        foreach ( $this->sourceStyles()->pseudoElementRules() as $rule ) {
             if ( $this->matchesCssSelector($element, $rule['selector']) ) {
                 return true;
             }
@@ -8552,7 +8552,7 @@ final class HtmlTransformer
                 return $attrs;
             }
         }
-        foreach ( $this->staticPseudoElementStyleRules as $rule ) {
+        foreach ( $this->sourceStyles()->pseudoElementRules() as $rule ) {
             if ( $this->matchesCssSelector($element, $rule['selector']) && array_intersect_key($rule['declarations'], array_flip(array( 'content', 'display', 'width', 'min-width' ))) ) {
                 return $attrs;
             }
@@ -10858,7 +10858,7 @@ final class HtmlTransformer
             return true;
         }
 
-        foreach ( $this->staticPseudoElementStyleRules as $rule ) {
+        foreach ( $this->sourceStyles()->pseudoElementRules() as $rule ) {
             if ( $this->matchesCssSelector($figure, $rule['selector']) && $this->hasVisibleEmptyVisualPaint($rule['declarations'], $figure) ) {
                 return true;
             }
@@ -13549,7 +13549,7 @@ final class HtmlTransformer
     {
         $controls = $this->formControls($element);
         $controlTopology = $this->formControlTopology($element);
-        $layoutGraph = (new FormLayoutGraphBuilder())->build($element, $this->authorStyles()->stylesheetAssets(), $this->formLayoutCss);
+        $layoutGraph = (new FormLayoutGraphBuilder())->build($element, $this->authorStyles()->stylesheetAssets(), $this->sourceStyles()->formLayoutCss());
         $boundedHtml = $this->boundedFallbackHtml($this->safeFallbackHtml($element));
         $replacesRuntimeIsland = null !== $bindingBlock;
         $bindingBlock ??= $readableFormBlock;
@@ -14832,7 +14832,7 @@ final class HtmlTransformer
         $inline = $this->cssDeclarations($this->attr($element, 'style'));
         foreach ( array( 'height', 'min-height' ) as $property ) {
             $family = $this->responsivePropertyFamily($property);
-            if ( array() !== $this->conditionalStyleRules
+            if ( array() !== $this->sourceStyles()->conditionalRules()
                 && $this->hasConditionalStyleFamily($element, $family)
                 && ! $this->inlineOwnsResponsiveProperty($property, $family, $inline)
             ) {
@@ -16164,7 +16164,7 @@ final class HtmlTransformer
     private function imageShapeDeclaration(DOMElement $element, string $property): string
     {
         $winner = null;
-        foreach ($this->imageShapeStyleRules as $rule) {
+        foreach ($this->sourceStyles()->imageShapeRules() as $rule) {
             if ($property !== $rule['property'] || ! $this->matchesCssSelector($element, $rule['selector'])) {
                 continue;
             }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -45,18 +45,11 @@ final class HtmlTransformerSession
     public array $syntheticHeaderAnchorStyleRules = array();
     public array $headerRichTextStyleRules = array();
     public array $gutenbergIncompatibilities = array();
-    public array $cssCustomProperties = array();
-    public array $staticClassPromotions = array();
-    public array $staticStyleRules = array();
-    public array $conditionalStyleRules = array();
-    public array $navigationStateStyleRules = array();
     public array $listNavigationPaddingFallbacks = array();
     public array $navigationLinkColorFallbacks = array();
     public array $navigationSubmenuBackgroundFallbacks = array();
     public array $navigationSpacingFallbacks = array();
     public array $buttonWrapperSpacingFallbacks = array();
-    public array $imageShapeStyleRules = array();
-    public array $staticPseudoElementStyleRules = array();
     private RuntimeSelectorState $runtimeSelectorState;
     public array $sourceTagMarkers = array();
     public array $sourceControlMarkers = array();
@@ -75,14 +68,12 @@ final class HtmlTransformerSession
     public array $sourceTableDescendantPaths = array();
     public array $sourceRichTextSemanticMarkers = array();
     public array $authorLayoutTopologies = array();
-    public array $parsedCssSelectors = array();
-    public string $formLayoutCss = '';
     private ?AuthorStyleAnalysis $authorStyleAnalysis = null;
     public int $nextSourceProvenanceId = 1;
     public bool $preserveShellLandmarks = false;
     public bool $fallbackReductionMode = false;
     public readonly PresentationResolutionCache $presentationResolutionCache;
-    public readonly SourceStyleResolutionState $sourceStyleResolutionState;
+    private readonly SourceStyleResolutionState $sourceStyleResolutionState;
     private ?LayoutGeometryState $layoutGeometryState = null;
     public readonly FallbackEmitter $fallbackEmitter;
 
@@ -149,5 +140,10 @@ final class HtmlTransformerSession
     public function runtimeSelectorState(): RuntimeSelectorState
     {
         return $this->runtimeSelectorState;
+    }
+
+    public function sourceStyleResolutionState(): SourceStyleResolutionState
+    {
+        return $this->sourceStyleResolutionState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
@@ -13,4 +13,108 @@ final class SourceStyleResolutionState
 
     /** @var array<string, array<string, array<int, string>>> */
     public array $authorDeclaredPropertyValues = array();
+
+    /** @var array<string, array<int, string>> */
+    private array $classPromotions = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $staticRules = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $conditionalRules = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $navigationStateRules = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $imageShapeRules = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $pseudoElementRules = array();
+
+    /** @var array<string, string> */
+    private array $customProperties = array();
+
+    /** @var array<string, array<string, mixed>|null> */
+    private array $parsedSelectors = array();
+
+    private string $formLayoutCss = '';
+
+    /**
+     * @param array<string, array<int, string>> $classPromotions
+     * @param array<string, mixed> $analysis
+     */
+    public function installStylesheetAnalysis(array $classPromotions, array $analysis): void
+    {
+        $this->classPromotions = $classPromotions;
+        $this->staticRules = $analysis['static'];
+        $this->conditionalRules = $analysis['conditional'];
+        $this->navigationStateRules = $analysis['navigation_state'];
+        $this->imageShapeRules = $analysis['image_shape'];
+        $this->pseudoElementRules = $analysis['pseudo'];
+        $this->customProperties = $analysis['custom_properties'];
+    }
+
+    /** @return array<int, string> */
+    public function classPromotions(string $className): array
+    {
+        return $this->classPromotions[$className] ?? array();
+    }
+
+    public function hasClassPromotions(): bool
+    {
+        return array() !== $this->classPromotions;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function staticRules(): array
+    {
+        return $this->staticRules;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function conditionalRules(): array
+    {
+        return $this->conditionalRules;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function navigationStateRules(): array
+    {
+        return $this->navigationStateRules;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function imageShapeRules(): array
+    {
+        return $this->imageShapeRules;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function pseudoElementRules(): array
+    {
+        return $this->pseudoElementRules;
+    }
+
+    /** @return array<string, string> */
+    public function customProperties(): array
+    {
+        return $this->customProperties;
+    }
+
+    /** @return array<string, mixed>|null */
+    public function parsedSelector(string $selector): ?array
+    {
+        return $this->parsedSelectors[$selector] ??= CssSelectorMatcher::parse($selector);
+    }
+
+    public function setFormLayoutCss(string $css): void
+    {
+        $this->formLayoutCss = $css;
+    }
+
+    public function formLayoutCss(): string
+    {
+        return $this->formLayoutCss;
+    }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -17,10 +17,9 @@ use DOMElement;
  * CSS-rule resolution the font/typography path and `ButtonStyleResolver` rely
  * on, given a single home so style work no longer collides in the god-object.
  *
- * Pure move: methods extracted verbatim from HtmlTransformer with no logic or
- * signature changes. Methods reference `$this->attr()` / `$this->safeAnchor()`
- * (DomHelpersTrait), `$this->promotedClassName()` / `$this->cardLikeChildCount()`,
- * and the `$staticStyleRules` property, all composed onto HtmlTransformer.
+ * Methods reference `$this->attr()` / `$this->safeAnchor()` (DomHelpersTrait),
+ * `$this->promotedClassName()` / `$this->cardLikeChildCount()`, and the typed
+ * source style state, all composed onto HtmlTransformer.
  */
 trait StyleResolutionTrait
 {
@@ -186,7 +185,7 @@ trait StyleResolutionTrait
 
     private function resetPresentationResolutionCache(): void
     {
-        $this->session->sourceStyleResolutionState->selectorMatchCache = new CssSelectorMatchCache();
+        $this->sourceStyles()->selectorMatchCache = new CssSelectorMatchCache();
     }
 
     private function styleAttributeMapper(): StyleAttributeMapper
@@ -294,7 +293,7 @@ trait StyleResolutionTrait
      */
     private function classOwnedResponsiveDeclarations(DOMElement $element, array $declarations): array
     {
-        if (array() === $declarations || array() === $this->conditionalStyleRules) {
+        if (array() === $declarations || array() === $this->sourceStyles()->conditionalRules()) {
             return $declarations;
         }
 
@@ -783,7 +782,7 @@ trait StyleResolutionTrait
      */
     private function authorDeclaredPropertyValues(DOMElement $element, array $properties): array
     {
-        $cache = $this->session->sourceStyleResolutionState;
+        $cache = $this->sourceStyles();
         sort($properties, SORT_STRING);
         $cacheKey = $this->presentationCacheKey($element) . ':' . implode(',', $properties);
         if ( isset($cache->authorDeclaredPropertyValues[ $cacheKey ]) ) {
@@ -1712,7 +1711,7 @@ trait StyleResolutionTrait
         }
 
         $inlineStyle = $this->attr($element, 'style');
-        if ( array() === $this->staticStyleRules || (! $this->isHighValueStyledElement($element) && ! $this->hasGenericRecognitionDemand($element)) ) {
+        if ( array() === $this->sourceStyles()->staticRules() || (! $this->isHighValueStyledElement($element) && ! $this->hasGenericRecognitionDemand($element)) ) {
             $cache->mergedStyles[$cacheKey] = $inlineStyle;
             return $inlineStyle;
         }
@@ -2457,19 +2456,19 @@ trait StyleResolutionTrait
 
     private function matchesCssSelector(DOMElement $element, string $selector): bool
     {
-        $cache = $this->session->sourceStyleResolutionState;
+        $cache = $this->sourceStyles();
         $match = ($cache->selectorMatchCache ??= new CssSelectorMatchCache())->matches($element, $selector, $this->parsedCssSelector($selector));
         return $match['supported'] && $match['matches'];
     }
 
     private function invalidateSourceSelectorMatchCache(): void
     {
-        $this->session->sourceStyleResolutionState->selectorMatchCache?->clear();
+        $this->sourceStyles()->selectorMatchCache?->clear();
     }
 
     private function recordSourceSelectorMatchWork(): void
     {
-        $selectorCache = $this->session->sourceStyleResolutionState->selectorMatchCache;
+        $selectorCache = $this->sourceStyles()->selectorMatchCache;
         if ( ! $selectorCache instanceof CssSelectorMatchCache ) {
             return;
         }
@@ -2493,7 +2492,7 @@ trait StyleResolutionTrait
     /** @return list<array<string, mixed>> */
     private function styleRuleCandidates(DOMElement $element, string $collection): array
     {
-        $cache = $this->session->sourceStyleResolutionState;
+        $cache = $this->sourceStyles();
         $index = $cache->ruleCandidateIndexes[$collection] ??= $this->styleRuleCandidateIndex($collection);
         return ($cache->selectorMatchCache ??= new CssSelectorMatchCache())->styleRuleCandidates($element, $collection, $index);
     }
@@ -2502,10 +2501,10 @@ trait StyleResolutionTrait
     private function styleRuleCandidateIndex(string $collection): array
     {
         $rules = match ($collection) {
-            'static' => $this->staticStyleRules,
-            'conditional' => $this->conditionalStyleRules,
-            'static-conditional' => array_merge($this->staticStyleRules, $this->conditionalStyleRules),
-            'static-conditional-pseudo' => array_merge($this->staticStyleRules, $this->conditionalStyleRules, $this->staticPseudoElementStyleRules),
+            'static' => $this->sourceStyles()->staticRules(),
+            'conditional' => $this->sourceStyles()->conditionalRules(),
+            'static-conditional' => array_merge($this->sourceStyles()->staticRules(), $this->sourceStyles()->conditionalRules()),
+            'static-conditional-pseudo' => array_merge($this->sourceStyles()->staticRules(), $this->sourceStyles()->conditionalRules(), $this->sourceStyles()->pseudoElementRules()),
         };
         $index = array('universal' => array(), 'ids' => array(), 'classes' => array(), 'tags' => array(), 'attributes' => array(), 'total' => count($rules));
         foreach ( $rules as $order => $rule ) {

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -512,7 +512,7 @@ trait SvgMaterializationTrait
             return $value;
         }
 
-        $customProperties = $this->cssCustomProperties;
+        $customProperties = $this->sourceStyles()->customProperties();
         if ( $element instanceof DOMElement ) {
             $ancestors = array();
             for ( $current = $element; $current instanceof DOMElement; $current = $current->parentNode instanceof DOMElement ? $current->parentNode : null ) {


### PR DESCRIPTION
## Summary
- move stylesheet analysis, selector parsing, class promotion, and form-layout CSS into the existing `SourceStyleResolutionState` owner
- hide that owner behind the transform session accessor and route style/SVG consumers through it
- reduce `HtmlTransformerSession` from 59 to 49 public properties while preserving per-transform initialization

Part of #242.

## Verification
- `composer test`
- 289 PHP transformer parity fixtures
- package installation proof
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode assisted with repository inspection, implementation, and verification. The resulting changes and test evidence were reviewed in the managed worktree.