### PR TITLE
Centralize transformation provenance state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -359,6 +359,11 @@ final class HtmlTransformer
             ?? throw new \LogicException('Layout geometry state has not been prepared for this transform.');
     }
 
+    private function transformationProvenance(): TransformationProvenanceState
+    {
+        return $this->session->transformationProvenanceState();
+    }
+
     private function generatedBlocks(): GeneratedBlockRegistry
     {
         return $this->session->generatedBlockRegistry()
@@ -417,7 +422,7 @@ final class HtmlTransformer
         );
         $context = TransformationOptions::context($options);
         $startedAt = hrtime(true);
-        $this->fallbackProvenance = TransformationOptions::provenance($options);
+        $this->transformationProvenance()->installFallback(TransformationOptions::provenance($options));
         $this->session->installGeneratedBlockRegistry(new GeneratedBlockRegistry($this->generatedBlockNamespaceFromOptions($options)));
         $this->session->installAssetMaterializationState(new AssetMaterializationState(
             trim((string) ($options['generated_asset_root'] ?? ''), '/'),
@@ -439,13 +444,12 @@ final class HtmlTransformer
         $this->session->installLayoutGeometryState(new LayoutGeometryState(
             is_array($options['layout_geometry_proof']['reductions'] ?? null) ? $options['layout_geometry_proof']['reductions'] : array()
         ));
-        $this->nextSourceProvenanceId = 1;
         $provenance               = array(
             array_merge(array(
                 'source_format' => 'html',
                 'input_bytes'   => strlen($html),
                 'transformer'   => self::class,
-            ), $this->fallbackProvenance),
+            ), $this->transformationProvenance()->fallback()),
         );
 
         $sourceBodyClasses = $this->documentBodyClassNames($html);
@@ -471,7 +475,7 @@ final class HtmlTransformer
                     'diagnostic_code' => 'html_parse_failed',
                     'source_format'   => 'html',
                     'html'            => $html,
-                ), $this->fallbackProvenance),
+                ), $this->transformationProvenance()->fallback()),
             );
 
             $metrics = $this->metrics($html, array(), '', $fallbacks, $diagnostics, $startedAt);
@@ -511,7 +515,7 @@ final class HtmlTransformer
         $this->navigationBlockNormalizer->hydrateDuplicateSubmenus($body);
         $this->materializeDeclarativeCounters($body, (string) ($options['declarative_state_html'] ?? ''));
         $this->prepareAuthorSelectorSemantics($html, (string) ($options['static_css'] ?? ''), $body, $options);
-        $this->fallbackEmitter->configure($this->fallbackProvenance, $this->runtimeScriptMetadata, $this->runtimeSelectors(), $this->authorSelectorProjections()->tagMarkers());
+        $this->fallbackEmitter->configure($this->transformationProvenance()->fallback(), $this->runtimeScriptMetadata, $this->runtimeSelectors(), $this->authorSelectorProjections()->tagMarkers());
         // Author-selector preparation marks source nodes for later projection.
         // General style matching begins only after those source mutations settle.
         $this->invalidateSourceSelectorMatchCache();
@@ -524,7 +528,7 @@ final class HtmlTransformer
         $this->collectSupersededNavToggleSelectors($body);
         $shellArtifacts = !array_key_exists('extract_global_shell', $options) || !empty($options['extract_global_shell']) ? $this->globalShellArtifacts($body, (string) ($options['source'] ?? 'html')) : array();
         $this->collectGeneratedComponentCandidates($body);
