### PR TITLE
Reuse structural presentation declarations

### DIFF
--- a/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
+++ b/php-transformer/src/HtmlToBlocks/HtmlTransformerAnalysisCache.php
@@ -97,6 +97,10 @@ final class HtmlTransformerAnalysisCache
 
     public int $sourceStyleCandidateRulePeakRetained = 0;
 
+    public int $sourceStructuralDeclarationBuilds = 0;
+
+    public int $sourceStructuralDeclarationHits = 0;
+
     /** @param array{static: array, conditional: array, navigation_state: array, image_shape: array, pseudo: array, custom_properties: array} $analysis */
     public function rememberStyle(string $key, array $analysis): void
     {

--- a/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
+++ b/php-transformer/src/HtmlToBlocks/Style/SourceStyleResolutionState.php
@@ -14,6 +14,9 @@ final class SourceStyleResolutionState
     /** @var array<string, array<string, array<int, string>>> */
     public array $authorDeclaredPropertyValues = array();
 
+    /** @var array<string, array<string, string>> */
+    public array $structuralDeclarations = array();
+
     /** @var array<string, array<int, string>> */
     private array $classPromotions = array();
 

--- a/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
+++ b/php-transformer/src/HtmlToBlocks/Style/StyleResolutionTrait.php
@@ -1206,6 +1206,14 @@ trait StyleResolutionTrait
      */
     private function structuralPresentationDeclarations(DOMElement $element): array
     {
+        $cache = $this->sourceStyles();
+        $cacheKey = $this->presentationCacheKey($element);
+        if ( isset($cache->structuralDeclarations[$cacheKey]) ) {
+            ++$this->analysisCache->sourceStructuralDeclarationHits;
+            return $cache->structuralDeclarations[$cacheKey];
+        }
+        ++$this->analysisCache->sourceStructuralDeclarationBuilds;
+
         $declarations = array();
         foreach ( $this->styleRuleCandidates($element, 'static') as $rule ) {
             if ( $this->matchesCssSelector($element, $rule['selector']) ) {
@@ -1213,7 +1221,7 @@ trait StyleResolutionTrait
             }
         }
 
-        return $this->mergeCssDeclarationMaps($declarations, $this->cssDeclarations($this->attr($element, 'style')));
+        return $cache->structuralDeclarations[$cacheKey] = $this->mergeCssDeclarationMaps($declarations, $this->cssDeclarations($this->attr($element, 'style')));
     }
 
     /**
@@ -2455,7 +2463,9 @@ trait StyleResolutionTrait
 
     private function invalidateSourceSelectorMatchCache(): void
     {
-        $this->sourceStyles()->selectorMatchCache?->clear();
+        $cache = $this->sourceStyles();
+        $cache->selectorMatchCache?->clear();
+        $cache->structuralDeclarations = array();
     }
 
     private function recordSourceSelectorMatchWork(): void

--- a/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
+++ b/php-transformer/tests/unit/html-transformer-shared-analysis-cache.php
@@ -136,9 +136,10 @@ $assert(4 === $selectorCache->authorSelectorMatchResultBuilds && $selectorCache-
 $sourceSelectorCache = new HtmlTransformerAnalysisCache();
 $sourceSelectorHtml = '<style>.card{display:grid;color:red}.card.primary{gap:1rem}.card[data-kind="primary"]{padding:1rem}</style><section class="card primary" data-kind="primary"><p>Repeated source selector matching</p></section>';
 $sourceSelectorResult = (new HtmlTransformer(analysisCache: $sourceSelectorCache))->transform($sourceSelectorHtml)->toArray();
-$assert(10 === $sourceSelectorCache->sourceSelectorMatchExecutions && 12 === $sourceSelectorCache->sourceSelectorMatchHits, 'Indexed general style resolution executes 10 matcher calls and reuses 12 repeated element-selector results.');
+$assert(10 === $sourceSelectorCache->sourceSelectorMatchExecutions && 3 === $sourceSelectorCache->sourceSelectorMatchHits, 'Indexed general style resolution executes 10 matcher calls and reuses three repeated element-selector results.');
 $assert(9 === $sourceSelectorCache->sourceSelectorClassTokenBuilds && 13 === $sourceSelectorCache->sourceSelectorClassTokenHits && 21 === $sourceSelectorCache->sourceSelectorAttributeReads, 'General style resolution reuses immutable class and common-attribute inputs.');
-$assert(12 === ($sourceSelectorResult['metrics']['selector_match_cache_hits'] ?? null) && 10 === ($sourceSelectorResult['metrics']['selector_match_cache_misses'] ?? null) && 0 === ($sourceSelectorResult['metrics']['selector_match_cache_evictions'] ?? null) && 3 === ($sourceSelectorResult['metrics']['selector_match_cache_peak_entries'] ?? null) && 7 === ($sourceSelectorResult['metrics']['style_rule_candidate_cache_hits'] ?? null) && 12 === ($sourceSelectorResult['metrics']['style_rule_candidate_cache_misses'] ?? null), 'Transform metrics expose selector and candidate-cache hit, miss, eviction, and peak counters without changing canonical blocks.');
+$assert(6 === $sourceSelectorCache->sourceStructuralDeclarationBuilds && 6 === $sourceSelectorCache->sourceStructuralDeclarationHits, 'Structural declaration resolution builds each source state once and reuses repeated element results.');
+$assert(3 === ($sourceSelectorResult['metrics']['selector_match_cache_hits'] ?? null) && 10 === ($sourceSelectorResult['metrics']['selector_match_cache_misses'] ?? null) && 0 === ($sourceSelectorResult['metrics']['selector_match_cache_evictions'] ?? null) && 3 === ($sourceSelectorResult['metrics']['selector_match_cache_peak_entries'] ?? null) && 1 === ($sourceSelectorResult['metrics']['style_rule_candidate_cache_hits'] ?? null) && 12 === ($sourceSelectorResult['metrics']['style_rule_candidate_cache_misses'] ?? null), 'Transform metrics expose selector and candidate-cache hit, miss, eviction, and peak counters without changing canonical blocks.');
 
 $candidateCache = new HtmlTransformerAnalysisCache();
 $noiseRules = array();
@@ -168,7 +169,8 @@ $assert(1601 === $hiddenStateCache->sourceStyleCandidateRulesSkipped && 1 === $h
 $pressureElementCount = 4097;
 $pressureHtml = '<main class="pressure">' . str_repeat('<p class="pressure">cache pressure</p>', $pressureElementCount) . '</main>';
 $pressureOptions = array('static_css' => '.pressure{color:#123456}', 'skip_author_stylesheet_materialization' => true);
-$pressureResult = (new HtmlTransformer())->transform($pressureHtml, $pressureOptions)->toArray();
+$pressureCache = new HtmlTransformerAnalysisCache();
+$pressureResult = (new HtmlTransformer(analysisCache: $pressureCache))->transform($pressureHtml, $pressureOptions)->toArray();
 $pressureIsolatedResult = (new HtmlTransformer())->transform($pressureHtml, $pressureOptions)->toArray();
 $pressureMetrics = $pressureResult['metrics'];
 $assert(
@@ -183,14 +185,16 @@ $assert(
 );
 $assert(
     8197 === ($pressureMetrics['selector_match_cache_misses'] ?? null)
-    && 4100 === ($pressureMetrics['selector_match_cache_hits'] ?? null)
+    && 1 === ($pressureMetrics['selector_match_cache_hits'] ?? null)
     && 2 === ($pressureMetrics['selector_match_cache_evictions'] ?? null)
-    && 4096 === ($pressureMetrics['selector_match_cache_peak_entries'] ?? null),
-    'Repeated hot selector matches are refreshed while the 4,097-element transform exceeds the selector-result capacity.'
+    && 4096 === ($pressureMetrics['selector_match_cache_peak_entries'] ?? null)
+    && 8199 === $pressureCache->sourceStructuralDeclarationBuilds
+    && 4101 === $pressureCache->sourceStructuralDeclarationHits,
+    'Structural declaration results absorb repeated passes while selector-result storage remains bounded across invalidations.'
 );
 $assert(
     16397 === ($pressureMetrics['style_rule_candidate_cache_misses'] ?? null)
-    && 4104 === ($pressureMetrics['style_rule_candidate_cache_hits'] ?? null)
+    && 3 === ($pressureMetrics['style_rule_candidate_cache_hits'] ?? null)
     && 7 === ($pressureMetrics['style_rule_candidate_cache_evictions'] ?? null)
     && 4096 === ($pressureMetrics['style_rule_candidate_cache_peak_entries'] ?? null)
     && 4096 === ($pressureMetrics['style_rule_candidate_cache_peak_rule_references'] ?? null),


### PR DESCRIPTION
## Summary

- memoize structural presentation declarations in the existing per-transform source-style state
- clear structural results at the same DOM-mutation boundary as selector-match results
- expose deterministic build/hit counters and extend pressure coverage across invalidations

Refs #1044.

## Evidence

On the same three prepared pages from a captured 130 MB, 19-page artifact, compared with merged trunk at `9f422df8`:

- page compile wall time: 39.75s -> 34.93s (-12.1%)
- selector probes: 1,101,956 -> 469,012 (-57.4%)
- selector matcher executions: 319,348 -> 310,767 (-2.7%)
- selector cache evictions: 25,094 -> 16,513 (-34.2%)
- structural declaration results: 3,712 builds / 7,089 hits (65.6% hit rate)
- all three compiled receipt digests remained identical
- peak PHP memory remained 264.8 MiB

## Verification

- `composer test`
- `php tests/contract/run.php`
- `php tests/unit/html-transformer-shared-analysis-cache.php`
- 289 parity fixtures
- package installation proof

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to profile merged selector call sites, identify repeated structural declaration resolution, implement mutation-safe per-transform memoization, add deterministic coverage, and run verification. The implementation and evidence were reviewed and orchestrated by Chris Huber.