### PR TITLE
Centralize generated support styles

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -57,6 +57,7 @@ use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTrans
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AdminBarAccommodation;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssValueSplitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\FormLayoutGraphBuilder;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeneratedSupportStylesheetState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\StyleAttributeMapper;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\SourceStyleResolutionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Support\BackgroundImageExtractor;
@@ -393,6 +394,11 @@ final class HtmlTransformer
     private function authorSelectorProjections(): AuthorSelectorProjectionState
     {
         return $this->session->authorSelectorProjectionState();
+    }
+
+    private function generatedSupportStyles(): GeneratedSupportStylesheetState
+    {
+        return $this->session->generatedSupportStylesheetState();
     }
 
     protected function fallbackSourceTagMarker(string $tagName): string
@@ -1073,37 +1079,14 @@ final class HtmlTransformer
         foreach ( $this->navigationLinkTextColorRules($serializedBlocks) as $navigationLinkTextColorRule ) {
             $afterAuthorCssParts[] = $navigationLinkTextColorRule;
         }
-        foreach ( $this->navigationSubmenuBackgroundFallbacks as $className => $color ) {
-            if ( str_contains($serializedBlocks, $className) ) {
-                $afterAuthorCssParts[] = '.wp-block-navigation-item.' . $className . '>.wp-block-navigation__submenu-container{background-color:' . $color . '}';
-            }
-        }
-        foreach ( $this->navigationSpacingFallbacks as $className => $declarations ) {
-            if ( str_contains($serializedBlocks, $className) ) {
-                $afterAuthorCssParts[] = '.wp-block-navigation.' . $className . '{' . $declarations . '}';
-            }
-        }
-        foreach ( $this->buttonWrapperSpacingFallbacks as $className => $declarations ) {
-            if ( str_contains($serializedBlocks, $className) ) {
-                $afterAuthorCssParts[] = '.wp-block-buttons.' . $className . '{' . $declarations . '}';
-            }
-        }
-        foreach ( $this->syntheticHeaderAnchorStyleRules as $className => $rule ) {
-            if ( str_contains($serializedBlocks, $className) ) {
-                $afterAuthorCssParts[] = $rule;
-            }
-        }
-        foreach ( $this->headerRichTextStyleRules as $marker => $rule ) {
-            if ( str_contains($serializedBlocks, $marker) ) {
-                $afterAuthorCssParts[] = $rule;
-            }
-        }
+        array_push($afterAuthorCssParts, ...$this->generatedSupportStyles()->conditionalAfterAuthorCss($serializedBlocks));
         if ( str_contains($serializedBlocks, 'blocks-engine-list-navigation') ) {
             $beforeAuthorCssParts[] = '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation-item.wp-block-navigation-link{display:list-item;font:inherit}'
                 . "\n" . '.wp-block-navigation.blocks-engine-list-navigation .wp-block-navigation-item__content{display:inline}';
         }