-        $blocks      = $this->navigationBlockNormalizer->normalize($this->convertChildren($body, $fallbacks, true), $this->sourceProvenance, $this->sourceBaseHiddenStates);
+        $blocks      = $this->navigationBlockNormalizer->normalize($this->convertChildren($body, $fallbacks, true), $this->transformationProvenance()->sources(), $this->transformationProvenance()->sourceBaseHiddenStates());
         $blocks = $this->compressProjectedGroupChains($blocks);
         if ($this->layoutGeometry()->hasProofReductions() && self::MAX_NATIVE_LIST_VIEW_DEPTH < $this->blockTreeDepth($blocks)) {
             $blocks = $this->compressProjectedGroupChains($blocks, true);
@@ -540,7 +544,7 @@ final class HtmlTransformer
         $serializedBlocks = $this->runtime->serializeBlocks($blocks);
         $this->finalizeFallbackBindings($fallbacks, $blocks, $serializedBlocks);
         $reusableComponentRecognition = $this->reusableComponents()->report($this->materializedAssets()->assets());
-        $sourceProvenance = $this->sourceProvenanceForBlocks($blocks);
+        $sourceProvenance = $this->transformationProvenance()->resolveBlockPaths($blocks);
         $authorStylesheetProjections = $this->authorStylesheetProjections();
         $this->materializeAuthorStylesheet(
             $html,
@@ -644,14 +648,14 @@ final class HtmlTransformer
             'content_round_trip' => $contentRoundTripReport,
             'editability_report' => (new EditabilityReport())->fromBlocks($blocks, (string) ($options['source'] ?? ''), $serializedBlocks, $generatedCarrierCss, $runtimeBlockPaths, $visualBlockPaths, $sourceProvenance),
             'html' => array(
-                'presentation_signals' => $this->presentationProvenance,
+                'presentation_signals' => $this->transformationProvenance()->presentationSignals(),
                 'frozen_hidden_state'  => $this->frozenHiddenStateFindings,
                 'dropped_link_wrappers' => $this->droppedLinkWrapperFindings,
                 'gutenberg_incompatibilities' => $this->gutenbergIncompatibilities,
                 'author_layout_topology' => $authorLayoutTopologyFindings,
                 'source_provenance'    => $sourceProvenance,
                 'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::fromBlocks($blocks, $fallbacks, $sourceProvenance),
-                'structure_signals'    => $this->structureProvenance,
+                'structure_signals'    => $this->transformationProvenance()->structureSignals(),
                 'reusable_components' => $reusableComponentRecognition,
                 'script_metadata'      => $this->scriptMetadata,
                 'runtime_islands'      => $this->runtimeDom()->islands(),
@@ -811,7 +815,7 @@ final class HtmlTransformer
             }
 
             $shellFallbacks = array();
-            $blocks = $this->navigationBlockNormalizer->normalize($this->convertChildren($child, $shellFallbacks, true), $this->sourceProvenance, $this->sourceBaseHiddenStates);
+            $blocks = $this->navigationBlockNormalizer->normalize($this->convertChildren($child, $shellFallbacks, true), $this->transformationProvenance()->sources(), $this->transformationProvenance()->sourceBaseHiddenStates());
             $innerMarkup = $this->runtime->serializeBlocks($blocks);
             $wrapperAttrs = $this->hoistedStylingAttributes($child);
             $wrapperAttrs['tagName'] = $area;
@@ -4263,7 +4267,7 @@ final class HtmlTransformer
                 fn (DOMElement $sourceElement): bool => $sourceElement->parentNode instanceof DOMElement && in_array($this->authoredDisplay($sourceElement->parentNode), array('grid', 'inline-grid'), true),
                 fn (DOMElement $anchor): PatternRecognitionResult => new PatternRecognitionResult(
                     $this->htmlPreservationBlock($anchor),
-                    array(FallbackDiagnostic::build(array('type' => 'html', 'reason' => 'stylable_button_accessible_name_requires_typed_companion', 'diagnostic_code' => 'html_stylable_button_accessible_name_fallback', 'source_format' => 'html', 'tag' => 'a', 'html' => $this->safeFallbackHtml($anchor)), $this->fallbackProvenance))
+                    array(FallbackDiagnostic::build(array('type' => 'html', 'reason' => 'stylable_button_accessible_name_requires_typed_companion', 'diagnostic_code' => 'html_stylable_button_accessible_name_fallback', 'source_format' => 'html', 'tag' => 'a', 'html' => $this->safeFallbackHtml($anchor)), $this->transformationProvenance()->fallback()))
                 )
             ),
             new QuotePatternContext(
@@ -4385,10 +4389,10 @@ final class HtmlTransformer
             }
         }
 
