### PR TITLE
Normalize stylesheet rule analysis once

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -2887,8 +2887,10 @@ final class HtmlTransformer
             $analysis = $this->analysisCache->style($key);
             if ( null === $analysis ) {
                 ++$this->analysisCache->styleBuilds;
-                $topLevel = $this->topLevelStyleAnalysis($payload);
-                $structured = $this->structuredStyleAnalysis($payload);
+                $ruleCss = trim($payload);
+                $ruleCss = preg_replace('@/\*.*?\*/@s', '', $ruleCss) ?? $ruleCss;
+                $topLevel = $this->topLevelStyleAnalysis($ruleCss);
+                $structured = $this->structuredStyleAnalysis($ruleCss);
                 $analysis = array(
                     'static' => $topLevel['static'],
                     'conditional' => $structured['conditional'],

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -1992,11 +1992,10 @@ trait StyleResolutionTrait
     private function topLevelStyleAnalysis(string $css): array
     {
         $analysis = array('static' => array(), 'navigation_state' => array(), 'pseudo' => array());
-        if ( '' === trim($css) ) {
+        if ( '' === $css ) {
             return $analysis;
         }
 
-        $css = preg_replace('@/\*.*?\*/@s', '', $css) ?? $css;
         $css = $this->topLevelCssRules($css);
         if ( ! preg_match_all('/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER) ) {
             return $analysis;
@@ -2077,14 +2076,8 @@ trait StyleResolutionTrait
     private function structuredStyleAnalysis(string $css): array
     {
         $analysis = array('conditional' => array(), 'image_shape' => array());
-        $css = trim($css);
         $order = 0;
-        $this->collectStructuredStyleAnalysis(
-            preg_replace('@/\*.*?\*/@s', '', $css) ?? $css,
-            array(),
-            $analysis,
-            $order
-        );
+        $this->collectStructuredStyleAnalysis($css, array(), $analysis, $order);
 
         return $analysis;
     }


### PR DESCRIPTION
## Summary

- trim and strip comments once at the immutable style-analysis cache-build boundary
- feed the same normalized CSS to top-level and structured rule analysis
- keep custom-property analysis on original source bytes so comments inside variable values remain unchanged

Related to #1044.

## Evidence

A payload containing top-level rules, nested conditional rules, image-shape declarations, and a custom-property value with an inline comment produced byte-identical cached analysis before and after:

- SHA-256: `44c5b03b4884519dff2f76d6d8a521395aaa9b69ccb7f1673f35722b98f07223`
- serialized bytes: 957
- custom property: `red/* inner */blue` preserved in both root and fallback maps

This is a bounded simplification that removes one duplicate full-payload normalization pass. Host contention made elapsed-time samples unreliable, so this PR does not claim a wall-time result.

## Verification

- `composer validate --strict`
- `composer test`
- 289 PHP transformer parity fixtures
- PHP package install proof
- post-tightening shared-analysis, compile-fragment, author-selector, and block-style contracts
- `git diff --check`

## AI Assistance

GPT-5.6-sol was used through OpenCode to identify duplicate normalization, preserve the original custom-property byte contract, compare serialized analysis output, and run repository verification. Chris Huber reviewed and directed the work.