-        if ( array() !== $this->nativeSearchTriggerCssRules ) {
-            $beforeAuthorCssParts[] = implode("\n", $this->nativeSearchTriggerCssRules);
+        $nativeSearchTriggerCss = $this->generatedSupportStyles()->beforeAuthorCss();
+        if ( '' !== $nativeSearchTriggerCss ) {
+            $beforeAuthorCssParts[] = $nativeSearchTriggerCss;
         }
         if ( '' !== trim($authorCss) ) {
             $authorCssParts[] = $authorCss;
@@ -1182,15 +1165,7 @@ final class HtmlTransformer
         if ( '' !== $directNavigationCss ) {
             $afterAuthorCssParts[] = $directNavigationCss;
         }
-        if ( array() !== $this->nativeButtonStyleRules ) {
-            $afterAuthorCssParts[] = implode("\n", $this->nativeButtonStyleRules);
-        }
-        if ( array() !== $this->directFlexButtonStyleRules ) {
-            $afterAuthorCssParts[] = implode("\n", $this->directFlexButtonStyleRules);
-        }
-        if ( array() !== $this->fullWidthButtonStyleRules ) {
-            $afterAuthorCssParts[] = implode("\n", $this->fullWidthButtonStyleRules);
-        }
+        array_push($afterAuthorCssParts, ...$this->generatedSupportStyles()->buttonAfterAuthorCss());
         $this->materializeStylesheetAsset($beforeAuthorCssParts, 'engine-support', 'before-author', 'engine-support-before-author');
         $this->materializeStylesheetAsset($authorCssParts, 'author-css', 'author', 'source-author');
         $this->materializeStylesheetAsset($afterAuthorCssParts, 'engine-support', 'after-author', 'engine-support-after-author');
@@ -1451,8 +1426,9 @@ final class HtmlTransformer
                 : array();
             if ( array() === $padding ) {
                 foreach ( $classes as $class ) {
-                    if ( isset($this->listNavigationPaddingFallbacks[ $class ]) ) {
-                        $padding = $this->listNavigationPaddingFallbacks[ $class ];
+                    $fallbackPadding = $this->generatedSupportStyles()->listNavigationPadding($class);
+                    if ( array() !== $fallbackPadding ) {
+                        $padding = $fallbackPadding;
                         break;
                     }
                 }
@@ -2247,8 +2223,9 @@ final class HtmlTransformer
             $color = trim((string) ($attrs['style']['color']['text'] ?? ''));
             if ( '' === $color ) {
                 foreach ( preg_split('/\s+/', trim((string) ($attrs['className'] ?? ''))) ?: array() as $class ) {
-                    if ( isset($this->navigationLinkColorFallbacks[ $class ]) ) {
-                        $color = $this->navigationLinkColorFallbacks[ $class ];
+                    $fallbackColor = $this->generatedSupportStyles()->navigationLinkColor($class);
+                    if ( '' !== $fallbackColor ) {
+                        $color = $fallbackColor;
                         break;
                     }
                 }
@@ -5672,10 +5649,10 @@ final class HtmlTransformer
                     if ( 'core/button' === $name ) {
                         $this->registerNativeButtonStyleRule($controlMarker, $attrs, $nativeButtonTextAlignment, $logicalControl);
                         if ( $this->isDirectChildOfAuthorFlexLayout($logicalControl) ) {
-                            $this->directFlexButtonStyleRules[$controlMarker] = $this->directFlexButtonStyleRule($controlMarker, $logicalControl);
+                            $this->generatedSupportStyles()->registerDirectFlexButton($controlMarker, $this->directFlexButtonStyleRule($controlMarker, $logicalControl));
                         }
                         if ( 100 === (int) ($attrs['width'] ?? 0) ) {
-                            $this->fullWidthButtonStyleRules[$controlMarker] = $this->fullWidthButtonStyleRule($controlMarker);
+                            $this->generatedSupportStyles()->registerFullWidthButton($controlMarker, $this->fullWidthButtonStyleRule($controlMarker));
                         }
                     }
                 }
@@ -5810,7 +5787,7 @@ final class HtmlTransformer
         $css = $this->cssDeclarationString($declarations);
         $className = self::SYNTHETIC_HEADER_ANCHOR_CLASS_PREFIX . substr(hash('sha256', $css), 0, 16);
         $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $className);
-        $this->syntheticHeaderAnchorStyleRules[$className] = 'p.' . $className . '>a{' . $css . '}';
+        $this->generatedSupportStyles()->registerSyntheticHeaderAnchor($className, 'p.' . $className . '>a{' . $css . '}');
     }
 
     /**
@@ -5831,13 +5808,13 @@ final class HtmlTransformer
         if ( '' !== $submenuBackground && array() !== $this->cssDeclarations('background-color:' . $submenuBackground) ) {
             $className = 'blocks-engine-navigation-submenu-background-' . hash('sha256', $submenuBackground);
             $attrs['className'] = $this->mergeClassNames((string) ($attrs['className'] ?? ''), $className);
-            $this->navigationSubmenuBackgroundFallbacks[ $className ] = $submenuBackground;
+            $this->generatedSupportStyles()->registerNavigationSubmenuBackground($className, $submenuBackground);
         }
         $classes = preg_split('/\s+/', trim((string) ($attrs['className'] ?? ''))) ?: array();
         if ( 'core/navigation' === $name && is_array($fallback['spacing']['padding'] ?? null) ) {
             foreach ( $classes as $class ) {
                 if ( 'blocks-engine-list-navigation' !== $class && ! str_starts_with($class, 'blocks-engine-') ) {
-                    $this->listNavigationPaddingFallbacks[ $class ] = $fallback['spacing']['padding'];
+                    $this->generatedSupportStyles()->registerListNavigationPadding($class, $fallback['spacing']['padding']);
                 }
             }
         }
@@ -5845,7 +5822,7 @@ final class HtmlTransformer
             $declarations = $this->styleAttributeMapper()->serialize(array( 'spacing' => $fallback['spacing'] ))['style'];
             foreach ( $classes as $class ) {
                 if ( '' !== $declarations && 'blocks-engine-list-navigation' !== $class && ! str_starts_with($class, 'blocks-engine-') ) {
-                    $this->navigationSpacingFallbacks[ $class ] = $declarations;
+                    $this->generatedSupportStyles()->registerNavigationSpacing($class, $declarations);
                     break;
                 }
             }
@@ -5854,7 +5831,7 @@ final class HtmlTransformer
             $declarations = $this->styleAttributeMapper()->serialize(array( 'spacing' => $fallback['spacing'] ))['style'];
             foreach ( $classes as $class ) {
                 if ( '' !== $declarations && str_starts_with($class, 'blocks-engine-control-') ) {
-                    $this->buttonWrapperSpacingFallbacks[ $class ] = $declarations;
+                    $this->generatedSupportStyles()->registerButtonWrapperSpacing($class, $declarations);
                     break;
                 }
             }
@@ -5865,7 +5842,7 @@ final class HtmlTransformer
                         && ! str_starts_with($class, 'blocks-engine-navigation-link-color-states-'))
                     || str_starts_with($class, 'blocks-engine-navigation-current-color-')
                 ) {
-                    $this->navigationLinkColorFallbacks[ $class ] = (string) $fallback['color']['text'];
+                    $this->generatedSupportStyles()->registerNavigationLinkColor($class, (string) $fallback['color']['text']);
                 }
             }
         }
@@ -6060,7 +6037,7 @@ final class HtmlTransformer
         $intrinsicWrapperRule = array() === $intrinsicWrapperDeclarations
             ? ''
             : '.' . $marker . '.' . $marker . '.wp-block-button{' . implode(';', $intrinsicWrapperDeclarations) . '}';
-        $this->nativeButtonStyleRules[$marker] = $outerWrapperRule . $wrapperRule . $intrinsicWrapperRule . '.' . $marker . '.' . $marker . '>.wp-block-button__link{' . implode(';', $declarations) . '}';
+        $this->generatedSupportStyles()->registerNativeButton($marker, $outerWrapperRule . $wrapperRule . $intrinsicWrapperRule . '.' . $marker . '.' . $marker . '>.wp-block-button__link{' . implode(';', $declarations) . '}');
     }
 
     private function sourceElementStartsHidden(DOMElement $element): bool
@@ -7269,7 +7246,7 @@ final class HtmlTransformer
                 if ( array() !== $headerCarrier && $this->hasAncestorTag($sourceInline, array( 'header' )) ) {
                     $selector = 'mark[style*="--blocks-engine-richtext-marker:' . $marker . '"]'
                         . ',span[data-blocks-engine-richtext-marker="' . $marker . '"]';
-                    $this->headerRichTextStyleRules[$marker] = $selector . '{' . $this->cssDeclarationString($headerCarrier) . '}';
+                    $this->generatedSupportStyles()->registerHeaderRichText($marker, $selector . '{' . $this->cssDeclarationString($headerCarrier) . '}');
                 }
                 $inline['--blocks-engine-richtext-marker'] = $marker;
             }
@@ -12823,7 +12800,7 @@ final class HtmlTransformer
             $svgMarkup = preg_replace('/<svg\b/i', '<svg xmlns="http://www.w3.org/2000/svg"', $svgMarkup, 1) ?? $svgMarkup;
         }
         $className = 'blocks-engine-source-search-icon-' . substr(hash('sha256', $svgMarkup), 0, 12);
-        if ( isset($this->nativeSearchTriggerCssRules[$className]) ) {
+        if ( $this->generatedSupportStyles()->hasNativeSearchTrigger($className) ) {
             return $className;
         }
 
@@ -12837,11 +12814,11 @@ final class HtmlTransformer
         $buttonWidth = $this->cssNumber($triggerWidth ?? ($width + 12));
         $dataUri = 'data:image/svg+xml,' . rawurlencode($svgMarkup);
         $selector = '.wp-block-search.' . $className;
-        $this->nativeSearchTriggerCssRules[$className] = $selector . '{display:block!important;box-sizing:border-box!important;flex:0 0 ' . $buttonWidth . 'px!important;width:' . $buttonWidth . 'px!important;' . $triggerHeight . '}'
+        $this->generatedSupportStyles()->registerNativeSearchTrigger($className, $selector . '{display:block!important;box-sizing:border-box!important;flex:0 0 ' . $buttonWidth . 'px!important;width:' . $buttonWidth . 'px!important;' . $triggerHeight . '}'
             . $selector . ' .wp-block-search__inside-wrapper{' . $triggerHeight . 'box-sizing:border-box!important;width:100%!important}'
             . $selector . ' .wp-block-search__button{display:block!important;box-sizing:border-box!important;width:100%!important;height:100%!important;min-width:0!important;margin:0!important;padding:1px 6px!important;font:400 13.3333px Arial!important;line-height:normal!important;text-align:center!important;color:#000!important;background:none!important;border:0!important;border-radius:0!important}'
             . $selector . '.wp-block-search__icon-button .wp-block-search__button.has-icon>svg.search-icon{display:none!important}'
-            . $selector . ' .wp-block-search__button:before{content:"";display:inline-block;width:' . $iconWidth . 'px;height:' . $iconHeight . 'px;background:url("' . $dataUri . '") center/contain no-repeat}';
+            . $selector . ' .wp-block-search__button:before{content:"";display:inline-block;width:' . $iconWidth . 'px;height:' . $iconHeight . 'px;background:url("' . $dataUri . '") center/contain no-repeat}');
 
         return $className;
     }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -6,6 +6,7 @@ namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Diagnostics\FallbackEmitter;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorSelectorProjectionState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\AuthorStyleAnalysis;
+use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\GeneratedSupportStylesheetState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\LayoutGeometryState;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\PresentationResolutionCache;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\SourceStyleResolutionState;
@@ -40,23 +41,13 @@ final class HtmlTransformerSession
     public bool $emptyRuntimeTargetGenerated = false;
     public array $runtimeScriptMetadata = array();
     private ?AssetMaterializationState $assetMaterializationState = null;
-    public array $nativeSearchTriggerCssRules = array();
-    public array $nativeButtonStyleRules = array();
-    public array $syntheticHeaderAnchorStyleRules = array();
-    public array $headerRichTextStyleRules = array();
     public array $gutenbergIncompatibilities = array();
-    public array $listNavigationPaddingFallbacks = array();
-    public array $navigationLinkColorFallbacks = array();
-    public array $navigationSubmenuBackgroundFallbacks = array();
-    public array $navigationSpacingFallbacks = array();
-    public array $buttonWrapperSpacingFallbacks = array();
     private RuntimeSelectorState $runtimeSelectorState;
-    public array $directFlexButtonStyleRules = array();
-    public array $fullWidthButtonStyleRules = array();
     public array $responsiveGeometryAmbiguities = array();
     public array $authorLayoutTopologies = array();
     private ?AuthorStyleAnalysis $authorStyleAnalysis = null;
     private readonly AuthorSelectorProjectionState $authorSelectorProjectionState;
+    private readonly GeneratedSupportStylesheetState $generatedSupportStylesheetState;
     public int $nextSourceProvenanceId = 1;
     public bool $preserveShellLandmarks = false;
     public bool $fallbackReductionMode = false;
@@ -74,6 +65,7 @@ final class HtmlTransformerSession
         $this->runtimeDomState = new RuntimeDomState();
         $this->reusableComponentState = new ReusableComponentState();
         $this->authorSelectorProjectionState = new AuthorSelectorProjectionState();
+        $this->generatedSupportStylesheetState = new GeneratedSupportStylesheetState();
         $this->runtimeSelectorState = new RuntimeSelectorState(array(), array(), array());
     }
 
@@ -146,5 +138,10 @@ final class HtmlTransformerSession
     public function authorSelectorProjectionState(): AuthorSelectorProjectionState
     {
         return $this->authorSelectorProjectionState;
+    }
+
+    public function generatedSupportStylesheetState(): GeneratedSupportStylesheetState
+    {
+        return $this->generatedSupportStylesheetState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/GeneratedSupportStylesheetState.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style;
+
+/** Per-transform CSS generated to bridge source styling into valid blocks. */
+final class GeneratedSupportStylesheetState
+{
+    /** @var array<string, string> */
+    private array $nativeSearchTriggerRules = array();
+
+    /** @var array<string, string> */
+    private array $nativeButtonRules = array();
+
+    /** @var array<string, string> */
+    private array $syntheticHeaderAnchorRules = array();
+
+    /** @var array<string, string> */
+    private array $headerRichTextRules = array();
+
+    /** @var array<string, array<string, mixed>> */
+    private array $listNavigationPadding = array();
+
+    /** @var array<string, string> */
+    private array $navigationLinkColors = array();
+
+    /** @var array<string, string> */
+    private array $navigationSubmenuBackgrounds = array();
+
+    /** @var array<string, string> */
+    private array $navigationSpacing = array();
+
+    /** @var array<string, string> */
+    private array $buttonWrapperSpacing = array();
+
+    /** @var array<string, string> */
+    private array $directFlexButtonRules = array();
+
+    /** @var array<string, string> */
+    private array $fullWidthButtonRules = array();
+
+    public function registerNativeSearchTrigger(string $className, string $rule): void
+    {
+        $this->nativeSearchTriggerRules[$className] = $rule;
+    }
+
+    public function hasNativeSearchTrigger(string $className): bool
+    {
+        return isset($this->nativeSearchTriggerRules[$className]);
+    }
+
+    public function registerNativeButton(string $marker, string $rule): void
+    {
+        $this->nativeButtonRules[$marker] = $rule;
+    }
+
+    public function registerSyntheticHeaderAnchor(string $className, string $rule): void
+    {
+        $this->syntheticHeaderAnchorRules[$className] = $rule;
+    }
+
+    public function registerHeaderRichText(string $marker, string $rule): void
+    {
+        $this->headerRichTextRules[$marker] = $rule;
+    }
+
+    /** @param array<string, mixed> $padding */
+    public function registerListNavigationPadding(string $className, array $padding): void
+    {
+        $this->listNavigationPadding[$className] = $padding;
+    }
+
+    /** @return array<string, mixed> */
+    public function listNavigationPadding(string $className): array
+    {
+        return $this->listNavigationPadding[$className] ?? array();
+    }
+
+    public function registerNavigationLinkColor(string $className, string $color): void
+    {
+        $this->navigationLinkColors[$className] = $color;
+    }
+
+    public function navigationLinkColor(string $className): string
+    {
+        return $this->navigationLinkColors[$className] ?? '';
+    }
+
+    public function registerNavigationSubmenuBackground(string $className, string $color): void
+    {
+        $this->navigationSubmenuBackgrounds[$className] = $color;
+    }
+
+    public function registerNavigationSpacing(string $className, string $declarations): void
+    {
+        $this->navigationSpacing[$className] = $declarations;
+    }
+
+    public function registerButtonWrapperSpacing(string $className, string $declarations): void
+    {
+        $this->buttonWrapperSpacing[$className] = $declarations;
+    }
+
+    public function registerDirectFlexButton(string $marker, string $rule): void
+    {
+        $this->directFlexButtonRules[$marker] = $rule;
+    }
+
+    public function registerFullWidthButton(string $marker, string $rule): void
+    {
+        $this->fullWidthButtonRules[$marker] = $rule;
+    }
+
+    public function beforeAuthorCss(): string
+    {
+        return implode("\n", $this->nativeSearchTriggerRules);
+    }
+
+    /** @return list<string> */
+    public function conditionalAfterAuthorCss(string $serializedBlocks): array
+    {
+        $parts = array();
+        foreach ($this->navigationSubmenuBackgrounds as $className => $color) {
+            if (str_contains($serializedBlocks, $className)) {
+                $parts[] = '.wp-block-navigation-item.' . $className . '>.wp-block-navigation__submenu-container{background-color:' . $color . '}';
+            }
+        }
+        foreach ($this->navigationSpacing as $className => $declarations) {
+            if (str_contains($serializedBlocks, $className)) {
+                $parts[] = '.wp-block-navigation.' . $className . '{' . $declarations . '}';
+            }
+        }
+        foreach ($this->buttonWrapperSpacing as $className => $declarations) {
+            if (str_contains($serializedBlocks, $className)) {
+                $parts[] = '.wp-block-buttons.' . $className . '{' . $declarations . '}';
+            }
+        }
+        foreach ($this->syntheticHeaderAnchorRules as $className => $rule) {
+            if (str_contains($serializedBlocks, $className)) {
+                $parts[] = $rule;
+            }
+        }
+        foreach ($this->headerRichTextRules as $marker => $rule) {
+            if (str_contains($serializedBlocks, $marker)) {
+                $parts[] = $rule;
+            }
+        }
+        return $parts;
+    }
+
+    /** @return list<string> */
+    public function buttonAfterAuthorCss(): array
+    {
+        return array_values(array_filter(array(
+            implode("\n", $this->nativeButtonRules),
+            implode("\n", $this->directFlexButtonRules),
+            implode("\n", $this->fullWidthButtonRules),
+        ), static fn (string $rules): bool => '' !== $rules));
+    }
+}


### PR DESCRIPTION
## Summary
- add `GeneratedSupportStylesheetState` to own generated CSS registration, deduplication, lookups, and cascade-phase emission
- preserve explicit before-author, conditional after-author, and button after-author ordering
- replace 11 parallel `HtmlTransformerSession` maps with typed behavior
- reduce the session surface from 34 to 23 public properties, down from 107 at the start of the #242 state-decomposition sequence

Part of #242.

## Verification
- `composer test`
- engine support CSS asset contract: 59 assertions
- engine support CSS specificity contract: 17 assertions
- navigation author-rule and inline-margin contracts
- reused-transformer session equivalence
- 289 PHP transformer parity fixtures
- package installation proof
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode assisted with repository inspection, implementation, and verification. The resulting changes and test evidence were reviewed in the managed worktree.