-        if ( isset($this->formControlSlotPaths[$element->getNodePath()]) ) {
+        $formControlSlotToken = $this->transformationProvenance()->formControlSlotToken($element->getNodePath());
+        if ( null !== $formControlSlotToken ) {
             $block = $this->htmlPreservationBlock($element);
-            $token = $this->formControlSlotPaths[$element->getNodePath()];
-            if (is_string($token)) $block['_binding_token'] = $token;
+            $block['_binding_token'] = $formControlSlotToken;
             return $block;
         }
 
@@ -5288,7 +5292,7 @@ final class HtmlTransformer
                 $fallback['control'] = $control;
             }
 
-            $fallbacks[] = FallbackDiagnostic::build($fallback, $this->fallbackProvenance);
+            $fallbacks[] = FallbackDiagnostic::build($fallback, $this->transformationProvenance()->fallback());
         }
 
         return null;
@@ -5669,7 +5673,6 @@ final class HtmlTransformer
                 $this->registerNativeButtonStyleRule($nativeButtonMarker, $hasNativeButtonColor ? $attrs : array(), $nativeButtonTextAlignment);
             }
             $attrs = $this->applyDeclaredBlockSupport($name, $attrs, $sourceElement);
-            $provenanceId = $this->nextSourceProvenanceId++;
             $this->recordPresentationProvenance($name, $attrs, $sourceElement);
             $this->recordStructureProvenance($name, $attrs, $sourceElement);
             if ( $this->isRuntimeDomTarget($sourceElement) && ! $this->isFormControlElement($sourceElement) && ! in_array($sourceTagName, array( 'canvas', 'form', 'script' ), true) ) {
@@ -5684,8 +5687,10 @@ final class HtmlTransformer
                     $this->recordNativeRuntimeDomPreservation($sourceElement, $name, in_array($name, array('core/paragraph', 'core/heading'), true));
                 }
             }
-            $this->sourceProvenance[$provenanceId] = $this->sourceProvenanceEntry($name, $sourceElement);
-            $this->sourceBaseHiddenStates[$provenanceId] = $this->sourceElementStartsHidden($sourceElement);
+            $provenanceId = $this->transformationProvenance()->registerSource(
+                $this->sourceProvenanceEntry($name, $sourceElement),
+                $this->sourceElementStartsHidden($sourceElement)
+            );
         }
 
         if ( 'core/group' === $name && $sourceElement instanceof DOMElement && ! isset($attrs['tagName']) ) {
@@ -5703,7 +5708,7 @@ final class HtmlTransformer
             $visualTopologyEvidence = $this->emptyVisualTopologyEvidence($sourceElement);
             if ( array() !== $visualTopologyEvidence ) {
                 $block['_editability_visual_owned'] = true;
-                $this->sourceProvenance[$provenanceId]['visual_topology_evidence'] = $visualTopologyEvidence;
+                $this->transformationProvenance()->addSourceEvidence($provenanceId, array( 'visual_topology_evidence' => $visualTopologyEvidence ));
             }
         }
 
@@ -6781,11 +6786,12 @@ final class HtmlTransformer
         $opening = '<' . $tagName . $this->authorLayoutHtmlAttributes($attrs) . '>';
         $closing = '</' . $tagName . '>';
 
-        $provenanceId = $this->nextSourceProvenanceId++;
         $this->recordPresentationProvenance(AuthorLayoutBlockGenerator::NAME, $attrs, $element);
         $this->recordStructureProvenance(AuthorLayoutBlockGenerator::NAME, $attrs, $element);
