### PR TITLE
Isolate reusable component state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -384,6 +384,11 @@ final class HtmlTransformer
         return $this->session->sourceStyleResolutionState();
     }
 
+    private function reusableComponents(): ReusableComponentState
+    {
+        return $this->session->reusableComponentState();
+    }
+
     /**
      * @param array<string, mixed> $options
      */
@@ -494,10 +499,7 @@ final class HtmlTransformer
         // General style matching begins only after those source mutations settle.
         $this->invalidateSourceSelectorMatchCache();
         $this->collectEditorHiddenStateFindings($body);
-        $reusableComponentRecognition = $this->reusableComponentRecognizer->recognize($body);
-        foreach ($reusableComponentRecognition['candidates'] as $candidate) {
-            if (is_array($candidate) && is_string($candidate['path'] ?? null) && is_string($candidate['fingerprint'] ?? null)) $this->reusableComponentFingerprints[$candidate['path']] = $candidate['fingerprint'];
-        }
+        $this->reusableComponents()->installRecognition($this->reusableComponentRecognizer->recognize($body));
 
         $fallbacks   = array();
         $interactionCandidates = $this->interactionCandidates($body);
@@ -520,7 +522,7 @@ final class HtmlTransformer
         $this->appendCommerceControlsFallbacks($body, $fallbacks);
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $this->finalizeFallbackBindings($fallbacks, $blocks, $serializedBlocks);
-        $reusableComponentRecognition = $this->finalizeReusableComponentRecognition($reusableComponentRecognition);
+        $reusableComponentRecognition = $this->reusableComponents()->report($this->materializedAssets()->assets());
         $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
         $authorStylesheetProjections = $this->authorStylesheetProjections();
         $this->materializeAuthorStylesheet(
@@ -881,7 +883,7 @@ final class HtmlTransformer
 
     private function reusableComponentFingerprintFor(DOMElement $element): ?string
     {
-        return $this->reusableComponentFingerprints[$element->getNodePath()] ?? null;
+        return $this->reusableComponents()->fingerprintForPath((string) $element->getNodePath());
     }
 
     private function collectGeneratedComponentCandidates(DOMElement $element, int $depth = 0): void
@@ -891,7 +893,7 @@ final class HtmlTransformer
             && ($this->hasRepeatedDirectChildTags($element) || str_contains(strtolower($element->tagName), '-'))
             && ($this->fallbackEmitter->isRepeatableContentComponent($element) || $this->fallbackEmitter->isSafeCustomElementHost($element))
         ) {
-            $this->generatedComponentCandidates[$element->getNodePath()] = true;
+            $this->reusableComponents()->markGeneratedCandidate((string) $element->getNodePath());
             return;
         }
 
@@ -920,7 +922,7 @@ final class HtmlTransformer
 
     private function isGeneratedComponentCandidate(DOMElement $element): bool
     {
-        return isset($this->generatedComponentCandidates[$element->getNodePath()]);
+        return $this->reusableComponents()->isGeneratedCandidate((string) $element->getNodePath());
     }
 
     /** @param array{blockName: string, attrs: array<string, mixed>} $generated @return array<string, mixed> */
@@ -935,26 +937,6 @@ final class HtmlTransformer
             $this->recordNativeRuntimeDomPreservation($target, $generated['blockName']);
         }
         return $block;
