### PR TITLE
Preserve responsive variant asset origins

### DIFF
--- a/php-transformer/src/ArtifactCompiler/ResponsiveDocumentVariants.php
+++ b/php-transformer/src/ArtifactCompiler/ResponsiveDocumentVariants.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler;
 
+use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter;
+use Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\SrcsetParser;
 use Automattic\BlocksEngine\PhpTransformer\HtmlToBlocks\Style\CssStylesheetTransformer;
 use Automattic\BlocksEngine\PhpTransformer\Path\ArtifactPath;
 
@@ -79,7 +81,7 @@ final class ResponsiveDocumentVariants
 
             $files[$primaryIndex] = $this->withFileContent(
                 $files[$primaryIndex],
-                $this->composeDocument($primaryHtml, $variantDocuments)
+                $this->composeDocument($primaryHtml, $variantDocuments, $sourcePath)
             );
             $variantPaths = array_fill_keys(array_column($variantDocuments, 'path'), true);
             foreach ($files as $index => $file) {
@@ -96,7 +98,7 @@ final class ResponsiveDocumentVariants
     }
 
     /** @param array<int,array{id:string,path:string,media:string,html:string}> $variants */
-    private function composeDocument(string $primaryHtml, array $variants): string
+    private function composeDocument(string $primaryHtml, array $variants, string $sourcePath): string
     {
         $primaryHtml = $this->scopeDocumentStyles($primaryHtml, 'site-document-variant-default');
         $primaryBody = $this->body($primaryHtml);
@@ -112,7 +114,8 @@ final class ResponsiveDocumentVariants
         $variantMarkup = '';
         $variantStyles = '';
         foreach ($variants as $variant) {
-            $body = $this->body($variant['html']);
+            $variantHtml = $this->rebaseDocumentReferences($variant['html'], $variant['path'], $sourcePath);
+            $body = $this->body($variantHtml);
             if (null === $body) {
                 throw new \InvalidArgumentException(sprintf('Document variant "%s" must contain a body element.', $variant['path']));
             }
@@ -129,7 +132,7 @@ final class ResponsiveDocumentVariants
                 . ('' !== $bodyStyle ? ' style="' . htmlspecialchars($bodyStyle, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '"' : '')
                 . '>' . preg_replace('@<style\b[^>]*>[\s\S]*?</style\s*>@i', '', $body['content']) . '</div>';
 
-            foreach ($this->styles($variant['html']) as $style) {
+            foreach ($this->styles($variantHtml) as $style) {
                 $css = $this->scopeDocumentStylesheet($style['css'], $variantClass);
                 $media = '' !== $style['media'] ? $variant['media'] . ' and ' . $style['media'] : $variant['media'];
                 $variantStyles .= '<style media="' . htmlspecialchars($media, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . $css . '</style>';
@@ -146,6 +149,67 @@ final class ResponsiveDocumentVariants
         return preg_match('@</head\s*>@i', $composed)
             ? (string) preg_replace('@</head\s*>@i', $styles . '</head>', $composed, 1)
             : $styles . $composed;
+    }
+
+    private function rebaseDocumentReferences(string $html, string $variantPath, string $primaryPath): string
+    {
+        $rebase = fn(string $reference): string => $this->rebaseReference($reference, $variantPath, $primaryPath);
+        $html = (string) preg_replace_callback(
+            '~<\s*[a-z][a-z0-9:-]*(?:\s+(?:"[^"]*"|\'[^\']*\'|[^\'"<>])*)?/?>~is',
+            static function (array $match) use ($rebase): string {
+                preg_match('~^<\s*([a-z][a-z0-9:-]*)~i', $match[0], $elementMatch);
+                $element = strtolower((string) ($elementMatch[1] ?? ''));
+                return (string) preg_replace_callback(
+                    '~(?<![a-z0-9:_-])(xlink:href|srcset|src|href|poster|style)\s*=\s*(["\'])(.*?)\2~is',
+                    static function (array $attribute) use ($element, $rebase): string {
+                        $name = strtolower($attribute[1]);
+                        $value = 'href' === $name && in_array($element, array('a', 'area'), true)
+                            ? $attribute[3]
+                            : ('style' === $name
+                                ? self::rebaseCss($attribute[3], $rebase)
+                                : ('srcset' === $name ? SrcsetParser::rewrite($attribute[3], $rebase) : $rebase($attribute[3])));
+                        return $attribute[1] . '=' . $attribute[2] . $value . $attribute[2];
+                    },
+                    $match[0]
+                );
+            },
+            $html
+        );
+        return (string) preg_replace_callback(
+            '~<style\b[^>]*>(.*?)</style\s*>~is',
+            static fn(array $match): string => str_replace($match[1], self::rebaseCss($match[1], $rebase), $match[0]),
+            $html
+        );
+    }
+
+    /** @param callable(string):string $rebase */
+    private static function rebaseCss(string $css, callable $rebase): string
+    {
+        $css = CssUrlRewriter::rewrite($css, $rebase);
+        return (string) preg_replace_callback(
+            '~(@import\s+)(["\'])([^"\']+)\2~i',
+            static fn(array $match): string => $match[1] . $match[2] . $rebase($match[3]) . $match[2],
+            $css
+        );
+    }
+
+    private function rebaseReference(string $reference, string $variantPath, string $primaryPath): string
+    {
+        if ('' === trim($reference) || preg_match('~^(?:[a-z][a-z0-9+.-]*:|//|/|#|\?)~i', $reference)) {
+            return $reference;
+        }
+        preg_match('/^([^?#]*)(.*)$/s', $reference, $parts);
+        $resolved = ArtifactPath::resolveRelativePath((string) ($parts[1] ?? ''), $variantPath);
+        if ('' === $resolved) {
+            return $reference;
+        }
+        $from = '.' === dirname($primaryPath) ? array() : explode('/', dirname($primaryPath));
+        $to = explode('/', $resolved);
+        while (array() !== $from && array() !== $to && $from[0] === $to[0]) {
+            array_shift($from);
+            array_shift($to);
+        }
+        return implode('/', array_merge(array_fill(0, count($from), '..'), $to)) . (string) ($parts[2] ?? '');
     }
 
     private function scopeDocumentSelectors(string $css): string

--- a/php-transformer/tests/unit/responsive-document-variants.php
+++ b/php-transformer/tests/unit/responsive-document-variants.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
 
 $assert = static function (bool $condition, string $message): void {
     if (!$condition) {
@@ -35,7 +36,7 @@ $artifact = array(
         array(
             'path' => 'website/.variants/mobile/index.html',
             'role' => 'document_variant',
-            'content' => '<!doctype html><html><head><style>:root{--site-width:320px}body.mobile{display:flex;min-width:320px;overflow:hidden}body.mobile main{width:var(--site-width)}.card{display:block}</style></head><body class="mobile" style="overflow:hidden"><main><h1 class="card">Mobile</h1></main></body></html>',
+            'content' => '<!doctype html><html><head><style>:root{--site-width:320px}body.mobile{display:flex;min-width:320px;overflow:hidden}body.mobile main{width:var(--site-width)}.card{display:block}</style></head><body class="mobile" style="overflow:hidden"><main><h1 class="card">Mobile</h1><a href="calendar/index.html">Calendar</a></main></body></html>',
         ),
     ),
 );
@@ -61,6 +62,7 @@ $assert(str_contains($assetCss, '@media not all and (max-width: 768px){.site-doc
 $assert(str_contains($assetCss, '@scope (.site-document-variant-default)') && str_contains($assetCss, '.card{display:grid}'), 'Primary selectors remain editable inside the default document scope.');
 $assert(str_contains($assetCss, '.card{display:block}'), 'Mobile selectors remain editable inside the mobile document scope.');
 $assert(str_contains($blocks, 'site-document-variant-default desktop'), 'Primary body classes are projected onto the default document wrapper.');
+$assert(str_contains($blocks, 'href="calendar/index.html"'), 'Mobile route destinations retain their existing primary-route interpretation.');
 
 $sharedPlan = $compiler->prepareShared($artifact);
 $pagePlan = $compiler->preparePage($artifact, $sharedPlan, 'website/index.html');
@@ -68,6 +70,57 @@ $staged = $compiler->compose($sharedPlan, array($pagePlan))->toArray();
 $stagedBlocks = (string) ($staged['serialized_blocks'] ?? '');
 $assert(str_contains($stagedBlocks, 'site-document-variant-default') && str_contains($stagedBlocks, 'site-document-variant-mobile'), 'Staged compilation preserves the same responsive variants.');
 $assert($blocks === $stagedBlocks && ($result['source_reports']['wordpress_site_plan'] ?? array()) === ($staged['source_reports']['wordpress_site_plan'] ?? array()), 'Direct and staged compilation preserve identical responsive document content and site plans.');
+
+$routeArtifact = array(
+    'schema' => ArtifactCompiler::INPUT_SCHEMA,
+    'entrypoint' => 'website/routes/hpgraduationday/index.html',
+    'document_variants' => array(
+        array(
+            'source_path' => 'website/routes/hpgraduationday/index.html',
+            'variants' => array(
+                array(
+                    'id' => 'mobile',
+                    'source_path' => 'website/.variants/mobile/routes/hpgraduationday/index.html',
+                    'media' => '(max-width: 500px)',
+                ),
+            ),
+        ),
+    ),
+    'files' => array(
+        array(
+            'path' => 'website/routes/hpgraduationday/index.html',
+            'content' => '<!doctype html><html><head></head><body><main><h1>Desktop graduation</h1><img src="artwork/hero.svg" alt="Desktop graduation artwork"></main></body></html>',
+        ),
+        array(
+            'path' => 'website/.variants/mobile/routes/hpgraduationday/index.html',
+            'role' => 'document_variant',
+            'content' => '<!doctype html><html><head></head><body><main><h1>Mobile graduation</h1><img src="artwork/hero.svg" alt="Mobile graduation artwork"></main></body></html>',
+        ),
+        array(
+            'path' => 'website/routes/hpgraduationday/artwork/hero.svg',
+            'mime_type' => 'image/svg+xml',
+            'content' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 1"><rect width="2" height="1" fill="orange"/></svg>',
+        ),
+        array(
+            'path' => 'website/.variants/mobile/routes/hpgraduationday/artwork/hero.svg',
+            'mime_type' => 'image/svg+xml',
+            'content' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 2"><rect width="1" height="2" fill="navy"/></svg>',
+        ),
+    ),
+);
+$routeResult = $compiler->compile($routeArtifact)->toArray();
+$routePlan = $routeResult['source_reports']['wordpress_site_plan'] ?? array();
+$tokensBySource = array_column($routePlan['reference_tokens'] ?? array(), 'token', 'source_path');
+$desktopToken = $tokensBySource['website/routes/hpgraduationday/artwork/hero.svg'] ?? '';
+$mobileToken = $tokensBySource['website/.variants/mobile/routes/hpgraduationday/artwork/hero.svg'] ?? '';
+$routeMarkup = (string) ($routePlan['pages'][0]['canonical_block_markup'] ?? '');
+$assert('' !== $desktopToken && '' !== $mobileToken && $desktopToken !== $mobileToken, 'Desktop and mobile artwork retain distinct publication identities.');
+$assert(str_contains($routeMarkup, '{{wordpress-site-plan:asset:' . $desktopToken . '}}'), 'The emitted desktop route selects its captured desktop artwork.');
+$assert(str_contains($routeMarkup, '{{wordpress-site-plan:asset:' . $mobileToken . '}}'), 'The emitted mobile route selects its captured mobile artwork.');
+$resolvedRoutePlan = (new WordPressSitePlanResolver())->resolve($routePlan, array('theme_uri' => 'https://example.test/wp-content/themes/captured'));
+$resolvedRouteMarkup = (string) ($resolvedRoutePlan['pages'][0]['resolved_block_markup'] ?? '');
+$assert(str_contains($resolvedRouteMarkup, 'https://example.test/wp-content/themes/captured/assets/website/routes/hpgraduationday/artwork/hero.svg'), 'Desktop artwork resolves to its materialized destination URL.');
+$assert(str_contains($resolvedRouteMarkup, 'https://example.test/wp-content/themes/captured/assets/website/.variants/mobile/routes/hpgraduationday/artwork/hero.svg'), 'Mobile artwork resolves to its materialized destination URL.');
 
 $invalid = $artifact;
 $invalid['document_variants'][0]['variants'][0]['media'] = '(max-width:768px)}body{display:none}';


### PR DESCRIPTION
## Summary
- preserve each responsive document variant's own base URL and asset origin through projection
- resolve variant-local resources against the route that authored them
- add regression coverage for desktop/mobile assets with distinct origins

Closes #1238

## Verification
- `composer --working-dir=php-transformer test`

## AI Assistance
OpenCode with OpenAI openai/gpt-5.6-sol, orchestrated by Chris Huber, implemented and verified the repair under direct human-directed workflow.