-        $this->sourceProvenance[$provenanceId] = $this->sourceProvenanceEntry(AuthorLayoutBlockGenerator::NAME, $element);
-        $this->sourceBaseHiddenStates[$provenanceId] = $this->sourceElementStartsHidden($element);
+        $provenanceId = $this->transformationProvenance()->registerSource(
+            $this->sourceProvenanceEntry(AuthorLayoutBlockGenerator::NAME, $element),
+            $this->sourceElementStartsHidden($element)
+        );
 
         return array(
             'blockName' => AuthorLayoutBlockGenerator::NAME,
@@ -7614,45 +7620,6 @@ final class HtmlTransformer
     }
 
     /**
-     * @param array<int, array<string, mixed>> $blocks
-     * @return array<int, array<string, mixed>>
-     */
-    private function sourceProvenanceForBlocks(array &$blocks): array
-    {
-        $resolved = array();
-        $this->resolveSourceProvenancePaths($blocks, 'blocks', $resolved);
-        return $resolved;
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $blocks
-     * @param array<int, array<string, mixed>> $resolved
-     */
-    private function resolveSourceProvenancePaths(array &$blocks, string $path, array &$resolved): void
-    {
-        foreach ( $blocks as $index => &$block ) {
-            $blockPath = $path . '.' . $index;
-            $provenanceIds = is_array($block['_source_provenance_ids'] ?? null) ? $block['_source_provenance_ids'] : array($block['_source_provenance_id'] ?? null);
-            foreach ($provenanceIds as $provenanceId) {
-                if ( is_int($provenanceId) && isset($this->sourceProvenance[$provenanceId]) ) {
-                    $resolved[] = array_merge(array( 'block_path' => $blockPath ), $this->sourceProvenance[$provenanceId], !empty($block['_editability_runtime_owned']) ? array('editability_runtime_owned' => true) : array(), !empty($block['_editability_visual_owned']) ? array('editability_visual_owned' => true) : array());
-                }
-            }
-            unset($block['_source_provenance_id']);
-            unset($block['_source_provenance_ids']);
-            unset($block['_layout_shell_wrappers']);
-            unset($block['_binding_token']);
-            unset($block['_editability_runtime_owned']);
-            unset($block['_editability_visual_owned']);
-
-            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
-                $this->resolveSourceProvenancePaths($block['innerBlocks'], $blockPath . '.innerBlocks', $resolved);
-            }
-        }
-        unset($block);
-    }
-
-    /**
      * @return array<string, mixed>
      */
     private function sourceProvenanceEntry(string $blockName, DOMElement $element): array
@@ -7666,7 +7633,7 @@ final class HtmlTransformer
             'source_fragment'   => $this->safeSourceFragment($element),
             'source_digest'     => hash('sha256', $sourceHtml),
             'source_bytes'      => strlen($sourceHtml),
-            'source_path'       => $this->fallbackProvenance['source'] ?? '',
+            'source_path'       => $this->transformationProvenance()->fallback()['source'] ?? '',
             'context'           => $this->sourceContext($element),
         ), $this->sourceConversionMetadata($blockName, $element), $this->navigationSourceOwnership($blockName, $element));
     }
@@ -7819,13 +7786,13 @@ final class HtmlTransformer
             return;
         }
 