-    }
-
-    /** @param array<string, mixed> $recognition @return array<string, mixed> */
-    private function finalizeReusableComponentRecognition(array $recognition): array
-    {
-        $assetOccurrences = array();
-        foreach ($this->materializedAssets()->assets() as $asset) {
-            if (!is_array($asset) || 'inline-svg' !== ($asset['source'] ?? null)) continue;
-            foreach (is_array($asset['component_occurrence_counts'] ?? null) ? $asset['component_occurrence_counts'] : array() as $fingerprint => $count) if (is_string($fingerprint) && is_int($count)) $assetOccurrences[$fingerprint] = (int) ($assetOccurrences[$fingerprint] ?? 0) + $count;
-        }
-        foreach ($recognition['components'] as &$component) {
-            if (!is_array($component) || 'svg' !== ($component['tag'] ?? null)) continue;
-            $mapped = (int) ($assetOccurrences[$component['fingerprint']] ?? 0);
-            $component['mapping'] = $mapped === ($component['occurrence_count'] ?? 0) && 0 < $mapped
-                ? 'shared_core_image_asset'
-                : 'capability_gap:svg_instances_not_all_core_image_assets';
-            $component['mapped_asset_occurrence_count'] = $mapped;
-        }
-        unset($component);
-        return $recognition;
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -20,8 +20,6 @@ use DOMElement;
  */
 final class HtmlTransformerSession
 {
-    public array $reusableComponentFingerprints = array();
-    public array $generatedComponentCandidates = array();
     public array $formControlEchoTexts = array();
     public array $responsiveImageFallbacks = array();
     public array $responsiveImageFallbackSelectors = array();
@@ -35,6 +33,7 @@ final class HtmlTransformerSession
     public array $structureProvenance = array();
     public array $scriptMetadata = array();
     private readonly RuntimeDomState $runtimeDomState;
+    private readonly ReusableComponentState $reusableComponentState;
     public array $nativeDisclosureRootIds = array();
     private ?GeneratedBlockRegistry $generatedBlockRegistry = null;
     public bool $emptyRuntimeTargetGenerated = false;
@@ -84,6 +83,7 @@ final class HtmlTransformerSession
         $this->presentationResolutionCache = new PresentationResolutionCache();
         $this->sourceStyleResolutionState = new SourceStyleResolutionState();
         $this->runtimeDomState = new RuntimeDomState();
+        $this->reusableComponentState = new ReusableComponentState();
         $this->runtimeSelectorState = new RuntimeSelectorState(array(), array(), array());
     }
 
@@ -145,5 +145,10 @@ final class HtmlTransformerSession
     public function sourceStyleResolutionState(): SourceStyleResolutionState
     {
         return $this->sourceStyleResolutionState;
+    }
+
+    public function reusableComponentState(): ReusableComponentState
+    {
+        return $this->reusableComponentState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/ReusableComponentState.php
+++ b/php-transformer/src/HtmlToBlocks/ReusableComponentState.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+/** Per-transform reusable component recognition and mapping state. */
+final class ReusableComponentState
+{
+    /** @var array<string, mixed>|null */
+    private ?array $recognition = null;
+
+    /** @var array<string, string> */
+    private array $fingerprints = array();
+
+    /** @var array<string, true> */
+    private array $generatedCandidates = array();
+
+    /** @param array<string, mixed> $recognition */
+    public function installRecognition(array $recognition): void
+    {
+        $this->recognition = $recognition;
+        foreach ($recognition['candidates'] as $candidate) {
+            if (is_array($candidate) && is_string($candidate['path'] ?? null) && is_string($candidate['fingerprint'] ?? null)) {
+                $this->fingerprints[$candidate['path']] = $candidate['fingerprint'];
+            }
+        }
+    }
+
+    public function fingerprintForPath(string $path): ?string
+    {
+        return $this->fingerprints[$path] ?? null;
+    }
+
+    public function markGeneratedCandidate(string $path): void
+    {
+        $this->generatedCandidates[$path] = true;
+    }
+
+    public function isGeneratedCandidate(string $path): bool
+    {
+        return isset($this->generatedCandidates[$path]);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assets
+     * @return array<string, mixed>
+     */
+    public function report(array $assets): array
+    {
+        $recognition = $this->recognition
+            ?? throw new \LogicException('Reusable component recognition has not been installed for this transform.');
+        $assetOccurrences = array();
+        foreach ($assets as $asset) {
+            if (!is_array($asset) || 'inline-svg' !== ($asset['source'] ?? null)) {
+                continue;
+            }
+            foreach (is_array($asset['component_occurrence_counts'] ?? null) ? $asset['component_occurrence_counts'] : array() as $fingerprint => $count) {
+                if (is_string($fingerprint) && is_int($count)) {
+                    $assetOccurrences[$fingerprint] = (int) ($assetOccurrences[$fingerprint] ?? 0) + $count;
+                }
+            }
+        }
+        foreach ($recognition['components'] as &$component) {
+            if (!is_array($component) || 'svg' !== ($component['tag'] ?? null)) {
+                continue;
+            }
+            $mapped = (int) ($assetOccurrences[$component['fingerprint']] ?? 0);
+            $component['mapping'] = $mapped === ($component['occurrence_count'] ?? 0) && 0 < $mapped
+                ? 'shared_core_image_asset'
+                : 'capability_gap:svg_instances_not_all_core_image_assets';
+            $component['mapped_asset_occurrence_count'] = $mapped;
+        }
+        unset($component);
+
+        return $recognition;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ReusableComponentState` to own recognition reports, fingerprint indexing, and generated candidate tracking
- move SVG asset mapping finalization out of `HtmlTransformer` into the state owner
- reduce `HtmlTransformerSession` from 49 to 47 public properties while preserving report output and per-transform isolation

Part of #242.

## Verification
- `composer test`
- reusable-component recognition contract
- reused-transformer session equivalence
- 289 PHP transformer parity fixtures
- package installation proof
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode assisted with repository inspection, implementation, and verification. The resulting changes and test evidence were reviewed in the managed worktree.