### PR TITLE
Centralize transformation evidence state

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformer.php
@@ -364,6 +364,11 @@ final class HtmlTransformer
         return $this->session->transformationProvenanceState();
     }
 
+    private function transformationEvidence(): TransformationEvidenceState
+    {
+        return $this->session->transformationEvidenceState();
+    }
+
     private function generatedBlocks(): GeneratedBlockRegistry
     {
         return $this->session->generatedBlockRegistry()
@@ -556,7 +561,7 @@ final class HtmlTransformer
         $this->materializeEditorStaticStateStylesheet();
         $blockValidityReport = $this->runtime->validateBlockSerialization($blocks);
         $semanticParityReport = $this->semanticParityReporter->report($body, $blocks, $sourceProvenance, $html, (string) ($options['static_css'] ?? ''));
-        $contentRoundTripReport = $this->contentRoundTripReporter->report($serializedBlocks, $html, $this->formControlEchoTexts);
+        $contentRoundTripReport = $this->contentRoundTripReporter->report($serializedBlocks, $html, $this->transformationEvidence()->formControlEchoTexts());
         $diagnostics = $this->diagnosticsCollector->collect(
             self::class,
             $this->scriptMetadata,
@@ -568,7 +573,7 @@ final class HtmlTransformer
             $semanticParityReport,
             $contentRoundTripReport
         );
-        foreach ( $this->responsiveGeometryAmbiguities as $ambiguity ) {
+        foreach ( $this->transformationEvidence()->responsiveGeometryAmbiguities() as $ambiguity ) {
             $diagnostics[] = array(
                 'code' => 'responsive_geometry_ambiguous_min_width',
                 'message' => 'A wide minimum-width rule matches both page-shell and authored content surfaces, so it was retained without a responsive projection.',
@@ -588,7 +593,7 @@ final class HtmlTransformer
                 'entries' => $headMetadata,
             );
         }
-        $authorLayoutTopologyFindings = $this->authorLayoutTopologyFindings();
+        $authorLayoutTopologyFindings = $this->transformationEvidence()->authorLayoutTopologyFindings();
         foreach ( $authorLayoutTopologyFindings as $finding ) {
             $diagnostics[] = array(
                 'code' => 'author_layout_topology_changed',
@@ -649,9 +654,9 @@ final class HtmlTransformer
             'editability_report' => (new EditabilityReport())->fromBlocks($blocks, (string) ($options['source'] ?? ''), $serializedBlocks, $generatedCarrierCss, $runtimeBlockPaths, $visualBlockPaths, $sourceProvenance),
             'html' => array(
                 'presentation_signals' => $this->transformationProvenance()->presentationSignals(),
-                'frozen_hidden_state'  => $this->frozenHiddenStateFindings,
-                'dropped_link_wrappers' => $this->droppedLinkWrapperFindings,
-                'gutenberg_incompatibilities' => $this->gutenbergIncompatibilities,
+                'frozen_hidden_state'  => $this->transformationEvidence()->frozenHiddenStateFindings(),
+                'dropped_link_wrappers' => $this->transformationEvidence()->droppedLinkWrapperFindings(),
+                'gutenberg_incompatibilities' => $this->transformationEvidence()->gutenbergIncompatibilities(),
                 'author_layout_topology' => $authorLayoutTopologyFindings,
                 'source_provenance'    => $sourceProvenance,
                 'core_html_fallback_evidence' => CoreHtmlFallbackEvidence::fromBlocks($blocks, $fallbacks, $sourceProvenance),
@@ -1279,7 +1284,7 @@ final class HtmlTransformer
         }
 
         $repairs = array();
-        foreach ( $this->frozenHiddenStateFindings as $finding ) {
+        foreach ( $this->transformationEvidence()->frozenHiddenStateFindings() as $finding ) {
             $selector = (string) ($finding['editor_selector'] ?? '');
             if ( '' === $selector ) {
                 continue;
@@ -3082,7 +3087,7 @@ final class HtmlTransformer
             $shellMatches = array_filter($matches, fn (DOMElement $element): bool => $this->isPageShellOrSectionSurface($element));
             if ( count($shellMatches) !== count($matches) ) {
                 if ( array() !== $shellMatches ) {
-                    $this->responsiveGeometryAmbiguities[$selector . "\0" . $minimumWidth] = array('selector' => $selector, 'min_width' => $minimumWidth);
+                    $this->transformationEvidence()->recordResponsiveGeometryAmbiguity($selector, $minimumWidth);
                 }
                 return $body;
             }
@@ -6513,44 +6518,17 @@ final class HtmlTransformer
         ));
     }
 
-    /**
-     * @return array<int, array{selector: string, source_child_count: int, block_child_count: int, source_tags: list<string>, block_tags: list<string>}>
-     */
-    private function authorLayoutTopologyFindings(): array
-    {
-        $findings = array();
-        foreach ( $this->authorLayoutTopologies as $layout ) {
-            // Text-only leaves have no element-child topology to compare. Their
-            // text may become a paragraph, but that is not a container loss.
-            if ( 0 === $layout['direct_child_count'] ) {
-                continue;
-            }
-            if ( $layout['direct_child_count'] === $layout['block_child_count'] && $layout['source_tags'] === $layout['block_tags'] ) {
-                continue;
-            }
-            $findings[] = array(
-                'selector' => $layout['selector'],
-                'source_child_count' => $layout['direct_child_count'],
-                'block_child_count' => $layout['block_child_count'],
-                'source_tags' => $layout['source_tags'],
-                'block_tags' => $layout['block_tags'],
-            );
-        }
-
-        return array_slice($findings, 0, 20);
-    }
-
     /** @param array<int, array<string, mixed>> $fallbacks */
     private function authorLayoutBlockFromElement(DOMElement $element, array &$fallbacks): array
     {
         $children = $this->convertChildren($element, $fallbacks, true);
         if ( $this->isAuthorOwnedLayout($element) ) {
-            $this->authorLayoutTopologies[] = array(
-                'selector' => $this->elementSelector($element),
-                'direct_child_count' => $this->childElementCount($element),
-                'block_child_count' => count($children),
-                'source_tags' => $this->directChildTags($element),
-                'block_tags' => $this->directBlockTags($children),
+            $this->transformationEvidence()->recordAuthorLayoutTopology(
+                $this->elementSelector($element),
+                $this->childElementCount($element),
+                count($children),
+                $this->directChildTags($element),
+                $this->directBlockTags($children)
             );
         }
         return $this->createBlock('core/group', $this->cssOwnedGroupAttributes($element), $children, $element);
@@ -13918,10 +13896,7 @@ final class HtmlTransformer
      */
     private function registerFormControlEcho(string $text): void
     {
-        $text = trim($text);
-        if ( '' !== $text ) {
-            $this->formControlEchoTexts[] = $text;
-        }
+        $this->transformationEvidence()->recordFormControlEcho($text);
     }
 
     private function readableFormControlLabel(DOMElement $control): string
@@ -15507,14 +15482,14 @@ final class HtmlTransformer
             return;
         }
 
-        $this->droppedLinkWrapperFindings[] = array_merge(
+        $this->transformationEvidence()->recordDroppedLinkWrapper(array_merge(
             array(
                 'kind'     => 'source link wrapper dropped / content no longer navigable',
                 'tag'      => strtolower($anchor->tagName),
                 'selector' => $this->elementSelector($anchor),
             ),
             $link
-        );
+        ));
     }
 
     /**

--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerSession.php
@@ -22,11 +22,9 @@ use DOMElement;
  */
 final class HtmlTransformerSession
 {
-    public array $formControlEchoTexts = array();
+    private readonly TransformationEvidenceState $transformationEvidenceState;
     public array $responsiveImageFallbacks = array();
     public array $responsiveImageFallbackSelectors = array();
-    public array $frozenHiddenStateFindings = array();
-    public array $droppedLinkWrapperFindings = array();
     private readonly TransformationProvenanceState $transformationProvenanceState;
     public array $scriptMetadata = array();
     private readonly RuntimeDomState $runtimeDomState;
@@ -36,10 +34,7 @@ final class HtmlTransformerSession
     public bool $emptyRuntimeTargetGenerated = false;
     public array $runtimeScriptMetadata = array();
     private ?AssetMaterializationState $assetMaterializationState = null;
-    public array $gutenbergIncompatibilities = array();
     private RuntimeSelectorState $runtimeSelectorState;
-    public array $responsiveGeometryAmbiguities = array();
-    public array $authorLayoutTopologies = array();
     private ?AuthorStyleAnalysis $authorStyleAnalysis = null;
     private readonly AuthorSelectorProjectionState $authorSelectorProjectionState;
     private readonly GeneratedSupportStylesheetState $generatedSupportStylesheetState;
@@ -61,6 +56,7 @@ final class HtmlTransformerSession
         $this->authorSelectorProjectionState = new AuthorSelectorProjectionState();
         $this->generatedSupportStylesheetState = new GeneratedSupportStylesheetState();
         $this->transformationProvenanceState = new TransformationProvenanceState();
+        $this->transformationEvidenceState = new TransformationEvidenceState();
         $this->runtimeSelectorState = new RuntimeSelectorState(array(), array(), array());
     }
 
@@ -143,5 +139,10 @@ final class HtmlTransformerSession
     public function transformationProvenanceState(): TransformationProvenanceState
     {
         return $this->transformationProvenanceState;
+    }
+
+    public function transformationEvidenceState(): TransformationEvidenceState
+    {
+        return $this->transformationEvidenceState;
     }
 }

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -1589,12 +1589,12 @@ trait StyleResolutionTrait
         }
 
         if ( array() !== $stripped ) {
-            $this->frozenHiddenStateFindings[] = array(
+            $this->transformationEvidence()->recordFrozenHiddenState(array(
                 'tag'          => strtolower($element->tagName),
                 'selector'     => $this->elementSelector($element),
                 'editor_selector' => $this->editorStaticStateSelector($element),
                 'declarations' => $stripped,
-            );
+            ));
         }
 
         return $declarations;

--- a/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Support/SvgMaterializationTrait.php
@@ -626,13 +626,13 @@ trait SvgMaterializationTrait
 
     private function recordGutenbergIncompatibility(DOMElement $element, string $reason, string $message): void
     {
-        $this->gutenbergIncompatibilities[] = array(
+        $this->transformationEvidence()->recordGutenbergIncompatibility(array(
             'type'     => 'svg_materialization_incompatibility',
             'element'  => 'svg',
             'selector' => $this->elementSelector($element),
             'reason'   => $reason,
             'message'  => $message,
-        );
+        ));
     }
 
     private function isNativeImageCompatibleSvg(DOMElement $element, string $html): bool

--- a/php-transformer/src/HtmlToBlocks/TransformationEvidenceState.php
+++ b/php-transformer/src/HtmlToBlocks/TransformationEvidenceState.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks;
+
+final class TransformationEvidenceState
+{
+    /** @var list<string> */
+    private array $formControlEchoTexts = array();
+
+    /** @var list<array<string, mixed>> */
+    private array $frozenHiddenStateFindings = array();
+
+    /** @var list<array<string, mixed>> */
+    private array $droppedLinkWrapperFindings = array();
+
+    /** @var list<array<string, mixed>> */
+    private array $gutenbergIncompatibilities = array();
+
+    /** @var array<string, array{selector: string, min_width: string}> */
+    private array $responsiveGeometryAmbiguities = array();
+
+    /** @var list<array{selector: string, direct_child_count: int, block_child_count: int, source_tags: list<string>, block_tags: list<string>}> */
+    private array $authorLayoutTopologies = array();
+
+    public function recordFormControlEcho(string $text): void
+    {
+        $text = trim($text);
+        if ( '' !== $text ) {
+            $this->formControlEchoTexts[] = $text;
+        }
+    }
+
+    /** @return list<string> */
+    public function formControlEchoTexts(): array
+    {
+        return $this->formControlEchoTexts;
+    }
+
+    /** @param array<string, mixed> $finding */
+    public function recordFrozenHiddenState(array $finding): void
+    {
+        $this->frozenHiddenStateFindings[] = $finding;
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function frozenHiddenStateFindings(): array
+    {
+        return $this->frozenHiddenStateFindings;
+    }
+
+    /** @param array<string, mixed> $finding */
+    public function recordDroppedLinkWrapper(array $finding): void
+    {
+        $this->droppedLinkWrapperFindings[] = $finding;
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function droppedLinkWrapperFindings(): array
+    {
+        return $this->droppedLinkWrapperFindings;
+    }
+
+    /** @param array<string, mixed> $finding */
+    public function recordGutenbergIncompatibility(array $finding): void
+    {
+        $this->gutenbergIncompatibilities[] = $finding;
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function gutenbergIncompatibilities(): array
+    {
+        return $this->gutenbergIncompatibilities;
+    }
+
+    public function recordResponsiveGeometryAmbiguity(string $selector, string $minimumWidth): void
+    {
+        $this->responsiveGeometryAmbiguities[$selector . "\0" . $minimumWidth] = array(
+            'selector' => $selector,
+            'min_width' => $minimumWidth,
+        );
+    }
+
+    /** @return list<array{selector: string, min_width: string}> */
+    public function responsiveGeometryAmbiguities(): array
+    {
+        return array_values($this->responsiveGeometryAmbiguities);
+    }
+
+    /**
+     * @param list<string> $sourceTags
+     * @param list<string> $blockTags
+     */
+    public function recordAuthorLayoutTopology(string $selector, int $sourceChildCount, int $blockChildCount, array $sourceTags, array $blockTags): void
+    {
+        $this->authorLayoutTopologies[] = array(
+            'selector' => $selector,
+            'direct_child_count' => $sourceChildCount,
+            'block_child_count' => $blockChildCount,
+            'source_tags' => $sourceTags,
+            'block_tags' => $blockTags,
+        );
+    }
+
+    /** @return list<array{selector: string, source_child_count: int, block_child_count: int, source_tags: list<string>, block_tags: list<string>}> */
+    public function authorLayoutTopologyFindings(): array
+    {
+        $findings = array();
+        foreach ( $this->authorLayoutTopologies as $layout ) {
+            if ( 0 === $layout['direct_child_count'] ) {
+                continue;
+            }
+            if ( $layout['direct_child_count'] === $layout['block_child_count'] && $layout['source_tags'] === $layout['block_tags'] ) {
+                continue;
+            }
+            $findings[] = array(
+                'selector' => $layout['selector'],
+                'source_child_count' => $layout['direct_child_count'],
+                'block_child_count' => $layout['block_child_count'],
+                'source_tags' => $layout['source_tags'],
+                'block_tags' => $layout['block_tags'],
+            );
+        }
+
+        return array_slice($findings, 0, 20);
+    }
+}


### PR DESCRIPTION
## Summary
- replace six public session fields with a typed `TransformationEvidenceState` lifecycle owner
- centralize form-control echo normalization, responsive ambiguity deduplication, and author-layout topology filtering
- keep diagnostic ordering and source-report schemas unchanged while returning evidence snapshots instead of mutable arrays
- reduce the public `HtmlTransformerSession` surface from 16 fields to 10

Part of #242.

## Verification
- `composer test`
- 289 PHP transformer parity fixtures
- reused-transformer session-state contract
- form-control round-trip, dropped-anchor, and responsive geometry contracts
- isolated Composer package install proof
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol was used through OpenCode to map evidence lifecycle coupling, implement the typed owner, and run the repository verification suite. The changes and test results were reviewed by the author.