-        $this->presentationProvenance[] = array(
+        $this->transformationProvenance()->recordPresentationSignal(array(
             'block_name'        => $blockName,
             'tag'               => strtolower($element->tagName),
             'selector'          => $this->elementSelector($element),
             'signals'           => $signals,
             'source_attributes' => array_intersect_key($this->htmlAttributes($element), array_flip(array( 'class', 'style', 'data-layout', 'data-wp-layout' ))),
-        );
+        ));
     }
 
     /**
@@ -7838,13 +7805,13 @@ final class HtmlTransformer
             return;
         }
 
-        $this->structureProvenance[] = array(
+        $this->transformationProvenance()->recordStructureSignal(array(
             'block_name'        => $blockName,
             'tag'               => strtolower($element->tagName),
             'selector'          => $this->elementSelector($element),
             'signals'           => $signals,
             'source_attributes' => array_intersect_key($this->htmlAttributes($element), array_flip(array( 'class', 'id', 'role', 'style', 'data-layout', 'data-wp-layout' ))),
-        );
+        ));
     }
 
     private function shouldPreserveWrapper(DOMElement $element): bool
@@ -7879,7 +7846,7 @@ final class HtmlTransformer
         }
 
         $provenanceId = $childBlock['_source_provenance_id'] ?? null;
-        $sourceChild = is_int($provenanceId) ? $this->sameSourceGroupChainLeaf($element, (string) ($this->sourceProvenance[$provenanceId]['source_digest'] ?? '')) : null;
+        $sourceChild = is_int($provenanceId) ? $this->sameSourceGroupChainLeaf($element, (string) ($this->transformationProvenance()->source($provenanceId)['source_digest'] ?? '')) : null;
         if (! $sourceChild instanceof DOMElement && 'core/image' === ($childBlock['blockName'] ?? null)) $sourceChild = $this->imageLeafInGroupChain($element);
         if ( ! $sourceChild instanceof DOMElement
             || ('core/image' === ($childBlock['blockName'] ?? null) && ! in_array(strtolower($sourceChild->tagName), array( 'img', 'svg' ), true) && ! str_contains($sourceChild->tagName, '-'))
@@ -9752,7 +9719,7 @@ final class HtmlTransformer
                 'html'                => $boundedHtml['html'],
                 'html_bytes'          => $boundedHtml['bytes'],
                 'html_truncated'      => $boundedHtml['truncated'],
-            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->fallbackProvenance);
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->transformationProvenance()->fallback());
             ++$emitted;
         }
     }
@@ -9824,7 +9791,7 @@ final class HtmlTransformer
                 'context'           => $this->sourceContext($element),
                 'products'          => $products,
                 'product_count'     => count($products),
-            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->fallbackProvenance);
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->transformationProvenance()->fallback());
             ++$emitted;
         }
     }
@@ -9870,7 +9837,7 @@ final class HtmlTransformer
                 'context'           => $this->sourceContext($element),
                 'controls'          => $controlGroups,
                 'control_count'     => count($controlGroups),
-            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->fallbackProvenance);
+            ), static fn (mixed $value): bool => null !== $value && '' !== $value && array() !== $value), $this->transformationProvenance()->fallback());
             ++$emitted;
         }
     }
@@ -9949,7 +9916,7 @@ final class HtmlTransformer
                 continue;
             }
             $provenanceId = $block['_source_provenance_id'] ?? null;
-            if ( is_int($provenanceId) && $selector === ($this->sourceProvenance[$provenanceId]['selector'] ?? null) ) {
+            if ( is_int($provenanceId) && $selector === ($this->transformationProvenance()->source($provenanceId)['selector'] ?? null) ) {
                 return $block;
             }
             $nested = $this->blockForSourceSelector(is_array($block['innerBlocks'] ?? null) ? $block['innerBlocks'] : array(), $selector);
@@ -13108,12 +13075,11 @@ final class HtmlTransformer
         if ( null === $slot ) return null;
 
         $path = $slot->getNodePath();
-        $token = 'form-control-slot-' . $this->nextSourceProvenanceId;
-        $this->formControlSlotPaths[$path] = $token;
+        $token = $this->transformationProvenance()->reserveFormControlSlot($path);
         try {
             $children = $this->convertChildren($form, $fallbacks, true);
         } finally {
-            unset($this->formControlSlotPaths[$path]);
+            $this->transformationProvenance()->releaseFormControlSlot($path);
         }
         $slotBlock = $this->blockForBindingToken($children, $token);
         if ( array() === $children || null === $slotBlock ) return null;
@@ -13553,7 +13519,7 @@ final class HtmlTransformer
             $finding['form_boundary'] = $this->pseudoFormBoundaryMetadata($element);
         }
 
-        return FallbackDiagnostic::build($finding, $this->fallbackProvenance);
+        return FallbackDiagnostic::build($finding, $this->transformationProvenance()->fallback());
     }
 
     /**
@@ -15363,7 +15329,7 @@ final class HtmlTransformer
                 'html'            => $boundedHtml['html'],
                 'html_bytes'      => $boundedHtml['bytes'],
                 'html_truncated'  => $boundedHtml['truncated'],
-            ), $this->fallbackProvenance);
+            ), $this->transformationProvenance()->fallback());
         }
 
         return $this->createBlock('core/html', array( 'content' => $this->safeFallbackHtml($element) ), array(), $element);
@@ -15949,7 +15915,7 @@ final class HtmlTransformer
             'html'            => $boundedHtml['html'],
             'html_bytes'      => $boundedHtml['bytes'],
             'html_truncated'  => $boundedHtml['truncated'],
-        ), $this->fallbackProvenance);
+        ), $this->transformationProvenance()->fallback());
 
         return null;
     }

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -25,14 +25,9 @@ final class HtmlTransformerSession
     public array $formControlEchoTexts = array();
     public array $responsiveImageFallbacks = array();
     public array $responsiveImageFallbackSelectors = array();
-    public array $fallbackProvenance = array();
-    public array $presentationProvenance = array();
     public array $frozenHiddenStateFindings = array();
     public array $droppedLinkWrapperFindings = array();
-    public array $sourceProvenance = array();
-    public array $sourceBaseHiddenStates = array();
-    public array $formControlSlotPaths = array();
-    public array $structureProvenance = array();
+    private readonly TransformationProvenanceState $transformationProvenanceState;
     public array $scriptMetadata = array();
     private readonly RuntimeDomState $runtimeDomState;
     private readonly ReusableComponentState $reusableComponentState;
@@ -48,7 +43,6 @@ final class HtmlTransformerSession
     private ?AuthorStyleAnalysis $authorStyleAnalysis = null;
     private readonly AuthorSelectorProjectionState $authorSelectorProjectionState;
     private readonly GeneratedSupportStylesheetState $generatedSupportStylesheetState;
-    public int $nextSourceProvenanceId = 1;
     public bool $preserveShellLandmarks = false;
     public bool $fallbackReductionMode = false;
     public readonly PresentationResolutionCache $presentationResolutionCache;
@@ -66,6 +60,7 @@ final class HtmlTransformerSession
         $this->reusableComponentState = new ReusableComponentState();
         $this->authorSelectorProjectionState = new AuthorSelectorProjectionState();
         $this->generatedSupportStylesheetState = new GeneratedSupportStylesheetState();
+        $this->transformationProvenanceState = new TransformationProvenanceState();
         $this->runtimeSelectorState = new RuntimeSelectorState(array(), array(), array());
     }
 
@@ -143,5 +138,10 @@ final class HtmlTransformerSession
     public function generatedSupportStylesheetState(): GeneratedSupportStylesheetState
     {
         return $this->generatedSupportStylesheetState;
+    }
+
+    public function transformationProvenanceState(): TransformationProvenanceState
+    {
+        return $this->transformationProvenanceState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -615,7 +615,7 @@ trait SvgMaterializationTrait
     private function transformSourcePath(): string
     {
         foreach ( array( 'source', 'path' ) as $key ) {
-            $value = $this->fallbackProvenance[$key] ?? '';
+            $value = $this->transformationProvenance()->fallback()[$key] ?? '';
             if ( '' !== trim((string) $value) ) {
                 return trim((string) $value);
             }

--- a/php-transformer/src/HtmlToBlocks/TransformationProvenanceState.php
+++ b/php-transformer/src/HtmlToBlocks/TransformationProvenanceState.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+final class TransformationProvenanceState
+{
+    /** @var array<string, mixed> */
+    private array $fallback = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $presentationSignals = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $structureSignals = array();
+
+    /** @var array<int, array<string, mixed>> */
+    private array $sources = array();
+
+    /** @var array<int, bool> */
+    private array $sourceBaseHiddenStates = array();
+
+    /** @var array<string, string> */
+    private array $formControlSlotTokens = array();
+
+    private int $nextSourceId = 1;
+
+    /** @param array<string, mixed> $fallback */
+    public function installFallback(array $fallback): void
+    {
+        $this->fallback = $fallback;
+    }
+
+    /** @return array<string, mixed> */
+    public function fallback(): array
+    {
+        return $this->fallback;
+    }
+
+    /** @param array<string, mixed> $signal */
+    public function recordPresentationSignal(array $signal): void
+    {
+        $this->presentationSignals[] = $signal;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function presentationSignals(): array
+    {
+        return $this->presentationSignals;
+    }
+
+    /** @param array<string, mixed> $signal */
+    public function recordStructureSignal(array $signal): void
+    {
+        $this->structureSignals[] = $signal;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function structureSignals(): array
+    {
+        return $this->structureSignals;
+    }
+
+    /** @param array<string, mixed> $entry */
+    public function registerSource(array $entry, bool $startsHidden): int
+    {
+        $id = $this->nextSourceId++;
+        $this->sources[$id] = $entry;
+        $this->sourceBaseHiddenStates[$id] = $startsHidden;
+
+        return $id;
+    }
+
+    /** @param array<string, mixed> $evidence */
+    public function addSourceEvidence(int $id, array $evidence): void
+    {
+        if ( isset($this->sources[$id]) ) {
+            $this->sources[$id] = array_merge($this->sources[$id], $evidence);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    public function source(int $id): array
+    {
+        return $this->sources[$id] ?? array();
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function sources(): array
+    {
+        return $this->sources;
+    }
+
+    /** @return array<int, bool> */
+    public function sourceBaseHiddenStates(): array
+    {
+        return $this->sourceBaseHiddenStates;
+    }
+
+    public function reserveFormControlSlot(string $path): string
+    {
+        $token = 'form-control-slot-' . $this->nextSourceId;
+        $this->formControlSlotTokens[$path] = $token;
+
+        return $token;
+    }
+
+    public function releaseFormControlSlot(string $path): void
+    {
+        unset($this->formControlSlotTokens[$path]);
+    }
+
+    public function formControlSlotToken(string $path): ?string
+    {
+        return $this->formControlSlotTokens[$path] ?? null;
+    }
+
+    /**
+     * Resolve temporary source IDs into report paths and remove all internal
+     * transformation annotations before block serialization.
+     *
+     * @param array<int, array<string, mixed>> $blocks
+     * @return array<int, array<string, mixed>>
+     */
+    public function resolveBlockPaths(array &$blocks): array
+    {
+        $resolved = array();
+        $this->resolveBlockPathsRecursive($blocks, 'blocks', $resolved);
+
+        return $resolved;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     * @param array<int, array<string, mixed>> $resolved
+     */
+    private function resolveBlockPathsRecursive(array &$blocks, string $path, array &$resolved): void
+    {
+        foreach ( $blocks as $index => &$block ) {
+            $blockPath = $path . '.' . $index;
+            $sourceIds = is_array($block['_source_provenance_ids'] ?? null)
+                ? $block['_source_provenance_ids']
+                : array($block['_source_provenance_id'] ?? null);
+            foreach ( $sourceIds as $sourceId ) {
+                if ( is_int($sourceId) && isset($this->sources[$sourceId]) ) {
+                    $resolved[] = array_merge(
+                        array( 'block_path' => $blockPath ),
+                        $this->sources[$sourceId],
+                        ! empty($block['_editability_runtime_owned']) ? array( 'editability_runtime_owned' => true ) : array(),
+                        ! empty($block['_editability_visual_owned']) ? array( 'editability_visual_owned' => true ) : array()
+                    );
+                }
+            }
+
+            unset($block['_source_provenance_id']);
+            unset($block['_source_provenance_ids']);
+            unset($block['_layout_shell_wrappers']);
+            unset($block['_binding_token']);
+            unset($block['_editability_runtime_owned']);
+            unset($block['_editability_visual_owned']);
+
+            if ( ! empty($block['innerBlocks']) && is_array($block['innerBlocks']) ) {
+                $this->resolveBlockPathsRecursive($block['innerBlocks'], $blockPath . '.innerBlocks', $resolved);
+            }
+        }
+        unset($block);
+    }
+}


### PR DESCRIPTION
## Summary
- replace seven public session fields with a typed `TransformationProvenanceState` lifecycle owner
- centralize source ID allocation, hidden-state pairing, presentation/structure signals, fallback context, and scoped form-slot tokens
- move temporary block annotation resolution and cleanup out of `HtmlTransformer`
- reduce the public `HtmlTransformerSession` surface from 23 fields to 16

Part of #242.

## Verification
- `composer test`
- 289 PHP transformer parity fixtures
- reused-transformer session-state contract
- navigation source-provenance contract
- isolated Composer package install proof
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol was used through OpenCode to map provenance lifecycle coupling, implement the typed owner, and run the repository verification suite. The changes and test results were reviewed by the author.